### PR TITLE
version sorting fixed for version detector

### DIFF
--- a/npx/bin.js
+++ b/npx/bin.js
@@ -45,13 +45,13 @@ function validateTransportVersion(version) {
   }
   
   // Check if version matches v{x.x.x} format
-  const versionRegex = /^v\d+\.\d+\.\d+$/;
+  const versionRegex = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
   if (versionRegex.test(version)) {
     return version;
   }
   
   console.error(`Invalid transport version format: ${version}`);
-  console.error(`Transport version must be either "latest" or in format v1.2.3`);
+  console.error(`Transport version must be either "latest", "v1.2.3", or "v1.2.3-prerelease1"`);
   process.exit(1);
 }
 

--- a/npx/package.json
+++ b/npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "High-performance AI gateway CLI - connect to 12+ providers through a single API",
   "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
   "homepage": "https://github.com/maximhq/bifrost",


### PR DESCRIPTION
## Summary

Improve the transport version detection logic in the CI workflow to properly handle prerelease versions and ensure correct version comparison.

## Changes

- Enhanced the transport tag detection to prioritize stable releases over prereleases for the same base version
- Added a function to extract base version by removing prerelease suffixes
- Fixed the version comparison logic to properly determine if a version has been incremented
- Improved debug output to help diagnose version comparison issues
- Added missing closing bracket in the script

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the detect-all-changes.sh script with different tag scenarios:

```sh
# Test with a mix of stable and prerelease tags
git tag -a "transports/v1.0.0" -m "Stable release"
git tag -a "transports/v1.0.1-beta" -m "Beta release"
git tag -a "transports/v1.1.0" -m "New stable release"

# Run the script
./.github/workflows/scripts/detect-all-changes.sh
```

The script should correctly identify the latest stable version and properly compare versions.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with transport release automation when prerelease versions are present.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified the script works as expected with different version scenarios
- [x] I verified the CI pipeline passes locally