### PR TITLE
fix: improve Bedrock tool choice handling and UI display

### DIFF
--- a/ui/components/logs/log-detail-sheet.tsx
+++ b/ui/components/logs/log-detail-sheet.tsx
@@ -53,13 +53,6 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
     } catch (ignored) {}
   }
 
-  let toolChoice = null
-  if (log.params?.tool_choice) {
-    try {
-      toolChoice = JSON.stringify(log.params.tool_choice, null, 2)
-    } catch (ignored) {}
-  }
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent className="flex w-full flex-col overflow-x-hidden p-8 sm:max-w-2xl">
@@ -150,21 +143,6 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
             </>
           )}
         </div>
-        {toolChoice && (
-          <div className="w-full rounded-sm border">
-            <div className="border-b px-6 py-2 text-sm font-medium">Tool Choice</div>
-            <CodeEditor
-              className="z-0 w-full"
-              shouldAdjustInitialHeight={true}
-              maxHeight={450}
-              wrap={true}
-              code={toolChoice}
-              lang="json"
-              readonly={true}
-              options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: 'off', alwaysConsumeMouseWheel: false }}
-            />
-          </div>
-        )}
         {toolsParameter && (
           <div className="w-full rounded-sm border">
             <div className="border-b px-6 py-2 text-sm font-medium">Tools</div>
@@ -198,7 +176,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
             />
           </>
         )}
-        
+
         {/* Show conversation history for chat/text completions */}
         {log.input_history && log.input_history.length > 1 && (
           <>
@@ -221,22 +199,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
           <>
             {log.output_message && (
               <>
-                <div className="mt-4 flex w-full items-center  gap-2">
-                  <div className="text-sm font-medium">Response</div>
-                  {log.stream && (
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Info className="h-4 w-4 text-gray-600" />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          The response shown may appear incomplete or out of order due to the way streamed data is accumulated for real-time
-                          display.
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  )}
-                </div>
+                <div className="mt-4 text-sm font-medium">Response</div>
                 <LogMessageView message={log.output_message} />
               </>
             )}

--- a/ui/components/logs/ui/log-entry-details-view.tsx
+++ b/ui/components/logs/ui/log-entry-details-view.tsx
@@ -2,7 +2,6 @@ import { cn } from '@/lib/utils'
 
 interface Props {
   className?: string
-  containerClassName?: string
   isBeta?: boolean
   valueClassName?: string
   label: string
@@ -19,28 +18,26 @@ export default function LogEntryDetailsView(props: Props) {
   const orientation = props.orientation || 'vertical'
   return (
     <div
-      className={cn('items-top flex flex-col gap-2', {
+      className={cn('items-top flex w-full flex-col gap-2 truncate text-ellipsis', {
         [`${props.className}`]: props.className !== undefined,
         'items-start': props.align === 'left' || props.align === undefined,
         'items-end': props.align === 'right',
       })}
     >
-      <div className={props.containerClassName}>
-        {props.label !== '' && (
-          <div className="text-muted-foreground flex shrink-0 flex-row items-center gap-2 text-xs font-medium">
-            {props.label.toUpperCase()}
-          </div>
-        )}
-        <div
-          className={cn('text-md flex whitespace-nowrap text-xs font-medium transition-transform delay-75', {
-            'w-full flex-col items-center gap-2': orientation === 'horizontal',
-            'flex-row items-start gap-2': orientation === 'vertical',
-            [`${props.valueClassName}`]: props.valueClassName !== undefined,
-            'text-end': props.align === 'right',
-          })}
-        >
-          {props.value}
+      {props.label !== '' && (
+        <div className="text-muted-foreground flex shrink-0 flex-row items-center gap-2 text-xs font-medium">
+          {props.label.toUpperCase().replaceAll('_', ' ')}
         </div>
+      )}
+      <div
+        className={cn('text-md text-xs font-medium transition-transform delay-75', {
+          'w-full flex-col items-center gap-2': orientation === 'horizontal',
+          'flex-row items-start gap-2': orientation === 'vertical',
+          [`${props.valueClassName}`]: props.valueClassName !== undefined,
+          'text-end': props.align === 'right',
+        })}
+      >
+        {props.value}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Improved Bedrock provider's tool choice handling and simplified the log detail UI by removing redundant elements.

## Changes

- Added `Type` field to `BedrockSpecificTool` struct with a fixed value of "tool"
- Modified `prepareToolChoice` to return `interface{}` instead of `*BedrockToolChoice`
- Enhanced tool choice handling for Anthropic and Mistral models
- Removed duplicate tools and tool_choice parameters from request body
- Simplified log detail sheet UI by removing the tool choice section and streamlining the response header
- Improved `LogEntryDetailsView` component by removing unnecessary container div and adding text truncation

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test Bedrock provider with Anthropic and Mistral models using tool choice:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm dev || npm run dev
```

Verify that tool choice works correctly with Bedrock provider and that the log detail UI displays correctly.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable