### PR TITLE
feat: implement PluginPipeline for improved plugin execution flow

### DIFF
--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -19,6 +19,9 @@ import "context"
 // No Plugin errors are returned to the caller, they are logged as warnings by the Bifrost instance.
 
 type Plugin interface {
+	// GetName returns the name of the plugin.
+	GetName() string
+
 	// PreHook is called before a request is processed by a provider.
 	// It allows plugins to modify the request before it is sent to the provider.
 	// The context parameter can be used to maintain state across plugin calls.
@@ -27,9 +30,9 @@ type Plugin interface {
 	PreHook(ctx *context.Context, req *BifrostRequest) (*BifrostRequest, *BifrostResponse, error)
 
 	// PostHook is called after a response is received from a provider.
-	// It allows plugins to modify the response before it is returned to the caller.
-	// Returns the modified response and any error that occurred during processing.
-	PostHook(ctx *context.Context, result *BifrostResponse) (*BifrostResponse, error)
+	// It allows plugins to modify the response/error before it is returned to the caller.
+	// Returns the modified response, bifrost error and any error that occurred during processing.
+	PostHook(ctx *context.Context, result *BifrostResponse, err *BifrostError) (*BifrostResponse, *BifrostError, error)
 
 	// Cleanup is called on bifrost shutdown.
 	// It allows plugins to clean up any resources they have allocated.


### PR DESCRIPTION
# Refactor Plugin Pipeline for Better Error Handling

This PR introduces a new `PluginPipeline` abstraction to improve the handling of plugin execution in Bifrost. The key improvements include:

1. Added proper error aggregation for both PreHooks and PostHooks
2. Enhanced PostHook interface to allow plugins to:
   - Recover from errors (transform an error into a valid response)
   - Invalidate responses (transform a response into an error)
   - Modify errors before they're returned to the caller

3. Implemented consistent execution flow for both text and chat completion requests
4. Added a `GetName()` method to the Plugin interface for better error reporting

The pipeline tracks which plugins ran during PreHook to ensure only those plugins have their PostHook called, and in the correct reverse order. This maintains the expected plugin execution lifecycle while providing more flexibility in how plugins can transform the request/response flow.