### PR TITLE
feat: add text block support for Bedrock Anthropic messages

### DIFF
--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -519,6 +519,12 @@ func (provider *BedrockProvider) prepareChatCompletionMessages(messages []schema
 						})
 					} else if msg.Content.ContentBlocks != nil {
 						for _, block := range *msg.Content.ContentBlocks {
+							if block.Text != nil {
+								content = append(content, BedrockAnthropicTextMessage{
+									Type: "text",
+									Text: *block.Text,
+								})
+							}
 							if block.ImageURL != nil {
 								sanitizedURL, _ := SanitizeImageURL(block.ImageURL.URL)
 								urlTypeInfo := ExtractURLTypeInfo(sanitizedURL)


### PR DESCRIPTION
Added support for text content blocks in Bedrock Anthropic chat completions. This change allows the provider to properly handle text blocks within content blocks, ensuring they are included in the message content sent to the Bedrock API.