### PR TITLE
chore: update Weaviate configuration and add UI path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bifrost-data
 **/temp/
 /transports/ui
 /transports/bifrost-http/lib/ui
+/transports/bifrost-http/ui/
 transports/bifrost-http/logs/
 transports/bifrost-http/tmp/
 node_modules

--- a/plugins/semanticcache/test_helpers.go
+++ b/plugins/semanticcache/test_helpers.go
@@ -21,12 +21,12 @@ const (
 func getWeaviateConfigFromEnv() vectorstore.WeaviateConfig {
 	scheme := os.Getenv("WEAVIATE_SCHEME")
 	if scheme == "" {
-		scheme = "https"
+		scheme = "http"
 	}
 
 	host := os.Getenv("WEAVIATE_HOST")
 	if host == "" {
-		host = "localhost:8080"
+		host = "localhost:9000"
 	}
 
 	apiKey := os.Getenv("WEAVIATE_API_KEY")

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,15 +2,39 @@ services:
     # Weaviate instance for basic tests
     weaviate:
         image: cr.weaviate.io/semitechnologies/weaviate:1.32.4
+        command:
+            - --host
+            - 0.0.0.0
+            - --port
+            - '8080'
+            - --scheme
+            - http
+        environment:
+            - CLUSTER_HOSTNAME=weaviate
+            - CLUSTER_ADVERTISE_ADDR=172.38.0.12
+            - CLUSTER_GOSSIP_BIND_PORT=7946
+            - CLUSTER_DATA_BIND_PORT=7947
+            - DISABLE_TELEMETRY=true
+            - PERSISTENCE_DATA_PATH=/var/lib/weaviate
+            - DEFAULT_VECTORIZER_MODULE=none
+            - ENABLE_MODULES=
+            - AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true
+            - LOG_LEVEL=info
         ports:
             - "9000:8080"
+        volumes:
+            - weaviate_data:/var/lib/weaviate
         networks:
-            - weaviate_network
+            bifrost_network:
+                ipv4_address: 172.38.0.12
 
 networks:
-    weaviate_network:
+    bifrost_network:
         driver: bridge
         ipam:
             config:
                 - subnet: 172.38.0.0/16
                   gateway: 172.38.0.1
+
+volumes:
+    weaviate_data:


### PR DESCRIPTION
## Summary

Updated Weaviate configuration for local development and testing, including Docker Compose settings and default connection parameters.

## Changes

- Updated `.gitignore` to exclude `/transports/bifrost-http/ui/` directory
- Modified Weaviate test configuration to use HTTP instead of HTTPS by default
- Changed default Weaviate host port from 8080 to 9000 in test helpers
- Enhanced Docker Compose configuration for Weaviate with detailed container settings
- Added persistent volume for Weaviate data
- Configured proper networking with fixed IP addresses for Weaviate container

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Weaviate tests with the updated configuration:

```sh
# Start the Docker containers
cd tests
docker-compose up -d

# Run the semantic cache tests
go test ./plugins/semanticcache/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The changes configure Weaviate to use HTTP instead of HTTPS for local development and testing environments only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable