### PR TITLE
fix: Maxim SDK logging fixes

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -44,28 +44,28 @@ const (
 // RequestInput represents the input for a model request, which can be either
 // a text completion or a chat completion, but either one must be provided.
 type RequestInput struct {
-	TextCompletionInput *string
-	ChatCompletionInput *[]Message
+	TextCompletionInput *string    `json:"text_completion_input,omitempty"`
+	ChatCompletionInput *[]Message `json:"chat_completion_input,omitempty"`
 }
 
 // BifrostRequest represents a request to be processed by Bifrost.
 // It must be provided when calling the Bifrost for text completion or chat completion.
 // It contains the model identifier, input data, and parameters for the request.
 type BifrostRequest struct {
-	Model  string
-	Input  RequestInput
-	Params *ModelParameters
+	Model  string           `json:"model"`
+	Input  RequestInput     `json:"input"`
+	Params *ModelParameters `json:"params,omitempty"`
 
 	// Fallbacks are tried in order, the first one to succeed is returned
 	// Provider config must be available for each fallback's provider in account's GetConfigForProvider,
 	// else it will be skipped.
-	Fallbacks []Fallback
+	Fallbacks []Fallback `json:"fallbacks,omitempty"`
 }
 
 // Fallback represents a fallback model to be used if the primary model is not available.
 type Fallback struct {
-	Provider ModelProvider
-	Model    string
+	Provider ModelProvider `json:"provider"`
+	Model    string        `json:"model"`
 }
 
 // ModelParameters represents the parameters that can be used to configure

--- a/plugins/maxim/go.mod
+++ b/plugins/maxim/go.mod
@@ -1,4 +1,4 @@
-module github.com/maximhq/bifrost/plugins
+module github.com/maximhq/bifrost/plugins/maxim
 
 go 1.24.1
 
@@ -6,3 +6,5 @@ require (
 	github.com/maximhq/bifrost/core v1.0.1
 	github.com/maximhq/maxim-go v0.1.1
 )
+
+require github.com/google/uuid v1.6.0

--- a/plugins/maxim/go.sum
+++ b/plugins/maxim/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/maximhq/bifrost/core v1.0.1 h1:B0u6o13faUexA+V0EUU0bsLW2dHg9+R2TZKQzPzCxlY=
 github.com/maximhq/bifrost/core v1.0.1/go.mod h1:4+Ept2EnX1EEjH/mBuSwK7eE56znI/BCoCbIrx25/x8=
 github.com/maximhq/maxim-go v0.1.1 h1:69uUQjjDPmUGcKg/M4/3AO0fbD+70Agt66pH/UCsI5M=


### PR DESCRIPTION
# Add JSON tags to Bifrost schemas and enhance Maxim SDK logging

This PR enhances the Bifrost codebase in two key areas:

1. Adds JSON struct tags to the Bifrost request and related schemas to ensure proper serialization/deserialization.

2. Significantly improves the Maxim SDK logging plugin:
   - Replaces timestamp-based trace IDs with UUID-based identifiers
   - Adds structured logging for different request types (chat vs. text completion)
   - Captures detailed information about requests including model parameters
   - Implements proper generation tracking with separate generation IDs
   - Adds proper trace and generation lifecycle management (ending traces and flushing logs)
   - Extracts and logs message content in a more structured way

The PR also updates the plugins module dependencies to include the Google UUID package.