### PR TITLE
adds back docker flow as always

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -258,7 +258,7 @@ jobs:
   # Docker build amd64
   docker-build-amd64:
     needs: [check-skip, detect-changes, bifrost-http-release]
-    if: "needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -301,7 +301,7 @@ jobs:
   # Docker build arm64
   docker-build-arm64:
       needs: [check-skip, detect-changes, bifrost-http-release]
-      if: "needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+      if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
       runs-on: ubuntu-24.04-arm
       permissions:
         contents: write
@@ -344,7 +344,7 @@ jobs:
   # Docker manifest   
   docker-manifest:
       needs: [check-skip, detect-changes, docker-build-amd64, docker-build-arm64]
-      if: "needs.check-skip.outputs.should-skip != 'true' && needs.docker-build-amd64.result == 'success' && needs.docker-build-arm64.result == 'success'"
+      if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.docker-build-amd64.result == 'success' && needs.docker-build-arm64.result == 'success'"
       runs-on: ubuntu-latest
       env:
         REGISTRY: docker.io


### PR DESCRIPTION
## Summary

Add `always()` condition to Docker build jobs in the release pipeline to ensure they run regardless of the status of other jobs.

## Changes

- Added `always()` condition to the `if` statements in `docker-build-amd64`, `docker-build-arm64`, and `docker-manifest` jobs
- This ensures Docker builds will attempt to run even if other jobs in the workflow have failed
- The original conditional logic is preserved alongside the new `always()` condition

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] CI/CD

## How to test

Trigger the release pipeline workflow and verify that Docker build jobs run even if previous jobs fail:

```sh
# Manually trigger the workflow from GitHub Actions UI
# Or push a tag that triggers the release pipeline
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses issues with Docker builds being skipped when other parts of the pipeline fail.

## Security considerations

No security implications as this only affects CI/CD workflow behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable