### PR TITLE
removes sync

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -15,8 +15,6 @@ TAG_NAME="transports/v${VERSION}"
 
 echo "🚀 Releasing bifrost-http v$VERSION..."
 
-# Get latest versions
-git pull origin
 # Ensure tags are available (CI often does shallow clones)
 git fetch --tags --force >/dev/null 2>&1 || true
 LATEST_CORE_TAG=$(git tag -l "core/v*" | sort -V | tail -1)


### PR DESCRIPTION
## Summary

Remove unnecessary `git pull origin` command from the bifrost-http release script to prevent potential conflicts during the release process.

## Changes

- Removed the `git pull origin` command from the release script as it's unnecessary and could potentially cause conflicts
- The script already fetches tags with `git fetch --tags --force`, which is sufficient for the release process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script and verify it completes successfully without the git pull:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves the reliability of the bifrost-http release process

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable