### PR TITLE
fix: only use Redis plugin when initialization succeeds

### DIFF
--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -452,11 +452,11 @@ func main() {
 		redisPlugin, err := redis.NewRedisPlugin(pluginConfig, logger)
 		if err != nil {
 			logger.Warn(fmt.Sprintf("failed to initialize Redis plugin: %v", err))
+		} else {
+			loadedPlugins = append(loadedPlugins, redisPlugin)
+
+			cacheHandler = handlers.NewCacheHandler(store, redisPlugin.(*redis.Plugin), logger)
 		}
-
-		loadedPlugins = append(loadedPlugins, redisPlugin)
-
-		cacheHandler = handlers.NewCacheHandler(store, redisPlugin.(*redis.Plugin), logger)
 	}
 
 	loadedPlugins = append(loadedPlugins, promPlugin)


### PR DESCRIPTION
## Summary

Fix Redis plugin initialization to only use the Redis plugin for cache handling when it's successfully initialized.

## Changes

- Modified the Redis plugin initialization logic to only append the plugin to `loadedPlugins` and set up the cache handler when the plugin is successfully initialized
- Added an `else` block to ensure the cache handler is only created when the Redis plugin is available
- Prevents potential nil pointer dereference if the Redis plugin fails to initialize

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Start the service with Redis configuration
# Verify that the service starts correctly when Redis is available
go run transports/bifrost-http/main.go

# Test with Redis unavailable
# Verify that the service starts without errors even when Redis is unavailable
go run transports/bifrost-http/main.go
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable