### PR TITLE
bug: fixed provider level minor message parsing bugs

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -335,8 +335,11 @@ func buildAnthropicImageSourceMap(imgContent *schemas.ImageURLStruct) map[string
 	urlTypeInfo := ExtractURLTypeInfo(sanitizedURL)
 
 	formattedImgContent := AnthropicImageContent{
-		Type:      urlTypeInfo.Type,
-		MediaType: *urlTypeInfo.MediaType,
+		Type: urlTypeInfo.Type,
+	}
+
+	if urlTypeInfo.MediaType != nil {
+		formattedImgContent.MediaType = *urlTypeInfo.MediaType
 	}
 
 	if urlTypeInfo.DataURLWithoutPrefix != nil {

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -522,8 +522,11 @@ func (provider *BedrockProvider) prepareChatCompletionMessages(messages []schema
 								urlTypeInfo := ExtractURLTypeInfo(sanitizedURL)
 
 								formattedImgContent := AnthropicImageContent{
-									Type:      urlTypeInfo.Type,
-									MediaType: *urlTypeInfo.MediaType,
+									Type: urlTypeInfo.Type,
+								}
+
+								if urlTypeInfo.MediaType != nil {
+									formattedImgContent.MediaType = *urlTypeInfo.MediaType
 								}
 
 								if urlTypeInfo.DataURLWithoutPrefix != nil {

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -459,9 +459,12 @@ func processImageContent(imageContent *schemas.ImageURLStruct) map[string]interf
 	urlTypeInfo := ExtractURLTypeInfo(sanitizedURL)
 
 	formattedImgContent := AnthropicImageContent{
-		Type:      urlTypeInfo.Type,
-		URL:       sanitizedURL,
-		MediaType: *urlTypeInfo.MediaType,
+		Type: urlTypeInfo.Type,
+		URL:  sanitizedURL,
+	}
+
+	if urlTypeInfo.MediaType != nil {
+		formattedImgContent.MediaType = *urlTypeInfo.MediaType
 	}
 
 	return map[string]interface{}{

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -212,7 +212,7 @@ func prepareOpenAIChatRequest(messages []schemas.BifrostMessage, params *schemas
 		if msg.Role == schemas.ModelChatMessageRoleAssistant {
 			assistantMessage := map[string]interface{}{
 				"role":    msg.Role,
-				"content": coalesceString(msg.Content.ContentStr),
+				"content": msg.Content,
 			}
 			if msg.AssistantMessage != nil && msg.AssistantMessage.ToolCalls != nil {
 				assistantMessage["tool_calls"] = *msg.AssistantMessage.ToolCalls

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -338,15 +338,6 @@ func StrPtr(s string) *string {
 	return &s
 }
 
-// coalesceString returns the string value of a pointer to a string, or an empty string if the pointer is nil.
-// This is a helper function for safely handling pointer-to-string values.
-func coalesceString(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
 //* IMAGE UTILS *//
 
 // SanitizeImageURL sanitizes and validates an image URL.


### PR DESCRIPTION
Fix handling of nil MediaType in image content processing

This PR addresses a bug where the code was dereferencing potentially nil MediaType pointers in the Anthropic, Bedrock, and Cohere providers. The fix adds null checks before accessing the MediaType field, preventing potential nil pointer dereference panics.

Additionally, the PR removes the unused `coalesceString` helper function and updates the OpenAI provider to directly use the Content field without unnecessary coalescing.