### PR TITLE
fixes transport build checks on release http flow

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -8,7 +8,7 @@ on:
 # Prevent concurrent runs
 concurrency:
   group: release-pipeline
-  cancel-in-progress: true  
+  cancel-in-progress: false  
 
 jobs:
   # Detect what needs to be released
@@ -21,6 +21,7 @@ jobs:
       framework-needs-release: ${{ steps.detect.outputs.framework-needs-release }}
       plugins-need-release: ${{ steps.detect.outputs.plugins-need-release }}
       bifrost-http-needs-release: ${{ steps.detect.outputs.bifrost-http-needs-release }}
+      docker-needs-release: ${{ steps.detect.outputs.docker-needs-release }}
       changed-plugins: ${{ steps.detect.outputs.changed-plugins }}
       core-version: ${{ steps.detect.outputs.core-version }}
       framework-version: ${{ steps.detect.outputs.framework-version }}
@@ -238,7 +239,7 @@ jobs:
   # Docker build and push
   docker-build:
     needs: [detect-changes, bifrost-http-release]
-    if: needs.bifrost-http-release.result == 'success'
+    if: "always() && !contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -121,13 +121,16 @@ else
 fi
 cd ..
 
+# We need to build UI first before we can validate the transport build
+echo "🎨 Building UI..."
+make build-ui
+
 # Validate transport build
 echo "🔨 Validating transport build..."
 cd transports
 go test ./...
 cd ..
 echo "✅ Transport build validation successful"
-
 
 # Commit and push changes if any
 if ! git diff --cached --quiet; then
@@ -137,9 +140,6 @@ if ! git diff --cached --quiet; then
 else
   echo "ℹ️ No staged changes to commit"
 fi
-
-echo "🎨 Building UI..."
-make build-ui
 
 # Install cross-compilation toolchains
 echo "📦 Installing cross-compilation toolchains..."


### PR DESCRIPTION
## Summary

Improve the release pipeline to handle Docker image builds independently from transport releases, allowing Docker images to be built even when the transport code hasn't changed.

## Changes

- Modified the release pipeline to check for Docker image existence separately from Git tags
- Changed concurrency settings to prevent cancellation of in-progress release pipelines
- Updated Docker build job conditions to run when Docker needs a release, even if bifrost-http release was skipped
- Added a new `docker-needs-release` output variable to the change detection script
- Added UI build step before transport validation to ensure proper build sequence

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release pipeline manually or push a commit that would trigger it:

```sh
# To skip the pipeline for testing purposes
git commit -m "Some changes --skip-pipeline"

# To test Docker build independently
# 1. Make sure the transport version exists as a Git tag
# 2. Delete the Docker image from DockerHub if it exists
# 3. Push a commit to trigger the pipeline
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses issues with Docker images not being built when transport code hasn't changed but Docker images are missing.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable