### PR TITLE
chore: update embedding model from text-embedding-3-small to text-embedding-3-large

### DIFF
--- a/plugins/semanticcache/plugin_core_test.go
+++ b/plugins/semanticcache/plugin_core_test.go
@@ -340,7 +340,7 @@ func TestCacheConfiguration(t *testing.T) {
 			config: Config{
 				CacheKey:       TestCacheKey,
 				Provider:       schemas.OpenAI,
-				EmbeddingModel: "text-embedding-3-small",
+				EmbeddingModel: "text-embedding-3-large",
 				Threshold:      0.95, // Very high threshold
 				Keys: []schemas.Key{
 					{Value: os.Getenv("OPENAI_API_KEY"), Models: []string{}, Weight: 1.0},
@@ -353,7 +353,7 @@ func TestCacheConfiguration(t *testing.T) {
 			config: Config{
 				CacheKey:       TestCacheKey,
 				Provider:       schemas.OpenAI,
-				EmbeddingModel: "text-embedding-3-small",
+				EmbeddingModel: "text-embedding-3-large",
 				Threshold:      0.1, // Very low threshold
 				Keys: []schemas.Key{
 					{Value: os.Getenv("OPENAI_API_KEY"), Models: []string{}, Weight: 1.0},
@@ -366,7 +366,7 @@ func TestCacheConfiguration(t *testing.T) {
 			config: Config{
 				CacheKey:       TestCacheKey,
 				Provider:       schemas.OpenAI,
-				EmbeddingModel: "text-embedding-3-small",
+				EmbeddingModel: "text-embedding-3-large",
 				Threshold:      0.8,
 				TTL:            1 * time.Hour, // Custom TTL
 				Keys: []schemas.Key{

--- a/plugins/semanticcache/test_helpers.go
+++ b/plugins/semanticcache/test_helpers.go
@@ -152,7 +152,7 @@ func NewRedisClusterTestSetup(t *testing.T) *TestSetup {
 	config := Config{
 		CacheKey:       TestCacheKey,
 		Provider:       schemas.OpenAI,
-		EmbeddingModel: "text-embedding-3-small",
+		EmbeddingModel: "text-embedding-3-large",
 		Threshold:      0.8,
 		Keys: []schemas.Key{
 			{


### PR DESCRIPTION
## Summary

Updated the semantic cache plugin to use the `text-embedding-3-large` model instead of `text-embedding-3-small` for all test configurations.

## Changes

- Replaced all instances of `text-embedding-3-small` with `text-embedding-3-large` in test configurations
- Updated model references in both `plugin_core_test.go` and `test_helpers.go` files

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Plugins

## How to test

Run the semantic cache plugin tests to verify they pass with the updated embedding model:

```sh
# Run semantic cache plugin tests
go test ./plugins/semanticcache/...
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only affects test configurations.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable