### PR TITLE
ci: add Docker build workflow for automated image publishing

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,82 @@
+name: Build and Push HTTP Transport Docker Image
+
+on:
+  push:
+    tags:
+      - "transports/v*" # Triggers on version tags like transports/v1.0.0, transports/v2.1.0, etc.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: docker.io
+  ACCOUNT: maximhq
+  IMAGE_NAME: bifrost
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract and validate metadata
+        id: meta
+        run: |
+          # Extract tag name
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+          # Extract version from tag
+          VERSION=${TAG#transports/v}
+
+          # Validate version format
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Invalid tag format '$TAG'. Expected format: transports/vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+          # Create image tags
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          echo "${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:${TAG}" >> $GITHUB_OUTPUT
+          echo "${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./transports
+          file: ./transports/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=Bifrost LLM Gateway (HTTP)
+            org.opencontainers.image.description=The fastest LLM gateway written in Go. Learn more here: https://github.com/maximhq/bifrost
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.tag }}
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          build-args: |
+            TRANSPORT_TYPE=http
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Image digest
+        run: echo "Image pushed successfully with tags from previous step"


### PR DESCRIPTION
# Add Docker Image Build and Push Workflow

This PR adds a GitHub Actions workflow that automatically builds and pushes Docker images to Docker Hub when transport-specific tags (`transports/v*`) are pushed to the repository.

The workflow:
- Builds the Docker image from the `transports/Dockerfile`
- Tags the image with both the specific tag and `latest`
- Pushes to Docker Hub under the repository name `maximhq/bifrost`
- Includes appropriate OCI metadata labels
- Configures the build with `TRANSPORT_TYPE=http` argument
- Builds for both AMD64 and ARM64 platforms
- Utilizes GitHub Actions cache for faster builds

Required secrets:
- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`