### PR TITLE
chore: shifted http-transport to core/v1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ bifrost/
 ├── core/                 # Core functionality and shared components
 │   ├── providers/        # Provider-specific implementations
 │   ├── schemas/          # Interfaces and structs used in bifrost
-│   ├── tests/            # Tests to make sure everything is in place
 │   ├── bifrost.go        # Main Bifrost implementation
 │
 ├── docs/                 # Documentations for Bifrost's configurations and contribution guides

--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -341,15 +341,17 @@ func (r *AnthropicMessageRequest) ConvertToBifrostRequest() *schemas.BifrostRequ
 			bifrostReq.Params = &schemas.ModelParameters{}
 		}
 		toolChoice := &schemas.ToolChoice{
-			Type: func() schemas.ToolChoiceType {
-				if r.ToolChoice.Type == "tool" {
-					return schemas.ToolChoiceTypeFunction
-				}
-				return schemas.ToolChoiceType(r.ToolChoice.Type)
-			}(),
+			ToolChoiceStruct: &schemas.ToolChoiceStruct{
+				Type: func() schemas.ToolChoiceType {
+					if r.ToolChoice.Type == "tool" {
+						return schemas.ToolChoiceTypeFunction
+					}
+					return schemas.ToolChoiceType(r.ToolChoice.Type)
+				}(),
+			},
 		}
 		if r.ToolChoice.Type == "tool" && r.ToolChoice.Name != "" {
-			toolChoice.Function = schemas.ToolChoiceFunction{
+			toolChoice.ToolChoiceStruct.Function = schemas.ToolChoiceFunction{
 				Name: r.ToolChoice.Name,
 			}
 		}

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/fasthttp/router v1.5.4
-	github.com/maximhq/bifrost/core v1.1.2
+	github.com/maximhq/bifrost/core v1.1.3
 	github.com/maximhq/bifrost/plugins/maxim v1.0.5
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.62.0

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -67,8 +67,8 @@ github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zt
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/maximhq/bifrost/core v1.1.2 h1:NR5zWD+2dMkj1ySmGqcE7VDJUhkvgrjoMoQikxsdXPU=
-github.com/maximhq/bifrost/core v1.1.2/go.mod h1:8ycaWQ9bjQezoUT/x6a82VmPjoqLzyGglQ0RnnlZjqo=
+github.com/maximhq/bifrost/core v1.1.3 h1:EBxwxqpCNNs3ck44qBwqrTiKGD+1Avyb57fM3/2wTKs=
+github.com/maximhq/bifrost/core v1.1.3/go.mod h1:8ycaWQ9bjQezoUT/x6a82VmPjoqLzyGglQ0RnnlZjqo=
 github.com/maximhq/bifrost/plugins/maxim v1.0.5 h1:K67bqb49X0q07UbNCu1jlmdhmQG+gTdC8sxXN5ok5bY=
 github.com/maximhq/bifrost/plugins/maxim v1.0.5/go.mod h1:Emik7JHo4BIa6kRWDEqOHgFp8M1BQv13bSOepoWw4aw=
 github.com/maximhq/maxim-go v0.1.3 h1:nVzdz3hEjZVxmWHARWIM+Yrn1Jp50qrsK4BA/sz2jj8=


### PR DESCRIPTION
Updated Anthropic integration to use the new ToolChoiceStruct in the Bifrost schema. This change adapts the Anthropic message request conversion to properly structure tool choice parameters according to the latest core library schema (v1.1.3).