### PR TITLE
fixes transport build checks on release http flow

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -121,13 +121,16 @@ else
 fi
 cd ..
 
+# We need to build UI first before we can validate the transport build
+echo "🎨 Building UI..."
+make build-ui
+
 # Validate transport build
 echo "🔨 Validating transport build..."
 cd transports
 go test ./...
 cd ..
 echo "✅ Transport build validation successful"
-
 
 # Commit and push changes if any
 if ! git diff --cached --quiet; then
@@ -137,9 +140,6 @@ if ! git diff --cached --quiet; then
 else
   echo "ℹ️ No staged changes to commit"
 fi
-
-echo "🎨 Building UI..."
-make build-ui
 
 # Install cross-compilation toolchains
 echo "📦 Installing cross-compilation toolchains..."


### PR DESCRIPTION
## Summary

Reorder build steps in the Bifrost HTTP release script to ensure UI is built before validating the transport build.

## Changes

- Moved the UI build step (`make build-ui`) before the transport validation step
- This ensures that the transport build validation has access to the compiled UI assets it may depend on

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Run the release script and verify that the transport validation succeeds:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where transport validation could fail due to missing UI assets.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable