### PR TITLE
docs icon fixes

### DIFF
--- a/docs/architecture/core/concurrency.mdx
+++ b/docs/architecture/core/concurrency.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Concurrency"
 description: "Deep dive into Bifrost's advanced concurrency architecture - worker pools, goroutine management, channel-based communication, and resource isolation patterns."
-icon: "tasks"
+icon: "traffic-light"
 ---
 
 ## Concurrency Philosophy

--- a/docs/architecture/core/mcp.mdx
+++ b/docs/architecture/core/mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Model Context Protocol (MCP)"
 description: "Deep dive into Bifrost's Model Context Protocol (MCP) integration - how external tool discovery, execution, and integration work internally."
-icon: "tools"
+icon: "toolbox"
 ---
 
 ## MCP Architecture Overview

--- a/docs/benchmarking/t3.xl.mdx
+++ b/docs/benchmarking/t3.xl.mdx
@@ -1,7 +1,7 @@
 ---
 title: "t3.xlarge"
 description: "Detailed performance metrics and analysis for Bifrost running on AWS t3.xlarge instances (4 vCPUs, 16GB RAM)."
-icon: "hdd"
+icon: "server"
 ---
 
 ## Instance Configuration

--- a/docs/features/mcp.mdx
+++ b/docs/features/mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Model Context Protocol (MCP)"
 description: "Enable AI models to discover and execute external tools dynamically. Transform static chat models into action-capable agents with filesystem access, web search, databases, and custom business logic."
-icon: "https://avatars.githubusercontent.com/u/182288589?s=400&v=4"
+icon: "toolbox"
 ---
 
 ## Overview

--- a/docs/integrations/anthropic-sdk.mdx
+++ b/docs/integrations/anthropic-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Anthropic SDK"
 description: "Use Bifrost as a drop-in replacement for Anthropic API with full compatibility and enhanced features."
-icon: "https://cdn.brandfetch.io/idmJWF3N06/theme/dark/symbol.svg?c=1bxid64Mup7aczewSAYMX&t=1721803183716"
+icon: "a"
 ---
 
 ## Overview

--- a/docs/integrations/genai-sdk.mdx
+++ b/docs/integrations/genai-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Google GenAI SDK"
 description: "Use Bifrost as a drop-in replacement for Google GenAI API with full compatibility and enhanced features."
-icon: "https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/google.svg"
+icon: "g"
 ---
 
 ## Overview

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Langchain SDK"
 description: "Use Bifrost as a drop-in proxy for Langchain applications with zero code changes."
-icon: "https://registry.npmmirror.com/@lobehub/icons-static-png/latest/files/dark/langchain-color.png"
+icon: "crow"
 ---
 
 Since Langchain already provides multi-provider abstraction and chaining capabilities, Bifrost adds enterprise features like governance, semantic caching, MCP tools, observability, etc, on top of your existing setup.

--- a/docs/integrations/litellm-sdk.mdx
+++ b/docs/integrations/litellm-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: "LiteLLM SDK"
 description: "Use Bifrost as a drop-in proxy for LiteLLM applications with zero code changes."
-icon: "https://cdn.brandfetch.io/idR1DDyp8M/w/512/h/512/theme/dark/logo.png?c=1bxid64Mup7aczewSAYMX&t=1754937941635"
+icon: "train"
 ---
 
 Since LiteLLM already provides multi-provider abstraction, Bifrost adds enterprise features like governance, semantic caching, MCP tools, observability, etc, on top of your existing setup.

--- a/docs/integrations/openai-sdk.mdx
+++ b/docs/integrations/openai-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenAI SDK"
 description: "Use Bifrost as a drop-in replacement for OpenAI API with full compatibility and enhanced features."
-icon: "https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/openai.svg"
+icon: "o"
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Updated icons across documentation pages to better represent their content and improve visual consistency.

## Changes

- Changed the icon for concurrency documentation from "tasks" to "traffic-light" to better represent the concept
- Updated Model Context Protocol (MCP) icon from "tools" to "toolbox" in both architecture and features sections
- Changed benchmarking icon from "hdd" to "server" for t3.xlarge documentation
- Replaced external URL icons with simple letter icons for SDK integrations:
  - Anthropic SDK: URL icon → "a"
  - Google GenAI SDK: URL icon → "g"
  - Langchain SDK: URL icon → "crow"
  - LiteLLM SDK: URL icon → "train"
  - OpenAI SDK: URL icon → "o"

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the documentation pages render correctly with the new icons:

```sh
# UI
cd ui
pnpm i || npm i
pnpm dev || npm run dev
```

Navigate to the affected documentation pages to ensure icons display properly.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable