### PR TITLE
feat: standardize image handling across all providers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -215,9 +215,9 @@ func (bifrost *Bifrost) releaseChannelMessage(msg *ChannelMessage) {
 	bifrost.channelMessagePool.Put(msg)
 }
 
-// SelectKeyFromProviderForModel selects an appropriate API key for a given provider and model.
+// selectKeyFromProviderForModel selects an appropriate API key for a given provider and model.
 // It uses weighted random selection if multiple keys are available.
-func (bifrost *Bifrost) SelectKeyFromProviderForModel(providerKey schemas.ModelProvider, model string) (string, error) {
+func (bifrost *Bifrost) selectKeyFromProviderForModel(providerKey schemas.ModelProvider, model string) (string, error) {
 	keys, err := bifrost.account.GetKeysForProvider(providerKey)
 	if err != nil {
 		return "", err
@@ -298,7 +298,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, queue chan Chan
 
 		key := ""
 		if provider.GetProviderKey() != schemas.Vertex {
-			key, err = bifrost.SelectKeyFromProviderForModel(provider.GetProviderKey(), req.Model)
+			key, err = bifrost.selectKeyFromProviderForModel(provider.GetProviderKey(), req.Model)
 			if err != nil {
 				bifrost.logger.Warn(fmt.Sprintf("Error selecting key for model %s: %v", req.Model, err))
 				req.Err <- schemas.BifrostError{
@@ -411,10 +411,10 @@ func (bifrost *Bifrost) GetConfiguredProviderFromProviderKey(key schemas.ModelPr
 	return nil, fmt.Errorf("no provider found for key: %s", key)
 }
 
-// GetProviderQueue returns the request queue for a given provider key.
+// getProviderQueue returns the request queue for a given provider key.
 // If the queue doesn't exist, it creates one at runtime and initializes the provider,
 // given the provider config is provided in the account interface implementation.
-func (bifrost *Bifrost) GetProviderQueue(providerKey schemas.ModelProvider) (chan ChannelMessage, error) {
+func (bifrost *Bifrost) getProviderQueue(providerKey schemas.ModelProvider) (chan ChannelMessage, error) {
 	var queue chan ChannelMessage
 	var exists bool
 
@@ -512,7 +512,7 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.
 // tryTextCompletion attempts a text completion request with a single provider.
 // This is a helper function used by TextCompletionRequest to handle individual provider attempts.
 func (bifrost *Bifrost) tryTextCompletion(req *schemas.BifrostRequest, ctx context.Context) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	queue, err := bifrost.GetProviderQueue(req.Provider)
+	queue, err := bifrost.getProviderQueue(req.Provider)
 	if err != nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
@@ -686,7 +686,7 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 // tryChatCompletion attempts a chat completion request with a single provider.
 // This is a helper function used by ChatCompletionRequest to handle individual provider attempts.
 func (bifrost *Bifrost) tryChatCompletion(req *schemas.BifrostRequest, ctx context.Context) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	queue, err := bifrost.GetProviderQueue(req.Provider)
+	queue, err := bifrost.getProviderQueue(req.Provider)
 	if err != nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -319,21 +319,23 @@ func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, model, ke
 
 // buildAnthropicImageSourceMap creates the "source" map for an Anthropic image content part.
 func buildAnthropicImageSourceMap(imgContent *schemas.ImageContent) map[string]interface{} {
-	if imgContent == nil || imgContent.Type == nil {
+	if imgContent == nil {
 		return nil
 	}
 
+	formattedImgContent := *FormatImageContent(imgContent, false)
+
 	sourceMap := map[string]interface{}{
-		"type": *imgContent.Type, // "base64" or "url"
+		"type": string(formattedImgContent.Type), // "base64" or "url"
 	}
 
-	if *imgContent.Type == "url" {
-		sourceMap["url"] = imgContent.URL
+	if formattedImgContent.Type == schemas.ImageContentTypeURL {
+		sourceMap["url"] = formattedImgContent.URL
 	} else {
-		if imgContent.MediaType != nil {
-			sourceMap["media_type"] = *imgContent.MediaType
+		if formattedImgContent.MediaType != nil {
+			sourceMap["media_type"] = *formattedImgContent.MediaType
 		}
-		sourceMap["data"] = imgContent.URL // URL field is used for base64 data string
+		sourceMap["data"] = formattedImgContent.URL // URL field contains base64 data string
 	}
 	return sourceMap
 }
@@ -375,8 +377,10 @@ func prepareAnthropicChatRequest(messages []schemas.BifrostMessage, params *sche
 				if (msg.UserMessage != nil && msg.UserMessage.ImageContent != nil) || (msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil) {
 					var messageImageContent schemas.ImageContent
 					if msg.UserMessage != nil && msg.UserMessage.ImageContent != nil {
+						// Create a copy to avoid modifying the original
 						messageImageContent = *msg.UserMessage.ImageContent
 					} else if msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil {
+						// Create a copy to avoid modifying the original
 						messageImageContent = *msg.ToolMessage.ImageContent
 					}
 
@@ -396,8 +400,10 @@ func prepareAnthropicChatRequest(messages []schemas.BifrostMessage, params *sche
 				if (msg.UserMessage != nil && msg.UserMessage.ImageContent != nil) || (msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil) {
 					var messageImageContent schemas.ImageContent
 					if msg.UserMessage != nil && msg.UserMessage.ImageContent != nil {
+						// Create a copy to avoid modifying the original
 						messageImageContent = *msg.UserMessage.ImageContent
 					} else if msg.ToolMessage != nil && msg.ToolMessage.ImageContent != nil {
+						// Create a copy to avoid modifying the original
 						messageImageContent = *msg.ToolMessage.ImageContent
 					}
 

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -494,19 +494,22 @@ func (provider *BedrockProvider) prepareChatCompletionMessages(messages []schema
 							messageImageContent = *msg.ToolMessage.ImageContent
 						}
 
+						formattedImgContent := *FormatImageContent(&messageImageContent, false)
+
 						content = append(content, BedrockAnthropicImageMessage{
 							Type: "image",
 							Image: BedrockAnthropicImage{
 								Format: func() string {
-									if messageImageContent.MediaType != nil {
-										mediaType := *messageImageContent.MediaType
+									if formattedImgContent.MediaType != nil {
+										mediaType := *formattedImgContent.MediaType
+										// Remove "image/" prefix if present, since normalizeMediaType ensures full format
 										mediaType = strings.TrimPrefix(mediaType, "image/")
 										return mediaType
 									}
 									return ""
 								}(),
 								Source: BedrockAnthropicImageSource{
-									Bytes: messageImageContent.URL,
+									Bytes: formattedImgContent.URL,
 								},
 							},
 						})

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -226,6 +226,8 @@ func prepareOpenAIChatRequest(messages []schemas.BifrostMessage, params *schemas
 				messageImageContent = *msg.ToolMessage.ImageContent
 			}
 
+			formattedImgContent := *FormatImageContent(&messageImageContent, true)
+
 			var content []map[string]interface{}
 
 			// Add text content if present
@@ -239,12 +241,12 @@ func prepareOpenAIChatRequest(messages []schemas.BifrostMessage, params *schemas
 			imageContent := map[string]interface{}{
 				"type": "image_url",
 				"image_url": map[string]interface{}{
-					"url": messageImageContent.URL,
+					"url": formattedImgContent.URL,
 				},
 			}
 
-			if messageImageContent.Detail != nil {
-				imageContent["image_url"].(map[string]interface{})["detail"] = messageImageContent.Detail
+			if formattedImgContent.Detail != nil {
+				imageContent["image_url"].(map[string]interface{})["detail"] = formattedImgContent.Detail
 			}
 
 			content = append(content, imageContent)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -170,12 +170,19 @@ type AssistantMessage struct {
 	Thought     *string      `json:"thought,omitempty"`
 }
 
+type ImageContentType string
+
+const (
+	ImageContentTypeBase64 ImageContentType = "base64"
+	ImageContentTypeURL    ImageContentType = "url"
+)
+
 // ImageContent represents image data in a message.
 type ImageContent struct {
-	Type      *string `json:"type"`
-	URL       string  `json:"url"`
-	MediaType *string `json:"media_type"`
-	Detail    *string `json:"detail"`
+	Type      ImageContentType `json:"type"`
+	URL       string           `json:"url"`
+	MediaType *string          `json:"media_type,omitempty"`
+	Detail    *string          `json:"detail,omitempty"`
 }
 
 //* Response Structs

--- a/core/tests/account.go
+++ b/core/tests/account.go
@@ -77,7 +77,7 @@ func (baseAccount *BaseAccount) GetKeysForProvider(providerKey schemas.ModelProv
 		return []schemas.Key{
 			{
 				Value:  os.Getenv("COHERE_API_KEY"),
-				Models: []string{"command-a-03-2025"},
+				Models: []string{"command-a-03-2025", "c4ai-aya-vision-8b"},
 				Weight: 1.0,
 			},
 		}, nil

--- a/core/tests/azure_test.go
+++ b/core/tests/azure_test.go
@@ -22,7 +22,7 @@ func TestAzure(t *testing.T) {
 		SetupText:      false, // gpt-4o does not support text completion
 		SetupToolCalls: true,
 		SetupImage:     true,
-		SetupBaseImage: false,
+		SetupBaseImage: true,
 	}
 
 	SetupAllRequests(bifrost, config)

--- a/core/tests/openai_test.go
+++ b/core/tests/openai_test.go
@@ -22,8 +22,8 @@ func TestOpenAI(t *testing.T) {
 		ChatModel:      "gpt-4o-mini",
 		SetupText:      false, // OpenAI does not support text completion
 		SetupToolCalls: true,
-		SetupImage:     false,
-		SetupBaseImage: false,
+		SetupImage:     true,
+		SetupBaseImage: true,
 		Fallbacks: []schemas.Fallback{
 			{
 				Provider: schemas.Anthropic,

--- a/core/tests/tests.go
+++ b/core/tests/tests.go
@@ -189,7 +189,7 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 			Content: bifrost.Ptr("What is Happening in this picture?"),
 			UserMessage: &schemas.UserMessage{
 				ImageContent: &schemas.ImageContent{
-					Type: bifrost.Ptr("url"),
+					Type: schemas.ImageContentTypeURL,
 					URL:  "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg",
 				},
 			},
@@ -225,7 +225,7 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 				Content: bifrost.Ptr("What is this image about?"),
 				UserMessage: &schemas.UserMessage{
 					ImageContent: &schemas.ImageContent{
-						Type:      bifrost.Ptr("base64"),
+						Type:      schemas.ImageContentTypeBase64,
 						URL:       "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
 						MediaType: bifrost.Ptr("image/jpeg"),
 					},

--- a/core/tests/vertex_test.go
+++ b/core/tests/vertex_test.go
@@ -21,8 +21,8 @@ func TestVertex(t *testing.T) {
 		ChatModel:      "google/gemini-2.0-flash-001",
 		SetupText:      false, // Vertex does not support text completion
 		SetupToolCalls: true,
-		SetupImage:     false,
-		SetupBaseImage: false,
+		SetupImage:     true,
+		SetupBaseImage: true,
 	}
 
 	SetupAllRequests(bifrostClient, config)


### PR DESCRIPTION
# Unified Image Content Handling Across Providers

This PR implements a standardized approach to handling image content across all LLM providers. It adds two key utility functions:

1. `NormalizeImageContent` - Automatically detects content type from URL patterns and normalizes media types
2. `ImageDataURLBuilder` - Formats base64 image data according to provider requirements

The implementation:
- Adds constants for image content types in the schema
- Ensures proper handling of both URL and base64 image formats
- Adapts each provider to use the new utilities:
  - Anthropic: Uses raw base64 data without prefix
  - OpenAI: Uses full data URI format
  - Bedrock: Properly formats images for Claude models
  - Cohere: Adds vision support with proper image formatting
  - Vertex: Enables image support

Tests have been updated to verify image handling across providers, including both URL and base64 formats.