### PR TITLE
chore: update bifrost/core to v1.1.17 and remove local replacements

### DIFF
--- a/plugins/redis/go.mod
+++ b/plugins/redis/go.mod
@@ -4,11 +4,9 @@ go 1.24.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/maximhq/bifrost/core v1.1.16
+	github.com/maximhq/bifrost/core v1.1.17
 	github.com/redis/go-redis/v9 v9.10.0
 )
-
-replace github.com/maximhq/bifrost/core => ../../core
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0 // indirect

--- a/plugins/redis/go.sum
+++ b/plugins/redis/go.sum
@@ -71,6 +71,8 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/maximhq/bifrost/core v1.1.17 h1:IeuadTlgTfHGh9P85+L1Fh37BGZAU3VP2p/nMGtnCdY=
+github.com/maximhq/bifrost/core v1.1.17/go.mod h1:ntn4qNg3wHd7U/mFvRpRv+dAuigsRdup8O4no0JepWY=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -7,19 +7,15 @@ require (
 	github.com/fasthttp/router v1.5.4
 	github.com/fasthttp/websocket v1.5.12
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.1.16
+	github.com/maximhq/bifrost/core v1.1.17
 	github.com/maximhq/bifrost/plugins/maxim v1.0.6
-	github.com/maximhq/bifrost/plugins/redis v0.0.0-00010101000000-000000000000
+	github.com/maximhq/bifrost/plugins/redis v1.0.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/valyala/fasthttp v1.62.0
 	google.golang.org/genai v1.4.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.30.0
 )
-
-replace github.com/maximhq/bifrost/plugins/redis => ../plugins/redis
-
-replace github.com/maximhq/bifrost/core => ../core
 
 require (
 	cloud.google.com/go v0.121.0 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -106,10 +106,12 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/maximhq/bifrost/core v1.1.16 h1:3lZfH7gzF/mXNjd5TCRlIjuMNHzZ/zRRWF/dqPJ+0+M=
-github.com/maximhq/bifrost/core v1.1.16/go.mod h1:ntn4qNg3wHd7U/mFvRpRv+dAuigsRdup8O4no0JepWY=
+github.com/maximhq/bifrost/core v1.1.17 h1:IeuadTlgTfHGh9P85+L1Fh37BGZAU3VP2p/nMGtnCdY=
+github.com/maximhq/bifrost/core v1.1.17/go.mod h1:ntn4qNg3wHd7U/mFvRpRv+dAuigsRdup8O4no0JepWY=
 github.com/maximhq/bifrost/plugins/maxim v1.0.6 h1:m1tWjbmxW9Lz4mDhXclQhZdFt/TrRPbZwFcoWY9ZAEk=
 github.com/maximhq/bifrost/plugins/maxim v1.0.6/go.mod h1:+D/E498VB4JNTEzG4fYyFJf9WQaq/9FgYrmzl49mLNc=
+github.com/maximhq/bifrost/plugins/redis v1.0.0 h1:/teFFjXo0u5lID7UwpMcyFUILRXBFduDXdZpa8hdU/8=
+github.com/maximhq/bifrost/plugins/redis v1.0.0/go.mod h1:nmHgyMpgPqGu45cve0HBXqOQP1L5SUTAhU3WnptD+1M=
 github.com/maximhq/maxim-go v0.1.3 h1:nVzdz3hEjZVxmWHARWIM+Yrn1Jp50qrsK4BA/sz2jj8=
 github.com/maximhq/maxim-go v0.1.3/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=


### PR DESCRIPTION
## Summary

Update Redis plugin to use the latest core version (v1.1.17) and publish it as v1.0.0, removing local development replace directives.

## Changes

- Updated `github.com/maximhq/bifrost/core` dependency from v1.1.16 to v1.1.17 in both Redis plugin and transports
- Removed replace directives that were pointing to local development paths
- Published Redis plugin as v1.0.0 and updated the reference in transports

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is a dependency version update.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable