### PR TITLE
feat: Support custom authentication for azure provider.

### DIFF
--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -52,6 +52,9 @@ type AzureError struct {
 	} `json:"error"`
 }
 
+// AzureAuthorizationTokenKey is the context key for the Azure authentication token.
+const AzureAuthorizationTokenKey ContextKey = "azure-authorization-token"
+
 // azureTextCompletionResponsePool provides a pool for Azure text completion response objects.
 var azureTextCompletionResponsePool = sync.Pool{
 	New: func() interface{} {
@@ -206,7 +209,11 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 	req.SetRequestURI(url)
 	req.Header.SetMethod("POST")
 	req.Header.SetContentType("application/json")
-	req.Header.Set("api-key", key)
+	if authToken, ok := ctx.Value(AzureAuthorizationTokenKey).(string); ok {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+	} else {
+		req.Header.Set("api-key", key)
+	}
 
 	req.SetBody(jsonData)
 

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -211,6 +211,8 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 	req.Header.SetContentType("application/json")
 	if authToken, ok := ctx.Value(AzureAuthorizationTokenKey).(string); ok {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+		// Ensure api-key is not accidentally present (from extra headers, etc.)
+		req.Header.Del("api-key")
 	} else {
 		req.Header.Set("api-key", key)
 	}

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -57,6 +57,11 @@ type URLTypeInfo struct {
 	DataURLWithoutPrefix *string // URL without the prefix (eg data:image/png;base64,iVBORw0KGgo...)
 }
 
+// ContextKey is a custom type for context keys to prevent key collisions in the context.
+// It provides type safety for context values and ensures that context keys are unique
+// across different packages.
+type ContextKey string
+
 // mergeConfig merges a default configuration map with custom parameters.
 // It creates a new map containing all default values, then overrides them with any custom values.
 // Returns a new map containing the merged configuration.


### PR DESCRIPTION
This enables custom authentication to azure via plugins.

A bit hacky to overload this in the context, but the least disruptive path I could find.

An alternative would be to add a plugin hook to modify the http request, but that felt pretty heavy.

For some additional context, I'm trying to use [azidentity.WorkloadIdentityCredential](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#WorkloadIdentityCredential) + bifrost azure provider. 