### PR TITLE
feat: enable CGO and optimize build platforms for cross-compilation

### DIFF
--- a/ci/scripts/go-executable-build.sh
+++ b/ci/scripts/go-executable-build.sh
@@ -41,7 +41,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-platforms=("windows/amd64" "windows/386" "darwin/amd64" "darwin/arm64" "linux/386" "linux/amd64")
+platforms=("windows/amd64" "darwin/amd64" "darwin/arm64" "linux/amd64")
 cd "$app_dir" || { echo "Error: Failed to change to directory $app_dir"; exit 1; }
 for platform in "${platforms[@]}"
 do
@@ -53,8 +53,36 @@ do
 	fi
 	echo "building $package_name for $GOOS/$GOARCH..."
 	mkdir -p "$output_path/$GOOS/$GOARCH"
-	if ! env GOOS="$GOOS" GOARCH="$GOARCH" go build -o "$output_path/$GOOS/$GOARCH/$output_name" "$3"; then
-   		echo 'An error has occurred! Aborting the script execution...'
-		exit 1
+	
+	# Set up cross-compilation environment with CGO enabled for all platforms
+	if [ "$GOOS" = "windows" ]; then
+		# Enable CGO for Windows with mingw-w64 cross-compiler
+		if ! env CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" CC="x86_64-w64-mingw32-gcc" CXX="x86_64-w64-mingw32-g++" go build -o "$output_path/$GOOS/$GOARCH/$output_name" "$3"; then
+			echo 'An error has occurred! Aborting the script execution...'
+			exit 1
+		fi
+	elif [ "$GOOS" = "linux" ]; then
+		# Enable CGO for Linux with musl cross-compiler
+		if [ "$GOARCH" = "amd64" ]; then
+			CC_COMPILER="x86_64-linux-musl-gcc"
+			CXX_COMPILER="x86_64-linux-musl-g++"
+		elif [ "$GOARCH" = "arm64" ]; then
+			CC_COMPILER="aarch64-linux-musl-gcc"
+			CXX_COMPILER="aarch64-linux-musl-g++"
+		else
+			echo "Unsupported Linux architecture: $GOARCH"
+			exit 1
+		fi
+		
+		if ! env CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" CC="$CC_COMPILER" CXX="$CXX_COMPILER" go build -o "$output_path/$GOOS/$GOARCH/$output_name" "$3"; then
+			echo 'An error has occurred! Aborting the script execution...'
+			exit 1
+		fi
+	else
+		# Enable CGO for native Darwin builds
+		if ! env CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" go build -o "$output_path/$GOOS/$GOARCH/$output_name" "$3"; then
+			echo 'An error has occurred! Aborting the script execution...'
+			exit 1
+		fi
 	fi
 done


### PR DESCRIPTION
# Enable CGO and Cross-Compilation Support for Build Scripts

This PR enhances our Go build pipeline with proper CGO support for cross-compilation:

1. Removes 32-bit builds (386 architecture) for both Windows and Linux
2. Adds proper cross-compilation with CGO enabled:
   - Windows: Uses mingw-w64 cross-compiler
   - Linux: Uses musl cross-compiler with architecture-specific settings
   - macOS: Enables CGO for native builds

3. Adds development build mode to the upload script:
   - Introduces a `--dev` flag that:
     - Uses version `v0.0.0` for development builds
     - Skips uploading to the "latest" path in S3
   - Improves error handling and logging during uploads

These changes will allow us to use C dependencies in our Go code while maintaining cross-platform compatibility.