### PR TITLE
fixes paths in build

### DIFF
--- a/.github/workflows/discord-notification.yml
+++ b/.github/workflows/discord-notification.yml
@@ -18,10 +18,5 @@ jobs:
         with:
           args: |
             📝 **Commit to Main Branch**
-            **Commit**: 
-            ```
-            ${{ github.event.head_commit.message }}
-            ```
-            **SHA**: `${{ github.sha }}`
             **Author**: ${{ github.event.head_commit.author.username || github.event.head_commit.author.name || github.event.sender.login || github.actor }}
             **[View Commit](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})**


### PR DESCRIPTION
## Summary

Improve the build script for executables by using absolute paths and proper directory navigation during the build process.

## Changes

- Added detection of script directory and project root using absolute paths
- Modified all path references to use absolute paths instead of relative paths
- Added directory navigation to properly build from the module directory
- Removed environment variable dependency for MODULE_PATH by setting it directly
- Added proper return to project root after each build

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the build script to verify it correctly builds executables for all platforms:

```sh
# From project root
./.github/workflows/scripts/build-executables.sh

# Verify the executables were created in the dist directory
ls -la dist/
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes build issues when running the script from different working directories.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable