### PR TITLE
fix: updated function calls to new version passing context

### DIFF
--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -438,7 +438,7 @@ func (provider *VertexProvider) handleVertexEmbedding(ctx context.Context, model
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: schemas.ErrorField{
-					Type:    StrPtr(schemas.RequestCancelled),
+					Type:    Ptr(schemas.RequestCancelled),
 					Message: fmt.Sprintf("Request cancelled or timed out by context: %v", ctx.Err()),
 					Error:   err,
 				},

--- a/tests/core-chatbot/main.go
+++ b/tests/core-chatbot/main.go
@@ -14,6 +14,8 @@ import (
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	// "github.com/maximhq/bifrost/core/schemas/meta" // FIXME: meta package doesn't exist
 )
 
@@ -270,7 +272,7 @@ func NewChatSession(config ChatbotConfig) (*ChatSession, error) {
 
 	}
 
-	client, err := bifrost.Init(schemas.BifrostConfig{
+	client, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
 		Account:   account,
 		Plugins:   []schemas.Plugin{}, // No separate plugins needed - MCP is integrated
 		Logger:    bifrost.NewDefaultLogger(schemas.LogLevelInfo),
@@ -727,7 +729,7 @@ func (s *ChatSession) PrintHistory() {
 			content = strings.Join(textParts, "\n")
 		}
 
-		role := strings.Title(string(msg.Role))
+		role := cases.Title(language.English).String(string(msg.Role))
 		timestamp := fmt.Sprintf("[%d]", i)
 
 		fmt.Printf("%s %s: %s\n\n", timestamp, role, content)
@@ -737,7 +739,7 @@ func (s *ChatSession) PrintHistory() {
 // Cleanup closes the chat session and cleans up resources
 func (s *ChatSession) Cleanup() {
 	if s.client != nil {
-		s.client.Cleanup()
+		s.client.Shutdown()
 	}
 }
 

--- a/tests/core-providers/anthropic_test.go
+++ b/tests/core-providers/anthropic_test.go
@@ -14,7 +14,7 @@ func TestAnthropic(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Anthropic,

--- a/tests/core-providers/azure_test.go
+++ b/tests/core-providers/azure_test.go
@@ -14,7 +14,7 @@ func TestAzure(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Azure,

--- a/tests/core-providers/bedrock_test.go
+++ b/tests/core-providers/bedrock_test.go
@@ -19,7 +19,7 @@ func TestBedrock(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Bedrock,

--- a/tests/core-providers/cerebras_test.go
+++ b/tests/core-providers/cerebras_test.go
@@ -14,7 +14,7 @@ func TestCerebras(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Cerebras,

--- a/tests/core-providers/cohere_test.go
+++ b/tests/core-providers/cohere_test.go
@@ -14,7 +14,7 @@ func TestCohere(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Cohere,

--- a/tests/core-providers/config/setup.go
+++ b/tests/core-providers/config/setup.go
@@ -31,11 +31,11 @@ const (
 // The function:
 //  1. Creates a comprehensive test account instance
 //  2. Configures Bifrost with the account and default logger
-func getBifrost() (*bifrost.Bifrost, error) {
+func getBifrost(ctx context.Context) (*bifrost.Bifrost, error) {
 	account := ComprehensiveTestAccount{}
 
 	// Initialize Bifrost
-	b, err := bifrost.Init(schemas.BifrostConfig{
+	b, err := bifrost.Init(ctx, schemas.BifrostConfig{
 		Account: &account,
 		Plugins: nil,
 		Logger:  bifrost.NewDefaultLogger(schemas.LogLevelDebug),
@@ -49,11 +49,12 @@ func getBifrost() (*bifrost.Bifrost, error) {
 
 // SetupTest initializes a test environment with timeout context
 func SetupTest() (*bifrost.Bifrost, context.Context, context.CancelFunc, error) {
-	client, err := getBifrost()
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
+	client, err := getBifrost(ctx)
 	if err != nil {
+		cancel()
 		return nil, nil, nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	return client, ctx, cancel, nil
 }

--- a/tests/core-providers/custom_test.go
+++ b/tests/core-providers/custom_test.go
@@ -18,7 +18,7 @@ func TestCustomProvider(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  config.ProviderOpenAICustom,
@@ -60,7 +60,7 @@ func TestCustomProvider_DisallowedOperation(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 
 	// Create a speech request to the custom provider
@@ -98,7 +98,7 @@ func TestCustomProvider_MismatchedIdentity(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	// Use a provider that doesn't exist
 	wrongProvider := schemas.ModelProvider("wrong-provider")

--- a/tests/core-providers/gemini_test.go
+++ b/tests/core-providers/gemini_test.go
@@ -19,7 +19,7 @@ func TestGemini(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Gemini,

--- a/tests/core-providers/groq_test.go
+++ b/tests/core-providers/groq_test.go
@@ -14,7 +14,7 @@ func TestGroq(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Groq,

--- a/tests/core-providers/mistral_test.go
+++ b/tests/core-providers/mistral_test.go
@@ -14,7 +14,7 @@ func TestMistral(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Mistral,

--- a/tests/core-providers/ollama_test.go
+++ b/tests/core-providers/ollama_test.go
@@ -14,7 +14,7 @@ func TestOllama(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Ollama,

--- a/tests/core-providers/openai_test.go
+++ b/tests/core-providers/openai_test.go
@@ -14,7 +14,7 @@ func TestOpenAI(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.OpenAI,

--- a/tests/core-providers/parasail_test.go
+++ b/tests/core-providers/parasail_test.go
@@ -14,7 +14,7 @@ func TestParasail(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Parasail,

--- a/tests/core-providers/sgl_test.go
+++ b/tests/core-providers/sgl_test.go
@@ -14,7 +14,7 @@ func TestSGL(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.SGL,

--- a/tests/core-providers/vertex_test.go
+++ b/tests/core-providers/vertex_test.go
@@ -14,7 +14,7 @@ func TestVertex(t *testing.T) {
 		t.Fatalf("Error initializing test setup: %v", err)
 	}
 	defer cancel()
-	defer client.Cleanup()
+	defer client.Shutdown()
 
 	testConfig := config.ComprehensiveTestConfig{
 		Provider:  schemas.Vertex,


### PR DESCRIPTION
## Summary

Refactored Bifrost initialization to accept a context parameter and renamed client cleanup method from `Cleanup()` to `Shutdown()` for better semantic clarity.

## Changes

- Modified `bifrost.Init()` to accept a context parameter, allowing for better context propagation
- Renamed client cleanup method from `Cleanup()` to `Shutdown()` across all test files
- Updated `getBifrost()` function in test setup to accept and use the context parameter
- Changed `StrPtr` to `Ptr` in vertex.go error handling

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the test suite to ensure all tests pass with the updated initialization and shutdown methods:

```sh
# Core/Transports
go version
go test ./tests/core-providers/...
```

## Breaking changes

- [x] Yes
- [ ] No

The `bifrost.Init()` function now requires a context parameter, and client cleanup should use `Shutdown()` instead of `Cleanup()`.

## Security considerations

No security implications. This is a refactoring change to improve context handling and method naming.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally if applicable