### PR TITLE
feat: invalidate params for cross provider requests in integrations

### DIFF
--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -413,6 +413,11 @@ func (r *AnthropicMessageRequest) ConvertToBifrostRequest() *schemas.BifrostRequ
 		bifrostReq.Params.ToolChoice = toolChoice
 	}
 
+	// Apply parameter validation
+	if bifrostReq.Params != nil {
+		bifrostReq.Params = integrations.ValidateAndFilterParamsForProvider(provider, bifrostReq.Params)
+	}
+
 	return bifrostReq
 }
 

--- a/transports/bifrost-http/integrations/openai/types.go
+++ b/transports/bifrost-http/integrations/openai/types.go
@@ -156,16 +156,17 @@ type OpenAIStreamResponse struct {
 func (r *OpenAIChatRequest) ConvertToBifrostRequest(checkProviderFromModel bool) *schemas.BifrostRequest {
 	provider, model := integrations.ParseModelString(r.Model, schemas.OpenAI, checkProviderFromModel)
 
+	// Convert parameters first
+	params := r.convertParameters()
+
 	bifrostReq := &schemas.BifrostRequest{
 		Provider: provider,
 		Model:    model,
 		Input: schemas.RequestInput{
 			ChatCompletionInput: &r.Messages,
 		},
+		Params: filterParams(provider, params),
 	}
-
-	// Map extra parameters and tool settings
-	bifrostReq.Params = r.convertParameters()
 
 	return bifrostReq
 }
@@ -200,8 +201,11 @@ func (r *OpenAISpeechRequest) ConvertToBifrostRequest(checkProviderFromModel boo
 		},
 	}
 
+	// Convert parameters first
+	params := r.convertSpeechParameters()
+
 	// Map parameters
-	bifrostReq.Params = r.convertSpeechParameters()
+	bifrostReq.Params = filterParams(provider, params)
 
 	return bifrostReq
 }
@@ -234,8 +238,11 @@ func (r *OpenAITranscriptionRequest) ConvertToBifrostRequest(checkProviderFromMo
 		},
 	}
 
+	// Convert parameters first
+	params := r.convertTranscriptionParameters()
+
 	// Map parameters
-	bifrostReq.Params = r.convertTranscriptionParameters()
+	bifrostReq.Params = filterParams(provider, params)
 
 	return bifrostReq
 }
@@ -274,8 +281,11 @@ func (r *OpenAIEmbeddingRequest) ConvertToBifrostRequest(checkProviderFromModel 
 		},
 	}
 
+	// Convert parameters first
+	params := r.convertEmbeddingParameters()
+
 	// Map parameters
-	bifrostReq.Params = r.convertEmbeddingParameters()
+	bifrostReq.Params = filterParams(provider, params)
 
 	return bifrostReq
 }
@@ -572,4 +582,9 @@ func DeriveOpenAIStreamFromBifrostResponse(bifrostResp *schemas.BifrostResponse)
 	}
 
 	return streamResp
+}
+
+func filterParams(provider schemas.ModelProvider, p *schemas.ModelParameters) *schemas.ModelParameters {
+	if p == nil { return nil }
+	return integrations.ValidateAndFilterParamsForProvider(provider, p)
 }


### PR DESCRIPTION
## Parameter Validation for Provider-Specific Model Parameters

Adds a parameter validation system that filters out unsupported parameters based on the target provider before sending requests. This prevents sending invalid parameters to providers that don't support them, which can cause request failures or unexpected behavior.

## Changes

- Created a `ParameterValidator` system that defines which parameters are supported by each provider
- Added parameter validation to all integration request converters (OpenAI, Anthropic)
- Implemented provider-specific parameter schemas for OpenAI, Azure, Anthropic, Cohere, Mistral, Groq, and Ollama
- Added logging for unsupported parameters to help with debugging
- Restructured request conversion flow to validate parameters after conversion but before sending

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Run the integration tests
go test ./transports/bifrost-http/integrations/...

# Test with specific providers that have different parameter support
# For example, sending top_k to OpenAI (unsupported) vs Anthropic (supported)
```

## Breaking changes

- [x] No

## Security considerations

This change improves security by preventing potentially sensitive parameters from being sent to providers that don't support them, reducing the risk of information leakage.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)