### PR TITLE
shell script fixes

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -190,7 +190,7 @@ if [[ "$VERSION" == *-* ]]; then
 fi
 
 LATEST_FLAG=""
-if [[ "$PLUGIN_VERSION" != *-* ]]; then
+if [[ "$VERSION" != *-* ]]; then
   LATEST_FLAG="--latest"
 fi
 

--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -50,7 +50,7 @@ if [[ "$VERSION" == *-* ]]; then
 fi
 
 LATEST_FLAG=""
-if [[ "$PLUGIN_VERSION" != *-* ]]; then
+if [[ "$VERSION" != *-* ]]; then
   LATEST_FLAG="--latest"
 fi
 

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -114,7 +114,7 @@ if [[ "$VERSION" == *-* ]]; then
 fi
 
 LATEST_FLAG=""
-if [[ "$PLUGIN_VERSION" != *-* ]]; then
+if [[ "$VERSION" != *-* ]]; then
   LATEST_FLAG="--latest"
 fi
 


### PR DESCRIPTION
## Summary

Fix release script bug by correcting variable name in conditional checks for latest flag.

## Changes

- Fixed a variable name bug in three release scripts (`release-bifrost-http.sh`, `release-core.sh`, and `release-framework.sh`)
- Changed incorrect variable `$PLUGIN_VERSION` to `$VERSION` in the conditional check that determines whether to set the `--latest` flag

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the release scripts work correctly by running them with different version formats:

```sh
# Test with a release version (should set --latest flag)
VERSION=1.0.0 ./.github/workflows/scripts/release-core.sh

# Test with a pre-release version (should not set --latest flag)
VERSION=1.0.0-beta ./.github/workflows/scripts/release-core.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes release script issues where the wrong variable was being checked to determine if a release should be tagged as latest.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable