### PR TITLE
fixed deps on each job for running

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -145,7 +145,7 @@ jobs:
 
   plugins-release:
     needs: [check-skip, detect-changes, core-release, framework-release]
-    if: "needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -200,7 +200,7 @@ jobs:
 
   bifrost-http-release:
     needs: [check-skip, detect-changes, core-release, framework-release, plugins-release]
-    if: "needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Modify the release pipeline workflow to ensure plugins and bifrost-http release jobs always run when needed, regardless of previous job statuses.

## Changes

- Added `always()` condition to the `plugins-release` job to ensure it runs when needed even if previous jobs fail
- Added `always()` condition to the `bifrost-http-release` job for the same reason
- This ensures that all components can be released independently when they have changes

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the GitHub Actions workflow by triggering a release where multiple components have changes:

```sh
# Trigger a release with changes to plugins and bifrost-http
# Observe that both jobs run even if earlier jobs fail
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes release pipeline issues where some components weren't being released when they should be.

## Security considerations

No security implications as this only affects the release workflow.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified the CI pipeline passes locally if applicable