### PR TITLE
fixes build validation

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -123,6 +123,9 @@ fi
 
 cd ..
 
+echo "🎨 Building UI..."
+make build-ui
+
 # Validate transport build
 echo "🔨 Validating transport build..."
 cd transports


### PR DESCRIPTION
## Summary

Add UI build step to the Bifrost HTTP release script to ensure the UI is properly built before validating the transport build.

## Changes

- Added a UI build step (`make build-ui`) to the release-bifrost-http.sh script
- Inserted the build step before the transport build validation
- Added a visual indicator ("🎨 Building UI...") to show progress in the console output

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Run the release script and verify that the UI build step executes properly:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

The script should show "🎨 Building UI..." and execute the make build-ui command before proceeding to validate the transport build.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the Bifrost HTTP release process was missing the UI build step.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable