### PR TITLE
feat: Add streaming accumulator with ordered chunk processing for logging

### DIFF
--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -485,7 +485,7 @@ func handleOpenAIStreaming(
 				processAndSendResponse(ctx, postHookRunner, &response, responseChan, logger)
 
 				// End stream processing after finish reason
-				break
+				continue
 			}
 
 			// Handle regular content chunks

--- a/transports/bifrost-http/plugins/logging/pool.go
+++ b/transports/bifrost-http/plugins/logging/pool.go
@@ -1,0 +1,81 @@
+package logging
+
+import "time"
+
+// getLogMessage gets a LogMessage from the pool
+func (p *LoggerPlugin) getLogMessage() *LogMessage {
+	return p.logMsgPool.Get().(*LogMessage)
+}
+
+// putLogMessage returns a LogMessage to the pool after resetting it
+func (p *LoggerPlugin) putLogMessage(msg *LogMessage) {
+	// Reset the message fields to avoid memory leaks
+	msg.Operation = ""
+	msg.RequestID = ""
+	msg.Timestamp = time.Time{}
+	msg.InitialData = nil
+
+	// Don't reset UpdateData and StreamUpdateData here since they're returned
+	// to their own pools in the defer function - just clear the pointers
+	msg.UpdateData = nil
+	msg.StreamUpdateData = nil
+
+	p.logMsgPool.Put(msg)
+}
+
+// getUpdateLogData gets an UpdateLogData from the pool
+func (p *LoggerPlugin) getUpdateLogData() *UpdateLogData {
+	return p.updateDataPool.Get().(*UpdateLogData)
+}
+
+// putUpdateLogData returns an UpdateLogData to the pool after resetting it
+func (p *LoggerPlugin) putUpdateLogData(data *UpdateLogData) {
+	// Reset all fields to avoid memory leaks
+	data.Status = ""
+	data.TokenUsage = nil
+	data.OutputMessage = nil
+	data.ToolCalls = nil
+	data.ErrorDetails = nil
+	data.Model = ""
+	data.Object = ""
+	data.SpeechOutput = nil
+	data.TranscriptionOutput = nil
+
+	p.updateDataPool.Put(data)
+}
+
+// getStreamUpdateData gets a StreamUpdateData from the pool
+func (p *LoggerPlugin) getStreamUpdateData() *StreamUpdateData {
+	return p.streamDataPool.Get().(*StreamUpdateData)
+}
+
+// putStreamUpdateData returns a StreamUpdateData to the pool after resetting it
+func (p *LoggerPlugin) putStreamUpdateData(data *StreamUpdateData) {
+	// Reset all fields to avoid memory leaks
+	data.ErrorDetails = nil
+	data.Model = ""
+	data.Object = ""
+	data.TokenUsage = nil
+	data.Delta = nil
+	data.FinishReason = nil
+	data.TranscriptionOutput = nil
+
+	p.streamDataPool.Put(data)
+}
+
+// getStreamChunk gets a StreamChunk from the pool
+func (p *LoggerPlugin) getStreamChunk() *StreamChunk {
+	return p.streamChunkPool.Get().(*StreamChunk)
+}
+
+// putStreamChunk returns a StreamChunk to the pool after resetting it
+func (p *LoggerPlugin) putStreamChunk(chunk *StreamChunk) {
+	// Reset all fields to avoid memory leaks
+	chunk.Timestamp = time.Time{}
+	chunk.Delta = nil
+	chunk.FinishReason = nil
+	chunk.TokenUsage = nil
+	chunk.ErrorDetails = nil
+
+	p.streamChunkPool.Put(chunk)
+}

--- a/transports/bifrost-http/plugins/logging/streaming.go
+++ b/transports/bifrost-http/plugins/logging/streaming.go
@@ -2,6 +2,11 @@
 package logging
 
 import (
+	"context"
+	"fmt"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -68,4 +73,325 @@ func (p *LoggerPlugin) accumulateToolCallsInMessage(message *schemas.BifrostMess
 	}
 
 	message.AssistantMessage.ToolCalls = &existingToolCalls
+}
+
+// Stream accumulator helper methods
+
+// createStreamAccumulator creates a new stream accumulator for a request
+func (p *LoggerPlugin) createStreamAccumulator(requestID string) *StreamAccumulator {
+	accumulator := &StreamAccumulator{
+		RequestID:  requestID,
+		Chunks:     make([]*StreamChunk, 0),
+		IsComplete: false,
+		Object:     "",
+	}
+
+	p.streamAccumulators.Store(requestID, accumulator)
+	return accumulator
+}
+
+// getOrCreateStreamAccumulator gets or creates a stream accumulator for a request
+func (p *LoggerPlugin) getOrCreateStreamAccumulator(requestID string) *StreamAccumulator {
+	if accumulator, exists := p.streamAccumulators.Load(requestID); exists {
+		return accumulator.(*StreamAccumulator)
+	}
+
+	// Create new accumulator if it doesn't exist
+	return p.createStreamAccumulator(requestID)
+}
+
+// addStreamChunk adds a chunk to the stream accumulator
+func (p *LoggerPlugin) addStreamChunk(requestID string, chunk *StreamChunk, object string) error {
+	accumulator := p.getOrCreateStreamAccumulator(requestID)
+
+	accumulator.mu.Lock()
+	defer accumulator.mu.Unlock()
+
+	// Store object type once (from first chunk)
+	if accumulator.Object == "" && object != "" {
+		accumulator.Object = object
+	}
+
+	// Add chunk to the list (chunks arrive in order)
+	accumulator.Chunks = append(accumulator.Chunks, chunk)
+
+	// Check if this is the final chunk
+	// Set FinalTimestamp when either FinishReason is present or token usage exists
+	// This handles both normal completion chunks and usage-only last chunks
+	if chunk.FinishReason != nil || chunk.TokenUsage != nil {
+		accumulator.IsComplete = true
+		accumulator.FinalTimestamp = chunk.Timestamp
+	}
+
+	return nil
+}
+
+// processAccumulatedChunks processes all accumulated chunks in order
+func (p *LoggerPlugin) processAccumulatedChunks(requestID string) error {
+	accumulator := p.getOrCreateStreamAccumulator(requestID)
+
+	accumulator.mu.Lock()
+	defer accumulator.mu.Unlock()
+
+	// Ensure cleanup happens
+	defer p.cleanupStreamAccumulator(requestID)
+
+	// Build complete message from accumulated chunks
+	completeMessage := p.buildCompleteMessageFromChunks(accumulator.Chunks)
+
+	// Calculate final latency
+	latency, err := p.calculateLatency(requestID, accumulator.FinalTimestamp, context.Background())
+	if err != nil {
+		p.logger.Error(fmt.Errorf("failed to calculate latency for request %s: %w", requestID, err))
+		latency = 0
+	}
+
+	// Update database with complete message
+	updates := make(map[string]interface{})
+	updates["status"] = "success"
+	updates["stream"] = true
+	updates["latency"] = latency
+	updates["timestamp"] = accumulator.FinalTimestamp
+
+	// Serialize complete message
+	tempEntry := &LogEntry{
+		OutputMessageParsed: completeMessage,
+	}
+	if completeMessage.AssistantMessage != nil && completeMessage.AssistantMessage.ToolCalls != nil {
+		tempEntry.ToolCallsParsed = completeMessage.AssistantMessage.ToolCalls
+	}
+
+	if err := tempEntry.serializeFields(); err != nil {
+		return fmt.Errorf("failed to serialize complete message: %w", err)
+	}
+
+	updates["output_message"] = tempEntry.OutputMessage
+	updates["content_summary"] = tempEntry.ContentSummary
+	if tempEntry.ToolCalls != "" {
+		updates["tool_calls"] = tempEntry.ToolCalls
+	}
+
+	// Update token usage from final chunk if available
+	if len(accumulator.Chunks) > 0 {
+		lastChunk := accumulator.Chunks[len(accumulator.Chunks)-1]
+		if lastChunk.TokenUsage != nil {
+			tempEntry.TokenUsageParsed = lastChunk.TokenUsage
+			if err := tempEntry.serializeFields(); err == nil {
+				updates["token_usage"] = tempEntry.TokenUsage
+				updates["prompt_tokens"] = lastChunk.TokenUsage.PromptTokens
+				updates["completion_tokens"] = lastChunk.TokenUsage.CompletionTokens
+				updates["total_tokens"] = lastChunk.TokenUsage.TotalTokens
+			}
+		}
+	}
+
+	// Update object field from accumulator (stored once for the entire stream)
+	if accumulator.Object != "" {
+		updates["object_type"] = accumulator.Object
+	}
+
+	// Perform final database update
+	if err := p.db.Model(&LogEntry{}).Where("id = ?", requestID).Updates(updates).Error; err != nil {
+		return fmt.Errorf("failed to update log entry with complete stream: %w", err)
+	}
+
+	// Trigger callback
+	p.mu.Lock()
+	if p.logCallback != nil {
+		if updatedEntry, getErr := p.getLogEntry(requestID); getErr == nil {
+			p.logCallback(updatedEntry)
+		}
+	}
+	p.mu.Unlock()
+
+	return nil
+}
+
+// buildCompleteMessageFromChunks builds a complete message from ordered chunks
+func (p *LoggerPlugin) buildCompleteMessageFromChunks(chunks []*StreamChunk) *schemas.BifrostMessage {
+	completeMessage := &schemas.BifrostMessage{
+		Role:    schemas.ModelChatMessageRoleAssistant,
+		Content: schemas.MessageContent{},
+	}
+
+	for _, chunk := range chunks {
+		if chunk.Delta == nil {
+			continue
+		}
+
+		// Handle role (usually in first chunk)
+		if chunk.Delta.Role != nil {
+			completeMessage.Role = schemas.ModelChatMessageRole(*chunk.Delta.Role)
+		}
+
+		// Append content
+		if chunk.Delta.Content != nil && *chunk.Delta.Content != "" {
+			p.appendContentToMessage(completeMessage, *chunk.Delta.Content)
+		}
+
+		// Handle refusal
+		if chunk.Delta.Refusal != nil && *chunk.Delta.Refusal != "" {
+			if completeMessage.AssistantMessage == nil {
+				completeMessage.AssistantMessage = &schemas.AssistantMessage{}
+			}
+			if completeMessage.AssistantMessage.Refusal == nil {
+				completeMessage.AssistantMessage.Refusal = chunk.Delta.Refusal
+			} else {
+				*completeMessage.AssistantMessage.Refusal += *chunk.Delta.Refusal
+			}
+		}
+
+		// Accumulate tool calls
+		if len(chunk.Delta.ToolCalls) > 0 {
+			p.accumulateToolCallsInMessage(completeMessage, chunk.Delta.ToolCalls)
+		}
+	}
+
+	return completeMessage
+}
+
+// cleanupStreamAccumulator removes the stream accumulator for a request
+func (p *LoggerPlugin) cleanupStreamAccumulator(requestID string) {
+	if accumulator, exists := p.streamAccumulators.Load(requestID); exists {
+		// Return all chunks to the pool before deleting
+		acc := accumulator.(*StreamAccumulator)
+		for _, chunk := range acc.Chunks {
+			p.putStreamChunk(chunk)
+		}
+		p.streamAccumulators.Delete(requestID)
+	}
+}
+
+// cleanupOldStreamAccumulators removes stream accumulators older than 5 minutes
+func (p *LoggerPlugin) cleanupOldStreamAccumulators() {
+	fiveMinutesAgo := time.Now().Add(-5 * time.Minute)
+	cleanedCount := 0
+
+	p.streamAccumulators.Range(func(key, value interface{}) bool {
+		requestID := key.(string)
+		accumulator := value.(*StreamAccumulator)
+		accumulator.mu.Lock()
+		defer accumulator.mu.Unlock()
+
+		// Check if this accumulator is old (no activity for 5 minutes)
+		// Use the timestamp of the first chunk as a reference
+		if len(accumulator.Chunks) > 0 {
+			firstChunkTime := accumulator.Chunks[0].Timestamp
+			if firstChunkTime.Before(fiveMinutesAgo) {
+				// Return all chunks to the pool
+				for _, chunk := range accumulator.Chunks {
+					p.putStreamChunk(chunk)
+				}
+				p.streamAccumulators.Delete(requestID)
+				cleanedCount++
+				p.logger.Debug(fmt.Sprintf("Cleaned up old stream accumulator for request %s", requestID))
+			}
+		}
+		return true
+	})
+
+	if cleanedCount > 0 {
+		p.logger.Debug(fmt.Sprintf("Cleaned up %d old stream accumulators", cleanedCount))
+	}
+}
+
+// handleStreamingResponse handles streaming responses with ordered accumulation
+func (p *LoggerPlugin) handleStreamingResponse(ctx *context.Context, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	requestID, ok := (*ctx).Value(ContextKey("request-id")).(string)
+	if !ok || requestID == "" {
+		p.logger.Error(fmt.Errorf("request-id not found in context or is empty"))
+		return result, err, nil
+	}
+
+	// Create chunk from current response using pool
+	chunk := p.getStreamChunk()
+	chunk.Timestamp = time.Now()
+	chunk.ErrorDetails = err
+
+	if err != nil {
+		// Error case - mark as final chunk
+		chunk.FinishReason = bifrost.Ptr("error")
+	} else if result != nil {
+		// Extract delta and other information
+		if len(result.Choices) > 0 {
+			choice := result.Choices[0]
+			if choice.BifrostStreamResponseChoice != nil {
+				// Create a deep copy of the Delta to avoid pointing to stack memory
+				deltaCopy := choice.BifrostStreamResponseChoice.Delta
+				chunk.Delta = &deltaCopy
+				chunk.FinishReason = choice.FinishReason
+			}
+		}
+
+		// Extract token usage
+		if result.Usage != nil && result.Usage.TotalTokens > 0 {
+			chunk.TokenUsage = result.Usage
+		}
+	}
+
+	// Add chunk to accumulator synchronously to maintain order
+	object := ""
+	if result != nil {
+		object = result.Object
+	}
+	if addErr := p.addStreamChunk(requestID, chunk, object); addErr != nil {
+		p.logger.Error(fmt.Errorf("failed to add stream chunk for request %s: %w", requestID, addErr))
+	}
+
+	// If this is the final chunk, process accumulated chunks asynchronously
+	if chunk.FinishReason != nil || chunk.TokenUsage != nil {
+		go func() {
+			if processErr := p.processAccumulatedChunks(requestID); processErr != nil {
+				p.logger.Error(fmt.Errorf("failed to process accumulated chunks for request %s: %w", requestID, processErr))
+			}
+		}()
+	}
+
+	return result, err, nil
+}
+
+// isStreamingResponse checks if the response is a streaming delta
+func (p *LoggerPlugin) isStreamingResponse(result *schemas.BifrostResponse) bool {
+	if result == nil {
+		return false
+	}
+
+	// Check for streaming choices (text-based streaming)
+	if len(result.Choices) > 0 {
+		for _, choice := range result.Choices {
+			if choice.BifrostStreamResponseChoice != nil {
+				return true
+			}
+		}
+	}
+
+	// Check for streaming speech output
+	if result.Speech != nil && result.Speech.BifrostSpeechStreamResponse != nil {
+		return true
+	}
+
+	// Check for streaming transcription output
+	if result.Transcribe != nil && result.Transcribe.BifrostTranscribeStreamResponse != nil {
+		return true
+	}
+
+	return false
+}
+
+// isTextStreamingResponse checks if the response is a text-based streaming delta
+func (p *LoggerPlugin) isTextStreamingResponse(result *schemas.BifrostResponse) bool {
+	if result == nil {
+		return false
+	}
+
+	// Check for streaming choices (text-based streaming only)
+	if len(result.Choices) > 0 {
+		for _, choice := range result.Choices {
+			if choice.BifrostStreamResponseChoice != nil {
+				return true
+			}
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
### TL;DR

Fix streaming response handling in OpenAI provider and improve logging plugin's stream accumulation.

### What changed?

- Fixed a bug in `handleOpenAIStreaming` by replacing `break` with `continue` to properly handle finish reason chunks
- Enhanced the logging plugin with a new stream accumulation system that:
  - Properly tracks and orders streaming chunks
  - Builds complete messages from accumulated chunks
  - Handles text-based streaming separately from speech/transcription streaming
  - Implements memory pooling for stream chunks to improve performance
  - Adds automatic cleanup of old stream accumulators

### How to test?

1. Test streaming responses with OpenAI models to verify they continue processing after receiving a finish reason
2. Check the logging plugin's handling of streaming responses:
   - Verify complete messages are properly reconstructed from stream chunks
   - Confirm tool calls are correctly accumulated
   - Test that old stream accumulators are cleaned up after 5 minutes of inactivity

### Why make this change?

The OpenAI streaming handler was prematurely terminating on finish reason chunks, which could cause incomplete responses. The logging plugin needed improvements to better handle streaming responses by properly accumulating and ordering chunks, which ensures more accurate logging and better performance through memory pooling.