### PR TITLE
chore: update bifrost to v1.0.3 and add node-fetch dependency

### DIFF
--- a/ci/npx/package-lock.json
+++ b/ci/npx/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maximhq/bifrost",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "bin": {
         "bifrost": "bin.js"

--- a/ci/npx/package.json
+++ b/ci/npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "High-performance AI gateway CLI - connect to 10+ providers through a single API",
   "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
   "homepage": "https://github.com/maximhq/bifrost",


### PR DESCRIPTION
Bumped package version from 1.0.1 to 1.0.3 and added node-fetch dependency (v3.3.2) to the bifrost NPX package.