### PR TITLE
feat: add environment variable support for MCP connection strings

### DIFF
--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -155,6 +155,10 @@ func main() {
 		log.Printf("warning: failed to read environment variables: %v", err)
 	}
 
+	if err := config.ReadMCPKeys(); err != nil {
+		log.Printf("warning: failed to read MCP environment variables: %v", err)
+	}
+
 	loadedPlugins := []schemas.Plugin{}
 
 	for _, plugin := range pluginsToLoad {


### PR DESCRIPTION
# Add environment variable support for MCP connection strings

This PR adds functionality to read environment variables for MCP connection strings in the Bifrost HTTP transport. The implementation:

- Adds a new `ReadMCPKeys()` method to the `BifrostHTTPConfig` struct
- Allows connection strings prefixed with "env." to be replaced with values from environment variables
- Processes each MCP client configuration and updates connection strings accordingly
- Returns appropriate error messages when required environment variables are missing
- Integrates the new functionality in the main application flow

This enhancement provides a more secure way to handle sensitive connection information by keeping it out of configuration files.