### PR TITLE
fix: update OpenAI streaming handler to check BifrostStreamResponseChoice

### DIFF
--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -486,7 +486,7 @@ func handleOpenAIStreaming(
 			}
 
 			// Handle regular content chunks
-			if choice.Delta.Content != nil || len(choice.Delta.ToolCalls) > 0 {
+			if choice.BifrostStreamResponseChoice != nil && (choice.BifrostStreamResponseChoice.Delta.Content != nil || len(choice.BifrostStreamResponseChoice.Delta.ToolCalls) > 0) {
 				if params != nil {
 					response.ExtraFields.Params = *params
 				}


### PR DESCRIPTION
## Summary

Fix conditional check in OpenAI streaming handler to properly access nested fields in the response structure.

## Changes

- Updated the conditional check in `handleOpenAIStreaming` function to correctly access content and tool calls through the `BifrostStreamResponseChoice` field
- The previous implementation was attempting to access fields directly on `choice.Delta` instead of through the proper nested structure

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that OpenAI streaming responses are properly handled:

```sh
# Core/Transports
go version
go test ./core/providers/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue with OpenAI streaming response handling where content and tool calls weren't being properly accessed.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable