### PR TITLE
feat: add LiteLLM router integration with model provider detection

### DIFF
--- a/transports/bifrost-http/integrations/anthropic/router.go
+++ b/transports/bifrost-http/integrations/anthropic/router.go
@@ -1,6 +1,8 @@
 package anthropic
 
 import (
+	"errors"
+
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
@@ -21,14 +23,14 @@ func NewAnthropicRouter(client *bifrost.Bifrost) *AnthropicRouter {
 			GetRequestTypeInstance: func() interface{} {
 				return &AnthropicMessageRequest{}
 			},
-			RequestConverter: func(req interface{}) *schemas.BifrostRequest {
+			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if anthropicReq, ok := req.(*AnthropicMessageRequest); ok {
-					return anthropicReq.ConvertToBifrostRequest()
+					return anthropicReq.ConvertToBifrostRequest(), nil
 				}
-				return nil
+				return nil, errors.New("invalid request type")
 			},
-			ResponseFunc: func(resp *schemas.BifrostResponse) interface{} {
-				return DeriveAnthropicFromBifrostResponse(resp)
+			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				return DeriveAnthropicFromBifrostResponse(resp), nil
 			},
 		},
 	}

--- a/transports/bifrost-http/integrations/genai/router.go
+++ b/transports/bifrost-http/integrations/genai/router.go
@@ -1,6 +1,7 @@
 package genai
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -24,14 +25,14 @@ func NewGenAIRouter(client *bifrost.Bifrost) *GenAIRouter {
 			GetRequestTypeInstance: func() interface{} {
 				return &GeminiChatRequest{}
 			},
-			RequestConverter: func(req interface{}) *schemas.BifrostRequest {
+			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if geminiReq, ok := req.(*GeminiChatRequest); ok {
-					return geminiReq.ConvertToBifrostRequest()
+					return geminiReq.ConvertToBifrostRequest(), nil
 				}
-				return nil
+				return nil, errors.New("invalid request type")
 			},
-			ResponseFunc: func(resp *schemas.BifrostResponse) interface{} {
-				return DeriveGenAIFromBifrostResponse(resp)
+			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				return DeriveGenAIFromBifrostResponse(resp), nil
 			},
 			PreCallback: extractAndSetModelFromURL,
 		},

--- a/transports/bifrost-http/integrations/genai/types.go
+++ b/transports/bifrost-http/integrations/genai/types.go
@@ -171,9 +171,8 @@ func (r *GeminiChatRequest) convertContentToBifrostMessages(content genai_sdk.Co
 
 		case part.InlineData != nil:
 			// Handle inline images/media
-			imageType := "base64"
 			imageContent := schemas.ImageContent{
-				Type:      &imageType,
+				Type:      schemas.ImageContentTypeBase64,
 				URL:       fmt.Sprintf("data:%s;base64,%s", part.InlineData.MIMEType, base64.StdEncoding.EncodeToString(part.InlineData.Data)),
 				MediaType: &part.InlineData.MIMEType,
 			}
@@ -181,9 +180,8 @@ func (r *GeminiChatRequest) convertContentToBifrostMessages(content genai_sdk.Co
 
 		case part.FileData != nil:
 			// Handle file references
-			imageType := "url"
 			imageContent := schemas.ImageContent{
-				Type:      &imageType,
+				Type:      schemas.ImageContentTypeURL,
 				URL:       part.FileData.FileURI,
 				MediaType: &part.FileData.MIMEType,
 			}

--- a/transports/bifrost-http/integrations/litellm/router.go
+++ b/transports/bifrost-http/integrations/litellm/router.go
@@ -1,0 +1,158 @@
+package litellm
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/anthropic"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/genai"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/openai"
+	"github.com/valyala/fasthttp"
+)
+
+// LiteLLMRequestWrapper wraps any provider-specific request type
+type LiteLLMRequestWrapper struct {
+	Model         string                `json:"model"`
+	ActualRequest interface{}           `json:"-"` // This will hold the actual provider-specific request
+	Provider      schemas.ModelProvider `json:"-"`
+}
+
+// LiteLLMRouter holds route registrations for LiteLLM endpoints.
+// It supports standard chat completions and image-enabled vision capabilities.
+// LiteLLM is fully OpenAI-compatible, so we reuse OpenAI types
+// with aliases for clarity and minimal LiteLLM-specific extensions
+type LiteLLMRouter struct {
+	*integrations.GenericRouter
+}
+
+// NewLiteLLMRouter creates a new LiteLLMRouter with the given bifrost client.
+func NewLiteLLMRouter(client *bifrost.Bifrost) *LiteLLMRouter {
+	paths := []string{
+		"/chat/completions",
+		"/v1/messages",
+	}
+
+	getRequestTypeInstance := func() interface{} {
+		return &LiteLLMRequestWrapper{}
+	}
+
+	availableProviders := []schemas.ModelProvider{
+		schemas.OpenAI,
+		schemas.Anthropic,
+		schemas.Vertex,
+		schemas.Azure,
+	}
+
+	// Pre-hook to determine provider and parse request with correct type
+	preHook := func(ctx *fasthttp.RequestCtx, req interface{}) error {
+		wrapper, ok := req.(*LiteLLMRequestWrapper)
+		if !ok {
+			return errors.New("invalid request wrapper type")
+		}
+
+		if wrapper.Model == "" {
+			return errors.New("model field is required")
+		}
+
+		// Determine provider from model
+		provider := integrations.GetProviderFromModel(wrapper.Model)
+		if !slices.Contains(availableProviders, provider) {
+			return errors.New("unsupported provider: " + string(provider))
+		}
+
+		// Get the request body
+		body := ctx.Request.Body()
+		if len(body) == 0 {
+			return errors.New("request body is required")
+		}
+
+		// Create the appropriate request type based on provider and re-parse
+		var actualReq interface{}
+		switch provider {
+		case schemas.OpenAI, schemas.Azure:
+			actualReq = &openai.OpenAIChatRequest{}
+		case schemas.Anthropic:
+			actualReq = &anthropic.AnthropicMessageRequest{}
+		case schemas.Vertex:
+			actualReq = &genai.GeminiChatRequest{}
+		default:
+			return errors.New("unsupported provider: " + string(provider))
+		}
+
+		// Parse the body into the correct request type
+		if err := json.Unmarshal(body, actualReq); err != nil {
+			return errors.New("failed to parse request for provider " + string(provider) + ": " + err.Error())
+		}
+
+		// Store the parsed request and provider in the wrapper
+		wrapper.ActualRequest = actualReq
+		wrapper.Provider = provider
+
+		return nil
+	}
+
+	requestConverter := func(req interface{}) (*schemas.BifrostRequest, error) {
+		wrapper, ok := req.(*LiteLLMRequestWrapper)
+		if !ok {
+			return nil, errors.New("invalid request wrapper type")
+		}
+
+		if wrapper.ActualRequest == nil {
+			return nil, errors.New("request was not properly processed by pre-hook")
+		}
+
+		// Handle different provider-specific request types
+		switch actualReq := wrapper.ActualRequest.(type) {
+		case *openai.OpenAIChatRequest:
+			bifrostReq := actualReq.ConvertToBifrostRequest()
+			bifrostReq.Provider = wrapper.Provider
+			return bifrostReq, nil
+
+		case *anthropic.AnthropicMessageRequest:
+			bifrostReq := actualReq.ConvertToBifrostRequest()
+			bifrostReq.Provider = wrapper.Provider
+			return bifrostReq, nil
+
+		case *genai.GeminiChatRequest:
+			bifrostReq := actualReq.ConvertToBifrostRequest()
+			bifrostReq.Provider = wrapper.Provider
+			return bifrostReq, nil
+
+		default:
+			return nil, errors.New("unsupported request type")
+		}
+	}
+
+	responseConverter := func(resp *schemas.BifrostResponse) (interface{}, error) {
+		switch resp.ExtraFields.Provider {
+		case schemas.OpenAI, schemas.Azure:
+			return openai.DeriveOpenAIFromBifrostResponse(resp), nil
+		case schemas.Anthropic:
+			return anthropic.DeriveAnthropicFromBifrostResponse(resp), nil
+		case schemas.Vertex:
+			return genai.DeriveGenAIFromBifrostResponse(resp), nil
+		default:
+			return resp, nil
+		}
+	}
+
+	routes := []integrations.RouteConfig{}
+	for _, path := range paths {
+		routes = append(routes, integrations.RouteConfig{
+			Path:                   "/litellm" + path,
+			Method:                 "POST",
+			GetRequestTypeInstance: getRequestTypeInstance,
+			RequestConverter:       requestConverter,
+			ResponseConverter:      responseConverter,
+			PreCallback:            preHook,
+		})
+	}
+
+	return &LiteLLMRouter{
+		GenericRouter: integrations.NewGenericRouter(client, routes),
+	}
+}

--- a/transports/bifrost-http/integrations/openai/router.go
+++ b/transports/bifrost-http/integrations/openai/router.go
@@ -1,6 +1,8 @@
 package openai
 
 import (
+	"errors"
+
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
@@ -21,14 +23,14 @@ func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
 			GetRequestTypeInstance: func() interface{} {
 				return &OpenAIChatRequest{}
 			},
-			RequestConverter: func(req interface{}) *schemas.BifrostRequest {
+			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if openaiReq, ok := req.(*OpenAIChatRequest); ok {
-					return openaiReq.ConvertToBifrostRequest()
+					return openaiReq.ConvertToBifrostRequest(), nil
 				}
-				return nil
+				return nil, errors.New("invalid request type")
 			},
-			ResponseFunc: func(resp *schemas.BifrostResponse) interface{} {
-				return DeriveOpenAIFromBifrostResponse(resp)
+			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				return DeriveOpenAIFromBifrostResponse(resp), nil
 			},
 		},
 	}

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/anthropic"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/genai"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/litellm"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/openai"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/maximhq/bifrost/transports/bifrost-http/tracking"
@@ -198,6 +199,7 @@ func main() {
 		genai.NewGenAIRouter(client),
 		openai.NewOpenAIRouter(client),
 		anthropic.NewAnthropicRouter(client),
+		litellm.NewLiteLLMRouter(client),
 	}
 
 	r.POST("/v1/text/completions", func(ctx *fasthttp.RequestCtx) {
@@ -218,7 +220,7 @@ func main() {
 	r.NotFound = func(ctx *fasthttp.RequestCtx) {
 		ctx.SetStatusCode(fasthttp.StatusNotFound)
 		ctx.SetContentType("text/plain")
-		ctx.SetBodyString("Route not found")
+		ctx.SetBodyString("Route not found: " + string(ctx.Path()))
 	}
 
 	server := &fasthttp.Server{

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/fasthttp/router v1.5.4
-	github.com/maximhq/bifrost/core v1.0.9
+	github.com/maximhq/bifrost/core v1.0.10
 	github.com/maximhq/bifrost/plugins/maxim v1.0.3
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.62.0

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -67,8 +67,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/maximhq/bifrost/core v1.0.9 h1:OWUHCWCQsBH43YPIy2AsqNMZhoFXYe/qhJSCLbw5su8=
-github.com/maximhq/bifrost/core v1.0.9/go.mod h1:8ycaWQ9bjQezoUT/x6a82VmPjoqLzyGglQ0RnnlZjqo=
+github.com/maximhq/bifrost/core v1.0.10 h1:HLDOg11tFK7AwEHKqBhImUHbeWhFB775TiE/7BJMQhE=
+github.com/maximhq/bifrost/core v1.0.10/go.mod h1:8ycaWQ9bjQezoUT/x6a82VmPjoqLzyGglQ0RnnlZjqo=
 github.com/maximhq/bifrost/plugins/maxim v1.0.3 h1:3m3BGfC30pNVVYdon77etOBinEaD9B9RVgsTB8HtuDU=
 github.com/maximhq/bifrost/plugins/maxim v1.0.3/go.mod h1:Zakfd201Id5uN368lFB09nrOJ3cCmGmzrKOFWq0KiAc=
 github.com/maximhq/maxim-go v0.1.3 h1:nVzdz3hEjZVxmWHARWIM+Yrn1Jp50qrsK4BA/sz2jj8=


### PR DESCRIPTION
# Add LiteLLM Integration Support

This PR adds support for LiteLLM integration to Bifrost HTTP transport. LiteLLM is a popular proxy that standardizes access to various LLM providers through an OpenAI-compatible interface.

Key changes:
- Created a new `LiteLLMRouter` that handles requests to `/litellm/chat/completions` endpoint
- Added model name pattern detection to automatically determine the appropriate provider based on the model name
- Implemented comprehensive pattern matching for various AI providers (OpenAI, Azure, Anthropic, Google Vertex, AWS Bedrock, Cohere)
- Registered the LiteLLM router in the main HTTP server

This integration allows users to route requests through Bifrost using LiteLLM's standardized interface while maintaining compatibility with existing OpenAI request/response formats.