### PR TITLE
ci: fix Docker tag format and add version pinning for transport builds

### DIFF
--- a/.github/workflows/transport-ci.yml
+++ b/.github/workflows/transport-ci.yml
@@ -145,18 +145,22 @@ jobs:
 
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
-          # Extract version from tag
-          VERSION=${TAG#transports/v}
+          # Extract version from tag (remove transports/ prefix)
+          VERSION=${TAG#transports/}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+          # Extract numeric version for validation
+          NUMERIC_VERSION=${VERSION#v}
 
           # Validate version format
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          if ! echo "$NUMERIC_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Error: Invalid tag format '$TAG'. Expected format: transports/vMAJOR.MINOR.PATCH"
             exit 1
           fi
 
           # Create image tags (Docker tags cannot contain slashes, so use version only)
           echo "tags<<EOF" >> $GITHUB_OUTPUT
-          echo "${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}" >> $GITHUB_OUTPUT
+          echo "${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:${VERSION}" >> $GITHUB_OUTPUT
           echo "${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
@@ -192,6 +196,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
           build-args: |
             TRANSPORT_TYPE=http
+            TAG_VERSION=${{ steps.meta.outputs.version }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -8,12 +8,13 @@ RUN apk add --no-cache upx
 # Set environment for static build
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
-# Define build-time variable for transport type
+# Define build-time variables
 ARG TRANSPORT_TYPE=http
+ARG TAG_VERSION=latest
 
-# Initialize go module and get bifrost-http
+# Initialize go module and get bifrost with specified tag
 RUN go mod init bifrost-build && \
-    go get github.com/maximhq/bifrost/transports/bifrost-${TRANSPORT_TYPE}@latest
+    go get github.com/maximhq/bifrost/transports/bifrost-${TRANSPORT_TYPE}@${TAG_VERSION}
 
 # Build the binary locally
 RUN go build \


### PR DESCRIPTION
# Fix Docker image versioning and add tag-based dependency resolution

This PR improves the Docker image build process for transports in two key ways:

1. Fixes the Docker image tag format by:
   - Preserving the 'v' prefix in version numbers
   - Properly extracting the version from tags (removing only the 'transports/' prefix)
   - Adding a separate step to extract the numeric version for validation

2. Adds tag-based dependency resolution:
   - Introduces a new `TAG_VERSION` build argument to the Dockerfile
   - Passes the extracted version from the GitHub workflow to the Dockerfile
   - Updates the Go dependency resolution to use the specific tagged version instead of always using 'latest'

These changes ensure that when building a specific transport version, the Docker image will use the matching tagged version of the bifrost dependency rather than always pulling the latest version.