### PR TITLE
feat: add Node.js npx installation method and simplify setup process

### DIFF
--- a/.github/workflows/transports-release.yml
+++ b/.github/workflows/transports-release.yml
@@ -125,7 +125,9 @@ jobs:
           # Strip 'transports/' prefix and add 'v' prefix for upload script
           VERSION_ONLY="${{ steps.manage_versions.outputs.transport_version }}"
           VERSION_ONLY=${VERSION_ONLY#transports/v}
-          node upload-builds.mjs v${VERSION_ONLY}
+          npm ci
+          cd ../..
+          node ci/scripts/upload-builds.mjs v${VERSION_ONLY}
 
   # Second job: Build and push Docker image
   # Runs after transport build completes successfully

--- a/README.md
+++ b/README.md
@@ -19,41 +19,30 @@ Bifrost is a high-performance AI gateway that connects you to 10+ providers (Ope
 **What You Need**
 
 - Any AI provider API key (OpenAI, Anthropic, Bedrock, etc.)
-- Docker **OR** Go 1.23+ installed
-- 30 seconds of your time ⏰
+- Node.js 18+ installed (or use Docker instead via [Docker installation](#using-bifrost-http-transport))
+- 20 seconds of your time ⏰
 
 ### Using Bifrost HTTP Transport
 
-📖 For detailed setup guides with multiple providers, advanced configuration, and language examples, see [Quick Start Documentation](./docs/quickstart/README.md)
+📖 For detailed setup guides with multiple providers, advanced configuration, and language examples, see [Quick Start Documentation](./docs/quickstart/http-transport.md)
 
-**Step 1:** Start Bifrost (choose one)
+**Step 1:** Start Bifrost
 
 ```bash
-# 🐳 Docker (easiest - zero config needed!)
-docker pull maximhq/bifrost
-docker run -p 8080:8080 maximhq/bifrost
-
-# 🔧 Or install Go binary (Make sure Go is in your PATH)
-go install github.com/maximhq/bifrost/transports/bifrost-http@latest
-bifrost-http -port 8080
+# 🔧 Run Bifrost binary
+npx @maximhq/bifrost
 ```
 
-**Step 2:** Open the built-in web interface
+**Step 2:** Open the built-in web interface and configure bifrost
 
 ```bash
-# 🖥️ Configure visually - no config files needed!
+# 🖥️ Open the web interface in your browser
 open http://localhost:8080
 
 # Or simply open http://localhost:8080 manually in your browser
 ```
 
-**Step 3:** Add your provider via the web UI or API
-
-Via Web UI: Just Go to providers tab and click "Add Provider" to configure your provider.
-
-Note: If using environment variables (e.g. `env.OPENAI_API_KEY`), make sure to set the corresponding environment variable in bifrost's session, or pass it as a flag in Docker (`docker run -e OPENAI_API_KEY maximhq/bifrost`).
-
-**Step 4:** Test it works
+**Step 3:** Test it works
 
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
@@ -122,6 +111,8 @@ Bifrost is built with a modular architecture:
 
 ```text
 bifrost/
+├── ci/                   # CI/CD pipeline scripts and npx configuration
+│
 ├── core/                 # Core functionality and shared components
 │   ├── providers/        # Provider-specific implementations
 │   ├── schemas/          # Interfaces and structs used in bifrost
@@ -135,6 +126,9 @@ bifrost/
 │
 ├── transports/           # Interface layers (HTTP, gRPC, etc.)
 │   ├── bifrost-http/     # HTTP transport implementation
+│   └── ...
+│
+├── ui/                  # UI files for the web interface of the HTTP transport
 │   └── ...
 │
 └── plugins/              # Plugin Implementations
@@ -171,11 +165,7 @@ For language-agnostic integration and microservices architecture.
 Quick example:
 
 ```bash
-docker pull maximhq/bifrost
-docker run -p 8080:8080 \
-  -v $(pwd)/config.json:/app/config/config.json \
-  -e OPENAI_API_KEY \
-  maximhq/bifrost
+npx @maximhq/bifrost
 ```
 
 ### 3. As a Drop-in Replacement (Zero Code Changes)

--- a/ci/npx/bin.js
+++ b/ci/npx/bin.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+import { execSync } from "child_process";
+import { chmodSync, createWriteStream } from "fs";
+import fetch from "node-fetch";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const BASE_URL = "https://downloads.getmaxim.ai";
+
+// Parse transport version from command line arguments
+function parseTransportVersion() {
+  const args = process.argv.slice(2);
+  let transportVersion = "latest"; // Default to latest
+  
+  // Find --transport-version argument
+  const versionArgIndex = args.findIndex(arg => arg.startsWith("--transport-version"));
+  
+  if (versionArgIndex !== -1) {
+    const versionArg = args[versionArgIndex];
+    
+    if (versionArg.includes("=")) {
+      // Format: --transport-version=v1.2.3
+      transportVersion = versionArg.split("=")[1];
+    } else if (versionArgIndex + 1 < args.length) {
+      // Format: --transport-version v1.2.3
+      transportVersion = args[versionArgIndex + 1];
+    }
+    
+    // Remove the transport-version arguments from args array so they don't get passed to the binary
+    if (versionArg.includes("=")) {
+      args.splice(versionArgIndex, 1);
+    } else {
+      args.splice(versionArgIndex, 2);
+    }
+  }
+  
+  return { version: validateTransportVersion(transportVersion), remainingArgs: args };
+}
+
+// Validate transport version format
+function validateTransportVersion(version) {
+  if (version === "latest") {
+    return version;
+  }
+  
+  // Check if version matches v{x.x.x} format
+  const versionRegex = /^v\d+\.\d+\.\d+$/;
+  if (versionRegex.test(version)) {
+    return version;
+  }
+  
+  console.error(`Invalid transport version format: ${version}`);
+  console.error(`Transport version must be either "latest" or in format v1.2.3`);
+  process.exit(1);
+}
+
+const { version: VERSION, remainingArgs } = parseTransportVersion();
+
+function getPlatformArchAndBinary() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  let platformDir;
+  let archDir;
+  let binaryName;
+
+  if (platform === "darwin") {
+    platformDir = "darwin";
+    if (arch === "arm64") archDir = "arm64";
+    else archDir = "amd64";
+    binaryName = "bifrost-http";
+  } else if (platform === "linux") {
+    platformDir = "linux";
+    if (arch === "x64") archDir = "amd64";
+    else if (arch === "ia32") archDir = "386";
+    else archDir = arch; // fallback
+    binaryName = "bifrost-http";
+  } else if (platform === "win32") {
+    platformDir = "windows";
+    if (arch === "x64") archDir = "amd64";
+    else if (arch === "ia32") archDir = "386";
+    else archDir = arch; // fallback
+    binaryName = "bifrost-http.exe";
+  } else {
+    console.error(`Unsupported platform/arch: ${platform}/${arch}`);
+    process.exit(1);
+  }
+
+  return { platformDir, archDir, binaryName };
+}
+
+async function downloadBinary(url, dest) {
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    console.error(`Download failed: ${res.status} ${res.statusText}`);
+    process.exit(1);
+  }
+
+  const fileStream = createWriteStream(dest);
+  await new Promise((resolve, reject) => {
+    res.body.pipe(fileStream);
+    res.body.on("error", reject);
+    fileStream.on("finish", resolve);
+  });
+
+  chmodSync(dest, 0o755);
+}
+
+(async () => {
+  const { platformDir, archDir, binaryName } = getPlatformArchAndBinary();
+  const binaryPath = join(tmpdir(), binaryName);
+
+  // The download URL now matches the CI pipeline's S3 structure with arch
+  // Example: https://downloads.getmaxim.ai/bifrost/latest/darwin/arm64/bifrost
+  const downloadUrl = `${BASE_URL}/bifrost/${VERSION}/${platformDir}/${archDir}/${binaryName}`;
+
+  try {
+    await downloadBinary(downloadUrl, binaryPath);
+  } catch (error) {
+    console.error(`❌ Failed to download binary from ${downloadUrl}:`, error.message);
+    process.exit(1);
+  }
+
+  // Get command-line arguments to pass to the binary (excluding --transport-version)
+  const args = remainingArgs.join(" ");
+
+  // Execute the binary, forwarding the arguments
+  try {
+    execSync(`${binaryPath} ${args}`, { stdio: "inherit" });
+  } catch (error) {
+    // The child process will have already printed its error message.
+    // Exit with the same status code as the child process.
+    process.exit(error.status || 1);
+  }
+})();

--- a/ci/npx/package-lock.json
+++ b/ci/npx/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "@maximhq/bifrost",
+  "version": "1.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@maximhq/bifrost",
+      "version": "1.0.1",
+      "license": "Apache-2.0",
+      "bin": {
+        "bifrost": "bin.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    }
+  }
+}

--- a/ci/npx/package.json
+++ b/ci/npx/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@maximhq/bifrost",
+  "version": "1.0.1",
+  "description": "High-performance AI gateway CLI - connect to 10+ providers through a single API",
+  "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
+  "homepage": "https://github.com/maximhq/bifrost",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/maximhq/bifrost.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Maxim HQ",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "bin": {
+    "bifrost": "bin.js"
+  },
+  "type": "module",
+  "dependencies": {}
+}

--- a/ci/scripts/package-lock.json
+++ b/ci/scripts/package-lock.json
@@ -1,11 +1,18 @@
 {
-  "name": "ci",
+  "name": "bifrost-ci-scripts",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "bifrost-ci-scripts",
+      "version": "1.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.846.0"
+        "@aws-sdk/client-s3": "^3.846.0",
+        "@octokit/rest": "^20.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -866,6 +873,161 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.4.4-cjs.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+      "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.7.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.3.2-cjs.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+      "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.8.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "^5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "20.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+      "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
@@ -1591,11 +1753,23 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "license": "MIT"
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -1613,6 +1787,15 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/strnum": {
@@ -1633,6 +1816,12 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "license": "ISC"
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -1645,6 +1834,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/docs/architecture/plugins.md
+++ b/docs/architecture/plugins.md
@@ -392,8 +392,8 @@ docker run -p 8080:8080 \
   -e APP_PLUGINS="maxim,custom-plugin" \
   maximhq/bifrost
 
-# Binary deployment
-bifrost-http -config config.json -plugins "maxim,ratelimit"
+# NPM deployment
+npx -y @maximhq/bifrost -plugins "maxim"
 ```
 
 **Future: JSON Configuration System**

--- a/docs/quickstart/http-transport.md
+++ b/docs/quickstart/http-transport.md
@@ -4,16 +4,15 @@ Get Bifrost running as an HTTP API in **15 seconds** with **zero configuration**
 
 ## 🚀 Zero-Config Setup (15 seconds!)
 
-### 1. Start Bifrost (No config needed!)
+### 1. Start Bifrost (No config needed)
 
 ```bash
-# 🐳 Docker (fastest)
+# 🐳 Docker
 docker pull maximhq/bifrost
 docker run -p 8080:8080 maximhq/bifrost
 
-# 🔧 OR Go Binary (Make sure Go is in your PATH)
-go install github.com/maximhq/bifrost/transports/bifrost-http@latest
-bifrost-http -port 8080
+# 🔧 OR Binary
+npx @maximhq/bifrost  # use -port flag to specify the port
 ```
 
 ### 2. Open the Web Interface
@@ -66,8 +65,8 @@ docker run -p 8080:8080 \
   -e OPENAI_API_KEY \
   maximhq/bifrost
 
-# OR Go Binary with app directory
-bifrost-http -app-dir . -port 8080
+# OR Binary with app directory
+npx @maximhq/bifrost -port 8080
 ```
 
 ---
@@ -80,13 +79,13 @@ The `-app-dir` flag tells Bifrost where to store and look for data:
 
 ```bash
 # Use current directory as app directory
-bifrost-http -app-dir .
+npx @maximhq/bifrost -app-dir .
 
 # Use specific directory as app directory
-bifrost-http -app-dir /path/to/bifrost-data
+npx @maximhq/bifrost -app-dir /path/to/bifrost-data
 
 # Default: current directory if no flag specified
-bifrost-http -port 8080
+npx @maximhq/bifrost -port 8080
 ```
 
 **What Bifrost stores in the app directory:**
@@ -318,7 +317,7 @@ response, err := http.Post(
 | **Zero Config** | No files needed, visual setup, instant start         | Quick testing, demos, new users  |
 | **File-Based**  | Version control, automation, reproducible deployment | Production, CI/CD, team setups   |
 | **Docker**      | No Go installation needed, isolated environment      | Production, CI/CD, quick testing |
-| **Go Binary**   | Direct execution, easier debugging                   | Development, custom builds       |
+| **Binary**   | Direct execution, easier debugging                   | Development, custom builds       |
 
 **Note:** When using file-based config, Bifrost only looks for `config.json` in your specified app directory.
 

--- a/docs/usage/http-transport/README.md
+++ b/docs/usage/http-transport/README.md
@@ -213,11 +213,8 @@ docker run -p 8080:8080 \
 ### **Binary Deployment**
 
 ```bash
-# Install
-go install github.com/maximhq/bifrost/transports/bifrost-http@latest
-
 # Zero config startup (uses current directory)
-bifrost-http -port 8080
+npx -y @maximhq/bifrost -port 8080
 ```
 
 For detailed deployment instructions including app directory setup, Docker volumes, and production best practices, see:

--- a/docs/usage/http-transport/configuration/mcp.md
+++ b/docs/usage/http-transport/configuration/mcp.md
@@ -680,7 +680,7 @@ export YOUR_MCP_SERVER_API_KEY="your-key"
 
 ### **Docker with MCP**
 
-> **⚠️ Important:** Docker currently does **NOT** support STDIO connection for MCP. Use Go binary if STDIO connection is required.
+> **⚠️ Important:** Docker currently does **NOT** support STDIO connection for MCP. Use binary if STDIO connection is required.
 
 ```bash
 # For HTTP/SSE MCP connections only
@@ -694,15 +694,14 @@ docker run -p 8080:8080 \
   maximhq/bifrost
 ```
 
-### **Go Binary with MCP (Supports all connection types)**
+### **Binary with MCP (Supports all connection types)**
 
 ```bash
 # All environment variables are picked up automatically
 export OPENAI_API_KEY="your-openai-key"
 export SEARCH_API_KEY="your-search-key"
 
-go install github.com/maximhq/bifrost/transports/bifrost-http@latest
-bifrost-http -config config.json -port 8080 -plugins maxim
+npx -y @maximhq/bifrost -port 8080 -plugins maxim
 ```
 
 ---

--- a/docs/usage/http-transport/configuration/plugins.md
+++ b/docs/usage/http-transport/configuration/plugins.md
@@ -18,10 +18,10 @@ Bifrost plugins provide middleware functionality:
 
 ### **Current Plugin Loading (Command-line)**
 
-**Go Binary:**
+**NPM:**
 
 ```bash
-bifrost-http -config config.json -plugins "maxim,custom-plugin"
+npx -y @maximhq/bifrost -plugins "maxim,custom-plugin"
 ```
 
 **Docker:**
@@ -48,7 +48,7 @@ export MAXIM_API_KEY="your-maxim-api-key"
 export MAXIM_LOG_REPO_ID="your-repo-id"
 
 # Start with Maxim plugin
-bifrost-http -config config.json -plugins "maxim"
+npx -y @maximhq/bifrost -plugins "maxim"
 ```
 
 **Features:**
@@ -297,7 +297,7 @@ func TestMyPlugin(t *testing.T) {
 go build -buildmode=plugin -o myplugin.so ./plugins/myplugin
 
 # Test with HTTP transport
-bifrost-http -config config.json -plugins "myplugin"
+npx -y @maximhq/bifrost -plugins "myplugin"
 
 # Send test request
 curl -X POST http://localhost:8080/v1/chat/completions \
@@ -318,7 +318,7 @@ Plugins execute in loading order:
 
 ```bash
 # This order: auth -> rate-limit -> maxim -> request
-bifrost-http -plugins "auth,rate-limit,maxim"
+npx -y @maximhq/bifrost -plugins "auth,rate-limit,maxim"
 ```
 
 **Request flow:**

--- a/docs/usage/http-transport/configuration/providers.md
+++ b/docs/usage/http-transport/configuration/providers.md
@@ -521,16 +521,6 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   }'
 ```
 
-### **Configuration Validation**
-
-```bash
-# Start Bifrost with config validation
-bifrost-http -config config.json -validate
-
-# Check which providers are loaded
-curl http://localhost:8080/metrics | grep bifrost_providers
-```
-
 ---
 
 ## 📚 Related Documentation

--- a/docs/usage/http-transport/integrations/migration-guide.md
+++ b/docs/usage/http-transport/integrations/migration-guide.md
@@ -44,8 +44,7 @@ docker run -d --name bifrost \
   maximhq/bifrost
 
 # Option B: Binary
-go install github.com/maximhq/bifrost/transports/bifrost-http@latest
-bifrost-http -config config.json -port 8080
+npx -y @maximhq/bifrost -port 8080
 ```
 
 ### **Step 2: Create Configuration (Or Use UI)**

--- a/plugins/maxim/README.md
+++ b/plugins/maxim/README.md
@@ -40,7 +40,7 @@ This plugin integrates the Maxim SDK into Bifrost, enabling seamless observabili
 2. Set up flags to add the plugin
    Add `maxim` to the `--plugins` flag
 
-   e.g., `bifrost-http -config config.json -env .env -plugins maxim`
+   e.g., `npx -y @maximhq/bifrost -plugins maxim`
 
    For docker build
 

--- a/transports/README.md
+++ b/transports/README.md
@@ -27,12 +27,11 @@ start http://localhost:8080
 
 **🎉 That's it!** No config files needed. Configure providers, monitor requests, and manage everything through the **built-in web interface**.
 
-### Go Binary
+### Binary
 
 ```bash
-# Install and run locally (Make sure Go is in your PATH)
-go install github.com/maximhq/bifrost/transports/bifrost-http@latest
-bifrost-http -port 8080
+# Install and run locally
+npx -y @maximhq/bifrost
 
 # Open web interface at http://localhost:8080
 ```
@@ -220,7 +219,7 @@ Add custom middleware for analytics, caching, rate limiting:
 
 ```bash
 # Run with plugins
-bifrost-http -app-dir . -plugins "maxim,redis"
+npx -y @maximhq/bifrost -plugins "maxim,redis"
 ```
 
 **Available plugins**: [Plugin Repository](https://github.com/maximhq/bifrost/tree/main/plugins) | [Plugin Guide](../docs/plugins.md)
@@ -239,7 +238,7 @@ curl http://localhost:8080/metrics
 
 ## 🔧 Runtime Configuration
 
-### For Go Binary
+### For Binary
 
 | Flag       | Default | Description                              |
 | ---------- | ------- | ---------------------------------------- |

--- a/ui/README.md
+++ b/ui/README.md
@@ -30,15 +30,6 @@ npm run dev
 
 The development server runs on `http://localhost:3000` and connects to your Bifrost HTTP transport backend (default: `http://localhost:8080`).
 
-### Production Build
-
-```bash
-# Build and prepare for integration with Bifrost HTTP transport
-npm run build
-```
-
-This creates a static export in the `out/` directory and automatically copies it to `../transports/bifrost-http/ui` for embedding in the Go binary.
-
 ### Environment Variables
 
 ```bash


### PR DESCRIPTION
# Add NPX Support for Easier Installation and Usage

This PR adds Node.js NPX support to Bifrost, simplifying the installation and usage process. Users can now run Bifrost with a simple `npx bifrost@latest` command instead of using Docker or Go binaries.

Key changes:
- Added NPX configuration files in the `ci/npx` directory
- Created a Node.js script that automatically downloads the appropriate binary for the user's platform
- Updated README and documentation to reflect the new installation method
- Simplified the quickstart process from 4 steps to 3 steps
- Reduced required setup time from 30 seconds to 20 seconds
- Updated all command examples in documentation to use the new NPX method

The NPX script handles platform detection, downloads the correct binary from our CDN, and executes it with any provided command-line arguments.