### PR TITLE
docs: add HTTP transport API reference documentation

### DIFF
--- a/docs/http-transport-api.md
+++ b/docs/http-transport-api.md
@@ -1,0 +1,664 @@
+# Bifrost HTTP Transport API Reference
+
+This document provides comprehensive API documentation for the Bifrost HTTP transport, which exposes REST endpoints for text and chat completions using various AI model providers.
+
+## Base URL
+
+```
+http://localhost:8080
+```
+
+## OpenAPI Specification
+
+The complete OpenAPI 3.0 specification is available as a JSON file:
+
+📄 **[OpenAPI Specification (JSON)](openapi.json)**
+
+This machine-readable specification can be used with:
+
+- **Swagger UI** - Interactive API documentation
+- **Postman** - Import for API testing
+- **Code Generation** - Generate client SDKs in multiple languages
+- **API Gateways** - Request/response validation
+- **Testing Tools** - Automated API testing
+
+## Authentication
+
+API keys are configured through environment variables for each provider. See the [providers documentation](providers.md) for setup instructions.
+
+## Endpoints
+
+### 1. Chat Completions
+
+**POST** `/v1/chat/completions`
+
+Creates a chat completion using conversational messages.
+
+#### Request Body
+
+```json
+{
+  "provider": "openai",
+  "model": "gpt-4o",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What's the weather like today?"
+    }
+  ],
+  "params": {
+    "max_tokens": 1000,
+    "temperature": 0.7,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "get_weather",
+          "description": "Get current weather for a location",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA"
+              }
+            },
+            "required": ["location"]
+          }
+        }
+      }
+    ]
+  },
+  "fallbacks": [
+    {
+      "provider": "anthropic",
+      "model": "claude-3-sonnet-20240229"
+    }
+  ]
+}
+```
+
+#### Response
+
+```json
+{
+  "id": "chatcmpl-123",
+  "object": "chat.completion",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "I'd be happy to help you check the weather! However, I'll need to know your location first.",
+        "tool_calls": [
+          {
+            "id": "call_123",
+            "type": "function",
+            "function": {
+              "name": "get_weather",
+              "arguments": "{\"location\": \"user_location\"}"
+            }
+          }
+        ]
+      },
+      "finish_reason": "tool_calls"
+    }
+  ],
+  "model": "gpt-4o",
+  "created": 1677652288,
+  "usage": {
+    "prompt_tokens": 56,
+    "completion_tokens": 31,
+    "total_tokens": 87
+  },
+  "extra_fields": {
+    "provider": "openai",
+    "model_params": {
+      "max_tokens": 1000,
+      "temperature": 0.7
+    },
+    "latency": 1.234,
+    "raw_response": {}
+  }
+}
+```
+
+### 2. Text Completions
+
+**POST** `/v1/text/completions`
+
+Creates a text completion from a prompt.
+
+#### Request Body
+
+```json
+{
+  "provider": "openai",
+  "model": "gpt-3.5-turbo-instruct",
+  "text": "The future of AI is",
+  "params": {
+    "max_tokens": 100,
+    "temperature": 0.7,
+    "stop_sequences": ["\n\n"]
+  },
+  "fallbacks": [
+    {
+      "provider": "cohere",
+      "model": "command"
+    }
+  ]
+}
+```
+
+#### Response
+
+```json
+{
+  "id": "cmpl-123",
+  "object": "text.completion",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The future of AI is incredibly promising, with advances in machine learning..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "model": "gpt-3.5-turbo-instruct",
+  "created": 1677652288,
+  "usage": {
+    "prompt_tokens": 5,
+    "completion_tokens": 95,
+    "total_tokens": 100
+  },
+  "extra_fields": {
+    "provider": "openai",
+    "model_params": {
+      "max_tokens": 100,
+      "temperature": 0.7
+    },
+    "latency": 0.856,
+    "raw_response": {}
+  }
+}
+```
+
+### 3. Metrics
+
+**GET** `/metrics`
+
+Returns Prometheus metrics for monitoring and observability.
+
+## Schema Definitions
+
+### CompletionRequest
+
+The main request object for both chat and text completions.
+
+| Field       | Type                                  | Required | Description                                                                       |
+| ----------- | ------------------------------------- | -------- | --------------------------------------------------------------------------------- |
+| `provider`  | `string`                              | ✅       | AI model provider (`openai`, `anthropic`, `azure`, `bedrock`, `cohere`, `vertex`) |
+| `model`     | `string`                              | ✅       | Model identifier (provider-specific)                                              |
+| `messages`  | [`BifrostMessage[]`](#bifrostmessage) | ✅\*     | Array of chat messages (required for chat completions)                            |
+| `text`      | `string`                              | ✅\*     | Text prompt (required for text completions)                                       |
+| `params`    | [`ModelParameters`](#modelparameters) | ❌       | Model parameters and configuration                                                |
+| `fallbacks` | [`Fallback[]`](#fallback)             | ❌       | Fallback providers and models                                                     |
+
+\*Either `messages` or `text` is required depending on the endpoint.
+
+### BifrostMessage
+
+Represents a message in a chat conversation.
+
+| Field           | Type                            | Required | Description                                          |
+| --------------- | ------------------------------- | -------- | ---------------------------------------------------- |
+| `role`          | `string`                        | ✅       | Message role (`user`, `assistant`, `system`, `tool`) |
+| `content`       | `string`                        | ❌       | Text content of the message                          |
+| `tool_call_id`  | `string`                        | ❌       | ID of the tool call (for tool messages)              |
+| `tool_calls`    | [`ToolCall[]`](#toolcall)       | ❌       | Tool calls made by assistant                         |
+| `image_content` | [`ImageContent`](#imagecontent) | ❌       | Image data in the message                            |
+| `refusal`       | `string`                        | ❌       | Refusal message from assistant                       |
+| `annotations`   | `Annotation[]`                  | ❌       | Message annotations                                  |
+| `thought`       | `string`                        | ❌       | Assistant's internal thought process                 |
+
+### ModelParameters
+
+Configuration parameters for model behavior.
+
+| Field                 | Type                        | Description                             |
+| --------------------- | --------------------------- | --------------------------------------- |
+| `temperature`         | `number`                    | Controls randomness (0.0-2.0)           |
+| `top_p`               | `number`                    | Nucleus sampling parameter (0.0-1.0)    |
+| `top_k`               | `integer`                   | Top-k sampling parameter                |
+| `max_tokens`          | `integer`                   | Maximum tokens to generate              |
+| `stop_sequences`      | `string[]`                  | Sequences that stop generation          |
+| `presence_penalty`    | `number`                    | Penalizes repeated tokens (-2.0 to 2.0) |
+| `frequency_penalty`   | `number`                    | Penalizes frequent tokens (-2.0 to 2.0) |
+| `tools`               | [`Tool[]`](#tool)           | Available tools for the model           |
+| `tool_choice`         | [`ToolChoice`](#toolchoice) | How tools should be chosen              |
+| `parallel_tool_calls` | `boolean`                   | Enable parallel tool execution          |
+
+### Tool
+
+Defines a function that the model can call.
+
+| Field      | Type                    | Required | Description                             |
+| ---------- | ----------------------- | -------- | --------------------------------------- |
+| `id`       | `string`                | ❌       | Unique tool identifier                  |
+| `type`     | `string`                | ✅       | Tool type (currently only `"function"`) |
+| `function` | [`Function`](#function) | ✅       | Function definition                     |
+
+### Function
+
+Defines the function details for a tool.
+
+| Field         | Type                                        | Required | Description                |
+| ------------- | ------------------------------------------- | -------- | -------------------------- |
+| `name`        | `string`                                    | ✅       | Function name              |
+| `description` | `string`                                    | ✅       | Function description       |
+| `parameters`  | [`FunctionParameters`](#functionparameters) | ✅       | Function parameters schema |
+
+### FunctionParameters
+
+JSON Schema defining function parameters.
+
+| Field         | Type       | Required | Description                         |
+| ------------- | ---------- | -------- | ----------------------------------- |
+| `type`        | `string`   | ✅       | Parameter type (usually `"object"`) |
+| `description` | `string`   | ❌       | Parameter description               |
+| `properties`  | `object`   | ❌       | Parameter properties (JSON Schema)  |
+| `required`    | `string[]` | ❌       | Required parameter names            |
+| `enum`        | `string[]` | ❌       | Enum values for parameters          |
+
+### ToolChoice
+
+Specifies how the model should choose tools.
+
+| Field      | Type                                        | Required | Description                                                 |
+| ---------- | ------------------------------------------- | -------- | ----------------------------------------------------------- |
+| `type`     | `string`                                    | ✅       | Choice type (`none`, `auto`, `any`, `function`, `required`) |
+| `function` | [`ToolChoiceFunction`](#toolchoicefunction) | ❌       | Specific function to call (when type is `function`)         |
+
+### ToolChoiceFunction
+
+Specifies a particular function to call.
+
+| Field  | Type     | Required | Description                  |
+| ------ | -------- | -------- | ---------------------------- |
+| `name` | `string` | ✅       | Name of the function to call |
+
+### Fallback
+
+Defines a fallback provider and model.
+
+| Field      | Type     | Required | Description            |
+| ---------- | -------- | -------- | ---------------------- |
+| `provider` | `string` | ✅       | Fallback provider name |
+| `model`    | `string` | ✅       | Fallback model name    |
+
+### BifrostResponse
+
+The response object returned by both endpoints.
+
+| Field                | Type                                                        | Description                                            |
+| -------------------- | ----------------------------------------------------------- | ------------------------------------------------------ |
+| `id`                 | `string`                                                    | Unique response identifier                             |
+| `object`             | `string`                                                    | Response type (`chat.completion` or `text.completion`) |
+| `choices`            | [`BifrostResponseChoice[]`](#bifrostresponsechoice)         | Array of completion choices                            |
+| `model`              | `string`                                                    | Model used for generation                              |
+| `created`            | `integer`                                                   | Unix timestamp of creation                             |
+| `service_tier`       | `string`                                                    | Service tier used                                      |
+| `system_fingerprint` | `string`                                                    | System fingerprint                                     |
+| `usage`              | [`LLMUsage`](#llmusage)                                     | Token usage statistics                                 |
+| `extra_fields`       | [`BifrostResponseExtraFields`](#bifrostresponseextrafields) | Additional Bifrost-specific data                       |
+
+### BifrostResponseChoice
+
+A single completion choice.
+
+| Field           | Type                                | Description                         |
+| --------------- | ----------------------------------- | ----------------------------------- |
+| `index`         | `integer`                           | Choice index                        |
+| `message`       | [`BifrostMessage`](#bifrostmessage) | The completion message              |
+| `finish_reason` | `string`                            | Reason completion stopped           |
+| `stop`          | `string`                            | Stop sequence that ended generation |
+| `log_probs`     | `LogProbs`                          | Log probabilities (if requested)    |
+
+### LLMUsage
+
+Token usage statistics.
+
+| Field                       | Type                      | Description                         |
+| --------------------------- | ------------------------- | ----------------------------------- |
+| `prompt_tokens`             | `integer`                 | Tokens in the prompt                |
+| `completion_tokens`         | `integer`                 | Tokens in the completion            |
+| `total_tokens`              | `integer`                 | Total tokens used                   |
+| `completion_tokens_details` | `CompletionTokensDetails` | Detailed completion token breakdown |
+
+### BifrostResponseExtraFields
+
+Additional Bifrost-specific response data.
+
+| Field          | Type                                  | Description                     |
+| -------------- | ------------------------------------- | ------------------------------- |
+| `provider`     | `string`                              | Provider used for the request   |
+| `model_params` | [`ModelParameters`](#modelparameters) | Parameters used for the request |
+| `latency`      | `number`                              | Request latency in seconds      |
+| `chat_history` | [`BifrostMessage[]`](#bifrostmessage) | Full conversation history       |
+| `billed_usage` | `BilledLLMUsage`                      | Billing usage information       |
+| `raw_response` | `object`                              | Raw provider response           |
+
+### ToolCall
+
+Represents a tool call made by the assistant.
+
+| Field      | Type                            | Description                 |
+| ---------- | ------------------------------- | --------------------------- |
+| `id`       | `string`                        | Unique tool call identifier |
+| `type`     | `string`                        | Tool call type (`function`) |
+| `function` | [`FunctionCall`](#functioncall) | Function call details       |
+
+### FunctionCall
+
+Details of a function call.
+
+| Field       | Type     | Description                       |
+| ----------- | -------- | --------------------------------- |
+| `name`      | `string` | Function name                     |
+| `arguments` | `string` | JSON string of function arguments |
+
+### ImageContent
+
+Image data in a message.
+
+| Field        | Type     | Description                                |
+| ------------ | -------- | ------------------------------------------ |
+| `type`       | `string` | Content type                               |
+| `url`        | `string` | Image URL or data URI                      |
+| `media_type` | `string` | MIME type of the image                     |
+| `detail`     | `string` | Image detail level (`low`, `high`, `auto`) |
+
+### BifrostError
+
+Error response format.
+
+| Field              | Type                        | Description                           |
+| ------------------ | --------------------------- | ------------------------------------- |
+| `event_id`         | `string`                    | Unique error event ID                 |
+| `type`             | `string`                    | Error type                            |
+| `is_bifrost_error` | `boolean`                   | Whether error originated from Bifrost |
+| `status_code`      | `integer`                   | HTTP status code                      |
+| `error`            | [`ErrorField`](#errorfield) | Detailed error information            |
+
+### ErrorField
+
+Detailed error information.
+
+| Field      | Type     | Description                     |
+| ---------- | -------- | ------------------------------- |
+| `type`     | `string` | Error type                      |
+| `code`     | `string` | Error code                      |
+| `message`  | `string` | Human-readable error message    |
+| `param`    | `any`    | Parameter that caused the error |
+| `event_id` | `string` | Error event ID                  |
+
+## Supported Providers
+
+| Provider         | Key         |
+| ---------------- | ----------- |
+| OpenAI           | `openai`    |
+| Anthropic        | `anthropic` |
+| Azure OpenAI     | `azure`     |
+| AWS Bedrock      | `bedrock`   |
+| Cohere           | `cohere`    |
+| Google Vertex AI | `vertex`    |
+
+## Error Codes
+
+| Status Code | Description                                                     |
+| ----------- | --------------------------------------------------------------- |
+| `400`       | Bad Request - Invalid request format or missing required fields |
+| `401`       | Unauthorized - Invalid or missing API key                       |
+| `429`       | Too Many Requests - Rate limit exceeded                         |
+| `500`       | Internal Server Error - Server or provider error                |
+| `502`       | Bad Gateway - Provider service unavailable                      |
+| `503`       | Service Unavailable - Bifrost service temporarily unavailable   |
+
+## Rate Limiting
+
+Rate limiting is handled by the individual providers. Bifrost respects provider rate limits and will return appropriate error responses when limits are exceeded.
+
+## Examples
+
+### Simple Chat
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "openai",
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "Hello, world!"}
+    ]
+  }'
+```
+
+### Chat with Tools
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "openai",
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "What'\''s the weather in San Francisco?"}
+    ],
+    "params": {
+      "tools": [
+        {
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "description": "Get current weather",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "location": {"type": "string"}
+              },
+              "required": ["location"]
+            }
+          }
+        }
+      ],
+      "tool_choice": {"type": "function", "function": {"name": "get_weather"}}
+    }
+  }'
+```
+
+### Text Completion
+
+```bash
+curl -X POST http://localhost:8080/v1/text/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "openai",
+    "model": "gpt-3.5-turbo-instruct",
+    "text": "The benefits of artificial intelligence include",
+    "params": {
+      "max_tokens": 150,
+      "temperature": 0.7
+    }
+  }'
+```
+
+### Using Fallbacks
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "openai",
+    "model": "gpt-4o",
+    "messages": [
+      {"role": "user", "content": "Explain quantum computing"}
+    ],
+    "fallbacks": [
+      {"provider": "anthropic", "model": "claude-3-sonnet-20240229"},
+      {"provider": "cohere", "model": "command"}
+    ]
+  }'
+```
+
+## Integration Examples
+
+### Python
+
+```python
+import requests
+
+def chat_completion(messages, provider="openai", model="gpt-4o"):
+    response = requests.post(
+        "http://localhost:8080/v1/chat/completions",
+        json={
+            "provider": provider,
+            "model": model,
+            "messages": messages,
+            "params": {"max_tokens": 1000}
+        }
+    )
+    return response.json()
+
+# Usage
+result = chat_completion([
+    {"role": "user", "content": "Hello, how are you?"}
+])
+print(result["choices"][0]["message"]["content"])
+```
+
+### Node.js
+
+```javascript
+const axios = require("axios");
+
+async function chatCompletion(messages, provider = "openai", model = "gpt-4o") {
+  try {
+    const response = await axios.post(
+      "http://localhost:8080/v1/chat/completions",
+      {
+        provider,
+        model,
+        messages,
+        params: { max_tokens: 1000 },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error:", error.response?.data || error.message);
+    throw error;
+  }
+}
+
+// Usage
+chatCompletion([{ role: "user", content: "Hello, how are you?" }]).then(
+  (result) => {
+    console.log(result.choices[0].message.content);
+  }
+);
+```
+
+### Go
+
+```go
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "net/http"
+)
+
+type ChatRequest struct {
+    Provider string            `json:"provider"`
+    Model    string            `json:"model"`
+    Messages []BifrostMessage  `json:"messages"`
+    Params   *ModelParameters  `json:"params,omitempty"`
+}
+
+type BifrostMessage struct {
+    Role    string `json:"role"`
+    Content string `json:"content"`
+}
+
+type ModelParameters struct {
+    MaxTokens *int `json:"max_tokens,omitempty"`
+}
+
+func chatCompletion(messages []BifrostMessage) error {
+    reqBody := ChatRequest{
+        Provider: "openai",
+        Model:    "gpt-4o",
+        Messages: messages,
+        Params:   &ModelParameters{MaxTokens: intPtr(1000)},
+    }
+
+    jsonData, _ := json.Marshal(reqBody)
+    resp, err := http.Post(
+        "http://localhost:8080/v1/chat/completions",
+        "application/json",
+        bytes.NewBuffer(jsonData),
+    )
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+
+    var result map[string]interface{}
+    json.NewDecoder(resp.Body).Decode(&result)
+    fmt.Println(result)
+    return nil
+}
+
+func intPtr(i int) *int { return &i }
+```
+
+## Configuration
+
+The HTTP transport can be configured via command-line flags:
+
+```bash
+./bifrost-http \
+  -config config.json \
+  -port 8080 \
+  -pool-size 300 \
+  -drop-excess-requests \
+  -plugins maxim \
+  -maxim-log-repo-id your-repo-id \
+  -prometheus-labels env,service
+```
+
+### Configuration Flags
+
+| Flag                    | Description                      | Default  |
+| ----------------------- | -------------------------------- | -------- |
+| `-config`               | Path to configuration file       | Required |
+| `-port`                 | Server port                      | `8080`   |
+| `-pool-size`            | Initial connection pool size     | `300`    |
+| `-drop-excess-requests` | Drop requests when queue is full | `false`  |
+| `-plugins`              | Comma-separated list of plugins  | None     |
+| `-maxim-log-repo-id`    | Maxim logging repository ID      | None     |
+| `-prometheus-labels`    | Additional Prometheus labels     | None     |
+
+## Monitoring
+
+The `/metrics` endpoint provides Prometheus-compatible metrics for monitoring:
+
+- Request counts by provider, model, and status
+- Request latency histograms
+- Token usage metrics
+- Error rates and types
+- Connection pool statistics

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1139 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Bifrost HTTP Transport API",
+    "description": "A unified HTTP API for accessing multiple AI model providers including OpenAI, Anthropic, Azure, Bedrock, Cohere, and Vertex AI. Bifrost provides standardized endpoints for text and chat completions with built-in fallback support and comprehensive monitoring.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Bifrost API Support",
+      "url": "https://github.com/maximhq/bifrost"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/licenses/MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Local development server"
+    }
+  ],
+  "paths": {
+    "/v1/chat/completions": {
+      "post": {
+        "summary": "Create Chat Completion",
+        "description": "Creates a chat completion using conversational messages. Supports tool calling, image inputs, and multiple AI providers with automatic fallbacks.",
+        "operationId": "createChatCompletion",
+        "tags": ["Chat Completions"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCompletionRequest"
+              },
+              "examples": {
+                "simple_chat": {
+                  "summary": "Simple chat message",
+                  "value": {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Hello, how are you?"
+                      }
+                    ]
+                  }
+                },
+                "tool_calling": {
+                  "summary": "Chat with tool calling",
+                  "value": {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "What's the weather in San Francisco?"
+                      }
+                    ],
+                    "params": {
+                      "tools": [
+                        {
+                          "type": "function",
+                          "function": {
+                            "name": "get_weather",
+                            "description": "Get current weather for a location",
+                            "parameters": {
+                              "type": "object",
+                              "properties": {
+                                "location": {
+                                  "type": "string",
+                                  "description": "The city and state, e.g. San Francisco, CA"
+                                }
+                              },
+                              "required": ["location"]
+                            }
+                          }
+                        }
+                      ],
+                      "tool_choice": {
+                        "type": "function",
+                        "function": {
+                          "name": "get_weather"
+                        }
+                      }
+                    }
+                  }
+                },
+                "with_fallbacks": {
+                  "summary": "Chat with fallback providers",
+                  "value": {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": "Explain quantum computing"
+                      }
+                    ],
+                    "fallbacks": [
+                      {
+                        "provider": "anthropic",
+                        "model": "claude-3-sonnet-20240229"
+                      },
+                      {
+                        "provider": "cohere",
+                        "model": "command"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful chat completion",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostResponse"
+                },
+                "examples": {
+                  "simple_response": {
+                    "summary": "Simple chat response",
+                    "value": {
+                      "id": "chatcmpl-123",
+                      "object": "chat.completion",
+                      "choices": [
+                        {
+                          "index": 0,
+                          "message": {
+                            "role": "assistant",
+                            "content": "Hello! I'm doing well, thank you for asking. How can I help you today?"
+                          },
+                          "finish_reason": "stop"
+                        }
+                      ],
+                      "model": "gpt-4o",
+                      "created": 1677652288,
+                      "usage": {
+                        "prompt_tokens": 12,
+                        "completion_tokens": 19,
+                        "total_tokens": 31
+                      },
+                      "extra_fields": {
+                        "provider": "openai",
+                        "model_params": {},
+                        "latency": 1.234,
+                        "raw_response": {}
+                      }
+                    }
+                  },
+                  "tool_response": {
+                    "summary": "Tool calling response",
+                    "value": {
+                      "id": "chatcmpl-456",
+                      "object": "chat.completion",
+                      "choices": [
+                        {
+                          "index": 0,
+                          "message": {
+                            "role": "assistant",
+                            "content": null,
+                            "tool_calls": [
+                              {
+                                "id": "call_123",
+                                "type": "function",
+                                "function": {
+                                  "name": "get_weather",
+                                  "arguments": "{\"location\": \"San Francisco, CA\"}"
+                                }
+                              }
+                            ]
+                          },
+                          "finish_reason": "tool_calls"
+                        }
+                      ],
+                      "model": "gpt-4o",
+                      "created": 1677652288,
+                      "usage": {
+                        "prompt_tokens": 45,
+                        "completion_tokens": 12,
+                        "total_tokens": 57
+                      },
+                      "extra_fields": {
+                        "provider": "openai",
+                        "model_params": {},
+                        "latency": 0.856,
+                        "raw_response": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1/text/completions": {
+      "post": {
+        "summary": "Create Text Completion",
+        "description": "Creates a text completion from a prompt. Useful for text generation, summarization, and other non-conversational tasks.",
+        "operationId": "createTextCompletion",
+        "tags": ["Text Completions"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TextCompletionRequest"
+              },
+              "examples": {
+                "simple_text": {
+                  "summary": "Simple text completion",
+                  "value": {
+                    "provider": "openai",
+                    "model": "gpt-3.5-turbo-instruct",
+                    "text": "The future of artificial intelligence is",
+                    "params": {
+                      "max_tokens": 100,
+                      "temperature": 0.7
+                    }
+                  }
+                },
+                "with_stop_sequences": {
+                  "summary": "Text completion with stop sequences",
+                  "value": {
+                    "provider": "cohere",
+                    "model": "command",
+                    "text": "Write a short story about a robot:",
+                    "params": {
+                      "max_tokens": 200,
+                      "temperature": 0.8,
+                      "stop_sequences": ["\n\n", "THE END"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful text completion",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostResponse"
+                },
+                "examples": {
+                  "text_response": {
+                    "summary": "Text completion response",
+                    "value": {
+                      "id": "cmpl-789",
+                      "object": "text.completion",
+                      "choices": [
+                        {
+                          "index": 0,
+                          "message": {
+                            "role": "assistant",
+                            "content": "The future of artificial intelligence is incredibly promising, with advances in machine learning, natural language processing, and robotics reshaping industries and daily life."
+                          },
+                          "finish_reason": "stop"
+                        }
+                      ],
+                      "model": "gpt-3.5-turbo-instruct",
+                      "created": 1677652288,
+                      "usage": {
+                        "prompt_tokens": 8,
+                        "completion_tokens": 32,
+                        "total_tokens": 40
+                      },
+                      "extra_fields": {
+                        "provider": "openai",
+                        "model_params": {
+                          "max_tokens": 100,
+                          "temperature": 0.7
+                        },
+                        "latency": 0.654,
+                        "raw_response": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Get Prometheus Metrics",
+        "description": "Returns Prometheus-compatible metrics for monitoring request counts, latency, token usage, and error rates.",
+        "operationId": "getMetrics",
+        "tags": ["Monitoring"],
+        "responses": {
+          "200": {
+            "description": "Prometheus metrics in text format",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                },
+                "example": "# HELP http_requests_total Total number of HTTP requests\n# TYPE http_requests_total counter\nhttp_requests_total{method=\"POST\",handler=\"/v1/chat/completions\",code=\"200\"} 42\n"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChatCompletionRequest": {
+        "type": "object",
+        "required": ["provider", "model", "messages"],
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/ModelProvider"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model identifier (provider-specific)",
+            "example": "gpt-4o"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BifrostMessage"
+            },
+            "description": "Array of chat messages",
+            "minItems": 1
+          },
+          "params": {
+            "$ref": "#/components/schemas/ModelParameters"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Fallback"
+            },
+            "description": "Fallback providers and models"
+          }
+        }
+      },
+      "TextCompletionRequest": {
+        "type": "object",
+        "required": ["provider", "model", "text"],
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/ModelProvider"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model identifier (provider-specific)",
+            "example": "gpt-3.5-turbo-instruct"
+          },
+          "text": {
+            "type": "string",
+            "description": "Text prompt for completion",
+            "example": "The benefits of artificial intelligence include"
+          },
+          "params": {
+            "$ref": "#/components/schemas/ModelParameters"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Fallback"
+            },
+            "description": "Fallback providers and models"
+          }
+        }
+      },
+      "ModelProvider": {
+        "type": "string",
+        "enum": ["openai", "anthropic", "azure", "bedrock", "cohere", "vertex"],
+        "description": "AI model provider",
+        "example": "openai"
+      },
+      "BifrostMessage": {
+        "type": "object",
+        "required": ["role"],
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/MessageRole"
+          },
+          "content": {
+            "type": "string",
+            "description": "Text content of the message",
+            "example": "Hello, how are you?"
+          },
+          "tool_call_id": {
+            "type": "string",
+            "description": "ID of the tool call (for tool messages)"
+          },
+          "tool_calls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolCall"
+            },
+            "description": "Tool calls made by assistant"
+          },
+          "image_content": {
+            "$ref": "#/components/schemas/ImageContent"
+          },
+          "refusal": {
+            "type": "string",
+            "description": "Refusal message from assistant"
+          },
+          "annotations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "description": "Message annotations"
+          },
+          "thought": {
+            "type": "string",
+            "description": "Assistant's internal thought process"
+          }
+        }
+      },
+      "MessageRole": {
+        "type": "string",
+        "enum": ["user", "assistant", "system", "tool"],
+        "description": "Role of the message sender",
+        "example": "user"
+      },
+      "ModelParameters": {
+        "type": "object",
+        "properties": {
+          "temperature": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 2.0,
+            "description": "Controls randomness in the output",
+            "example": 0.7
+          },
+          "top_p": {
+            "type": "number",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "description": "Nucleus sampling parameter",
+            "example": 0.9
+          },
+          "top_k": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Top-k sampling parameter",
+            "example": 40
+          },
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of tokens to generate",
+            "example": 1000
+          },
+          "stop_sequences": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Sequences that stop generation",
+            "example": ["\n\n", "END"]
+          },
+          "presence_penalty": {
+            "type": "number",
+            "minimum": -2.0,
+            "maximum": 2.0,
+            "description": "Penalizes repeated tokens",
+            "example": 0.0
+          },
+          "frequency_penalty": {
+            "type": "number",
+            "minimum": -2.0,
+            "maximum": 2.0,
+            "description": "Penalizes frequent tokens",
+            "example": 0.0
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "description": "Available tools for the model"
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/ToolChoice"
+          },
+          "parallel_tool_calls": {
+            "type": "boolean",
+            "description": "Enable parallel tool execution",
+            "example": true
+          }
+        }
+      },
+      "Tool": {
+        "type": "object",
+        "required": ["type", "function"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique tool identifier"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["function"],
+            "description": "Tool type",
+            "example": "function"
+          },
+          "function": {
+            "$ref": "#/components/schemas/Function"
+          }
+        }
+      },
+      "Function": {
+        "type": "object",
+        "required": ["name", "description", "parameters"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Function name",
+            "example": "get_weather"
+          },
+          "description": {
+            "type": "string",
+            "description": "Function description",
+            "example": "Get current weather for a location"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/FunctionParameters"
+          }
+        }
+      },
+      "FunctionParameters": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Parameter type",
+            "example": "object"
+          },
+          "description": {
+            "type": "string",
+            "description": "Parameter description"
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Parameter properties (JSON Schema)"
+          },
+          "required": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Required parameter names"
+          },
+          "enum": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Enum values for parameters"
+          }
+        }
+      },
+      "ToolChoice": {
+        "type": "object",
+        "required": ["type"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["none", "auto", "any", "function", "required"],
+            "description": "How tools should be chosen",
+            "example": "auto"
+          },
+          "function": {
+            "$ref": "#/components/schemas/ToolChoiceFunction"
+          }
+        }
+      },
+      "ToolChoiceFunction": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the function to call",
+            "example": "get_weather"
+          }
+        }
+      },
+      "ToolCall": {
+        "type": "object",
+        "required": ["function"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique tool call identifier",
+            "example": "call_123"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["function"],
+            "description": "Tool call type",
+            "example": "function"
+          },
+          "function": {
+            "$ref": "#/components/schemas/FunctionCall"
+          }
+        }
+      },
+      "FunctionCall": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Function name",
+            "example": "get_weather"
+          },
+          "arguments": {
+            "type": "string",
+            "description": "JSON string of function arguments",
+            "example": "{\"location\": \"San Francisco, CA\"}"
+          }
+        }
+      },
+      "ImageContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Content type"
+          },
+          "url": {
+            "type": "string",
+            "description": "Image URL or data URI",
+            "example": "https://example.com/image.jpg"
+          },
+          "media_type": {
+            "type": "string",
+            "description": "MIME type of the image",
+            "example": "image/jpeg"
+          },
+          "detail": {
+            "type": "string",
+            "enum": ["low", "high", "auto"],
+            "description": "Image detail level",
+            "example": "auto"
+          }
+        }
+      },
+      "Annotation": {
+        "type": "object",
+        "required": ["type", "url_citation"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Annotation type"
+          },
+          "url_citation": {
+            "$ref": "#/components/schemas/Citation"
+          }
+        }
+      },
+      "Citation": {
+        "type": "object",
+        "required": ["start_index", "end_index", "title"],
+        "properties": {
+          "start_index": {
+            "type": "integer",
+            "description": "Start index in the text"
+          },
+          "end_index": {
+            "type": "integer",
+            "description": "End index in the text"
+          },
+          "title": {
+            "type": "string",
+            "description": "Citation title"
+          },
+          "url": {
+            "type": "string",
+            "description": "Citation URL"
+          },
+          "sources": {
+            "description": "Citation sources"
+          },
+          "type": {
+            "type": "string",
+            "description": "Citation type"
+          }
+        }
+      },
+      "Fallback": {
+        "type": "object",
+        "required": ["provider", "model"],
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/ModelProvider"
+          },
+          "model": {
+            "type": "string",
+            "description": "Fallback model name",
+            "example": "claude-3-sonnet-20240229"
+          }
+        }
+      },
+      "BifrostResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique response identifier",
+            "example": "chatcmpl-123"
+          },
+          "object": {
+            "type": "string",
+            "enum": ["chat.completion", "text.completion"],
+            "description": "Response type",
+            "example": "chat.completion"
+          },
+          "choices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BifrostResponseChoice"
+            },
+            "description": "Array of completion choices"
+          },
+          "model": {
+            "type": "string",
+            "description": "Model used for generation",
+            "example": "gpt-4o"
+          },
+          "created": {
+            "type": "integer",
+            "description": "Unix timestamp of creation",
+            "example": 1677652288
+          },
+          "service_tier": {
+            "type": "string",
+            "description": "Service tier used"
+          },
+          "system_fingerprint": {
+            "type": "string",
+            "description": "System fingerprint"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/LLMUsage"
+          },
+          "extra_fields": {
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
+      "BifrostResponseChoice": {
+        "type": "object",
+        "required": ["index", "message"],
+        "properties": {
+          "index": {
+            "type": "integer",
+            "description": "Choice index",
+            "example": 0
+          },
+          "message": {
+            "$ref": "#/components/schemas/BifrostMessage"
+          },
+          "finish_reason": {
+            "type": "string",
+            "enum": [
+              "stop",
+              "length",
+              "tool_calls",
+              "content_filter",
+              "function_call"
+            ],
+            "description": "Reason completion stopped",
+            "example": "stop"
+          },
+          "stop": {
+            "type": "string",
+            "description": "Stop sequence that ended generation"
+          },
+          "log_probs": {
+            "$ref": "#/components/schemas/LogProbs"
+          }
+        }
+      },
+      "LLMUsage": {
+        "type": "object",
+        "properties": {
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Tokens in the prompt",
+            "example": 56
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Tokens in the completion",
+            "example": 31
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total tokens used",
+            "example": 87
+          },
+          "completion_tokens_details": {
+            "$ref": "#/components/schemas/CompletionTokensDetails"
+          }
+        }
+      },
+      "CompletionTokensDetails": {
+        "type": "object",
+        "properties": {
+          "reasoning_tokens": {
+            "type": "integer",
+            "description": "Tokens used for reasoning"
+          },
+          "audio_tokens": {
+            "type": "integer",
+            "description": "Tokens used for audio"
+          },
+          "accepted_prediction_tokens": {
+            "type": "integer",
+            "description": "Accepted prediction tokens"
+          },
+          "rejected_prediction_tokens": {
+            "type": "integer",
+            "description": "Rejected prediction tokens"
+          }
+        }
+      },
+      "BifrostResponseExtraFields": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "$ref": "#/components/schemas/ModelProvider"
+          },
+          "model_params": {
+            "$ref": "#/components/schemas/ModelParameters"
+          },
+          "latency": {
+            "type": "number",
+            "description": "Request latency in seconds",
+            "example": 1.234
+          },
+          "chat_history": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BifrostMessage"
+            },
+            "description": "Full conversation history"
+          },
+          "billed_usage": {
+            "$ref": "#/components/schemas/BilledLLMUsage"
+          },
+          "raw_response": {
+            "type": "object",
+            "description": "Raw provider response"
+          }
+        }
+      },
+      "BilledLLMUsage": {
+        "type": "object",
+        "properties": {
+          "prompt_tokens": {
+            "type": "number",
+            "description": "Billed prompt tokens"
+          },
+          "completion_tokens": {
+            "type": "number",
+            "description": "Billed completion tokens"
+          },
+          "search_units": {
+            "type": "number",
+            "description": "Billed search units"
+          },
+          "classifications": {
+            "type": "number",
+            "description": "Billed classifications"
+          }
+        }
+      },
+      "LogProbs": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ContentLogProb"
+            },
+            "description": "Log probabilities for content"
+          },
+          "refusal": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LogProb"
+            },
+            "description": "Log probabilities for refusal"
+          }
+        }
+      },
+      "ContentLogProb": {
+        "type": "object",
+        "required": ["logprob", "token"],
+        "properties": {
+          "bytes": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Byte representation"
+          },
+          "logprob": {
+            "type": "number",
+            "description": "Log probability",
+            "example": -0.123
+          },
+          "token": {
+            "type": "string",
+            "description": "Token",
+            "example": "hello"
+          },
+          "top_logprobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LogProb"
+            },
+            "description": "Top log probabilities"
+          }
+        }
+      },
+      "LogProb": {
+        "type": "object",
+        "required": ["logprob", "token"],
+        "properties": {
+          "bytes": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Byte representation"
+          },
+          "logprob": {
+            "type": "number",
+            "description": "Log probability",
+            "example": -0.456
+          },
+          "token": {
+            "type": "string",
+            "description": "Token",
+            "example": "world"
+          }
+        }
+      },
+      "BifrostError": {
+        "type": "object",
+        "required": ["is_bifrost_error", "error"],
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "description": "Unique error event ID",
+            "example": "evt_123"
+          },
+          "type": {
+            "type": "string",
+            "description": "Error type",
+            "example": "invalid_request_error"
+          },
+          "is_bifrost_error": {
+            "type": "boolean",
+            "description": "Whether error originated from Bifrost",
+            "example": true
+          },
+          "status_code": {
+            "type": "integer",
+            "description": "HTTP status code",
+            "example": 400
+          },
+          "error": {
+            "$ref": "#/components/schemas/ErrorField"
+          }
+        }
+      },
+      "ErrorField": {
+        "type": "object",
+        "required": ["message"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Error type",
+            "example": "invalid_request_error"
+          },
+          "code": {
+            "type": "string",
+            "description": "Error code",
+            "example": "missing_required_parameter"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message",
+            "example": "Provider is required"
+          },
+          "param": {
+            "description": "Parameter that caused the error",
+            "example": "provider"
+          },
+          "event_id": {
+            "type": "string",
+            "description": "Error event ID",
+            "example": "evt_123"
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad Request - Invalid request format or missing required fields",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BifrostError"
+            },
+            "example": {
+              "is_bifrost_error": true,
+              "status_code": 400,
+              "error": {
+                "type": "invalid_request_error",
+                "code": "missing_required_parameter",
+                "message": "Provider is required",
+                "param": "provider"
+              }
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - Invalid or missing API key",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BifrostError"
+            },
+            "example": {
+              "is_bifrost_error": true,
+              "status_code": 401,
+              "error": {
+                "type": "authentication_error",
+                "message": "Invalid API key provided"
+              }
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Too Many Requests - Rate limit exceeded",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BifrostError"
+            },
+            "example": {
+              "is_bifrost_error": false,
+              "status_code": 429,
+              "error": {
+                "type": "rate_limit_error",
+                "message": "Rate limit exceeded. Please try again later."
+              }
+            }
+          }
+        }
+      },
+      "InternalServerError": {
+        "description": "Internal Server Error - Server or provider error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/BifrostError"
+            },
+            "example": {
+              "is_bifrost_error": true,
+              "status_code": 500,
+              "error": {
+                "type": "api_error",
+                "message": "Internal server error occurred"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Chat Completions",
+      "description": "Create chat completions using conversational messages"
+    },
+    {
+      "name": "Text Completions",
+      "description": "Create text completions from prompts"
+    },
+    {
+      "name": "Monitoring",
+      "description": "Monitoring and observability endpoints"
+    }
+  ]
+}

--- a/transports/README.md
+++ b/transports/README.md
@@ -2,6 +2,8 @@
 
 This package contains clients for various transports that can be used to spin up your Bifrost client with just a single line of code.
 
+📖 **Comprehensive HTTP API documentation is available in** _[`docs/http-transport-api.md`](../docs/http-transport-api.md)_.
+
 ## 📑 Table of Contents
 
 - [Bifrost Transports](#bifrost-transports)
@@ -94,7 +96,7 @@ docker run -p 8080:8080 -e OPENAI_API_KEY -e ANTHROPIC_API_KEY bifrost-transport
 Note: In the command above, `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are just example environment variables.
 You need to pass all environment variables referenced in your `config.json` file that start with the prefix `env.` to the docker run command using the -e flag. This ensures Docker sets them correctly inside the container.
 
-example usage: Suppose your config.json only contains one environment variable placeholder, `env.COHERE_API_KEY`. Here’s how you would run it:
+example usage: Suppose your config.json only contains one environment variable placeholder, `env.COHERE_API_KEY`. Here's how you would run it:
 
 ```bash
 export COHERE_API_KEY=your_cohere_api_key


### PR DESCRIPTION
# Add HTTP Transport API Documentation

Added comprehensive API documentation for the Bifrost HTTP transport, including:

- A detailed markdown reference guide (`docs/http-transport-api.md`) covering all endpoints, request/response formats, and schema definitions
- A complete OpenAPI 3.0 specification file (`docs/openapi.json`) for machine-readable API documentation
- Updated the transports README with a link to the new API documentation

The documentation provides detailed information about the chat completions and text completions endpoints, including request parameters, response formats, error handling, and examples in multiple programming languages. It also covers authentication, monitoring, and supported model providers.