### PR TITLE
fix: base provider level request level restriction and updated custom provider docs for go SDK

### DIFF
--- a/docs/features/custom-providers.mdx
+++ b/docs/features/custom-providers.mdx
@@ -109,6 +109,73 @@ curl --location 'http://localhost:8080/api/providers' \
 
 </Tab>
 
+<Tab title="Using Go SDK">
+
+```go
+type MyAccount struct{}
+
+const OpenAICustom = schemas.ModelProvider("openai-custom")
+
+func (a *MyAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
+    return []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic, OpenAICustom}, nil
+}
+
+func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.ModelProvider) ([]schemas.Key, error) {
+    switch provider {
+    case schemas.OpenAI:
+        return []schemas.Key{{
+            Value:  os.Getenv("OPENAI_API_KEY"),
+            Models: []string{},
+            Weight: 1.0,
+        }}, nil
+    case schemas.Anthropic:
+        return []schemas.Key{{
+            Value:  os.Getenv("ANTHROPIC_API_KEY"),
+            Models: []string{},
+            Weight: 1.0,
+        }}, nil
+    case OpenAICustom:
+        return []schemas.Key{{
+            Value:  os.Getenv("PROVIDER_API_KEY"),
+            Models: []string{},
+            Weight: 1.0,
+        }}, nil
+    }
+    return nil, fmt.Errorf("provider %s not supported", provider)
+}
+
+func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+    switch provider {
+        case OpenAICustom:
+            // Return config with base provider and allowed requests
+            return &schemas.ProviderConfig{
+                    NetworkConfig:            schemas.DefaultNetworkConfig,
+                    ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
+                    BaseProviderType: schemas.OpenAI,
+                    AllowedRequests: &schemas.AllowedRequests{
+                        TextCompletion:       false,
+                        ChatCompletion:       true,
+                        ChatCompletionStream: true,
+                        Embedding:            true,
+                        Speech:               false,
+                        SpeechStream:         false,
+                        Transcription:        false,
+                        TranscriptionStream:  false,
+                    },
+            }, nil
+        default: 
+            // Return default config for other providers
+            return &schemas.ProviderConfig{
+                    NetworkConfig:            schemas.DefaultNetworkConfig,
+                    ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
+            }, nil     
+    }
+}
+```
+
+
+</Tab>
+
 </Tabs>
 
 ## Configuration Options

--- a/ui/app/providers/configure/page.tsx
+++ b/ui/app/providers/configure/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { closeConfigureDialog, useAppDispatch, useAppSelector, useGetProvidersQuery } from "@/lib/store";
+import { closeConfigureDialog, setSelectedProvider, useAppDispatch, useAppSelector, useGetProvidersQuery } from "@/lib/store";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import ProviderForm from "./provider-form";
 
 export default function ConfigurePage() {
@@ -9,6 +10,16 @@ export default function ConfigurePage() {
 	const dispatch = useAppDispatch();
 	const selectedProvider = useAppSelector((state) => state.provider.selectedProvider);
 	const { data: providersData, refetch } = useGetProvidersQuery();
+
+	// Auto-select first available provider when no provider is selected and data is loaded
+	useEffect(() => {
+		if (!selectedProvider && providersData?.providers && providersData.providers.length > 0) {
+			const providerToSelect = providersData.providers[0];
+
+			// Update Redux state to select this provider
+			dispatch(setSelectedProvider(providerToSelect));
+		}
+	}, [selectedProvider, providersData?.providers, dispatch]);
 
 	const handleSave = () => {
 		refetch();

--- a/ui/app/providers/views/providers-list.tsx
+++ b/ui/app/providers/views/providers-list.tsx
@@ -156,7 +156,7 @@ export default function ProvidersList({ providers, onRefresh }: ProvidersListPro
 														)}
 													</Button>
 												</AlertDialogTrigger>
-												<AlertDialogContent onClick={(e) => e.stopPropagation()}>
+												<AlertDialogContent className="bg-secondary" onClick={(e) => e.stopPropagation()}>
 													<AlertDialogHeader>
 														<AlertDialogTitle>Delete Provider</AlertDialogTitle>
 														<AlertDialogDescription>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -29,3 +29,73 @@ export const DEFAULT_ALLOWED_REQUESTS = {
 	transcription: true,
 	transcription_stream: true,
 } as const satisfies Required<AllowedRequests>;
+
+// Define the default allowed requests for each provider type
+// This is based on the actual capabilities of each provider
+export const PROVIDER_DEFAULT_ALLOWED_REQUESTS: Record<string, AllowedRequests> = {
+	// OpenAI
+	openai: {
+		text_completion: false,
+		chat_completion: true,
+		chat_completion_stream: true,
+		embedding: true,
+		speech: true,
+		speech_stream: true,
+		transcription: true,
+		transcription_stream: true,
+	},
+
+	// Anthropic
+	anthropic: {
+		text_completion: true,
+		chat_completion: true,
+		chat_completion_stream: true,
+		embedding: false,
+		speech: false,
+		speech_stream: false,
+		transcription: false,
+		transcription_stream: false,
+	},
+
+	// Cohere
+	cohere: {
+		text_completion: false,
+		chat_completion: true,
+		chat_completion_stream: true,
+		embedding: true,
+		speech: false,
+		speech_stream: false,
+		transcription: false,
+		transcription_stream: false,
+	},
+
+	// AWS Bedrock
+	bedrock: {
+		text_completion: true,
+		chat_completion: true,
+		chat_completion_stream: true,
+		embedding: true,
+		speech: false,
+		speech_stream: false,
+		transcription: false,
+		transcription_stream: false,
+	},
+
+	// Gemini
+	gemini: {
+		text_completion: false,
+		chat_completion: true,
+		chat_completion_stream: true,
+		embedding: true,
+		speech: true,
+		speech_stream: true,
+		transcription: true,
+		transcription_stream: true,
+	},
+};
+
+// Helper function to get default allowed requests for a provider
+export const getProviderDefaultAllowedRequests = (providerName: string): AllowedRequests => {
+	const normalizedName = providerName.toLowerCase().trim();
+	return PROVIDER_DEFAULT_ALLOWED_REQUESTS[normalizedName] ?? (DEFAULT_ALLOWED_REQUESTS as AllowedRequests);
+};

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -1,18 +1,18 @@
 // Known provider names array - centralized definition
 export const KNOWN_PROVIDERS = [
-	"openai",
 	"anthropic",
 	"azure",
 	"bedrock",
+	"cerebras",
 	"cohere",
-	"vertex",
+	"gemini",
+	"groq",
 	"mistral",
 	"ollama",
-	"groq",
+	"openai",
 	"parasail",
 	"sgl",
-	"cerebras",
-	"gemini",
+	"vertex",
 ] as const;
 
 // Local Provider type derived from KNOWN_PROVIDERS constant


### PR DESCRIPTION
## Provider Capabilities and Validation for Custom Providers

Added a new system to define and validate provider capabilities, ensuring custom providers only enable operations supported by their base provider type.

## Changes

- Added `ProviderCapabilities` struct to define what operations each provider supports
- Implemented `GetProviderCapabilities` function to return capabilities for each provider type
- Created `ValidateAllowedRequests` function to automatically disable unsupported operations
- Updated UI to dynamically adjust allowed operations based on the selected base provider
- Added validation in HTTP handlers and config validation to ensure custom providers only enable supported operations
- Enhanced documentation with Go SDK example for custom providers
- Updated UI to disable checkboxes for unsupported operations

## Type of change

- [x] Feature
- [x] Refactor
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] UI (Next.js)
- [x] Docs

## How to test

1. Create a custom provider with different base provider types and observe how the allowed operations change
2. Try to enable unsupported operations and verify they are automatically disabled
3. Test with the Go SDK example from the documentation

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] No

## Security considerations

This change improves system integrity by preventing custom providers from attempting operations not supported by their base provider.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)