### PR TITLE
adds explicit gopath

### DIFF
--- a/.github/workflows/transport-ci.yml
+++ b/.github/workflows/transport-ci.yml
@@ -2,9 +2,11 @@ name: Transport CI - Dependency Update and Docker Build
 
 on:
   push:
-    tags:
-      - "core/v*" # Triggers dependency update
-      - "transports/v*" # Triggers docker build (for manual tags)
+    branches:
+      - test/gh-actions
+    # tags:
+    #   - "core/v*" # Triggers dependency update
+    #   - "transports/v*" # Triggers docker build (for manual tags)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -1,7 +1,7 @@
 # --- First Stage: Builder image ---
 FROM golang:1.24-alpine AS builder
 WORKDIR /app
-
+ENV GOPATH=/go
 # Install dependencies in a single layer
 RUN apk add --no-cache upx
 


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow to trigger on test branch and set GOPATH in Docker build.

### What changed?

- Modified `.github/workflows/transport-ci.yml` to trigger on the `test/gh-actions` branch instead of tags
- Commented out the tag triggers for dependency updates and docker builds
- Added `ENV GOPATH=/go` to the transports Dockerfile to explicitly set the Go path

### How to test?

1. Push changes to the `test/gh-actions` branch
2. Verify that the Transport CI workflow triggers correctly
3. Confirm that Docker builds complete successfully with the explicit GOPATH set

### Why make this change?

The changes allow for testing GitHub Actions workflows on a test branch without requiring tag creation. Setting the GOPATH explicitly in the Dockerfile ensures consistent build environments across different systems and CI platforms.