### PR TITLE
fixes github actions trigger

### DIFF
--- a/.github/workflows/transport-ci.yml
+++ b/.github/workflows/transport-ci.yml
@@ -2,11 +2,9 @@ name: Transport CI - Dependency Update and Docker Build
 
 on:
   push:
-    branches:
-      - test/gh-actions
-    # tags:
-    #   - "core/v*" # Triggers dependency update
-    #   - "transports/v*" # Triggers docker build (for manual tags)
+    tags:
+      - "core/v*" # Triggers dependency update
+      - "transports/v*" # Triggers docker build (for manual tags)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### TL;DR

Updated GitHub Actions workflow to trigger on tag pushes instead of branch pushes.

### What changed?

Modified the `transport-ci.yml` workflow to:
- Remove the branch trigger for `test/gh-actions`
- Uncomment and enable tag-based triggers for `core/v*` and `transports/v*`

### How to test?

1. Push a tag with the format `core/v*` to verify dependency update is triggered
2. Push a tag with the format `transports/v*` to verify docker build is triggered

### Why make this change?

This change moves the workflow from a testing phase to production usage, ensuring that the CI pipeline only runs when specific version tags are pushed rather than on branch commits. This provides better control over when dependency updates and Docker builds are triggered.