### PR TITLE
fix: simplify Bedrock tool choice handling for auto/any options

### DIFF
--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -912,10 +912,8 @@ func (provider *BedrockProvider) prepareToolChoice(params *schemas.ModelParamete
 		if params.ToolChoice.ToolChoiceStr != nil {
 			choice := *params.ToolChoice.ToolChoiceStr
 			switch choice {
-			case string(schemas.ToolChoiceTypeAuto):
-				return &BedrockToolChoice{Auto: map[string]interface{}{}}
-			case string(schemas.ToolChoiceTypeAny):
-				return &BedrockToolChoice{Any: map[string]interface{}{}}
+			case string(schemas.ToolChoiceTypeAuto), string(schemas.ToolChoiceTypeAny):
+				return nil
 			case string(schemas.ToolChoiceTypeFunction), "tool":
 				if params.ToolChoice.ToolChoiceStruct == nil {
 					return nil


### PR DESCRIPTION
## Summary

Fix Bedrock provider's handling of tool choice parameters by removing unnecessary mappings for "auto" and "any" tool choice types.

## Changes

- Modified `prepareToolChoice` function in the Bedrock provider to return `nil` for both "auto" and "any" tool choice types instead of creating empty map objects
- Updated the transports module to use the latest core version (v1.1.20)
- Added a local replace directive in transports/go.mod to use the local core module during development

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the Bedrock provider correctly handles tool choice parameters:

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue with Bedrock provider's handling of tool choice parameters.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable