### PR TITLE
ci: trim whitespace from R2 secrets and improve debug logging

### DIFF
--- a/.github/workflows/transports-release.yml
+++ b/.github/workflows/transports-release.yml
@@ -145,6 +145,10 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
+          # Trim whitespace from secrets
+          export R2_ENDPOINT="$(echo "$R2_ENDPOINT" | tr -d '[:space:]')"
+          export R2_ACCESS_KEY_ID="$(echo "$R2_ACCESS_KEY_ID" | tr -d '[:space:]')"
+          export R2_SECRET_ACCESS_KEY="$(echo "$R2_SECRET_ACCESS_KEY" | tr -d '[:space:]')"
           # Strip 'transports/' prefix and add 'v' prefix for upload script
           VERSION_ONLY="${{ steps.manage_versions.outputs.transport_version }}"
           VERSION_ONLY=${VERSION_ONLY#transports/v}

--- a/ci/scripts/upload-builds.mjs
+++ b/ci/scripts/upload-builds.mjs
@@ -60,15 +60,27 @@ async function uploadWithRetry(filePath, s3Key, maxRetries = 3) {
   }
 }
 
-// Exit if any required environment variables are missing
+// Debug and validate environment variables
+console.log('🔍 Environment variables debug:');
 const requiredEnvVars = ['R2_ENDPOINT', 'R2_ACCESS_KEY_ID', 'R2_SECRET_ACCESS_KEY'];
-const missingEnvVars = requiredEnvVars.filter(varName => !process.env[varName]);
 
-if (missingEnvVars.length > 0) {
-  console.error(`❌ Missing required environment variables: ${missingEnvVars.join(', ')}`);
-  console.error('Please set all required environment variables before running this script.');
-  process.exit(1);
-}
+requiredEnvVars.forEach(varName => {
+  const value = process.env[varName];
+  if (!value) {
+    console.log(`❌ ${varName}: Missing`);
+    process.exit(1);
+  } else {
+    // Show first/last few chars to verify without exposing secrets
+    const masked = value.length > 4 
+      ? `${value.substring(0, 2)}...${value.substring(value.length - 2)}`
+      : `${value.substring(0, 1)}...`;
+    console.log(`✅ ${varName}: Set (${value.length} chars) ${masked}`);
+    
+    // Check for common issues
+    if (value.includes('\n')) console.log(`⚠️  ${varName}: Contains newlines`);
+    if (value.startsWith(' ') || value.endsWith(' ')) console.log(`⚠️  ${varName}: Contains leading/trailing spaces`);
+  }
+});
 
 // Uploadig new folder
 console.log("uploading new release...");


### PR DESCRIPTION
# Trim whitespace from R2 secrets and improve environment variable validation

This PR addresses an issue with R2 credentials in our release workflow by:

1. Adding whitespace trimming for R2 environment variables in the transports-release workflow
2. Enhancing the upload-builds.mjs script with better environment variable validation:
   - Displays the length of each credential
   - Shows first/last few characters of credentials (partially masked)
   - Detects and warns about common issues like newlines or trailing spaces

These changes will help prevent authentication failures caused by invisible whitespace characters in secrets.