### PR TITLE
feat: add system prompt exclusion option to semantic cache

### DIFF
--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -111,18 +111,19 @@ cacheConfig := semanticcache.Config{
     CacheTTLKey: "request-cache-ttl",     // Optional: bifrost will look for this key in ctx for TTL override
     CacheThresholdKey: "request-cache-threshold", // Optional: bifrost will look for this key in ctx for threshold override
     
-    // Embedding model configuration
+    // Embedding model configuration (Required)
     Provider:       schemas.OpenAI,
     Keys:          []schemas.Key{{Value: "sk-..."}},
-    EmbeddingModel: "text-embedding-3-small", // Optional: defaults to provider default
+    EmbeddingModel: "text-embedding-3-small",
     
     // Cache behavior
-    TTL:       5 * time.Minute,  // Default TTL: 5 minutes
-    Threshold: 0.8,              // Similarity threshold: 0.8 (80%)
+    TTL:       5 * time.Minute,  // Time to live for cached responses (default: 5 minutes)
+    Threshold: 0.8,              // Similarity threshold for cache lookup (default: 0.8)
     
     // Advanced options
     CacheByModel:    bifrost.Ptr(true),  // Include model in cache key (default: true)
     CacheByProvider: bifrost.Ptr(true),  // Include provider in cache key (default: true)
+    ExcludeSystemPrompt: bifrost.Ptr(false), // Exclude system messages in cache key (default: false)
 }
 
 // Create plugin
@@ -137,6 +138,28 @@ bifrostConfig := schemas.BifrostConfig{
     // ... other config
 }
 ```
+
+</Tab>
+
+<Tab title="Web UI">
+
+![Semantic Cache Plugin Configuration](./images/semantic-cache-plugin-config.png)
+
+**Note**: Make sure you have a vector store setup (using `config.json`) before configuring the semantic cache plugin.
+
+1. **Navigate to Settings**
+   - Open Bifrost UI at `http://localhost:8080`
+   - Go to Settings.
+
+2. **Configure Semantic Cache Plugin**
+
+- Toggle the plugin switch to enable it, and fill in the required fields.
+
+**Required Fields:**
+- **Provider**: The provider to use for caching.
+- **Embedding Model**: The embedding model to use for caching.
+
+**Note**: Changes will need a restart of the Bifrost server to take effect, because the plugin is loaded on startup only.
 
 </Tab>
 
@@ -156,14 +179,15 @@ bifrostConfig := schemas.BifrostConfig{
         "threshold": 0.8,
         
         "cache_by_model": true,
-        "cache_by_provider": true
+        "cache_by_provider": true,
+        "exclude_system_prompt": false
       }
     }
   ]
 }
 ```
 
-**Note**: All the available keys will be taken from the provider config on initialization, so make sure to add the keys to the provider you have specified in the config. Any updates to the keys will not be reflected until next restart.
+> **Note**: All the available keys will be taken from the provider config on initialization, so make sure to add the keys to the provider you have specified in the config. Any updates to the keys will not be reflected until next restart.
 
 **TTL Format Options:**
 - Duration strings: `"30s"`, `"5m"`, `"1h"`, `"24h"`
@@ -290,6 +314,18 @@ Use the request ID from cached responses to clear specific entries:
 
 <Tabs group="cache-clear">
 
+<Tab title="Go SDK">
+
+```go
+// Clear specific entry by request ID
+err := plugin.ClearCacheForRequestID("550e8400-e29b-41d4-a716-446655440000")
+
+// Clear all entries for a cache key  
+err := plugin.ClearCacheForKey("support-session-456")
+```
+
+</Tab>
+
 <Tab title="HTTP API">
 
 ```bash
@@ -298,18 +334,6 @@ curl -X DELETE http://localhost:8080/api/cache/clear/550e8400-e29b-41d4-a716-446
 
 # Clear all entries for a cache key
 curl -X DELETE http://localhost:8080/api/cache/clear-by-key/support-session-456
-```
-
-</Tab>
-
-<Tab title="Go SDK">
-
-```go
-// Clear specific entry by request ID
-err := plugin.ClearCacheForRequestID(nil, "550e8400-e29b-41d4-a716-446655440000")
-
-// Clear all entries for a cache key  
-err := plugin.ClearCacheForKey("support-session-456")
 ```
 
 </Tab>

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -6,6 +6,8 @@ icon: "crow"
 
 Since Langchain already provides multi-provider abstraction and chaining capabilities, Bifrost adds enterprise features like governance, semantic caching, MCP tools, observability, etc, on top of your existing setup.
 
+**Endpoint:** `/langchain`
+
 <Warning>
 **Provider Compatibility:** This integration only works for AI providers that both Langchain and Bifrost support. If you're using a provider specific to Langchain that Bifrost doesn't support (or vice versa), those requests will fail.
 </Warning>

--- a/docs/integrations/litellm-sdk.mdx
+++ b/docs/integrations/litellm-sdk.mdx
@@ -6,6 +6,8 @@ icon: "train"
 
 Since LiteLLM already provides multi-provider abstraction, Bifrost adds enterprise features like governance, semantic caching, MCP tools, observability, etc, on top of your existing setup.
 
+**Endpoint:** `/litellm`
+
 <Warning>
  **Provider Compatibility:** This integration only works for AI providers that both LiteLLM and Bifrost support. If you're using a provider specific to LiteLLM that Bifrost doesn't support (or vice versa), those requests will fail.
 </Warning>

--- a/docs/quickstart/gateway/streaming.mdx
+++ b/docs/quickstart/gateway/streaming.mdx
@@ -33,6 +33,8 @@ data: [DONE]
 
 Each chunk contains partial content that you can append to build the complete response in real-time.
 
+> **Note:** Streaming requests also follow the default timeout setting defined in provider configuration, which defaults to **30 seconds**.
+
 ## Text-to-Speech Streaming: Real-time Audio Generation
 
 Stream audio generation in real-time as text is converted to speech. Ideal for long texts or when you need immediate audio playback.

--- a/docs/quickstart/go-sdk/streaming.mdx
+++ b/docs/quickstart/go-sdk/streaming.mdx
@@ -44,6 +44,8 @@ for chunk := range stream {
 }
 ```
 
+> **Note:** Streaming requests also follow the default timeout setting defined in provider configuration, which defaults to **30 seconds**.
+
 ## Text-to-Speech Streaming: Real-time Audio Generation
 
 Stream audio generation in real-time as text is converted to speech. Ideal for long texts or when you need immediate audio playback.

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -37,8 +37,9 @@ type Config struct {
 	Threshold float64       `json:"threshold,omitempty"` // Cosine similarity threshold for semantic matching (default: 0.8)
 
 	// Advanced caching behavior
-	CacheByModel    *bool `json:"cache_by_model,omitempty"`    // Include model in cache key (default: true)
-	CacheByProvider *bool `json:"cache_by_provider,omitempty"` // Include provider in cache key (default: true)
+	CacheByModel        *bool `json:"cache_by_model,omitempty"`        // Include model in cache key (default: true)
+	CacheByProvider     *bool `json:"cache_by_provider,omitempty"`     // Include provider in cache key (default: true)
+	ExcludeSystemPrompt *bool `json:"exclude_system_prompt,omitempty"` // Exclude system prompt in cache key (default: false)
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for semantic cache Config.
@@ -46,16 +47,17 @@ type Config struct {
 func (c *Config) UnmarshalJSON(data []byte) error {
 	// Define a temporary struct to avoid infinite recursion
 	type TempConfig struct {
-		CacheKey          string        `json:"cache_key"`
-		CacheTTLKey       string        `json:"cache_ttl_key"`
-		CacheThresholdKey string        `json:"cache_threshold_key"`
-		Provider          string        `json:"provider"`
-		Keys              []schemas.Key `json:"keys"`
-		EmbeddingModel    string        `json:"embedding_model,omitempty"`
-		TTL               interface{}   `json:"ttl,omitempty"`
-		Threshold         float64       `json:"threshold,omitempty"`
-		CacheByModel      *bool         `json:"cache_by_model,omitempty"`
-		CacheByProvider   *bool         `json:"cache_by_provider,omitempty"`
+		CacheKey            string        `json:"cache_key"`
+		CacheTTLKey         string        `json:"cache_ttl_key"`
+		CacheThresholdKey   string        `json:"cache_threshold_key"`
+		Provider            string        `json:"provider"`
+		Keys                []schemas.Key `json:"keys"`
+		EmbeddingModel      string        `json:"embedding_model,omitempty"`
+		TTL                 interface{}   `json:"ttl,omitempty"`
+		Threshold           float64       `json:"threshold,omitempty"`
+		CacheByModel        *bool         `json:"cache_by_model,omitempty"`
+		CacheByProvider     *bool         `json:"cache_by_provider,omitempty"`
+		ExcludeSystemPrompt *bool         `json:"exclude_system_prompt,omitempty"`
 	}
 
 	var temp TempConfig
@@ -73,7 +75,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	c.CacheByModel = temp.CacheByModel
 	c.CacheByProvider = temp.CacheByProvider
 	c.Threshold = temp.Threshold
-
+	c.ExcludeSystemPrompt = temp.ExcludeSystemPrompt
 	// Handle TTL field with custom parsing for VectorStore-backed cache behavior
 	if temp.TTL != nil {
 		switch v := temp.TTL.(type) {

--- a/plugins/semanticcache/version
+++ b/plugins/semanticcache/version
@@ -1,1 +1,1 @@
-1.2.0-prerelease3
+1.2.0-prerelease4


### PR DESCRIPTION
## Summary

Added a new `ExcludeSystemPrompt` option to the semantic cache plugin, allowing users to exclude system messages from cache key generation, and improved documentation with Web UI configuration instructions.

## Changes

- Added `ExcludeSystemPrompt` configuration option (defaults to false) to control whether system messages are included in cache key generation
- Implemented filtering logic to remove system prompts from requests when generating cache keys
- Added Web UI configuration tab to the documentation with screenshot and setup instructions
- Improved documentation comments for configuration options
- Bumped plugin version from 1.2.0-prerelease3 to 1.2.0-prerelease4
- Reordered tabs in documentation for better flow

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Plugins
- [x] Docs

## How to test

Test the new `ExcludeSystemPrompt` option:

```sh
# Run with exclude_system_prompt set to true
go run main.go -config config.json

# Make identical requests with different system prompts
# They should hit the same cache entry when exclude_system_prompt is true
# They should create different cache entries when exclude_system_prompt is false
```

## Breaking changes

- [x] No

## Related issues

Implements feature request for excluding system prompts from cache key generation

## Security considerations

No security implications as this is a feature enhancement for the caching system.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed