### PR TITLE
feat: add support for direct API key usage via headers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1462,6 +1462,14 @@ func (bifrost *Bifrost) releaseChannelMessage(msg *ChannelMessage) {
 // selectKeyFromProviderForModel selects an appropriate API key for a given provider and model.
 // It uses weighted random selection if multiple keys are available.
 func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *context.Context, providerKey schemas.ModelProvider, model string) (schemas.Key, error) {
+	// Check if key has been set in the context explicitly
+	if ctx != nil {
+		key, ok := (*ctx).Value(schemas.BifrostContextKey).(schemas.Key)
+		if ok {
+			return key, nil
+		}
+	}
+
 	keys, err := bifrost.account.GetKeysForProvider(ctx, providerKey)
 	if err != nil {
 		return schemas.Key{}, err

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -42,6 +42,12 @@ type BedrockKeyConfig struct {
 	Deployments  map[string]string `json:"deployments,omitempty"`   // Mapping of model identifiers to inference profiles
 }
 
+type BifrostContext string
+
+const (
+	BifrostContextKey BifrostContext = "bifrost-key"
+)
+
 // Account defines the interface for managing provider accounts and their configurations.
 // It provides methods to access provider-specific settings, API keys, and configurations.
 type Account interface {

--- a/docs/usage/http-transport/README.md
+++ b/docs/usage/http-transport/README.md
@@ -156,10 +156,28 @@ Notes:
 ```python
 from openai import OpenAI
 
-# Change base URL to use Bifrost
+# Option 1: Change base URL to use Bifrost with configured keys
 client = OpenAI(
     base_url="http://localhost:8080/openai",  # Point to Bifrost
-    api_key="your-openai-key"
+    api_key="your-openai-key"  # Will be passed in Authorization header
+)
+
+# Option 2: Use Bifrost unified API with header-based keys
+
+> Note: This requires enabling "Allow Direct Keys" in the Bifrost UI (Settings) or setting `allow_direct_keys: true` in client config.
+
+import requests
+
+response = requests.post(
+    "http://localhost:8080/v1/chat/completions",
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": "Bearer sk-your-openai-key"  # Bearer format required
+    },
+    json={
+        "model": "openai/gpt-4o-mini",
+        "messages": [{"role": "user", "content": "Hello!"}]
+    }
 )
 
 # Use normally - Bifrost handles provider routing
@@ -177,14 +195,28 @@ response = client.chat.completions.create(
 ```javascript
 import OpenAI from "openai";
 
+// Option 1: Use OpenAI SDK with Bifrost
 const openai = new OpenAI({
   baseURL: "http://localhost:8080/openai", // Point to Bifrost
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.OPENAI_API_KEY,      // Passed in Authorization header
 });
 
 const response = await openai.chat.completions.create({
   model: "gpt-4o-mini",
   messages: [{ role: "user", content: "Hello!" }],
+});
+
+// Option 2: Use fetch with direct headers
+const response = await fetch("http://localhost:8080/v1/chat/completions", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${process.env.OPENAI_API_KEY}` // Bearer format required
+  },
+  body: JSON.stringify({
+    model: "openai/gpt-4o-mini",
+    messages: [{ role: "user", content: "Hello!" }]
+  })
 });
 ```
 

--- a/docs/usage/http-transport/endpoints.md
+++ b/docs/usage/http-transport/endpoints.md
@@ -82,6 +82,34 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   }'
 ```
 
+**Using API Key Headers:**
+
+> Note: This requires allow_direct_keys to be enabled in the server configuration.
+
+You can provide API keys directly in headers instead of relying on configured keys:
+
+```bash
+# Using Authorization header with Bearer format (OpenAI style)
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-your-openai-key-here" \
+  -d '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+
+# Using x-api-key header (Anthropic style)
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: sk-ant-your-anthropic-key-here" \
+  -d '{
+    "model": "anthropic/claude-3-5-sonnet-20241022",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+> **📖 For more details:** See [Direct API Key Usage](../key-management.md#-direct-api-key-usage) for complete usage patterns and security considerations.
+
 ### **Streaming Responses**
 
 To receive a stream of partial responses, set `"stream": true` in your request. The response will be a `text/event-stream` of Server-Sent Events (SSE).

--- a/transports/bifrost-http/handlers/completions.go
+++ b/transports/bifrost-http/handlers/completions.go
@@ -24,15 +24,17 @@ import (
 
 // CompletionHandler manages HTTP requests for completion operations
 type CompletionHandler struct {
-	client *bifrost.Bifrost
-	logger schemas.Logger
+	client       *bifrost.Bifrost
+	handlerStore lib.HandlerStore
+	logger       schemas.Logger
 }
 
 // NewCompletionHandler creates a new completion handler instance
-func NewCompletionHandler(client *bifrost.Bifrost, logger schemas.Logger) *CompletionHandler {
+func NewCompletionHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *CompletionHandler {
 	return &CompletionHandler{
-		client: client,
-		logger: logger,
+		client:       client,
+		handlerStore: handlerStore,
+		logger:       logger,
 	}
 }
 
@@ -372,7 +374,7 @@ func (h *CompletionHandler) TranscriptionCompletion(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx := lib.ConvertToBifrostContext(ctx)
+	bifrostCtx := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys())
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context", h.logger)
 		return
@@ -491,7 +493,7 @@ func (h *CompletionHandler) handleRequest(ctx *fasthttp.RequestCtx, completionTy
 	}
 
 	// Convert context
-	bifrostCtx := lib.ConvertToBifrostContext(ctx)
+	bifrostCtx := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys())
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context", h.logger)
 		return

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -85,6 +85,7 @@ func (h *ConfigHandler) handleUpdateConfig(ctx *fasthttp.RequestCtx) {
 	updatedConfig.EnableLogging = req.EnableLogging
 	updatedConfig.EnableGovernance = req.EnableGovernance
 	updatedConfig.EnforceGovernanceHeader = req.EnforceGovernanceHeader
+	updatedConfig.AllowDirectKeys = req.AllowDirectKeys
 	updatedConfig.EnableCaching = req.EnableCaching
 
 	// Update the store with the new config

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -10,6 +10,7 @@ import (
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/genai"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/litellm"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/openai"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
 
 // IntegrationHandler manages HTTP requests for AI provider integrations
@@ -18,13 +19,13 @@ type IntegrationHandler struct {
 }
 
 // NewIntegrationHandler creates a new integration handler instance
-func NewIntegrationHandler(client *bifrost.Bifrost) *IntegrationHandler {
+func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *IntegrationHandler {
 	// Initialize all available integration routers
 	extensions := []integrations.ExtensionRouter{
-		genai.NewGenAIRouter(client),
-		openai.NewOpenAIRouter(client),
-		anthropic.NewAnthropicRouter(client),
-		litellm.NewLiteLLMRouter(client),
+		genai.NewGenAIRouter(client, handlerStore),
+		openai.NewOpenAIRouter(client, handlerStore),
+		anthropic.NewAnthropicRouter(client, handlerStore),
+		litellm.NewLiteLLMRouter(client, handlerStore),
 	}
 
 	return &IntegrationHandler{

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -55,7 +55,7 @@ func (h *MCPHandler) ExecuteTool(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx := lib.ConvertToBifrostContext(ctx)
+	bifrostCtx := lib.ConvertToBifrostContext(ctx, false)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context", h.logger)
 		return

--- a/transports/bifrost-http/integrations/anthropic/router.go
+++ b/transports/bifrost-http/integrations/anthropic/router.go
@@ -6,6 +6,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
 
 // AnthropicRouter handles Anthropic-compatible API endpoints
@@ -14,7 +15,7 @@ type AnthropicRouter struct {
 }
 
 // NewAnthropicRouter creates a new AnthropicRouter with the given bifrost client.
-func NewAnthropicRouter(client *bifrost.Bifrost) *AnthropicRouter {
+func NewAnthropicRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *AnthropicRouter {
 	routes := []integrations.RouteConfig{
 		{
 			Path:   "/anthropic/v1/messages",
@@ -46,6 +47,6 @@ func NewAnthropicRouter(client *bifrost.Bifrost) *AnthropicRouter {
 	}
 
 	return &AnthropicRouter{
-		GenericRouter: integrations.NewGenericRouter(client, routes),
+		GenericRouter: integrations.NewGenericRouter(client, handlerStore, routes),
 	}
 }

--- a/transports/bifrost-http/integrations/genai/router.go
+++ b/transports/bifrost-http/integrations/genai/router.go
@@ -8,6 +8,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -17,7 +18,7 @@ type GenAIRouter struct {
 }
 
 // NewGenAIRouter creates a new GenAIRouter with the given bifrost client.
-func NewGenAIRouter(client *bifrost.Bifrost) *GenAIRouter {
+func NewGenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *GenAIRouter {
 	routes := []integrations.RouteConfig{
 		{
 			Path:   "/genai/v1beta/models/{model}",
@@ -50,7 +51,7 @@ func NewGenAIRouter(client *bifrost.Bifrost) *GenAIRouter {
 	}
 
 	return &GenAIRouter{
-		GenericRouter: integrations.NewGenericRouter(client, routes),
+		GenericRouter: integrations.NewGenericRouter(client, handlerStore, routes),
 	}
 }
 

--- a/transports/bifrost-http/integrations/litellm/router.go
+++ b/transports/bifrost-http/integrations/litellm/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/anthropic"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/genai"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations/openai"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -45,7 +46,7 @@ type LiteLLMRouter struct {
 }
 
 // NewLiteLLMRouter creates a new LiteLLMRouter with the given bifrost client.
-func NewLiteLLMRouter(client *bifrost.Bifrost) *LiteLLMRouter {
+func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *LiteLLMRouter {
 	paths := []string{
 		"/chat/completions",
 		"/v1/messages",
@@ -222,6 +223,6 @@ func NewLiteLLMRouter(client *bifrost.Bifrost) *LiteLLMRouter {
 	}
 
 	return &LiteLLMRouter{
-		GenericRouter: integrations.NewGenericRouter(client, routes),
+		GenericRouter: integrations.NewGenericRouter(client, handlerStore, routes),
 	}
 }

--- a/transports/bifrost-http/integrations/openai/router.go
+++ b/transports/bifrost-http/integrations/openai/router.go
@@ -8,6 +8,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -18,7 +19,7 @@ type OpenAIRouter struct {
 }
 
 // NewOpenAIRouter creates a new OpenAIRouter with the given bifrost client.
-func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
+func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *OpenAIRouter {
 	var routes []integrations.RouteConfig
 
 	// Chat completions endpoint
@@ -156,7 +157,7 @@ func NewOpenAIRouter(client *bifrost.Bifrost) *OpenAIRouter {
 	}
 
 	return &OpenAIRouter{
-		GenericRouter: integrations.NewGenericRouter(client, routes),
+		GenericRouter: integrations.NewGenericRouter(client, handlerStore, routes),
 	}
 }
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -6,6 +6,14 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+// HandlerStore provides access to runtime configuration values for handlers.
+// This interface allows handlers to access only the configuration they need
+// without depending on the entire ConfigStore, improving testability and decoupling.
+type HandlerStore interface {
+	// ShouldAllowDirectKeys returns whether direct API keys in headers are allowed
+	ShouldAllowDirectKeys() bool
+}
+
 // ClientConfig represents the core configuration for Bifrost HTTP transport and the Bifrost Client.
 // It includes settings for excess request handling, Prometheus metrics, and initial pool size.
 type ClientConfig struct {
@@ -15,6 +23,7 @@ type ClientConfig struct {
 	EnableLogging           bool     `json:"enable_logging"`            // Enable logging of requests and responses
 	EnableGovernance        bool     `json:"enable_governance"`         // Enable governance on all requests
 	EnforceGovernanceHeader bool     `json:"enforce_governance_header"` // Enforce governance on all requests
+	AllowDirectKeys         bool     `json:"allow_direct_keys"`         // Allow direct keys to be used for requests
 	EnableCaching           bool     `json:"enable_caching"`            // Enable Redis caching plugin
 	AllowedOrigins          []string `json:"allowed_origins,omitempty"` // Additional allowed origins for CORS and WebSocket (localhost is always allowed)
 }

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/plugins/maxim"
 	"github.com/maximhq/bifrost/plugins/redis"
 	"github.com/maximhq/bifrost/transports/bifrost-http/plugins/logging"
@@ -23,7 +24,7 @@ import (
 // ConvertToBifrostContext converts a FastHTTP RequestCtx to a Bifrost context,
 // preserving important header values for monitoring and tracing purposes.
 //
-// The function processes two types of special headers:
+// The function processes several types of special headers:
 // 1. Prometheus Headers (x-bf-prom-*):
 //   - All headers prefixed with 'x-bf-prom-' are copied to the context
 //   - The prefix is stripped and the remainder becomes the context key
@@ -45,6 +46,12 @@ import (
 //   - x-bf-user: User identifier for user-based governance rules
 //   - x-bf-customer: Customer identifier for customer-based governance rules
 //
+// 5. API Key Headers:
+//   - Authorization: Bearer token format only (e.g., "Bearer sk-...") - OpenAI style
+//   - x-api-key: Direct API key value - Anthropic style
+//   - Keys are extracted and stored in the context using schemas.BifrostContextKey
+//   - This enables explicit key usage for requests via headers
+//
 
 // Parameters:
 //   - ctx: The FastHTTP request context containing the original headers
@@ -60,7 +67,7 @@ import (
 
 type ContextKey string
 
-func ConvertToBifrostContext(ctx *fasthttp.RequestCtx) *context.Context {
+func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool) *context.Context {
 	bifrostCtx := context.Background()
 
 	// First, check if x-request-id header exists
@@ -140,6 +147,45 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx) *context.Context {
 			// If both parsing attempts fail, we silently ignore the header and use default TTL
 		}
 	})
+
+	if allowDirectKeys {
+		// Extract API key from Authorization header (Bearer format) or x-api-key header
+		var apiKey string
+
+		// TODO: fix plugin data leak
+		// Check Authorization header (Bearer format only - OpenAI style)
+		authHeader := string(ctx.Request.Header.Peek("Authorization"))
+		if authHeader != "" {
+			// Only accept Bearer token format: "Bearer ..."
+			if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+				authHeaderValue := strings.TrimSpace(authHeader[7:]) // Remove "Bearer " prefix
+				if authHeaderValue != "" {
+					apiKey = authHeaderValue
+				}
+			} else {
+				apiKey = authHeader
+			}
+		}
+
+		// Check x-api-key header if no valid Authorization header found (Anthropic style)
+		if apiKey == "" {
+			xApiKey := string(ctx.Request.Header.Peek("x-api-key"))
+			if xApiKey != "" {
+				apiKey = strings.TrimSpace(xApiKey)
+			}
+		}
+
+		// If we found an API key, create a Key object and store it in context
+		if apiKey != "" {
+			key := schemas.Key{
+				ID:     "header-provided", // Identifier for header-provided keys
+				Value:  apiKey,
+				Models: []string{}, // Empty models list - will be validated by provider
+				Weight: 1.0,        // Default weight
+			}
+			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey, key)
+		}
+	}
 
 	return &bifrostCtx
 }

--- a/transports/bifrost-http/lib/models.go
+++ b/transports/bifrost-http/lib/models.go
@@ -110,6 +110,7 @@ type DBClientConfig struct {
 	EnableLogging           bool      `gorm:"" json:"enable_logging"`
 	EnableGovernance        bool      `gorm:"" json:"enable_governance"`
 	EnforceGovernanceHeader bool      `gorm:"" json:"enforce_governance_header"`
+	AllowDirectKeys         bool      `gorm:"" json:"allow_direct_keys"`
 	EnableCaching           bool      `gorm:"" json:"enable_caching"`
 	CreatedAt               time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt               time.Time `gorm:"index;not null" json:"updated_at"`

--- a/transports/bifrost-http/lib/store.go
+++ b/transports/bifrost-http/lib/store.go
@@ -62,6 +62,8 @@ var DefaultClientConfig = ClientConfig{
 	EnableLogging:           true,
 	EnableGovernance:        true,
 	EnforceGovernanceHeader: false,
+	AllowDirectKeys:         false,
+	AllowedOrigins:          []string{},
 	EnableCaching:           false,
 }
 
@@ -315,6 +317,7 @@ func (s *ConfigStore) loadClientConfigFromDB() error {
 		EnableLogging:           dbConfig.EnableLogging,
 		EnableGovernance:        dbConfig.EnableGovernance,
 		EnforceGovernanceHeader: dbConfig.EnforceGovernanceHeader,
+		AllowDirectKeys:         dbConfig.AllowDirectKeys,
 		EnableCaching:           dbConfig.EnableCaching,
 		AllowedOrigins:          dbConfig.AllowedOrigins,
 	}
@@ -696,6 +699,7 @@ func (s *ConfigStore) saveClientConfigToDB() error {
 		EnableLogging:           s.ClientConfig.EnableLogging,
 		EnableGovernance:        s.ClientConfig.EnableGovernance,
 		EnforceGovernanceHeader: s.ClientConfig.EnforceGovernanceHeader,
+		AllowDirectKeys:         s.ClientConfig.AllowDirectKeys,
 		EnableCaching:           s.ClientConfig.EnableCaching,
 		PrometheusLabels:        s.ClientConfig.PrometheusLabels,
 		AllowedOrigins:          s.ClientConfig.AllowedOrigins,
@@ -868,6 +872,15 @@ func (s *ConfigStore) GetProviderConfigRaw(provider schemas.ModelProvider) (*Pro
 	return &config, nil
 }
 
+// HandlerStore interface implementation
+// ShouldAllowDirectKeys returns whether direct API keys in headers are allowed
+// Note: This method doesn't use locking for performance. In rare cases during
+// config updates, it may return stale data, but this is acceptable since bool
+// reads are atomic and won't cause panics.
+func (s *ConfigStore) ShouldAllowDirectKeys() bool {
+	return s.ClientConfig.AllowDirectKeys
+}
+
 func (s *ConfigStore) GetClientConfigFromDB() (*DBClientConfig, error) {
 	var dbConfig DBClientConfig
 	if err := s.db.First(&dbConfig).Error; err != nil {
@@ -879,6 +892,8 @@ func (s *ConfigStore) GetClientConfigFromDB() (*DBClientConfig, error) {
 				EnableLogging:           s.ClientConfig.EnableLogging,
 				EnableGovernance:        s.ClientConfig.EnableGovernance,
 				EnforceGovernanceHeader: s.ClientConfig.EnforceGovernanceHeader,
+				AllowDirectKeys:         s.ClientConfig.AllowDirectKeys,
+				AllowedOrigins:          s.ClientConfig.AllowedOrigins,
 				EnableCaching:           s.ClientConfig.EnableCaching,
 			}, nil
 		}

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -477,9 +477,9 @@ func main() {
 
 	// Initialize handlers
 	providerHandler := handlers.NewProviderHandler(store, client, logger)
-	completionHandler := handlers.NewCompletionHandler(client, logger)
+	completionHandler := handlers.NewCompletionHandler(client, store, logger)
 	mcpHandler := handlers.NewMCPHandler(client, logger, store)
-	integrationHandler := handlers.NewIntegrationHandler(client)
+	integrationHandler := handlers.NewIntegrationHandler(client, store)
 	configHandler := handlers.NewConfigHandler(client, logger, store)
 
 	// Set up WebSocket callback for real-time log updates

--- a/ui/app/config/page.tsx
+++ b/ui/app/config/page.tsx
@@ -23,6 +23,7 @@ const defaultConfig = {
   enable_logging: true,
   enable_governance: true,
   enforce_governance_header: false,
+  allow_direct_keys: false,
   enable_caching: false,
   allowed_origins: [],
 }
@@ -246,6 +247,24 @@ export default function ConfigPage() {
               />
             </div>
           )}
+
+          <div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+            <div className="space-y-0.5">
+              <label htmlFor="allow-direct-keys" className="text-sm font-medium">
+                Allow Direct API Keys
+              </label>
+              <p className="text-muted-foreground text-sm">
+                Allow API keys to be passed directly in request headers (<b>Authorization</b> or <b>x-api-key</b>). Bifrost will directly
+                use the key.
+              </p>
+            </div>
+            <Switch
+              id="allow-direct-keys"
+              size="md"
+              checked={config.allow_direct_keys}
+              onCheckedChange={(checked) => handleConfigChange('allow_direct_keys', checked)}
+            />
+          </div>
 
           <Alert variant="destructive">
             <AlertTriangle className="h-4 w-4" />

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -126,6 +126,7 @@ export interface CoreConfig {
   enable_logging: boolean
   enable_governance: boolean
   enforce_governance_header: boolean
+  allow_direct_keys: boolean
   enable_caching: boolean
   allowed_origins: string[]
 }


### PR DESCRIPTION
## Summary

Add support for direct API key usage via HTTP headers, allowing clients to provide API keys on a per-request basis without requiring pre-configuration in Bifrost.

## Changes

- Added ability to extract API keys from `Authorization` (Bearer format) and `x-api-key` headers
- Implemented context-based key injection using `schemas.BifrostContextKey`
- Added configuration toggle `allow_direct_keys` to enable/disable this feature
- Updated documentation with examples for direct key usage patterns
- Extended UI settings to control this feature

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] UI (Next.js)
- [x] Docs

## How to test

Test direct API key usage with the HTTP transport:

```sh
# Start Bifrost with direct keys enabled
# Enable via UI or set allow_direct_keys: true in config

# Test with OpenAI-style Bearer token
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-your-openai-key-here" \
  -d '{
    "model": "openai/gpt-4o-mini",
    "messages": [{"role": "user", "content": "Hello!"}]
  }'

# Test with Anthropic-style x-api-key header
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-api-key: sk-ant-your-anthropic-key-here" \
  -d '{
    "model": "anthropic/claude-3-5-sonnet-20241022",
    "messages": [{"role": "user", "content": "Hello!"}]
  }'
```

Test with Go package:

```go
// Create context with API key
ctx := context.Background()
key := schemas.Key{
    ID:     "direct-provided",
    Value:  "sk-your-openai-key-here",
    Models: []string{},
    Weight: 1.0,
}
ctx = context.WithValue(ctx, schemas.BifrostContextKey, key)

// Make request with explicit key
response, err := client.ChatCompletionRequest(ctx, request)
```

## Breaking changes

- [x] No

## Related issues

Implements feature request for direct API key usage without configuration

## Security considerations

- Direct key usage is disabled by default and must be explicitly enabled
- Keys provided in headers are not stored in Bifrost's configuration or database
- Applications should implement proper authentication and authorization when using this feature
- Headers are processed only when the feature is enabled via configuration

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)