### PR TITLE
skip github bot commits for pipeline trigger

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -77,7 +77,7 @@ jobs:
 
   framework-release:
     needs: [detect-changes, core-release]
-    if: always() && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped')
+    if: always() && github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -125,7 +125,7 @@ jobs:
 
   plugins-release:
     needs: [detect-changes, core-release, framework-release]
-    if: always() && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')
+    if: always() && github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -180,7 +180,7 @@ jobs:
 
   bifrost-http-release:
     needs: [detect-changes, core-release, framework-release, plugins-release]
-    if: always() && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')
+    if: always() && github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -293,7 +293,7 @@ jobs:
   # Notification
   notify:
     needs: [detect-changes, core-release, framework-release, plugins-release, bifrost-http-release, docker-build]
-    if: always()
+    if: always() && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Install jq


### PR DESCRIPTION
## Summary

Prevent GitHub Actions bot from triggering release workflows to avoid potential infinite loops in the CI/CD pipeline.

## Changes

- Added condition `github.actor != 'github-actions[bot]'` to the following jobs:
  - `framework-release`
  - `plugins-release`
  - `bifrost-http-release`
  - `notify`
- This prevents the GitHub Actions bot from triggering releases, which could cause recursive workflow runs

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that release workflows don't trigger recursively when automated PRs are merged:

```sh
# Observe GitHub Actions behavior after merging this PR
# Confirm that release workflows don't run when triggered by github-actions[bot]
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Prevents CI/CD infinite loops when automated PRs are merged.

## Security considerations

Improves CI/CD security by preventing potential denial of service through recursive workflow runs.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable