### PR TITLE
feat: add support for custom headers in provider requests

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -77,10 +77,10 @@ type AnthropicImageContent struct {
 
 // AnthropicProvider implements the Provider interface for Anthropic's Claude API.
 type AnthropicProvider struct {
-	logger     schemas.Logger   // Logger for provider operations
-	client     *fasthttp.Client // HTTP client for API requests
-	baseURL    string           // Base URL for the provider
-	apiVersion string           // API version for the provider
+	logger        schemas.Logger        // Logger for provider operations
+	client        *fasthttp.Client      // HTTP client for API requests
+	apiVersion    string                // API version for the provider
+	networkConfig schemas.NetworkConfig // Network configuration including extra headers
 }
 
 // anthropicChatResponsePool provides a pool for Anthropic chat response objects.
@@ -147,16 +147,17 @@ func NewAnthropicProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 	// Configure proxy if provided
 	client = configureProxy(client, config.ProxyConfig, logger)
 
-	baseURL := strings.TrimRight(config.NetworkConfig.BaseURL, "/")
-	if baseURL == "" {
-		baseURL = "https://api.anthropic.com"
+	// Set default BaseURL if not provided
+	if config.NetworkConfig.BaseURL == "" {
+		config.NetworkConfig.BaseURL = "https://api.anthropic.com"
 	}
+	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
 	return &AnthropicProvider{
-		logger:     logger,
-		client:     client,
-		baseURL:    baseURL,
-		apiVersion: "2023-06-01",
+		logger:        logger,
+		client:        client,
+		apiVersion:    "2023-06-01",
+		networkConfig: config.NetworkConfig,
 	}
 }
 
@@ -203,11 +204,15 @@ func (provider *AnthropicProvider) completeRequest(ctx context.Context, requestB
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
+	// Set any extra headers from network config
+	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+
 	req.SetRequestURI(url)
 	req.Header.SetMethod("POST")
 	req.Header.SetContentType("application/json")
 	req.Header.Set("x-api-key", key)
 	req.Header.Set("anthropic-version", provider.apiVersion)
+
 	req.SetBody(jsonData)
 
 	// Send the request
@@ -247,7 +252,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, model, ke
 		"prompt": fmt.Sprintf("\n\nHuman: %s\n\nAssistant:", text),
 	}, preparedParams)
 
-	responseBody, err := provider.completeRequest(ctx, requestBody, provider.baseURL+"/v1/complete", key)
+	responseBody, err := provider.completeRequest(ctx, requestBody, provider.networkConfig.BaseURL+"/v1/complete", key)
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +308,7 @@ func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, model, ke
 		"messages": formattedMessages,
 	}, preparedParams)
 
-	responseBody, err := provider.completeRequest(ctx, requestBody, provider.baseURL+"/v1/messages", key)
+	responseBody, err := provider.completeRequest(ctx, requestBody, provider.networkConfig.BaseURL+"/v1/messages", key)
 	if err != nil {
 		return nil, err
 	}

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -96,9 +96,10 @@ func releaseAzureTextResponse(resp *AzureTextResponse) {
 
 // AzureProvider implements the Provider interface for Azure's OpenAI API.
 type AzureProvider struct {
-	logger schemas.Logger     // Logger for provider operations
-	client *fasthttp.Client   // HTTP client for API requests
-	meta   schemas.MetaConfig // Azure-specific configuration
+	logger        schemas.Logger        // Logger for provider operations
+	client        *fasthttp.Client      // HTTP client for API requests
+	meta          schemas.MetaConfig    // Azure-specific configuration
+	networkConfig schemas.NetworkConfig // Network configuration including extra headers
 }
 
 // NewAzureProvider creates a new Azure provider instance.
@@ -128,9 +129,10 @@ func NewAzureProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*A
 	client = configureProxy(client, config.ProxyConfig, logger)
 
 	return &AzureProvider{
-		logger: logger,
-		client: client,
-		meta:   config.MetaConfig,
+		logger:        logger,
+		client:        client,
+		meta:          config.MetaConfig,
+		networkConfig: config.NetworkConfig,
 	}, nil
 }
 
@@ -198,10 +200,14 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
+	// Set any extra headers from network config
+	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+
 	req.SetRequestURI(url)
 	req.Header.SetMethod("POST")
 	req.Header.SetContentType("application/json")
 	req.Header.Set("api-key", key)
+
 	req.SetBody(jsonData)
 
 	// Send the request

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -25,11 +25,12 @@ type VertexError struct {
 	} `json:"error"`
 }
 
-// VertexProvider implements the Provider interface for Vertex's API.
+// VertexProvider implements the Provider interface for Google's Vertex AI API.
 type VertexProvider struct {
-	logger schemas.Logger     // Logger for provider operations
-	client *http.Client       // HTTP client for API requests
-	meta   schemas.MetaConfig // Vertex-specific configuration
+	logger        schemas.Logger        // Logger for provider operations
+	client        *http.Client          // HTTP client for API requests
+	meta          schemas.MetaConfig    // Vertex-specific configuration
+	networkConfig schemas.NetworkConfig // Network configuration including extra headers
 }
 
 // NewVertexProvider creates a new Vertex provider instance.
@@ -64,9 +65,10 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	}
 
 	return &VertexProvider{
-		logger: logger,
-		client: client,
-		meta:   config.MetaConfig,
+		logger:        logger,
+		client:        client,
+		meta:          config.MetaConfig,
+		networkConfig: config.NetworkConfig,
 	}, nil
 }
 
@@ -163,6 +165,10 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key s
 			},
 		}
 	}
+
+	// Set any extra headers from network config
+	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+
 	req.Header.Set("Content-Type", "application/json")
 
 	// Make request

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -22,6 +22,12 @@ Bifrost currently supports the following providers:
 ```golang
 schemas.ProviderConfig{
     NetworkConfig: schemas.NetworkConfig{
+        BaseURL:                        "https://api.custom-deployment.com", // Custom base URL (optional)
+        ExtraHeaders:                   map[string]string{                   // Additional headers (optional)
+            "X-Organization-ID": "org-123",
+            "X-Environment":     "production",
+            "User-Agent":        "MyApp/1.0 Bifrost/1.0",
+        },
         DefaultRequestTimeoutInSeconds: 30,
         MaxRetries:                     2,
         RetryBackoffInitial:            100 * time.Millisecond,
@@ -187,7 +193,97 @@ schemas.ProxyConfig{
    - Configure retry policies
    - Monitor proxy errors
 
-## 6. Provider Development Guidelines
+## 6. Extra Headers Configuration
+
+Bifrost supports custom headers that can be added to all requests sent to a provider. This is useful for enterprise deployments, custom authentication, or provider-specific requirements.
+
+### Configuration
+
+Extra headers are configured in the `NetworkConfig` section:
+
+```golang
+schemas.NetworkConfig{
+    ExtraHeaders: map[string]string{
+        "X-Organization-ID": "org-123",
+        "X-Environment":     "production",
+        "User-Agent":        "MyApp/1.0 Bifrost/1.0",
+        "X-Custom-Auth":     "bearer-token-xyz",
+    },
+}
+```
+
+### JSON Configuration
+
+```json
+{
+  "openai": {
+    "keys": [...],
+    "network_config": {
+      "extra_headers": {
+        "X-Organization-ID": "org-123",
+        "X-Environment": "production",
+        "User-Agent": "MyApp/1.0 Bifrost/1.0"
+      }
+    }
+  }
+}
+```
+
+### Use Cases
+
+1. **Enterprise Deployments**
+
+   - Organization or tenant identification
+   - Custom authentication headers
+   - Environment tracking (dev/staging/prod)
+
+2. **Self-hosted Providers**
+
+   - Custom routing headers for Ollama deployments
+   - Load balancer identification
+   - Custom API versions
+
+3. **Monitoring & Observability**
+
+   - Request source identification
+   - Custom correlation IDs
+   - Application version tracking
+
+4. **Provider-specific Requirements**
+   - Beta feature flags
+   - Custom API versions
+   - Regional preferences
+
+### Header Precedence
+
+Headers configured in `extra_headers` are applied before mandatory provider headers. If there are conflicts (such as duplicate header names), the mandatory headers will take precedence and overwrite or ignore the `extra_headers` values. This ensures that critical provider functionality is not compromised by custom header configurations.
+
+**Important Notes:**
+
+- Authorization headers are automatically filtered out from `extra_headers` for security reasons
+- Provider-specific mandatory headers (like API keys, content-type, etc.) always take precedence
+- Custom headers should not conflict with standard HTTP headers required by the provider
+
+### Best Practices
+
+1. **Security**
+
+   - Use environment variables for sensitive headers
+   - Avoid hardcoding authentication tokens
+   - Review headers regularly for security implications
+
+2. **Performance**
+
+   - Keep header count minimal for performance
+   - Use short, descriptive header names
+   - Monitor header impact on request size
+
+3. **Compliance**
+   - Document custom headers for audit purposes
+   - Ensure headers comply with HTTP standards
+   - Validate header values before deployment
+
+## 7. Provider Development Guidelines
 
 ### 1. Provider Structure
 

--- a/transports/config.example.json
+++ b/transports/config.example.json
@@ -8,6 +8,10 @@
       }
     ],
     "network_config": {
+      "extra_headers": {
+        "X-Organization-ID": "org-123",
+        "X-Environment": "production"
+      },
       "default_request_timeout_in_seconds": 30,
       "max_retries": 1,
       "retry_backoff_initial_ms": 100,


### PR DESCRIPTION
# Add support for custom headers in provider requests

This PR adds the ability to configure custom HTTP headers for all provider requests, enabling enterprise deployments, custom authentication, and provider-specific requirements.

## Changes:

- Added `ExtraHeaders` field to `NetworkConfig` to support custom headers for all providers
- Implemented header application in all provider request methods
- Created utility functions `setExtraHeaders` and `setExtraHeadersHTTP` to standardize header application
- Refactored provider structs to store the entire `NetworkConfig` rather than just the base URL
- Updated documentation with examples and best practices for using custom headers
- Added example configuration in `config.example.json`

## Use cases:

- Organization or tenant identification
- Custom authentication headers
- Environment tracking (dev/staging/prod)
- Request source identification
- Custom correlation IDs
- Provider-specific requirements like beta feature flags

This enhancement maintains backward compatibility while providing more flexibility for enterprise deployments and custom provider configurations.