### PR TITLE
feat: add multi-provider model syntax support across integrations

### DIFF
--- a/docs/contributing/provider.md
+++ b/docs/contributing/provider.md
@@ -595,6 +595,51 @@ Before submitting your provider implementation:
 - [ ] **Key Handling** - Proper API key requirement configuration
 - [ ] **Configuration** - Standard provider configuration support
 
+### **HTTP Transport Integration**
+
+- [ ] **Provider Recognition** - Added to `validProviders` map in `transports/bifrost-http/integrations/utils.go`
+- [ ] **Model Patterns** - Added patterns to appropriate `is*Model()` functions in utils.go
+- [ ] **Transport Tests** - All tests pass in `tests/transports-integrations/` directory
+- [ ] **Multi-Provider Support** - Verified `ParseModelString` correctly handles your provider prefix
+
+**Required Updates in `utils.go`:**
+
+```go
+// 1. Add to validProviders map
+var validProviders = map[schemas.ModelProvider]bool{
+    // ... existing providers
+    schemas.YourProvider: true,  // Add this line
+}
+
+// 2. Add model patterns to appropriate function
+func isYourProviderModel(model string) bool {
+    yourProviderPatterns := []string{
+        "your-provider-pattern", "your-model-prefix", "yourprovider/",
+    }
+    return matchesAnyPattern(model, yourProviderPatterns)
+}
+
+// 3. Add pattern check to GetProviderFromModel
+func GetProviderFromModel(model string) schemas.ModelProvider {
+    // ... existing checks
+
+    // Your Provider Models
+    if isYourProviderModel(modelLower) {
+        return schemas.YourProvider
+    }
+
+    // ... rest of function
+}
+```
+
+**Test Your Integration:**
+
+```bash
+# Run HTTP transport integration tests
+cd tests/transports-integrations
+python -m pytest tests/integrations/ -v
+```
+
 ---
 
 ## 🚀 **Advanced Features**

--- a/docs/usage/http-transport/integrations/README.md
+++ b/docs/usage/http-transport/integrations/README.md
@@ -64,7 +64,7 @@ client = openai.OpenAI(
 
 Your existing code gets these features automatically:
 
-- **Multi-provider fallbacks** - Automatic failover between providers
+- **Multi-provider fallbacks** - Automatic failover between multiple providers, regardless of the SDK you use
 - **Load balancing** - Distribute requests across multiple API keys
 - **Rate limiting** - Built-in request throttling and queuing
 - **Tool integration** - MCP tools available in all requests
@@ -157,6 +157,99 @@ export ANTHROPIC_BASE_URL="https://api.anthropic.com"
 # Production - via Bifrost
 export OPENAI_BASE_URL="http://bifrost:8080/openai"
 export ANTHROPIC_BASE_URL="http://bifrost:8080/anthropic"
+```
+
+---
+
+## 🌐 Multi-Provider Usage
+
+### **Provider-Prefixed Models**
+
+Use multiple providers seamlessly by prefixing model names with the provider:
+
+```python
+import openai
+
+# Single client, multiple providers
+client = openai.OpenAI(
+    base_url="http://localhost:8080/openai",
+    api_key="dummy"  # API keys configured in Bifrost
+)
+
+# OpenAI models
+response1 = client.chat.completions.create(
+    model="gpt-4o-mini", # (default OpenAI since it's OpenAI's SDK)
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Anthropic models using OpenAI SDK format
+response2 = client.chat.completions.create(
+    model="anthropic/claude-3-sonnet-20240229",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Google Vertex models
+response3 = client.chat.completions.create(
+    model="vertex/gemini-pro",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Azure OpenAI models
+response4 = client.chat.completions.create(
+    model="azure/gpt-4o",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Local Ollama models
+response5 = client.chat.completions.create(
+    model="ollama/llama3.1:8b",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+### **Provider-Specific Optimization**
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:8080/openai",
+    api_key="dummy"
+)
+
+def choose_optimal_model(task_type: str, content: str):
+    """Choose the best model based on task requirements"""
+
+    if task_type == "code":
+        # OpenAI excels at code generation
+        return "openai/gpt-4o-mini"
+
+    elif task_type == "creative":
+        # Anthropic is great for creative writing
+        return "anthropic/claude-3-sonnet-20240229"
+
+    elif task_type == "analysis" and len(content) > 10000:
+        # Anthropic has larger context windows
+        return "anthropic/claude-3-sonnet-20240229"
+
+    elif task_type == "multilingual":
+        # Google models excel at multilingual tasks
+        return "vertex/gemini-pro"
+
+    else:
+        # Default to fastest/cheapest
+        return "openai/gpt-4o-mini"
+
+# Usage examples
+code_response = client.chat.completions.create(
+    model=choose_optimal_model("code", ""),
+    messages=[{"role": "user", "content": "Write a Python web scraper"}]
+)
+
+creative_response = client.chat.completions.create(
+    model=choose_optimal_model("creative", ""),
+    messages=[{"role": "user", "content": "Write a short story about AI"}]
+)
 ```
 
 ---

--- a/docs/usage/http-transport/integrations/anthropic-compatible.md
+++ b/docs/usage/http-transport/integrations/anthropic-compatible.md
@@ -542,6 +542,42 @@ test_tool_use()
 
 ---
 
+## 🌐 Multi-Provider Support
+
+Use multiple providers with Anthropic SDK format by prefixing model names:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="http://localhost:8080/anthropic",
+    api_key="dummy"  # API keys configured in Bifrost
+)
+
+# Anthropic models (default)
+response1 = client.messages.create(
+    model="claude-3-sonnet-20240229",
+    max_tokens=100,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# OpenAI models via Anthropic SDK
+response2 = client.messages.create(
+    model="openai/gpt-4o-mini",
+    max_tokens=100,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Vertex models via Anthropic SDK
+response3 = client.messages.create(
+    model="vertex/gemini-pro",
+    max_tokens=100,
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+---
+
 ## 🔧 Configuration
 
 ### **Bifrost Config for Anthropic**

--- a/docs/usage/http-transport/integrations/genai-compatible.md
+++ b/docs/usage/http-transport/integrations/genai-compatible.md
@@ -493,6 +493,33 @@ test_function_calling()
 
 ---
 
+## 🌐 Multi-Provider Support
+
+Use multiple providers with Google GenAI SDK format by prefixing model names:
+
+```python
+import google.generativeai as genai
+
+genai.configure(
+    api_key="dummy",  # API keys configured in Bifrost
+    client_options={"api_endpoint": "http://localhost:8080/genai"}
+)
+
+# Google models (default)
+model1 = genai.GenerativeModel('gemini-pro')
+response1 = model1.generate_content("Hello!")
+
+# OpenAI models via GenAI SDK
+model2 = genai.GenerativeModel('openai/gpt-4o-mini')
+response2 = model2.generate_content("Hello!")
+
+# Anthropic models via GenAI SDK
+model3 = genai.GenerativeModel('anthropic/claude-3-sonnet-20240229')
+response3 = model3.generate_content("Hello!")
+```
+
+---
+
 ## 🔧 Configuration
 
 ### **Bifrost Config for Google GenAI**

--- a/docs/usage/http-transport/integrations/openai-compatible.md
+++ b/docs/usage/http-transport/integrations/openai-compatible.md
@@ -467,6 +467,39 @@ benchmark_response_time(openai_client, "Direct OpenAI")
 
 ---
 
+## 🌐 Multi-Provider Support
+
+Use multiple providers with OpenAI SDK format by prefixing model names:
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:8080/openai",
+    api_key="dummy"  # API keys configured in Bifrost
+)
+
+# OpenAI models (default)
+response1 = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Anthropic models via OpenAI SDK
+response2 = client.chat.completions.create(
+    model="anthropic/claude-3-sonnet-20240229",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+
+# Vertex models via OpenAI SDK
+response3 = client.chat.completions.create(
+    model="vertex/gemini-pro",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+---
+
 ## 🔧 Configuration
 
 ### **Bifrost Config for OpenAI**

--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -6,6 +6,7 @@ import (
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 )
 
 var fnTypePtr = bifrost.Ptr(string(schemas.ToolChoiceTypeFunction))
@@ -133,9 +134,11 @@ func (mc *AnthropicContent) UnmarshalJSON(data []byte) error {
 
 // ConvertToBifrostRequest converts an Anthropic messages request to Bifrost format
 func (r *AnthropicMessageRequest) ConvertToBifrostRequest() *schemas.BifrostRequest {
+	provider, model := integrations.ParseModelString(r.Model, schemas.Anthropic)
+
 	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Anthropic,
-		Model:    r.Model,
+		Provider: provider,
+		Model:    model,
 	}
 
 	messages := []schemas.BifrostMessage{}

--- a/transports/bifrost-http/integrations/genai/types.go
+++ b/transports/bifrost-http/integrations/genai/types.go
@@ -8,6 +8,7 @@ import (
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 	genai_sdk "google.golang.org/genai"
 )
 
@@ -136,9 +137,11 @@ type GeminiChatRequest struct {
 }
 
 func (r *GeminiChatRequest) ConvertToBifrostRequest() *schemas.BifrostRequest {
+	provider, model := integrations.ParseModelString(r.Model, schemas.Vertex)
+
 	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Vertex,
-		Model:    r.Model,
+		Provider: provider,
+		Model:    model,
 		Input: schemas.RequestInput{
 			ChatCompletionInput: &[]schemas.BifrostMessage{},
 		},

--- a/transports/bifrost-http/integrations/openai/types.go
+++ b/transports/bifrost-http/integrations/openai/types.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 )
 
 // OpenAIChatRequest represents an OpenAI chat completion request
@@ -40,9 +41,11 @@ type OpenAIChatResponse struct {
 
 // ConvertToBifrostRequest converts an OpenAI chat request to Bifrost format
 func (r *OpenAIChatRequest) ConvertToBifrostRequest() *schemas.BifrostRequest {
+	provider, model := integrations.ParseModelString(r.Model, schemas.OpenAI)
+
 	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.OpenAI,
-		Model:    r.Model,
+		Provider: provider,
+		Model:    model,
 		Input: schemas.RequestInput{
 			ChatCompletionInput: &r.Messages,
 		},


### PR DESCRIPTION
# Add multi-provider model syntax support to HTTP integrations

This PR adds support for multi-provider model syntax across all HTTP integrations, allowing users to access any provider through any SDK by prefixing model names with the provider.

## Key Changes:

- Added `ParseModelString` utility function that extracts provider and model from strings like `"anthropic/claude-3-sonnet"`
- Updated OpenAI, Anthropic, and GenAI integrations to use this function for provider detection
- Added comprehensive documentation with examples for each integration
- Updated contributing guides to include multi-provider support requirements

## Examples:

```python
# Using OpenAI SDK to access Anthropic models
client = openai.OpenAI(base_url="http://localhost:8080/openai")
response = client.chat.completions.create(
    model="anthropic/claude-3-sonnet",
    messages=[{"role": "user", "content": "Hello!"}]
)

# Using Anthropic SDK to access OpenAI models
client = anthropic.Anthropic(base_url="http://localhost:8080/anthropic")
response = client.messages.create(
    model="openai/gpt-4o",
    messages=[{"role": "user", "content": "Hello!"}]
)
```

This feature enables more flexible model selection while maintaining backward compatibility with existing code.