### PR TITLE
ci: remove Windows/386 and Linux/386 platforms from build script

### DIFF
--- a/ci/scripts/go-executable-build.sh
+++ b/ci/scripts/go-executable-build.sh
@@ -41,7 +41,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-platforms=("windows/amd64" "windows/386" "darwin/amd64" "darwin/arm64" "linux/386" "linux/amd64")
+platforms=("windows/amd64" "darwin/amd64" "darwin/arm64" "linux/amd64")
 cd "$app_dir" || { echo "Error: Failed to change to directory $app_dir"; exit 1; }
 for platform in "${platforms[@]}"
 do


### PR DESCRIPTION
Removed Windows 386 and Linux 386 platforms from the build script, focusing only on Windows amd64, Darwin amd64/arm64, and Linux amd64 architectures.