### PR TITLE
adds skip-pipeline support as github bot check not working

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -8,14 +8,14 @@ on:
 # Prevent concurrent runs
 concurrency:
   group: release-pipeline
-  cancel-in-progress: true
+  cancel-in-progress: true  
 
 jobs:
   # Detect what needs to be released
   detect-changes:
     runs-on: ubuntu-latest
-    # Skip if pusher is GitHub Actions Bot to avoid infinite loops
-    if: github.actor != 'github-actions[bot]'
+    # Skip if pusher is GitHub Actions Bot to avoid infinite loops or if commit message contains --skip-pipeline
+    if: !contains(github.event.head_commit.message, '--skip-pipeline')
     outputs:
       core-needs-release: ${{ steps.detect.outputs.core-needs-release }}
       framework-needs-release: ${{ steps.detect.outputs.framework-needs-release }}
@@ -77,7 +77,7 @@ jobs:
 
   framework-release:
     needs: [detect-changes, core-release]
-    if: always() && github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped')
+    if: always() &&  !contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -125,7 +125,7 @@ jobs:
 
   plugins-release:
     needs: [detect-changes, core-release, framework-release]
-    if: always() && github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')
+    if: always()  && !contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -180,7 +180,7 @@ jobs:
 
   bifrost-http-release:
     needs: [detect-changes, core-release, framework-release, plugins-release]
-    if: always() && github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')
+    if: always() && !contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -293,7 +293,7 @@ jobs:
   # Notification
   notify:
     needs: [detect-changes, core-release, framework-release, plugins-release, bifrost-http-release, docker-build]
-    if: always() && github.actor != 'github-actions[bot]'
+    if: always() && !contains(github.event.head_commit.message, '--skip-pipeline')
     runs-on: ubuntu-latest
     steps:
       - name: Install jq

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -115,7 +115,7 @@ if ! git diff --quiet go.mod go.sum; then
   if [ ${#PLUGINS_USED[@]} -gt 0 ]; then
     commit_msg="$commit_msg, plugins: ${PLUGINS_USED[*]}"
   fi
-  git commit -m "$commit_msg"
+  git commit -m "$commit_msg --skip-pipeline"
   git push -u origin HEAD
   echo "✅ Transport dependencies updated"
 else

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -45,15 +45,6 @@ git add go.mod go.sum
 # Check if there are any changes to commit
 git add go.mod go.sum
 
-# Check if there are any changes to commit
-if ! git diff --cached --quiet; then
-  git commit -m "framework: bump core to $CORE_VERSION"
-  # Push the bump so go.mod/go.sum changes are recorded on the branch
-  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-  git push origin "$CURRENT_BRANCH"
-else
-  echo "No dependency changes detected; skipping commit."
-fi
 
 # Validate framework build
 echo "🔨 Validating framework build..."
@@ -85,6 +76,18 @@ fi
 cd ..
 
 echo "✅ Framework build validation successful"
+
+# Check if there are any changes to commit
+if ! git diff --cached --quiet; then
+  git commit -m "framework: bump core to $CORE_VERSION --skip-pipeline"
+  # Push the bump so go.mod/go.sum changes are recorded on the branch
+  CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+  git push origin "$CURRENT_BRANCH"
+else
+  echo "No dependency changes detected; skipping commit."
+fi
+
+echo "🔧 Pushed framework bump to $CURRENT_BRANCH"
 
 # Create and push tag
 echo "🏷️ Creating tag: $TAG_NAME"

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -52,7 +52,7 @@ if [ -f "go.mod" ]; then
   go mod tidy
   git add go.mod go.sum || true
   if ! git diff --cached --quiet; then
-    git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION"
+    git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION --skip-pipeline"
     git push -u origin HEAD
   fi
 


### PR DESCRIPTION
## Summary

Add ability to skip the release pipeline by including `--skip-pipeline` in commit messages to prevent infinite loops during automated dependency updates.

## Changes

- Modified the release pipeline to check for `--skip-pipeline` in commit messages and skip execution when present
- Updated dependency update scripts to include `--skip-pipeline` in their commit messages
- Reordered framework release script to validate build before committing changes
- Fixed conditional logic in workflow files to use the new skip mechanism

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the release pipeline by making commits with and without the `--skip-pipeline` flag:

```
# Should trigger pipeline
git commit -m "normal commit message"

# Should skip pipeline
git commit -m "dependency update --skip-pipeline"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses issues with release pipeline triggering infinite loops when automated commits update dependencies.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md`and followed the guidelines
- [x] I verified the CI pipeline logic works as expected