### PR TITLE
fix: change Redis plugin initialization failure from fatal to warning

### DIFF
--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -451,7 +451,7 @@ func main() {
 
 		redisPlugin, err := redis.NewRedisPlugin(pluginConfig, logger)
 		if err != nil {
-			logger.Fatal("failed to initialize Redis plugin", err)
+			logger.Warn(fmt.Sprintf("failed to initialize Redis plugin: %v", err))
 		}
 
 		loadedPlugins = append(loadedPlugins, redisPlugin)


### PR DESCRIPTION
## Summary

Change Redis plugin initialization failure from fatal error to warning, allowing the application to continue running even when Redis connection fails.

## Changes

- Modified error handling in the Redis plugin initialization to log a warning instead of terminating the application
- This allows the application to continue running with other plugins even when Redis is unavailable
- The Redis plugin will still be added to the loaded plugins list, but operations requiring Redis will fail gracefully

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Start the application with incorrect Redis configuration
2. Verify the application logs a warning but continues to run
3. Verify other functionality works correctly

```sh
# Run with invalid Redis configuration
REDIS_HOST=nonexistent-host go run transports/bifrost-http/main.go

# Verify application continues to run and logs warning
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves application resilience when Redis is temporarily unavailable.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable