### PR TITLE
docker compose manual install

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -101,7 +101,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
+        run: |
+          # Verify Docker is available
+          docker --version
+          # Install Docker Compose if not available as plugin
+          if ! docker compose version >/dev/null 2>&1; then
+            echo "Installing Docker Compose..."
+            sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+            docker-compose --version
+          else
+            echo "Docker Compose plugin is available"
+            docker compose version
+          fi
 
       - name: Release framework
         id: release
@@ -141,7 +153,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
+        run: |
+          # Verify Docker is available
+          docker --version
+          # Install Docker Compose if not available as plugin
+          if ! docker compose version >/dev/null 2>&1; then
+            echo "Installing Docker Compose..."
+            sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+            docker-compose --version
+          else
+            echo "Docker Compose plugin is available"
+            docker compose version
+          fi
 
       - name: Release all changed plugins
         id: release
@@ -182,7 +206,19 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
+        run: |
+          # Verify Docker is available
+          docker --version
+          # Install Docker Compose if not available as plugin
+          if ! docker compose version >/dev/null 2>&1; then
+            echo "Installing Docker Compose..."
+            sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+            docker-compose --version
+          else
+            echo "Docker Compose plugin is available"
+            docker compose version
+          fi
 
       - name: Release bifrost-http
         id: release

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -60,12 +60,28 @@ echo "🔨 Validating framework build..."
 go build ./...
 # Starting dependencies of framework tests
 echo "🔧 Starting dependencies of framework tests..."
-docker-compose -f ../tests/docker-compose.yml up -d
+# Use docker compose (v2) if available, fallback to docker-compose (v1)
+if command -v docker-compose >/dev/null 2>&1; then
+  docker-compose -f ../tests/docker-compose.yml up -d
+elif docker compose version >/dev/null 2>&1; then
+  docker compose -f ../tests/docker-compose.yml up -d
+else
+  echo "❌ Neither docker-compose nor docker compose is available"
+  exit 1
+fi
 sleep 20
 go test ./...
 # Shutting down dependencies
 echo "🔧 Shutting down dependencies of framework tests..."
-docker-compose -f ../tests/docker-compose.yml down
+# Use docker compose (v2) if available, fallback to docker-compose (v1)
+if command -v docker-compose >/dev/null 2>&1; then
+  docker-compose -f ../tests/docker-compose.yml down
+elif docker compose version >/dev/null 2>&1; then
+  docker compose -f ../tests/docker-compose.yml down
+else
+  echo "❌ Neither docker-compose nor docker compose is available"
+  exit 1
+fi
 cd ..
 
 echo "✅ Framework build validation successful"


### PR DESCRIPTION
## Summary

Replace Docker Compose setup action with a custom script that supports both Docker Compose V1 and V2 formats in the release pipeline.

## Changes

- Replaced `docker/setup-compose-action@v1` with a custom shell script in all three release jobs
- Added version detection to use either `docker compose` (V2) or `docker-compose` (V1) command format
- Updated the framework release script to support both Docker Compose command formats
- Added fallback logic to install Docker Compose if not available as a plugin
- Added version verification to ensure Docker and Docker Compose are properly configured

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release pipeline workflow to verify Docker Compose setup works correctly:

```sh
# Verify Docker is available
docker --version

# Check if Docker Compose is available as plugin (V2)
docker compose version

# Or check if Docker Compose is available as standalone (V1)
docker-compose --version

# Run a simple compose file to verify functionality
docker compose -f tests/docker-compose.yml up -d
# or
docker-compose -f tests/docker-compose.yml up -d
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No significant security implications as this only affects the CI/CD pipeline infrastructure.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable