### PR TITLE
release-http fixes

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -108,20 +108,8 @@ go get "github.com/maximhq/bifrost/framework@$FRAMEWORK_VERSION"
 # Upgrade core at the end
 echo "  🔧 Updating core to $CORE_VERSION"
 go get "github.com/maximhq/bifrost/core@$CORE_VERSION"
-
 go mod tidy
 
-# Only commit if there are changes
-if ! git diff --quiet go.mod go.sum; then
-  git add go.mod go.sum
-  commit_msg="transports: update to core $CORE_VERSION, framework $FRAMEWORK_VERSION"
-  if [ ${#PLUGINS_USED[@]} -gt 0 ]; then
-    commit_msg="$commit_msg, plugins: ${PLUGINS_USED[*]}"
-  fi
-  echo "✅ Transport dependencies updated"
-else
-  echo "ℹ️  No dependency changes detected in transports"
-fi
 cd ..
 
 # We need to build UI first before we can validate the transport build


### PR DESCRIPTION
## Summary

Simplify the release script for Bifrost HTTP transport by removing the automatic git commit functionality.

## Changes

- Removed the git commit logic from the `release-bifrost-http.sh` script
- The script now updates dependencies and runs `go mod tidy` without attempting to create a commit
- This change allows for more flexible release workflows where commits can be managed separately

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Transports (HTTP)
- [x] Chore/CI

## How to test

Verify the script still updates dependencies correctly:

```sh
# Run the release script
./.github/workflows/scripts/release-bifrost-http.sh <version>

# Verify dependencies were updated
cat go.mod
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is a change to the release automation process only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable