### PR TITLE
feat: add IAM role authentication for AWS Bedrock

### DIFF
--- a/docs/usage/go-package/account.md
+++ b/docs/usage/go-package/account.md
@@ -97,7 +97,7 @@ func (a *MultiProviderAccount) GetConfiguredProviders() ([]schemas.ModelProvider
     if os.Getenv("AZURE_API_KEY") != "" {
         providers = append(providers, schemas.Azure)
     }
-    if os.Getenv("AWS_ACCESS_KEY_ID") != "" {
+    if os.Getenv("AWS_ACCESS_KEY_ID_ID") != "" {
         providers = append(providers, schemas.Bedrock)
     }
     if os.Getenv("VERTEX_PROJECT_ID") != "" {
@@ -146,8 +146,8 @@ func (a *MultiProviderAccount) GetKeysForProvider(ctx *context.Context, provider
             Models: []string{"anthropic.claude-3-sonnet-20240229-v1:0"},
             Weight: 1.0,
             BedrockKeyConfig: &schemas.BedrockKeyConfig{
-                AccessKey:    os.Getenv("AWS_ACCESS_KEY"),
-                SecretKey:    os.Getenv("AWS_SECRET_KEY"),
+                AccessKey:    os.Getenv("AWS_ACCESS_KEY_ID"),
+                SecretKey:    os.Getenv("AWS_SECRET_ACCESS_KEY"),
                 SessionToken: bifrost.Ptr(os.Getenv("AWS_SESSION_TOKEN")),
                 Region:       bifrost.Ptr("us-east-1"),
             },

--- a/docs/usage/http-transport/openapi.json
+++ b/docs/usage/http-transport/openapi.json
@@ -2780,12 +2780,12 @@
               "access_key": {
                 "type": "string",
                 "description": "Bedrock access key",
-                "example": "env.AWS_ACCESS_KEY"
+                "example": "env.AWS_ACCESS_KEY_ID"
               },
               "secret_key": {
                 "type": "string",
                 "description": "Bedrock secret key",
-                "example": "env.AWS_SECRET_KEY"
+                "example": "env.AWS_SECRET_ACCESS_KEY"
               },
               "session_token": {
                 "type": "string",

--- a/docs/usage/key-management.md
+++ b/docs/usage/key-management.md
@@ -645,13 +645,33 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
             },
         }, nil
     case schemas.Bedrock:
+        // Option 1: IAM Role Authentication (Recommended for Production)
         return []schemas.Key{
             {
-                Value:  os.Getenv("AWS_ACCESS_KEY_ID"),
                 Models: []string{"anthropic.claude-3-5-sonnet-20241022-v2:0"},
                 Weight: 1.0,
+                BedrockKeyConfig: &schemas.BedrockKeyConfig{
+                    AccessKey: "", // Empty for IAM role authentication
+                    SecretKey: "", // Empty for IAM role authentication  
+                    Region:    "us-east-1",
+                },
             },
         }, nil
+        
+        // Option 2: Explicit Credentials (Development/Testing)
+        /*
+        return []schemas.Key{
+            {
+                Models: []string{"anthropic.claude-3-5-sonnet-20241022-v2:0"},
+                Weight: 1.0,
+                BedrockKeyConfig: &schemas.BedrockKeyConfig{
+                    AccessKey: os.Getenv("AWS_ACCESS_KEY_ID_ID"),
+                    SecretKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+                    Region:    "us-east-1",
+                },
+            },
+        }, nil
+        */
     }
     return nil, fmt.Errorf("provider %s not configured", provider)
 }
@@ -699,15 +719,27 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
           "models": ["anthropic.claude-3-5-sonnet-20241022-v2:0"],
           "weight": 1.0,
           "bedrock_key_config": {
-            "access_key": "env.AWS_ACCESS_KEY_ID",
-            "secret_key": "env.AWS_SECRET_ACCESS_KEY",
-            "session_token": "env.AWS_SESSION_TOKEN",
-            "region": "us-east-1",
-            "arn": "arn:aws:iam::123456789012:role/BedrockRole"
+            "region": "us-east-1"
+            // IAM Role Authentication - no access_key or secret_key needed
           }
         }
-      ],
-    }
+      ]
+    },
+    // "bedrock_explicit_credentials": {
+    //   "keys": [
+    //     {
+    //       "models": ["anthropic.claude-3-5-sonnet-20241022-v2:0"],
+    //       "weight": 1.0,
+    //       "bedrock_key_config": {
+    //         "access_key": "env.AWS_ACCESS_KEY_ID_ID",
+    //         "secret_key": "env.AWS_SECRET_ACCESS_KEY",
+    //         "session_token": "env.AWS_SESSION_TOKEN",
+    //         "region": "us-east-1",
+    //         "arn": "your-arn"
+    //       }
+    //     }
+    //   ]
+    // }
   }
 }
 ```

--- a/docs/usage/providers.md
+++ b/docs/usage/providers.md
@@ -176,7 +176,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
     case schemas.Bedrock:
         return []schemas.Key{
             {
-                Value:  os.Getenv("AWS_ACCESS_KEY_ID"),
+                Value:  os.Getenv("AWS_ACCESS_KEY_ID_ID"),
                 Models: []string{"anthropic.claude-3-5-sonnet-20241022-v2:0"},
                 Weight: 1.0,
             },
@@ -263,7 +263,7 @@ func useWithFallback(bf *bifrost.Bifrost) {
           "models": ["anthropic.claude-3-5-sonnet-20241022-v2:0"],
           "weight": 1.0,
           "bedrock_key_config": {
-            "access_key": "env.AWS_ACCESS_KEY_ID",
+            "access_key": "env.AWS_ACCESS_KEY_ID_ID",
             "secret_key": "env.AWS_SECRET_ACCESS_KEY",
             "session_token": "env.AWS_SESSION_TOKEN",
             "region": "us-east-1",
@@ -311,6 +311,165 @@ echo "$response"
 ## 🔧 Provider-Specific Configuration
 
 ### Enterprise Providers
+
+<details>
+<summary><strong>AWS Bedrock Configuration</strong></summary>
+
+AWS Bedrock supports both explicit credential configuration and IAM role-based authentication for enhanced security.
+
+#### **Explicit Credentials (Traditional Method)**
+
+**Go Package:**
+
+```go
+func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.ModelProvider) ([]schemas.Key, error) {
+    if provider == schemas.Bedrock {
+        return []schemas.Key{
+            {
+                Models: []string{"anthropic.claude-3-5-sonnet-20241022-v2:0"},
+                Weight: 1.0,
+                BedrockKeyConfig: &schemas.BedrockKeyConfig{
+                    AccessKey:    os.Getenv("AWS_ACCESS_KEY_ID_ID"),
+                    SecretKey:    os.Getenv("AWS_SECRET_ACCESS_KEY"),
+                    SessionToken: os.Getenv("AWS_SESSION_TOKEN"), // Optional
+                    Region:       "us-east-1",
+                },
+            },
+        }, nil
+    }
+    return nil, fmt.Errorf("provider not configured")
+}
+```
+
+**HTTP Transport:**
+
+```json
+{
+  "providers": {
+    "bedrock": {
+      "keys": [
+        {
+          "models": ["anthropic.claude-3-5-sonnet-20241022-v2:0"],
+          "weight": 1.0,
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID_ID",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY",
+            "session_token": "env.AWS_SESSION_TOKEN",
+            "region": "us-east-1"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+#### **IAM Role Authentication (Recommended for Production)**
+
+For enhanced security, Bifrost supports IAM role-based authentication when running in AWS environments.
+
+**Go Package:**
+
+```go
+func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.ModelProvider) ([]schemas.Key, error) {
+    if provider == schemas.Bedrock {
+        return []schemas.Key{
+            {
+                Models: []string{"anthropic.claude-3-5-sonnet-20241022-v2:0"},
+                Weight: 1.0,
+                BedrockKeyConfig: &schemas.BedrockKeyConfig{
+                    // Leave AccessKey and SecretKey empty for IAM role authentication
+                    AccessKey: "",
+                    SecretKey: "",
+                    Region:    "us-east-1",
+                },
+            },
+        }, nil
+    }
+    return nil, fmt.Errorf("provider not configured")
+}
+```
+
+**HTTP Transport:**
+
+```json
+{
+  "providers": {
+    "bedrock": {
+      "keys": [
+        {
+          "models": ["anthropic.claude-3-5-sonnet-20241022-v2:0"],
+          "weight": 1.0,
+          "bedrock_key_config": {
+            "region": "us-east-1"
+            // No access_key or secret_key - uses IAM role
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+#### **IAM Role Authentication Environments**
+
+IAM role authentication automatically works in these AWS environments:
+
+- **🟢 EC2 Instances** - Instance profiles with attached IAM roles
+- **🟢 Lambda Functions** - Execution role credentials
+- **🟢 ECS Tasks** - Task role credentials
+- **🟢 EKS Pods** - IAM roles for service accounts (IRSA)
+- **🟢 AWS CodeBuild** - Service role credentials
+- **🟢 On-Premises** - IAM Roles Anywhere for hybrid environments
+
+#### **Required IAM Permissions**
+
+Your IAM role must have the following permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/*"
+      ]
+    }
+  ]
+}
+```
+
+#### **Setup Examples**
+
+**EC2 Instance Setup:**
+```bash
+# 1. Create IAM role with Bedrock permissions
+# 2. Attach role to EC2 instance
+# 3. Configure Bifrost with empty credentials
+export AWS_REGION=us-east-1
+# No need to set AWS_ACCESS_KEY_ID_ID or AWS_SECRET_ACCESS_KEY
+```
+
+**Docker on EC2:**
+```bash
+docker run -p 8080:8080 \
+  -e AWS_REGION=us-east-1 \
+  -v $(pwd)/config.json:/app/config/config.json \
+  maximhq/bifrost
+```
+
+**Lambda Function:**
+```javascript
+// Lambda execution role automatically provides credentials
+// No additional configuration needed
+```
+
+</details>
 
 <details>
 <summary><strong>Azure OpenAI Configuration</strong></summary>

--- a/tests/core-providers/README.md
+++ b/tests/core-providers/README.md
@@ -61,7 +61,7 @@ export AZURE_API_KEY="your-azure-key"
 export AZURE_ENDPOINT="your-azure-endpoint"
 
 # AWS Bedrock
-export AWS_ACCESS_KEY_ID="your-aws-access-key"
+export AWS_ACCESS_KEY_ID_ID="your-aws-access-key"
 export AWS_SECRET_ACCESS_KEY="your-aws-secret-key"
 export AWS_REGION="us-east-1"
 

--- a/transports/config.example.json
+++ b/transports/config.example.json
@@ -74,17 +74,17 @@
     "bedrock": {
       "keys": [
         {
-          "value": "env.BEDROCK_API_KEY",
-          "models": [
-            "anthropic.claude-v2:1",
-            "mistral.mixtral-8x7b-instruct-v0:1",
-            "mistral.mistral-large-2402-v1:0",
-            "anthropic.claude-3-sonnet-20240229-v1:0"
-          ],
+          "value": "",
+          "models": [],
           "weight": 1.0,
           "bedrock_key_config": {
-            "access_key": "env.AWS_ACCESS_KEY_ID",
+            "access_key": "env.AWS_ACCESS_KEY_ID_ID",
             "secret_key": "env.AWS_SECRET_ACCESS_KEY",
+            "session_token": "env.AWS_SESSION_TOKEN",
+            "deployments": {
+              "gpt-4o": "gpt-4o-deployment-id"
+            },
+            "arn": "your-arn",
             "region": "us-east-1"
           }
         }


### PR DESCRIPTION
## Add IAM role authentication support for AWS Bedrock

This PR enhances AWS Bedrock integration by adding support for IAM role-based authentication, allowing Bifrost to use the AWS credentials chain when running in AWS environments (EC2, Lambda, ECS, EKS) without requiring explicit access keys.

## Changes

- Modified `signAWSRequest` to support IAM role authentication when access keys are not provided
- Updated error handling in Bedrock provider to use IAM roles when explicit credentials are missing
- Added context propagation to AWS credential retrieval functions
- Enhanced documentation with IAM role setup instructions and examples
- Added UI support for IAM role configuration with helpful guidance

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (Next.js)
- [x] Docs

## How to test

Test with IAM role authentication:
```sh
# When running on EC2/ECS/Lambda with IAM role
export AWS_REGION=us-east-1
# No need to set AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY

# Run Bifrost
go run main.go
```

Test with explicit credentials:
```sh
# Set credentials explicitly
export AWS_ACCESS_KEY_ID=your-access-key
export AWS_SECRET_ACCESS_KEY=your-secret-key
export AWS_REGION=us-east-1

# Run Bifrost
go run main.go
```

## Security considerations

This PR improves security by:
- Supporting IAM role-based authentication (recommended AWS best practice)
- Eliminating the need to store AWS credentials in environment variables or config files
- Allowing for fine-grained IAM policies to control Bedrock access

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)