### PR TITLE
chore: update bifrost/core dependency to v1.1.22

### DIFF
--- a/transports/go.mod
+++ b/transports/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fasthttp/router v1.5.4
 	github.com/fasthttp/websocket v1.5.12
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.1.21
+	github.com/maximhq/bifrost/core v1.1.22
 	github.com/maximhq/bifrost/plugins/maxim v1.0.6
 	github.com/maximhq/bifrost/plugins/redis v1.0.0
 	github.com/prometheus/client_golang v1.22.0

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -106,8 +106,8 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/maximhq/bifrost/core v1.1.21 h1:dlEK+iXfNnuiFzuuCN9zNEdlL1+QO0XM/qpLEfUlXEE=
-github.com/maximhq/bifrost/core v1.1.21/go.mod h1:bmzsZed8KUgYFSGCFgT4HDedNZm5Ptr1Sm7jSsGEgT0=
+github.com/maximhq/bifrost/core v1.1.22 h1:xtR7tmFn7fQRAKS7MU9R2+h2KqM7msxGYanRUqFUsVE=
+github.com/maximhq/bifrost/core v1.1.22/go.mod h1:bmzsZed8KUgYFSGCFgT4HDedNZm5Ptr1Sm7jSsGEgT0=
 github.com/maximhq/bifrost/plugins/maxim v1.0.6 h1:m1tWjbmxW9Lz4mDhXclQhZdFt/TrRPbZwFcoWY9ZAEk=
 github.com/maximhq/bifrost/plugins/maxim v1.0.6/go.mod h1:+D/E498VB4JNTEzG4fYyFJf9WQaq/9FgYrmzl49mLNc=
 github.com/maximhq/bifrost/plugins/redis v1.0.0 h1:/teFFjXo0u5lID7UwpMcyFUILRXBFduDXdZpa8hdU/8=


### PR DESCRIPTION
## Summary

Update the Bifrost core dependency from v1.1.21 to v1.1.22 in the transports module.

## Changes

- Upgraded `github.com/maximhq/bifrost/core` from v1.1.21 to v1.1.22
- Updated corresponding go.sum entries

## Type of change

- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the transports module works correctly with the updated core dependency:

```sh
# Core/Transports
cd transports
go mod tidy
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

This is a routine dependency update with no direct security implications.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable