### PR TITLE
feat: add streaming support for OpenAI provider

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -369,7 +369,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, queue chan Chan
 					}
 					break // Don't retry client errors
 				} else {
-					result, bifrostError = provider.ChatCompletion(req.Model, key, *req.Input.ChatCompletionInput, req.Params)
+					if req.Stream { // Check if it's a streaming request
+						result, bifrostError = provider.StreamChatCompletion(req.Model, key, *req.Input.ChatCompletionInput, req.Params)
+					} else {
+						result, bifrostError = provider.ChatCompletion(req.Model, key, *req.Input.ChatCompletionInput, req.Params)
+					}
 				}
 			}
 

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -462,3 +462,15 @@ func parseAnthropicResponse(response *AnthropicChatResponse, bifrostResponse *sc
 
 	return bifrostResponse, nil
 }
+
+// StreamChatCompletion performs a chat completion request to Anthropic's API.
+// It formats the request, sends it to Anthropic, and processes the response.
+// Returns a BifrostResponse containing the completion results or an error if the request fails.
+func (provider *AnthropicProvider) StreamChatCompletion(model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: true, // It's a Bifrost limitation that this provider doesn't support it yet.
+		Error: schemas.ErrorField{
+			Message: fmt.Sprintf("StreamChatCompletion is not implemented for %s provider", provider.GetProviderKey()),
+		},
+	}
+}

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -346,3 +346,15 @@ func (provider *AzureProvider) ChatCompletion(model, key string, messages []sche
 
 	return bifrostResponse, nil
 }
+
+// StreamChatCompletion performs a stream chat completion request to Azure's API.
+// It formats the request, sends it to Azure, and processes the response.
+// Returns a BifrostResponse containing the completion results or an error if the request fails.
+func (provider *AzureProvider) StreamChatCompletion(model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: true,
+		Error: schemas.ErrorField{
+			Message: fmt.Sprintf("StreamChatCompletion is not implemented for %s provider", provider.GetProviderKey()),
+		},
+	}
+}

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -671,6 +671,18 @@ func (provider *BedrockProvider) ChatCompletion(model, key string, messages []sc
 	return bifrostResponse, nil
 }
 
+// StreamChatCompletion performs a stream chat completion request to Bedrock's API.
+// It formats the request, sends it to Bedrock, and processes the response.
+// Returns a BifrostResponse containing the completion results or an error if the request fails.
+func (provider *BedrockProvider) StreamChatCompletion(model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: true,
+		Error: schemas.ErrorField{
+			Message: fmt.Sprintf("StreamChatCompletion is not implemented for %s provider", provider.GetProviderKey()),
+		},
+	}
+}
+
 // signAWSRequest signs an HTTP request using AWS Signature Version 4.
 // It is used in providers like Bedrock.
 // It sets required headers, calculates the request body hash, and signs the request

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -360,3 +360,14 @@ func convertChatHistory(history []struct {
 	}
 	return &converted
 }
+
+// StreamChatCompletion is not implemented for the Cohere provider.
+// Returns an error indicating that stream chat completion is not supported.
+func (provider *CohereProvider) StreamChatCompletion(model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: true,
+		Error: schemas.ErrorField{
+			Message: fmt.Sprintf("StreamChatCompletion is not implemented for %s provider", provider.GetProviderKey()),
+		},
+	}
+}

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -291,3 +291,12 @@ func (provider *VertexProvider) ChatCompletion(model, key string, messages []sch
 		return result, nil
 	}
 }
+
+func (provider *VertexProvider) StreamChatCompletion(model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: true,
+		Error: schemas.ErrorField{
+			Message: fmt.Sprintf("StreamChatCompletion is not implemented for %s provider", provider.GetProviderKey()),
+		},
+	}
+}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -129,4 +129,6 @@ type Provider interface {
 	TextCompletion(model, key, text string, params *ModelParameters) (*BifrostResponse, *BifrostError)
 	// ChatCompletion performs a chat completion request
 	ChatCompletion(model, key string, messages []Message, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	// StreamChatCompletion performs a streaming chat completion request
+	StreamChatCompletion(model, key string, messages []Message, params *ModelParameters) (*BifrostResponse, *BifrostError)
 }

--- a/core/tests/openai_test.go
+++ b/core/tests/openai_test.go
@@ -24,6 +24,7 @@ func TestOpenAI(t *testing.T) {
 		SetupToolCalls: false,
 		SetupImage:     false,
 		SetupBaseImage: false,
+		StreamRequest:  true,
 		Fallbacks: []schemas.Fallback{
 			{
 				Provider: schemas.Anthropic,


### PR DESCRIPTION
# Add streaming support for chat completions

This PR adds streaming support for chat completions in Bifrost. The implementation includes:

- Added a new `StreamChatCompletion` method to the Provider interface
- Implemented streaming for OpenAI provider with proper SSE (Server-Sent Events) handling
- Added placeholder implementations for other providers (Anthropic, Azure, Bedrock, Cohere, Vertex)
- Modified the request worker to check for streaming requests and route them appropriately
- Updated the BifrostResponse struct to include a StreamChannel for receiving chunks
- Added support for delta messages in response choices for streaming responses
- Enhanced test framework to support and demonstrate streaming functionality

The streaming implementation uses a buffered channel to pass chunks from the provider to the consumer, allowing for real-time processing of model outputs.