### PR TITLE
feat: allow setting the host to listen on

### DIFF
--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -40,6 +40,7 @@ USER appuser
 
 # Environment variables with defaults
 ENV APP_PORT=8080 \
+    APP_HOST=0.0.0.0 \
     APP_PLUGINS=""
 
 # Declare volume for data persistence
@@ -51,4 +52,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 --spider http://localhost:${APP_PORT}/metrics || exit 1
 
 # Use entrypoint script that handles volume permissions
-ENTRYPOINT ["/bin/sh", "-c", "/app/docker-entrypoint.sh -app-dir /app/data -port ${APP_PORT} -plugins \"${APP_PLUGINS}\""]
+ENTRYPOINT ["/bin/sh", "-c", "/app/docker-entrypoint.sh -app-dir /app/data -port ${APP_PORT} -host \"${APP_HOST}\" -plugins \"${APP_PLUGINS}\""]

--- a/transports/README.md
+++ b/transports/README.md
@@ -240,11 +240,12 @@ curl http://localhost:8080/metrics
 
 ### For Binary
 
-| Flag       | Default | Description                              |
-| ---------- | ------- | ---------------------------------------- |
-| `-app-dir` | .       | Application data directory (config+logs) |
-| `-port`    | 8080    | HTTP server port                         |
-| `-plugins` | -       | Comma-separated plugin list              |
+| Flag       | Default   | Description                              |
+| ---------- | --------- | ---------------------------------------- |
+| `-app-dir` | .         | Application data directory (config+logs) |
+| `-port`    | 8080      | HTTP server port                         |
+| `-host`    | localhost | Host to bind server to                   |
+| `-plugins` | -         | Comma-separated plugin list              |
 
 ### Understanding App Directory & Docker Volumes
 
@@ -260,10 +261,24 @@ For complete setup instructions, deployment scenarios, and best practices, see t
 
 ### For Docker
 
-| Variable      | Description          |
-| ------------- | -------------------- |
-| `APP_PORT`    | Server port override |
-| `APP_PLUGINS` | Plugin list override |
+| Variable      | Default   | Description                    |
+| ------------- | --------- | ------------------------------ |
+| `APP_PORT`    | 8080      | Server port override           |
+| `APP_HOST`    | 0.0.0.0   | Host to bind server to         |
+| `APP_PLUGINS` | -         | Plugin list override           |
+
+**Network Configuration Examples:**
+
+```bash
+# Listen on all interfaces (for container access)
+docker run -p 8080:8080 -e APP_HOST=0.0.0.0 maximhq/bifrost
+
+# IPv6 support - listen on all IPv6 interfaces
+docker run -p 8080:8080 -e APP_HOST=:: maximhq/bifrost
+
+# Specific interface binding
+docker run -p 8080:8080 -e APP_HOST=192.168.1.100 maximhq/bifrost
+```
 
 ---
 
@@ -297,8 +312,8 @@ For complete setup instructions, deployment scenarios, and best practices, see t
 
 ## 🎉 Ready to Scale?
 
-🚀 **Production Deployment**: [Production Guide](../docs/usage/http-transport/configuration/)  
-📈 **Performance Tuning**: [Benchmarks & Optimization](../docs/benchmarks.md)  
+🚀 **Production Deployment**: [Production Guide](../docs/usage/http-transport/configuration/)
+📈 **Performance Tuning**: [Benchmarks & Optimization](../docs/benchmarks.md)
 🔍 **Troubleshooting**: [Common Issues](../docs/usage/errors.md)
 
 ---


### PR DESCRIPTION
This change adds the addition of an optional -host parameter and `BIFROST_HOST` environment variable that allows users to set the hostname (or IP) to listen on.

fixes #231 