### PR TITLE
fix: minor stream optimisation and docs fixes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1358,9 +1358,13 @@ func (bifrost *Bifrost) getChannelMessage(req schemas.BifrostRequest, reqType Re
 	msg := bifrost.channelMessagePool.Get().(*ChannelMessage)
 	msg.BifrostRequest = req
 	msg.Response = responseChan
-	msg.ResponseStream = make(chan chan *schemas.BifrostStream, 1) // Initialize the ResponseStream channel
 	msg.Err = errorChan
 	msg.Type = reqType
+
+	// Conditionally allocate ResponseStream for streaming requests only
+	if reqType == ChatCompletionStreamRequest {
+		msg.ResponseStream = make(chan chan *schemas.BifrostStream, 1)
+	}
 
 	return msg
 }

--- a/docs/usage/networking.md
+++ b/docs/usage/networking.md
@@ -260,6 +260,8 @@ export NO_PROXY=localhost,127.0.0.1,.company.com
 
 </details>
 
+> Please note that the proxy configuration is not supported for **streaming requests**, and for **Bedrock** and **Vertex** Providers.
+
 ---
 
 ## ⏱️ Timeout & Retry Configuration

--- a/tests/core-providers/README.md
+++ b/tests/core-providers/README.md
@@ -13,6 +13,7 @@ This directory contains comprehensive tests for all Bifrost AI providers, ensuri
 - **Mistral** - Mistral AI models with vision capabilities
 - **Ollama** - Local LLM serving platform
 - **Groq** - Groq models
+- **SGLang** - SGLang models
 
 ## 🏃‍♂️ Running Tests
 


### PR DESCRIPTION
Optimize memory usage by conditionally allocating ResponseStream channel

This PR optimizes memory usage by only allocating the ResponseStream channel for streaming requests, rather than for all request types. Previously, we were creating this channel for every request, but it's only needed for streaming operations.

Additionally:
- Added a note in the networking documentation that proxy configuration is not supported for streaming requests, Bedrock, and Vertex providers
- Updated the core-providers README to include SGLang in the list of supported providers