### PR TITLE
feat: add dynamic MCP client management API

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -32,3 +32,21 @@ type MCPStdioConfig struct {
 	Args    []string `json:"args"`    // Command line arguments
 	Envs    []string `json:"envs"`    // Environment variables required
 }
+
+type MCPConnectionState string
+
+const (
+	MCPConnectionStateConnected    MCPConnectionState = "connected"    // Client is connected and ready to use
+	MCPConnectionStateDisconnected MCPConnectionState = "disconnected" // Client is not connected
+	MCPConnectionStateError        MCPConnectionState = "error"        // Client is in an error state, and cannot be used
+)
+
+// MCPClient represents a connected MCP client with its configuration and tools,
+// and connection information, after it has been initialized.
+// It is returned by GetMCPClients() method.
+type MCPClient struct {
+	Name   string             `json:"name"`   // Unique name for this client
+	Config MCPClientConfig    `json:"config"` // Tool filtering settings
+	Tools  []string           `json:"tools"`  // Available tools mapped by name
+	State  MCPConnectionState `json:"state"`  // Connection state
+}

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -211,10 +211,12 @@ func main() {
 		log.Fatalf("failed to initialize bifrost: %v", err)
 	}
 
+	store.SetBifrostClient(client)
+
 	// Initialize handlers
 	providerHandler := handlers.NewProviderHandler(store, client, logger)
 	completionHandler := handlers.NewCompletionHandler(client, logger)
-	mcpHandler := handlers.NewMCPHandler(client, logger)
+	mcpHandler := handlers.NewMCPHandler(client, logger, store)
 	integrationHandler := handlers.NewIntegrationHandler(client)
 	configHandler := handlers.NewConfigHandler(client, logger, configPath)
 


### PR DESCRIPTION
# Dynamic MCP Client Management API

This PR adds a comprehensive API for managing Model Control Protocol (MCP) clients at runtime. The implementation allows users to:

- List all connected MCP clients with their status and available tools
- Add new MCP clients dynamically
- Remove existing MCP clients
- Edit tool configurations for MCP clients
- Reconnect disconnected clients

The implementation includes:

1. New Bifrost core methods for MCP client management:
   - `GetMCPClients()`
   - `AddMCPClient()`
   - `RemoveMCPClient()`
   - `EditMCPClientTools()`
   - `ReconnectMCPClient()`

2. New HTTP endpoints in the REST API:
   - `GET /mcp/clients` - List all clients
   - `POST /mcp/client` - Add a new client
   - `DELETE /mcp/client/{name}` - Remove a client
   - `PUT /mcp/client/{name}` - Edit client tools
   - `POST /mcp/client/{name}/reconnect` - Reconnect a client

3. Enhanced `ConfigStore` with methods to persist MCP client changes

4. New schema types for representing MCP client connection states

The implementation includes proper mutex handling to ensure thread safety during client management operations, with a warning note about potential brief latency increases during these operations.