### PR TITLE
fixes r2 upload flow

### DIFF
--- a/.github/workflows/scripts/build-executables.sh
+++ b/.github/workflows/scripts/build-executables.sh
@@ -55,8 +55,8 @@ for platform in "${platforms[@]}"; do
     fi
 
     env GOWORK=off CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" CC="$CC_COMPILER" CXX="$CXX_COMPILER" \
-      go build -trimpath -tags "netgo,osusergo,static_build" \
-      -ldflags "-s -w -buildid= -linkmode external -extldflags -static" \
+      go build -trimpath -tags "netgo,osusergo" \
+      -ldflags "-s -w -buildid=" \
       -o "$PROJECT_ROOT/dist/$PLATFORM_DIR/$GOARCH/$output_name" .
 
   elif [[ "$GOOS" = "windows" ]]; then


### PR DESCRIPTION
## Summary

Modify build flags for non-Windows platforms to remove static linking requirements, making the build process more flexible across different environments.

## Changes

- Removed `static_build` tag from the build command for non-Windows platforms
- Removed `-linkmode external -extldflags -static` from the ldflags, eliminating forced static linking
- These changes allow for dynamic linking on platforms where static linking might cause issues

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the build process works correctly on different platforms:

```sh
# Run the build script
./.github/workflows/scripts/build-executables.sh

# Verify the executables are created properly in the dist directory
ls -la dist/
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses build issues on platforms where static linking is problematic.

## Security considerations

No security implications as this only affects the build process.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable