### PR TITLE
Loser commit

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -264,7 +264,7 @@ jobs:
         id: tags
         run: |
           # Make sure we refetch the current branch
-          git pull origin ${{ github.ref_name }}"
+          git pull origin ${{ github.ref_name }}
           # Checking docker image tag
           VERSION="${{ needs.detect-changes.outputs.transport-version }}"
           BASE_TAG="${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}"


### PR DESCRIPTION
## Summary

Fix syntax error in GitHub workflow by removing an extra quotation mark in the git pull command.

## Changes

- Removed an extraneous double quote at the end of the `git pull origin ${{ github.ref_name }}` command in the release pipeline workflow

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the GitHub workflow runs successfully:

```sh
# Manually trigger the workflow or make a commit that would trigger it
# Check that the git pull command executes without syntax errors
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue with the release pipeline failing due to a syntax error in the git pull command.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable