### PR TITLE
fixes release script for plugins

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -115,17 +115,10 @@ if ! git diff --quiet go.mod go.sum; then
   if [ ${#PLUGINS_USED[@]} -gt 0 ]; then
     commit_msg="$commit_msg, plugins: ${PLUGINS_USED[*]}"
   fi
-  git commit -m "$commit_msg --skip-pipeline"
-  git push -u origin HEAD
   echo "✅ Transport dependencies updated"
 else
   echo "ℹ️  No dependency changes detected in transports"
 fi
-
-cd ..
-
-echo "🎨 Building UI..."
-make build-ui
 
 # Validate transport build
 echo "🔨 Validating transport build..."
@@ -133,6 +126,20 @@ cd transports
 go test ./...
 cd ..
 echo "✅ Transport build validation successful"
+
+cd ..
+
+# Commit and push changes if any
+if ! git diff --cached --quiet; then
+  echo "🔧 Committing and pushing changes..."
+  git commit -m "${commit_msg:-"transports: update dependencies"} --skip-pipeline"
+  git push -u origin HEAD
+else
+  echo "ℹ️ No staged changes to commit"
+fi
+
+echo "🎨 Building UI..."
+make build-ui
 
 # Install cross-compilation toolchains
 echo "📦 Installing cross-compilation toolchains..."

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -67,10 +67,6 @@ if [ -f "go.mod" ]; then
   go get "github.com/maximhq/bifrost/framework@${FRAMEWORK_VERSION}"
   go mod tidy
   git add go.mod go.sum || true
-  if ! git diff --cached --quiet; then
-    git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION and framework to $FRAMEWORK_VERSION --skip-pipeline"
-    git push -u origin HEAD
-  fi
 
   # Validate build
   echo "🔨 Validating plugin build..."
@@ -88,6 +84,15 @@ else
 fi
 
 cd ../..
+
+# Commit and push changes if any
+if ! git diff --cached --quiet; then
+  echo "🔧 Committing and pushing changes..."
+  git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION and framework to $FRAMEWORK_VERSION --skip-pipeline"
+  git push -u origin HEAD
+else
+  echo "ℹ️ No staged changes to commit"
+fi
 
 # Create and push tag
 echo "🏷️ Creating tag: $TAG_NAME"


### PR DESCRIPTION
## Summary

Fix the release scripts to ensure changes are committed and pushed at the correct time in the workflow.

## Changes

- Modified `release-bifrost-http.sh` to move the git commit and push commands outside the dependency check condition
- Updated `release-single-plugin.sh` to move the git commit and push commands after all changes are made
- These changes ensure that all modifications are properly committed and pushed at the end of the script execution

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release scripts to verify they properly commit and push changes:

```
# For HTTP transport
.github/workflows/scripts/release-bifrost-http.sh <version>

# For a single plugin
.github/workflows/scripts/release-single-plugin.sh <plugin-name> <version>
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects the release workflow.

## Checklist

- [x] I read `docs/contributing/README.md`and followed the guidelines
- [x] I verified the CI pipeline passes locally if applicable