### PR TITLE
feat: add workflow to auto-update transport dependencies on core releases

### DIFF
--- a/.github/workflows/transport-dependency-update.yml
+++ b/.github/workflows/transport-dependency-update.yml
@@ -1,0 +1,114 @@
+name: Transport Dependency Update
+
+on:
+  push:
+    tags:
+      - "core/v*" # Triggers on tags that start with core/v
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-transport:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.24.1"
+
+      - name: Get and validate core version from tag
+        id: get_version
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/core/}
+
+          # Validate core tag format
+          if ! echo "$TAG_NAME" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Invalid core tag format 'core/$TAG_NAME'. Expected format: core/vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+
+          echo "version=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "Core version: ${TAG_NAME}"
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get latest transport version and increment
+        id: next_version
+        run: |
+          # Get the latest transport tag
+          LATEST_TAG=$(git tag -l 'transport/v*' | sort -V | tail -n 1)
+          if [ -z "$LATEST_TAG" ]; then
+            # If no transport tag exists, start with v0.1.0
+            NEW_TAG="transport/v0.1.0"
+          else
+            # Extract version numbers
+            VERSION=${LATEST_TAG#transport/v}
+            
+            # Validate version format
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "Error: Invalid tag format '$LATEST_TAG'. Expected format: transport/vMAJOR.MINOR.PATCH"
+              exit 1
+            fi
+            
+            MAJOR=$(echo $VERSION | cut -d. -f1)
+            MINOR=$(echo $VERSION | cut -d. -f2)
+            PATCH=$(echo $VERSION | cut -d. -f3)
+            
+            # Increment patch version
+            NEW_PATCH=$((PATCH + 1))
+            NEW_TAG="transport/v${MAJOR}.${MINOR}.${NEW_PATCH}"
+          fi
+
+          # Check if the new tag already exists
+          if git tag --list | grep -q "^${NEW_TAG}$"; then
+            echo "Error: Tag '$NEW_TAG' already exists!"
+            exit 1
+          fi
+
+          echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
+          echo "New transport version will be: ${NEW_TAG}"
+
+      - name: Update transport dependency
+        working-directory: transports
+        run: |
+          echo "Updating core dependency to ${{ steps.get_version.outputs.version }}"
+          if ! go get github.com/maximhq/bifrost/core@${{ steps.get_version.outputs.version }}; then
+            echo "Error: Failed to fetch core version ${{ steps.get_version.outputs.version }}"
+            exit 1
+          fi
+          go mod tidy
+
+      - name: Build transport
+        working-directory: transports
+        run: go build ./...
+
+      - name: Commit and push changes
+        run: |
+          git add transports/go.mod transports/go.sum
+          if git diff --staged --quiet; then
+            echo "No changes to commit. Dependency is already up to date."
+            exit 0
+          fi
+
+          git commit -m "chore: update transport's core dependency to ${{ steps.get_version.outputs.version }}"
+          git push
+
+      - name: Create and push transport tag
+        run: |
+          git tag ${{ steps.next_version.outputs.new_tag }}
+          git push origin ${{ steps.next_version.outputs.new_tag }}

--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ Bifrost is an open-source middleware that serves as a unified gateway to various
    }
    ```
 
-2. **Setup your Environment**: Add your environment variable to the session.
+2. **Set Up Your Environment**: Add your environment variable to the session.
 
    ```bash
    export OPENAI_API_KEY=your_openai_api_key
    export ANTHROPIC_API_KEY=your_anthropic_api_key
    ```
 
-   Note: Make sure to add all the variables stated in your `config.json` file.
+   Note: Ensure you add all variables stated in your `config.json` file.
 
 3. **Start the Bifrost HTTP Server**:
 
-   You have two options to run the server, either using Go Binary or a Docker setup if go is not installed.
+   You can run the server using either a Go Binary or Docker (if Go is not installed).
 
    #### i) Using Go Binary
 
@@ -51,7 +51,7 @@ Bifrost is an open-source middleware that serves as a unified gateway to various
      go install github.com/maximhq/bifrost/transports/bifrost-http@latest
      ```
 
-   - Run the server (make sure Go is set in your PATH):
+   - Run the server (ensure Go is in your PATH):
 
      ```bash
      bifrost-http -config config.json -port 8080 -pool-size 300
@@ -92,11 +92,11 @@ Bifrost is an open-source middleware that serves as a unified gateway to various
    }'
    ```
 
-For additional configurations in HTTP server setup, please read [this](https://github.com/maximhq/bifrost/blob/main/transports/README.md).
+For additional HTTP server configuration options, read [this](https://github.com/maximhq/bifrost/blob/main/transports/README.md).
 
 ### B. Using Bifrost as a Go Package
 
-1. **Implement Your Account Interface**: You first need to create your account which follows [Bifrost's account interface](https://github.com/maximhq/bifrost/blob/main/core/schemas/account.go).
+1. **Implement Your Account Interface**: First, create an account that follows [Bifrost's account interface](https://github.com/maximhq/bifrost/blob/main/core/schemas/account.go).
 
    ```golang
    type BaseAccount struct{}
@@ -122,7 +122,7 @@ For additional configurations in HTTP server setup, please read [this](https://g
    }
    ```
 
-   Bifrost uses these methods to get all the keys and configurations it needs to call the providers. You can check the [Additional Configurations](#additional-configurations) section for further customizations.
+   Bifrost uses these methods to get all the keys and configurations it needs to call the providers. See the [Additional Configurations](#additional-configurations) section for additional customization options.
 
 2. **Initialize Bifrost**: Set up the Bifrost instance by providing your account implementation.
 
@@ -154,7 +154,7 @@ For additional configurations in HTTP server setup, please read [this](https://g
      )
    ```
 
-   you can add model parameters by passing them in `Params: &schemas.ModelParameters{...yourParams}` in ChatCompletionRequest.
+   You can add model parameters by including `Params: &schemas.ModelParameters{...yourParams}` in ChatCompletionRequest.
 
 ## 📑 Table of Contents
 

--- a/plugins/maxim/README.md
+++ b/plugins/maxim/README.md
@@ -72,7 +72,7 @@ This plugin integrates the Maxim SDK into Bifrost, enabling seamless observabili
 
 ## Additional Features
 
-The plugin also supports custom `session-id`, `trace-id` and `generation-id` if the user wish to log the generations to their custom logging implementation. To use it, just pass your trace id to the passed request context with the key `trace-id`, and similarly to `generation-id` for generation id. In these cases no new trace/generation is created and the output is just logged to your provided generation. Likewise, `session-id` can be used to add the traces to your generated session.
+The plugin also supports custom `session-id`, `trace-id` and `generation-id` if the user wishes to log the generations to their custom logging implementation. To use it, pass your trace ID to the request context with the key `trace-id`, and similarly `generation-id` for generation ID. In these cases, no new trace/generation is created and the output is logged to your provided generation. Likewise, `session-id` can be used to add the traces to your generated session.
 
 e.g.
 
@@ -88,7 +88,7 @@ e.g.
             }, ctx)
 ```
 
-HTTP transport offers out of the box support for this feature(when maxim plugin is used), just pass `x-bf-maxim-session-id`, `x-bf-maxim-trace-id`, or `x-bf-maxim-generation-id` header with your request to use this feature.
+HTTP transport offers out-of-the-box support for this feature (when the Maxim plugin is used). Pass `x-bf-maxim-session-id`, `x-bf-maxim-trace-id`, or `x-bf-maxim-generation-id` headers with your request to use this feature.
 
 ## Testing Maxim Logger
 

--- a/tests/core-providers/README.md
+++ b/tests/core-providers/README.md
@@ -17,7 +17,7 @@ This directory contains comprehensive tests for all Bifrost AI providers, ensuri
 
 ### Development with Local Bifrost Core
 
-If you're working with a forked or local version of bifrost-core and want to test your changes:
+To test changes with a forked or local version of bifrost-core:
 
 1. **Uncomment the replace directive** in `tests/core-providers/go.mod`:
 
@@ -39,11 +39,11 @@ If you're working with a forked or local version of bifrost-core and want to tes
    go test -v ./tests/core-providers/
    ```
 
-⚠️ **Important**: Make sure your local `../../core` directory contains your bifrost-core implementation. The path should be relative to the `tests/core-providers` directory.
+⚠️ **Important**: Ensure your local `../../core` directory contains your bifrost-core implementation. The path should be relative to the `tests/core-providers` directory.
 
 ### Prerequisites
 
-Set up your environment variables for the providers you want to test:
+Set up environment variables for the providers you want to test:
 
 ```bash
 # OpenAI

--- a/transports/README.md
+++ b/transports/README.md
@@ -122,7 +122,7 @@ If you wish to run Bifrost in your Go environment, follow these steps:
    go install github.com/maximhq/bifrost/transports/bifrost-http@latest
    ```
 
-2. Run your binary (make sure Go is set in your PATH):
+2. Run your binary (ensure Go is in your PATH):
 
 ```bash
 bifrost-http -config config.json -port 8080 -pool-size 300
@@ -140,7 +140,7 @@ Ensure that:
 ### Text Completions
 
 ```bash
-# Make sure to setup anthropic and claude-2.1 in your config.json
+# Make sure to set up Anthropic and claude-2.1 in your config.json
 curl -X POST http://localhost:8080/v1/text/completions \
   -H "Content-Type: application/json" \
   -d '{
@@ -179,7 +179,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 ### Prometheus Support
 
-HTTP transport supports Prometheus out of the box. By default all the metrics are available at `/metrics` endpoint. It providers metrics for httpRequestsTotal, httpRequestDuration, httpRequestSizeBytes, httpResponseSizeBytes, bifrostUpstreamRequestsTotal, and bifrostUpstreamLatencySeconds. To add custom labels to these metrics using can pass a flag of `-prometheus-labels` while running the http transport.
+HTTP transport supports Prometheus out of the box. By default, all metrics are available at the `/metrics` endpoint. It provides metrics for httpRequestsTotal, httpRequestDuration, httpRequestSizeBytes, httpResponseSizeBytes, bifrostUpstreamRequestsTotal, and bifrostUpstreamLatencySeconds. To add custom labels to these metrics, pass the `-prometheus-labels` flag while running the HTTP transport.
 
 e.g., `-prometheus-labels team-id,task-id,location`
 
@@ -191,7 +191,7 @@ You can explore the [available plugins](https://github.com/maximhq/bifrost/tree/
 
 e.g., `-plugins maxim`
 
-Note: Please check plugin specific documentations (github.com/maximhq/bifrost/tree/main/plugins/{plugin_name}) for more nuanced control and any additional setup.
+Note: Check plugin-specific documentation (github.com/maximhq/bifrost/tree/main/plugins/{plugin_name}) for more granular control and additional setup requirements.
 
 ### Fallbacks
 


### PR DESCRIPTION
# Add Automated Transport Dependency Update Workflow

This PR adds a new GitHub Actions workflow that automatically updates the transport module's dependency on the core module whenever a new core version is released.

The workflow:
- Triggers when a new tag with the format `core/v*` is pushed
- Extracts the core version from the tag
- Updates the transport module's dependency to the new core version
- Increments the transport version (patch level)
- Creates and pushes a new transport tag with the format `transport/v*`

This automation ensures that transport modules stay in sync with core releases without manual intervention.