### PR TITLE
fix: handle Windows paths with spaces in npx binary execution

### DIFF
--- a/ci/npx/bin.js
+++ b/ci/npx/bin.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { chmodSync, createWriteStream } from "fs";
 import fetch from "node-fetch";
 import { tmpdir } from "os";
@@ -123,12 +123,9 @@ async function downloadBinary(url, dest) {
     process.exit(1);
   }
 
-  // Get command-line arguments to pass to the binary (excluding --transport-version)
-  const args = remainingArgs.join(" ");
-
   // Execute the binary, forwarding the arguments
   try {
-    execSync(`${binaryPath} ${args}`, { stdio: "inherit" });
+    execFileSync(binaryPath, remainingArgs, { stdio: "inherit" });
   } catch (error) {
     // The child process will have already printed its error message.
     // Exit with the same status code as the child process.


### PR DESCRIPTION
### TL;DR

Fix Windows command execution in the CI binary runner to properly handle paths with spaces.

### What changed?

Modified the binary execution logic in `ci/npx/bin.js` to use array form with `execSync` instead of string concatenation. This ensures that paths containing spaces are properly handled on Windows systems.

### Why make this change?

The previous implementation concatenated the binary path with arguments as a string, which can cause issues on Windows when paths contain spaces. Using the array form of `execSync` ensures proper escaping of paths and arguments, making the tool more robust across different operating systems.