### PR TITLE
fixes secret location

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -172,7 +172,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           MAXIM_API_KEY: ${{ secrets.MAXIM_API_KEY }}
-          MAXIM_LOG_REPO_ID: ${{ secrets.MAXIM_LOGGER_ID }}
+          MAXIM_LOGGER_ID: ${{ secrets.MAXIM_LOG_REPO_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: ./.github/workflows/scripts/release-all-plugins.sh '${{ needs.detect-changes.outputs.changed-plugins }}'
 


### PR DESCRIPTION
## Summary

Fixed an environment variable name mismatch in the release pipeline workflow.

## Changes

- Swapped the environment variable names in the release-pipeline.yml file
- Changed `MAXIM_LOG_REPO_ID: ${{ secrets.MAXIM_LOGGER_ID }}` to `MAXIM_LOGGER_ID: ${{ secrets.MAXIM_LOG_REPO_ID }}`
- This ensures the correct environment variable name is used in the release script

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the release pipeline can successfully access the MAXIM_LOGGER_ID environment variable:

```sh
# Run a test release with the updated environment variable names
GH_TOKEN=test MAXIM_API_KEY=test MAXIM_LOGGER_ID=test OPENAI_API_KEY=test ./.github/workflows/scripts/release-all-plugins.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the release pipeline was failing due to incorrect environment variable naming.

## Security considerations

No security implications as this only renames environment variables without changing their content or access patterns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable