### PR TITLE
feat: add URL-safe base64 decoding for Google GenAI and improve parameter handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *_creds*
 **/venv/
 **/__pycache__/
+**/__pycache__/**

--- a/transports/bifrost-http/integrations/openai/types.go
+++ b/transports/bifrost-http/integrations/openai/types.go
@@ -66,19 +66,19 @@ func (r *OpenAIChatRequest) convertParameters() *schemas.ModelParameters {
 
 	// Direct field mapping
 	if r.MaxTokens != nil {
-		params.ExtraParams["max_tokens"] = *r.MaxTokens
+		params.MaxTokens = r.MaxTokens
 	}
 	if r.Temperature != nil {
-		params.ExtraParams["temperature"] = *r.Temperature
+		params.Temperature = r.Temperature
 	}
 	if r.TopP != nil {
-		params.ExtraParams["top_p"] = *r.TopP
+		params.TopP = r.TopP
 	}
 	if r.PresencePenalty != nil {
-		params.ExtraParams["presence_penalty"] = *r.PresencePenalty
+		params.PresencePenalty = r.PresencePenalty
 	}
 	if r.FrequencyPenalty != nil {
-		params.ExtraParams["frequency_penalty"] = *r.FrequencyPenalty
+		params.FrequencyPenalty = r.FrequencyPenalty
 	}
 	if r.N != nil {
 		params.ExtraParams["n"] = *r.N
@@ -101,16 +101,8 @@ func (r *OpenAIChatRequest) convertParameters() *schemas.ModelParameters {
 	if r.Stream != nil {
 		params.ExtraParams["stream"] = *r.Stream
 	}
-	if r.ResponseFormat != nil {
-		params.ExtraParams["response_format"] = r.ResponseFormat
-	}
 	if r.Seed != nil {
 		params.ExtraParams["seed"] = *r.Seed
-	}
-
-	// Return nil if no parameters were set
-	if len(params.ExtraParams) == 0 {
-		return nil
 	}
 
 	return params


### PR DESCRIPTION
# Add support for URL-safe base64 decoding in Google GenAI requests

This PR adds custom types to handle URL-safe base64 encoding in Google GenAI requests. When clients send base64-encoded image data using URL-safe encoding (replacing '/' with '_' and '+' with '-'), the standard decoder fails. 

The changes include:
- Added `CustomBlob` type with custom JSON unmarshalling to handle URL-safe base64 decoding
- Created `CustomPart` and `CustomContent` types that wrap the GenAI SDK types
- Added conversion methods to transform the custom types back to standard GenAI SDK types
- Updated the OpenAI parameter handling to use the proper parameter fields instead of storing values in ExtraParams

This ensures proper handling of image data in multimodal requests while maintaining compatibility with the existing API.