### PR TITLE
moves docker run at release all plugins level and env fixes for plugin release

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Release framework
         id: release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}          
         run: ./.github/workflows/scripts/release-framework.sh "${{ needs.detect-changes.outputs.framework-version }}"
 
   plugins-release:
@@ -171,6 +171,8 @@ jobs:
         id: release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          MAXIM_API_KEY: ${{ secrets.MAXIM_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: ./.github/workflows/scripts/release-all-plugins.sh '${{ needs.detect-changes.outputs.changed-plugins }}'
 
   bifrost-http-release:

--- a/.github/workflows/scripts/release-all-plugins.sh
+++ b/.github/workflows/scripts/release-all-plugins.sh
@@ -29,6 +29,20 @@ if ! echo "$CHANGED_PLUGINS_JSON" | jq empty >/dev/null 2>&1; then
   exit 1
 fi
 
+
+# Starting dependencies of plugin tests
+echo "🔧 Starting dependencies of plugin tests..."
+# Use docker compose (v2) if available, fallback to docker-compose (v1)
+if command -v docker-compose >/dev/null 2>&1; then
+  docker-compose -f tests/docker-compose.yml up -d
+elif docker compose version >/dev/null 2>&1; then
+  docker compose -f tests/docker-compose.yml up -d
+else
+  echo "❌ Neither docker-compose nor docker compose is available"
+  exit 1
+fi
+sleep 20
+
 echo "🔌 Processing plugin releases..."
 echo "📋 Changed plugins JSON: $CHANGED_PLUGINS_JSON"
 
@@ -90,6 +104,19 @@ for plugin in "${PLUGINS[@]}"; do
     OVERALL_EXIT_CODE=1
   fi
 done
+
+
+# Shutting down dependencies
+echo "🔧 Shutting down dependencies of plugin tests..."
+# Use docker compose (v2) if available, fallback to docker-compose (v1)
+if command -v docker-compose >/dev/null 2>&1; then
+  docker-compose -f tests/docker-compose.yml down
+elif docker compose version >/dev/null 2>&1; then
+  docker compose -f tests/docker-compose.yml down
+else
+  echo "❌ Neither docker-compose nor docker compose is available"
+  exit 1
+fi
 
 # Summary
 echo ""

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -41,18 +41,6 @@ TAG_NAME="plugins/${PLUGIN_NAME}/v${PLUGIN_VERSION}"
 echo "📦 Plugin version: $PLUGIN_VERSION"
 echo "🏷️ Tag name: $TAG_NAME"
 
-# Starting dependencies of plugin tests
-echo "🔧 Starting dependencies of plugin tests..."
-# Use docker compose (v2) if available, fallback to docker-compose (v1)
-if command -v docker-compose >/dev/null 2>&1; then
-  docker-compose -f tests/docker-compose.yml up -d
-elif docker compose version >/dev/null 2>&1; then
-  docker compose -f tests/docker-compose.yml up -d
-else
-  echo "❌ Neither docker-compose nor docker compose is available"
-  exit 1
-fi
-sleep 20
 
 # Update plugin dependencies
 echo "🔧 Updating plugin dependencies..."
@@ -83,18 +71,6 @@ else
 fi
 
 cd ../..
-
-# Shutting down dependencies
-echo "🔧 Shutting down dependencies of plugin tests..."
-# Use docker compose (v2) if available, fallback to docker-compose (v1)
-if command -v docker-compose >/dev/null 2>&1; then
-  docker-compose -f tests/docker-compose.yml down
-elif docker compose version >/dev/null 2>&1; then
-  docker compose -f tests/docker-compose.yml down
-else
-  echo "❌ Neither docker-compose nor docker compose is available"
-  exit 1
-fi
 
 # Create and push tag
 echo "🏷️ Creating tag: $TAG_NAME"


### PR DESCRIPTION
## Summary

Improve the plugin release process by moving Docker container management to the parent script and adding necessary API keys for plugin testing.

## Changes

- Moved Docker container startup/shutdown from `release-single-plugin.sh` to `release-all-plugins.sh` to manage containers once for all plugin releases
- Added `MAXIM_API_KEY` and `OPENAI_API_KEY` environment variables to the plugins-release job to support plugin testing
- Docker containers now start before any plugin processing and shut down after all plugins are processed

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Plugins
- [x] Core (Go)

## How to test

Run the release pipeline for plugins to verify the Docker containers are properly managed:

```sh
# Manually trigger the release pipeline or
# Make changes to a plugin and push to trigger the workflow
```

## Breaking changes

- [x] No

## Security considerations

Added API keys as secrets to the GitHub workflow to enable proper testing of plugins that require external API access.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable