### PR TITLE
plugins release script fixes

### DIFF
--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # Release a single plugin
-# Usage: ./release-single-plugin.sh <plugin-name> [core-version]
+# Usage: ./release-single-plugin.sh <plugin-name> [core-version] [framework-version]
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <plugin-name> [core-version]"
+  echo "Usage: $0 <plugin-name> [core-version] [framework-version]"
   exit 1
 fi
 
@@ -24,8 +24,23 @@ else
   fi
 fi
 
+# Get framework version from parameter or latest tag
+if [ -n "${3:-}" ]; then
+  FRAMEWORK_VERSION="$3"
+else
+  # Get latest framework version from git tags
+  LATEST_FRAMEWORK_TAG=$(git tag -l "framework/v*" | sort -V | tail -1)
+  if [ -z "$LATEST_FRAMEWORK_TAG" ]; then
+    echo "❌ No framework tags found, using version from file"
+    FRAMEWORK_VERSION="v$(tr -d '\n\r' < framework/version)"
+  else
+    FRAMEWORK_VERSION=${LATEST_FRAMEWORK_TAG#framework/}
+  fi
+fi
+
 echo "🔌 Releasing plugin: $PLUGIN_NAME"
 echo "🔧 Core version: $CORE_VERSION"
+echo "🔧 Framework version: $FRAMEWORK_VERSION"
 
 PLUGIN_DIR="plugins/$PLUGIN_NAME"
 VERSION_FILE="$PLUGIN_DIR/version"
@@ -49,10 +64,11 @@ cd "$PLUGIN_DIR"
 # Update core dependency
 if [ -f "go.mod" ]; then
   go get "github.com/maximhq/bifrost/core@${CORE_VERSION}"
+  go get "github.com/maximhq/bifrost/framework@${FRAMEWORK_VERSION}"
   go mod tidy
   git add go.mod go.sum || true
   if ! git diff --cached --quiet; then
-    git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION --skip-pipeline"
+    git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION and framework to $FRAMEWORK_VERSION --skip-pipeline"
     git push -u origin HEAD
   fi
 
@@ -100,6 +116,7 @@ This release updates the $PLUGIN_NAME plugin.
 
 ### Dependencies
 - **Core**: \`$CORE_VERSION\`
+- **Framework**: \`$FRAMEWORK_VERSION\`
 
 ### Installation
 
@@ -112,6 +129,7 @@ go get github.com/maximhq/bifrost/plugins/$PLUGIN_NAME@v$PLUGIN_VERSION
 - **Name**: $PLUGIN_NAME
 - **Version**: $PLUGIN_VERSION
 - **Core Dependency**: $CORE_VERSION
+- **Framework Dependency**: $FRAMEWORK_VERSION
 
 ---
 _This release was automatically created from version file: \`plugins/$PLUGIN_NAME/version\`_"

--- a/plugins/governance/version
+++ b/plugins/governance/version
@@ -1,1 +1,1 @@
-1.2.0-prerelease3
+1.2.0-prerelease4

--- a/plugins/logging/version
+++ b/plugins/logging/version
@@ -1,1 +1,1 @@
-1.2.0-prerelease3
+1.2.0-prerelease4

--- a/transports/version
+++ b/transports/version
@@ -1,1 +1,1 @@
-1.2.0-prerelease3
+1.2.0-prerelease4


### PR DESCRIPTION
## Summary

Enhanced the plugin release script to include framework version management and updated version numbers for governance, logging plugins, and transports.

## Changes

- Added framework version parameter to `release-single-plugin.sh` script
- Implemented automatic framework version detection from git tags when parameter is not provided
- Updated the script to include framework version in release notes and commit messages
- Bumped version numbers for governance and logging plugins from `1.2.0-prerelease3` to `1.2.0-prerelease4`
- Bumped transports version from `1.2.0-prerelease3` to `1.2.0-prerelease4`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the enhanced release script with the new framework version parameter:

```sh
# Test with all parameters
.github/workflows/scripts/release-single-plugin.sh logging v1.0.0 v2.0.0

# Test with automatic framework version detection
.github/workflows/scripts/release-single-plugin.sh governance v1.0.0
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable