### PR TITLE
feat: improve plugin pipeline and add custom base URLs to providers

### DIFF
--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -27,6 +27,8 @@ const (
 
 // NetworkConfig represents the network configuration for provider connections.
 type NetworkConfig struct {
+	// BaseURL is only supported for OpenAI, Anthropic and Cohere providers
+	BaseURL                        string        `json:"base_url,omitempty"`                 // Base URL for the provider (optional)
 	DefaultRequestTimeoutInSeconds int           `json:"default_request_timeout_in_seconds"` // Default timeout for requests
 	MaxRetries                     int           `json:"max_retries"`                        // Maximum number of retries
 	RetryBackoffInitial            time.Duration `json:"retry_backoff_initial"`              // Initial backoff duration


### PR DESCRIPTION
# Add Custom Base URL Support for OpenAI, Anthropic, and Cohere Providers

This PR adds support for configuring custom base URLs for the OpenAI, Anthropic, and Cohere providers. This enhancement allows users to:

- Connect to alternative API endpoints or self-hosted instances
- Use compatible API proxies
- Support enterprise deployments with custom domains

The implementation:
- Adds a `base_url` field to the `NetworkConfig` struct
- Modifies each provider to use the configured base URL or fall back to the default if not specified
- Ensures proper URL handling by trimming trailing slashes from configured URLs
- Maintains the API version for Anthropic as a provider property

For Anthropic, the default remains `https://api.anthropic.com`, for OpenAI it's `https://api.openai.com`, and for Cohere it's `https://api.cohere.ai`.