### PR TITLE
fixed ref for docker build flow

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -250,6 +250,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: 'main'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -135,6 +135,8 @@ echo "✅ Transport build validation successful"
 
 # Commit and push changes if any
 if ! git diff --cached --quiet; then
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   echo "🔧 Committing and pushing changes..."
   git commit -m "${commit_msg:-"transports: update dependencies"} --skip-pipeline"
   git push -u origin HEAD

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -81,6 +81,8 @@ echo "✅ Framework build validation successful"
 
 # Check if there are any changes to commit
 if ! git diff --cached --quiet; then
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   git commit -m "framework: bump core to $CORE_VERSION --skip-pipeline"
   # Push the bump so go.mod/go.sum changes are recorded on the branch
   CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -90,6 +90,8 @@ cd ../..
 
 # Commit and push changes if any
 if ! git diff --cached --quiet; then
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   echo "🔧 Committing and pushing changes..."
   git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION and framework to $FRAMEWORK_VERSION --skip-pipeline"
   git push -u origin HEAD


### PR DESCRIPTION
## Summary

Fix GitHub Actions release pipeline by ensuring proper git configuration for automated commits and explicitly checking out the main branch.

## Changes

- Added explicit `ref: 'main'` parameter to the checkout action in the release pipeline workflow
- Added git configuration for user name and email in all release scripts to properly identify the GitHub Actions bot as the committer
- Ensures automated commits during releases are properly attributed to the GitHub Actions bot

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the release pipeline works correctly by triggering a release:

```sh
# The pipeline should now properly commit changes with the GitHub Actions bot identity
# and ensure it's working with the main branch
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with automated commits during the release process.

## Security considerations

No security implications as this only affects the CI/CD pipeline configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable