### PR TITLE
feat: add Mistral provider and enhance ToolChoice handling

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -138,6 +138,8 @@ func (bifrost *Bifrost) createProviderFromProviderKey(providerKey schemas.ModelP
 		return providers.NewAzureProvider(config, bifrost.logger)
 	case schemas.Vertex:
 		return providers.NewVertexProvider(config, bifrost.logger)
+	case schemas.Mistral:
+		return providers.NewMistralProvider(config, bifrost.logger), nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", providerKey)
 	}

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -114,7 +114,7 @@ func NewAzureProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*A
 	client := &fasthttp.Client{
 		ReadTimeout:     time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
 		WriteTimeout:    time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
-		MaxConnsPerHost: config.ConcurrencyAndBufferSize.BufferSize,
+		MaxConnsPerHost: config.ConcurrencyAndBufferSize.Concurrency,
 	}
 
 	// Pre-warm response pools

--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -1,0 +1,180 @@
+// Package providers implements various LLM providers and their utility functions.
+// This file contains the Mistral provider implementation.
+package providers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// MistralResponse represents the response structure from the Mistral API.
+type MistralResponse struct {
+	ID      string                          `json:"id"`
+	Object  string                          `json:"object"`
+	Choices []schemas.BifrostResponseChoice `json:"choices"`
+	Model   string                          `json:"model"`
+	Created int                             `json:"created"`
+	Usage   schemas.LLMUsage                `json:"usage"`
+}
+
+// mistralResponsePool provides a pool for Mistral response objects.
+var mistralResponsePool = sync.Pool{
+	New: func() interface{} {
+		return &MistralResponse{}
+	},
+}
+
+// acquireMistralResponse gets a Mistral response from the pool and resets it.
+func acquireMistralResponse() *MistralResponse {
+	resp := mistralResponsePool.Get().(*MistralResponse)
+	*resp = MistralResponse{} // Reset the struct
+	return resp
+}
+
+// releaseMistralResponse returns a Mistral response to the pool.
+func releaseMistralResponse(resp *MistralResponse) {
+	if resp != nil {
+		mistralResponsePool.Put(resp)
+	}
+}
+
+// MistralProvider implements the Provider interface for Mistral's API.
+type MistralProvider struct {
+	logger  schemas.Logger   // Logger for provider operations
+	client  *fasthttp.Client // HTTP client for API requests
+	baseURL string           // Base URL for the provider
+}
+
+// NewMistralProvider creates a new Mistral provider instance.
+// It initializes the HTTP client with the provided configuration and sets up response pools.
+// The client is configured with timeouts, concurrency limits, and optional proxy settings.
+func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *MistralProvider {
+	config.CheckAndSetDefaults()
+
+	client := &fasthttp.Client{
+		ReadTimeout:     time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
+		WriteTimeout:    time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
+		MaxConnsPerHost: config.ConcurrencyAndBufferSize.Concurrency,
+	}
+
+	// Pre-warm response pools
+	for range config.ConcurrencyAndBufferSize.Concurrency {
+		mistralResponsePool.Put(&MistralResponse{})
+		bifrostResponsePool.Put(&schemas.BifrostResponse{})
+	}
+
+	// Configure proxy if provided
+	client = configureProxy(client, config.ProxyConfig, logger)
+
+	baseURL := strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = "https://api.mistral.ai"
+	}
+
+	return &MistralProvider{
+		logger:  logger,
+		client:  client,
+		baseURL: baseURL,
+	}
+}
+
+// GetProviderKey returns the provider identifier for Mistral.
+func (provider *MistralProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.Mistral
+}
+
+// TextCompletion is not supported by the Mistral provider.
+func (provider *MistralProvider) TextCompletion(ctx context.Context, model, key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, &schemas.BifrostError{
+		IsBifrostError: false,
+		Error: schemas.ErrorField{
+			Message: "text completion is not supported by mistral provider",
+		},
+	}
+}
+
+// ChatCompletion performs a chat completion request to the Mistral API.
+func (provider *MistralProvider) ChatCompletion(ctx context.Context, model, key string, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	formattedMessages, preparedParams := prepareOpenAIChatRequest(messages, params)
+
+	requestBody := mergeConfig(map[string]interface{}{
+		"model":    model,
+		"messages": formattedMessages,
+	}, preparedParams)
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderJSONMarshaling,
+				Error:   err,
+			},
+		}
+	}
+
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.SetRequestURI(provider.baseURL + "/v1/chat/completions")
+	req.Header.SetMethod("POST")
+	req.Header.SetContentType("application/json")
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.SetBody(jsonBody)
+
+	// Make request
+	bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug(fmt.Sprintf("error from mistral provider: %s", string(resp.Body())))
+
+		var errorResp map[string]interface{}
+		bifrostErr := handleProviderAPIError(resp, &errorResp)
+		bifrostErr.Error.Message = fmt.Sprintf("Mistral error: %v", errorResp)
+		return nil, bifrostErr
+	}
+
+	responseBody := resp.Body()
+
+	// Pre-allocate response structs from pools
+	response := acquireMistralResponse()
+	defer releaseMistralResponse(response)
+
+	result := acquireBifrostResponse()
+	defer releaseBifrostResponse(result)
+
+	// Use enhanced response handler with pre-allocated response
+	rawResponse, bifrostErr := handleProviderResponse(responseBody, response)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Populate result from response
+	result.ID = response.ID
+	result.Choices = response.Choices
+	result.Object = response.Object
+	result.Usage = response.Usage
+	result.Model = response.Model
+	result.Created = response.Created
+	result.ExtraFields = schemas.BifrostResponseExtraFields{
+		Provider:    schemas.Mistral,
+		RawResponse: rawResponse,
+	}
+
+	return result, nil
+}

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -79,7 +79,7 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 	client := &fasthttp.Client{
 		ReadTimeout:     time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
 		WriteTimeout:    time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
-		MaxConnsPerHost: config.ConcurrencyAndBufferSize.BufferSize,
+		MaxConnsPerHost: config.ConcurrencyAndBufferSize.Concurrency,
 	}
 
 	// Pre-warm response pools

--- a/core/schemas/meta/azure.go
+++ b/core/schemas/meta/azure.go
@@ -11,31 +11,6 @@ type AzureMetaConfig struct {
 	APIVersion  *string           `json:"api_version,omitempty"` // Azure API version to use; defaults to "2024-02-01"
 }
 
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetSecretAccessKey() *string {
-	return nil
-}
-
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetRegion() *string {
-	return nil
-}
-
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetSessionToken() *string {
-	return nil
-}
-
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetARN() *string {
-	return nil
-}
-
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetInferenceProfiles() map[string]string {
-	return nil
-}
-
 // GetEndpoint returns the Azure service endpoint.
 // This specifies the base URL for Azure API requests.
 func (c *AzureMetaConfig) GetEndpoint() *string {
@@ -55,12 +30,11 @@ func (c *AzureMetaConfig) GetAPIVersion() *string {
 	return c.APIVersion
 }
 
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetProjectID() *string {
-	return nil
-}
-
-// This is not used for Azure.
-func (c *AzureMetaConfig) GetAuthCredentials() *string {
-	return nil
-}
+// These are not used for Azure.
+func (c *AzureMetaConfig) GetARN() *string                         { return nil }
+func (c *AzureMetaConfig) GetAuthCredentials() *string             { return nil }
+func (c *AzureMetaConfig) GetInferenceProfiles() map[string]string { return nil }
+func (c *AzureMetaConfig) GetProjectID() *string                   { return nil }
+func (c *AzureMetaConfig) GetRegion() *string                      { return nil }
+func (c *AzureMetaConfig) GetSecretAccessKey() *string             { return nil }
+func (c *AzureMetaConfig) GetSessionToken() *string                { return nil }

--- a/core/schemas/meta/bedrock.go
+++ b/core/schemas/meta/bedrock.go
@@ -43,27 +43,9 @@ func (c *BedrockMetaConfig) GetInferenceProfiles() map[string]string {
 	return c.InferenceProfiles
 }
 
-// This is not used for Bedrock.
-func (c *BedrockMetaConfig) GetEndpoint() *string {
-	return nil
-}
-
-// This is not used for Bedrock.
-func (c *BedrockMetaConfig) GetDeployments() map[string]string {
-	return nil
-}
-
-// This is not used for Bedrock.
-func (c *BedrockMetaConfig) GetAPIVersion() *string {
-	return nil
-}
-
-// This is not used for Bedrock.
-func (c *BedrockMetaConfig) GetProjectID() *string {
-	return nil
-}
-
-// This is not used for Bedrock.
-func (c *BedrockMetaConfig) GetAuthCredentials() *string {
-	return nil
-}
+// These are not used for Bedrock.
+func (c *BedrockMetaConfig) GetAPIVersion() *string            { return nil }
+func (c *BedrockMetaConfig) GetAuthCredentials() *string       { return nil }
+func (c *BedrockMetaConfig) GetDeployments() map[string]string { return nil }
+func (c *BedrockMetaConfig) GetEndpoint() *string              { return nil }
+func (c *BedrockMetaConfig) GetProjectID() *string             { return nil }

--- a/core/schemas/meta/vertex.go
+++ b/core/schemas/meta/vertex.go
@@ -11,45 +11,10 @@ type VertexMetaConfig struct {
 	AuthCredentials string `json:"auth_credentials,omitempty"`
 }
 
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetSecretAccessKey() *string {
-	return nil
-}
-
 // GetRegion returns the Vertex region.
 // This is the region for the Vertex project.
 func (c *VertexMetaConfig) GetRegion() *string {
 	return &c.Region
-}
-
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetSessionToken() *string {
-	return nil
-}
-
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetARN() *string {
-	return nil
-}
-
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetInferenceProfiles() map[string]string {
-	return nil
-}
-
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetEndpoint() *string {
-	return nil
-}
-
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetDeployments() map[string]string {
-	return nil
-}
-
-// This is not used for Vertex.
-func (c *VertexMetaConfig) GetAPIVersion() *string {
-	return nil
 }
 
 // GetProjectID returns the Vertex project ID.
@@ -63,3 +28,12 @@ func (c *VertexMetaConfig) GetProjectID() *string {
 func (c *VertexMetaConfig) GetAuthCredentials() *string {
 	return &c.AuthCredentials
 }
+
+// These are not used for Vertex.
+func (c *VertexMetaConfig) GetAPIVersion() *string                  { return nil }
+func (c *VertexMetaConfig) GetARN() *string                         { return nil }
+func (c *VertexMetaConfig) GetDeployments() map[string]string       { return nil }
+func (c *VertexMetaConfig) GetEndpoint() *string                    { return nil }
+func (c *VertexMetaConfig) GetInferenceProfiles() map[string]string { return nil }
+func (c *VertexMetaConfig) GetSecretAccessKey() *string             { return nil }
+func (c *VertexMetaConfig) GetSessionToken() *string                { return nil }

--- a/core/tests/account.go
+++ b/core/tests/account.go
@@ -27,7 +27,7 @@ type BaseAccount struct{}
 //   - []schemas.SupportedModelProvider: A slice containing the supported provider identifiers
 //   - error: Always returns nil as this implementation doesn't produce errors
 func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
-	return []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic, schemas.Bedrock, schemas.Cohere, schemas.Azure, schemas.Vertex}, nil
+	return []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic, schemas.Bedrock, schemas.Cohere, schemas.Azure, schemas.Vertex, schemas.Mistral}, nil
 }
 
 // GetKeysForProvider returns the API keys and associated models for a given provider.
@@ -86,6 +86,14 @@ func (baseAccount *BaseAccount) GetKeysForProvider(providerKey schemas.ModelProv
 			{
 				Value:  os.Getenv("AZURE_API_KEY"),
 				Models: []string{"gpt-4o"},
+				Weight: 1.0,
+			},
+		}, nil
+	case schemas.Mistral:
+		return []schemas.Key{
+			{
+				Value:  os.Getenv("MISTRAL_API_KEY"),
+				Models: []string{"mistral-large-2411", "ministral-3b-2410", "pixtral-12b-latest"},
 				Weight: 1.0,
 			},
 		}, nil
@@ -198,6 +206,11 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 				Concurrency: 3,
 				BufferSize:  10,
 			},
+		}, nil
+	case schemas.Mistral:
+		return &schemas.ProviderConfig{
+			NetworkConfig:            schemas.DefaultNetworkConfig,
+			ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
 		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", providerKey)

--- a/core/tests/e2e_tool_test.go
+++ b/core/tests/e2e_tool_test.go
@@ -41,9 +41,11 @@ func TestToolCallingEndToEnd(t *testing.T) {
 
 	toolParams := WeatherToolParams
 	toolParams.ToolChoice = &schemas.ToolChoice{
-		Type: schemas.ToolChoiceTypeFunction,
-		Function: schemas.ToolChoiceFunction{
-			Name: "get_weather",
+		ToolChoiceStruct: &schemas.ToolChoiceStruct{
+			Type: schemas.ToolChoiceTypeFunction,
+			Function: schemas.ToolChoiceFunction{
+				Name: "get_weather",
+			},
 		},
 	}
 	toolParams.MaxTokens = bifrost.Ptr(1000)

--- a/core/tests/mistral_test.go
+++ b/core/tests/mistral_test.go
@@ -1,0 +1,36 @@
+// Package tests provides test utilities and configurations for the Bifrost system.
+// It includes test implementations of schemas, mock objects, and helper functions
+// for testing the Bifrost functionality with various AI providers.
+package tests
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestMistral(t *testing.T) {
+	bifrost, err := getBifrost()
+	if err != nil {
+		t.Fatalf("Error initializing bifrost: %v", err)
+		return
+	}
+
+	config := TestConfig{
+		Provider:       schemas.Mistral,
+		TextModel:      "ministral-3b-2410",
+		ChatModel:      "pixtral-12b-latest",
+		SetupText:      false, // Mistral does not support text completion
+		SetupToolCalls: true,
+		SetupImage:     true,
+		SetupBaseImage: true,
+		Fallbacks: []schemas.Fallback{
+			{
+				Provider: schemas.Anthropic,
+				Model:    "claude-3-7-sonnet-20250219",
+			},
+		},
+	}
+
+	SetupAllRequests(bifrost, config)
+}


### PR DESCRIPTION
# Add Mistral Provider Support

This PR adds support for the Mistral AI provider to Bifrost. The implementation includes:

- New `MistralProvider` with chat completion capabilities
- Added Mistral to the list of supported model providers
- Enhanced `ToolChoice` to support both string and struct representations
- Updated Anthropic and Cohere providers to work with the new `ToolChoice` structure
- Added Mistral tests with support for tool calls and image handling
- Refactored provider meta config files to use more concise function declarations

The Mistral implementation follows the same pattern as other providers, using connection pooling and efficient memory management. It supports models like `mistral-large-2411`, `ministral-3b-2410`, and `pixtral-12b-latest`.