### PR TITLE
feat: add configurable CORS and WebSocket allowed origins

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -77,6 +77,10 @@ func (h *ConfigHandler) handleUpdateConfig(ctx *fasthttp.RequestCtx) {
 		updatedConfig.PrometheusLabels = req.PrometheusLabels
 	}
 
+	if !slices.Equal(req.AllowedOrigins, currentConfig.AllowedOrigins) {
+		updatedConfig.AllowedOrigins = req.AllowedOrigins
+	}
+
 	updatedConfig.InitialPoolSize = req.InitialPoolSize
 	updatedConfig.EnableLogging = req.EnableLogging
 	updatedConfig.EnableGovernance = req.EnableGovernance

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -5,6 +5,8 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
@@ -65,4 +67,24 @@ func SendSSEError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError, lo
 	if _, err := fmt.Fprintf(ctx, "data: %s\n\n", errorJSON); err != nil {
 		logger.Warn(fmt.Sprintf("Failed to write SSE error: %v", err))
 	}
+}
+
+// IsOriginAllowed checks if the given origin is allowed based on localhost rules and configured allowed origins.
+// Localhost origins are always allowed. Additional origins can be configured in allowedOrigins.
+func IsOriginAllowed(origin string, allowedOrigins []string) bool {
+	// Always allow localhost origins
+	if isLocalhostOrigin(origin) {
+		return true
+	}
+
+	// Check configured allowed origins
+	return slices.Contains(allowedOrigins, origin)
+}
+
+// isLocalhostOrigin checks if the given origin is a localhost origin
+func isLocalhostOrigin(origin string) bool {
+	return strings.HasPrefix(origin, "http://localhost:") ||
+		strings.HasPrefix(origin, "https://localhost:") ||
+		strings.HasPrefix(origin, "http://127.0.0.1:") ||
+		strings.HasPrefix(origin, "https://127.0.0.1:")
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -15,6 +15,7 @@ type ClientConfig struct {
 	EnableLogging           bool     `json:"enable_logging"`            // Enable logging of requests and responses
 	EnableGovernance        bool     `json:"enable_governance"`         // Enable governance on all requests
 	EnforceGovernanceHeader bool     `json:"enforce_governance_header"` // Enforce governance on all requests
+	AllowedOrigins          []string `json:"allowed_origins,omitempty"` // Additional allowed origins for CORS and WebSocket (localhost is always allowed)
 }
 
 // ProviderConfig represents the configuration for a specific AI model provider.

--- a/transports/bifrost-http/lib/store.go
+++ b/transports/bifrost-http/lib/store.go
@@ -313,6 +313,7 @@ func (s *ConfigStore) loadClientConfigFromDB() error {
 		EnableLogging:           dbConfig.EnableLogging,
 		EnableGovernance:        dbConfig.EnableGovernance,
 		EnforceGovernanceHeader: dbConfig.EnforceGovernanceHeader,
+		AllowedOrigins:          dbConfig.AllowedOrigins,
 	}
 
 	return nil
@@ -693,6 +694,7 @@ func (s *ConfigStore) saveClientConfigToDB() error {
 		EnableGovernance:        s.ClientConfig.EnableGovernance,
 		EnforceGovernanceHeader: s.ClientConfig.EnforceGovernanceHeader,
 		PrometheusLabels:        s.ClientConfig.PrometheusLabels,
+		AllowedOrigins:          s.ClientConfig.AllowedOrigins,
 	}
 
 	// Delete existing client config and create new one

--- a/transports/config.example.json
+++ b/transports/config.example.json
@@ -2,7 +2,12 @@
   "client": {
     "drop_excess_requests": false,
     "initial_pool_size": 500,
-    "prometheus_labels": ["model", "provider"]
+    "prometheus_labels": ["model", "provider"],
+    "allowed_origins": [
+      "https://myapp.example.com",
+      "https://staging.myapp.com",
+      "https://app.production.com"
+    ]
   },
   "providers": {
     "openai": {

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -126,6 +126,7 @@ export interface CoreConfig {
   enable_logging: boolean
   enable_governance: boolean
   enforce_governance_header: boolean
+  allowed_origins: string[]
 }
 
 // Utility types for form handling

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -261,3 +261,51 @@ export function isValidDeployments(value: Record<string, string> | string | unde
 
   return false
 }
+
+/**
+ * Validates if a string is a valid origin URL
+ * @param origin - The origin URL to validate
+ * @returns true if valid origin (protocol + hostname + optional port)
+ */
+export function isValidOrigin(origin: string): boolean {
+  if (!origin || !origin.trim()) {
+    return false
+  }
+
+  try {
+    const url = new URL(origin)
+
+    // Must have protocol and hostname
+    if (!url.protocol || !url.hostname) {
+      return false
+    }
+
+    // Must be http or https
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return false
+    }
+
+    // Must not have path, query, or fragment (origin should be just protocol + hostname + port)
+    if (url.pathname !== '/' || url.search || url.hash) {
+      return false
+    }
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Validates an array of origin URLs
+ * @param origins - Array of origin URLs to validate
+ * @returns Object with validation result and invalid origins
+ */
+export function validateOrigins(origins: string[]): { isValid: boolean; invalidOrigins: string[] } {
+  const invalidOrigins = origins.filter((origin) => !isValidOrigin(origin))
+
+  return {
+    isValid: invalidOrigins.length === 0,
+    invalidOrigins,
+  }
+}


### PR DESCRIPTION
# Add CORS and WebSocket Origin Control

This PR adds the ability to configure allowed origins for CORS and WebSocket connections beyond localhost. Previously, only localhost origins were allowed, but now administrators can specify additional trusted origins.

Key changes:
- Added `AllowedOrigins` field to client configuration to store allowed origins
- Created utility functions to validate origins and check if an origin is allowed
- Updated WebSocket handler to use the configured allowed origins
- Modified CORS middleware to respect the allowed origins configuration
- Added UI controls in the config page to manage allowed origins with validation
- Updated config example to demonstrate the new allowed origins feature

Localhost origins (http://localhost:* and http://127.0.0.1:*) remain always allowed for backward compatibility, while additional origins must be explicitly configured.