### PR TITLE
feat: enhance plugin system with short-circuit capability and cleanup method

### DIFF
--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -16,15 +16,23 @@ import "context"
 // - Logging
 // - Monitoring
 
+// No Plugin errors are returned to the caller, they are logged as warnings by the Bifrost instance.
+
 type Plugin interface {
 	// PreHook is called before a request is processed by a provider.
 	// It allows plugins to modify the request before it is sent to the provider.
 	// The context parameter can be used to maintain state across plugin calls.
-	// Returns the modified request and any error that occurred during processing.
-	PreHook(ctx *context.Context, req *BifrostRequest) (*BifrostRequest, error)
+	// Returns the modified request, an optional response (if the plugin wants to short-circuit the provider call), and any error that occurred during processing.
+	// If a response is returned, the provider call is skipped and only the PostHook methods of plugins that had their PreHook executed are called in reverse order.
+	PreHook(ctx *context.Context, req *BifrostRequest) (*BifrostRequest, *BifrostResponse, error)
 
 	// PostHook is called after a response is received from a provider.
 	// It allows plugins to modify the response before it is returned to the caller.
 	// Returns the modified response and any error that occurred during processing.
 	PostHook(ctx *context.Context, result *BifrostResponse) (*BifrostResponse, error)
+
+	// Cleanup is called on bifrost shutdown.
+	// It allows plugins to clean up any resources they have allocated.
+	// Returns any error that occurred during cleanup, which will be logged as a warning by the Bifrost instance.
+	Cleanup() error
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -1,5 +1,30 @@
 package bifrost
 
+import schemas "github.com/maximhq/bifrost/core/schemas"
+
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+// newBifrostError wraps a standard error into a BifrostError with IsBifrostError set to false.
+// This helper function reduces code duplication when handling non-Bifrost errors.
+func newBifrostError(err error) *schemas.BifrostError {
+	return &schemas.BifrostError{
+		IsBifrostError: false,
+		Error: schemas.ErrorField{
+			Message: err.Error(),
+			Error:   err,
+		},
+	}
+}
+
+// newBifrostErrorFromMsg creates a BifrostError with a custom message.
+// This helper function is used for static error messages.
+func newBifrostErrorFromMsg(message string) *schemas.BifrostError {
+	return &schemas.BifrostError{
+		IsBifrostError: false,
+		Error: schemas.ErrorField{
+			Message: message,
+		},
+	}
 }


### PR DESCRIPTION
# Allow plugins to short-circuit request processing

This PR enhances the plugin system by allowing plugins to short-circuit the request processing flow. The `PreHook` method signature has been updated to return an optional response in addition to the modified request.

When a plugin returns a non-nil response from its `PreHook` method, Bifrost will skip the provider call and immediately run all remaining plugins' `PostHook` methods in reverse order before returning the response to the client.

This change enables plugins to:
- Serve cached responses
- Implement custom routing logic
- Handle certain requests entirely within the plugin

The implementation maintains the existing error handling pattern while adding the new short-circuit capability.