### PR TITLE
fix: improve Azure deployment handling and prevent UI event propagation

### DIFF
--- a/transports/bifrost-http/integrations/langchain/router.go
+++ b/transports/bifrost-http/integrations/langchain/router.go
@@ -22,7 +22,7 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore) 
 	routes := []integrations.RouteConfig{}
 
 	// Add OpenAI routes to LangChain for OpenAI API compatibility
-	routes = append(routes, openai.CreateOpenAIRouteConfigs("/langchain")...)
+	routes = append(routes, openai.CreateOpenAIRouteConfigs("/langchain", handlerStore)...)
 
 	// Add Anthropic routes to LangChain for Anthropic API compatibility
 	routes = append(routes, anthropic.CreateAnthropicRouteConfigs("/langchain")...)

--- a/transports/bifrost-http/integrations/litellm/router.go
+++ b/transports/bifrost-http/integrations/litellm/router.go
@@ -22,7 +22,7 @@ func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *L
 	routes := []integrations.RouteConfig{}
 
 	// Add OpenAI routes to LiteLLM for OpenAI API compatibility
-	routes = append(routes, openai.CreateOpenAIRouteConfigs("/litellm")...)
+	routes = append(routes, openai.CreateOpenAIRouteConfigs("/litellm", handlerStore)...)
 
 	// Add Anthropic routes to LiteLLM for Anthropic API compatibility
 	routes = append(routes, anthropic.CreateAnthropicRouteConfigs("/litellm")...)

--- a/ui/components/config/providers-list.tsx
+++ b/ui/components/config/providers-list.tsx
@@ -49,7 +49,7 @@ export default function ProvidersList({ providers, onRefresh }: ProvidersListPro
 
   const handleAddProvider = () => {
     // Open with first existing provider if any exist, otherwise null (which will default to first available)
-    const firstExistingProvider = providers.find(p => p.name === 'openai') || null
+    const firstExistingProvider = providers.find((p) => p.name === 'openai') || null
     setSelectedProvider(firstExistingProvider)
     setShowProviderForm(true)
   }
@@ -112,9 +112,9 @@ export default function ProvidersList({ providers, onRefresh }: ProvidersListPro
               </TableRow>
             )}
             {providers.map((provider) => (
-              <TableRow 
+              <TableRow
                 key={provider.name}
-                className="cursor-pointer hover:bg-muted/50 transition-colors"
+                className="hover:bg-muted/50 cursor-pointer transition-colors"
                 onClick={() => handleEditProvider(provider)}
               >
                 <TableCell>
@@ -154,7 +154,12 @@ export default function ProvidersList({ providers, onRefresh }: ProvidersListPro
                   <div className="flex items-center justify-end space-x-2">
                     <AlertDialog>
                       <AlertDialogTrigger asChild>
-                        <Button variant="outline" size="sm" disabled={deletingProvider === provider.name}>
+                        <Button
+                          onClick={(e) => e.stopPropagation()}
+                          variant="outline"
+                          size="sm"
+                          disabled={deletingProvider === provider.name}
+                        >
                           {deletingProvider === provider.name ? (
                             <Loader2 className="h-4 w-4 animate-spin" />
                           ) : (
@@ -162,7 +167,7 @@ export default function ProvidersList({ providers, onRefresh }: ProvidersListPro
                           )}
                         </Button>
                       </AlertDialogTrigger>
-                      <AlertDialogContent>
+                      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
                         <AlertDialogHeader>
                           <AlertDialogTitle>Delete Provider</AlertDialogTitle>
                           <AlertDialogDescription>


### PR DESCRIPTION
## Summary

Improved Azure OpenAI integration by enhancing the deployment ID handling and fixing UI provider deletion issues.

## Changes

- Modified Azure endpoint pre-hook to always set the model name based on deployment ID, even when other Azure credentials are missing
- Added proper error handling when deployment ID is missing in the path
- Fixed UI issue where clicking the delete button on a provider would also trigger the row click event
- Added stopPropagation to prevent delete dialog from closing when clicking inside it

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Test Azure OpenAI integration with only deployment ID:
   - Make a request with a deployment ID in the path but without Azure endpoint or key
   - Verify the model name is correctly set based on the deployment ID

2. Test error handling:
   - Make a request without deployment ID and verify appropriate error is returned

3. Test UI provider deletion:
   - Navigate to providers list
   - Click the delete button on a provider
   - Verify the delete dialog opens without triggering the row click event
   - Click inside the dialog and verify it doesn't close unexpectedly

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No significant security implications. The changes maintain the existing authentication flow for Azure OpenAI.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)