### PR TITLE
refactor: remove BifrostResponse object pool for improved memory management

### DIFF
--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -68,7 +68,6 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	// Pre-warm response pools
 	for range config.ConcurrencyAndBufferSize.Concurrency {
 		ollamaResponsePool.Put(&OllamaResponse{})
-		bifrostResponsePool.Put(&schemas.BifrostResponse{})
 	}
 
 	// Configure proxy if provided
@@ -163,26 +162,29 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, model, key s
 	response := acquireOllamaResponse()
 	defer releaseOllamaResponse(response)
 
-	result := acquireBifrostResponse()
-	defer releaseBifrostResponse(result)
-
 	// Use enhanced response handler with pre-allocated response
 	rawResponse, bifrostErr := handleProviderResponse(responseBody, response)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
-	// Populate result from response
-	result.ID = response.ID
-	result.Choices = response.Choices
-	result.Object = response.Object
-	result.Usage = response.Usage
-	result.Model = response.Model
-	result.Created = response.Created
-	result.ExtraFields = schemas.BifrostResponseExtraFields{
-		Provider:    schemas.Ollama,
-		RawResponse: rawResponse,
+	// Create final response
+	bifrostResponse := &schemas.BifrostResponse{
+		ID:      response.ID,
+		Object:  response.Object,
+		Choices: response.Choices,
+		Model:   response.Model,
+		Created: response.Created,
+		Usage:   response.Usage,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider:    schemas.Ollama,
+			RawResponse: rawResponse,
+		},
 	}
 
-	return result, nil
+	if params != nil {
+		bifrostResponse.ExtraFields.Params = *params
+	}
+
+	return bifrostResponse, nil
 }

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -85,7 +85,6 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 	// Pre-warm response pools
 	for range config.ConcurrencyAndBufferSize.Concurrency {
 		openAIResponsePool.Put(&OpenAIResponse{})
-		bifrostResponsePool.Put(&schemas.BifrostResponse{})
 	}
 
 	// Configure proxy if provided
@@ -192,30 +191,33 @@ func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, model, key s
 	response := acquireOpenAIResponse()
 	defer releaseOpenAIResponse(response)
 
-	result := acquireBifrostResponse()
-	defer releaseBifrostResponse(result)
-
 	// Use enhanced response handler with pre-allocated response
 	rawResponse, bifrostErr := handleProviderResponse(responseBody, response)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
-	// Populate result from response
-	result.ID = response.ID
-	result.Choices = response.Choices
-	result.Object = response.Object
-	result.Usage = response.Usage
-	result.ServiceTier = response.ServiceTier
-	result.SystemFingerprint = response.SystemFingerprint
-	result.Model = response.Model
-	result.Created = response.Created
-	result.ExtraFields = schemas.BifrostResponseExtraFields{
-		Provider:    schemas.OpenAI,
-		RawResponse: rawResponse,
+	// Create final response
+	bifrostResponse := &schemas.BifrostResponse{
+		ID:                response.ID,
+		Object:            response.Object,
+		Choices:           response.Choices,
+		Model:             response.Model,
+		Created:           response.Created,
+		ServiceTier:       response.ServiceTier,
+		SystemFingerprint: response.SystemFingerprint,
+		Usage:             response.Usage,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider:    schemas.OpenAI,
+			RawResponse: rawResponse,
+		},
 	}
 
-	return result, nil
+	if params != nil {
+		bifrostResponse.ExtraFields.Params = *params
+	}
+
+	return bifrostResponse, nil
 }
 
 func prepareOpenAIChatRequest(messages []schemas.BifrostMessage, params *schemas.ModelParameters) ([]map[string]interface{}, map[string]interface{}) {

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -22,13 +22,6 @@ import (
 	"maps"
 )
 
-// bifrostResponsePool provides a pool for Bifrost response objects.
-var bifrostResponsePool = sync.Pool{
-	New: func() interface{} {
-		return &schemas.BifrostResponse{}
-	},
-}
-
 // dataURIRegex is a precompiled regex for matching data URI format patterns.
 // It matches patterns like: data:image/png;base64,iVBORw0KGgo...
 var dataURIRegex = regexp.MustCompile(`^data:([^;]+)(;base64)?,(.+)$`)
@@ -62,20 +55,6 @@ type URLTypeInfo struct {
 	Type                 ImageContentType
 	MediaType            *string
 	DataURLWithoutPrefix *string // URL without the prefix (eg data:image/png;base64,iVBORw0KGgo...)
-}
-
-// acquireBifrostResponse gets a Bifrost response from the pool and resets it.
-func acquireBifrostResponse() *schemas.BifrostResponse {
-	resp := bifrostResponsePool.Get().(*schemas.BifrostResponse)
-	*resp = schemas.BifrostResponse{} // Reset the struct
-	return resp
-}
-
-// releaseBifrostResponse returns a Bifrost response to the pool.
-func releaseBifrostResponse(resp *schemas.BifrostResponse) {
-	if resp != nil {
-		bifrostResponsePool.Put(resp)
-	}
 }
 
 // mergeConfig merges a default configuration map with custom parameters.

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -61,7 +61,7 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	for range config.ConcurrencyAndBufferSize.Concurrency {
 		openAIResponsePool.Put(&OpenAIResponse{})
 		anthropicChatResponsePool.Put(&AnthropicChatResponse{})
-		bifrostResponsePool.Put(&schemas.BifrostResponse{})
+
 	}
 
 	return &VertexProvider{
@@ -250,15 +250,13 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key s
 		response := acquireAnthropicChatResponse()
 		defer releaseAnthropicChatResponse(response)
 
-		// Create Bifrost response from pool
-		bifrostResponse := acquireBifrostResponse()
-		defer releaseBifrostResponse(bifrostResponse)
-
 		rawResponse, bifrostErr := handleProviderResponse(body, response)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
 
+		// Create final response
+		bifrostResponse := &schemas.BifrostResponse{}
 		var err *schemas.BifrostError
 		bifrostResponse, err = parseAnthropicResponse(response, bifrostResponse)
 		if err != nil {
@@ -270,14 +268,15 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key s
 			RawResponse: rawResponse,
 		}
 
+		if params != nil {
+			bifrostResponse.ExtraFields.Params = *params
+		}
+
 		return bifrostResponse, nil
 	} else {
 		// Pre-allocate response structs from pools
 		response := acquireOpenAIResponse()
 		defer releaseOpenAIResponse(response)
-
-		result := acquireBifrostResponse()
-		defer releaseBifrostResponse(result)
 
 		// Use enhanced response handler with pre-allocated response
 		rawResponse, bifrostErr := handleProviderResponse(body, response)
@@ -285,20 +284,26 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model, key s
 			return nil, bifrostErr
 		}
 
-		// Populate result from response
-		result.ID = response.ID
-		result.Choices = response.Choices
-		result.Object = response.Object
-		result.Usage = response.Usage
-		result.ServiceTier = response.ServiceTier
-		result.SystemFingerprint = response.SystemFingerprint
-		result.Model = response.Model
-		result.Created = response.Created
-		result.ExtraFields = schemas.BifrostResponseExtraFields{
-			Provider:    schemas.Vertex,
-			RawResponse: rawResponse,
+		// Create final response
+		bifrostResponse := &schemas.BifrostResponse{
+			ID:                response.ID,
+			Object:            response.Object,
+			Choices:           response.Choices,
+			Model:             response.Model,
+			Created:           response.Created,
+			ServiceTier:       response.ServiceTier,
+			SystemFingerprint: response.SystemFingerprint,
+			Usage:             response.Usage,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				Provider:    schemas.Vertex,
+				RawResponse: rawResponse,
+			},
 		}
 
-		return result, nil
+		if params != nil {
+			bifrostResponse.ExtraFields.Params = *params
+		}
+
+		return bifrostResponse, nil
 	}
 }

--- a/core/tests/account.go
+++ b/core/tests/account.go
@@ -102,7 +102,7 @@ func (baseAccount *BaseAccount) GetKeysForProvider(providerKey schemas.ModelProv
 		return []schemas.Key{
 			{
 				Value:  os.Getenv("MISTRAL_API_KEY"),
-				Models: []string{"mistral-large-2411", "ministral-3b-2410", "pixtral-12b-latest"},
+				Models: []string{"mistral-large-2411", "mistral-3b-2410", "pixtral-12b-latest"},
 				Weight: 1.0,
 			},
 		}, nil

--- a/core/tests/mistral_test.go
+++ b/core/tests/mistral_test.go
@@ -18,7 +18,7 @@ func TestMistral(t *testing.T) {
 
 	config := TestConfig{
 		Provider:       schemas.Mistral,
-		TextModel:      "ministral-3b-2410",
+		TextModel:      "mistral-3b-2410",
 		ChatModel:      "pixtral-12b-latest",
 		SetupText:      false, // Mistral does not support text completion
 		SetupToolCalls: true,


### PR DESCRIPTION
# Remove BifrostResponse Object Pool

This PR removes the object pooling for BifrostResponse objects across all providers. Instead of using a shared pool, each provider now creates a new BifrostResponse directly when needed. Key changes include:

- Removed `bifrostResponsePool` and its associated acquire/release functions
- Updated all providers to create BifrostResponse objects directly with proper initialization
- Fixed Anthropic tool choice formatting to use the correct structure with a "type" field
- Added support for text blocks in Bedrock Anthropic messages
- Fixed a typo in the Mistral model name (changed "ministral-3b-2410" to "mistral-3b-2410")

This change simplifies the code and eliminates potential issues with shared object pooling while maintaining the performance benefits of provider-specific response object pools.

# 🔧 Fix: Remove Unsafe BifrostResponse Pooling to Prevent Memory Corruption

## Problem Statement

The previous implementation attempted to pool `BifrostResponse` objects with `defer` cleanup, which created a **critical memory safety vulnerability**. This pattern caused immediate memory corruption because:

1. **Dangling Pointer Issue**: Functions returned pooled `BifrostResponse` objects to callers
2. **Immediate Release**: `defer` statements released objects back to the pool immediately after return
3. **Memory Reuse**: Subsequent requests reused the same memory, corrupting data for previous callers
4. **Data Races**: Concurrent requests could simultaneously modify the same pooled memory

## Root Cause Analysis

```go
// PROBLEMATIC PATTERN (removed in this PR)
func (provider *Provider) ChatCompletion(...) (*schemas.BifrostResponse, *schemas.BifrostError) {
    bifrostResponse := acquireBifrostResponse()
    defer releaseBifrostResponse(bifrostResponse)  // ❌ Released immediately after return
    
    // Populate response...
    return bifrostResponse, nil  // ❌ Returning soon-to-be-invalid pointer
}
```

**Memory Lifecycle Issue**:
- Function returns pointer to pooled memory (e.g., `0x1000`)
- `defer` executes immediately, returning `0x1000` to pool
- Next request gets same memory address `0x1000`
- Previous caller's data gets corrupted when new request writes to `0x1000`

## Solution

**Removed BifrostResponse pooling entirely** and reverted to safe heap allocation:

```go
// SAFE PATTERN (current implementation)
func (provider *Provider) ChatCompletion(...) (*schemas.BifrostResponse, *schemas.BifrostError) {
    bifrostResponse := &schemas.BifrostResponse{  // ✅ Independent allocation
        Choices: response.Choices,
        // ... other fields
    }
    return bifrostResponse, nil  // ✅ Caller owns independent memory
}
```

## Why This Fix is Correct

1. **Memory Safety**: Each response gets independent heap allocation
2. **No Data Races**: No shared memory between concurrent requests  
3. **Caller Ownership**: Returned objects are fully owned by the caller
4. **Garbage Collection**: Memory is properly freed when no longer referenced
5. **Architectural Consistency**: Aligns with Go's memory management patterns

## Performance Considerations

**Trade-off Analysis**:
- ❌ **Lost**: Minor allocation optimization from pooling
- ✅ **Gained**: Complete memory safety and data integrity
- ✅ **Gained**: Elimination of potential crashes and data corruption
- ✅ **Gained**: Simplified code without complex pool management

**Impact**: The performance cost of heap allocation is negligible compared to the network I/O and JSON processing already happening in these code paths.

## Key Insight: Pooling Scope Limitations

This fix highlights an important architectural principle:

> **Object pooling works for internal/temporary objects but breaks when objects need to outlive function scope**

- ✅ **Safe to pool**: Internal response objects (e.g., `OpenAIResponse`, `AnthropicResponse`) that are used and released within the same function
- ❌ **Unsafe to pool**: Return values that must remain valid after function exit

## Files Changed

- Removed `BifrostResponse` pooling logic
- Reverted to direct heap allocation in all provider implementations
- Maintained existing pooling for internal response objects (which remains safe)

## Related Issues

This fix resolves potential memory corruption that could manifest as:
- Intermittent data corruption in API responses
- Race conditions in high-concurrency scenarios  
- Unpredictable crashes due to accessing freed memory
- Data leakage between different API requests

---

**Priority**: 🔴 **Critical** - Memory safety fix preventing data corruption

**Type**: 🐛 **Bug Fix** - Removes unsafe memory management pattern

**Breaking Changes**: ❌ **None** - API remains unchanged, only internal implementation