### PR TITLE
fixes maxim repo id plugin

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -172,7 +172,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           MAXIM_API_KEY: ${{ secrets.MAXIM_API_KEY }}
-          MAXIM_LOGGER_ID: ${{ secrets.MAXIM_LOGGER_ID }}
+          MAXIM_LOG_REPO_ID: ${{ secrets.MAXIM_LOGGER_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: ./.github/workflows/scripts/release-all-plugins.sh '${{ needs.detect-changes.outputs.changed-plugins }}'
 


### PR DESCRIPTION
## Summary

Rename environment variable from `MAXIM_LOGGER_ID` to `MAXIM_LOG_REPO_ID` in the release pipeline workflow.

## Changes

- Renamed the environment variable `MAXIM_LOGGER_ID` to `MAXIM_LOG_REPO_ID` in the release-pipeline.yml workflow file
- The value of the variable still references the same secret (`${{ secrets.MAXIM_LOGGER_ID }}`)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the GitHub Actions workflow runs successfully with the renamed environment variable:

```sh
# Trigger the release pipeline workflow manually or through a qualifying event
# Check that the release-all-plugins.sh script receives the correct environment variable
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change only renames an environment variable reference in the CI pipeline and doesn't affect security posture.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable