### PR TITLE
detect changes fixes

### DIFF
--- a/.github/workflows/scripts/detect-all-changes.sh
+++ b/.github/workflows/scripts/detect-all-changes.sh
@@ -42,7 +42,8 @@ else
   else
     PREVIOUS_CORE_VERSION=${LATEST_CORE_TAG#core/v}
     echo "   📋 Previous: $PREVIOUS_CORE_VERSION, Current: $CORE_VERSION"
-    if [ "$(printf '%s\n' "$PREVIOUS_CORE_VERSION" "$CORE_VERSION" | sort -V | tail -1)" = "$CORE_VERSION" ] && [ "$PREVIOUS_CORE_VERSION" != "$CORE_VERSION" ]; then
+    # Fixed: Use head -1 instead of tail -1 for your sort -V behavior, and check against current version
+    if [ "$(printf '%s\n' "$PREVIOUS_CORE_VERSION" "$CORE_VERSION" | sort -V | head -1)" = "$CORE_VERSION" ] && [ "$PREVIOUS_CORE_VERSION" != "$CORE_VERSION" ]; then
       echo "   ✅ Core version incremented: $PREVIOUS_CORE_VERSION → $CORE_VERSION"
       CORE_NEEDS_RELEASE="true"
     else
@@ -65,7 +66,8 @@ else
   else
     PREVIOUS_FRAMEWORK_VERSION=${LATEST_FRAMEWORK_TAG#framework/v}
     echo "   📋 Previous: $PREVIOUS_FRAMEWORK_VERSION, Current: $FRAMEWORK_VERSION"
-    if [ "$(printf '%s\n' "$PREVIOUS_FRAMEWORK_VERSION" "$FRAMEWORK_VERSION" | sort -V | tail -1)" = "$FRAMEWORK_VERSION" ] && [ "$PREVIOUS_FRAMEWORK_VERSION" != "$FRAMEWORK_VERSION" ]; then
+    # Fixed: Use head -1 instead of tail -1 for your sort -V behavior, and check against current version
+    if [ "$(printf '%s\n' "$PREVIOUS_FRAMEWORK_VERSION" "$FRAMEWORK_VERSION" | sort -V | head -1)" = "$FRAMEWORK_VERSION" ] && [ "$PREVIOUS_FRAMEWORK_VERSION" != "$FRAMEWORK_VERSION" ]; then
       echo "   ✅ Framework version incremented: $PREVIOUS_FRAMEWORK_VERSION → $FRAMEWORK_VERSION"
       FRAMEWORK_NEEDS_RELEASE="true"
     else
@@ -112,7 +114,10 @@ for plugin_dir in plugins/*/; do
     PLUGIN_CHANGES+=("$plugin_name")
   else
     previous_version=${latest_tag#plugins/${plugin_name}/v}
-    if [ "$(printf '%s\n' "$previous_version" "$current_version" | sort -V | tail -1)" = "$current_version" ] && [ "$previous_version" != "$current_version" ]; then
+    echo "previous version: $previous_version"
+    echo "current version: $current_version"
+    echo "latest tag: $latest_tag"
+    if [ "$(printf '%s\n' "$previous_version" "$current_version" | sort -V | head -1)" = "$current_version" ] && [ "$previous_version" != "$current_version" ]; then
       echo "      ✅ Version incremented: $previous_version → $current_version"
       PLUGIN_CHANGES+=("$plugin_name")
     else
@@ -166,7 +171,13 @@ else
   else
     PREVIOUS_TRANSPORT_VERSION=${LATEST_TRANSPORT_TAG#transports/v}
     echo "   📋 Previous: $PREVIOUS_TRANSPORT_VERSION, Current: $TRANSPORT_VERSION"
-    if [ "$(printf '%s\n' "$PREVIOUS_TRANSPORT_VERSION" "$TRANSPORT_VERSION" | sort -V | tail -1)" = "$TRANSPORT_VERSION" ] && [ "$PREVIOUS_TRANSPORT_VERSION" != "$TRANSPORT_VERSION" ]; then
+    # Debug the sort behavior
+    sorted_first=$(printf '%s\n' "$PREVIOUS_TRANSPORT_VERSION" "$TRANSPORT_VERSION" | sort -V | head -1)
+    echo "   🔍 DEBUG: sort -V | head -1 returns: '$sorted_first'"
+    echo "   🔍 DEBUG: Current version: '$TRANSPORT_VERSION'"
+    echo "   🔍 DEBUG: Versions different? $([ "$PREVIOUS_TRANSPORT_VERSION" != "$TRANSPORT_VERSION" ] && echo "YES" || echo "NO")"
+    # Fixed: Use head -1 instead of tail -1 for your sort -V behavior, and check against current version
+    if [ "$sorted_first" = "$TRANSPORT_VERSION" ] && [ "$PREVIOUS_TRANSPORT_VERSION" != "$TRANSPORT_VERSION" ]; then
       echo "   ✅ Transport version incremented: $PREVIOUS_TRANSPORT_VERSION → $TRANSPORT_VERSION"
       if [ "$GIT_TAG_EXISTS" = "false" ]; then
         echo "   🏷️  Git tag missing - transport release needed"
@@ -183,9 +194,6 @@ else
     DOCKER_NEEDS_RELEASE="true"
   fi
 fi
-
-
-
 
 # Convert plugin array to JSON (compact format)
 if [ ${#PLUGIN_CHANGES[@]} -eq 0 ]; then

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -35,6 +35,12 @@ else
   FRAMEWORK_VERSION=${LATEST_FRAMEWORK_TAG#framework/}
 fi
 
+echo "🔍 DEBUG: LATEST_CORE_TAG: $LATEST_CORE_TAG"
+echo "🔍 DEBUG: CORE_VERSION: $CORE_VERSION"
+echo "🔍 DEBUG: LATEST_FRAMEWORK_TAG: $LATEST_FRAMEWORK_TAG"
+echo "🔍 DEBUG: FRAMEWORK_VERSION: $FRAMEWORK_VERSION"
+
+
 # Get latest plugin versions
 echo "🔌 Getting latest plugin release versions..."
 declare -A PLUGIN_VERSIONS
@@ -44,7 +50,7 @@ for plugin_dir in plugins/*/; do
   if [ -d "$plugin_dir" ]; then
     plugin_name=$(basename "$plugin_dir")
     # Get the latest released version for this plugin
-    LATEST_PLUGIN_TAG=$(git tag -l "plugins/${plugin_name}/v*" | sort -V | tail -1)
+    LATEST_PLUGIN_TAG=$(git tag -l "plugins/${plugin_name}/v*" | sort -V | head -1)
     
     if [ -z "$LATEST_PLUGIN_TAG" ]; then
       # No release yet, use version from file


### PR DESCRIPTION
## Summary

Fix version comparison logic in release detection scripts by changing from `tail -1` to `head -1` when comparing semantic versions.

## Changes

- Fixed version comparison logic in `detect-all-changes.sh` by using `head -1` instead of `tail -1` when sorting versions with `sort -V`
- The previous implementation incorrectly identified version increments, as it was checking if the current version was greater than the previous version
- Added debug logging in the transport version check to help diagnose sorting behavior
- Applied the same fix to the `release-bifrost-http.sh` script
- Added additional debug output to help troubleshoot version detection

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that version detection works correctly by running the scripts with different version combinations:

```sh
# Test with a version that should be detected as a downgrade
export CORE_VERSION="1.0.0"
export PREVIOUS_CORE_VERSION="1.1.0"
./.github/workflows/scripts/detect-all-changes.sh

# Test with a version that should be detected as an upgrade
export CORE_VERSION="1.2.0"
export PREVIOUS_CORE_VERSION="1.1.0"
./.github/workflows/scripts/detect-all-changes.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes incorrect version detection in release workflows

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable