### PR TITLE
release pipeline fixes

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -276,15 +276,28 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          VERSION="${{ needs.detect-changes.outputs.transport-version }}"
+          BASE_TAG="${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}"
+          
+          # Check if version contains prerelease identifiers (hyphen)
+          if [[ "$VERSION" == *-* ]]; then
+            echo "🔍 Detected prerelease version: v${VERSION} - skipping 'latest' tag"
+            echo "tags=${BASE_TAG}" >> $GITHUB_OUTPUT
+          else
+            echo "🔍 Detected stable version: v${VERSION} - including 'latest' tag"
+            echo "tags=${BASE_TAG},${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./transports/Dockerfile
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${{ needs.detect-changes.outputs.transport-version }}
-            ${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ steps.tags.outputs.tags }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/scripts/release-all-plugins.sh
+++ b/.github/workflows/scripts/release-all-plugins.sh
@@ -35,7 +35,7 @@ echo "📋 Changed plugins JSON: $CHANGED_PLUGINS_JSON"
 # No work early‐exit if array is empty
 if jq -e 'length==0' <<<"$CHANGED_PLUGINS_JSON" >/dev/null 2>&1; then
   echo "⏭️ No plugins to release"
-  echo "success=true" >> "$GITHUB_OUTPUT"
+  echo "success=true" >> "${GITHUB_OUTPUT:-/dev/null}"
   exit 0
 fi
 
@@ -60,7 +60,7 @@ fi
 
 if [ ${#PLUGINS[@]} -eq 0 ]; then
   echo "⏭️ No plugins to release"
-  echo "success=true" >> "$GITHUB_OUTPUT"
+  echo "success=true" >> "${GITHUB_OUTPUT:-/dev/null}"
   exit 0
 fi
 
@@ -99,11 +99,11 @@ echo "   ❌ Failed: ${#FAILED_PLUGINS[@]}"
 
 if [ ${#FAILED_PLUGINS[@]} -gt 0 ]; then
   echo "   Failed plugins: ${FAILED_PLUGINS[*]}"
-  echo "success=false" >> "$GITHUB_OUTPUT"
+  echo "success=false" >> "${GITHUB_OUTPUT:-/dev/null}"
   echo "❌ Plugin release process completed with failures"
   exit $OVERALL_EXIT_CODE
 else
   echo "   🎉 All plugins released successfully!"
-  echo "success=true" >> "$GITHUB_OUTPUT"
+  echo "success=true" >> "${GITHUB_OUTPUT:-/dev/null}"
   echo "✅ All plugin releases completed successfully"
 fi

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -88,6 +88,13 @@ git push origin "$TAG_NAME"
 
 # Create GitHub release
 TITLE="Bifrost HTTP v$VERSION"
+
+# Mark prereleases when version contains a hyphen
+PRERELEASE_FLAG=""
+if [[ "$VERSION" == *-* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+fi
+
 BODY="## Bifrost HTTP Transport Release v$VERSION
 
 ### 🚀 Bifrost HTTP Transport v$VERSION
@@ -126,7 +133,8 @@ fi
 echo "🎉 Creating GitHub release for $TITLE..."
 gh release create "$TAG_NAME" \
   --title "$TITLE" \
-  --notes "$BODY"
+  --notes "$BODY" \
+  ${PRERELEASE_FLAG}
 
 echo "✅ Bifrost HTTP released successfully"
 echo "success=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -42,6 +42,13 @@ git push origin "$TAG_NAME"
 
 # Create GitHub release
 TITLE="Core v$VERSION"
+
+# Mark prereleases when version contains a hyphen
+PRERELEASE_FLAG=""
+if [[ "$VERSION" == *-* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+fi
+
 BODY="## Core Release v$VERSION
 
 ### 🔧 Core Library v$VERSION
@@ -65,7 +72,8 @@ _This release was automatically created from version file: \`core/version\`_"
 echo "🎉 Creating GitHub release for $TITLE..."
 gh release create "$TAG_NAME" \
   --title "$TITLE" \
-  --notes "$BODY"
+  --notes "$BODY" \
+  ${PRERELEASE_FLAG}
 
 echo "✅ Core released successfully"
 echo "success=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -81,6 +81,13 @@ fi
 
 # Create GitHub release
 TITLE="Framework $VERSION"
+
+# Mark prereleases when version contains a hyphen
+PRERELEASE_FLAG=""
+if [[ "$VERSION" == *-* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+fi
+
 BODY="## Framework Release $VERSION
 
 ### 📦 Framework Library $VERSION
@@ -105,7 +112,8 @@ if gh release view "$TAG_NAME" >/dev/null 2>&1; then
 else
   gh release create "$TAG_NAME" \
     --title "$TITLE" \
-    --notes "$BODY"
+    --notes "$BODY" \
+    ${PRERELEASE_FLAG}
 fi
 
 echo "✅ Framework released successfully"

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -43,7 +43,7 @@ echo "🏷️ Tag name: $TAG_NAME"
 
 # Starting dependencies of plugin tests
 echo "🔧 Starting dependencies of plugin tests..."
-docker-compose -f ../tests/docker-compose.yml up -d
+docker-compose -f tests/docker-compose.yml up -d
 sleep 20
 
 # Update plugin dependencies
@@ -78,7 +78,7 @@ cd ../..
 
 # Shutting down dependencies
 echo "🔧 Shutting down dependencies of plugin tests..."
-docker-compose -f ../tests/docker-compose.yml down
+docker-compose -f tests/docker-compose.yml down
 
 # Create and push tag
 echo "🏷️ Creating tag: $TAG_NAME"
@@ -92,6 +92,12 @@ fi
 
 # Create GitHub release
 TITLE="Plugin $PLUGIN_NAME v$PLUGIN_VERSION"
+
+# Mark prereleases when version contains a hyphen
+PRERELEASE_FLAG=""
+if [[ "$PLUGIN_VERSION" == *-* ]]; then
+  PRERELEASE_FLAG="--prerelease"
+fi
 
 BODY="## Plugin Release: $PLUGIN_NAME v$PLUGIN_VERSION
 
@@ -124,8 +130,9 @@ if gh release view "$TAG_NAME" >/dev/null 2>&1; then
 else
   gh release create "$TAG_NAME" \
     --title "$TITLE" \
-    --notes "$BODY"
+    --notes "$BODY" \
+    ${PRERELEASE_FLAG}
 fi
 
 echo "✅ Plugin $PLUGIN_NAME released successfully"
-echo "success=true" >> "$GITHUB_OUTPUT"
+echo "success=true" >> "${GITHUB_OUTPUT:-/dev/null}"


### PR DESCRIPTION
## Improve Release Pipeline for Prerelease Versions

This PR enhances our release pipeline to properly handle prerelease versions by:

1. Adding prerelease detection and tagging in Docker images
2. Marking GitHub releases as prereleases when version contains a hyphen
3. Fixing path issues in plugin release scripts

## Changes

- Added logic to detect prerelease versions (containing hyphens) in Docker image tagging
- Modified Docker image tagging to skip the `latest` tag for prerelease versions
- Added prerelease flag to GitHub release creation in all release scripts
- Fixed paths in plugin release scripts for Docker Compose
- Added fallback for GITHUB_OUTPUT to prevent errors when running scripts locally

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the release pipeline with both stable and prerelease versions:

```sh
# Test with a stable version (e.g., 1.2.3)
# Should create both versioned and latest tags

# Test with a prerelease version (e.g., 1.2.3-beta.1)
# Should only create versioned tag and mark as prerelease
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.