### PR TITLE
feat: error handling added in integrations with their test cases

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -192,6 +192,7 @@ func Init(config schemas.BifrostConfig) (*Bifrost, error) {
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
 func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
 		return nil, err
 	}
 
@@ -202,12 +203,14 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.
 	}
 
 	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
 		return nil, primaryErr
 	}
 
 	// Check if this is a short-circuit error that doesn't allow fallbacks
 	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
 	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
 		return nil, primaryErr
 	}
 
@@ -234,12 +237,15 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.
 				return result, nil
 			}
 			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
 				return nil, fallbackErr
 			}
 
 			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
 		}
 	}
+
+	primaryErr.Provider = req.Provider
 
 	// All providers failed, return the original error
 	return nil, primaryErr
@@ -250,6 +256,7 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
 func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
 		return nil, err
 	}
 
@@ -259,9 +266,15 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 		return primaryResult, nil
 	}
 
+	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
 	// Check if this is a short-circuit error that doesn't allow fallbacks
 	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
 	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
 		return nil, primaryErr
 	}
 
@@ -288,12 +301,15 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 				return result, nil
 			}
 			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
 				return nil, fallbackErr
 			}
 
 			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
 		}
 	}
+
+	primaryErr.Provider = req.Provider
 
 	// All providers failed, return the original error
 	return nil, primaryErr
@@ -304,6 +320,7 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 // If the primary provider fails, it will try each fallback provider in order until one succeeds.
 func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
 		return nil, err
 	}
 
@@ -317,9 +334,15 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.Bifro
 		return primaryResult, nil
 	}
 
+	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
 	// Check if this is a short-circuit error that doesn't allow fallbacks
 	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
 	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
 		return nil, primaryErr
 	}
 
@@ -345,12 +368,15 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.Bifro
 				return result, nil
 			}
 			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
 				return nil, fallbackErr
 			}
 
 			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
 		}
 	}
+
+	primaryErr.Provider = req.Provider
 
 	// All providers failed, return the original error
 	return nil, primaryErr

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -431,12 +431,13 @@ const (
 // - AllowFallbacks = &false: Bifrost will return this error immediately, no fallbacks
 // - AllowFallbacks = nil: Treated as true by default (fallbacks allowed for resilience)
 type BifrostError struct {
-	EventID        *string    `json:"event_id,omitempty"`
-	Type           *string    `json:"type,omitempty"`
-	IsBifrostError bool       `json:"is_bifrost_error"`
-	StatusCode     *int       `json:"status_code,omitempty"`
-	Error          ErrorField `json:"error"`
-	AllowFallbacks *bool      `json:"-"` // Optional: Controls fallback behavior (nil = true by default)
+	Provider       ModelProvider `json:"-"`
+	EventID        *string       `json:"event_id,omitempty"`
+	Type           *string       `json:"type,omitempty"`
+	IsBifrostError bool          `json:"is_bifrost_error"`
+	StatusCode     *int          `json:"status_code,omitempty"`
+	Error          ErrorField    `json:"error"`
+	AllowFallbacks *bool         `json:"-"` // Optional: Controls fallback behavior (nil = true by default)
 }
 
 // ErrorField represents detailed error information.

--- a/tests/transports-integrations/README.md
+++ b/tests/transports-integrations/README.md
@@ -34,7 +34,7 @@ The Bifrost integration tests use a centralized configuration system that routes
 
 ## 📋 Test Categories
 
-Our test suite covers 11 comprehensive scenarios for each integration:
+Our test suite covers 12 comprehensive scenarios for each integration:
 
 1. **Simple Chat** - Basic single-message conversations
 2. **Multi-turn Conversation** - Conversation history and context retention
@@ -47,6 +47,7 @@ Our test suite covers 11 comprehensive scenarios for each integration:
 9. **Multiple Images** - Multi-image analysis and comparison
 10. **Complex End-to-End** - Comprehensive multimodal workflows
 11. **Integration-Specific Features** - Integration-unique capabilities
+12. **Error Handling** - Invalid request error processing and propagation
 
 ## 📁 Directory Structure
 
@@ -179,6 +180,10 @@ python run_integration_tests.py litellm
 
 # Option 3: Using pytest directly
 pytest tests/integrations/test_openai.py -v
+
+# Run specific test categories
+pytest tests/integrations/ -k "error_handling" -v  # Run only error handling tests
+pytest tests/integrations/ -k "test_12" -v         # Run all 12th test cases (error handling)
 ```
 
 #### Makefile Commands

--- a/tests/transports-integrations/tests/integrations/test_anthropic.py
+++ b/tests/transports-integrations/tests/integrations/test_anthropic.py
@@ -35,12 +35,16 @@ from ..utils.common import (
     MULTIPLE_TOOL_CALL_MESSAGES,
     IMAGE_URL,
     BASE64_IMAGE,
+    INVALID_ROLE_MESSAGES,
     WEATHER_TOOL,
     CALCULATOR_TOOL,
+    ALL_TOOLS,
     mock_tool_response,
     assert_valid_chat_response,
     assert_has_tool_calls,
     assert_valid_image_response,
+    assert_valid_error_response,
+    assert_error_propagation,
     extract_tool_calls,
     get_api_key,
     skip_if_no_api_key,
@@ -543,6 +547,21 @@ class TestAnthropicIntegration:
         tool_calls = extract_anthropic_tool_calls(response3)
         # Should prefer calculator for math question
         assert tool_calls[0]["name"] == "calculate"
+
+    @skip_if_no_api_key("anthropic")
+    def test_12_error_handling_invalid_roles(self, anthropic_client, test_config):
+        """Test Case 12: Error handling for invalid roles"""
+        with pytest.raises(Exception) as exc_info:
+            anthropic_client.messages.create(
+                model=get_model("anthropic", "chat"),
+                messages=INVALID_ROLE_MESSAGES,
+                max_tokens=100,
+            )
+
+        # Verify the error is properly caught and contains role-related information
+        error = exc_info.value
+        assert_valid_error_response(error, "tester")
+        assert_error_propagation(error, "anthropic")
 
 
 # Additional helper functions specific to Anthropic

--- a/tests/transports-integrations/tests/integrations/test_google.py
+++ b/tests/transports-integrations/tests/integrations/test_google.py
@@ -31,15 +31,19 @@ from ..utils.common import (
     MULTIPLE_TOOL_CALL_MESSAGES,
     IMAGE_URL,
     BASE64_IMAGE,
+    INVALID_ROLE_MESSAGES,
     WEATHER_TOOL,
     CALCULATOR_TOOL,
     assert_valid_chat_response,
     assert_valid_image_response,
+    assert_valid_error_response,
+    assert_error_propagation,
     get_api_key,
     skip_if_no_api_key,
     COMPARISON_KEYWORDS,
     WEATHER_KEYWORDS,
     LOCATION_KEYWORDS,
+    GENAI_INVALID_ROLE_CONTENT,
 )
 from ..utils.config_loader import get_model
 
@@ -421,6 +425,19 @@ class TestGoogleIntegration:
         )
 
         assert_valid_chat_response(response3)
+
+    @skip_if_no_api_key("google")
+    def test_12_error_handling_invalid_roles(self, google_client, test_config):
+        """Test Case 12: Error handling for invalid roles"""
+        with pytest.raises(Exception) as exc_info:
+            google_client.models.generate_content(
+                model=get_model("google", "chat"), contents=GENAI_INVALID_ROLE_CONTENT
+            )
+
+        # Verify the error is properly caught and contains role-related information
+        error = exc_info.value
+        assert_valid_error_response(error, "tester")
+        assert_error_propagation(error, "google")
 
 
 # Additional helper functions specific to Google GenAI

--- a/tests/transports-integrations/tests/integrations/test_litellm.py
+++ b/tests/transports-integrations/tests/integrations/test_litellm.py
@@ -36,13 +36,18 @@ from ..utils.common import (
     IMAGE_BASE64_MESSAGES,
     MULTIPLE_IMAGES_MESSAGES,
     COMPLEX_E2E_MESSAGES,
+    INVALID_ROLE_MESSAGES,
     WEATHER_TOOL,
     CALCULATOR_TOOL,
     mock_tool_response,
     assert_valid_chat_response,
     assert_has_tool_calls,
     assert_valid_image_response,
+    assert_valid_error_response,
+    assert_error_propagation,
     extract_tool_calls,
+    get_api_key,
+    skip_if_no_api_key,
     COMPARISON_KEYWORDS,
     WEATHER_KEYWORDS,
     LOCATION_KEYWORDS,
@@ -338,6 +343,20 @@ class TestLiteLLMIntegration:
         )
 
         assert_valid_chat_response(response3)
+
+    def test_12_error_handling_invalid_roles(self, test_config):
+        """Test Case 12: Error handling for invalid roles"""
+        with pytest.raises(Exception) as exc_info:
+            litellm.completion(
+                model=get_model("litellm", "chat"),
+                messages=INVALID_ROLE_MESSAGES,
+                max_tokens=100,
+            )
+
+        # Verify the error is properly caught and contains role-related information
+        error = exc_info.value
+        assert_valid_error_response(error, "tester")
+        assert_error_propagation(error, "litellm")
 
 
 # Additional helper functions specific to LiteLLM

--- a/tests/transports-integrations/tests/integrations/test_openai.py
+++ b/tests/transports-integrations/tests/integrations/test_openai.py
@@ -36,12 +36,15 @@ from ..utils.common import (
     IMAGE_BASE64_MESSAGES,
     MULTIPLE_IMAGES_MESSAGES,
     COMPLEX_E2E_MESSAGES,
+    INVALID_ROLE_MESSAGES,
     WEATHER_TOOL,
     CALCULATOR_TOOL,
     mock_tool_response,
     assert_valid_chat_response,
     assert_has_tool_calls,
     assert_valid_image_response,
+    assert_valid_error_response,
+    assert_error_propagation,
     extract_tool_calls,
     get_api_key,
     skip_if_no_api_key,
@@ -389,3 +392,18 @@ class TestOpenAIIntegration:
         )
 
         assert_valid_chat_response(response3)
+
+    @skip_if_no_api_key("openai")
+    def test_12_error_handling_invalid_roles(self, openai_client, test_config):
+        """Test Case 12: Error handling for invalid roles"""
+        with pytest.raises(Exception) as exc_info:
+            openai_client.chat.completions.create(
+                model=get_model("openai", "chat"),
+                messages=INVALID_ROLE_MESSAGES,
+                max_tokens=100,
+            )
+
+        # Verify the error is properly caught and contains role-related information
+        error = exc_info.value
+        assert_valid_error_response(error, "tester")
+        assert_error_propagation(error, "openai")

--- a/transports/bifrost-http/integrations/anthropic/router.go
+++ b/transports/bifrost-http/integrations/anthropic/router.go
@@ -32,6 +32,9 @@ func NewAnthropicRouter(client *bifrost.Bifrost) *AnthropicRouter {
 			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
 				return DeriveAnthropicFromBifrostResponse(resp), nil
 			},
+			ErrorConverter: func(err *schemas.BifrostError) interface{} {
+				return DeriveAnthropicErrorFromBifrostError(err)
+			},
 		},
 	}
 

--- a/transports/bifrost-http/integrations/genai/router.go
+++ b/transports/bifrost-http/integrations/genai/router.go
@@ -34,6 +34,9 @@ func NewGenAIRouter(client *bifrost.Bifrost) *GenAIRouter {
 			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
 				return DeriveGenAIFromBifrostResponse(resp), nil
 			},
+			ErrorConverter: func(err *schemas.BifrostError) interface{} {
+				return DeriveGeminiErrorFromBifrostError(err)
+			},
 			PreCallback: extractAndSetModelFromURL,
 		},
 	}

--- a/transports/bifrost-http/integrations/openai/router.go
+++ b/transports/bifrost-http/integrations/openai/router.go
@@ -32,6 +32,9 @@ func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
 			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
 				return DeriveOpenAIFromBifrostResponse(resp), nil
 			},
+			ErrorConverter: func(err *schemas.BifrostError) interface{} {
+				return DeriveOpenAIErrorFromBifrostError(err)
+			},
 		},
 	}
 


### PR DESCRIPTION
# Add Provider Information to BifrostError for Improved Error Propagation

This PR enhances error handling in Bifrost by adding provider information to `BifrostError` objects and ensuring proper error propagation through the system. The changes enable more accurate error reporting when requests fail, making it easier to identify which provider encountered an issue.

Key improvements:

- Added a `Provider` field to the `BifrostError` struct to track which provider generated the error
- Set the provider field at all error creation points in the request flow
- Implemented provider-specific error converters for each integration (OpenAI, Anthropic, Google, LiteLLM)
- Added proper error propagation in the HTTP transport layer
- Enhanced error handling for cancelled requests
- Added comprehensive error handling tests for all integrations

These changes ensure that when a request fails, the error response will accurately reflect which provider encountered the issue, with the error formatted according to that provider's API conventions. This is particularly important for applications that need to handle errors differently based on the provider that generated them.

The PR also adds a new test category for error handling, verifying that invalid role errors are properly detected and propagated through the system.