### PR TITLE
fix arm lable for github workflow

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -283,7 +283,7 @@ jobs:
   docker-build-arm64:
       needs: [detect-changes, bifrost-http-release]
       if: "always() && !contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
-      runs-on: ubuntu-24.04-arm64
+      runs-on: ubuntu-24.04-arm
       permissions:
         contents: write
       env:


### PR DESCRIPTION
## Summary

Fix the runner specification for ARM64 Docker builds in the release pipeline.

## Changes

- Changed the runner specification from `ubuntu-24.04-arm64` to `ubuntu-24.04-arm` in the `docker-build-arm64` job
- This ensures the job uses the correct runner architecture for ARM64 Docker builds

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the ARM64 Docker build job runs successfully in the release pipeline:

```sh
# Trigger the release pipeline and check that the docker-build-arm64 job completes
# Or review the GitHub Actions logs for the job
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects the CI/CD infrastructure.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable