### PR TITLE
fixes clang clash for darwin builds

### DIFF
--- a/.github/workflows/scripts/build-executables.sh
+++ b/.github/workflows/scripts/build-executables.sh
@@ -70,7 +70,9 @@ for platform in "${platforms[@]}"; do
       -o "$PROJECT_ROOT/dist/$PLATFORM_DIR/$GOARCH/$output_name" .
 
   else # Darwin (macOS)
-    env GOWORK=off CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" \
+    # Disable CGO for Darwin cross-compilation to avoid toolchain complexity
+    # This will require using alternative drivers for database functionality
+    env GOWORK=off CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
       go build -trimpath -ldflags "-s -w -buildid=" \
       -o "$PROJECT_ROOT/dist/$PLATFORM_DIR/$GOARCH/$output_name" .
   fi


### PR DESCRIPTION
## Summary

Disable CGO for Darwin (macOS) cross-compilation in the build script to avoid toolchain complexity.

## Changes

- Modified the build-executables.sh script to set `CGO_ENABLED=0` for Darwin builds
- Added a comment explaining that this change avoids toolchain complexity during cross-compilation
- Added a note that alternative drivers will be required for database functionality as a result of disabling CGO

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that cross-compilation for macOS works without CGO-related errors:

```sh
# Run the build script
./.github/workflows/scripts/build-executables.sh

# Verify the macOS binaries were created successfully
ls -la dist/darwin/
```

## Breaking changes

- [x] Yes
- [ ] No

This change disables CGO for Darwin builds, which means any functionality that depends on CGO (like certain database drivers) will need to use alternative pure Go implementations.

## Security considerations

No security implications as this only affects the build process.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable