### PR TITLE
docker compose v2 support

### DIFF
--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -43,7 +43,15 @@ echo "🏷️ Tag name: $TAG_NAME"
 
 # Starting dependencies of plugin tests
 echo "🔧 Starting dependencies of plugin tests..."
-docker-compose -f tests/docker-compose.yml up -d
+# Use docker compose (v2) if available, fallback to docker-compose (v1)
+if command -v docker-compose >/dev/null 2>&1; then
+  docker-compose -f tests/docker-compose.yml up -d
+elif docker compose version >/dev/null 2>&1; then
+  docker compose -f tests/docker-compose.yml up -d
+else
+  echo "❌ Neither docker-compose nor docker compose is available"
+  exit 1
+fi
 sleep 20
 
 # Update plugin dependencies
@@ -78,7 +86,15 @@ cd ../..
 
 # Shutting down dependencies
 echo "🔧 Shutting down dependencies of plugin tests..."
-docker-compose -f tests/docker-compose.yml down
+# Use docker compose (v2) if available, fallback to docker-compose (v1)
+if command -v docker-compose >/dev/null 2>&1; then
+  docker-compose -f tests/docker-compose.yml down
+elif docker compose version >/dev/null 2>&1; then
+  docker compose -f tests/docker-compose.yml down
+else
+  echo "❌ Neither docker-compose nor docker compose is available"
+  exit 1
+fi
 
 # Create and push tag
 echo "🏷️ Creating tag: $TAG_NAME"


### PR DESCRIPTION
## Summary

Add support for Docker Compose V2 in the plugin release script by detecting and using the appropriate command format.

## Changes

- Modified `release-single-plugin.sh` to check for both `docker-compose` (V1) and `docker compose` (V2) commands
- Added fallback logic to use whichever version is available on the system
- Implemented error handling to exit with a helpful message if neither version is found
- Applied the same detection logic in both the startup and shutdown sections of the script

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the script with both Docker Compose V1 and V2 installations:

```sh
# With Docker Compose V1
.github/workflows/scripts/release-single-plugin.sh <plugin-name> <version>

# With Docker Compose V2
.github/workflows/scripts/release-single-plugin.sh <plugin-name> <version>

# With neither installed (should fail with error message)
# First temporarily rename or uninstall docker-compose
.github/workflows/scripts/release-single-plugin.sh <plugin-name> <version>
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses compatibility issues with newer Docker installations that use Docker Compose V2.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable