### PR TITLE
fix: remove redundant budget null check and improve provider form validation

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -429,7 +429,7 @@ func (h *GovernanceHandler) UpdateVirtualKey(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Update in-memory cache for budget and rate limit changes
-	if req.Budget != nil && vk.BudgetID != nil && vk.Budget != nil {
+	if req.Budget != nil && vk.BudgetID != nil {
 		if err := h.pluginStore.UpdateBudgetInMemory(vk.Budget); err != nil {
 			h.logger.Error(fmt.Errorf("failed to update budget cache: %w", err))
 		}
@@ -681,7 +681,7 @@ func (h *GovernanceHandler) UpdateTeam(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Update in-memory cache for budget changes
-	if req.Budget != nil && team.BudgetID != nil && team.Budget != nil {
+	if req.Budget != nil && team.BudgetID != nil {
 		if err := h.pluginStore.UpdateBudgetInMemory(team.Budget); err != nil {
 			h.logger.Error(fmt.Errorf("failed to update budget cache: %w", err))
 		}
@@ -926,7 +926,7 @@ func (h *GovernanceHandler) UpdateCustomer(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Update in-memory cache for budget changes
-	if req.Budget != nil && customer.BudgetID != nil && customer.Budget != nil {
+	if req.Budget != nil && customer.BudgetID != nil {
 		if err := h.pluginStore.UpdateBudgetInMemory(customer.Budget); err != nil {
 			h.logger.Error(fmt.Errorf("failed to update budget cache: %w", err))
 		}

--- a/ui/components/config/provider-form.tsx
+++ b/ui/components/config/provider-form.tsx
@@ -284,6 +284,9 @@ export default function ProviderForm({ provider, onSave, onCancel, existingProvi
   }
 
   const validator = new Validator([
+    // IsDirty validation - check for existing providers with no changes
+    Validator.custom(!(allProviders.find((p) => p.name === selectedProvider) && !isDirty), 'No changes to save'),
+
     // Provider selection
     Validator.required(selectedProvider, 'Please select a provider'),
 
@@ -1082,7 +1085,7 @@ export default function ProviderForm({ provider, onSave, onCancel, existingProvi
                       <span>
                         <Button
                           type="submit"
-                          disabled={!validator.isValid() || isLoading || (allProviders.find((p) => p.name === selectedProvider) && !isDirty)}
+                          disabled={!validator.isValid() || isLoading}
                           isLoading={isLoading}
                           className="transition-all duration-200 ease-in-out"
                         >
@@ -1095,16 +1098,9 @@ export default function ProviderForm({ provider, onSave, onCancel, existingProvi
                         </Button>
                       </span>
                     </TooltipTrigger>
-                    {(!validator.isValid() || isLoading || (allProviders.find((p) => p.name === selectedProvider) && !isDirty)) && (
+                    {(!validator.isValid() || isLoading) && (
                       <TooltipContent>
-                        <p>
-                          {isLoading 
-                            ? 'Saving...' 
-                            : allProviders.find((p) => p.name === selectedProvider) && !isDirty
-                              ? 'No changes to save'
-                              : validator.getFirstError() || 'Please fix validation errors'
-                          }
-                        </p>
+                        <p>{isLoading ? 'Saving...' : validator.getFirstError() || 'Please fix validation errors'}</p>
                       </TooltipContent>
                     )}
                   </Tooltip>


### PR DESCRIPTION
# Fix budget update conditions and improve provider form validation

This PR makes two key improvements:

1. Removes unnecessary null checks on Budget objects in the governance handlers. The previous code was checking `vk.Budget != nil`, `team.Budget != nil`, and `customer.Budget != nil` which was redundant since we already verify the BudgetID exists.

2. Enhances the provider form validation:
   - Moves the "No changes to save" check into the validator system for consistency
   - Simplifies the disabled state logic on the save button
   - Cleans up the tooltip content rendering to use the validator's error message

These changes improve code reliability and provide a more consistent user experience when working with budgets and provider configurations.