### PR TITLE
feat: add runtime configuration updates with atomic drop request handling

### DIFF
--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -43,11 +43,9 @@ USER appuser
 # Environment variables with defaults
 ENV APP_PORT=8080 \
     APP_POOL_SIZE=300 \
-    APP_DROP_EXCESS_REQUESTS=false \
-    APP_PLUGINS="" \
-    APP_PROMETHEUS_LABELS=""
+    APP_PLUGINS=""
 
 EXPOSE 8080
 
 # Direct entrypoint with environment variable expansion
-ENTRYPOINT ["/bin/sh", "-c", "exec /app/main -config /app/config/config.json -port \"${APP_PORT}\" -pool-size \"${APP_POOL_SIZE}\" -drop-excess-requests \"${APP_DROP_EXCESS_REQUESTS}\" -plugins \"${APP_PLUGINS}\" -prometheus-labels \"${APP_PROMETHEUS_LABELS}\""]
+ENTRYPOINT ["/bin/sh", "-c", "exec /app/main -config /app/config/config.json -port \"${APP_PORT}\" -pool-size \"${APP_POOL_SIZE}\" -plugins \"${APP_PLUGINS}\""]

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/fasthttp/router"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// ConfigHandler manages runtime configuration updates for Bifrost.
+// It provides an endpoint to hot-reload settings from the configuration file.
+type ConfigHandler struct {
+	client     *bifrost.Bifrost
+	logger     schemas.Logger
+	configPath string
+}
+
+// NewConfigHandler creates a new handler for configuration management.
+// It requires the Bifrost client, a logger, and the path to the config file to be reloaded.
+func NewConfigHandler(client *bifrost.Bifrost, logger schemas.Logger, configPath string) *ConfigHandler {
+	return &ConfigHandler{
+		client:     client,
+		logger:     logger,
+		configPath: configPath,
+	}
+}
+
+// RegisterRoutes registers the configuration-related routes.
+// It adds the `PUT /config` endpoint.
+func (h *ConfigHandler) RegisterRoutes(r *router.Router) {
+	r.PUT("/config", h.handleReloadConfig)
+}
+
+// handleReloadConfig re-reads the configuration file and applies updatable settings.
+// Currently, it supports hot-reloading of the `drop_excess_requests` setting.
+// Note that settings like `prometheus_labels` cannot be changed at runtime.
+func (h *ConfigHandler) handleReloadConfig(ctx *fasthttp.RequestCtx) {
+	var config struct {
+		BifrostSettings struct {
+			DropExcessRequests *bool `json:"drop_excess_requests,omitempty"`
+		} `json:"bifrost_settings"`
+	}
+
+	data, err := os.ReadFile(h.configPath)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to read config file: %v", err), h.logger)
+		return
+	}
+
+	if err := json.Unmarshal(data, &config); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("failed to parse config file: %v", err), h.logger)
+		return
+	}
+
+	if config.BifrostSettings.DropExcessRequests != nil {
+		h.client.UpdateDropExcessRequests(*config.BifrostSettings.DropExcessRequests)
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	SendJSON(ctx, map[string]interface{}{"status": "config reloaded", "drop_excess_requests": config.BifrostSettings.DropExcessRequests}, h.logger)
+}

--- a/transports/config.example.json
+++ b/transports/config.example.json
@@ -1,4 +1,8 @@
 {
+  "client": {
+    "drop_excess_requests": false,
+    "prometheus_labels": ["model", "provider"]
+  },
   "providers": {
     "openai": {
       "keys": [


### PR DESCRIPTION
# Add runtime configuration updates and atomic drop request handling

This PR adds the ability to update certain configuration settings at runtime without restarting the service. Key changes include:

1. Added a new `/config` endpoint that allows hot-reloading configuration settings
2. Converted `dropExcessRequests` from a boolean to an atomic value for thread-safe updates
3. Added `UpdateDropExcessRequests()` method to the Bifrost client
4. Moved configuration settings from command-line flags to the config file:
   - Moved `drop_excess_requests` to the config file under `client` section
   - Moved `prometheus_labels` to the config file under `client` section
5. Updated the Dockerfile to remove environment variables for settings now in the config file

This change improves operational flexibility by allowing configuration updates without service restarts, particularly useful for adjusting request handling behavior in high-load situations.