### PR TITLE
feat: add Google Vertex AI provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .vscode
 .DS_Store
+*_creds*

--- a/core/go.mod
+++ b/core/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/goccy/go-json v0.10.5
 	github.com/maximhq/bifrost/plugins v1.0.0
 	github.com/valyala/fasthttp v1.60.0
+	golang.org/x/oauth2 v0.30.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/andybalholm/brotli v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/andybalholm/brotli v1.1.1 h1:PR2pgnyFznKEugtsUo0xLdDop5SKXd5Qf5ysW+7XdTA=
 github.com/andybalholm/brotli v1.1.1/go.mod h1:05ib4cKhjx3OQYUY22hTVd34Bc8upXjOLL2rKwwZBoA=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
@@ -44,5 +46,7 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
 golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -101,7 +101,7 @@ type CohereProvider struct {
 // It initializes the HTTP client with the provided configuration and sets up response pools.
 // The client is configured with timeouts and connection limits.
 func NewCohereProvider(config *schemas.ProviderConfig, logger schemas.Logger) *CohereProvider {
-	setConfigDefaults(config)
+	config.CheckAndSetDefaults()
 
 	client := &fasthttp.Client{
 		ReadTimeout:     time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
@@ -234,6 +234,8 @@ func (provider *CohereProvider) ChatCompletion(model, key string, messages []sch
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug(fmt.Sprintf("error from cohere provider: %s", string(resp.Body())))
+
 		var errorResp CohereError
 
 		bifrostErr := handleProviderAPIError(resp, &errorResp)

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -161,17 +161,18 @@ func configureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 // It attempts to unmarshal the error response and returns a BifrostError
 // with the appropriate status code and error information.
 func handleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.BifrostError {
+	statusCode := resp.StatusCode()
+
 	if err := json.Unmarshal(resp.Body(), &errorResp); err != nil {
 		return &schemas.BifrostError{
 			IsBifrostError: true,
+			StatusCode:     &statusCode,
 			Error: schemas.ErrorField{
 				Message: schemas.ErrProviderResponseUnmarshal,
 				Error:   err,
 			},
 		}
 	}
-
-	statusCode := resp.StatusCode()
 
 	return &schemas.BifrostError{
 		IsBifrostError: false,
@@ -227,32 +228,6 @@ func handleProviderResponse[T any](responseBody []byte, response *T) (interface{
 // This is a helper function for creating pointers to float64 values.
 func float64Ptr(f float64) *float64 {
 	return &f
-}
-
-func setConfigDefaults(config *schemas.ProviderConfig) {
-	if config.ConcurrencyAndBufferSize.Concurrency == 0 {
-		config.ConcurrencyAndBufferSize.Concurrency = schemas.DefaultConcurrency
-	}
-
-	if config.ConcurrencyAndBufferSize.BufferSize == 0 {
-		config.ConcurrencyAndBufferSize.BufferSize = schemas.DefaultBufferSize
-	}
-
-	if config.NetworkConfig.DefaultRequestTimeoutInSeconds == 0 {
-		config.NetworkConfig.DefaultRequestTimeoutInSeconds = schemas.DefaultRequestTimeoutInSeconds
-	}
-
-	if config.NetworkConfig.MaxRetries == 0 {
-		config.NetworkConfig.MaxRetries = schemas.DefaultMaxRetries
-	}
-
-	if config.NetworkConfig.RetryBackoffInitial == 0 {
-		config.NetworkConfig.RetryBackoffInitial = schemas.DefaultRetryBackoffInitial
-	}
-
-	if config.NetworkConfig.RetryBackoffMax == 0 {
-		config.NetworkConfig.RetryBackoffMax = schemas.DefaultRetryBackoffMax
-	}
 }
 
 func StrPtr(s string) *string {

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -1,0 +1,294 @@
+// Package providers implements various LLM providers and their utility functions.
+// This file contains the Vertex provider implementation.
+package providers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/goccy/go-json"
+	"golang.org/x/oauth2/google"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+type VertexError struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+// VertexProvider implements the Provider interface for Vertex's API.
+type VertexProvider struct {
+	logger schemas.Logger     // Logger for provider operations
+	client *http.Client       // HTTP client for API requests
+	meta   schemas.MetaConfig // Vertex-specific configuration
+}
+
+// NewVertexProvider creates a new Vertex provider instance.
+// It initializes the HTTP client with the provided configuration and sets up response pools.
+// The client is configured with timeouts, concurrency limits, and optional proxy settings.
+func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*VertexProvider, error) {
+	config.CheckAndSetDefaults()
+
+	if config.MetaConfig == nil {
+		return nil, fmt.Errorf("meta config is not set")
+	}
+
+	authCredentialPath := config.MetaConfig.GetAuthCredentialPath()
+	if authCredentialPath == nil {
+		return nil, fmt.Errorf("auth credential path is not set")
+	}
+
+	data, err := os.ReadFile(*authCredentialPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read auth credentials: %w", err)
+	}
+
+	// Get a Google JWT Config for the correct scope
+	conf, err := google.JWTConfigFromJSON(data, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT config: %w", err)
+	}
+
+	// Get an access token
+	client := conf.Client(context.Background())
+
+	// Pre-warm response pools
+	for range config.ConcurrencyAndBufferSize.Concurrency {
+		openAIResponsePool.Put(&OpenAIResponse{})
+		anthropicChatResponsePool.Put(&AnthropicChatResponse{})
+		bifrostResponsePool.Put(&schemas.BifrostResponse{})
+	}
+
+	return &VertexProvider{
+		logger: logger,
+		client: client,
+		meta:   config.MetaConfig,
+	}, nil
+}
+
+// GetProviderKey returns the provider identifier for Vertex.
+func (provider *VertexProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.Vertex
+}
+
+// TextCompletion is not supported by the Vertex provider.
+// Returns an error indicating that text completion is not available.
+func (provider *VertexProvider) TextCompletion(model, key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: false,
+		Error: schemas.ErrorField{
+			Message: "text completion is not supported by vertex provider",
+		},
+	}
+}
+
+// ChatCompletion performs a chat completion request to the Vertex API.
+// It supports both text and image content in messages.
+// Returns a BifrostResponse containing the completion results or an error if the request fails.
+func (provider *VertexProvider) ChatCompletion(model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	// Format messages for Vertex API
+	var formattedMessages []map[string]interface{}
+	var preparedParams map[string]interface{}
+
+	if strings.Contains(model, "claude") {
+		formattedMessages, preparedParams = prepareAnthropicChatRequest(model, messages, params)
+	} else {
+		formattedMessages, preparedParams = prepareOpenAIChatRequest(model, messages, params)
+	}
+
+	requestBody := mergeConfig(map[string]interface{}{
+		"model":    model,
+		"messages": formattedMessages,
+	}, preparedParams)
+
+	if strings.Contains(model, "claude") {
+		if _, exists := requestBody["anthropic_version"]; !exists {
+			requestBody["anthropic_version"] = "vertex-2023-10-16"
+		}
+
+		delete(requestBody, "model")
+	}
+
+	delete(requestBody, "region")
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderJSONMarshaling,
+				Error:   err,
+			},
+		}
+	}
+
+	projectID := provider.meta.GetProjectID()
+	if projectID == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "project ID is not set",
+			},
+		}
+	}
+
+	region := params.Region
+	if region == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "region is not set in model params",
+			},
+		}
+	}
+
+	url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/openapi/chat/completions", *region, *projectID, *region)
+
+	if strings.Contains(model, "claude") {
+		url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", *region, *projectID, *region, model)
+	}
+
+	// Create request
+	req, err := http.NewRequest("POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderRequest,
+				Error:   err,
+			},
+		}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Make request
+	resp, err := provider.client.Do(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "error creating request",
+				Error:   err,
+			},
+		}
+	}
+	defer resp.Body.Close()
+
+	// Handle error response
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "error reading request",
+				Error:   err,
+			},
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var openAIErr OpenAIError
+		var vertexErr []VertexError
+
+		provider.logger.Debug(fmt.Sprintf("error from vertex provider: %s", string(body)))
+
+		if err := json.Unmarshal(body, &openAIErr); err != nil {
+			// Try Vertex error format if OpenAI format fails
+			if err := json.Unmarshal(body, &vertexErr); err != nil {
+				fmt.Printf("error unmarshalling vertex error: %s, body: %s", err, string(body))
+				return nil, &schemas.BifrostError{
+					IsBifrostError: true,
+					StatusCode:     &resp.StatusCode,
+					Error: schemas.ErrorField{
+						Message: schemas.ErrProviderResponseUnmarshal,
+						Error:   err,
+					},
+				}
+			}
+
+			if len(vertexErr) > 0 {
+				return nil, &schemas.BifrostError{
+					StatusCode: &resp.StatusCode,
+					Type:       &vertexErr[0].Error.Status,
+					Error: schemas.ErrorField{
+						Message: vertexErr[0].Error.Message,
+					},
+				}
+			}
+		}
+
+		return nil, &schemas.BifrostError{
+			StatusCode: &resp.StatusCode,
+			Error: schemas.ErrorField{
+				Message: openAIErr.Error.Message,
+			},
+		}
+	}
+
+	if strings.Contains(model, "claude") {
+		// Create response object from pool
+		response := acquireAnthropicChatResponse()
+		defer releaseAnthropicChatResponse(response)
+
+		// Create Bifrost response from pool
+		bifrostResponse := acquireBifrostResponse()
+		defer releaseBifrostResponse(bifrostResponse)
+
+		rawResponse, bifrostErr := handleProviderResponse(body, response)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+
+		var err *schemas.BifrostError
+		bifrostResponse, err = parseAnthropicResponse(response, bifrostResponse)
+		if err != nil {
+			return nil, err
+		}
+
+		bifrostResponse.ExtraFields = schemas.BifrostResponseExtraFields{
+			Provider:    schemas.Vertex,
+			RawResponse: rawResponse,
+		}
+
+		return bifrostResponse, nil
+	} else {
+		// Pre-allocate response structs from pools
+		response := acquireOpenAIResponse()
+		defer releaseOpenAIResponse(response)
+
+		result := acquireBifrostResponse()
+		defer releaseBifrostResponse(result)
+
+		// Use enhanced response handler with pre-allocated response
+		rawResponse, bifrostErr := handleProviderResponse(body, response)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+
+		// Populate result from response
+		result.ID = response.ID
+		result.Choices = response.Choices
+		result.Object = response.Object
+		result.Usage = response.Usage
+		result.ServiceTier = response.ServiceTier
+		result.SystemFingerprint = response.SystemFingerprint
+		result.Model = response.Model
+		result.Created = response.Created
+		result.ExtraFields = schemas.BifrostResponseExtraFields{
+			Provider:    schemas.Vertex,
+			RawResponse: rawResponse,
+		}
+
+		return result, nil
+	}
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -36,6 +36,7 @@ const (
 	Anthropic ModelProvider = "anthropic"
 	Bedrock   ModelProvider = "bedrock"
 	Cohere    ModelProvider = "cohere"
+	Vertex    ModelProvider = "vertex"
 )
 
 //* Request Structs
@@ -81,7 +82,7 @@ type ModelParameters struct {
 	PresencePenalty   *float64    `json:"presence_penalty,omitempty"`    // Penalizes repeated tokens
 	FrequencyPenalty  *float64    `json:"frequency_penalty,omitempty"`   // Penalizes frequent tokens
 	ParallelToolCalls *bool       `json:"parallel_tool_calls,omitempty"` // Enables parallel tool calls
-
+	Region            *string     `json:"region"`
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`

--- a/core/schemas/meta/azure.go
+++ b/core/schemas/meta/azure.go
@@ -54,3 +54,13 @@ func (c *AzureMetaConfig) GetDeployments() map[string]string {
 func (c *AzureMetaConfig) GetAPIVersion() *string {
 	return c.APIVersion
 }
+
+// This is not used for Azure.
+func (c *AzureMetaConfig) GetProjectID() *string {
+	return nil
+}
+
+// This is not used for Azure.
+func (c *AzureMetaConfig) GetAuthCredentialPath() *string {
+	return nil
+}

--- a/core/schemas/meta/bedrock.go
+++ b/core/schemas/meta/bedrock.go
@@ -57,3 +57,13 @@ func (c *BedrockMetaConfig) GetDeployments() map[string]string {
 func (c *BedrockMetaConfig) GetAPIVersion() *string {
 	return nil
 }
+
+// This is not used for Bedrock.
+func (c *BedrockMetaConfig) GetProjectID() *string {
+	return nil
+}
+
+// This is not used for Bedrock.
+func (c *BedrockMetaConfig) GetAuthCredentialPath() *string {
+	return nil
+}

--- a/core/schemas/meta/vertex.go
+++ b/core/schemas/meta/vertex.go
@@ -1,0 +1,63 @@
+// Package meta provides provider-specific configuration structures and schemas.
+// This file contains the AWS Vertex-specific configuration implementation.
+
+package meta
+
+// VertexMetaConfig represents the Vertex-specific configuration.
+// It contains Vertex-specific settings required for authentication and service access.
+type VertexMetaConfig struct {
+	ProjectID          string `json:"project_id,omitempty"`
+	AuthCredentialPath string `json:"auth_credential_path,omitempty"`
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetSecretAccessKey() *string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetRegion() *string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetSessionToken() *string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetARN() *string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetInferenceProfiles() map[string]string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetEndpoint() *string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetDeployments() map[string]string {
+	return nil
+}
+
+// This is not used for Vertex.
+func (c *VertexMetaConfig) GetAPIVersion() *string {
+	return nil
+}
+
+// GetProjectID returns the Vertex project ID.
+// This is the project ID for the Vertex project.
+func (c *VertexMetaConfig) GetProjectID() *string {
+	return &c.ProjectID
+}
+
+// GetAuthCredentialPath returns the path to the authentication credentials for the provider.
+// This is the path to the authentication credentials for the google cloud api.
+func (c *VertexMetaConfig) GetAuthCredentialPath() *string {
+	return &c.AuthCredentialPath
+}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -49,6 +49,10 @@ type MetaConfig interface {
 	GetDeployments() map[string]string
 	// GetAPIVersion returns the API version
 	GetAPIVersion() *string
+	// GetProjectID returns the project ID
+	GetProjectID() *string
+	// GetAuthCredentialPath returns the path to the authentication credentials for the provider
+	GetAuthCredentialPath() *string
 }
 
 // ConcurrencyAndBufferSize represents configuration for concurrent operations and buffer sizes.
@@ -89,6 +93,32 @@ type ProviderConfig struct {
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
 	Logger      Logger       `json:"logger"`
 	ProxyConfig *ProxyConfig `json:"proxy_config,omitempty"` // Proxy configuration
+}
+
+func (config *ProviderConfig) CheckAndSetDefaults() {
+	if config.ConcurrencyAndBufferSize.Concurrency == 0 {
+		config.ConcurrencyAndBufferSize.Concurrency = DefaultConcurrency
+	}
+
+	if config.ConcurrencyAndBufferSize.BufferSize == 0 {
+		config.ConcurrencyAndBufferSize.BufferSize = DefaultBufferSize
+	}
+
+	if config.NetworkConfig.DefaultRequestTimeoutInSeconds == 0 {
+		config.NetworkConfig.DefaultRequestTimeoutInSeconds = DefaultRequestTimeoutInSeconds
+	}
+
+	if config.NetworkConfig.MaxRetries == 0 {
+		config.NetworkConfig.MaxRetries = DefaultMaxRetries
+	}
+
+	if config.NetworkConfig.RetryBackoffInitial == 0 {
+		config.NetworkConfig.RetryBackoffInitial = DefaultRetryBackoffInitial
+	}
+
+	if config.NetworkConfig.RetryBackoffMax == 0 {
+		config.NetworkConfig.RetryBackoffMax = DefaultRetryBackoffMax
+	}
 }
 
 // Provider defines the interface for AI model providers.

--- a/core/tests/account.go
+++ b/core/tests/account.go
@@ -27,7 +27,7 @@ type BaseAccount struct{}
 //   - []schemas.SupportedModelProvider: A slice containing the supported provider identifiers
 //   - error: Always returns nil as this implementation doesn't produce errors
 func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
-	return []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic, schemas.Bedrock, schemas.Cohere, schemas.Azure}, nil
+	return []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic, schemas.Bedrock, schemas.Cohere, schemas.Azure, schemas.Vertex}, nil
 }
 
 // GetKeysForProvider returns the API keys and associated models for a given provider.
@@ -191,6 +191,23 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 					"gpt-4o": "gpt-4o-aug",
 				},
 				APIVersion: bifrost.Ptr("2024-08-01-preview"),
+			},
+			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+				Concurrency: 3,
+				BufferSize:  10,
+			},
+		}, nil
+	case schemas.Vertex:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 30,
+				MaxRetries:                     1,
+				RetryBackoffInitial:            100 * time.Millisecond,
+				RetryBackoffMax:                2 * time.Second,
+			},
+			MetaConfig: &meta.VertexMetaConfig{
+				ProjectID:          os.Getenv("VERTEX_PROJECT_ID"),
+				AuthCredentialPath: os.Getenv("VERTEX_CREDENTIALS_PATH"),
 			},
 			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
 				Concurrency: 3,

--- a/core/tests/vertex_test.go
+++ b/core/tests/vertex_test.go
@@ -1,0 +1,34 @@
+// Package tests provides test utilities and configurations for the Bifrost system.
+// It includes test implementations of schemas, mock objects, and helper functions
+// for testing the Bifrost functionality with various AI providers.
+package tests
+
+import (
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestVertex(t *testing.T) {
+	bifrostClient, err := getBifrost()
+	if err != nil {
+		t.Fatalf("Error initializing bifrost: %v", err)
+		return
+	}
+
+	config := TestConfig{
+		Provider:       schemas.Vertex,
+		ChatModel:      "google/gemini-2.0-flash-001",
+		SetupText:      false, // Vertex does not support text completion
+		SetupToolCalls: false,
+		SetupImage:     false,
+		SetupBaseImage: false,
+		CustomParams: &schemas.ModelParameters{
+			Region: bifrost.Ptr("us-central1"),
+		},
+	}
+
+	SetupAllRequests(bifrostClient, config)
+	bifrostClient.Cleanup()
+}


### PR DESCRIPTION
# Add Google Vertex AI Provider Support

This PR adds support for Google Vertex AI as a new provider in Bifrost, allowing users to access Google's AI models like Gemini and third-party models hosted on Vertex AI.

Key changes:
- Implemented a new `VertexProvider` that supports chat completion with Google's models
- Added authentication via Google Cloud credentials
- Created region-specific model routing for Vertex AI endpoints
- Refactored provider code to extract common request preparation logic
- Added support for both OpenAI-style and Anthropic-style models on Vertex
- Enhanced error handling and debugging for all providers

The implementation uses Google's OAuth2 authentication and doesn't require API keys like other providers, instead using service account credentials. The PR also updates the gitignore to exclude credential files for security.