### PR TITLE
fixes version selection for release-bifrost

### DIFF
--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -49,6 +49,11 @@ if [[ "$VERSION" == *-* ]]; then
   PRERELEASE_FLAG="--prerelease"
 fi
 
+LATEST_FLAG=""
+if [[ "$PLUGIN_VERSION" != *-* ]]; then
+  LATEST_FLAG="--latest"
+fi
+
 BODY="## Core Release v$VERSION
 
 ### 🔧 Core Library v$VERSION
@@ -73,7 +78,7 @@ echo "🎉 Creating GitHub release for $TITLE..."
 gh release create "$TAG_NAME" \
   --title "$TITLE" \
   --notes "$BODY" \
-  ${PRERELEASE_FLAG}
+  ${PRERELEASE_FLAG} ${LATEST_FLAG}  
 
 echo "✅ Core released successfully"
 echo "success=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -113,6 +113,11 @@ if [[ "$VERSION" == *-* ]]; then
   PRERELEASE_FLAG="--prerelease"
 fi
 
+LATEST_FLAG=""
+if [[ "$PLUGIN_VERSION" != *-* ]]; then
+  LATEST_FLAG="--latest"
+fi
+
 BODY="## Framework Release $VERSION
 
 ### 📦 Framework Library $VERSION
@@ -138,7 +143,8 @@ else
   gh release create "$TAG_NAME" \
     --title "$TITLE" \
     --notes "$BODY" \
-    ${PRERELEASE_FLAG}
+    ${PRERELEASE_FLAG} ${LATEST_FLAG}
+    
 fi
 
 echo "✅ Framework released successfully"

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -121,6 +121,13 @@ if [[ "$PLUGIN_VERSION" == *-* ]]; then
   PRERELEASE_FLAG="--prerelease"
 fi
 
+# Mark as latest if not a prerelease
+LATEST_FLAG=""
+if [[ "$PLUGIN_VERSION" != *-* ]]; then
+  LATEST_FLAG="--latest"
+fi
+
+
 BODY="## Plugin Release: $PLUGIN_NAME v$PLUGIN_VERSION
 
 ### 🔌 Plugin: $PLUGIN_NAME v$PLUGIN_VERSION
@@ -155,7 +162,7 @@ else
   gh release create "$TAG_NAME" \
     --title "$TITLE" \
     --notes "$BODY" \
-    ${PRERELEASE_FLAG}
+    ${PRERELEASE_FLAG} ${LATEST_FLAG}    
 fi
 
 echo "✅ Plugin $PLUGIN_NAME released successfully"


### PR DESCRIPTION
## Improve Plugin Version Selection Logic in Release Scripts

This PR enhances the plugin version selection logic in our release scripts to better handle prerelease versions and ensure proper version tagging.

## Changes

- Enhanced plugin version selection in `release-bifrost-http.sh` to intelligently handle prerelease versions:
  - When releasing a prerelease version, the script now considers both stable and prerelease plugin versions, preferring stable ones when available
  - When releasing a stable version, the script only considers stable plugin versions
  - Added detailed logging to show which type of plugin tag was selected
  - Fixed sorting to use `tail -1` instead of `head -1` to get the latest version

- Added `--latest` flag to GitHub releases in `release-single-plugin.sh` for non-prerelease versions:
  - Ensures stable releases are properly marked as latest
  - Preserves prerelease flag behavior for prerelease versions

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the release process with both stable and prerelease versions:

```sh
# Test with a stable version
VERSION=1.0.0 ./.github/workflows/scripts/release-bifrost-http.sh

# Test with a prerelease version
VERSION=1.0.0-beta.1 ./.github/workflows/scripts/release-bifrost-http.sh

# Test plugin release
PLUGIN_NAME=example VERSION=1.0.0 ./.github/workflows/scripts/release-single-plugin.sh
PLUGIN_NAME=example VERSION=1.0.0-beta.1 ./.github/workflows/scripts/release-single-plugin.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects our release process.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable