### PR TITLE
chore: corrected function call of Ptr

### DIFF
--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -438,7 +438,7 @@ func (provider *VertexProvider) handleVertexEmbedding(ctx context.Context, model
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: schemas.ErrorField{
-					Type:    StrPtr(schemas.RequestCancelled),
+					Type:    Ptr(schemas.RequestCancelled),
 					Message: fmt.Sprintf("Request cancelled or timed out by context: %v", ctx.Err()),
 					Error:   err,
 				},


### PR DESCRIPTION
## Summary

Replace `StrPtr` with `Ptr` in Vertex provider error handling to maintain consistency in pointer creation functions.

## Changes

- Updated the error handling in `handleVertexEmbedding` to use the `Ptr` function instead of `StrPtr` when setting the error type
- This change ensures consistent usage of pointer creation helper functions throughout the codebase

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that error handling in the Vertex provider still works correctly:

```sh
# Core/Transports
go version
go test ./core/providers/vertex_test.go
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a simple function name change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable