### PR TITLE
feat: Refactor message schema and enhance multi-modal support across AI providers

### DIFF
--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -263,11 +263,14 @@ func (provider *AzureProvider) TextCompletion(ctx context.Context, model, key, t
 
 	// Create the completion result
 	if len(response.Choices) > 0 {
+		// Create a copy of the text to avoid dangling pointer to pooled object
+		textCopy := response.Choices[0].Text
+
 		choices = append(choices, schemas.BifrostResponseChoice{
 			Index: 0,
-			Message: schemas.BifrostResponseChoiceMessage{
-				Role:    schemas.RoleAssistant,
-				Content: &response.Choices[0].Text,
+			Message: schemas.BifrostMessage{
+				Role:    schemas.ModelChatMessageRoleAssistant,
+				Content: &textCopy,
 			},
 			FinishReason: response.Choices[0].FinishReason,
 			LogProbs: &schemas.LogProbs{
@@ -293,16 +296,22 @@ func (provider *AzureProvider) TextCompletion(ctx context.Context, model, key, t
 // ChatCompletion performs a chat completion request to Azure's API.
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *AzureProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *AzureProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	preparedParams := prepareParams(params)
 
 	// Format messages for Azure API
 	var formattedMessages []map[string]interface{}
 	for _, msg := range messages {
-		formattedMessages = append(formattedMessages, map[string]interface{}{
-			"role":    msg.Role,
-			"content": msg.Content,
-		})
+		message := map[string]interface{}{
+			"role": msg.Role,
+		}
+
+		// Only add content if it's not nil
+		if msg.Content != nil {
+			message["content"] = *msg.Content
+		}
+
+		formattedMessages = append(formattedMessages, message)
 	}
 
 	// Merge additional parameters

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -114,7 +114,7 @@ func (provider *OpenAIProvider) TextCompletion(ctx context.Context, model, key, 
 // ChatCompletion performs a chat completion request to the OpenAI API.
 // It supports both text and image content in messages.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	formattedMessages, preparedParams := prepareOpenAIChatRequest(model, messages, params)
 
 	requestBody := mergeConfig(map[string]interface{}{
@@ -205,30 +205,37 @@ func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, model, key s
 	return result, nil
 }
 
-func prepareOpenAIChatRequest(model string, messages []schemas.Message, params *schemas.ModelParameters) ([]map[string]interface{}, map[string]interface{}) {
+func prepareOpenAIChatRequest(model string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) ([]map[string]interface{}, map[string]interface{}) {
 	// Format messages for OpenAI API
 	var formattedMessages []map[string]interface{}
 	for _, msg := range messages {
-		if msg.ImageContent != nil {
+		if (msg.UserMessage != nil && msg.UserMessage.ImageContent != nil) || (msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil) {
+			var messageImageContent schemas.ImageContent
+			if msg.UserMessage != nil && msg.UserMessage.ImageContent != nil {
+				messageImageContent = *msg.UserMessage.ImageContent
+			} else if msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil {
+				messageImageContent = *msg.ToolMessage.ImageContent
+			}
+
 			var content []map[string]interface{}
 
 			// Add text content if present
 			if msg.Content != nil {
 				content = append(content, map[string]interface{}{
 					"type": "text",
-					"text": msg.Content,
+					"text": *msg.Content,
 				})
 			}
 
 			imageContent := map[string]interface{}{
 				"type": "image_url",
 				"image_url": map[string]interface{}{
-					"url": msg.ImageContent.URL,
+					"url": messageImageContent.URL,
 				},
 			}
 
-			if msg.ImageContent.Detail != nil {
-				imageContent["image_url"].(map[string]interface{})["detail"] = msg.ImageContent.Detail
+			if messageImageContent.Detail != nil {
+				imageContent["image_url"].(map[string]interface{})["detail"] = messageImageContent.Detail
 			}
 
 			content = append(content, imageContent)
@@ -243,8 +250,8 @@ func prepareOpenAIChatRequest(model string, messages []schemas.Message, params *
 				"content": msg.Content,
 			}
 
-			if msg.ToolCallID != nil {
-				message["tool_call_id"] = msg.ToolCallID
+			if msg.ToolMessage != nil && msg.ToolMessage.ToolCallID != nil {
+				message["tool_call_id"] = *msg.ToolMessage.ToolCallID
 			}
 
 			formattedMessages = append(formattedMessages, message)

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -89,7 +89,7 @@ func (provider *VertexProvider) TextCompletion(ctx context.Context, model, key, 
 // ChatCompletion performs a chat completion request to the Vertex API.
 // It supports both text and image content in messages.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.Message, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Format messages for Vertex API
 	var formattedMessages []map[string]interface{}
 	var preparedParams map[string]interface{}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -145,5 +145,5 @@ type Provider interface {
 	// TextCompletion performs a text completion request
 	TextCompletion(ctx context.Context, model, key, text string, params *ModelParameters) (*BifrostResponse, *BifrostError)
 	// ChatCompletion performs a chat completion request
-	ChatCompletion(ctx context.Context, model, key string, messages []Message, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	ChatCompletion(ctx context.Context, model, key string, messages []BifrostMessage, params *ModelParameters) (*BifrostResponse, *BifrostError)
 }

--- a/core/tests/tests.go
+++ b/core/tests/tests.go
@@ -143,9 +143,9 @@ func setupChatCompletionRequests(bifrostClient *bifrost.Bifrost, config TestConf
 		go func(msg string, delay time.Duration, index int) {
 			defer wg.Done()
 			time.Sleep(delay)
-			messages := []schemas.Message{
+			messages := []schemas.BifrostMessage{
 				{
-					Role:    schemas.RoleUser,
+					Role:    schemas.ModelChatMessageRoleUser,
 					Content: &msg,
 				},
 			}
@@ -182,19 +182,17 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 	}
 
 	// URL image test
-	urlImageMessages := []schemas.Message{
+	urlImageMessages := []schemas.BifrostMessage{
 		{
-			Role:    schemas.RoleUser,
+			Role:    schemas.ModelChatMessageRoleUser,
 			Content: bifrost.Ptr("What is Happening in this picture?"),
-			ImageContent: &schemas.ImageContent{
-				Type: bifrost.Ptr("url"),
-				URL:  "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg",
+			UserMessage: &schemas.UserMessage{
+				ImageContent: &schemas.ImageContent{
+					Type: bifrost.Ptr("url"),
+					URL:  "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg",
+				},
 			},
 		},
-	}
-
-	if config.Provider == schemas.Anthropic {
-		urlImageMessages[0].ImageContent.Type = bifrost.Ptr("url")
 	}
 
 	wg.Add(1)
@@ -218,14 +216,16 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 
 	// Base64 image test (only for providers that support it)
 	if config.SetupBaseImage {
-		base64ImageMessages := []schemas.Message{
+		base64ImageMessages := []schemas.BifrostMessage{
 			{
-				Role:    schemas.RoleUser,
+				Role:    schemas.ModelChatMessageRoleUser,
 				Content: bifrost.Ptr("What is this image about?"),
-				ImageContent: &schemas.ImageContent{
-					Type:      bifrost.Ptr("base64"),
-					URL:       "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
-					MediaType: bifrost.Ptr("image/jpeg"),
+				UserMessage: &schemas.UserMessage{
+					ImageContent: &schemas.ImageContent{
+						Type:      bifrost.Ptr("base64"),
+						URL:       "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
+						MediaType: bifrost.Ptr("image/jpeg"),
+					},
 				},
 			},
 		}
@@ -279,9 +279,9 @@ func setupToolCalls(bifrostClient *bifrost.Bifrost, config TestConfig, ctx conte
 		go func(msg string, delay time.Duration, index int) {
 			defer wg.Done()
 			time.Sleep(delay)
-			messages := []schemas.Message{
+			messages := []schemas.BifrostMessage{
 				{
-					Role:    schemas.RoleUser,
+					Role:    schemas.ModelChatMessageRoleUser,
 					Content: &msg,
 				},
 			}
@@ -297,7 +297,7 @@ func setupToolCalls(bifrostClient *bifrost.Bifrost, config TestConfig, ctx conte
 			if err != nil {
 				log.Println("Error in", config.Provider, "tool call request", index+1, ":", err.Error.Message)
 			} else {
-				if result.Choices[0].Message.ToolCalls != nil && len(*result.Choices[0].Message.ToolCalls) > 0 {
+				if result.Choices[0].Message.AssistantMessage != nil && result.Choices[0].Message.ToolCalls != nil && len(*result.Choices[0].Message.ToolCalls) > 0 {
 					for i, choice := range result.Choices {
 						if choice.Message.ToolCalls != nil && len(*choice.Message.ToolCalls) > 0 {
 							toolCall := *choice.Message.ToolCalls

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -277,6 +277,13 @@ func handleCompletion(ctx *fasthttp.RequestCtx, client *bifrost.Bifrost, isChat 
 
 	var resp *schemas.BifrostResponse
 	var err *schemas.BifrostError
+
+	if bifrostCtx == nil {
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetBodyString("Failed to convert context")
+		return
+	}
+
 	if isChat {
 		resp, err = client.ChatCompletionRequest(*bifrostCtx, bifrostReq)
 	} else {


### PR DESCRIPTION
## Description

This PR introduces a comprehensive refactoring of the message handling system across all AI providers (Anthropic, Azure, and Bedrock) to support a more robust and extensible message schema.

### Key Changes

**🔄 Message Schema Standardization**
- Migrated from `schemas.Message` to `schemas.BifrostMessage` across all providers
- Updated role constants from `schemas.RoleAssistant/RoleSystem` to `schemas.ModelChatMessageRoleAssistant/ModelChatMessageRoleSystem`
- Replaced `schemas.BifrostResponseChoiceMessage` with unified `schemas.BifrostMessage`

**🎯 Enhanced Message Structure**
- Introduced structured message types: `AssistantMessage`, `UserMessage`, `ToolMessage`
- Added support for specialized content types within each message role
- Improved type safety and clarity in message handling

**🖼️ Multi-Modal Content Support**
- Enhanced image content handling across all providers
- Better separation of concerns for different content types (text, images, tool calls)
- Improved support for mixed content messages

**🧠 Anthropic Provider Enhancements**
- Added support for "thinking" content in Claude responses
- Improved tool call parsing and formatting
- Enhanced content block structure handling
- Better error handling for malformed JSON in tool arguments

**🔧 Bug Fixes & Improvements**
- Added null check for secret access key in Bedrock provider
- Fixed content handling edge cases in Azure provider
- Improved error messages and validation

### Breaking Changes
- `ChatCompletion` method signature updated to use `[]schemas.BifrostMessage` instead of `[]schemas.Message`
- Message role constants have been renamed and moved
- Response message structure has been updated

### Migration Impact
This change affects all consumers of the provider interfaces and will require corresponding updates to maintain compatibility.