### PR TITLE
ci: install script dependencies separately in workflows

### DIFF
--- a/.github/workflows/core-dependency-update.yml
+++ b/.github/workflows/core-dependency-update.yml
@@ -38,6 +38,11 @@ jobs:
         with:
           node-version: "18"
 
+      # Install script dependencies first
+      - name: Install script dependencies
+        working-directory: ci/scripts
+        run: npm ci
+
       # Configure Git for automated commits
       - name: Configure Git
         working-directory: ci/scripts
@@ -49,9 +54,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          # Install dependencies
-          npm ci
-          
           # Extract core version from tag
           CORE_VERSION=$(node extract-version.mjs "${GITHUB_REF}" core version)
           echo "📦 Extracted core version: ${CORE_VERSION}"

--- a/.github/workflows/transports-release.yml
+++ b/.github/workflows/transports-release.yml
@@ -75,6 +75,11 @@ jobs:
         with:
           node-version: "18"
 
+      # Install script dependencies first
+      - name: Install script dependencies
+        working-directory: ci/scripts
+        run: npm ci
+
       # Configure Git for automated commits and tagging
       - name: Configure Git
         working-directory: ci/scripts
@@ -85,9 +90,6 @@ jobs:
         id: manage_versions
         working-directory: ci/scripts
         run: |
-          # Install dependencies
-          npm ci
-          
           # Get current core version from go.mod and generate new transport version
           node manage-versions.mjs transport-release >> "$GITHUB_OUTPUT"
           
@@ -125,7 +127,6 @@ jobs:
           # Strip 'transports/' prefix and add 'v' prefix for upload script
           VERSION_ONLY="${{ steps.manage_versions.outputs.transport_version }}"
           VERSION_ONLY=${VERSION_ONLY#transports/v}
-          npm ci
           cd ../..
           node ci/scripts/upload-builds.mjs v${VERSION_ONLY}
 


### PR DESCRIPTION
Fixes dependency installation in core-dependency-update workflow

This PR modifies the core-dependency-update GitHub workflow to install script dependencies in a separate step before configuring Git. The dependencies are now installed specifically in the `ci/scripts` directory with a dedicated step, rather than as part of the Git configuration step. This ensures dependencies are properly installed before any scripts are executed.