### PR TITLE
feat: Add tag on input blur in TagInput component

### DIFF
--- a/ui/components/ui/tag-input.tsx
+++ b/ui/components/ui/tag-input.tsx
@@ -20,17 +20,25 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(({ cla
 		setInputValue(e.target.value);
 	};
 
+	const addCurrentTag = () => {
+		const newTag = inputValue.trim();
+		if (newTag && !value.includes(newTag)) {
+			onValueChange([...value, newTag]);
+		}
+		setInputValue("");
+	};
+
 	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
 		if (e.key === "Enter" || e.key === ",") {
 			e.preventDefault();
-			const newTag = inputValue.trim();
-			if (newTag && !value.includes(newTag)) {
-				onValueChange([...value, newTag]);
-			}
-			setInputValue("");
+			addCurrentTag();
 		} else if (e.key === "Backspace" && inputValue === "" && value.length > 0) {
 			onValueChange(value.slice(0, -1));
 		}
+	};
+
+	const handleBlur = () => {
+		addCurrentTag();
 	};
 
 	const removeTag = (tagToRemove: string) => {
@@ -57,6 +65,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(({ cla
 				value={inputValue}
 				onChange={handleInputChange}
 				onKeyDown={handleKeyDown}
+				onBlur={handleBlur}
 				className="flex-1 border-0 shadow-none focus-visible:ring-0"
 				{...props}
 			/>


### PR DESCRIPTION
### TL;DR

Added tag creation on input blur in the TagInput component.

### What changed?

- Extracted tag creation logic into a reusable `addCurrentTag` function
- Added an `onBlur` event handler to the input element that calls `addCurrentTag`
- This ensures tags are created not only when pressing Enter or comma, but also when the input loses focus
