### PR TITLE
fixed release http

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -119,6 +119,7 @@ if ! git diff --quiet go.mod go.sum; then
 else
   echo "ℹ️  No dependency changes detected in transports"
 fi
+cd ..
 
 # Validate transport build
 echo "🔨 Validating transport build..."
@@ -127,7 +128,6 @@ go test ./...
 cd ..
 echo "✅ Transport build validation successful"
 
-cd ..
 
 # Commit and push changes if any
 if ! git diff --cached --quiet; then


### PR DESCRIPTION
## Summary

Fix directory navigation in the Bifrost HTTP release script by moving the `cd ..` command to the correct location.

## Changes

- Moved the `cd ..` command to execute before the transport build validation step
- This ensures the script returns to the correct directory before proceeding with subsequent steps
- Removed a redundant `cd ..` command that was incorrectly placed after the validation step

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script to verify it navigates directories correctly:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

The script should complete without directory-related errors.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue with directory navigation in the Bifrost HTTP release workflow.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable