### PR TITLE
ci: ensure Docker build runs even when core dep update is skipped

### DIFF
--- a/.github/workflows/transport-ci.yml
+++ b/.github/workflows/transport-ci.yml
@@ -122,7 +122,7 @@ jobs:
           git push origin ${{ steps.next_version.outputs.new_tag }}
 
   build-and-push-docker:
-    if: startsWith(github.ref, 'refs/tags/transports/v') || needs.update-transport-dependency.result == 'success'
+    if: always() && needs.update-transport-dependency.result != 'failure' && (startsWith(github.ref, 'refs/tags/transports/v') || needs.update-transport-dependency.result == 'success')
     needs: [update-transport-dependency]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Fixed conditional logic for Docker build job to ensure it runs when the dependency update job is skipped but a valid tag exists. The updated condition checks for either a successful dependency update OR a combination of a skipped update with a valid transport version tag.