### PR TITLE
feat: add speech and transcription API support

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -25,16 +25,22 @@ const (
 	ChatCompletionRequest       RequestType = "chat_completion"
 	ChatCompletionStreamRequest RequestType = "chat_completion_stream"
 	EmbeddingRequest            RequestType = "embedding"
+	SpeechRequest               RequestType = "speech"
+	SpeechStreamRequest         RequestType = "speech_stream"
+	TranscriptionRequest        RequestType = "transcription"
+	TranscriptionStreamRequest  RequestType = "transcription_stream"
 )
 
 // executor is a function type that handles specific request types.
 type executor func(provider schemas.Provider, req *ChannelMessage, key schemas.Key) (*schemas.BifrostResponse, *schemas.BifrostError)
 
-// messageExecutors is a factory map for handling different request types.
+// messageExecutors is a factory map for handling different request types. (stream requests are handled in the tryStreamRequest function)
 var messageExecutors = map[RequestType]executor{
 	TextCompletionRequest: handleTextCompletion,
 	ChatCompletionRequest: handleChatCompletion,
 	EmbeddingRequest:      handleEmbedding,
+	SpeechRequest:         handleSpeech,
+	TranscriptionRequest:  handleTranscription,
 }
 
 // ChannelMessage represents a message passed through the request channel.
@@ -429,6 +435,248 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.Bifro
 
 			// Try the fallback provider
 			result, fallbackErr := bifrost.tryRequest(&fallbackReq, ctx, EmbeddingRequest)
+			if fallbackErr == nil {
+				bifrost.logger.Info(fmt.Sprintf("Successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+				return result, nil
+			}
+			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
+				return nil, fallbackErr
+			}
+
+			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+		}
+	}
+
+	primaryErr.Provider = req.Provider
+
+	// All providers failed, return the original error
+	return nil, primaryErr
+}
+
+func (bifrost *Bifrost) SpeechRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
+		return nil, err
+	}
+
+	// Try the primary provider first
+	primaryResult, primaryErr := bifrost.tryRequest(req, ctx, SpeechRequest)
+	if primaryErr == nil {
+		return primaryResult, nil
+	}
+
+	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// Check if this is a short-circuit error that doesn't allow fallbacks
+	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
+	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// If primary provider failed and we have fallbacks, try them in order
+	if len(req.Fallbacks) > 0 {
+		for _, fallback := range req.Fallbacks {
+			// Check if we have config for this fallback provider
+			_, err := bifrost.account.GetConfigForProvider(fallback.Provider)
+			if err != nil {
+				bifrost.logger.Warn(fmt.Sprintf("Config not found for provider %s, skipping fallback: %v", fallback.Provider, err))
+				continue
+			}
+
+			// Create a new request with the fallback provider and model
+			fallbackReq := *req
+			fallbackReq.Provider = fallback.Provider
+			fallbackReq.Model = fallback.Model
+
+			// Try the fallback provider
+			result, fallbackErr := bifrost.tryRequest(&fallbackReq, ctx, SpeechRequest)
+			if fallbackErr == nil {
+				bifrost.logger.Info(fmt.Sprintf("Successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+				return result, nil
+			}
+			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
+				return nil, fallbackErr
+			}
+
+			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+		}
+	}
+
+	primaryErr.Provider = req.Provider
+
+	// All providers failed, return the original error
+	return nil, primaryErr
+}
+
+func (bifrost *Bifrost) SpeechStreamRequest(ctx context.Context, req *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
+		return nil, err
+	}
+
+	// Try the primary provider first
+	primaryResult, primaryErr := bifrost.tryStreamRequest(req, ctx, SpeechStreamRequest)
+	if primaryErr == nil {
+		return primaryResult, nil
+	}
+
+	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// Check if this is a short-circuit error that doesn't allow fallbacks
+	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
+	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// If primary provider failed and we have fallbacks, try them in order
+	// This includes both regular provider errors and plugin short-circuit errors with AllowFallbacks=true/nil
+	if len(req.Fallbacks) > 0 {
+		for _, fallback := range req.Fallbacks {
+			// Check if we have config for this fallback provider
+			_, err := bifrost.account.GetConfigForProvider(fallback.Provider)
+			if err != nil {
+				bifrost.logger.Warn(fmt.Sprintf("Config not found for provider %s, skipping fallback: %v", fallback.Provider, err))
+				continue
+			}
+
+			// Create a new request with the fallback provider and model
+			fallbackReq := *req
+			fallbackReq.Provider = fallback.Provider
+			fallbackReq.Model = fallback.Model
+
+			// Try the fallback provider
+			result, fallbackErr := bifrost.tryStreamRequest(&fallbackReq, ctx, SpeechStreamRequest)
+			if fallbackErr == nil {
+				bifrost.logger.Info(fmt.Sprintf("Successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+				return result, nil
+			}
+			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
+				return nil, fallbackErr
+			}
+
+			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+		}
+	}
+
+	primaryErr.Provider = req.Provider
+
+	// All providers failed, return the original error
+	return nil, primaryErr
+}
+
+func (bifrost *Bifrost) TranscriptionRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
+		return nil, err
+	}
+
+	// Try the primary provider first
+	primaryResult, primaryErr := bifrost.tryRequest(req, ctx, TranscriptionRequest)
+	if primaryErr == nil {
+		return primaryResult, nil
+	}
+
+	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// Check if this is a short-circuit error that doesn't allow fallbacks
+	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
+	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// If primary provider failed and we have fallbacks, try them in order
+	if len(req.Fallbacks) > 0 {
+		for _, fallback := range req.Fallbacks {
+			// Check if we have config for this fallback provider
+			_, err := bifrost.account.GetConfigForProvider(fallback.Provider)
+			if err != nil {
+				bifrost.logger.Warn(fmt.Sprintf("Config not found for provider %s, skipping fallback: %v", fallback.Provider, err))
+				continue
+			}
+
+			// Create a new request with the fallback provider and model
+			fallbackReq := *req
+			fallbackReq.Provider = fallback.Provider
+			fallbackReq.Model = fallback.Model
+
+			// Try the fallback provider
+			result, fallbackErr := bifrost.tryRequest(&fallbackReq, ctx, TranscriptionRequest)
+			if fallbackErr == nil {
+				bifrost.logger.Info(fmt.Sprintf("Successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
+				return result, nil
+			}
+			if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+				fallbackErr.Provider = fallback.Provider
+				return nil, fallbackErr
+			}
+
+			bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+		}
+	}
+
+	primaryErr.Provider = req.Provider
+
+	// All providers failed, return the original error
+	return nil, primaryErr
+}
+
+func (bifrost *Bifrost) TranscriptionStreamRequest(ctx context.Context, req *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	if err := validateRequest(req); err != nil {
+		err.Provider = req.Provider
+		return nil, err
+	}
+
+	// Try the primary provider first
+	primaryResult, primaryErr := bifrost.tryStreamRequest(req, ctx, TranscriptionStreamRequest)
+	if primaryErr == nil {
+		return primaryResult, nil
+	}
+
+	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// Check if this is a short-circuit error that doesn't allow fallbacks
+	// Note: AllowFallbacks = nil is treated as true (allow fallbacks by default)
+	if primaryErr.AllowFallbacks != nil && !*primaryErr.AllowFallbacks {
+		primaryErr.Provider = req.Provider
+		return nil, primaryErr
+	}
+
+	// If primary provider failed and we have fallbacks, try them in order
+	// This includes both regular provider errors and plugin short-circuit errors with AllowFallbacks=true/nil
+	if len(req.Fallbacks) > 0 {
+		for _, fallback := range req.Fallbacks {
+			// Check if we have config for this fallback provider
+			_, err := bifrost.account.GetConfigForProvider(fallback.Provider)
+			if err != nil {
+				bifrost.logger.Warn(fmt.Sprintf("Config not found for provider %s, skipping fallback: %v", fallback.Provider, err))
+				continue
+			}
+
+			// Create a new request with the fallback provider and model
+			fallbackReq := *req
+			fallbackReq.Provider = fallback.Provider
+			fallbackReq.Model = fallback.Model
+
+			// Try the fallback provider
+			result, fallbackErr := bifrost.tryStreamRequest(&fallbackReq, ctx, TranscriptionStreamRequest)
 			if fallbackErr == nil {
 				bifrost.logger.Info(fmt.Sprintf("Successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
 				return result, nil
@@ -905,7 +1153,7 @@ func (bifrost *Bifrost) tryRequest(req *schemas.BifrostRequest, ctx context.Cont
 	}
 
 	// Add MCP tools to request if MCP is configured and requested
-	if requestType != EmbeddingRequest && bifrost.mcpManager != nil {
+	if requestType != EmbeddingRequest && requestType != SpeechRequest && bifrost.mcpManager != nil {
 		req = bifrost.mcpManager.addMCPToolsToBifrostRequest(ctx, req)
 	}
 
@@ -993,7 +1241,7 @@ func (bifrost *Bifrost) tryStreamRequest(req *schemas.BifrostRequest, ctx contex
 	}
 
 	// Add MCP tools to request if MCP is configured and requested
-	if requestType != EmbeddingRequest && bifrost.mcpManager != nil {
+	if requestType != SpeechStreamRequest && requestType != TranscriptionStreamRequest && bifrost.mcpManager != nil {
 		req = bifrost.mcpManager.addMCPToolsToBifrostRequest(ctx, req)
 	}
 
@@ -1141,6 +1389,33 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, queue chan Chan
 				if bifrostError != nil && !bifrostError.IsBifrostError {
 					break // Don't retry client errors
 				}
+			} else if req.Type == SpeechStreamRequest {
+				pipeline := bifrost.getPluginPipeline()
+				defer bifrost.releasePluginPipeline(pipeline)
+
+				postHookRunner := func(ctx *context.Context, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+					resp, bifrostErr := pipeline.RunPostHooks(ctx, result, err, len(bifrost.plugins))
+					if bifrostErr != nil {
+						return nil, bifrostErr
+					}
+					return resp, nil
+				}
+				stream, bifrostError = handleSpeechStream(provider, &req, key, postHookRunner)
+				if bifrostError != nil && !bifrostError.IsBifrostError {
+					break // Don't retry client errors
+				}
+			} else if req.Type == TranscriptionStreamRequest {
+				pipeline := bifrost.getPluginPipeline()
+				defer bifrost.releasePluginPipeline(pipeline)
+
+				postHookRunner := func(ctx *context.Context, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+					resp, bifrostErr := pipeline.RunPostHooks(ctx, result, err, len(bifrost.plugins))
+					if bifrostErr != nil {
+						return nil, bifrostErr
+					}
+					return resp, nil
+				}
+				stream, bifrostError = handleTranscriptionStream(provider, &req, key, postHookRunner)
 			} else {
 				executor := messageExecutors[req.Type]
 				if executor == nil {
@@ -1179,7 +1454,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, queue chan Chan
 			}
 			req.Err <- *bifrostError
 		} else {
-			if req.Type == ChatCompletionStreamRequest {
+			if req.Type == ChatCompletionStreamRequest || req.Type == SpeechStreamRequest || req.Type == TranscriptionStreamRequest {
 				req.ResponseStream <- stream
 			} else {
 				req.Response <- result
@@ -1229,6 +1504,32 @@ func handleEmbedding(provider schemas.Provider, req *ChannelMessage, key schemas
 	return provider.Embedding(req.Context, req.Model, key, req.Input.EmbeddingInput, req.Params)
 }
 
+// handleSpeech executes a speech request
+func handleSpeech(provider schemas.Provider, req *ChannelMessage, key schemas.Key) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	if req.Input.SpeechInput == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "input not provided for speech request",
+			},
+		}
+	}
+	return provider.Speech(req.Context, req.Model, key, req.Input.SpeechInput, req.Params)
+}
+
+// handleTranscription executes a transcription request
+func handleTranscription(provider schemas.Provider, req *ChannelMessage, key schemas.Key) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	if req.Input.TranscriptionInput == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "input not provided for transcription request",
+			},
+		}
+	}
+	return provider.Transcription(req.Context, req.Model, key, req.Input.TranscriptionInput, req.Params)
+}
+
 // handleChatCompletionStream executes a chat completion stream request
 func handleChatCompletionStream(provider schemas.Provider, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	if req.Input.ChatCompletionInput == nil {
@@ -1241,6 +1542,32 @@ func handleChatCompletionStream(provider schemas.Provider, req *ChannelMessage, 
 	}
 
 	return provider.ChatCompletionStream(req.Context, postHookRunner, req.Model, key, *req.Input.ChatCompletionInput, req.Params)
+}
+
+// handleSpeechStream executes a speech stream request
+func handleSpeechStream(provider schemas.Provider, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	if req.Input.SpeechInput == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "input not provided for speech request",
+			},
+		}
+	}
+	return provider.SpeechStream(req.Context, postHookRunner, req.Model, key, req.Input.SpeechInput, req.Params)
+}
+
+// handleTranscriptionStream executes a transcription stream request
+func handleTranscriptionStream(provider schemas.Provider, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	if req.Input.TranscriptionInput == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: "input not provided for transcription request",
+			},
+		}
+	}
+	return provider.TranscriptionStream(req.Context, postHookRunner, req.Model, key, req.Input.TranscriptionInput, req.Params)
 }
 
 // PLUGIN MANAGEMENT
@@ -1346,7 +1673,7 @@ func (bifrost *Bifrost) getChannelMessage(req schemas.BifrostRequest, reqType Re
 	msg.Type = reqType
 
 	// Conditionally allocate ResponseStream for streaming requests only
-	if reqType == ChatCompletionStreamRequest {
+	if reqType == ChatCompletionStreamRequest || reqType == SpeechStreamRequest || reqType == TranscriptionStreamRequest {
 		msg.ResponseStream = make(chan chan *schemas.BifrostStream, 1)
 	}
 

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -876,12 +877,14 @@ func handleAnthropicStreaming(
 
 	// Check for HTTP errors
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &resp.StatusCode,
 			Error: schemas.ErrorField{
 				Message: fmt.Sprintf("HTTP error from %s: %d", providerType, resp.StatusCode),
+				Error:   fmt.Errorf("%s", string(body)),
 			},
 		}
 	}
@@ -1289,4 +1292,20 @@ func handleAnthropicStreaming(
 	}()
 
 	return responseChan, nil
+}
+
+func (provider *AnthropicProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "anthropic")
+}
+
+func (provider *AnthropicProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "anthropic")
+}
+
+func (provider *AnthropicProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "anthropic")
+}
+
+func (provider *AnthropicProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "anthropic")
 }

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -581,3 +581,19 @@ func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHoo
 		provider.logger,
 	)
 }
+
+func (provider *AzureProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "azure")
+}
+
+func (provider *AzureProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "azure")
+}
+
+func (provider *AzureProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "azure")
+}
+
+func (provider *AzureProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "azure")
+}

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -1418,12 +1418,14 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 
 	// Check for HTTP errors
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &resp.StatusCode,
 			Error: schemas.ErrorField{
 				Message: fmt.Sprintf("HTTP error from Bedrock: %d", resp.StatusCode),
+				Error:   fmt.Errorf("%s", string(body)),
 			},
 		}
 	}
@@ -1715,4 +1717,20 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 	}()
 
 	return responseChan, nil
+}
+
+func (provider *BedrockProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "bedrock")
+}
+
+func (provider *BedrockProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "bedrock")
+}
+
+func (provider *BedrockProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "bedrock")
+}
+
+func (provider *BedrockProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "bedrock")
 }

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 	"sync"
@@ -786,12 +787,14 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 
 	// Check for HTTP errors
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &resp.StatusCode,
 			Error: schemas.ErrorField{
 				Message: fmt.Sprintf("HTTP error from Cohere: %d", resp.StatusCode),
+				Error:   fmt.Errorf("%s", string(body)),
 			},
 		}
 	}
@@ -1019,4 +1022,20 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	}()
 
 	return responseChan, nil
+}
+
+func (provider *CohereProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "cohere")
+}
+
+func (provider *CohereProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "cohere")
+}
+
+func (provider *CohereProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "cohere")
+}
+
+func (provider *CohereProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "cohere")
 }

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -230,3 +230,19 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 		provider.logger,
 	)
 }
+
+func (provider *GroqProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "groq")
+}
+
+func (provider *GroqProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "groq")
+}
+
+func (provider *GroqProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "groq")
+}
+
+func (provider *GroqProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "groq")
+}

--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -380,3 +380,19 @@ func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postH
 		provider.logger,
 	)
 }
+
+func (provider *MistralProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "mistral")
+}
+
+func (provider *MistralProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "mistral")
+}
+
+func (provider *MistralProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "mistral")
+}
+
+func (provider *MistralProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "mistral")
+}

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -236,3 +236,19 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 		provider.logger,
 	)
 }
+
+func (provider *OllamaProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "ollama")
+}
+
+func (provider *OllamaProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "ollama")
+}
+
+func (provider *OllamaProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "ollama")
+}
+
+func (provider *OllamaProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "ollama")
+}

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -4,11 +4,14 @@ package providers
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"sync"
@@ -178,23 +181,7 @@ func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, model string
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		provider.logger.Debug(fmt.Sprintf("error from openai provider: %s", string(resp.Body())))
-
-		var errorResp OpenAIError
-
-		bifrostErr := handleProviderAPIError(resp, &errorResp)
-
-		if errorResp.EventID != "" {
-			bifrostErr.EventID = &errorResp.EventID
-		}
-		bifrostErr.Error.Type = &errorResp.Error.Type
-		bifrostErr.Error.Code = &errorResp.Error.Code
-		bifrostErr.Error.Message = errorResp.Error.Message
-		bifrostErr.Error.Param = errorResp.Error.Param
-		if errorResp.Error.EventID != "" {
-			bifrostErr.Error.EventID = &errorResp.Error.EventID
-		}
-
-		return nil, bifrostErr
+		return nil, parseOpenAIError(resp)
 	}
 
 	responseBody := resp.Body()
@@ -350,23 +337,7 @@ func (provider *OpenAIProvider) Embedding(ctx context.Context, model string, key
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		provider.logger.Debug(fmt.Sprintf("error from openai provider: %s", string(resp.Body())))
-
-		var errorResp OpenAIError
-
-		bifrostErr := handleProviderAPIError(resp, &errorResp)
-
-		if errorResp.EventID != "" {
-			bifrostErr.EventID = &errorResp.EventID
-		}
-		bifrostErr.Error.Type = &errorResp.Error.Type
-		bifrostErr.Error.Code = &errorResp.Error.Code
-		bifrostErr.Error.Message = errorResp.Error.Message
-		bifrostErr.Error.Param = errorResp.Error.Param
-		if errorResp.Error.EventID != "" {
-			bifrostErr.Error.EventID = &errorResp.Error.EventID
-		}
-
-		return nil, bifrostErr
+		return nil, parseOpenAIError(resp)
 	}
 
 	// Parse response
@@ -558,12 +529,14 @@ func handleOpenAIStreaming(
 
 	// Check for HTTP errors
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &resp.StatusCode,
 			Error: schemas.ErrorField{
 				Message: fmt.Sprintf("HTTP error from %s: %d", providerType, resp.StatusCode),
+				Error:   fmt.Errorf("%s", string(body)),
 			},
 		}
 	}
@@ -730,4 +703,804 @@ func handleOpenAIStreaming(
 	}()
 
 	return responseChan, nil
+}
+
+func (provider *OpenAIProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	responseFormat := input.ResponseFormat
+	if responseFormat == "" {
+		responseFormat = "mp3"
+	}
+
+	requestBody := map[string]interface{}{
+		"input":           input.Input,
+		"model":           model,
+		"voice":           input.VoiceConfig.Voice,
+		"instructions":    input.Instructions,
+		"response_format": responseFormat,
+	}
+
+	if params != nil {
+		requestBody = mergeConfig(requestBody, params.ExtraParams)
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderJSONMarshaling,
+				Error:   err,
+			},
+		}
+	}
+
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set any extra headers from network config
+	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/audio/speech")
+	req.Header.SetMethod("POST")
+	req.Header.SetContentType("application/json")
+	req.Header.Set("Authorization", "Bearer "+key.Value)
+
+	req.SetBody(jsonBody)
+
+	// Make request
+	bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug(fmt.Sprintf("error from openai provider: %s", string(resp.Body())))
+		return nil, parseOpenAIError(resp)
+	}
+
+	// Get the binary audio data from the response body
+	audioData := resp.Body()
+
+	// Create final response with the audio data
+	// Note: For speech synthesis, we return the binary audio data in the raw response
+	// The audio data is typically in MP3, WAV, or other audio formats as specified by response_format
+	bifrostResponse := &schemas.BifrostResponse{
+		Object: "audio.speech",
+		Model:  model,
+		Speech: &schemas.BifrostSpeech{
+			Audio: audioData,
+		},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider: schemas.OpenAI,
+		},
+	}
+
+	if params != nil {
+		bifrostResponse.ExtraFields.Params = *params
+	}
+
+	return bifrostResponse, nil
+}
+
+func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	responseFormat := input.ResponseFormat
+	if responseFormat == "" {
+		responseFormat = "mp3"
+	}
+
+	requestBody := map[string]interface{}{
+		"input":           input.Input,
+		"model":           model,
+		"voice":           input.VoiceConfig.Voice,
+		"instructions":    input.Instructions,
+		"response_format": responseFormat,
+		"stream_format":   "sse",
+	}
+
+	if params != nil {
+		requestBody = mergeConfig(requestBody, params.ExtraParams)
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderJSONMarshaling,
+				Error:   err,
+			},
+		}
+	}
+
+	// Prepare OpenAI headers
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "Bearer " + key.Value,
+		"Accept":        "text/event-stream",
+		"Cache-Control": "no-cache",
+	}
+
+	// Create HTTP request for streaming
+	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/v1/audio/speech", strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to create HTTP request",
+				Error:   err,
+			},
+		}
+	}
+
+	// Set headers
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	// Set any extra headers from network config
+	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+
+	// Make the request
+	resp, err := provider.streamClient.Do(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderRequest,
+				Error:   err,
+			},
+		}
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &resp.StatusCode,
+			Error: schemas.ErrorField{
+				Message: fmt.Sprintf("HTTP error from %s: %d", schemas.OpenAI, resp.StatusCode),
+				Error:   fmt.Errorf("%s", string(body)),
+			},
+		}
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStream, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer close(responseChan)
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Skip empty lines and comments
+			if line == "" || strings.HasPrefix(line, ":") {
+				continue
+			}
+
+			// Check for end of stream
+			if line == "data: [DONE]" {
+				break
+			}
+
+			var jsonData string
+			var isDataLine bool
+
+			// Parse SSE data
+			if strings.HasPrefix(line, "data: ") {
+				jsonData = strings.TrimPrefix(line, "data: ")
+				isDataLine = true
+			} else {
+				// Handle raw JSON errors (without "data: " prefix)
+				jsonData = line
+				isDataLine = false
+			}
+
+			// Skip empty data
+			if strings.TrimSpace(jsonData) == "" {
+				continue
+			}
+
+			// First, check if this is an error response
+			var errorCheck map[string]interface{}
+			if err := json.Unmarshal([]byte(jsonData), &errorCheck); err != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse stream data as JSON: %v", err))
+				continue
+			}
+
+			// Handle error responses
+			if _, hasError := errorCheck["error"]; hasError {
+				var openAIError OpenAIError
+				if err := json.Unmarshal([]byte(jsonData), &openAIError); err != nil {
+					provider.logger.Warn(fmt.Sprintf("Failed to parse error response: %v", err))
+					continue
+				}
+
+				// Send error through channel
+				errorResponse := &schemas.BifrostStream{
+					BifrostError: &schemas.BifrostError{
+						IsBifrostError: false,
+						Error: schemas.ErrorField{
+							Type:    &openAIError.Error.Type,
+							Code:    &openAIError.Error.Code,
+							Message: openAIError.Error.Message,
+							Param:   openAIError.Error.Param,
+						},
+					},
+				}
+
+				if openAIError.EventID != "" {
+					errorResponse.BifrostError.EventID = &openAIError.EventID
+				}
+				if openAIError.Error.EventID != "" {
+					errorResponse.BifrostError.Error.EventID = &openAIError.Error.EventID
+				}
+
+				select {
+				case responseChan <- errorResponse:
+				case <-ctx.Done():
+				}
+				return // Stop processing on error
+			}
+
+			// Only process as regular response if it's a proper data line
+			if !isDataLine {
+				provider.logger.Warn(fmt.Sprintf("Received non-data line that's not an error: %s", line))
+				continue
+			}
+
+			// Parse into bifrost response
+			var response schemas.BifrostResponse
+
+			var speechResponse schemas.BifrostSpeech
+			if err := json.Unmarshal([]byte(jsonData), &speechResponse); err != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse stream response: %v", err))
+				continue
+			}
+
+			response.Speech = &speechResponse
+			response.Object = "audio.speech.chunk"
+			response.Model = model
+			response.ExtraFields = schemas.BifrostResponseExtraFields{
+				Provider: schemas.OpenAI,
+			}
+
+			if params != nil {
+				response.ExtraFields.Params = *params
+			}
+
+			ProcessAndSendResponse(ctx, postHookRunner, &response, responseChan)
+		}
+
+		// Handle scanner errors
+		if err := scanner.Err(); err != nil {
+			provider.logger.Warn(fmt.Sprintf("Error reading stream: %v", err))
+
+			// Send scanner error through channel
+			errorResponse := &schemas.BifrostStream{
+				BifrostError: &schemas.BifrostError{
+					IsBifrostError: true,
+					Error: schemas.ErrorField{
+						Message: "Error reading stream",
+						Error:   err,
+					},
+				},
+			}
+
+			select {
+			case responseChan <- errorResponse:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return responseChan, nil
+}
+
+func (provider *OpenAIProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	// Create multipart form
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// Add file field
+	fileWriter, err := writer.CreateFormFile("file", "audio.mp3") // OpenAI requires a filename
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to create form file",
+				Error:   err,
+			},
+		}
+	}
+	if _, err := fileWriter.Write(input.File); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to write file data",
+				Error:   err,
+			},
+		}
+	}
+
+	// Add model field
+	if err := writer.WriteField("model", model); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to write model field",
+				Error:   err,
+			},
+		}
+	}
+
+	// Add optional fields
+	if input.Language != nil {
+		if err := writer.WriteField("language", *input.Language); err != nil {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: schemas.ErrorField{
+					Message: "failed to write language field",
+					Error:   err,
+				},
+			}
+		}
+	}
+
+	if input.Prompt != nil {
+		if err := writer.WriteField("prompt", *input.Prompt); err != nil {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: schemas.ErrorField{
+					Message: "failed to write prompt field",
+					Error:   err,
+				},
+			}
+		}
+	}
+
+	if input.ResponseFormat != nil {
+		if err := writer.WriteField("response_format", *input.ResponseFormat); err != nil {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: schemas.ErrorField{
+					Message: "failed to write response_format field",
+					Error:   err,
+				},
+			}
+		}
+	}
+
+	// Note: Temperature and TimestampGranularities can be added via params.ExtraParams if needed
+
+	// Add extra params if provided
+	if params != nil && params.ExtraParams != nil {
+		for key, value := range params.ExtraParams {
+			if err := writer.WriteField(key, fmt.Sprintf("%v", value)); err != nil {
+				return nil, &schemas.BifrostError{
+					IsBifrostError: true,
+					Error: schemas.ErrorField{
+						Message: fmt.Sprintf("failed to write extra param %s", key),
+						Error:   err,
+					},
+				}
+			}
+		}
+	}
+
+	// Close the multipart writer
+	if err := writer.Close(); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to close multipart writer",
+				Error:   err,
+			},
+		}
+	}
+
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set any extra headers from network config
+	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/audio/transcriptions")
+	req.Header.SetMethod("POST")
+	req.Header.SetContentType(writer.FormDataContentType()) // This sets multipart/form-data with boundary
+	req.Header.Set("Authorization", "Bearer "+key.Value)
+
+	req.SetBody(body.Bytes())
+
+	// Make request
+	bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug(fmt.Sprintf("error from openai provider: %s", string(resp.Body())))
+		return nil, parseOpenAIError(resp)
+	}
+
+	responseBody := resp.Body()
+
+	// Parse OpenAI's transcription response directly into BifrostTranscribe
+	transcribeResponse := &schemas.BifrostTranscribe{
+		BifrostTranscribeNonStreamResponse: &schemas.BifrostTranscribeNonStreamResponse{},
+	}
+
+	if err := json.Unmarshal(responseBody, transcribeResponse); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderResponseUnmarshal,
+				Error:   err,
+			},
+		}
+	}
+
+	// Parse raw response for RawResponse field
+	var rawResponse interface{}
+	if err := json.Unmarshal(responseBody, &rawResponse); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderDecodeRaw,
+				Error:   err,
+			},
+		}
+	}
+
+	// Create final response
+	bifrostResponse := &schemas.BifrostResponse{
+		Object:     "audio.transcription",
+		Model:      model,
+		Transcribe: transcribeResponse,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Provider:    schemas.OpenAI,
+			RawResponse: rawResponse,
+		},
+	}
+
+	if params != nil {
+		bifrostResponse.ExtraFields.Params = *params
+	}
+
+	return bifrostResponse, nil
+
+}
+
+func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	// Create multipart form
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	// Add file field
+	fileWriter, err := writer.CreateFormFile("file", "audio.mp3") // OpenAI requires a filename
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to create form file",
+				Error:   err,
+			},
+		}
+	}
+	if _, err := fileWriter.Write(input.File); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to write file data",
+				Error:   err,
+			},
+		}
+	}
+
+	// Add model field
+	if err := writer.WriteField("model", model); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to write model field",
+				Error:   err,
+			},
+		}
+	}
+
+	// Add optional fields
+	if input.Language != nil {
+		if err := writer.WriteField("language", *input.Language); err != nil {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: schemas.ErrorField{
+					Message: "failed to write language field",
+					Error:   err,
+				},
+			}
+		}
+	}
+
+	if input.Prompt != nil {
+		if err := writer.WriteField("prompt", *input.Prompt); err != nil {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: schemas.ErrorField{
+					Message: "failed to write prompt field",
+					Error:   err,
+				},
+			}
+		}
+	}
+
+	if input.ResponseFormat != nil {
+		if err := writer.WriteField("response_format", *input.ResponseFormat); err != nil {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: schemas.ErrorField{
+					Message: "failed to write response_format field",
+					Error:   err,
+				},
+			}
+		}
+	}
+
+	// Note: Temperature and TimestampGranularities can be added via params.ExtraParams if needed
+
+	// Add extra params if provided
+	if params != nil && params.ExtraParams != nil {
+		for key, value := range params.ExtraParams {
+			if err := writer.WriteField(key, fmt.Sprintf("%v", value)); err != nil {
+				return nil, &schemas.BifrostError{
+					IsBifrostError: true,
+					Error: schemas.ErrorField{
+						Message: fmt.Sprintf("failed to write extra param %s", key),
+						Error:   err,
+					},
+				}
+			}
+		}
+	}
+
+	if err := writer.WriteField("stream", "true"); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to write stream field",
+				Error:   err,
+			},
+		}
+	}
+
+	// Close the multipart writer
+	if err := writer.Close(); err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to close multipart writer",
+				Error:   err,
+			},
+		}
+	}
+
+	// Prepare OpenAI headers
+	headers := map[string]string{
+		"Content-Type":  writer.FormDataContentType(),
+		"Authorization": "Bearer " + key.Value,
+		"Accept":        "text/event-stream",
+		"Cache-Control": "no-cache",
+	}
+
+	// Create HTTP request for streaming
+	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/v1/audio/transcriptions", &body)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: schemas.ErrorField{
+				Message: "failed to create HTTP request",
+				Error:   err,
+			},
+		}
+	}
+
+	// Set headers
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	// Set any extra headers from network config
+	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+
+	// Make the request
+	resp, err := provider.streamClient.Do(req)
+	if err != nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: schemas.ErrorField{
+				Message: schemas.ErrProviderRequest,
+				Error:   err,
+			},
+		}
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		//TODO: proper openAI error handling
+		resp.Body.Close()
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &resp.StatusCode,
+			Error: schemas.ErrorField{
+				Message: fmt.Sprintf("HTTP error from %s: %d", schemas.OpenAI, resp.StatusCode),
+			},
+		}
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStream, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer close(responseChan)
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Skip empty lines and comments
+			if line == "" {
+				continue
+			}
+
+			// Check for end of stream
+			if line == "data: [DONE]" {
+				break
+			}
+
+			var jsonData string
+			var isDataLine bool
+
+			// Parse SSE data
+			if strings.HasPrefix(line, "data: ") {
+				jsonData = strings.TrimPrefix(line, "data: ")
+				isDataLine = true
+			} else {
+				// Handle raw JSON errors (without "data: " prefix)
+				jsonData = line
+				isDataLine = false
+			}
+
+			// Skip empty data
+			if strings.TrimSpace(jsonData) == "" {
+				continue
+			}
+
+			// First, check if this is an error response
+			var errorCheck map[string]interface{}
+			if err := json.Unmarshal([]byte(jsonData), &errorCheck); err != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse stream data as JSON: %v", err))
+				continue
+			}
+
+			// Handle error responses
+			if _, hasError := errorCheck["error"]; hasError {
+				var openAIError OpenAIError
+				if err := json.Unmarshal([]byte(jsonData), &openAIError); err != nil {
+					provider.logger.Warn(fmt.Sprintf("Failed to parse error response: %v", err))
+					continue
+				}
+
+				// Send error through channel
+				errorResponse := &schemas.BifrostStream{
+					BifrostError: &schemas.BifrostError{
+						IsBifrostError: false,
+						Error: schemas.ErrorField{
+							Type:    &openAIError.Error.Type,
+							Code:    &openAIError.Error.Code,
+							Message: openAIError.Error.Message,
+							Param:   openAIError.Error.Param,
+						},
+					},
+				}
+
+				if openAIError.EventID != "" {
+					errorResponse.BifrostError.EventID = &openAIError.EventID
+				}
+				if openAIError.Error.EventID != "" {
+					errorResponse.BifrostError.Error.EventID = &openAIError.Error.EventID
+				}
+
+				select {
+				case responseChan <- errorResponse:
+				case <-ctx.Done():
+				}
+				return // Stop processing on error
+			}
+
+			// Only process as regular response if it's a proper data line
+			if !isDataLine {
+				provider.logger.Warn(fmt.Sprintf("Received non-data line that's not an error: %s", line))
+				continue
+			}
+
+			var response schemas.BifrostResponse
+
+			var transcriptionResponse schemas.BifrostTranscribe
+			if err := json.Unmarshal([]byte(jsonData), &transcriptionResponse); err != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse stream response: %v", err))
+				continue
+			}
+
+			response.Transcribe = &transcriptionResponse
+			response.Object = "audio.transcription.chunk"
+			response.Model = model
+			response.ExtraFields = schemas.BifrostResponseExtraFields{
+				Provider: schemas.OpenAI,
+			}
+
+			if params != nil {
+				response.ExtraFields.Params = *params
+			}
+
+			ProcessAndSendResponse(ctx, postHookRunner, &response, responseChan)
+		}
+
+		// Handle scanner errors
+		if err := scanner.Err(); err != nil {
+			provider.logger.Warn(fmt.Sprintf("Error reading stream: %v", err))
+
+			// Send scanner error through channel
+			errorResponse := &schemas.BifrostStream{
+				BifrostError: &schemas.BifrostError{
+					IsBifrostError: true,
+					Error: schemas.ErrorField{
+						Message: "Error reading stream",
+						Error:   err,
+					},
+				},
+			}
+
+			select {
+			case responseChan <- errorResponse:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return responseChan, nil
+}
+
+func parseOpenAIError(resp *fasthttp.Response) *schemas.BifrostError {
+	var errorResp OpenAIError
+
+	bifrostErr := handleProviderAPIError(resp, &errorResp)
+
+	if errorResp.EventID != "" {
+		bifrostErr.EventID = &errorResp.EventID
+	}
+	bifrostErr.Error.Type = &errorResp.Error.Type
+	bifrostErr.Error.Code = &errorResp.Error.Code
+	bifrostErr.Error.Message = errorResp.Error.Message
+	bifrostErr.Error.Param = errorResp.Error.Param
+	if errorResp.Error.EventID != "" {
+		bifrostErr.Error.EventID = &errorResp.Error.EventID
+	}
+
+	return bifrostErr
 }

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -236,3 +236,19 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 		provider.logger,
 	)
 }
+
+func (provider *SGLProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "sgl")
+}
+
+func (provider *SGLProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "sgl")
+}
+
+func (provider *SGLProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "sgl")
+}
+
+func (provider *SGLProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "sgl")
+}

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -500,3 +500,19 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 		)
 	}
 }
+
+func (provider *VertexProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech", "vertex")
+}
+
+func (provider *VertexProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("speech stream", "vertex")
+}
+
+func (provider *VertexProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription", "vertex")
+}
+
+func (provider *VertexProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, newUnsupportedOperationError("transcription stream", "vertex")
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -52,16 +52,87 @@ const (
 //* Request Structs
 
 // RequestInput represents the input for a model request, which can be either
-// a text completion, a chat completion, or an embedding request.
+// a text completion, a chat completion, an embedding request, a speech request, or a translate request.
 type RequestInput struct {
-	TextCompletionInput *string           `json:"text_completion_input,omitempty"`
-	ChatCompletionInput *[]BifrostMessage `json:"chat_completion_input,omitempty"`
-	EmbeddingInput      *EmbeddingInput   `json:"embedding_input,omitempty"`
+	TextCompletionInput *string             `json:"text_completion_input,omitempty"`
+	ChatCompletionInput *[]BifrostMessage   `json:"chat_completion_input,omitempty"`
+	EmbeddingInput      *EmbeddingInput     `json:"embedding_input,omitempty"`
+	SpeechInput         *SpeechInput        `json:"speech_input,omitempty"`
+	TranscriptionInput  *TranscriptionInput `json:"transcription_input,omitempty"`
 }
 
 // EmbeddingInput represents the input for an embedding request.
 type EmbeddingInput struct {
 	Texts []string `json:"texts"`
+}
+
+// SpeechInput represents the input for a speech request.
+type SpeechInput struct {
+	Input          string           `json:"input"`
+	VoiceConfig    SpeechVoiceInput `json:"voice"`
+	Instructions   string           `json:"instructions,omitempty"`
+	ResponseFormat string           `json:"response_format,omitempty"` // Default is "mp3"
+}
+
+type SpeechVoiceInput struct {
+	Voice            *string
+	MultiVoiceConfig []VoiceConfig
+}
+
+type VoiceConfig struct {
+	Speaker string `json:"speaker"`
+	Voice   string `json:"voice"`
+}
+
+// MarshalJSON implements custom JSON marshalling for SpeechVoiceInput.
+// It marshals either Voice or MultiVoiceConfig directly without wrapping.
+func (tc SpeechVoiceInput) MarshalJSON() ([]byte, error) {
+	// Validation: ensure only one field is set at a time
+	if tc.Voice != nil && len(tc.MultiVoiceConfig) > 0 {
+		return nil, fmt.Errorf("both Voice and MultiVoiceConfig are set; only one should be non-nil")
+	}
+
+	if tc.Voice != nil {
+		return json.Marshal(*tc.Voice)
+	}
+	if len(tc.MultiVoiceConfig) > 0 {
+		return json.Marshal(tc.MultiVoiceConfig)
+	}
+	// If both are nil, return null
+	return json.Marshal(nil)
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for SpeechVoiceInput.
+// It determines whether "voice" is a string or struct and assigns to the appropriate field.
+// It also handles direct string/array content without a wrapper object.
+func (tc *SpeechVoiceInput) UnmarshalJSON(data []byte) error {
+	// First, try to unmarshal as a direct string
+	var stringContent string
+	if err := json.Unmarshal(data, &stringContent); err == nil {
+		tc.Voice = &stringContent
+		return nil
+	}
+
+	// Try to unmarshal as a direct struct of ToolChoiceStruct
+	var voiceConfig VoiceConfig
+	if err := json.Unmarshal(data, &voiceConfig); err == nil {
+		// Validate the Type field is not empty and is a valid value
+		if voiceConfig.Voice == "" {
+			return fmt.Errorf("voice config has empty voice field")
+		}
+
+		tc.MultiVoiceConfig = append(tc.MultiVoiceConfig, voiceConfig)
+		return nil
+	}
+
+	return fmt.Errorf("voice field is neither a string nor a struct")
+}
+
+type TranscriptionInput struct {
+	File           []byte  `json:"file"`
+	Language       *string `json:"language,omitempty"`
+	Prompt         *string `json:"prompt,omitempty"`
+	ResponseFormat *string `json:"response_format,omitempty"` // Default is "json"
 }
 
 // BifrostRequest represents a request to be processed by Bifrost.
@@ -302,7 +373,9 @@ type BifrostResponse struct {
 	ID                string                     `json:"id,omitempty"`
 	Object            string                     `json:"object,omitempty"` // text.completion, chat.completion, or embedding
 	Choices           []BifrostResponseChoice    `json:"choices,omitempty"`
-	Embedding         [][]float32                `json:"data,omitempty"` // Maps to "data" field in provider responses (e.g., OpenAI embedding format)
+	Embedding         [][]float32                `json:"data,omitempty"`       // Maps to "data" field in provider responses (e.g., OpenAI embedding format)
+	Speech            *BifrostSpeech             `json:"speech,omitempty"`     // Maps to "speech" field in provider responses (e.g., OpenAI speech format)
+	Transcribe        *BifrostTranscribe         `json:"transcribe,omitempty"` // Maps to "transcribe" field in provider responses (e.g., OpenAI transcription format)
 	Model             string                     `json:"model,omitempty"`
 	Created           int                        `json:"created,omitempty"` // The Unix timestamp (in seconds).
 	ServiceTier       *string                    `json:"service_tier,omitempty"`
@@ -318,6 +391,18 @@ type LLMUsage struct {
 	TotalTokens             int                      `json:"total_tokens"`
 	TokenDetails            *TokenDetails            `json:"prompt_tokens_details,omitempty"`
 	CompletionTokensDetails *CompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+type AudioLLMUsage struct {
+	InputTokens        int                `json:"input_tokens"`
+	InputTokensDetails *AudioTokenDetails `json:"input_tokens_details,omitempty"`
+	OutputTokens       int                `json:"output_tokens"`
+	TotalTokens        int                `json:"total_tokens"`
+}
+
+type AudioTokenDetails struct {
+	TextTokens  int `json:"text_tokens"`
+	AudioTokens int `json:"audio_tokens"`
 }
 
 // TokenDetails provides detailed information about token usage.
@@ -434,6 +519,81 @@ type BifrostStreamDelta struct {
 	Thought   *string    `json:"thought,omitempty"`    // May be empty string or null
 	Refusal   *string    `json:"refusal,omitempty"`    // Refusal content if any
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
+}
+
+type BifrostSpeech struct {
+	Usage *AudioLLMUsage `json:"usage,omitempty"`
+	Audio []byte         `json:"audio"`
+
+	*BifrostSpeechStreamResponse
+}
+type BifrostSpeechStreamResponse struct {
+	Type string `json:"type"`
+}
+
+// BifrostTranscribe represents transcription response data
+type BifrostTranscribe struct {
+	// Common fields for both streaming and non-streaming
+	Text     string                 `json:"text"`
+	LogProbs []TranscriptionLogProb `json:"logprobs,omitempty"`
+	Usage    *TranscriptionUsage    `json:"usage,omitempty"`
+
+	// Embedded structs for specific fields only
+	*BifrostTranscribeNonStreamResponse
+	*BifrostTranscribeStreamResponse
+}
+
+// BifrostTranscribeNonStreamResponse represents non-streaming specific fields only
+type BifrostTranscribeNonStreamResponse struct {
+	Task     *string                `json:"task,omitempty"`     // e.g., "transcribe"
+	Language *string                `json:"language,omitempty"` // e.g., "english"
+	Duration *float64               `json:"duration,omitempty"` // Duration in seconds
+	Words    []TranscriptionWord    `json:"words,omitempty"`
+	Segments []TranscriptionSegment `json:"segments,omitempty"`
+}
+
+// BifrostTranscribeStreamResponse represents streaming specific fields only
+type BifrostTranscribeStreamResponse struct {
+	Type  *string `json:"type,omitempty"`  // "transcript.text.delta" or "transcript.text.done"
+	Delta *string `json:"delta,omitempty"` // For delta events
+}
+
+// TranscriptionLogProb represents log probability information for transcription
+type TranscriptionLogProb struct {
+	Token   string  `json:"token"`
+	LogProb float64 `json:"logprob"`
+	Bytes   []int   `json:"bytes"`
+}
+
+// TranscriptionWord represents word-level timing information
+type TranscriptionWord struct {
+	Word  string  `json:"word"`
+	Start float64 `json:"start"`
+	End   float64 `json:"end"`
+}
+
+// TranscriptionSegment represents segment-level transcription information
+type TranscriptionSegment struct {
+	ID               int     `json:"id"`
+	Seek             int     `json:"seek"`
+	Start            float64 `json:"start"`
+	End              float64 `json:"end"`
+	Text             string  `json:"text"`
+	Tokens           []int   `json:"tokens"`
+	Temperature      float64 `json:"temperature"`
+	AvgLogProb       float64 `json:"avg_logprob"`
+	CompressionRatio float64 `json:"compression_ratio"`
+	NoSpeechProb     float64 `json:"no_speech_prob"`
+}
+
+// TranscriptionUsage represents usage information for transcription
+type TranscriptionUsage struct {
+	Type              string             `json:"type"` // "tokens" or "duration"
+	InputTokens       *int               `json:"input_tokens,omitempty"`
+	InputTokenDetails *AudioTokenDetails `json:"input_token_details,omitempty"`
+	OutputTokens      *int               `json:"output_tokens,omitempty"`
+	TotalTokens       *int               `json:"total_tokens,omitempty"`
+	Seconds           *int               `json:"seconds,omitempty"` // For duration-based usage
 }
 
 // BifrostResponseExtraFields contains additional fields in a response.

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -155,4 +155,12 @@ type Provider interface {
 	ChatCompletionStream(ctx context.Context, postHookRunner PostHookRunner, model string, key Key, messages []BifrostMessage, params *ModelParameters) (chan *BifrostStream, *BifrostError)
 	// Embedding performs an embedding request
 	Embedding(ctx context.Context, model string, key Key, input *EmbeddingInput, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	// Speech performs a text to speech request
+	Speech(ctx context.Context, model string, key Key, input *SpeechInput, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	// SpeechStream performs a text to speech stream request
+	SpeechStream(ctx context.Context, postHookRunner PostHookRunner, model string, key Key, input *SpeechInput, params *ModelParameters) (chan *BifrostStream, *BifrostError)
+	// Transcription performs a transcription request
+	Transcription(ctx context.Context, model string, key Key, input *TranscriptionInput, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	// TranscriptionStream performs a transcription stream request
+	TranscriptionStream(ctx context.Context, postHookRunner PostHookRunner, model string, key Key, input *TranscriptionInput, params *ModelParameters) (chan *BifrostStream, *BifrostError)
 }

--- a/transports/bifrost-http/handlers/completions.go
+++ b/transports/bifrost-http/handlers/completions.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/fasthttp/router"
@@ -38,13 +39,22 @@ type CompletionRequest struct {
 	Params    *schemas.ModelParameters `json:"params"`    // Additional model parameters
 	Fallbacks []string                 `json:"fallbacks"` // Fallback providers and models in "provider/model" format
 	Stream    *bool                    `json:"stream"`    // Whether to stream the response
+
+	// Speech inputs
+	Input          string                   `json:"input"`
+	Voice          schemas.SpeechVoiceInput `json:"voice"`
+	Instructions   string                   `json:"instructions"`
+	ResponseFormat string                   `json:"response_format"`
+	StreamFormat   *string                  `json:"stream_format,omitempty"`
 }
 
 type CompletionType string
 
 const (
-	CompletionTypeText CompletionType = "text"
-	CompletionTypeChat CompletionType = "chat"
+	CompletionTypeText          CompletionType = "text"
+	CompletionTypeChat          CompletionType = "chat"
+	CompletionTypeSpeech        CompletionType = "speech"
+	CompletionTypeTranscription CompletionType = "transcription"
 )
 
 // RegisterRoutes registers all completion-related routes
@@ -52,21 +62,33 @@ func (h *CompletionHandler) RegisterRoutes(r *router.Router) {
 	// Completion endpoints
 	r.POST("/v1/text/completions", h.TextCompletion)
 	r.POST("/v1/chat/completions", h.ChatCompletion)
+	r.POST("/v1/audio/speech", h.SpeechCompletion)
+	r.POST("/v1/audio/transcriptions", h.TranscriptionCompletion)
 }
 
 // TextCompletion handles POST /v1/text/completions - Process text completion requests
 func (h *CompletionHandler) TextCompletion(ctx *fasthttp.RequestCtx) {
-	h.handleCompletion(ctx, CompletionTypeText)
+	h.handleRequest(ctx, CompletionTypeText)
 }
 
 // ChatCompletion handles POST /v1/chat/completions - Process chat completion requests
 func (h *CompletionHandler) ChatCompletion(ctx *fasthttp.RequestCtx) {
-	h.handleCompletion(ctx, CompletionTypeChat)
+	h.handleRequest(ctx, CompletionTypeChat)
+}
+
+// SpeechCompletion handles POST /v1/audio/speech - Process speech completion requests
+func (h *CompletionHandler) SpeechCompletion(ctx *fasthttp.RequestCtx) {
+	h.handleRequest(ctx, CompletionTypeSpeech)
+}
+
+// TranscriptionCompletion handles POST /v1/audio/transcriptions - Process transcription requests
+func (h *CompletionHandler) TranscriptionCompletion(ctx *fasthttp.RequestCtx) {
+	h.handleTranscriptionRequest(ctx)
 }
 
 // handleCompletion processes both text and chat completion requests
 // It handles request parsing, validation, and response formatting
-func (h *CompletionHandler) handleCompletion(ctx *fasthttp.RequestCtx, completionType CompletionType) {
+func (h *CompletionHandler) handleRequest(ctx *fasthttp.RequestCtx, completionType CompletionType) {
 	var req CompletionRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err), h.logger)
@@ -126,6 +148,23 @@ func (h *CompletionHandler) handleCompletion(ctx *fasthttp.RequestCtx, completio
 		bifrostReq.Input = schemas.RequestInput{
 			ChatCompletionInput: &req.Messages,
 		}
+	case CompletionTypeSpeech:
+		if req.Input == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "Input is required for speech completion", h.logger)
+			return
+		}
+		if req.Voice.Voice == nil && len(req.Voice.MultiVoiceConfig) == 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "Voice is required for speech completion", h.logger)
+			return
+		}
+		bifrostReq.Input = schemas.RequestInput{
+			SpeechInput: &schemas.SpeechInput{
+				Input:          req.Input,
+				VoiceConfig:    req.Voice,
+				Instructions:   req.Instructions,
+				ResponseFormat: req.ResponseFormat,
+			},
+		}
 	}
 
 	// Convert context
@@ -136,12 +175,18 @@ func (h *CompletionHandler) handleCompletion(ctx *fasthttp.RequestCtx, completio
 	}
 
 	// Check if streaming is requested
-	isStreaming := req.Stream != nil && *req.Stream
+	isStreaming := req.Stream != nil && *req.Stream || req.StreamFormat != nil && *req.StreamFormat == "sse"
 
 	// Handle streaming for chat completions only
-	if isStreaming && completionType == CompletionTypeChat {
-		h.handleStreamingChatCompletion(ctx, bifrostReq, bifrostCtx)
-		return
+	if isStreaming {
+		switch completionType {
+		case CompletionTypeChat:
+			h.handleStreamingChatCompletion(ctx, bifrostReq, bifrostCtx)
+			return
+		case CompletionTypeSpeech:
+			h.handleStreamingSpeech(ctx, bifrostReq, bifrostCtx)
+			return
+		}
 	}
 
 	// Handle non-streaming requests
@@ -153,11 +198,26 @@ func (h *CompletionHandler) handleCompletion(ctx *fasthttp.RequestCtx, completio
 		resp, bifrostErr = h.client.TextCompletionRequest(*bifrostCtx, bifrostReq)
 	case CompletionTypeChat:
 		resp, bifrostErr = h.client.ChatCompletionRequest(*bifrostCtx, bifrostReq)
+	case CompletionTypeSpeech:
+		resp, bifrostErr = h.client.SpeechRequest(*bifrostCtx, bifrostReq)
 	}
 
 	// Handle response
 	if bifrostErr != nil {
 		SendBifrostError(ctx, bifrostErr, h.logger)
+		return
+	}
+
+	if completionType == CompletionTypeSpeech {
+		if resp.Speech.Audio == nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, "Speech response is missing audio data", h.logger)
+			return
+		}
+
+		ctx.Response.Header.Set("Content-Type", "audio/mpeg")
+		ctx.Response.Header.Set("Content-Disposition", "attachment; filename=speech.mp3")
+		ctx.Response.Header.Set("Content-Length", strconv.Itoa(len(resp.Speech.Audio)))
+		ctx.Response.SetBody(resp.Speech.Audio)
 		return
 	}
 
@@ -193,6 +253,213 @@ func (h *CompletionHandler) handleStreamingChatCompletion(ctx *fasthttp.RequestC
 
 			// Convert response to JSON
 			responseJSON, err := json.Marshal(response)
+			if err != nil {
+				h.logger.Warn(fmt.Sprintf("Failed to marshal streaming response: %v", err))
+				continue
+			}
+
+			// Send as SSE data
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", responseJSON); err != nil {
+				h.logger.Warn(fmt.Sprintf("Failed to write SSE data: %v", err))
+				break
+			}
+
+			// Flush immediately to send the chunk
+			if err := w.Flush(); err != nil {
+				h.logger.Warn(fmt.Sprintf("Failed to flush SSE data: %v", err))
+				break
+			}
+		}
+
+		// Send the [DONE] marker to indicate the end of the stream
+		if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
+			h.logger.Warn(fmt.Sprintf("Failed to write SSE done marker: %v", err))
+		}
+	})
+}
+
+// handleStreamingChatCompletion handles streaming chat completion requests using Server-Sent Events (SSE)
+func (h *CompletionHandler) handleStreamingSpeech(ctx *fasthttp.RequestCtx, req *schemas.BifrostRequest, bifrostCtx *context.Context) {
+	// Set SSE headers
+	ctx.SetContentType("text/event-stream")
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.Response.Header.Set("Connection", "keep-alive")
+	ctx.Response.Header.Set("Access-Control-Allow-Origin", "*")
+
+	// Get the streaming channel from Bifrost
+	stream, bifrostErr := h.client.SpeechStreamRequest(*bifrostCtx, req)
+	if bifrostErr != nil {
+		// Send error in SSE format
+		SendSSEError(ctx, bifrostErr, h.logger)
+		return
+	}
+
+	// Use streaming response writer
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer w.Flush()
+
+		// Process streaming responses
+		for response := range stream {
+			if response == nil || response.Speech == nil || response.Speech.BifrostSpeechStreamResponse == nil {
+				continue
+			}
+
+			// Convert response to JSON
+			responseJSON, err := json.Marshal(response.Speech)
+			if err != nil {
+				h.logger.Warn(fmt.Sprintf("Failed to marshal streaming response: %v", err))
+				continue
+			}
+
+			// Send as SSE data
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", responseJSON); err != nil {
+				h.logger.Warn(fmt.Sprintf("Failed to write SSE data: %v", err))
+				break
+			}
+
+			// Flush immediately to send the chunk
+			if err := w.Flush(); err != nil {
+				h.logger.Warn(fmt.Sprintf("Failed to flush SSE data: %v", err))
+				break
+			}
+		}
+
+		// Send the [DONE] marker to indicate the end of the stream
+		if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
+			h.logger.Warn(fmt.Sprintf("Failed to write SSE done marker: %v", err))
+		}
+	})
+}
+
+// handleTranscriptionRequest handles transcription requests with multipart form data
+func (h *CompletionHandler) handleTranscriptionRequest(ctx *fasthttp.RequestCtx) {
+	// Parse multipart form
+	form, err := ctx.MultipartForm()
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Failed to parse multipart form: %v", err), h.logger)
+		return
+	}
+
+	// Extract model (required)
+	modelValues := form.Value["model"]
+	if len(modelValues) == 0 || modelValues[0] == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "Model is required", h.logger)
+		return
+	}
+
+	modelParts := strings.SplitN(modelValues[0], "/", 2)
+	if len(modelParts) < 2 {
+		SendError(ctx, fasthttp.StatusBadRequest, "Model must be in the format of 'provider/model'", h.logger)
+		return
+	}
+
+	provider := modelParts[0]
+	modelName := modelParts[1]
+
+	// Extract file (required)
+	fileHeaders := form.File["file"]
+	if len(fileHeaders) == 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, "File is required", h.logger)
+		return
+	}
+
+	fileHeader := fileHeaders[0]
+	file, err := fileHeader.Open()
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Failed to open uploaded file: %v", err), h.logger)
+		return
+	}
+	defer file.Close()
+
+	// Read file data
+	fileData := make([]byte, fileHeader.Size)
+	if _, err := file.Read(fileData); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to read uploaded file: %v", err), h.logger)
+		return
+	}
+
+	// Create transcription input
+	transcriptionInput := &schemas.TranscriptionInput{
+		File: fileData,
+	}
+
+	// Extract optional parameters
+	if languageValues := form.Value["language"]; len(languageValues) > 0 && languageValues[0] != "" {
+		transcriptionInput.Language = &languageValues[0]
+	}
+
+	if promptValues := form.Value["prompt"]; len(promptValues) > 0 && promptValues[0] != "" {
+		transcriptionInput.Prompt = &promptValues[0]
+	}
+
+	if responseFormatValues := form.Value["response_format"]; len(responseFormatValues) > 0 && responseFormatValues[0] != "" {
+		transcriptionInput.ResponseFormat = &responseFormatValues[0]
+	}
+
+	// Create BifrostRequest
+	bifrostReq := &schemas.BifrostRequest{
+		Model:    modelName,
+		Provider: schemas.ModelProvider(provider),
+		Input: schemas.RequestInput{
+			TranscriptionInput: transcriptionInput,
+		},
+	}
+
+	// Convert context
+	bifrostCtx := lib.ConvertToBifrostContext(ctx)
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context", h.logger)
+		return
+	}
+
+	if streamValues := form.Value["stream"]; len(streamValues) > 0 && streamValues[0] != "" {
+		stream := streamValues[0]
+		if stream == "true" {
+			h.handleStreamingTranscriptionRequest(ctx, bifrostReq, bifrostCtx)
+			return
+		}
+	}
+
+	// Make transcription request
+	resp, bifrostErr := h.client.TranscriptionRequest(*bifrostCtx, bifrostReq)
+
+	// Handle response
+	if bifrostErr != nil {
+		SendBifrostError(ctx, bifrostErr, h.logger)
+		return
+	}
+
+	// Send successful response
+	SendJSON(ctx, resp, h.logger)
+}
+
+func (h *CompletionHandler) handleStreamingTranscriptionRequest(ctx *fasthttp.RequestCtx, req *schemas.BifrostRequest, bifrostCtx *context.Context) {
+	// Set SSE headers
+	ctx.SetContentType("text/event-stream")
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.Response.Header.Set("Connection", "keep-alive")
+	ctx.Response.Header.Set("Access-Control-Allow-Origin", "*")
+
+	// Get the streaming channel from Bifrost
+	stream, bifrostErr := h.client.TranscriptionStreamRequest(*bifrostCtx, req)
+	if bifrostErr != nil {
+		// Send error in SSE format
+		SendSSEError(ctx, bifrostErr, h.logger)
+		return
+	}
+
+	// Use streaming response writer
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer w.Flush()
+
+		// Process streaming responses
+		for response := range stream {
+			if response == nil || response.Transcribe == nil || response.Transcribe.BifrostTranscribeStreamResponse == nil {
+				continue
+			}
+
+			// Convert response to JSON
+			responseJSON, err := json.Marshal(response.Transcribe)
 			if err != nil {
 				h.logger.Warn(fmt.Sprintf("Failed to marshal streaming response: %v", err))
 				continue

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -3,6 +3,7 @@
 package lib
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -35,7 +36,7 @@ func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvide
 // GetKeysForProvider returns the API keys configured for a specific provider.
 // Keys are already processed (environment variables resolved) by the store.
 // Implements the Account interface.
-func (baseAccount *BaseAccount) GetKeysForProvider(providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (baseAccount *BaseAccount) GetKeysForProvider(ctx *context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	if baseAccount.store == nil {
 		return nil, fmt.Errorf("store not initialized")
 	}

--- a/transports/bifrost-http/plugins/logging/main.go
+++ b/transports/bifrost-http/plugins/logging/main.go
@@ -41,13 +41,15 @@ const (
 
 // UpdateLogData contains data for log entry updates
 type UpdateLogData struct {
-	Status        string
-	TokenUsage    *schemas.LLMUsage
-	OutputMessage *schemas.BifrostMessage
-	ToolCalls     *[]schemas.ToolCall
-	ErrorDetails  *schemas.BifrostError
-	Model         string // May be different from request
-	Object        string // May be different from request
+	Status              string
+	TokenUsage          *schemas.LLMUsage
+	OutputMessage       *schemas.BifrostMessage
+	ToolCalls           *[]schemas.ToolCall
+	ErrorDetails        *schemas.BifrostError
+	Model               string                     // May be different from request
+	Object              string                     // May be different from request
+	SpeechOutput        *schemas.BifrostSpeech     // For non-streaming speech responses
+	TranscriptionOutput *schemas.BifrostTranscribe // For non-streaming transcription responses
 }
 
 // StreamUpdateData contains lightweight data for streaming delta updates
@@ -72,32 +74,38 @@ type LogMessage struct {
 
 // InitialLogData contains data for initial log entry creation
 type InitialLogData struct {
-	Provider     string
-	Model        string
-	Object       string
-	InputHistory []schemas.BifrostMessage
-	Params       *schemas.ModelParameters
-	Tools        *[]schemas.Tool
+	Provider           string
+	Model              string
+	Object             string
+	InputHistory       []schemas.BifrostMessage
+	Params             *schemas.ModelParameters
+	SpeechInput        *schemas.SpeechInput
+	TranscriptionInput *schemas.TranscriptionInput
+	Tools              *[]schemas.Tool
 }
 
 // LogEntry represents a complete log entry for a request/response cycle
 type LogEntry struct {
-	ID            string                   `json:"id"`
-	Timestamp     time.Time                `json:"timestamp"`
-	Object        string                   `json:"object"` // text.completion, chat.completion, or embedding
-	Provider      string                   `json:"provider"`
-	Model         string                   `json:"model"`
-	InputHistory  []schemas.BifrostMessage `json:"input_history,omitempty"`
-	OutputMessage *schemas.BifrostMessage  `json:"output_message,omitempty"`
-	Params        *schemas.ModelParameters `json:"params,omitempty"`
-	Tools         *[]schemas.Tool          `json:"tools,omitempty"`
-	ToolCalls     *[]schemas.ToolCall      `json:"tool_calls,omitempty"`
-	Latency       *float64                 `json:"latency,omitempty"`
-	TokenUsage    *schemas.LLMUsage        `json:"token_usage,omitempty"`
-	Status        string                   `json:"status"` // "processing", "success", or "error"
-	ErrorDetails  *schemas.BifrostError    `json:"error_details,omitempty"`
-	Stream        bool                     `json:"stream"` // true if this was a streaming response
-	CreatedAt     time.Time                `json:"created_at"`
+	ID                  string                      `json:"id"`
+	Timestamp           time.Time                   `json:"timestamp"`
+	Object              string                      `json:"object"` // text.completion, chat.completion, embedding, audio.speech, or audio.transcription
+	Provider            string                      `json:"provider"`
+	Model               string                      `json:"model"`
+	InputHistory        []schemas.BifrostMessage    `json:"input_history,omitempty"`
+	OutputMessage       *schemas.BifrostMessage     `json:"output_message,omitempty"`
+	Params              *schemas.ModelParameters    `json:"params,omitempty"`
+	SpeechInput         *schemas.SpeechInput        `json:"speech_input,omitempty"`
+	TranscriptionInput  *schemas.TranscriptionInput `json:"transcription_input,omitempty"`
+	SpeechOutput        *schemas.BifrostSpeech      `json:"speech_output,omitempty"`
+	TranscriptionOutput *schemas.BifrostTranscribe  `json:"transcription_output,omitempty"`
+	Tools               *[]schemas.Tool             `json:"tools,omitempty"`
+	ToolCalls           *[]schemas.ToolCall         `json:"tool_calls,omitempty"`
+	Latency             *float64                    `json:"latency,omitempty"`
+	TokenUsage          *schemas.LLMUsage           `json:"token_usage,omitempty"`
+	Status              string                      `json:"status"` // "processing", "success", or "error"
+	ErrorDetails        *schemas.BifrostError       `json:"error_details,omitempty"`
+	Stream              bool                        `json:"stream"` // true if this was a streaming response
+	CreatedAt           time.Time                   `json:"created_at"`
 }
 
 // SearchFilters represents the available filters for log searches
@@ -258,6 +266,10 @@ func (p *LoggerPlugin) createTables() error {
 		tool_calls TEXT,
 		params TEXT,
 		error_details TEXT,
+		speech_input TEXT,
+		transcription_input TEXT,
+		speech_output TEXT,
+		transcription_output TEXT,
 		
 		-- For content search
 		content_summary TEXT,
@@ -334,29 +346,32 @@ func (p *LoggerPlugin) createTables() error {
 
 // migrateTableSchema adds new columns if they don't exist
 func (p *LoggerPlugin) migrateTableSchema() error {
-	// Check if created_at column exists
-	var columnExists bool
-	err := p.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('logs') WHERE name = 'created_at'").Scan(&columnExists)
-	if err != nil {
-		return fmt.Errorf("failed to check for created_at column: %w", err)
+	// List of columns to check and add
+	columnsToAdd := []struct {
+		name         string
+		definition   string
+		defaultValue string
+	}{
+		{"created_at", "INTEGER", "0"},
+		{"stream", "BOOLEAN", "FALSE"},
+		{"speech_input", "TEXT", "NULL"},
+		{"transcription_input", "TEXT", "NULL"},
+		{"speech_output", "TEXT", "NULL"},
+		{"transcription_output", "TEXT", "NULL"},
 	}
 
-	if !columnExists {
-		if _, err := p.db.Exec("ALTER TABLE logs ADD COLUMN created_at INTEGER DEFAULT 0"); err != nil {
-			return fmt.Errorf("failed to add created_at column: %w", err)
+	for _, column := range columnsToAdd {
+		var columnExists bool
+		err := p.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('logs') WHERE name = ?", column.name).Scan(&columnExists)
+		if err != nil {
+			return fmt.Errorf("failed to check for %s column: %w", column.name, err)
 		}
-	}
 
-	// Check if stream column exists
-	columnExists = false
-	err = p.db.QueryRow("SELECT COUNT(*) FROM pragma_table_info('logs') WHERE name = 'stream'").Scan(&columnExists)
-	if err != nil {
-		return fmt.Errorf("failed to check for stream column: %w", err)
-	}
-
-	if !columnExists {
-		if _, err := p.db.Exec("ALTER TABLE logs ADD COLUMN stream BOOLEAN DEFAULT FALSE"); err != nil {
-			return fmt.Errorf("failed to add stream column: %w", err)
+		if !columnExists {
+			query := fmt.Sprintf("ALTER TABLE logs ADD COLUMN %s %s DEFAULT %s", column.name, column.definition, column.defaultValue)
+			if _, err := p.db.Exec(query); err != nil {
+				return fmt.Errorf("failed to add %s column: %w", column.name, err)
+			}
 		}
 	}
 
@@ -433,6 +448,8 @@ func (p *LoggerPlugin) putUpdateLogData(data *UpdateLogData) {
 	data.ErrorDetails = nil
 	data.Model = ""
 	data.Object = ""
+	data.SpeechOutput = nil
+	data.TranscriptionOutput = nil
 
 	p.updateDataPool.Put(data)
 }
@@ -488,11 +505,13 @@ func (p *LoggerPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest
 	inputHistory := p.extractInputHistory(req.Input)
 
 	initialData := &InitialLogData{
-		Provider:     string(req.Provider),
-		Model:        req.Model,
-		Object:       objectType,
-		InputHistory: inputHistory,
-		Params:       req.Params,
+		Provider:           string(req.Provider),
+		Model:              req.Model,
+		Object:             objectType,
+		InputHistory:       inputHistory,
+		Params:             req.Params,
+		SpeechInput:        req.Input.SpeechInput,
+		TranscriptionInput: req.Input.TranscriptionInput,
 	}
 
 	if req.Params != nil && req.Params.Tools != nil {
@@ -516,17 +535,19 @@ func (p *LoggerPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest
 			p.mu.Lock()
 			if p.logCallback != nil {
 				initialEntry := &LogEntry{
-					ID:           logMsg.RequestID,
-					Timestamp:    logMsg.Timestamp,
-					Object:       logMsg.InitialData.Object,
-					Provider:     logMsg.InitialData.Provider,
-					Model:        logMsg.InitialData.Model,
-					InputHistory: logMsg.InitialData.InputHistory,
-					Params:       logMsg.InitialData.Params,
-					Tools:        logMsg.InitialData.Tools,
-					Status:       "processing",
-					Stream:       false, // Initially false, will be updated if streaming
-					CreatedAt:    logMsg.Timestamp,
+					ID:                 logMsg.RequestID,
+					Timestamp:          logMsg.Timestamp,
+					Object:             logMsg.InitialData.Object,
+					Provider:           logMsg.InitialData.Provider,
+					Model:              logMsg.InitialData.Model,
+					InputHistory:       logMsg.InitialData.InputHistory,
+					Params:             logMsg.InitialData.Params,
+					SpeechInput:        logMsg.InitialData.SpeechInput,
+					TranscriptionInput: logMsg.InitialData.TranscriptionInput,
+					Tools:              logMsg.InitialData.Tools,
+					Status:             "processing",
+					Stream:             false, // Initially false, will be updated if streaming
+					CreatedAt:          logMsg.Timestamp,
 				}
 				p.logCallback(initialEntry)
 			}
@@ -601,6 +622,42 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 				}
 				streamUpdateData.FinishReason = choice.FinishReason
 			}
+
+			// Extract token usage from speech and transcription streaming (lightweight)
+			if result.Speech != nil && result.Speech.Usage != nil && streamUpdateData.TokenUsage == nil {
+				streamUpdateData.TokenUsage = &schemas.LLMUsage{
+					PromptTokens:     result.Speech.Usage.InputTokens,
+					CompletionTokens: result.Speech.Usage.OutputTokens,
+					TotalTokens:      result.Speech.Usage.TotalTokens,
+				}
+				// Map audio token details if available
+				if result.Speech.Usage.InputTokensDetails != nil {
+					streamUpdateData.TokenUsage.TokenDetails = &schemas.TokenDetails{
+						AudioTokens: result.Speech.Usage.InputTokensDetails.AudioTokens,
+					}
+				}
+			}
+			if result.Transcribe != nil && result.Transcribe.Usage != nil && streamUpdateData.TokenUsage == nil {
+				transcriptionUsage := result.Transcribe.Usage
+				streamUpdateData.TokenUsage = &schemas.LLMUsage{}
+
+				if transcriptionUsage.InputTokens != nil {
+					streamUpdateData.TokenUsage.PromptTokens = *transcriptionUsage.InputTokens
+				}
+				if transcriptionUsage.OutputTokens != nil {
+					streamUpdateData.TokenUsage.CompletionTokens = *transcriptionUsage.OutputTokens
+				}
+				if transcriptionUsage.TotalTokens != nil {
+					streamUpdateData.TokenUsage.TotalTokens = *transcriptionUsage.TotalTokens
+				}
+
+				// Map audio token details if available
+				if transcriptionUsage.InputTokenDetails != nil {
+					streamUpdateData.TokenUsage.TokenDetails = &schemas.TokenDetails{
+						AudioTokens: transcriptionUsage.InputTokenDetails.AudioTokens,
+					}
+				}
+			}
 		}
 
 		logMsg.StreamUpdateData = streamUpdateData
@@ -644,13 +701,62 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 					updateData.ToolCalls = result.Choices[0].Message.AssistantMessage.ToolCalls
 				}
 			}
+
+			// Handle speech and transcription outputs for NON-streaming responses
+			if result.Speech != nil {
+				updateData.SpeechOutput = result.Speech
+				// Extract token usage
+				if result.Speech.Usage != nil && updateData.TokenUsage == nil {
+					updateData.TokenUsage = &schemas.LLMUsage{
+						PromptTokens:     result.Speech.Usage.InputTokens,
+						CompletionTokens: result.Speech.Usage.OutputTokens,
+						TotalTokens:      result.Speech.Usage.TotalTokens,
+					}
+					// Map audio token details if available
+					if result.Speech.Usage.InputTokensDetails != nil {
+						updateData.TokenUsage.TokenDetails = &schemas.TokenDetails{
+							AudioTokens: result.Speech.Usage.InputTokensDetails.AudioTokens,
+						}
+					}
+				}
+			}
+			if result.Transcribe != nil {
+				updateData.TranscriptionOutput = result.Transcribe
+				// Extract token usage
+				if result.Transcribe.Usage != nil && updateData.TokenUsage == nil {
+					transcriptionUsage := result.Transcribe.Usage
+					updateData.TokenUsage = &schemas.LLMUsage{}
+
+					if transcriptionUsage.InputTokens != nil {
+						updateData.TokenUsage.PromptTokens = *transcriptionUsage.InputTokens
+					}
+					if transcriptionUsage.OutputTokens != nil {
+						updateData.TokenUsage.CompletionTokens = *transcriptionUsage.OutputTokens
+					}
+					if transcriptionUsage.TotalTokens != nil {
+						updateData.TokenUsage.TotalTokens = *transcriptionUsage.TotalTokens
+					}
+
+					// Map audio token details if available
+					if transcriptionUsage.InputTokenDetails != nil {
+						updateData.TokenUsage.TokenDetails = &schemas.TokenDetails{
+							AudioTokens: transcriptionUsage.InputTokenDetails.AudioTokens,
+						}
+					}
+				}
+			}
 		}
 
 		logMsg.UpdateData = updateData
 	}
 
+	isFinalChunk := logMsg.StreamUpdateData != nil &&
+		(logMsg.StreamUpdateData.FinishReason != nil ||
+			(result.Speech != nil && result.Speech.BifrostSpeechStreamResponse != nil && result.Speech.Usage != nil) ||
+			(result.Transcribe != nil && result.Transcribe.BifrostTranscribeStreamResponse != nil && result.Transcribe.Usage != nil))
+
 	// Both streaming and regular updates now use the same async pattern
-	go func(logMsg *LogMessage) {
+	go func(logMsg *LogMessage, isFinalChunk bool) {
 		defer p.putLogMessage(logMsg) // Return to pool when done
 
 		// Return pooled data structures to their respective pools
@@ -665,7 +771,7 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 
 		var processingErr error
 		if logMsg.Operation == LogOperationStreamUpdate {
-			processingErr = p.processStreamUpdate(logMsg.RequestID, logMsg.Timestamp, logMsg.StreamUpdateData)
+			processingErr = p.processStreamUpdate(logMsg.RequestID, logMsg.Timestamp, logMsg.StreamUpdateData, isFinalChunk)
 		} else {
 			processingErr = p.updateLogEntry(logMsg.RequestID, logMsg.Timestamp, logMsg.UpdateData)
 		}
@@ -683,22 +789,34 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 			}
 			p.mu.Unlock()
 		}
-	}(logMsg)
+	}(logMsg, isFinalChunk)
 
 	return result, err, nil
 }
 
 // isStreamingResponse checks if the response is a streaming delta
 func (p *LoggerPlugin) isStreamingResponse(result *schemas.BifrostResponse) bool {
-	if result == nil || len(result.Choices) == 0 {
+	if result == nil {
 		return false
 	}
 
-	// Check if any choice has BifrostStreamResponseChoice (indicating streaming)
-	for _, choice := range result.Choices {
-		if choice.BifrostStreamResponseChoice != nil {
-			return true
+	// Check for streaming choices
+	if len(result.Choices) > 0 {
+		for _, choice := range result.Choices {
+			if choice.BifrostStreamResponseChoice != nil {
+				return true
+			}
 		}
+	}
+
+	// Check for streaming speech output
+	if result.Speech != nil && result.Speech.BifrostSpeechStreamResponse != nil {
+		return true
+	}
+
+	// Check for streaming transcription output
+	if result.Transcribe != nil && result.Transcribe.BifrostTranscribeStreamResponse != nil {
+		return true
 	}
 
 	return false

--- a/transports/bifrost-http/plugins/logging/utils.go
+++ b/transports/bifrost-http/plugins/logging/utils.go
@@ -16,6 +16,8 @@ func (p *LoggerPlugin) insertInitialLogEntry(requestID string, timestamp time.Ti
 	inputHistoryJSON, _ := json.Marshal(data.InputHistory)
 	toolsJSON, _ := json.Marshal(data.Tools)
 	paramsJSON, _ := json.Marshal(data.Params)
+	speechInputJSON, _ := json.Marshal(data.SpeechInput)
+	transcriptionInputJSON, _ := json.Marshal(data.TranscriptionInput)
 
 	// Create content summary for searching
 	contentSummary := p.createContentSummaryFromInitialData(data)
@@ -24,14 +26,15 @@ func (p *LoggerPlugin) insertInitialLogEntry(requestID string, timestamp time.Ti
 	query := `
 	INSERT INTO logs (
 		id, provider, model, object_type, status,
-		input_history, tools, params, content_summary,
-		stream, created_at
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		input_history, tools, params, speech_input, transcription_input,
+		content_summary, stream, created_at
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := p.db.Exec(query,
 		requestID, data.Provider, data.Model,
 		data.Object, "processing",
 		string(inputHistoryJSON), string(toolsJSON), string(paramsJSON),
+		string(speechInputJSON), string(transcriptionInputJSON),
 		contentSummary, false, timestamp.UnixNano())
 
 	if err != nil {
@@ -110,6 +113,20 @@ func (p *LoggerPlugin) updateLogEntry(requestID string, timestamp time.Time, dat
 		args = append(args, string(errorDetailsJSON))
 	}
 
+	// Update speech output (for non-streaming)
+	if data.SpeechOutput != nil {
+		speechOutputJSON, _ := json.Marshal(data.SpeechOutput)
+		setParts = append(setParts, "speech_output = ?")
+		args = append(args, string(speechOutputJSON))
+	}
+
+	// Update transcription output (for non-streaming)
+	if data.TranscriptionOutput != nil {
+		transcriptionOutputJSON, _ := json.Marshal(data.TranscriptionOutput)
+		setParts = append(setParts, "transcription_output = ?")
+		args = append(args, string(transcriptionOutputJSON))
+	}
+
 	// Add the WHERE clause parameter
 	args = append(args, requestID)
 
@@ -135,7 +152,7 @@ func (p *LoggerPlugin) updateLogEntry(requestID string, timestamp time.Time, dat
 }
 
 // processStreamUpdate handles streaming delta updates efficiently with minimal database operations
-func (p *LoggerPlugin) processStreamUpdate(requestID string, timestamp time.Time, data *StreamUpdateData) error {
+func (p *LoggerPlugin) processStreamUpdate(requestID string, timestamp time.Time, data *StreamUpdateData, isFinalChunk bool) error {
 	// Handle error case first
 	if data.ErrorDetails != nil {
 		// For errors, we should also calculate latency
@@ -163,7 +180,7 @@ func (p *LoggerPlugin) processStreamUpdate(requestID string, timestamp time.Time
 	var needsLatency bool
 	var latency float64
 
-	if data.FinishReason != nil {
+	if isFinalChunk {
 		// Stream is finishing, calculate latency
 		var createdAtUnix int64
 		err := p.db.QueryRow("SELECT created_at FROM logs WHERE id = ?", requestID).Scan(&createdAtUnix)
@@ -209,7 +226,7 @@ func (p *LoggerPlugin) processStreamUpdate(requestID string, timestamp time.Time
 	}
 
 	// Handle finish reason - if present, mark as complete
-	if data.FinishReason != nil {
+	if isFinalChunk {
 		setParts = append(setParts, "status = ?")
 		args = append(args, "success")
 	}
@@ -381,6 +398,19 @@ func (p *LoggerPlugin) createContentSummaryFromInitialData(data *InitialLogData)
 		}
 	}
 
+	// Add speech input content
+	if data.SpeechInput != nil && data.SpeechInput.Input != "" {
+		parts = append(parts, data.SpeechInput.Input)
+		if data.SpeechInput.Instructions != "" {
+			parts = append(parts, data.SpeechInput.Instructions)
+		}
+	}
+
+	// Add transcription input prompt if available
+	if data.TranscriptionInput != nil && data.TranscriptionInput.Prompt != nil && *data.TranscriptionInput.Prompt != "" {
+		parts = append(parts, *data.TranscriptionInput.Prompt)
+	}
+
 	return strings.Join(parts, " ")
 }
 
@@ -390,13 +420,16 @@ func (p *LoggerPlugin) getLogEntry(requestID string) (*LogEntry, error) {
 	SELECT id, timestamp, provider, model, object_type, status, latency,
 		   prompt_tokens, completion_tokens, total_tokens,
 		   input_history, output_message, tools, tool_calls,
-		   params, error_details, stream, created_at
+		   params, error_details, speech_input, transcription_input,
+		   speech_output, transcription_output, stream, created_at
 	FROM logs WHERE id = ?`
 
 	var entry LogEntry
 	var timestampUnix, createdAtUnix int64
 	var inputHistoryJSON, outputMessageJSON, toolsJSON, toolCallsJSON sql.NullString
 	var paramsJSON, errorDetailsJSON sql.NullString
+	var speechInputJSON, transcriptionInputJSON sql.NullString
+	var speechOutputJSON, transcriptionOutputJSON sql.NullString
 	var promptTokens, completionTokens, totalTokensRow sql.NullInt64
 	var latency sql.NullFloat64
 	var stream sql.NullBool
@@ -406,7 +439,8 @@ func (p *LoggerPlugin) getLogEntry(requestID string) (*LogEntry, error) {
 		&entry.Object, &entry.Status, &latency,
 		&promptTokens, &completionTokens, &totalTokensRow,
 		&inputHistoryJSON, &outputMessageJSON, &toolsJSON, &toolCallsJSON,
-		&paramsJSON, &errorDetailsJSON, &stream,
+		&paramsJSON, &errorDetailsJSON, &speechInputJSON, &transcriptionInputJSON,
+		&speechOutputJSON, &transcriptionOutputJSON, &stream,
 		&createdAtUnix,
 	)
 	if err != nil {
@@ -461,6 +495,18 @@ func (p *LoggerPlugin) getLogEntry(requestID string) (*LogEntry, error) {
 	if errorDetailsJSON.Valid {
 		json.Unmarshal([]byte(errorDetailsJSON.String), &entry.ErrorDetails)
 	}
+	if speechInputJSON.Valid {
+		json.Unmarshal([]byte(speechInputJSON.String), &entry.SpeechInput)
+	}
+	if transcriptionInputJSON.Valid {
+		json.Unmarshal([]byte(transcriptionInputJSON.String), &entry.TranscriptionInput)
+	}
+	if speechOutputJSON.Valid {
+		json.Unmarshal([]byte(speechOutputJSON.String), &entry.SpeechOutput)
+	}
+	if transcriptionOutputJSON.Valid {
+		json.Unmarshal([]byte(transcriptionOutputJSON.String), &entry.TranscriptionOutput)
+	}
 
 	return &entry, nil
 }
@@ -488,6 +534,24 @@ func (p *LoggerPlugin) createContentSummary(entry *LogEntry) string {
 				parts = append(parts, toolCall.Function.Arguments)
 			}
 		}
+	}
+
+	// Add speech input content
+	if entry.SpeechInput != nil && entry.SpeechInput.Input != "" {
+		parts = append(parts, entry.SpeechInput.Input)
+		if entry.SpeechInput.Instructions != "" {
+			parts = append(parts, entry.SpeechInput.Instructions)
+		}
+	}
+
+	// Add transcription input prompt if available
+	if entry.TranscriptionInput != nil && entry.TranscriptionInput.Prompt != nil && *entry.TranscriptionInput.Prompt != "" {
+		parts = append(parts, *entry.TranscriptionInput.Prompt)
+	}
+
+	// Add transcription output text
+	if entry.TranscriptionOutput != nil && entry.TranscriptionOutput.Text != "" {
+		parts = append(parts, entry.TranscriptionOutput.Text)
 	}
 
 	// Add error details
@@ -570,6 +634,8 @@ func (p *LoggerPlugin) SearchLogs(filters *SearchFilters, pagination *Pagination
 		var timestampUnix sql.NullInt64
 		var inputHistoryJSON, outputMessageJSON, toolsJSON, toolCallsJSON sql.NullString
 		var paramsJSON, errorDetailsJSON sql.NullString
+		var speechInputJSON, transcriptionInputJSON sql.NullString
+		var speechOutputJSON, transcriptionOutputJSON sql.NullString
 		var promptTokens, completionTokens, totalTokensRow sql.NullInt64
 		var latency sql.NullFloat64
 
@@ -578,7 +644,8 @@ func (p *LoggerPlugin) SearchLogs(filters *SearchFilters, pagination *Pagination
 			&entry.Object, &entry.Status, &latency,
 			&promptTokens, &completionTokens, &totalTokensRow,
 			&inputHistoryJSON, &outputMessageJSON, &toolsJSON, &toolCallsJSON,
-			&paramsJSON, &errorDetailsJSON,
+			&paramsJSON, &errorDetailsJSON, &speechInputJSON, &transcriptionInputJSON,
+			&speechOutputJSON, &transcriptionOutputJSON,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
@@ -630,6 +697,18 @@ func (p *LoggerPlugin) SearchLogs(filters *SearchFilters, pagination *Pagination
 		if errorDetailsJSON.Valid {
 			json.Unmarshal([]byte(errorDetailsJSON.String), &entry.ErrorDetails)
 		}
+		if speechInputJSON.Valid {
+			json.Unmarshal([]byte(speechInputJSON.String), &entry.SpeechInput)
+		}
+		if transcriptionInputJSON.Valid {
+			json.Unmarshal([]byte(transcriptionInputJSON.String), &entry.TranscriptionInput)
+		}
+		if speechOutputJSON.Valid {
+			json.Unmarshal([]byte(speechOutputJSON.String), &entry.SpeechOutput)
+		}
+		if transcriptionOutputJSON.Valid {
+			json.Unmarshal([]byte(transcriptionOutputJSON.String), &entry.TranscriptionOutput)
+		}
 
 		logs = append(logs, entry)
 	}
@@ -666,7 +745,8 @@ func (p *LoggerPlugin) buildSearchQuery(filters *SearchFilters, pagination *Pagi
 	SELECT id, timestamp, provider, model, object_type, status, latency,
 		   prompt_tokens, completion_tokens, total_tokens,
 		   input_history, output_message, tools, tool_calls,
-		   params, error_details
+		   params, error_details, speech_input, transcription_input,
+		   speech_output, transcription_output
 	FROM logs`
 
 	countQuery := "SELECT COUNT(*) FROM logs"
@@ -805,6 +885,10 @@ func (p *LoggerPlugin) determineObjectType(input schemas.RequestInput) string {
 		return "text.completion"
 	} else if input.EmbeddingInput != nil {
 		return "embedding"
+	} else if input.SpeechInput != nil {
+		return "audio.speech"
+	} else if input.TranscriptionInput != nil {
+		return "audio.transcription"
 	}
 	return "unknown"
 }

--- a/transports/bifrost-http/plugins/telemetry/main.go
+++ b/transports/bifrost-http/plugins/telemetry/main.go
@@ -59,6 +59,10 @@ func (p *PrometheusPlugin) PreHook(ctx *context.Context, req *schemas.BifrostReq
 		*ctx = context.WithValue(*ctx, methodKey, "chat")
 	} else if req.Input.TextCompletionInput != nil {
 		*ctx = context.WithValue(*ctx, methodKey, "text")
+	} else if req.Input.SpeechInput != nil {
+		*ctx = context.WithValue(*ctx, methodKey, "speech")
+	} else if req.Input.TranscriptionInput != nil {
+		*ctx = context.WithValue(*ctx, methodKey, "transcription")
 	}
 
 	return req, nil, nil

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -14,6 +14,8 @@ require (
 	google.golang.org/genai v1.4.0
 )
 
+replace github.com/maximhq/bifrost/core => ../core
+
 require (
 	cloud.google.com/go v0.121.0 // indirect
 	cloud.google.com/go/auth v0.16.0 // indirect

--- a/ui/components/logs/log-detail-sheet.tsx
+++ b/ui/components/logs/log-detail-sheet.tsx
@@ -10,6 +10,8 @@ import { DottedSeparator } from '@/components/ui/separator'
 import { PROVIDER_LABELS, Provider, Status, STATUS_COLORS, REQUEST_TYPE_LABELS, REQUEST_TYPE_COLORS } from '@/lib/constants/logs'
 import { CodeEditor } from './ui/code-editor'
 import LogMessageView from './ui/log-message-view'
+import SpeechView from './ui/speech-view'
+import TranscriptionView from './ui/transcription-view'
 
 interface LogDetailSheetProps {
   log: LogEntry | null
@@ -168,8 +170,34 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
           </div>
         )}
 
-        <div className="mt-4 w-full text-center text-sm font-medium">Conversation History</div>
-        {log.input_history && log.input_history.map((message, index) => <LogMessageView key={index} message={message} />)}
+        {/* Speech and Transcription Views */}
+        {(log.speech_input || log.speech_output) && (
+          <>
+            <div className="mt-4 w-full text-center text-sm font-medium">Speech</div>
+            <SpeechView speechInput={log.speech_input} speechOutput={log.speech_output} isStreaming={log.stream} />
+          </>
+        )}
+
+        {(log.transcription_input || log.transcription_output) && (
+          <>
+            <div className="mt-4 w-full text-center text-sm font-medium">Transcription</div>
+            <TranscriptionView
+              transcriptionInput={log.transcription_input}
+              transcriptionOutput={log.transcription_output}
+              isStreaming={log.stream}
+            />
+          </>
+        )}
+
+        {/* Show conversation history for chat/text completions */}
+        {log.input_history && log.input_history.length > 0 && (
+          <>
+            <div className="mt-4 w-full text-center text-sm font-medium">Conversation History</div>
+            {log.input_history.map((message, index) => (
+              <LogMessageView key={index} message={message} />
+            ))}
+          </>
+        )}
 
         {log.status !== 'processing' && (
           <>

--- a/ui/components/logs/ui/audio-player.tsx
+++ b/ui/components/logs/ui/audio-player.tsx
@@ -1,0 +1,63 @@
+import { Button } from '@/components/ui/button'
+import { Pause, Play, Download } from 'lucide-react'
+import { useState } from 'react'
+
+const AudioPlayer = ({ src }: { src: string }) => {
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [audio] = useState<HTMLAudioElement | null>(typeof window !== 'undefined' ? new Audio() : null)
+
+  const handlePlayPause = () => {
+    if (!audio || !src) return
+
+    if (isPlaying) {
+      audio.pause()
+      setIsPlaying(false)
+    } else {
+      // Convert base64 to blob URL
+      const audioBlob = new Blob([Uint8Array.from(atob(src), (c) => c.charCodeAt(0))], {
+        type: 'audio/mpeg',
+      })
+      const audioUrl = URL.createObjectURL(audioBlob)
+      audio.src = audioUrl
+      audio.play()
+      setIsPlaying(true)
+
+      audio.onended = () => {
+        setIsPlaying(false)
+        URL.revokeObjectURL(audioUrl)
+      }
+    }
+  }
+
+  const handleDownload = () => {
+    if (!src) return
+
+    const audioBlob = new Blob([Uint8Array.from(atob(src), (c) => c.charCodeAt(0))], {
+      type: 'audio/mpeg',
+    })
+    const audioUrl = URL.createObjectURL(audioBlob)
+
+    const a = document.createElement('a')
+    a.href = audioUrl
+    a.download = 'speech-output.mp3'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(audioUrl)
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <Button onClick={handlePlayPause} variant="outline" size="sm" className="flex items-center gap-2">
+        {isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+        {isPlaying ? 'Pause' : 'Play'}
+      </Button>
+
+      <Button onClick={handleDownload} variant="outline" size="sm" className="flex items-center gap-2">
+        <Download className="h-4 w-4" />
+        Download
+      </Button>
+    </div>
+  )
+}
+
+export default AudioPlayer

--- a/ui/components/logs/ui/speech-view.tsx
+++ b/ui/components/logs/ui/speech-view.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { BifrostSpeech, SpeechInput } from '@/lib/types/logs'
+import { Play, Volume2 } from 'lucide-react'
+import AudioPlayer from './audio-player'
+
+interface SpeechViewProps {
+  speechInput?: SpeechInput
+  speechOutput?: BifrostSpeech
+  isStreaming?: boolean
+}
+
+export default function SpeechView({ speechInput, speechOutput, isStreaming }: SpeechViewProps) {
+  return (
+    <div className="space-y-4">
+      {/* Speech Input */}
+      {speechInput && (
+        <div className="w-full rounded-sm border">
+          <div className="flex items-center gap-2 border-b px-6 py-2 text-sm font-medium">
+            <Volume2 className="h-4 w-4" />
+            Speech Input
+          </div>
+          <div className="space-y-4 p-6">
+            <div>
+              <div className="text-muted-foreground mb-2 text-xs font-medium">TEXT TO SYNTHESIZE</div>
+              <div className="font-mono text-xs">{speechInput.input}</div>
+            </div>
+
+            {speechInput.instructions && (
+              <div>
+                <div className="text-muted-foreground mb-2 text-xs font-medium">INSTRUCTIONS</div>
+                <div className="font-mono text-xs">{speechInput.instructions}</div>
+              </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <div className="text-muted-foreground mb-2 text-xs font-medium">VOICE</div>
+                <div className="font-mono text-xs">
+                  {typeof speechInput.voice === 'string' ? speechInput.voice : JSON.stringify(speechInput.voice)}
+                </div>
+              </div>
+
+              {speechInput.response_format && (
+                <div>
+                  <div className="text-muted-foreground mb-2 text-xs font-medium">FORMAT</div>
+                  <div className="font-mono text-xs">{speechInput.response_format}</div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Speech Output */}
+      {(speechOutput || isStreaming) && (
+        <div className="w-full rounded-sm border">
+          <div className="flex items-center gap-2 border-b px-6 py-2 text-sm font-medium">
+            <Play className="h-4 w-4" />
+            Speech Output
+          </div>
+          <div className="space-y-4 p-6">
+            {isStreaming ? <div className="font-mono text-xs">Output was streamed.</div> : <AudioPlayer src={speechOutput?.audio || ''} />}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/components/logs/ui/transcription-view.tsx
+++ b/ui/components/logs/ui/transcription-view.tsx
@@ -1,0 +1,183 @@
+import React from 'react'
+import { BifrostTranscribe, TranscriptionInput } from '@/lib/types/logs'
+import { FileAudio, Clock, Mic } from 'lucide-react'
+import { CodeEditor } from './code-editor'
+import { Badge } from '@/components/ui/badge'
+import AudioPlayer from './audio-player'
+
+interface TranscriptionViewProps {
+  transcriptionInput?: TranscriptionInput
+  transcriptionOutput?: BifrostTranscribe
+  isStreaming?: boolean
+}
+
+export default function TranscriptionView({ transcriptionInput, transcriptionOutput, isStreaming }: TranscriptionViewProps) {
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60)
+    const secs = (seconds % 60).toFixed(1)
+    return `${mins}:${secs.padStart(4, '0')}`
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Transcription Input */}
+      {transcriptionInput && (
+        <div className="w-full rounded-sm border">
+          <div className="flex items-center gap-2 border-b px-6 py-2 text-sm font-medium">
+            <FileAudio className="h-4 w-4" />
+            Transcription Input
+          </div>
+          <div className="space-y-4 p-6">
+            <div className="m-0">
+              <div className="text-muted-foreground mb-2 text-xs font-medium">AUDIO FILE</div>
+              {/* Audio Controls */}
+              <AudioPlayer src={transcriptionInput.file} />
+            </div>
+
+            <div className="grid grid-cols-2 gap-4">
+              {transcriptionInput.language && (
+                <div>
+                  <div className="text-muted-foreground mb-2 text-xs font-medium">LANGUAGE</div>
+                  <div className="font-mono text-xs">{transcriptionInput.language}</div>
+                </div>
+              )}
+
+              {transcriptionInput.response_format && (
+                <div>
+                  <div className="text-muted-foreground mb-2 text-xs font-medium">FORMAT</div>
+                  <div className="font-mono text-xs">{transcriptionInput.response_format}</div>
+                </div>
+              )}
+            </div>
+
+            {transcriptionInput.prompt && (
+              <div>
+                <div className="text-muted-foreground mb-2 text-xs font-medium">PROMPT</div>
+                <div className="font-mono text-xs">{transcriptionInput.prompt}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Transcription Output */}
+      {(transcriptionOutput || isStreaming) && (
+        <div className="w-full rounded-sm border">
+          <div className="flex items-center gap-2 border-b px-6 py-2 text-sm font-medium">
+            <Mic className="h-4 w-4" />
+            Transcription Output
+          </div>
+
+          <div className="space-y-4 p-6">
+            {isStreaming ? (
+              <div className="font-mono text-xs">Output was streamed.</div>
+            ) : (
+              <>
+                {/* Main Transcription Text */}
+                <div className="m-0">
+                  <div className="text-muted-foreground mb-2 text-xs font-medium">TRANSCRIBED TEXT</div>
+                  <div className="font-mono text-xs">{transcriptionOutput?.text}</div>
+                </div>
+
+                {/* Basic Information */}
+                <div className="grid grid-cols-3 gap-4">
+                  {transcriptionOutput?.task && (
+                    <div>
+                      <div className="text-muted-foreground mb-2 text-xs font-medium">TASK</div>
+                      <div className="font-mono text-xs">{transcriptionOutput.task}</div>
+                    </div>
+                  )}
+
+                  {transcriptionOutput?.language && (
+                    <div>
+                      <div className="text-muted-foreground mb-2 text-xs font-medium">DETECTED LANGUAGE</div>
+                      <div className="font-mono text-xs">{transcriptionOutput.language}</div>
+                    </div>
+                  )}
+
+                  {transcriptionOutput?.duration && (
+                    <div>
+                      <div className="text-muted-foreground mb-2 text-xs font-medium">DURATION</div>
+                      <div className="font-mono text-xs">{transcriptionOutput.duration.toFixed(1)}s</div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Words with Timing */}
+                {transcriptionOutput?.words && transcriptionOutput.words.length > 0 && (
+                  <div>
+                    <div className="text-muted-foreground mb-2 text-xs font-medium">WORD-LEVEL TIMING</div>
+                    <div className="max-h-40 overflow-y-auto rounded border p-3">
+                      <div className="flex flex-wrap gap-2">
+                        {transcriptionOutput.words.map((word, index) => (
+                          <div
+                            key={index}
+                            className="inline-flex items-center gap-1 rounded bg-gray-100 px-2 py-1 text-xs"
+                            title={`${formatTime(word.start)} - ${formatTime(word.end)}`}
+                          >
+                            <span>{word.word}</span>
+                            <span className="text-muted-foreground text-xs">{formatTime(word.start)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Segments */}
+                {transcriptionOutput?.segments && transcriptionOutput.segments.length > 0 && (
+                  <div>
+                    <div className="text-muted-foreground mb-2 text-xs font-medium">SEGMENTS</div>
+                    <div className="max-h-60 space-y-2 overflow-y-auto">
+                      {transcriptionOutput.segments.map((segment, index) => (
+                        <div key={segment.id} className="rounded border p-3">
+                          <div className="mb-2 flex items-center justify-between">
+                            <Badge variant="outline" className="text-xs">
+                              Segment {segment.id}
+                            </Badge>
+                            <div className="text-muted-foreground flex items-center gap-1 text-xs">
+                              <Clock className="h-3 w-3" />
+                              {formatTime(segment.start)} - {formatTime(segment.end)}
+                            </div>
+                          </div>
+                          <div className="text-sm">{segment.text}</div>
+                          <div className="text-muted-foreground mt-2 flex gap-4 text-xs">
+                            <span>Avg LogProb: {segment.avg_logprob.toFixed(3)}</span>
+                            <span>No Speech: {(segment.no_speech_prob * 100).toFixed(1)}%</span>
+                            <span>Temp: {segment.temperature.toFixed(1)}</span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Log Probabilities */}
+                {transcriptionOutput?.logprobs && transcriptionOutput.logprobs.length > 0 && (
+                  <div>
+                    <div className="text-muted-foreground mb-2 text-xs font-medium">LOG PROBABILITIES</div>
+                    <CodeEditor
+                      className="z-0 w-full"
+                      shouldAdjustInitialHeight={true}
+                      maxHeight={200}
+                      wrap={true}
+                      code={JSON.stringify(transcriptionOutput.logprobs, null, 2)}
+                      lang="json"
+                      readonly={true}
+                      options={{
+                        scrollBeyondLastLine: false,
+                        collapsibleBlocks: true,
+                        lineNumbers: 'off',
+                        alwaysConsumeMouseWheel: false,
+                      }}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -1,8 +1,17 @@
 export const PROVIDERS = ['openai', 'anthropic', 'azure', 'bedrock', 'cohere', 'vertex', 'mistral', 'ollama', 'groq', 'sgl'] as const
 
-export const STATUSES = ['success', 'error', 'cancelled'] as const
+export const STATUSES = ['success', 'error', 'processing', 'cancelled'] as const
 
-export const REQUEST_TYPES = ['chat.completion', 'text.completion', 'embedding', 'chat.completion.chunk'] as const
+export const REQUEST_TYPES = [
+  'chat.completion',
+  'text.completion',
+  'embedding',
+  'audio.speech',
+  'audio.transcription',
+  'chat.completion.chunk',
+  'audio.speech.chunk',
+  'audio.transcription.chunk',
+] as const
 
 export const PROVIDER_LABELS = {
   openai: 'OpenAI',
@@ -20,6 +29,7 @@ export const PROVIDER_LABELS = {
 export const STATUS_COLORS = {
   success: 'bg-green-100 text-green-800',
   error: 'bg-red-100 text-red-800',
+  processing: 'bg-blue-100 text-blue-800',
   cancelled: 'bg-gray-100 text-gray-800',
 } as const
 
@@ -27,14 +37,22 @@ export const REQUEST_TYPE_LABELS = {
   'chat.completion': 'Chat',
   'text.completion': 'Text',
   embedding: 'Embedding',
-  'chat.completion.chunk': 'Stream',
+  'audio.speech': 'Speech',
+  'audio.transcription': 'Transcription',
+  'chat.completion.chunk': 'Chat Stream',
+  'audio.speech.chunk': 'Speech Stream',
+  'audio.transcription.chunk': 'Transcription Stream',
 } as const
 
 export const REQUEST_TYPE_COLORS = {
   'chat.completion': 'bg-blue-100 text-blue-800',
   'text.completion': 'bg-green-100 text-green-800',
   embedding: 'bg-red-100 text-red-800',
+  'audio.speech': 'bg-purple-100 text-purple-800',
+  'audio.transcription': 'bg-orange-100 text-orange-800',
   'chat.completion.chunk': 'bg-yellow-100 text-yellow-800',
+  'audio.speech.chunk': 'bg-pink-100 text-pink-800',
+  'audio.transcription.chunk': 'bg-lime-100 text-lime-800',
 } as const
 
 export type Provider = (typeof PROVIDERS)[number]

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -1,5 +1,88 @@
 // Types for the logs interface based on BifrostResponse schema
 
+// Speech and Transcription types
+export interface VoiceConfig {
+  speaker: string
+  voice: string
+}
+
+export interface SpeechInput {
+  input: string
+  voice: string | VoiceConfig[]
+  instructions?: string
+  response_format?: string // Default is "mp3"
+}
+
+export interface TranscriptionInput {
+  file: string // base64 encoded
+  language?: string
+  prompt?: string
+  response_format?: string // Default is "json"
+}
+
+export interface AudioTokenDetails {
+  text_tokens: number
+  audio_tokens: number
+}
+
+export interface AudioLLMUsage {
+  input_tokens: number
+  input_tokens_details?: AudioTokenDetails
+  output_tokens: number
+  total_tokens: number
+}
+
+export interface TranscriptionWord {
+  word: string
+  start: number
+  end: number
+}
+
+export interface TranscriptionSegment {
+  id: number
+  seek: number
+  start: number
+  end: number
+  text: string
+  tokens: number[]
+  temperature: number
+  avg_logprob: number
+  compression_ratio: number
+  no_speech_prob: number
+}
+
+export interface TranscriptionLogProb {
+  token: string
+  logprob: number
+  bytes: number[]
+}
+
+export interface TranscriptionUsage {
+  type: string // "tokens" or "duration"
+  input_tokens?: number
+  input_token_details?: AudioTokenDetails
+  output_tokens?: number
+  total_tokens?: number
+  seconds?: number // For duration-based usage
+}
+
+export interface BifrostSpeech {
+  usage?: AudioLLMUsage
+  audio: string // base64 encoded audio data
+}
+
+export interface BifrostTranscribe {
+  text: string
+  logprobs?: TranscriptionLogProb[]
+  usage?: TranscriptionUsage
+  // Non-streaming specific fields
+  task?: string // e.g., "transcribe"
+  language?: string // e.g., "english"
+  duration?: number // Duration in seconds
+  words?: TranscriptionWord[]
+  segments?: TranscriptionSegment[]
+}
+
 // Message content types
 export type MessageContentType = 'text' | 'image_url'
 
@@ -128,13 +211,17 @@ export interface Annotation {
 // Main LogEntry interface matching backend
 export interface LogEntry {
   id: string
-  object: string // text.completion, chat.completion, or embedding
+  object: string // text.completion, chat.completion, embedding, audio.speech, or audio.transcription
   timestamp: string // ISO string format from Go time.Time
   provider: string
   model: string
   input_history: BifrostMessage[]
   output_message?: BifrostMessage
   params?: ModelParameters
+  speech_input?: SpeechInput
+  transcription_input?: TranscriptionInput
+  speech_output?: BifrostSpeech
+  transcription_output?: BifrostTranscribe
   tools?: Tool[]
   tool_calls?: ToolCall[]
   latency?: number


### PR DESCRIPTION
# Add Speech and Transcription API Support

This PR adds support for text-to-speech and speech-to-text capabilities to Bifrost, enabling applications to generate audio from text and transcribe audio to text. The implementation follows the same pattern as existing completion and embedding APIs, with both streaming and non-streaming variants.

Key additions:

- New request types for speech and transcription (both streaming and non-streaming)
- Implementation of speech and transcription handlers in the core Bifrost engine
- Full OpenAI provider implementation for speech and transcription APIs
- Unsupported operation stubs for other providers
- HTTP transport layer support with multipart form handling for transcription
- UI components for displaying and playing speech outputs and transcription results
- Logging and telemetry support for the new API types

The implementation supports all OpenAI speech synthesis features including voice selection, instructions, and format options. For transcription, it supports file uploads, language specification, and timestamps.

This extends Bifrost's capabilities beyond text-based AI to audio processing, making it a more comprehensive AI gateway.