### PR TITLE
fix: correct Anthropic streaming response format and usage tracking

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -1171,7 +1171,6 @@ func handleAnthropicStreaming(
 				// Handle delta changes to the top-level message
 				if event.Usage != nil && usage != nil {
 					usage.OutputTokens = event.Usage.OutputTokens
-					usage.CacheCreationInputTokens = event.Usage.CacheCreationInputTokens
 				}
 
 				// Send usage information immediately if present

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -515,6 +515,10 @@ func prepareAnthropicChatRequest(messages []schemas.BifrostMessage, params *sche
 					"tool_use_id": *msg.ToolMessage.ToolCallID,
 				}
 
+				if msg.ToolMessage.IsError != nil {
+					toolCallResult["is_error"] = *msg.ToolMessage.IsError
+				}
+
 				var toolCallResultContent []map[string]interface{}
 
 				if msg.Content.ContentStr != nil {

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -594,6 +594,9 @@ func handleOpenAIStreaming(
 
 			// Handle usage-only chunks (when stream_options include_usage is true)
 			if len(response.Choices) == 0 && response.Usage != nil {
+				// Empty choices array.
+				response.Choices = []schemas.BifrostResponseChoice{}
+
 				// This is a usage information chunk at the end of stream
 				if params != nil {
 					response.ExtraFields.Params = *params
@@ -619,9 +622,7 @@ func handleOpenAIStreaming(
 				response.ExtraFields.Provider = providerType
 
 				processAndSendResponse(ctx, postHookRunner, &response, responseChan)
-
-				// End stream processing after finish reason
-				break
+				continue
 			}
 
 			// Handle regular content chunks
@@ -632,6 +633,7 @@ func handleOpenAIStreaming(
 				response.ExtraFields.Provider = providerType
 
 				processAndSendResponse(ctx, postHookRunner, &response, responseChan)
+				continue
 			}
 		}
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -10,6 +10,11 @@ const (
 	DefaultInitialPoolSize = 100
 )
 
+// StreamOptions represents the options for streaming requests.
+type StreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
 // BifrostConfig represents the configuration for initializing a Bifrost instance.
 // It contains the necessary components for setting up the system including account details,
 // plugins, logging, and initial pool size.
@@ -161,19 +166,20 @@ type Fallback struct {
 // your request to the model. Bifrost follows a standard set of parameters which
 // mapped to the provider's parameters.
 type ModelParameters struct {
-	ToolChoice        *ToolChoice `json:"tool_choice,omitempty"`         // Whether to call a tool
-	Tools             *[]Tool     `json:"tools,omitempty"`               // Tools to use
-	Temperature       *float64    `json:"temperature,omitempty"`         // Controls randomness in the output
-	TopP              *float64    `json:"top_p,omitempty"`               // Controls diversity via nucleus sampling
-	TopK              *int        `json:"top_k,omitempty"`               // Controls diversity via top-k sampling
-	MaxTokens         *int        `json:"max_tokens,omitempty"`          // Maximum number of tokens to generate
-	StopSequences     *[]string   `json:"stop_sequences,omitempty"`      // Sequences that stop generation
-	PresencePenalty   *float64    `json:"presence_penalty,omitempty"`    // Penalizes repeated tokens
-	FrequencyPenalty  *float64    `json:"frequency_penalty,omitempty"`   // Penalizes frequent tokens
-	ParallelToolCalls *bool       `json:"parallel_tool_calls,omitempty"` // Enables parallel tool calls
-	EncodingFormat    *string     `json:"encoding_format,omitempty"`     // Format for embedding output (e.g., "float", "base64")
-	Dimensions        *int        `json:"dimensions,omitempty"`          // Number of dimensions for embedding output
-	User              *string     `json:"user,omitempty"`                // User identifier for tracking
+	ToolChoice        *ToolChoice    `json:"tool_choice,omitempty"`         // Whether to call a tool
+	Tools             *[]Tool        `json:"tools,omitempty"`               // Tools to use
+	Temperature       *float64       `json:"temperature,omitempty"`         // Controls randomness in the output
+	TopP              *float64       `json:"top_p,omitempty"`               // Controls diversity via nucleus sampling
+	TopK              *int           `json:"top_k,omitempty"`               // Controls diversity via top-k sampling
+	MaxTokens         *int           `json:"max_tokens,omitempty"`          // Maximum number of tokens to generate
+	StopSequences     *[]string      `json:"stop_sequences,omitempty"`      // Sequences that stop generation
+	PresencePenalty   *float64       `json:"presence_penalty,omitempty"`    // Penalizes repeated tokens
+	FrequencyPenalty  *float64       `json:"frequency_penalty,omitempty"`   // Penalizes frequent tokens
+	ParallelToolCalls *bool          `json:"parallel_tool_calls,omitempty"` // Enables parallel tool calls
+	EncodingFormat    *string        `json:"encoding_format,omitempty"`     // Format for embedding output (e.g., "float", "base64")
+	Dimensions        *int           `json:"dimensions,omitempty"`          // Number of dimensions for embedding output
+	User              *string        `json:"user,omitempty"`                // User identifier for tracking
+	StreamOptions     *StreamOptions `json:"stream_options,omitempty"`      // Stream options for streaming requests
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`
@@ -351,6 +357,7 @@ type ContentBlock struct {
 // ToolMessage represents a message from a tool
 type ToolMessage struct {
 	ToolCallID *string `json:"tool_call_id,omitempty"`
+	IsError    *bool   `json:"is_error,omitempty"`
 }
 
 // AssistantMessage represents a message from an assistant

--- a/transports/bifrost-http/integrations/anthropic/router.go
+++ b/transports/bifrost-http/integrations/anthropic/router.go
@@ -35,8 +35,8 @@ func NewAnthropicRouter(client *bifrost.Bifrost) *AnthropicRouter {
 				return DeriveAnthropicErrorFromBifrostError(err)
 			},
 			StreamConfig: &integrations.StreamConfig{
-				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
-					return DeriveAnthropicStreamFromBifrostResponse(resp, 0), nil
+				ResponseConverter: func(resp *schemas.BifrostResponse, streamIndex int) (interface{}, error) {
+					return DeriveAnthropicStreamFromBifrostResponse(resp, streamIndex), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {
 					return DeriveAnthropicStreamFromBifrostError(err)

--- a/transports/bifrost-http/integrations/anthropic/router.go
+++ b/transports/bifrost-http/integrations/anthropic/router.go
@@ -36,7 +36,7 @@ func NewAnthropicRouter(client *bifrost.Bifrost) *AnthropicRouter {
 			},
 			StreamConfig: &integrations.StreamConfig{
 				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
-					return DeriveAnthropicStreamFromBifrostResponse(resp), nil
+					return DeriveAnthropicStreamFromBifrostResponse(resp, 0), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {
 					return DeriveAnthropicStreamFromBifrostError(err)

--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -135,15 +135,6 @@ func (s *AnthropicStreamResponse) ToSSE() string {
 	return fmt.Sprintf("event: %s\ndata: %s\n\n", s.Type, string(jsonData))
 }
 
-func (s *AnthropicStreamResponse) SetModel(model string) {
-	if s.Model != nil {
-		*s.Model = model
-	}
-	if s.Message != nil && s.Message.Model != "" {
-		s.Message.Model = model
-	}
-}
-
 // AnthropicStreamMessage represents the message structure in streaming events
 type AnthropicStreamMessage struct {
 	ID           string                  `json:"id"`

--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -521,7 +521,7 @@ func DeriveAnthropicFromBifrostResponse(bifrostResp *schemas.BifrostResponse) *A
 }
 
 // DeriveAnthropicStreamFromBifrostResponse converts a Bifrost streaming response to Anthropic SSE string format
-func DeriveAnthropicStreamFromBifrostResponse(bifrostResp *schemas.BifrostResponse, messageIndex int) string {
+func DeriveAnthropicStreamFromBifrostResponse(bifrostResp *schemas.BifrostResponse, streamIndex int) string {
 	if bifrostResp == nil {
 		return ""
 	}
@@ -537,7 +537,7 @@ func DeriveAnthropicStreamFromBifrostResponse(bifrostResp *schemas.BifrostRespon
 			delta := choice.BifrostStreamResponseChoice.Delta
 
 			// Handle message start event
-			if messageIndex == 0 {
+			if streamIndex == 0 {
 				streamResp := &AnthropicStreamResponse{}
 				var usage *AnthropicUsage
 
@@ -570,7 +570,7 @@ func DeriveAnthropicStreamFromBifrostResponse(bifrostResp *schemas.BifrostRespon
 
 			// Handle text content deltas
 			if delta.Content != nil {
-				if messageIndex == 0 {
+				if streamIndex == 0 {
 					streamResp.Type = "content_block_start"
 					streamResp.ContentBlock = &AnthropicContentBlock{
 						Type: "text",

--- a/transports/bifrost-http/integrations/genai/router.go
+++ b/transports/bifrost-http/integrations/genai/router.go
@@ -38,7 +38,7 @@ func NewGenAIRouter(client *bifrost.Bifrost) *GenAIRouter {
 				return DeriveGeminiErrorFromBifrostError(err)
 			},
 			StreamConfig: &integrations.StreamConfig{
-				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				ResponseConverter: func(resp *schemas.BifrostResponse, streamIndex int) (interface{}, error) {
 					return DeriveGeminiStreamFromBifrostResponse(resp), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {

--- a/transports/bifrost-http/integrations/litellm/router.go
+++ b/transports/bifrost-http/integrations/litellm/router.go
@@ -168,7 +168,7 @@ func NewLiteLLMRouter(client *bifrost.Bifrost) *LiteLLMRouter {
 		}
 	}
 
-	streamResponseConverter := func(resp *schemas.BifrostResponse) (interface{}, error) {
+	streamResponseConverter := func(resp *schemas.BifrostResponse, streamIndex int) (interface{}, error) {
 		if resp == nil {
 			return nil, errors.New("response is nil")
 		}
@@ -183,7 +183,7 @@ func NewLiteLLMRouter(client *bifrost.Bifrost) *LiteLLMRouter {
 		case schemas.OpenAI, schemas.Azure:
 			return openai.DeriveOpenAIStreamFromBifrostResponse(resp), nil
 		case schemas.Anthropic:
-			return anthropic.DeriveAnthropicStreamFromBifrostResponse(resp), nil
+			return anthropic.DeriveAnthropicStreamFromBifrostResponse(resp, streamIndex), nil
 		case schemas.Vertex:
 			return genai.DeriveGeminiStreamFromBifrostResponse(resp), nil
 		default:

--- a/transports/bifrost-http/integrations/openai/router.go
+++ b/transports/bifrost-http/integrations/openai/router.go
@@ -45,7 +45,7 @@ func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
 				return DeriveOpenAIErrorFromBifrostError(err)
 			},
 			StreamConfig: &integrations.StreamConfig{
-				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				ResponseConverter: func(resp *schemas.BifrostResponse, streamIndex int) (interface{}, error) {
 					return DeriveOpenAIStreamFromBifrostResponse(resp), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -84,7 +84,7 @@ func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
 				return DeriveOpenAIErrorFromBifrostError(err)
 			},
 			StreamConfig: &integrations.StreamConfig{
-				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				ResponseConverter: func(resp *schemas.BifrostResponse, streamIndex int) (interface{}, error) {
 					return DeriveOpenAISpeechFromBifrostResponse(resp), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -119,7 +119,7 @@ func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
 				return DeriveOpenAIErrorFromBifrostError(err)
 			},
 			StreamConfig: &integrations.StreamConfig{
-				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				ResponseConverter: func(resp *schemas.BifrostResponse, streamIndex int) (interface{}, error) {
 					return DeriveOpenAITranscriptionFromBifrostResponse(resp), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {

--- a/transports/bifrost-http/integrations/openai/types.go
+++ b/transports/bifrost-http/integrations/openai/types.go
@@ -21,6 +21,7 @@ type OpenAIChatRequest struct {
 	Tools            *[]schemas.Tool          `json:"tools,omitempty"` // Reuse schema type
 	ToolChoice       *schemas.ToolChoice      `json:"tool_choice,omitempty"`
 	Stream           *bool                    `json:"stream,omitempty"`
+	StreamOptions    *schemas.StreamOptions   `json:"stream_options,omitempty"`
 	LogProbs         *bool                    `json:"logprobs,omitempty"`
 	TopLogProbs      *int                     `json:"top_logprobs,omitempty"`
 	ResponseFormat   interface{}              `json:"response_format,omitempty"`
@@ -264,6 +265,9 @@ func (r *OpenAIChatRequest) convertParameters() *schemas.ModelParameters {
 	}
 	if r.Seed != nil {
 		params.ExtraParams["seed"] = *r.Seed
+	}
+	if r.StreamOptions != nil {
+		params.StreamOptions = r.StreamOptions
 	}
 
 	return params

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -2,6 +2,8 @@ module github.com/maximhq/bifrost/transports
 
 go 1.24.1
 
+replace github.com/maximhq/bifrost/core => ../core
+
 require (
 	github.com/fasthttp/router v1.5.4
 	github.com/fasthttp/websocket v1.5.12


### PR DESCRIPTION
- Add dedicated AnthropicUsage type with cache token fields
- Fix streaming event sequence to match Anthropic API format
- Include usage data in streaming responses
- Properly handle message_start, content_block_start/stop events
- Track usage updates through message_delta events