### PR TITLE
feat: refactor message content structure to support multi-modal content blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,12 @@ For additional configurations in HTTP server setup, please read [this](https://g
          Provider: schemas.OpenAI,
          Model: "gpt-4o-mini", // make sure you have configured gpt-4o-mini in your account interface
          Input: schemas.RequestInput{
-           ChatCompletionInput: bifrost.Ptr([]schemas.Message{{
-            Role:    schemas.RoleUser,
-            Content: bifrost.Ptr("What is a LLM gateway?"),
-            }}),
+           ChatCompletionInput: bifrost.Ptr([]schemas.BifrostMessage{{
+            Role: schemas.ModelChatMessageRoleUser,
+            Content: schemas.MessageContent{
+              ContentStr: bifrost.Ptr("What is a LLM gateway?"),
+            },
+           }}),
          },
        },
      )

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -269,8 +269,10 @@ func (provider *AzureProvider) TextCompletion(ctx context.Context, model, key, t
 		choices = append(choices, schemas.BifrostResponseChoice{
 			Index: 0,
 			Message: schemas.BifrostMessage{
-				Role:    schemas.ModelChatMessageRoleAssistant,
-				Content: &textCopy,
+				Role: schemas.ModelChatMessageRoleAssistant,
+				Content: schemas.MessageContent{
+					ContentStr: &textCopy,
+				},
 			},
 			FinishReason: response.Choices[0].FinishReason,
 			LogProbs: &schemas.LogProbs{

--- a/core/tests/e2e_tool_test.go
+++ b/core/tests/e2e_tool_test.go
@@ -33,8 +33,10 @@ func TestToolCallingEndToEnd(t *testing.T) {
 
 	// Step 1: User asks for weather, LLM should request tool usage
 	userMessage := schemas.BifrostMessage{
-		Role:    schemas.ModelChatMessageRoleUser,
-		Content: bifrost.Ptr("What's the weather in London?"),
+		Role: schemas.ModelChatMessageRoleUser,
+		Content: schemas.MessageContent{
+			ContentStr: bifrost.Ptr("What's the weather in London?"),
+		},
 	}
 
 	toolParams := WeatherToolParams
@@ -89,8 +91,10 @@ func TestToolCallingEndToEnd(t *testing.T) {
 		userMessage,
 		message,
 		{
-			Role:    schemas.ModelChatMessageRoleTool,
-			Content: &toolResult,
+			Role: schemas.ModelChatMessageRoleTool,
+			Content: schemas.MessageContent{
+				ContentStr: bifrost.Ptr(toolResult),
+			},
 			ToolMessage: &schemas.ToolMessage{
 				ToolCallID: toolCall.ID,
 			},
@@ -114,11 +118,11 @@ func TestToolCallingEndToEnd(t *testing.T) {
 	require.NotNil(t, finalResponse)
 	require.NotEmpty(t, finalResponse.Choices)
 
-	// Verify final response
-	finalMessage := finalResponse.Choices[0].Message
-	require.NotNil(t, finalMessage.Content)
+	// Verify final response using getResultContent which handles pointer dereferencing
+	content := getResultContent(finalResponse)
+	require.NotEmpty(t, content, "Response content should not be empty")
 
-	content := *finalMessage.Content
+	// Verify response contains expected information
 	assert.Contains(t, content, "London", "Response should mention London")
 	assert.Contains(t, content, "15", "Response should mention temperature")
 	assert.Contains(t, content, "cloudy", "Response should mention weather description")

--- a/core/tests/tests.go
+++ b/core/tests/tests.go
@@ -111,9 +111,9 @@ func setupTextCompletionRequest(bifrostClient *bifrost.Bifrost, config TestConfi
 			Fallbacks: config.Fallbacks,
 		})
 		if err != nil {
-			log.Println("Error in", config.Provider, "text completion:", err.Error.Message)
+			log.Println("❌ Error in", config.Provider, "text completion:", err.Error.Message)
 		} else {
-			log.Println("🐒", config.Provider, "Text Completion Result:", *result.Choices[0].Message.Content)
+			log.Println("🐒", config.Provider, "Text Completion Result:", getResultContent(result))
 		}
 	}()
 }
@@ -145,8 +145,10 @@ func setupChatCompletionRequests(bifrostClient *bifrost.Bifrost, config TestConf
 			time.Sleep(delay)
 			messages := []schemas.BifrostMessage{
 				{
-					Role:    schemas.ModelChatMessageRoleUser,
-					Content: &msg,
+					Role: schemas.ModelChatMessageRoleUser,
+					Content: schemas.MessageContent{
+						ContentStr: bifrost.Ptr(msg),
+					},
 				},
 			}
 
@@ -160,9 +162,9 @@ func setupChatCompletionRequests(bifrostClient *bifrost.Bifrost, config TestConf
 				Fallbacks: config.Fallbacks,
 			})
 			if err != nil {
-				log.Println("Error in", config.Provider, "request", index+1, ":", err.Error.Message)
+				log.Println("❌ Error in", config.Provider, "request", index+1, ":", err.Error.Message)
 			} else {
-				log.Println("🐒", config.Provider, "Chat Completion Result", index+1, ":", *result.Choices[0].Message.Content)
+				log.Println("🐒", config.Provider, "Chat Completion Result", index+1, ":", getResultContent(result))
 			}
 		}(message, delay, i)
 	}
@@ -185,12 +187,19 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 	// URL image test
 	urlImageMessages := []schemas.BifrostMessage{
 		{
-			Role:    schemas.ModelChatMessageRoleUser,
-			Content: bifrost.Ptr("What is Happening in this picture?"),
-			UserMessage: &schemas.UserMessage{
-				ImageContent: &schemas.ImageContent{
-					Type: schemas.ImageContentTypeURL,
-					URL:  "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg",
+			Role: schemas.ModelChatMessageRoleUser,
+			Content: schemas.MessageContent{
+				ContentBlocks: &[]schemas.ContentBlock{
+					{
+						Type: schemas.ContentBlockTypeText,
+						Text: bifrost.Ptr("What is Happening in this picture?"),
+					},
+					{
+						Type: schemas.ContentBlockTypeImage,
+						ImageURL: &schemas.ImageURLStruct{
+							URL: "https://upload.wikimedia.org/wikipedia/commons/a/a7/Camponotus_flavomarginatus_ant.jpg",
+						},
+					},
 				},
 			},
 		},
@@ -210,9 +219,9 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 				Fallbacks: config.Fallbacks,
 			})
 			if err != nil {
-				log.Println("Error in", config.Provider, "URL image request:", err.Error.Message)
+				log.Println("❌ Error in", config.Provider, "URL image request:", err.Error.Message)
 			} else {
-				log.Println("🐒", config.Provider, "URL Image Result:", *result.Choices[0].Message.Content)
+				log.Println("🐒", config.Provider, "URL Image Result:", getResultContent(result))
 			}
 		}()
 	}
@@ -221,13 +230,19 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 	if config.SetupBaseImage {
 		base64ImageMessages := []schemas.BifrostMessage{
 			{
-				Role:    schemas.ModelChatMessageRoleUser,
-				Content: bifrost.Ptr("What is this image about?"),
-				UserMessage: &schemas.UserMessage{
-					ImageContent: &schemas.ImageContent{
-						Type:      schemas.ImageContentTypeBase64,
-						URL:       "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
-						MediaType: bifrost.Ptr("image/jpeg"),
+				Role: schemas.ModelChatMessageRoleUser,
+				Content: schemas.MessageContent{
+					ContentBlocks: &[]schemas.ContentBlock{
+						{
+							Type: schemas.ContentBlockTypeText,
+							Text: bifrost.Ptr("What is Happening in this picture?"),
+						},
+						{
+							Type: schemas.ContentBlockTypeImage,
+							ImageURL: &schemas.ImageURLStruct{
+								URL: "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAIAAoDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k=",
+							},
+						},
 					},
 				},
 			},
@@ -246,9 +261,9 @@ func setupImageTests(bifrostClient *bifrost.Bifrost, config TestConfig, ctx cont
 				Fallbacks: config.Fallbacks,
 			})
 			if err != nil {
-				log.Println("Error in", config.Provider, "base64 image request:", err.Error.Message)
+				log.Println("❌ Error in", config.Provider, "base64 image request:", err.Error.Message)
 			} else {
-				log.Println("🐒", config.Provider, "Base64 Image Result:", *result.Choices[0].Message.Content)
+				log.Println("🐒", config.Provider, "Base64 Image Result:", getResultContent(result))
 			}
 		}()
 	}
@@ -284,8 +299,10 @@ func setupToolCalls(bifrostClient *bifrost.Bifrost, config TestConfig, ctx conte
 			time.Sleep(delay)
 			messages := []schemas.BifrostMessage{
 				{
-					Role:    schemas.ModelChatMessageRoleUser,
-					Content: &msg,
+					Role: schemas.ModelChatMessageRoleUser,
+					Content: schemas.MessageContent{
+						ContentStr: bifrost.Ptr(msg),
+					},
 				},
 			}
 			result, err := bifrostClient.ChatCompletionRequest(ctx, &schemas.BifrostRequest{
@@ -298,7 +315,7 @@ func setupToolCalls(bifrostClient *bifrost.Bifrost, config TestConfig, ctx conte
 				Fallbacks: config.Fallbacks,
 			})
 			if err != nil {
-				log.Println("Error in", config.Provider, "tool call request", index+1, ":", err.Error.Message)
+				log.Println("❌ Error in", config.Provider, "tool call request", index+1, ":", err.Error.Message)
 			} else {
 				if result.Choices[0].Message.AssistantMessage != nil && result.Choices[0].Message.ToolCalls != nil && len(*result.Choices[0].Message.ToolCalls) > 0 {
 					for i, choice := range result.Choices {
@@ -371,4 +388,22 @@ func SetupAllRequests(bifrostClient *bifrost.Bifrost, config TestConfig) {
 	}
 	log.Println("Test setup finished.")
 	bifrostClient.Cleanup()
+}
+
+func getResultContent(result *schemas.BifrostResponse) string {
+	if result == nil || len(result.Choices) == 0 {
+		return ""
+	}
+
+	resultContent := ""
+	if result.Choices[0].Message.Content.ContentStr != nil {
+		resultContent = *result.Choices[0].Message.Content.ContentStr
+	} else if result.Choices[0].Message.Content.ContentBlocks != nil {
+		for _, block := range *result.Choices[0].Message.Content.ContentBlocks {
+			if block.Text != nil {
+				resultContent += *block.Text
+			}
+		}
+	}
+	return resultContent
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -109,6 +109,35 @@
                       }
                     ]
                   }
+                },
+                "structured_content": {
+                  "summary": "Chat with structured content (text and image)",
+                  "value": {
+                    "provider": "openai",
+                    "model": "gpt-4o",
+                    "messages": [
+                      {
+                        "role": "user",
+                        "content": [
+                          {
+                            "type": "text",
+                            "text": "What's happening in this image? What's the weather like?"
+                          },
+                          {
+                            "type": "image_url",
+                            "image_url": {
+                              "url": "https://example.com/weather-photo.jpg",
+                              "detail": "high"
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "params": {
+                      "max_tokens": 1000,
+                      "temperature": 0.7
+                    }
+                  }
                 }
               }
             }
@@ -415,9 +444,21 @@
             "$ref": "#/components/schemas/MessageRole"
           },
           "content": {
-            "type": "string",
-            "description": "Text content of the message",
-            "example": "Hello, how are you?"
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Simple text content",
+                "example": "Hello, how are you?"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ContentBlock"
+                },
+                "description": "Structured content with text and images"
+              }
+            ],
+            "description": "Message content - can be simple text or structured content with text and images"
           },
           "tool_call_id": {
             "type": "string",
@@ -429,9 +470,6 @@
               "$ref": "#/components/schemas/ToolCall"
             },
             "description": "Tool calls made by assistant"
-          },
-          "image_content": {
-            "$ref": "#/components/schemas/ImageContent"
           },
           "refusal": {
             "type": "string",
@@ -455,6 +493,67 @@
         "enum": ["user", "assistant", "system", "tool"],
         "description": "Role of the message sender",
         "example": "user"
+      },
+      "ContentBlock": {
+        "type": "object",
+        "required": ["type"],
+        "discriminator": {
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "type": "object",
+            "required": ["type", "text"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["text"],
+                "description": "Content type for text blocks",
+                "example": "text"
+              },
+              "text": {
+                "type": "string",
+                "description": "Text content",
+                "example": "What do you see in this image?"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": ["type", "image_url"],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["image_url"],
+                "description": "Content type for image blocks",
+                "example": "image_url"
+              },
+              "image_url": {
+                "$ref": "#/components/schemas/ImageURLStruct",
+                "description": "Image data"
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ImageURLStruct": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Image URL or data URI",
+            "example": "https://example.com/image.jpg"
+          },
+          "detail": {
+            "type": "string",
+            "enum": ["low", "high", "auto"],
+            "description": "Image detail level",
+            "example": "auto"
+          }
+        }
       },
       "ModelParameters": {
         "type": "object",
@@ -654,31 +753,6 @@
             "type": "string",
             "description": "JSON string of function arguments",
             "example": "{\"location\": \"San Francisco, CA\"}"
-          }
-        }
-      },
-      "ImageContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "description": "Content type"
-          },
-          "url": {
-            "type": "string",
-            "description": "Image URL or data URI",
-            "example": "https://example.com/image.jpg"
-          },
-          "media_type": {
-            "type": "string",
-            "description": "MIME type of the image",
-            "example": "image/jpeg"
-          },
-          "detail": {
-            "type": "string",
-            "enum": ["low", "high", "auto"],
-            "description": "Image detail level",
-            "example": "auto"
           }
         }
       },


### PR DESCRIPTION
# Update Message Content Structure for Multi-Modal Support

This PR refactors the message content structure to better support multi-modal interactions (text and images) across all providers. The key changes include:

1. Replaced the simple `Content *string` field with a structured `MessageContent` type that can contain either a string or an array of content blocks
2. Added new `ContentBlock` type to represent different content types (text or image)
3. Removed the separate `ImageContent` type in favor of the more flexible `ImageURLStruct`
4. Updated all providers (OpenAI, Anthropic, Bedrock, Azure, Cohere) to use the new content structure
5. Enhanced image processing utilities with better URL sanitization and media type detection
6. Updated the README example to use the new message structure
7. Updated documentation and OpenAPI specs to reflect the new content structure

This change provides a more consistent way to handle multi-modal content across different providers and aligns better with OpenAI's content structure, making it easier to work with both text and image inputs in the same message.