### PR TITLE
fixes docker manifest step

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -332,6 +332,9 @@ jobs:
         ACCOUNT: maximhq
         IMAGE_NAME: bifrost
       steps:
+        - name: Checkout repository
+          uses: actions/checkout@v4             
+          
         - name: Log in to Docker Hub
           uses: docker/login-action@v3
           with:


### PR DESCRIPTION
## Summary

Add checkout step to Docker Hub publishing workflow to ensure the repository is available for subsequent steps.

## Changes

- Added a checkout step using `actions/checkout@v4` to the Docker Hub publishing workflow before the login action
- This ensures the repository content is available for the Docker build process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the Docker Hub publishing workflow completes successfully:

```sh
# Trigger the workflow manually or through a release
# Check that the Docker image is published correctly to Docker Hub
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes Docker Hub publishing workflow failures due to missing repository checkout

## Security considerations

No security implications as this only affects the CI/CD pipeline.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable