### PR TITLE
fixes skipped condition for release guard in github workflow

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -78,7 +78,7 @@ jobs:
 
   framework-release:
     needs: [detect-changes, core-release]
-    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
+    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -126,7 +126,7 @@ jobs:
 
   plugins-release:
     needs: [detect-changes, core-release, framework-release]
-    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
+    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -181,7 +181,7 @@ jobs:
 
   bifrost-http-release:
     needs: [detect-changes, core-release, framework-release, plugins-release]
-    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
+    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -239,7 +239,7 @@ jobs:
   # Docker build amd64
   docker-build-amd64:
     needs: [detect-changes, bifrost-http-release]
-    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -282,7 +282,7 @@ jobs:
   # Docker build arm64
   docker-build-arm64:
       needs: [detect-changes, bifrost-http-release]
-      if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+      if: "!contains(github.event.head_commit.message, '--skip-pipeline') && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
       runs-on: ubuntu-24.04-arm
       permissions:
         contents: write


### PR DESCRIPTION
## Summary

Optimize release pipeline workflow by allowing jobs to run immediately when their dependencies don't need changes.

## Changes

- Modified conditional checks in the release pipeline to allow jobs to run when their dependencies don't need to be released
- Added checks for `needs.detect-changes.outputs.*-needs-release == 'false'` in the conditional logic for framework, plugins, bifrost-http, and docker build jobs
- This allows jobs to proceed immediately when their dependencies don't need changes rather than waiting for skipped jobs to complete

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Trigger the release pipeline with changes that only affect one component and verify that dependent jobs run without waiting for skipped jobs:

```sh
# Make a change to only the framework component
# Push with a commit message that doesn't contain --skip-pipeline
git push origin main
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves CI/CD efficiency by reducing unnecessary waiting time between jobs.

## Security considerations

No security implications as this only affects the CI/CD pipeline flow.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable