### PR TITLE
chore: update bifrost/core to v1.0.6 and fix provider type casting

### DIFF
--- a/plugins/maxim/go.sum
+++ b/plugins/maxim/go.sum
@@ -1,6 +1,6 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/maximhq/bifrost/core v1.0.1 h1:B0u6o13faUexA+V0EUU0bsLW2dHg9+R2TZKQzPzCxlY=
-github.com/maximhq/bifrost/core v1.0.1/go.mod h1:4+Ept2EnX1EEjH/mBuSwK7eE56znI/BCoCbIrx25/x8=
+github.com/maximhq/bifrost/core v1.0.6 h1:MTpRMUeMdjatMKJTRCZSEVxOpKsWpCREvzgYNW+BYP0=
+github.com/maximhq/bifrost/core v1.0.6/go.mod h1:nL2tc1SVJ7EAKxUb1G1yS4nO46ZsCdm1qC3Oc78oYIU=
 github.com/maximhq/maxim-go v0.1.1 h1:69uUQjjDPmUGcKg/M4/3AO0fbD+70Agt66pH/UCsI5M=
 github.com/maximhq/maxim-go v0.1.1/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -195,7 +195,7 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 	plugin.logger.AddGenerationToTrace(traceID, &logging.GenerationConfig{
 		Id:              generationID,
 		Model:           req.Model,
-		Provider:        req.Provider,
+		Provider:        string(req.Provider),
 		Tags:            &tags,
 		Messages:        messages,
 		ModelParameters: modelParams,


### PR DESCRIPTION
Update Bifrost core dependency to v1.0.6 and fix type conversion in PreHook method

This PR updates the Bifrost core dependency from v1.0.1 to v1.0.6 in the Maxim plugin. It also fixes a type conversion issue in the PreHook method by explicitly converting the req.Provider to string when adding generation to trace.