### PR TITLE
refactor: standardize error handling across providers

### DIFF
--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -115,13 +115,7 @@ func (provider *GroqProvider) ChatCompletion(ctx context.Context, model string, 
 
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: true,
-			Error: schemas.ErrorField{
-				Message: schemas.ErrProviderJSONMarshaling,
-				Error:   err,
-			},
-		}
+		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, schemas.Groq)
 	}
 
 	// Create request

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -116,13 +116,7 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, model string
 
 	jsonBody, err := json.Marshal(requestBody)
 	if err != nil {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: true,
-			Error: schemas.ErrorField{
-				Message: schemas.ErrProviderJSONMarshaling,
-				Error:   err,
-			},
-		}
+		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, schemas.Ollama)
 	}
 
 	// Create request


### PR DESCRIPTION
# Standardize Error Handling Across Providers

This PR introduces a consistent error handling approach across all LLM providers by implementing standardized error creation functions. The changes:

- Add three new helper functions for creating consistent error types:
  - `newConfigurationError`: For errors related to missing or invalid configuration
  - `newBifrostOperationError`: For internal Bifrost operation errors
  - `newProviderAPIError`: For errors returned by provider APIs

- Rename utility functions to follow Go naming conventions:
  - `ProcessAndSendResponse` → `processAndSendResponse`
  - Add new `processAndSendError` function to handle stream errors consistently

- Refactor error handling in all providers (OpenAI, Anthropic, Azure, Bedrock, Cohere, Groq, Mistral, Ollama, Vertex) to use the new standardized error functions

- Improve error handling in streaming implementations to properly process errors through post-hook runners

- Extract common form data handling logic in OpenAI's transcription methods to reduce code duplication

These changes make the codebase more maintainable by reducing duplication, ensuring consistent error structures, and improving error propagation through the system.