### PR TITLE
feat: docker documentation updates to docker pull

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/venv/
 **/__pycache__/
 **/__pycache__/**
+private.*

--- a/README.md
+++ b/README.md
@@ -59,16 +59,10 @@ Bifrost is an open-source middleware that serves as a unified gateway to various
 
    #### ii) OR Using Docker
 
-   - Download the Dockerfile:
+   - Pull the Docker image:
 
      ```bash
-     curl -L -o Dockerfile https://raw.githubusercontent.com/maximhq/bifrost/main/transports/Dockerfile
-     ```
-
-   - Build the Docker image:
-
-     ```bash
-     docker build -t bifrost-transports .
+     docker pull maximhq/bifrost
      ```
 
    - Run the Docker container:
@@ -78,7 +72,7 @@ Bifrost is an open-source middleware that serves as a unified gateway to various
        -v $(pwd)/config.json:/app/config/config.json \
        -e OPENAI_API_KEY \
        -e ANTHROPIC_API_KEY \
-       bifrost-transports
+       maximhq/bifrost
      ```
 
      Note: Ensure you mount your config file and add all environment variables referenced in your `config.json` file.

--- a/transports/README.md
+++ b/transports/README.md
@@ -71,27 +71,21 @@ In this example, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` refer to keys in the e
 
 ### Docker Setup
 
-1. Download the Dockerfile:
+1. Pull the Docker image:
 
    ```bash
-   curl -L -o Dockerfile https://raw.githubusercontent.com/maximhq/bifrost/main/transports/Dockerfile
+   docker pull maximhq/bifrost
    ```
 
-2. Build the Docker image:
+2. Run the Docker container:
 
    ```bash
-   docker build -t bifrost-transports .
+   docker run -p 8080:8080 \
+     -v $(pwd)/config.json:/app/config/config.json \
+     -e OPENAI_API_KEY \
+     -e ANTHROPIC_API_KEY \
+     maximhq/bifrost
    ```
-
-3. Run the Docker container:
-
-```bash
-docker run -p 8080:8080 \
-  -v $(pwd)/config.json:/app/config/config.json \
-  -e OPENAI_API_KEY \
-  -e ANTHROPIC_API_KEY \
-  bifrost-transports
-```
 
 Note: In the command above, `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` are just example environment variables.
 Ensure you mount your config file and use the `-e` flag to pass all environment variables referenced in your `config.json` that are prefixed with `env.` to the container. This ensures Docker sets them correctly inside the container.
@@ -101,12 +95,10 @@ Example usage: Suppose your config.json only contains one environment variable p
 ```bash
 export COHERE_API_KEY=your_cohere_api_key
 
-docker build -t bifrost-transports .
-
 docker run -p 8080:8080 \
   -v $(pwd)/config.example.json:/app/config/config.json \
   -e COHERE_API_KEY \
-  bifrost-transports
+  maximhq/bifrost
 ```
 
 You can also set runtime environment variables for configuration:


### PR DESCRIPTION
# Update Docker image configuration and documentation

This PR updates the Docker build workflow and documentation to use a public Docker image:

- Changed Docker image name from `bifrost-transport` to `maximeng/bifrost`
- Updated Docker Hub credentials environment variable names
- Added multi-architecture support (linux/amd64, linux/arm64) using QEMU
- Updated README files to reference the public Docker image instead of building locally
- Added `private.*` to .gitignore

The documentation now instructs users to pull the pre-built image from Docker Hub rather than building it themselves, simplifying the setup process.