### PR TITLE
refactor: use auth credentials directly instead of file path for Vertex provider

### DIFF
--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/goccy/go-json"
@@ -42,18 +41,13 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		return nil, fmt.Errorf("meta config is not set")
 	}
 
-	authCredentialPath := config.MetaConfig.GetAuthCredentialPath()
-	if authCredentialPath == nil {
-		return nil, fmt.Errorf("auth credential path is not set")
-	}
-
-	data, err := os.ReadFile(*authCredentialPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read auth credentials: %w", err)
+	authCredentials := config.MetaConfig.GetAuthCredentials()
+	if authCredentials == nil {
+		return nil, fmt.Errorf("auth credentials are not set")
 	}
 
 	// Get a Google JWT Config for the correct scope
-	conf, err := google.JWTConfigFromJSON(data, "https://www.googleapis.com/auth/cloud-platform")
+	conf, err := google.JWTConfigFromJSON([]byte(*authCredentials), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create JWT config: %w", err)
 	}

--- a/core/schemas/meta/azure.go
+++ b/core/schemas/meta/azure.go
@@ -61,6 +61,6 @@ func (c *AzureMetaConfig) GetProjectID() *string {
 }
 
 // This is not used for Azure.
-func (c *AzureMetaConfig) GetAuthCredentialPath() *string {
+func (c *AzureMetaConfig) GetAuthCredentials() *string {
 	return nil
 }

--- a/core/schemas/meta/bedrock.go
+++ b/core/schemas/meta/bedrock.go
@@ -64,6 +64,6 @@ func (c *BedrockMetaConfig) GetProjectID() *string {
 }
 
 // This is not used for Bedrock.
-func (c *BedrockMetaConfig) GetAuthCredentialPath() *string {
+func (c *BedrockMetaConfig) GetAuthCredentials() *string {
 	return nil
 }

--- a/core/schemas/meta/vertex.go
+++ b/core/schemas/meta/vertex.go
@@ -6,9 +6,9 @@ package meta
 // VertexMetaConfig represents the Vertex-specific configuration.
 // It contains Vertex-specific settings required for authentication and service access.
 type VertexMetaConfig struct {
-	ProjectID          string `json:"project_id,omitempty"`
-	Region             string `json:"region,omitempty"`
-	AuthCredentialPath string `json:"auth_credential_path,omitempty"`
+	ProjectID       string `json:"project_id,omitempty"`
+	Region          string `json:"region,omitempty"`
+	AuthCredentials string `json:"auth_credentials,omitempty"`
 }
 
 // This is not used for Vertex.
@@ -58,8 +58,8 @@ func (c *VertexMetaConfig) GetProjectID() *string {
 	return &c.ProjectID
 }
 
-// GetAuthCredentialPath returns the path to the authentication credentials for the provider.
-// This is the path to the authentication credentials for the google cloud api.
-func (c *VertexMetaConfig) GetAuthCredentialPath() *string {
-	return &c.AuthCredentialPath
+// GetAuthCredentials returns the authentication credentials for the provider.
+// This is the authentication credentials for the google cloud api.
+func (c *VertexMetaConfig) GetAuthCredentials() *string {
+	return &c.AuthCredentials
 }

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -59,8 +59,8 @@ type MetaConfig interface {
 	GetAPIVersion() *string
 	// GetProjectID returns the project ID
 	GetProjectID() *string
-	// GetAuthCredentialPath returns the path to the authentication credentials for the provider
-	GetAuthCredentialPath() *string
+	// GetAuthCredentials returns the authentication credentials for the provider
+	GetAuthCredentials() *string
 }
 
 // ConcurrencyAndBufferSize represents configuration for concurrent operations and buffer sizes.

--- a/core/tests/account.go
+++ b/core/tests/account.go
@@ -190,9 +190,9 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 				RetryBackoffMax:                2 * time.Second,
 			},
 			MetaConfig: &meta.VertexMetaConfig{
-				ProjectID:          os.Getenv("VERTEX_PROJECT_ID"),
-				Region:             "us-central1",
-				AuthCredentialPath: os.Getenv("VERTEX_CREDENTIALS_PATH"),
+				ProjectID:       os.Getenv("VERTEX_PROJECT_ID"),
+				Region:          "us-central1",
+				AuthCredentials: os.Getenv("VERTEX_CREDENTIALS"),
 			},
 			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
 				Concurrency: 3,

--- a/transports/config.example.json
+++ b/transports/config.example.json
@@ -119,7 +119,7 @@
     "meta_config": {
       "project_id": "env.VERTEX_PROJECT_ID",
       "region": "us-central1",
-      "auth_credential_path": "env.VERTEX_CREDENTIALS_PATH"
+      "auth_credentials": "env.VERTEX_CREDENTIALS"
     },
     "concurrency_and_buffer_size": {
       "concurrency": 3,


### PR DESCRIPTION
# Use Vertex credentials directly instead of reading from file

This PR changes the Vertex provider to accept authentication credentials directly as a string rather than reading them from a file path. This simplifies configuration and deployment by:

1. Replacing `auth_credential_path` with `auth_credentials` in the Vertex meta configuration
2. Modifying the provider interface to use `GetAuthCredentials()` instead of `GetAuthCredentialPath()`
3. Updating the Vertex provider to use the credentials directly instead of reading from a file
4. Updating test configurations and example config to use the new approach

This change allows credentials to be passed directly as environment variables or configuration values without requiring file system access.