### PR TITLE
chore: update bifrost/core to v1.0.6 and use released plugins/maxim v1.0.2

### DIFF
--- a/plugins/maxim/go.mod
+++ b/plugins/maxim/go.mod
@@ -3,7 +3,7 @@ module github.com/maximhq/bifrost/plugins/maxim
 go 1.24.1
 
 require (
-	github.com/maximhq/bifrost/core v1.0.1
+	github.com/maximhq/bifrost/core v1.0.6
 	github.com/maximhq/maxim-go v0.1.1
 )
 

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -4,16 +4,12 @@ go 1.24.1
 
 require (
 	github.com/fasthttp/router v1.5.4
-	github.com/maximhq/bifrost/core v1.0.5
-	github.com/maximhq/bifrost/plugins/maxim v0.0.0-00010101000000-000000000000
+	github.com/maximhq/bifrost/core v1.0.6
+	github.com/maximhq/bifrost/plugins/maxim v1.0.2
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.60.0
 	google.golang.org/genai v1.4.0
 )
-
-replace github.com/maximhq/bifrost/core => ../core
-
-replace github.com/maximhq/bifrost/plugins/maxim => ../plugins/maxim
 
 require (
 	cloud.google.com/go v0.121.0 // indirect


### PR DESCRIPTION
Update dependencies to use released versions of bifrost/core and bifrost/plugins/maxim

This PR updates the dependencies in both the maxim plugin and transports modules:

1. In the maxim plugin, updates bifrost/core from v1.0.1 to v1.0.6
2. In the transports module:
   - Updates bifrost/core from v1.0.5 to v1.0.6
   - Replaces the local development reference to bifrost/plugins/maxim with the released v1.0.2
   - Removes the local replace directives, allowing the modules to use the published versions