### PR TITLE
fix: logs for streaming chat completion requests

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -135,14 +135,14 @@ func retryOnNotFound(ctx context.Context, operation func() error) error {
 		if err == nil {
 			return nil
 		}
-		
+
 		// Check if the error is logstore.ErrNotFound
 		if !errors.Is(err, logstore.ErrNotFound) {
 			return err
 		}
-		
+
 		lastErr = err
-		
+
 		// Don't wait after the last attempt
 		if attempt < maxRetries-1 {
 			select {
@@ -153,7 +153,7 @@ func retryOnNotFound(ctx context.Context, operation func() error) error {
 			}
 		}
 	}
-	
+
 	return lastErr
 }
 
@@ -346,15 +346,15 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 
 	// Check if this is a streaming response
 	requestType := (*ctx).Value(Bifrost.BifrostContextKeyRequestType).(Bifrost.RequestType)
-	isStreaming := requestType == Bifrost.ChatCompletionStreamRequest || requestType == Bifrost.SpeechStreamRequest || requestType == Bifrost.TranscriptionStreamRequest
-	isTextStreaming := requestType == Bifrost.TextCompletionRequest
+	isStreaming := requestType == Bifrost.SpeechStreamRequest || requestType == Bifrost.TranscriptionStreamRequest
+	isChatStreaming := requestType == Bifrost.ChatCompletionStreamRequest
 
 	// Queue the log update message (non-blocking) - use same pattern for both streaming and regular
 	logMsg := p.getLogMessage()
 	logMsg.RequestID = requestID
 	logMsg.Timestamp = time.Now()
 
-	if isTextStreaming {
+	if isChatStreaming {
 		// Handle text-based streaming with ordered accumulation
 		return p.handleStreamingResponse(ctx, result, err)
 	} else if isStreaming {


### PR DESCRIPTION
## Summary

Fix streaming response handling in the logging plugin to correctly process chat completion streams and prevent duplicate processing of accumulated chunks.

## Changes

- Fixed streaming type detection by separating chat streaming (`isChatStreaming`) from other streaming types (`isStreaming`)
- Improved handling of stream completion by adding a check to prevent duplicate processing of accumulated chunks
- Removed redundant `isStreamingResponse` and `isTextStreamingResponse` helper methods
- Added a flag to track when stream processing has already been triggered
- Fixed a bug where `IsComplete` was being set too early in the stream accumulation process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test chat completion streaming to verify that logs are correctly accumulated and processed:

```sh
# Core/Transports
go version
go test ./plugins/logging/...

# Test with a streaming chat completion request
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}],
    "stream": true
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with chat completion stream logging and prevents duplicate processing of stream chunks.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable