### PR TITLE
refactor: update import paths to use /core subdirectory

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -14,8 +14,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/maximhq/bifrost/providers"
-	schemas "github.com/maximhq/bifrost/schemas"
+	"github.com/maximhq/bifrost/core/providers"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 // RequestType represents the type of request being made to a provider.

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,4 +1,4 @@
-module github.com/maximhq/bifrost
+module github.com/maximhq/bifrost/core
 
 go 1.24.1
 
@@ -9,7 +9,6 @@ replace github.com/maximhq/bifrost/plugins => ../plugins
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
-	github.com/maximhq/bifrost/plugins v0.0.0-00010101000000-000000000000
 	github.com/valyala/fasthttp v1.60.0
 )
 

--- a/core/logger.go
+++ b/core/logger.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 // DefaultLogger implements the Logger interface with stdout/stderr printing.

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
 

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
 

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 // BedrockAnthropicTextResponse represents the response structure from Bedrock's Anthropic text completion API.

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
 

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
 

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpproxy"
 

--- a/core/tests/account.go
+++ b/core/tests/account.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	schemas "github.com/maximhq/bifrost/schemas"
-	"github.com/maximhq/bifrost/schemas/meta"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/core/schemas/meta"
 )
 
 // BaseAccount provides a test implementation of the Account interface.

--- a/core/tests/anthropic_test.go
+++ b/core/tests/anthropic_test.go
@@ -6,7 +6,7 @@ package tests
 import (
 	"testing"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 func TestAnthropic(t *testing.T) {

--- a/core/tests/azure_test.go
+++ b/core/tests/azure_test.go
@@ -6,7 +6,7 @@ package tests
 import (
 	"testing"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 func TestAzure(t *testing.T) {

--- a/core/tests/bedrock_test.go
+++ b/core/tests/bedrock_test.go
@@ -6,7 +6,7 @@ package tests
 import (
 	"testing"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 func TestBedrock(t *testing.T) {

--- a/core/tests/cohere_test.go
+++ b/core/tests/cohere_test.go
@@ -6,7 +6,7 @@ package tests
 import (
 	"testing"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 func TestCohere(t *testing.T) {

--- a/core/tests/openai_test.go
+++ b/core/tests/openai_test.go
@@ -6,7 +6,7 @@ package tests
 import (
 	"testing"
 
-	schemas "github.com/maximhq/bifrost/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 func TestOpenAI(t *testing.T) {

--- a/core/tests/setup.go
+++ b/core/tests/setup.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/maximhq/bifrost"
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/plugins"
-	schemas "github.com/maximhq/bifrost/schemas"
 
 	"github.com/joho/godotenv"
 )

--- a/core/tests/tests.go
+++ b/core/tests/tests.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/maximhq/bifrost"
-	schemas "github.com/maximhq/bifrost/schemas"
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 // TestConfig holds configuration for test requests across different AI providers.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,0 @@
-module github.com/maximhq/bifrost
-
-go 1.24.1
-
-replace github.com/maximhq/bifrost => ./core
-
-require github.com/maximhq/bifrost v0.0.0-00010101000000-000000000000

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -2,12 +2,12 @@ module github.com/maximhq/bifrost/transports
 
 go 1.24.1
 
-replace github.com/maximhq/bifrost => ../core
+replace github.com/maximhq/bifrost/core => ../core
 
 require (
 	github.com/fasthttp/router v1.5.4
 	github.com/joho/godotenv v1.5.1
-	github.com/maximhq/bifrost v1.0.0
+	github.com/maximhq/bifrost/core v1.0.0
 	github.com/valyala/fasthttp v1.60.0
 )
 

--- a/transports/http.go
+++ b/transports/http.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/fasthttp/router"
 	"github.com/joho/godotenv"
-	"github.com/maximhq/bifrost"
-	schemas "github.com/maximhq/bifrost/schemas"
-	"github.com/maximhq/bifrost/schemas/meta"
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/core/schemas/meta"
 	"github.com/valyala/fasthttp"
 )
 


### PR DESCRIPTION
# Update module path to use nested structure

This PR updates the module path from `github.com/maximhq/bifrost` to `github.com/maximhq/bifrost/core` to better organize the codebase. The change ensures that imports across the project consistently reference the new module path.

Key changes:
- Updated the core module path in `go.mod` to `github.com/maximhq/bifrost/core`
- Updated all import statements to reference the new path structure
- Removed the root-level `go.mod` file as it's no longer needed
- Updated the transports module to import from the new core path

This change improves the project's organization by making the core functionality a proper submodule, which will make it easier to maintain and extend the codebase in the future.