### PR TITLE
ci: add manual trigger support to transports release workflow --trigger-release

### DIFF
--- a/.github/workflows/transports-release.yml
+++ b/.github/workflows/transports-release.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: ["main"]
     paths: ["transports/go.mod"]
+  # Add manual trigger support
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual release'
+        required: true
+        type: string
 
 # Prevent concurrent runs for the same trigger to avoid conflicts
 concurrency:
@@ -30,6 +37,17 @@ jobs:
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
+          echo "📝 Checking release trigger..."
+          
+          # If manually triggered, always release
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "🚀 Manual release triggered: ${{ github.event.inputs.reason }}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          
+          # For push events, check commit message
           echo "📝 Commit message: $COMMIT_MSG"
           
           # Check for --trigger-release flag


### PR DESCRIPTION
# Add manual trigger support for transports release workflow

This PR enhances the transports release workflow by adding a manual trigger option. Users can now manually initiate the release process through the GitHub UI by providing a reason for the release.

The workflow now supports two trigger methods:
1. Automatic trigger when changes are pushed to `transports/go.mod` (existing behavior)
2. Manual trigger via workflow_dispatch with a required reason field

When manually triggered, the workflow will always proceed with the release regardless of commit message flags, displaying the provided reason in the logs.