### PR TITLE
chore: update bifrost/plugins/maxim to v1.0.2

### DIFF
--- a/transports/go.mod
+++ b/transports/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/fasthttp/router v1.5.4
 	github.com/maximhq/bifrost/core v1.0.7
-	github.com/maximhq/bifrost/plugins/maxim v1.0.1
+	github.com/maximhq/bifrost/plugins/maxim v1.0.2
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.62.0
 	google.golang.org/genai v1.4.0

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -69,8 +69,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/maximhq/bifrost/core v1.0.7 h1:+89Vq+FuD7FFZNbF161/FLBSFjAYLr4/UuWR8Do0Hyc=
 github.com/maximhq/bifrost/core v1.0.7/go.mod h1:8aUSLGVdOhwxDzMcdQnSyMfSBA3lT05ICgX0b/VKc8g=
-github.com/maximhq/bifrost/plugins/maxim v1.0.1 h1:09FEFn1AL6OuORernn87J+huoNlxrNGMvwRmrt69lME=
-github.com/maximhq/bifrost/plugins/maxim v1.0.1/go.mod h1:gURhMUJKqJYKMmIckhqc2b6RHzFtstnWkG4m9crpFE4=
+github.com/maximhq/bifrost/plugins/maxim v1.0.2 h1:l+J+HL9Kag6I7at/YKwwnDHOGoyUcySHXanJXALtXg0=
+github.com/maximhq/bifrost/plugins/maxim v1.0.2/go.mod h1:9jC7ZaI7+N+3XZxJ9rmjwn+pfXHMwBcZk/omvzhgbP0=
 github.com/maximhq/maxim-go v0.1.3 h1:nVzdz3hEjZVxmWHARWIM+Yrn1Jp50qrsK4BA/sz2jj8=
 github.com/maximhq/maxim-go v0.1.3/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
Updates the `github.com/maximhq/bifrost/plugins/maxim` dependency from v1.0.1 to v1.0.2 in the transports module.