### PR TITLE
ci: improve release workflow instructions and fix tag creation

### DIFF
--- a/.github/workflows/transports-release.yml
+++ b/.github/workflows/transports-release.yml
@@ -239,7 +239,12 @@ jobs:
           echo "**Reason:** ${{ needs.check-release-flags.outputs.skip_reason }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### To trigger a release:" >> $GITHUB_STEP_SUMMARY
-          echo "Include \`--trigger-release\` in your commit message when pushing changes to \`transports/go.mod\`" >> $GITHUB_STEP_SUMMARY
+          echo "When merging a PR that changes \`transports/go.mod\`, edit the merge commit message to include \`--trigger-release\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### How to do this:" >> $GITHUB_STEP_SUMMARY
+          echo "1. Click **\"Merge pull request\"** in GitHub UI" >> $GITHUB_STEP_SUMMARY
+          echo "2. Edit the commit message to include \`--trigger-release\`" >> $GITHUB_STEP_SUMMARY
+          echo "3. Click **\"Confirm merge\"**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Default behavior:" >> $GITHUB_STEP_SUMMARY
           echo "Changes to \`transports/go.mod\` without \`--trigger-release\` flag will not trigger a release" >> $GITHUB_STEP_SUMMARY 

--- a/ci/scripts/git-operations.mjs
+++ b/ci/scripts/git-operations.mjs
@@ -167,11 +167,13 @@ switch (operation) {
   }
   
   case "create-tag":{
-    if (!tag) {
+    // For create-tag operation, the tag name is the second argument (argv[3])
+    const tagName = message || tag;
+    if (!tagName) {
       console.error("❌ Tag name is required for create-tag");
       process.exit(1);
     }
-    createTag(tag);
+    createTag(tagName);
     break;
   }
 


### PR DESCRIPTION
# Improve release workflow instructions and fix tag creation

This PR makes two improvements:

1. Enhances the release workflow instructions with clearer step-by-step guidance on how to trigger a release when changing `transports/go.mod`. The updated instructions explain exactly how to edit the merge commit message to include the `--trigger-release` flag.

2. Fixes a bug in the `create-tag` operation in `git-operations.mjs` by properly handling the tag name parameter. The code now correctly uses the message parameter as the tag name when provided, falling back to the tag parameter.

These changes make the release process more user-friendly and fix an issue with tag creation in our CI scripts.