### PR TITLE
fixes docker compose action

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -101,7 +101,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v3
+        uses: docker/setup-compose-action@v1
 
       - name: Release framework
         id: release
@@ -141,7 +141,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v3
+        uses: docker/setup-compose-action@v1
 
       - name: Release all changed plugins
         id: release
@@ -182,7 +182,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v3
+        uses: docker/setup-compose-action@v1
 
       - name: Release bifrost-http
         id: release


### PR DESCRIPTION
## Summary

Downgrade Docker Compose setup action from v3 to v1 in the release pipeline workflow.

## Changes

- Downgraded `docker/setup-compose-action` from v3 to v1 in three jobs:
  - Release framework job
  - Release plugins job
  - Release bifrost-http job
- This change ensures compatibility with the current CI environment and prevents potential issues with newer Docker Compose versions

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the release pipeline workflow runs successfully with the downgraded Docker Compose action:

```sh
# Trigger the workflow manually or through a release event
# Check that all jobs complete successfully
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects the CI/CD pipeline configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable