### PR TITLE
bump npx package and publish

### DIFF
--- a/ci/npx/package.json
+++ b/ci/npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "High-performance AI gateway CLI - connect to 10+ providers through a single API",
   "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
   "homepage": "https://github.com/maximhq/bifrost",


### PR DESCRIPTION
### TL;DR

Bump NPX package version from 1.0.1 to 1.0.2

### What changed?

Updated the version number of the `@maximhq/bifrost` NPX package from `1.0.1` to `1.0.2` in the `ci/npx/package.json` file.

### How to test?

1. Install the package using NPX: `npx @maximhq/bifrost@1.0.2`
2. Verify the installed version matches 1.0.2

### Why make this change?

This version bump is needed to release a new version of the Bifrost AI gateway CLI to NPM, making the latest features and fixes available to users.