### PR TITLE
ci: fix git tag creation in transport release workflow --trigger-release

### DIFF
--- a/.github/workflows/transports-release.yml
+++ b/.github/workflows/transports-release.yml
@@ -106,17 +106,21 @@ jobs:
       # Determine versions and create transport tag
       - name: Create transport tag
         id: manage_versions
-        working-directory: .
         run: |
           # Get current core version from go.mod and generate new transport version
           node ci/scripts/manage-versions.mjs transport-release >> "$GITHUB_OUTPUT"
           
-          # Get the transport version for tagging
+          # Store the transport version in a shell variable
           TRANSPORT_VERSION=$(grep "transport_version=" "$GITHUB_OUTPUT" | cut -d'=' -f2)
+          
+          # Echo for logging
           echo "📦 Creating transport tag: ${TRANSPORT_VERSION}"
           
-          # Create and push transport tag
-          node ci/scripts/git-operations.mjs create-tag "${TRANSPORT_VERSION}"
+          # Export the variable so it's available after cd
+          export TRANSPORT_VERSION
+          
+          # Create and push transport tag from scripts directory
+          cd ci/scripts && node git-operations.mjs create-tag "$TRANSPORT_VERSION"
 
       # Build the UI from the current repo state
       - name: Build UI static files
@@ -127,15 +131,14 @@ jobs:
 
       # Cross-compile Go binaries for multiple platforms
       - name: Build Go executables
-        working-directory: .
         run: |
           echo "🔨 Building Go executables..."
           chmod +x ci/scripts/go-executable-build.sh
+          # go-executable-build.sh called from root, expects paths relative to root
           ci/scripts/go-executable-build.sh bifrost-http ./dist ./bifrost-http "$(pwd)/transports"
 
       # Upload the built binaries to S3 for distribution
       - name: Upload builds to S3
-        working-directory: .
         env:
           # R2 (Cloudflare S3-compatible storage) credentials
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
@@ -145,6 +148,7 @@ jobs:
           # Strip 'transports/' prefix and add 'v' prefix for upload script
           VERSION_ONLY="${{ steps.manage_versions.outputs.transport_version }}"
           VERSION_ONLY=${VERSION_ONLY#transports/v}
+          # upload-builds.mjs must run from root to find ./dist directory
           node ci/scripts/upload-builds.mjs v${VERSION_ONLY}
 
   # Second job: Build and push Docker image


### PR DESCRIPTION
# Fixed transport release workflow script paths and execution context

This PR improves the transport release workflow by fixing issues with script execution paths and working directories:

- Removed redundant `working-directory: .` declarations that were unnecessary
- Modified the tag creation process to properly handle the working directory change:
  - Exports the `TRANSPORT_VERSION` variable to make it available after changing directories
  - Changes to the `ci/scripts` directory before executing the tag creation script
- Added clarifying comments about script execution context and path expectations
- Ensured the `go-executable-build.sh` script is called from the repository root
- Added a comment clarifying that `upload-builds.mjs` must run from the root to find the `./dist` directory

These changes ensure scripts are executed from the correct directories while maintaining proper access to environment variables.