### PR TITLE
fixes git syncing for releases

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -16,6 +16,7 @@ TAG_NAME="transports/v${VERSION}"
 echo "🚀 Releasing bifrost-http v$VERSION..."
 
 # Get latest versions
+git pull origin
 # Ensure tags are available (CI often does shallow clones)
 git fetch --tags --force >/dev/null 2>&1 || true
 LATEST_CORE_TAG=$(git tag -l "core/v*" | sort -V | tail -1)

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -22,6 +22,8 @@ TAG_NAME="framework/${VERSION}"
 
 echo "📦 Releasing framework $VERSION..."
 
+# Ensure we have the latest version
+git pull origin
 # Fetching all tags
 git fetch --tags >/dev/null 2>&1 || true
 

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -38,6 +38,9 @@ else
   fi
 fi
 
+# Ensure we have the latest version
+git pull origin
+
 echo "🔌 Releasing plugin: $PLUGIN_NAME"
 echo "🔧 Core version: $CORE_VERSION"
 echo "🔧 Framework version: $FRAMEWORK_VERSION"


### PR DESCRIPTION
## Summary

Enhance release scripts by ensuring they always work with the latest code before creating releases.

## Changes

- Added `git pull origin` command to three release scripts:
  - `release-bifrost-http.sh`
  - `release-framework.sh`
  - `release-single-plugin.sh`
- This ensures that the release scripts fetch the latest code from the origin before proceeding with the release process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release scripts to verify they properly pull the latest code:

```sh
# Test bifrost-http release script
./.github/workflows/scripts/release-bifrost-http.sh

# Test framework release script
./.github/workflows/scripts/release-framework.sh

# Test plugin release script
./.github/workflows/scripts/release-single-plugin.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where release scripts might use outdated code when creating releases.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable