### PR TITLE
feat: add context propagation to provider requests

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -143,6 +143,7 @@ type ToolChoice struct {
 type Message struct {
 	Role         ModelChatMessageRole `json:"role"`
 	Content      *string              `json:"content,omitempty"`
+	ToolCallID   *string              `json:"tool_call_id,omitempty"`
 	ImageContent *ImageContent        `json:"image_content,omitempty"`
 	ToolCalls    *[]Tool              `json:"tool_calls,omitempty"`
 }
@@ -289,6 +290,10 @@ type BifrostResponseExtraFields struct {
 	BilledUsage *BilledLLMUsage                 `json:"billed_usage,omitempty"`
 	RawResponse interface{}                     `json:"raw_response"`
 }
+
+const (
+	RequestCancelled = "request_cancelled"
+)
 
 // BifrostError represents an error from the Bifrost system.
 type BifrostError struct {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -1,7 +1,10 @@
 // Package schemas defines the core schemas and types used by the Bifrost system.
 package schemas
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	DefaultMaxRetries              = 0
@@ -140,7 +143,7 @@ type Provider interface {
 	// GetProviderKey returns the provider's identifier
 	GetProviderKey() ModelProvider
 	// TextCompletion performs a text completion request
-	TextCompletion(model, key, text string, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	TextCompletion(ctx context.Context, model, key, text string, params *ModelParameters) (*BifrostResponse, *BifrostError)
 	// ChatCompletion performs a chat completion request
-	ChatCompletion(model, key string, messages []Message, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	ChatCompletion(ctx context.Context, model, key string, messages []Message, params *ModelParameters) (*BifrostResponse, *BifrostError)
 }

--- a/core/tests/anthropic_test.go
+++ b/core/tests/anthropic_test.go
@@ -32,6 +32,4 @@ func TestAnthropic(t *testing.T) {
 	}
 
 	SetupAllRequests(bifrost, config)
-
-	bifrost.Cleanup()
 }

--- a/core/tests/azure_test.go
+++ b/core/tests/azure_test.go
@@ -26,5 +26,4 @@ func TestAzure(t *testing.T) {
 	}
 
 	SetupAllRequests(bifrost, config)
-	bifrost.Cleanup()
 }

--- a/core/tests/bedrock_test.go
+++ b/core/tests/bedrock_test.go
@@ -34,5 +34,4 @@ func TestBedrock(t *testing.T) {
 	}
 
 	SetupAllRequests(bifrost, config)
-	bifrost.Cleanup()
 }

--- a/core/tests/cohere_test.go
+++ b/core/tests/cohere_test.go
@@ -26,6 +26,4 @@ func TestCohere(t *testing.T) {
 	}
 
 	SetupAllRequests(bifrost, config)
-
-	bifrost.Cleanup()
 }

--- a/core/tests/openai_test.go
+++ b/core/tests/openai_test.go
@@ -27,11 +27,10 @@ func TestOpenAI(t *testing.T) {
 		Fallbacks: []schemas.Fallback{
 			{
 				Provider: schemas.Anthropic,
-				Model:    "claude-3-5-sonnet-20240620",
+				Model:    "claude-3-7-sonnet-20250219",
 			},
 		},
 	}
 
 	SetupAllRequests(bifrost, config)
-	bifrost.Cleanup()
 }

--- a/core/tests/vertex_test.go
+++ b/core/tests/vertex_test.go
@@ -26,5 +26,4 @@ func TestVertex(t *testing.T) {
 	}
 
 	SetupAllRequests(bifrostClient, config)
-	bifrostClient.Cleanup()
 }


### PR DESCRIPTION
# Add context propagation and request cancellation support

This PR adds support for context propagation and request cancellation throughout the Bifrost system. It allows clients to cancel in-flight requests when their context is cancelled or times out, improving resource management and responsiveness.

Key changes:
- Added context propagation from client requests to provider API calls
- Implemented request cancellation handling in all providers
- Added a new `RequestCancelled` error type to identify cancelled requests
- Modified the `ChannelMessage` struct to include the request context
- Improved the `Cleanup` method to gracefully shut down without signal handling
- Added proper context handling in test utilities to ensure clean test termination
- Refactored provider interfaces to accept context in method signatures

The implementation ensures that when a client cancels a request context, Bifrost will stop processing that request and return an appropriate cancellation error. This is particularly important for long-running requests or when clients need to implement timeouts.