### PR TITLE
fixes skip pipeline logic

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -19,8 +19,9 @@ jobs:
     steps:
       - name: Check if pipeline should be skipped
         id: check
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
           FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n 1)
           if [[ "$FIRST_LINE" == *"--skip-pipeline"* ]]; then
             echo "should-skip=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Refactored the GitHub Actions workflow to use an environment variable for the commit message instead of directly embedding it in the run command.

## Changes

- Moved the commit message from an inline variable in the `run` command to a proper environment variable declaration
- This improves readability and follows best practices for GitHub Actions workflows

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

This change can be verified by ensuring the GitHub Actions workflow still correctly identifies commits with the `--skip-pipeline` flag.

```sh
# Make a commit with the --skip-pipeline flag
git commit -m "Some change --skip-pipeline"

# Push and verify the workflow skips as expected
git push
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a minor refactoring of how environment variables are handled in the workflow.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable