### PR TITLE
framework v1.0.0

### DIFF
--- a/framework/go.mod
+++ b/framework/go.mod
@@ -5,13 +5,11 @@ go 1.24
 toolchain go1.24.3
 
 require (
-	github.com/maximhq/bifrost/core v1.1.21
+	github.com/maximhq/bifrost/core v1.1.23
 	github.com/redis/go-redis/v9 v9.12.1
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.30.1
 )
-
-replace github.com/maximhq/bifrost/core => ../core
 
 require (
 	cloud.google.com/go/compute/metadata v0.8.0 // indirect

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -84,6 +84,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/maximhq/bifrost/core v1.1.23 h1:ZgZVQp6E3QkGDb120iyJNL1HAo5MNQFaWrKR98uISDc=
+github.com/maximhq/bifrost/core v1.1.23/go.mod h1:2HP/S4Mo4kQTaRkTYR9R/0fnfzc2b5yzInsPW3YOpXE=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/plugins/logging/streaming.go
+++ b/plugins/logging/streaming.go
@@ -283,14 +283,14 @@ func (p *LoggerPlugin) cleanupOldStreamAccumulators() {
 				}
 				p.streamAccumulators.Delete(requestID)
 				cleanedCount++
-				p.logger.Debug(fmt.Sprintf("Cleaned up old stream accumulator for request %s", requestID))
+				p.logger.Debug("cleaned up old stream accumulator for request %s")
 			}
 		}
 		return true
 	})
 
 	if cleanedCount > 0 {
-		p.logger.Debug(fmt.Sprintf("Cleaned up %d old stream accumulators", cleanedCount))
+		p.logger.Debug("cleaned up %d old stream accumulators", cleanedCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Update the Bifrost core dependency to v1.1.23 and improve logging format in the streaming logger.

## Changes

- Updated `github.com/maximhq/bifrost/core` from v1.1.21 to v1.1.23
- Removed the local replace directive for the core module
- Fixed logging format in the streaming logger by removing redundant `fmt.Sprintf` calls

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Verify that logs from the streaming logger are properly formatted.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable