### PR TITLE
feat: add Maxim logger plugin support to HTTP transport

### DIFF
--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -36,11 +36,15 @@ ARG ENV_PATH
 ARG PORT
 ARG POOL_SIZE
 ARG DROP_EXCESS_REQUESTS
+ARG PLUGINS
+ARG MAXIM_LOG_REPO_ID
 
 # Set default values if args are not provided
 ENV APP_PORT=${PORT:-8080}
 ENV APP_POOL_SIZE=${POOL_SIZE:-300}
 ENV APP_DROP_EXCESS_REQUESTS=${DROP_EXCESS_REQUESTS:-false}
+ENV APP_PLUGINS=${PLUGINS:-""}
+ENV APP_MAXIM_LOG_REPO_ID=${MAXIM_LOG_REPO_ID:-""}
 
 # Copy the config and environment files into the image
 COPY ${CONFIG_PATH} /app/config/config.json
@@ -51,7 +55,7 @@ RUN echo '#!/bin/sh' > /app/entrypoint.sh && \
     echo 'if [ ! -f /app/config/config.json ]; then echo "Missing config.json"; exit 1; fi' >> /app/entrypoint.sh && \
     echo 'if [ ! -f /app/config/.env ]; then echo "Missing .env"; exit 1; fi' >> /app/entrypoint.sh && \
     echo 'if [ ! -f /app/main ]; then echo "Missing main binary"; exit 1; fi' >> /app/entrypoint.sh && \
-    echo 'exec /app/main -config /app/config/config.json -env /app/config/.env -port "$APP_PORT" -pool-size "$APP_POOL_SIZE" -drop-excess-requests "$APP_DROP_EXCESS_REQUESTS"' >> /app/entrypoint.sh && \
+    echo 'exec /app/main -config /app/config/config.json -env /app/config/.env -port "$APP_PORT" -pool-size "$APP_POOL_SIZE" -drop-excess-requests "$APP_DROP_EXCESS_REQUESTS" -plugins "$APP_PLUGINS" -maxim-log-repo-id "$APP_MAXIM_LOG_REPO_ID"' >> /app/entrypoint.sh && \
     chmod +x /app/entrypoint.sh
 
 # Expose the port defined by argument

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/fasthttp/router v1.5.4
 	github.com/joho/godotenv v1.5.1
 	github.com/maximhq/bifrost/core v1.0.5
+	github.com/maximhq/bifrost/plugins v1.0.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.60.0
 	google.golang.org/genai v1.4.0
@@ -41,6 +42,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/maximhq/maxim-go v0.1.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -71,6 +71,10 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/maximhq/bifrost/core v1.0.5 h1:JopRRuV2zylwisj+cBonIpB/Dw4p8gEQoW3hrKsPyI8=
 github.com/maximhq/bifrost/core v1.0.5/go.mod h1:nL2tc1SVJ7EAKxUb1G1yS4nO46ZsCdm1qC3Oc78oYIU=
+github.com/maximhq/bifrost/plugins v1.0.1 h1:wu+kEwdEFvnhEiNLsrFHpxVdd/dJ2Uvkk3el3DkFoWc=
+github.com/maximhq/bifrost/plugins v1.0.1/go.mod h1:c5L95RCOHGAKGAl9up03/00DHqjdxVG+3MdIUlAnzYM=
+github.com/maximhq/maxim-go v0.1.1 h1:69uUQjjDPmUGcKg/M4/3AO0fbD+70Agt66pH/UCsI5M=
+github.com/maximhq/maxim-go v0.1.1/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
# Add support for Maxim Logger plugin

This PR adds support for the Maxim Logger plugin in the Bifrost HTTP transport. The implementation includes:

- Added new command line arguments for plugin configuration:
  - `-plugins`: Comma-separated list of plugins to load
  - `-maxim-logger-id`: ID for the Maxim logger

- Updated the Dockerfile to support these new arguments with environment variables:
  - `APP_PLUGINS`
  - `APP_MAXIM_LOGGER_ID`

- Implemented plugin loading logic that:
  - Parses the plugins string into a list
  - Handles the "maxim" plugin specifically, checking for required configuration
  - Requires `MAXIM_API_KEY` environment variable for the Maxim plugin

- Added the Maxim plugin dependency to go.mod

The Prometheus plugin is now included in the loadedPlugins list alongside any other enabled plugins.