### PR TITLE
refactor: move provider parameter from function arguments to request struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ For additional configurations in HTTP server setup, please read [this](https://g
 
    ```golang
      bifrostResult, bifrostErr := bifrost.ChatCompletionRequest(
-       schemas.OpenAI, &schemas.BifrostRequest{
+      context.Background(),
+      &schemas.BifrostRequest{
+         Provider: schemas.OpenAI,
          Model: "gpt-4o-mini", // make sure you have configured gpt-4o-mini in your account interface
          Input: schemas.RequestInput{
            ChatCompletionInput: bifrost.Ptr([]schemas.Message{{
@@ -154,7 +156,7 @@ For additional configurations in HTTP server setup, please read [this](https://g
             Content: bifrost.Ptr("What is a LLM gateway?"),
             }}),
          },
-       }, context.Background(),
+       },
      )
    ```
 
@@ -272,7 +274,7 @@ client, err := bifrost.Init(schemas.BifrostConfig{
 ### Additional Configurations
 
 - [Memory Management](https://github.com/maximhq/bifrost/blob/main/docs/memory-management.md)
-- [Logger](https://github.com/maximhq/bifrost/blob/main/docs/logger.md))
+- [Logger](https://github.com/maximhq/bifrost/blob/main/docs/logger.md)
 - [Plugins](https://github.com/maximhq/bifrost/blob/main/docs/plugins.md)
 - [Provider Configurations](https://github.com/maximhq/bifrost/blob/main/docs/providers.md)
 - [Fallbacks](https://github.com/maximhq/bifrost/blob/main/docs/fallbacks.md)

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -437,12 +437,21 @@ func (bifrost *Bifrost) GetProviderQueue(providerKey schemas.ModelProvider) (cha
 // TextCompletionRequest sends a text completion request to the specified provider.
 // It handles plugin hooks, request validation, response processing, and fallback providers.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
-func (bifrost *Bifrost) TextCompletionRequest(providerKey schemas.ModelProvider, req *schemas.BifrostRequest, ctx context.Context) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if req == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: schemas.ErrorField{
 				Message: "bifrost request cannot be nil",
+			},
+		}
+	}
+
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "provider is required",
 			},
 		}
 	}
@@ -457,7 +466,7 @@ func (bifrost *Bifrost) TextCompletionRequest(providerKey schemas.ModelProvider,
 	}
 
 	// Try the primary provider first
-	primaryResult, primaryErr := bifrost.tryTextCompletion(providerKey, req, ctx)
+	primaryResult, primaryErr := bifrost.tryTextCompletion(req.Provider, req, ctx)
 	if primaryErr == nil {
 		return primaryResult, nil
 	}
@@ -600,12 +609,21 @@ func (bifrost *Bifrost) tryTextCompletion(providerKey schemas.ModelProvider, req
 // ChatCompletionRequest sends a chat completion request to the specified provider.
 // It handles plugin hooks, request validation, response processing, and fallback providers.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
-func (bifrost *Bifrost) ChatCompletionRequest(providerKey schemas.ModelProvider, req *schemas.BifrostRequest, ctx context.Context) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if req == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: schemas.ErrorField{
 				Message: "bifrost request cannot be nil",
+			},
+		}
+	}
+
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "provider is required",
 			},
 		}
 	}
@@ -620,7 +638,7 @@ func (bifrost *Bifrost) ChatCompletionRequest(providerKey schemas.ModelProvider,
 	}
 
 	// Try the primary provider first
-	primaryResult, primaryErr := bifrost.tryChatCompletion(providerKey, req, ctx)
+	primaryResult, primaryErr := bifrost.tryChatCompletion(req.Provider, req, ctx)
 	if primaryErr == nil {
 		return primaryResult, nil
 	}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -52,9 +52,10 @@ type RequestInput struct {
 // It must be provided when calling the Bifrost for text completion or chat completion.
 // It contains the model identifier, input data, and parameters for the request.
 type BifrostRequest struct {
-	Model  string           `json:"model"`
-	Input  RequestInput     `json:"input"`
-	Params *ModelParameters `json:"params,omitempty"`
+	Provider ModelProvider    `json:"provider"`
+	Model    string           `json:"model"`
+	Input    RequestInput     `json:"input"`
+	Params   *ModelParameters `json:"params,omitempty"`
 
 	// Fallbacks are tried in order, the first one to succeed is returned
 	// Provider config must be available for each fallback's provider in account's GetConfigForProvider,

--- a/core/tests/tests.go
+++ b/core/tests/tests.go
@@ -94,14 +94,15 @@ func setupTextCompletionRequest(bifrostClient *bifrost.Bifrost, config TestConfi
 	}
 
 	go func() {
-		result, err := bifrostClient.TextCompletionRequest(config.Provider, &schemas.BifrostRequest{
-			Model: config.TextModel,
+		result, err := bifrostClient.TextCompletionRequest(ctx, &schemas.BifrostRequest{
+			Provider: config.Provider,
+			Model:    config.TextModel,
 			Input: schemas.RequestInput{
 				TextCompletionInput: &text,
 			},
 			Params:    &params,
 			Fallbacks: config.Fallbacks,
-		}, ctx)
+		})
 		if err != nil {
 			log.Println("Error in", config.Provider, "text completion:", err.Error.Message)
 		} else {
@@ -138,14 +139,15 @@ func setupChatCompletionRequests(bifrostClient *bifrost.Bifrost, config TestConf
 					Content: &msg,
 				},
 			}
-			result, err := bifrostClient.ChatCompletionRequest(config.Provider, &schemas.BifrostRequest{
-				Model: config.ChatModel,
+			result, err := bifrostClient.ChatCompletionRequest(ctx, &schemas.BifrostRequest{
+				Provider: config.Provider,
+				Model:    config.ChatModel,
 				Input: schemas.RequestInput{
 					ChatCompletionInput: &messages,
 				},
 				Params:    &params,
 				Fallbacks: config.Fallbacks,
-			}, ctx)
+			})
 			if err != nil {
 				log.Println("Error in", config.Provider, "request", index+1, ":", err.Error.Message)
 			} else {
@@ -185,14 +187,15 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 	}
 
 	go func() {
-		result, err := bifrostClient.ChatCompletionRequest(config.Provider, &schemas.BifrostRequest{
-			Model: config.ChatModel,
+		result, err := bifrostClient.ChatCompletionRequest(ctx, &schemas.BifrostRequest{
+			Provider: config.Provider,
+			Model:    config.ChatModel,
 			Input: schemas.RequestInput{
 				ChatCompletionInput: &urlImageMessages,
 			},
 			Params:    &params,
 			Fallbacks: config.Fallbacks,
-		}, ctx)
+		})
 		if err != nil {
 			log.Println("Error in", config.Provider, "URL image request:", err.Error.Message)
 		} else {
@@ -215,14 +218,15 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 		}
 
 		go func() {
-			result, err := bifrostClient.ChatCompletionRequest(config.Provider, &schemas.BifrostRequest{
-				Model: config.ChatModel,
+			result, err := bifrostClient.ChatCompletionRequest(ctx, &schemas.BifrostRequest{
+				Provider: config.Provider,
+				Model:    config.ChatModel,
 				Input: schemas.RequestInput{
 					ChatCompletionInput: &base64ImageMessages,
 				},
 				Params:    &params,
 				Fallbacks: config.Fallbacks,
-			}, ctx)
+			})
 			if err != nil {
 				log.Println("Error in", config.Provider, "base64 image request:", err.Error.Message)
 			} else {
@@ -263,14 +267,15 @@ func setupToolCalls(bifrostClient *bifrost.Bifrost, config TestConfig, ctx conte
 					Content: &msg,
 				},
 			}
-			result, err := bifrostClient.ChatCompletionRequest(config.Provider, &schemas.BifrostRequest{
-				Model: config.ChatModel,
+			result, err := bifrostClient.ChatCompletionRequest(ctx, &schemas.BifrostRequest{
+				Provider: config.Provider,
+				Model:    config.ChatModel,
 				Input: schemas.RequestInput{
 					ChatCompletionInput: &messages,
 				},
 				Params:    &params,
 				Fallbacks: config.Fallbacks,
-			}, ctx)
+			})
 			if err != nil {
 				log.Println("Error in", config.Provider, "tool call request", index+1, ":", err.Error.Message)
 			} else {

--- a/transports/bifrost-http/integrations/genai/router.go
+++ b/transports/bifrost-http/integrations/genai/router.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fasthttp/router"
 	bifrost "github.com/maximhq/bifrost/core"
-	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -50,7 +49,7 @@ func (g *GenAIRouter) handleChatCompletion(ctx *fasthttp.RequestCtx) {
 
 	bifrostCtx := lib.ConvertToBifrostContext(ctx)
 
-	result, err := g.client.ChatCompletionRequest(schemas.Vertex, bifrostReq, *bifrostCtx)
+	result, err := g.client.ChatCompletionRequest(*bifrostCtx, bifrostReq)
 	if err != nil {
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 		json.NewEncoder(ctx).Encode(err)

--- a/transports/bifrost-http/integrations/genai/types.go
+++ b/transports/bifrost-http/integrations/genai/types.go
@@ -18,7 +18,8 @@ type GeminiChatRequest struct {
 
 func (r *GeminiChatRequest) ConvertToBifrostRequest(modelStr string) *schemas.BifrostRequest {
 	bifrostReq := &schemas.BifrostRequest{
-		Model: modelStr,
+		Provider: schemas.Vertex,
+		Model:    modelStr,
 		Input: schemas.RequestInput{
 			ChatCompletionInput: &[]schemas.Message{},
 		},

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -247,6 +247,7 @@ func handleCompletion(ctx *fasthttp.RequestCtx, client *bifrost.Bifrost, isChat 
 	}
 
 	bifrostReq := &schemas.BifrostRequest{
+		Provider:  req.Provider,
 		Model:     req.Model,
 		Params:    req.Params,
 		Fallbacks: req.Fallbacks,
@@ -277,9 +278,9 @@ func handleCompletion(ctx *fasthttp.RequestCtx, client *bifrost.Bifrost, isChat 
 	var resp *schemas.BifrostResponse
 	var err *schemas.BifrostError
 	if isChat {
-		resp, err = client.ChatCompletionRequest(req.Provider, bifrostReq, *bifrostCtx)
+		resp, err = client.ChatCompletionRequest(*bifrostCtx, bifrostReq)
 	} else {
-		resp, err = client.TextCompletionRequest(req.Provider, bifrostReq, *bifrostCtx)
+		resp, err = client.TextCompletionRequest(*bifrostCtx, bifrostReq)
 	}
 
 	if err != nil {

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -5,11 +5,15 @@ go 1.24.1
 require (
 	github.com/fasthttp/router v1.5.4
 	github.com/maximhq/bifrost/core v1.0.5
-	github.com/maximhq/bifrost/plugins v1.0.0
+	github.com/maximhq/bifrost/plugins/maxim v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.60.0
 	google.golang.org/genai v1.4.0
 )
+
+replace github.com/maximhq/bifrost/core => ../core
+
+replace github.com/maximhq/bifrost/plugins/maxim => ../plugins/maxim
 
 require (
 	cloud.google.com/go v0.121.0 // indirect
@@ -42,7 +46,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
-	github.com/maximhq/bifrost/plugins/maxim v0.0.0-00010101000000-000000000000 // indirect
 	github.com/maximhq/maxim-go v0.1.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -67,10 +67,6 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/maximhq/bifrost/core v1.0.5 h1:JopRRuV2zylwisj+cBonIpB/Dw4p8gEQoW3hrKsPyI8=
-github.com/maximhq/bifrost/core v1.0.5/go.mod h1:nL2tc1SVJ7EAKxUb1G1yS4nO46ZsCdm1qC3Oc78oYIU=
-github.com/maximhq/bifrost/plugins v1.0.0 h1:ul4tMMQHOdhyFQueyZwmQB3uX+s2buYSKzq1FW0m090=
-github.com/maximhq/bifrost/plugins v1.0.0/go.mod h1:IUDZ2NMgCjIn1SVCvYbWZd/Lsk96MNytOvEKpinjvHo=
 github.com/maximhq/maxim-go v0.1.1 h1:69uUQjjDPmUGcKg/M4/3AO0fbD+70Agt66pH/UCsI5M=
 github.com/maximhq/maxim-go v0.1.1/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
# Refactor API signature for ChatCompletionRequest and TextCompletionRequest

This PR changes the function signature of the core Bifrost request methods to improve API consistency and type safety:

1. Moved `context.Context` to be the first parameter in both `ChatCompletionRequest` and `TextCompletionRequest` functions, following Go conventions
2. Moved the provider information from being a separate parameter to being part of the `BifrostRequest` struct
3. Added validation to ensure the provider is specified in the request
4. Updated all function calls throughout the codebase to match the new signature
5. Updated examples in the README to reflect the new API pattern

These changes make the API more intuitive and consistent with Go standards while ensuring all necessary information is contained within the request object itself.