### PR TITLE
feat: filter out empty API keys and improve tool call handling

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -229,7 +230,7 @@ func (bifrost *Bifrost) SelectKeyFromProviderForModel(providerKey schemas.ModelP
 	// filter out keys which dont support the model
 	var supportedKeys []schemas.Key
 	for _, key := range keys {
-		if slices.Contains(key.Models, model) {
+		if slices.Contains(key.Models, model) && strings.TrimSpace(key.Value) != "" {
 			supportedKeys = append(supportedKeys, key)
 		}
 	}

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -278,7 +278,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, model, ke
 // It formats the request, sends it to Anthropic, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	formattedMessages, preparedParams := prepareAnthropicChatRequest(model, messages, params)
+	formattedMessages, preparedParams := prepareAnthropicChatRequest(messages, params)
 
 	// Merge additional parameters
 	requestBody := mergeConfig(map[string]interface{}{
@@ -317,12 +317,32 @@ func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, model, ke
 	return bifrostResponse, nil
 }
 
-func prepareAnthropicChatRequest(model string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) ([]map[string]interface{}, map[string]interface{}) {
+// buildAnthropicImageSourceMap creates the "source" map for an Anthropic image content part.
+func buildAnthropicImageSourceMap(imgContent *schemas.ImageContent) map[string]interface{} {
+	if imgContent == nil || imgContent.Type == nil {
+		return nil
+	}
+
+	sourceMap := map[string]interface{}{
+		"type": *imgContent.Type, // "base64" or "url"
+	}
+
+	if *imgContent.Type == "url" {
+		sourceMap["url"] = imgContent.URL
+	} else {
+		if imgContent.MediaType != nil {
+			sourceMap["media_type"] = *imgContent.MediaType
+		}
+		sourceMap["data"] = imgContent.URL // URL field is used for base64 data string
+	}
+	return sourceMap
+}
+
+func prepareAnthropicChatRequest(messages []schemas.BifrostMessage, params *schemas.ModelParameters) ([]map[string]interface{}, map[string]interface{}) {
 	// Add system messages if present
 	var systemMessages []BedrockAnthropicSystemMessage
 	for _, msg := range messages {
 		if msg.Role == schemas.ModelChatMessageRoleSystem {
-			//TODO handling image inputs here
 			if msg.Content != nil {
 				systemMessages = append(systemMessages, BedrockAnthropicSystemMessage{
 					Text: *msg.Content,
@@ -335,56 +355,63 @@ func prepareAnthropicChatRequest(model string, messages []schemas.BifrostMessage
 	var formattedMessages []map[string]interface{}
 	for _, msg := range messages {
 		if msg.Role != schemas.ModelChatMessageRoleSystem {
-			if (msg.UserMessage != nil && msg.UserMessage.ImageContent != nil) || (msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil) {
-				var messageImageContent schemas.ImageContent
-				if msg.UserMessage != nil && msg.UserMessage.ImageContent != nil {
-					messageImageContent = *msg.UserMessage.ImageContent
-				} else if msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil {
-					messageImageContent = *msg.ToolMessage.ImageContent
+			if msg.Role == schemas.ModelChatMessageRoleTool && msg.ToolCallID != nil {
+				toolCallResult := map[string]interface{}{
+					"type":        "tool_result",
+					"tool_use_id": *msg.ToolCallID,
 				}
 
-				var content []map[string]interface{}
+				var toolCallResultContent []map[string]interface{}
 
-				imageContent := map[string]interface{}{
-					"type": "image",
-					"source": map[string]interface{}{
-						"type": messageImageContent.Type,
-					},
-				}
-
-				// Handle different image source types
-				if messageImageContent.Type != nil && *messageImageContent.Type == "url" {
-					imageContent["source"].(map[string]interface{})["url"] = messageImageContent.URL
-				} else {
-					imageContent["source"].(map[string]interface{})["media_type"] = messageImageContent.MediaType
-					imageContent["source"].(map[string]interface{})["data"] = messageImageContent.URL
-				}
-
-				content = append(content, imageContent)
-
-				// Add text content if present
 				if msg.Content != nil {
-					content = append(content, map[string]interface{}{
+					toolCallResultContent = append(toolCallResultContent, map[string]interface{}{
 						"type": "text",
 						"text": *msg.Content,
 					})
 				}
 
-				// Add thinking content if present in AssistantMessage
-				if msg.AssistantMessage != nil && msg.AssistantMessage.Thought != nil {
-					content = append(content, map[string]interface{}{
-						"type":     "thinking",
-						"thinking": *msg.AssistantMessage.Thought,
-					})
+				if msg.UserMessage.ImageContent != nil || msg.ToolMessage.ImageContent != nil {
+					var messageImageContent schemas.ImageContent
+					if msg.UserMessage.ImageContent != nil {
+						messageImageContent = *msg.UserMessage.ImageContent
+					} else if msg.ToolMessage.ImageContent != nil {
+						messageImageContent = *msg.ToolMessage.ImageContent
+					}
+
+					imageSource := buildAnthropicImageSourceMap(&messageImageContent)
+					if imageSource != nil {
+						toolCallResultContent = append(toolCallResultContent, map[string]interface{}{
+							"type":   "image",
+							"source": imageSource,
+						})
+					}
 				}
 
+				toolCallResult["content"] = toolCallResultContent
+
 				formattedMessages = append(formattedMessages, map[string]interface{}{
-					"role":    msg.Role,
-					"content": content,
+					"role":    schemas.ModelChatMessageRoleTool,
+					"content": toolCallResult,
 				})
 			} else {
-				// Handle non-image messages
 				var content []map[string]interface{}
+
+				if (msg.UserMessage != nil && msg.UserMessage.ImageContent != nil) || (msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil) {
+					var messageImageContent schemas.ImageContent
+					if msg.UserMessage != nil && msg.UserMessage.ImageContent != nil {
+						messageImageContent = *msg.UserMessage.ImageContent
+					} else if msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil {
+						messageImageContent = *msg.ToolMessage.ImageContent
+					}
+
+					imageSource := buildAnthropicImageSourceMap(&messageImageContent)
+					if imageSource != nil {
+						content = append(content, map[string]interface{}{
+							"type":   "image",
+							"source": imageSource,
+						})
+					}
+				}
 
 				// Add text content if present
 				if msg.Content != nil && *msg.Content != "" {
@@ -429,7 +456,6 @@ func prepareAnthropicChatRequest(model string, messages []schemas.BifrostMessage
 					}
 				}
 
-				// Always use content block structure
 				if len(content) > 0 {
 					formattedMessages = append(formattedMessages, map[string]interface{}{
 						"role":    msg.Role,
@@ -464,6 +490,54 @@ func prepareAnthropicChatRequest(model string, messages []schemas.BifrostMessage
 
 		preparedParams["system"] = strings.Join(messages, " ")
 	}
+
+	// Post-process formattedMessages for tool call results
+	processedFormattedMessages := []map[string]interface{}{} // Use a new slice
+	i := 0
+	for i < len(formattedMessages) {
+		currentMsg := formattedMessages[i]
+		currentRole, roleOk := getRoleFromMessage(currentMsg)
+
+		if !roleOk {
+			// If role is of an unexpected type or missing, treat as non-tool message
+			processedFormattedMessages = append(processedFormattedMessages, currentMsg)
+			i++
+			continue
+		}
+
+		if currentRole == schemas.ModelChatMessageRoleTool {
+			// Content of a tool message is the toolCallResult map
+			// Initialize accumulatedToolResults with the content of the current tool message.
+			accumulatedToolResults := []interface{}{currentMsg["content"]}
+
+			// Look ahead for more sequential tool messages
+			j := i + 1
+			for j < len(formattedMessages) {
+				nextMsg := formattedMessages[j]
+				nextRole, nextRoleOk := getRoleFromMessage(nextMsg)
+
+				if !nextRoleOk || nextRole != schemas.ModelChatMessageRoleTool {
+					break // Not a sequential tool message or role is invalid/missing
+				}
+
+				accumulatedToolResults = append(accumulatedToolResults, nextMsg["content"])
+				j++
+			}
+
+			// Create a new message with role User and accumulated content
+			mergedMsg := map[string]interface{}{
+				"role":    schemas.ModelChatMessageRoleUser, // Final role is User
+				"content": accumulatedToolResults,
+			}
+			processedFormattedMessages = append(processedFormattedMessages, mergedMsg)
+			i = j // Advance main loop index past all merged messages
+		} else {
+			// Not a tool message, add it as is
+			processedFormattedMessages = append(processedFormattedMessages, currentMsg)
+			i++
+		}
+	}
+	formattedMessages = processedFormattedMessages // Update with processed messages
 
 	return formattedMessages, preparedParams
 }

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -268,6 +268,28 @@ func handleProviderResponse[T any](responseBody []byte, response *T) (interface{
 	return rawResponse, nil
 }
 
+// getRoleFromMessage extracts and validates the role from a message map.
+func getRoleFromMessage(msg map[string]interface{}) (schemas.ModelChatMessageRole, bool) {
+	roleVal, exists := msg["role"]
+	if !exists {
+		return "", false // Role key doesn't exist
+	}
+
+	// Try direct assertion to ModelChatMessageRole
+	roleAsModelType, ok := roleVal.(schemas.ModelChatMessageRole)
+	if ok {
+		return roleAsModelType, true
+	}
+
+	// Try assertion to string and then convert
+	roleAsString, okStr := roleVal.(string)
+	if okStr {
+		return schemas.ModelChatMessageRole(roleAsString), true
+	}
+
+	return "", false // Role is of an unexpected or invalid type
+}
+
 // float64Ptr creates a pointer to a float64 value.
 // This is a helper function for creating pointers to float64 values.
 func float64Ptr(f float64) *float64 {

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -95,7 +95,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key s
 	var preparedParams map[string]interface{}
 
 	if strings.Contains(model, "claude") {
-		formattedMessages, preparedParams = prepareAnthropicChatRequest(model, messages, params)
+		formattedMessages, preparedParams = prepareAnthropicChatRequest(messages, params)
 	} else {
 		formattedMessages, preparedParams = prepareOpenAIChatRequest(model, messages, params)
 	}

--- a/core/tests/openai_test.go
+++ b/core/tests/openai_test.go
@@ -21,7 +21,7 @@ func TestOpenAI(t *testing.T) {
 		TextModel:      "gpt-4o-mini",
 		ChatModel:      "gpt-4o-mini",
 		SetupText:      false, // OpenAI does not support text completion
-		SetupToolCalls: false,
+		SetupToolCalls: true,
 		SetupImage:     false,
 		SetupBaseImage: false,
 		Fallbacks: []schemas.Fallback{

--- a/core/tests/tests.go
+++ b/core/tests/tests.go
@@ -149,6 +149,7 @@ func setupChatCompletionRequests(bifrostClient *bifrost.Bifrost, config TestConf
 					Content: &msg,
 				},
 			}
+
 			result, err := bifrostClient.ChatCompletionRequest(ctx, &schemas.BifrostRequest{
 				Provider: config.Provider,
 				Model:    config.ChatModel,

--- a/core/tests/vertex_test.go
+++ b/core/tests/vertex_test.go
@@ -20,7 +20,7 @@ func TestVertex(t *testing.T) {
 		Provider:       schemas.Vertex,
 		ChatModel:      "google/gemini-2.0-flash-001",
 		SetupText:      false, // Vertex does not support text completion
-		SetupToolCalls: false,
+		SetupToolCalls: true,
 		SetupImage:     false,
 		SetupBaseImage: false,
 	}


### PR DESCRIPTION
# Add support for tool call results in Anthropic and Bedrock providers

This PR enhances the handling of tool call results in the Anthropic and Bedrock providers, enabling proper communication with AI models when tools are used. Key changes include:

- Added proper handling of `ToolCallResultID` in message processing for Anthropic and Bedrock providers
- Renamed `ToolCallID` to `ToolCallResultID` in the Message schema for consistency
- Implemented special handling for sequential tool messages, merging them appropriately
- Added helper function `getRoleFromMessage` to extract and validate message roles
- Enhanced image content handling in tool call results
- Added validation to filter out keys with empty values in `SelectKeyFromProviderForModel`
- Updated test configurations to enable tool call testing for OpenAI and Vertex providers

These changes ensure that tool call results are properly formatted according to each provider's API requirements, improving the reliability of tool-based interactions across different AI models.