### PR TITLE
feat: add option to disable raw response in provider responses

### DIFF
--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -53,8 +53,9 @@ func removeVertexClient(authCredentials string) {
 
 // VertexProvider implements the Provider interface for Google's Vertex AI API.
 type VertexProvider struct {
-	logger        schemas.Logger        // Logger for provider operations
-	networkConfig schemas.NetworkConfig // Network configuration including extra headers
+	logger              schemas.Logger        // Logger for provider operations
+	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
 // NewVertexProvider creates a new Vertex provider instance.
@@ -71,8 +72,9 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	}
 
 	return &VertexProvider{
-		logger:        logger,
-		networkConfig: config.NetworkConfig,
+		logger:              logger,
+		networkConfig:       config.NetworkConfig,
+		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
 
@@ -260,7 +262,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 		response := acquireAnthropicChatResponse()
 		defer releaseAnthropicChatResponse(response)
 
-		rawResponse, bifrostErr := handleProviderResponse(body, response)
+		rawResponse, bifrostErr := handleProviderResponse(body, response, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -289,7 +291,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 		defer releaseOpenAIResponse(response)
 
 		// Use enhanced response handler with pre-allocated response
-		rawResponse, bifrostErr := handleProviderResponse(body, response)
+		rawResponse, bifrostErr := handleProviderResponse(body, response, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -104,8 +104,9 @@ type ProviderConfig struct {
 	MetaConfig               MetaConfig               `json:"meta_config,omitempty"`       // Provider-specific configuration
 	ConcurrencyAndBufferSize ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
-	Logger      Logger       `json:"logger"`
-	ProxyConfig *ProxyConfig `json:"proxy_config,omitempty"` // Proxy configuration
+	Logger              Logger       `json:"logger"`
+	ProxyConfig         *ProxyConfig `json:"proxy_config,omitempty"` // Proxy configuration
+	SendBackRawResponse bool         `json:"send_back_raw_response"` // Send raw response back in the bifrost response (default: false)
 }
 
 func (config *ProviderConfig) CheckAndSetDefaults() {

--- a/tests/core-providers/config/account.go
+++ b/tests/core-providers/config/account.go
@@ -151,7 +151,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *context.Context
 		return []schemas.Key{
 			{
 				Value:  os.Getenv("GROQ_API_KEY"),
-				Models: []string{"llama-3.3-70b-versatile"},
+				Models: []string{},
 				Weight: 1.0,
 			},
 		}, nil

--- a/tests/core-providers/scenarios/tool_calls.go
+++ b/tests/core-providers/scenarios/tool_calls.go
@@ -21,7 +21,7 @@ func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 
 	t.Run("ToolCalls", func(t *testing.T) {
 		messages := []schemas.BifrostMessage{
-			CreateBasicChatMessage("What's the weather like in New York?"),
+			CreateBasicChatMessage("What's the weather like in New York? answer in celsius"),
 		}
 
 		params := MergeModelParameters(&schemas.ModelParameters{

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -41,15 +41,17 @@ type AddProviderRequest struct {
 	MetaConfig               *map[string]interface{}           `json:"meta_config,omitempty"`                 // Provider-specific metadata
 	ConcurrencyAndBufferSize *schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size,omitempty"` // Concurrency settings
 	ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config,omitempty"`                // Proxy configuration
+	SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"`      // Include raw response in BifrostResponse
 }
 
 // UpdateProviderRequest represents the request body for updating a provider
 type UpdateProviderRequest struct {
-	Keys                     []schemas.Key                    `json:"keys"`                        // API keys for the provider
-	NetworkConfig            schemas.NetworkConfig            `json:"network_config"`              // Network-related settings
-	MetaConfig               *map[string]interface{}          `json:"meta_config,omitempty"`       // Provider-specific metadata
-	ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
-	ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config,omitempty"`      // Proxy configuration
+	Keys                     []schemas.Key                    `json:"keys"`                             // API keys for the provider
+	NetworkConfig            schemas.NetworkConfig            `json:"network_config"`                   // Network-related settings
+	MetaConfig               *map[string]interface{}          `json:"meta_config,omitempty"`            // Provider-specific metadata
+	ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"`      // Concurrency settings
+	ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config,omitempty"`           // Proxy configuration
+	SendBackRawResponse      *bool                            `json:"send_back_raw_response,omitempty"` // Include raw response in BifrostResponse
 }
 
 // ProviderResponse represents the response for provider operations
@@ -60,6 +62,7 @@ type ProviderResponse struct {
 	MetaConfig               *schemas.MetaConfig              `json:"meta_config"`                 // Provider-specific metadata
 	ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
 	ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config"`                // Proxy configuration
+	SendBackRawResponse      bool                             `json:"send_back_raw_response"`      // Include raw response in BifrostResponse
 }
 
 // ListProvidersResponse represents the response for listing all providers
@@ -182,6 +185,7 @@ func (h *ProviderHandler) AddProvider(ctx *fasthttp.RequestCtx) {
 		Keys:                     req.Keys,
 		NetworkConfig:            req.NetworkConfig,
 		ConcurrencyAndBufferSize: req.ConcurrencyAndBufferSize,
+		SendBackRawResponse:      req.SendBackRawResponse != nil && *req.SendBackRawResponse,
 	}
 
 	// Handle meta config if provided
@@ -312,6 +316,9 @@ func (h *ProviderHandler) UpdateProvider(ctx *fasthttp.RequestCtx) {
 	config.ConcurrencyAndBufferSize = &req.ConcurrencyAndBufferSize
 	config.NetworkConfig = &req.NetworkConfig
 	config.ProxyConfig = req.ProxyConfig
+	if req.SendBackRawResponse != nil {
+		config.SendBackRawResponse = *req.SendBackRawResponse
+	}
 
 	// Update provider config in store (env vars will be processed by store)
 	if err := h.store.UpdateProviderConfig(provider, config); err != nil {
@@ -547,6 +554,7 @@ func (h *ProviderHandler) getProviderResponseFromConfig(provider schemas.ModelPr
 		MetaConfig:               config.MetaConfig,
 		ConcurrencyAndBufferSize: *config.ConcurrencyAndBufferSize,
 		ProxyConfig:              config.ProxyConfig,
+		SendBackRawResponse:      config.SendBackRawResponse,
 	}
 }
 

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -84,5 +84,7 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 		providerConfig.ConcurrencyAndBufferSize = schemas.DefaultConcurrencyAndBufferSize
 	}
 
+	providerConfig.SendBackRawResponse = config.SendBackRawResponse
+
 	return providerConfig, nil
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -23,6 +23,7 @@ type ProviderConfig struct {
 	MetaConfig               *schemas.MetaConfig               `json:"-"`                                     // Provider-specific metadata
 	ConcurrencyAndBufferSize *schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size,omitempty"` // Concurrency settings
 	ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config,omitempty"`                // Proxy configuration
+	SendBackRawResponse      bool                              `json:"send_back_raw_response"`                // Include raw response in BifrostResponse
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/ui/components/config/provider-form.tsx
+++ b/ui/components/config/provider-form.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { TagInput } from '@/components/ui/tag-input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -85,6 +86,7 @@ const createInitialState = (provider?: ProviderResponse | null, defaultProvider?
       username: '',
       password: '',
     },
+    sendBackRawResponse: provider?.send_back_raw_response || false,
   }
 }
 
@@ -95,6 +97,7 @@ interface ProviderFormData {
   performanceConfig: ConcurrencyAndBufferSize
   metaConfig: MetaConfig
   proxyConfig: ProxyConfig
+  sendBackRawResponse: boolean
   isDirty: boolean
 }
 
@@ -108,7 +111,7 @@ export default function ProviderForm({ provider, onSave, onCancel, existingProvi
   })
   const [isLoading, setIsLoading] = useState(false)
 
-  const { selectedProvider, keys, networkConfig, performanceConfig, metaConfig, proxyConfig, isDirty } = formData
+  const { selectedProvider, keys, networkConfig, performanceConfig, metaConfig, proxyConfig, sendBackRawResponse, isDirty } = formData
 
   const baseURLRequired = selectedProvider === 'ollama' || selectedProvider === 'sgl'
   const keysRequired = !['ollama', 'sgl'].includes(selectedProvider) // Vertex needs keys for config
@@ -226,6 +229,7 @@ export default function ProviderForm({ provider, onSave, onCancel, existingProvi
         concurrency_and_buffer_size: performanceConfig,
         meta_config: metaConfig,
         proxy_config: proxyConfig,
+        send_back_raw_response: sendBackRawResponse,
       }
       ;[, error] = await apiService.updateProvider(provider.name, data)
     } else {
@@ -913,6 +917,21 @@ export default function ProviderForm({ provider, onSave, onCancel, existingProvi
                               })
                             }
                             className={`transition-all duration-200 ease-in-out ${!performanceValid ? 'border-destructive' : ''}`}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="mt-6 space-y-4">
+                        <div className="flex items-center justify-between space-x-2">
+                          <div className="space-y-0.5">
+                            <label className="text-sm font-medium">Include Raw Response</label>
+                            <p className="text-muted-foreground text-xs">
+                              Include the raw provider response alongside the parsed response for debugging and advanced use cases
+                            </p>
+                          </div>
+                          <Switch
+                            checked={sendBackRawResponse}
+                            onCheckedChange={(checked) => updateField('sendBackRawResponse', checked)}
                           />
                         </div>
                       </div>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -74,6 +74,7 @@ export interface ProviderConfig {
   meta_config?: MetaConfig
   concurrency_and_buffer_size: ConcurrencyAndBufferSize
   proxy_config?: ProxyConfig
+  send_back_raw_response?: boolean
 }
 
 // ProviderResponse matching Go's ProviderResponse
@@ -95,6 +96,7 @@ export interface AddProviderRequest {
   meta_config?: MetaConfig
   concurrency_and_buffer_size?: ConcurrencyAndBufferSize
   proxy_config?: ProxyConfig
+  send_back_raw_response?: boolean
 }
 
 // UpdateProviderRequest matching Go's UpdateProviderRequest
@@ -104,6 +106,7 @@ export interface UpdateProviderRequest {
   meta_config?: MetaConfig
   concurrency_and_buffer_size: ConcurrencyAndBufferSize
   proxy_config: ProxyConfig
+  send_back_raw_response?: boolean
 }
 
 // BifrostErrorResponse matching Go's schemas.BifrostError

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3871,7 +3871,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
+				"form-data": "^4.0.4",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
@@ -5475,9 +5475,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",


### PR DESCRIPTION
# Make Raw Response Optional in Provider Responses

This PR adds a configuration option to control whether raw provider responses are included in Bifrost responses. Previously, raw responses were always included, which could increase response size and bandwidth usage unnecessarily.

Key changes:
- Added `send_back_raw_response` boolean flag to provider configuration
- Modified all providers to respect this setting when processing responses
- Updated the UI to include a toggle for this option in the provider configuration form
- Optimized response handling to avoid unnecessary JSON parsing when raw responses aren't needed
- Standardized response object pools across providers to use the common `BifrostResponse` type

This change improves performance by avoiding unnecessary JSON parsing and reduces response sizes when raw responses aren't needed, while maintaining backward compatibility for users who rely on the raw response data.