### PR TITLE
fix: set default values for NetworkConfig and ConcurrencyAndBufferSize

### DIFF
--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -57,6 +57,8 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 
 	if config.NetworkConfig != nil {
 		providerConfig.NetworkConfig = *config.NetworkConfig
+	} else {
+		providerConfig.NetworkConfig = schemas.DefaultNetworkConfig
 	}
 
 	if config.MetaConfig != nil {
@@ -65,6 +67,8 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 
 	if config.ConcurrencyAndBufferSize != nil {
 		providerConfig.ConcurrencyAndBufferSize = *config.ConcurrencyAndBufferSize
+	} else {
+		providerConfig.ConcurrencyAndBufferSize = schemas.DefaultConcurrencyAndBufferSize
 	}
 
 	return providerConfig, nil


### PR DESCRIPTION
Set default values for NetworkConfig and ConcurrencyAndBufferSize in GetConfigForProvider method when these configurations are not explicitly provided. This ensures that the provider configuration always has appropriate values even when the corresponding fields are nil.