### PR TITLE
fix: individual crud funtions for providers

### DIFF
--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -19,6 +19,9 @@ type ConfigStore interface {
 
 	// Provider config CRUD
 	UpdateProvidersConfig(providers map[schemas.ModelProvider]ProviderConfig) error
+	AddProvider(provider schemas.ModelProvider, config ProviderConfig, envKeys map[string][]EnvKeyInfo) error
+	UpdateProvider(provider schemas.ModelProvider, config ProviderConfig, envKeys map[string][]EnvKeyInfo) error
+	DeleteProvider(provider schemas.ModelProvider) error
 	GetProvidersConfig() (map[schemas.ModelProvider]ProviderConfig, error)
 
 	// MCP config CRUD

--- a/framework/configstore/utils.go
+++ b/framework/configstore/utils.go
@@ -1,0 +1,105 @@
+package configstore
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// deepCopy creates a deep copy of a given type
+func deepCopy[T any](in T) (T, error) {
+	var out T
+	b, err := json.Marshal(in)
+	if err != nil {
+		return out, err
+	}
+	err = json.Unmarshal(b, &out)
+	return out, err
+}
+
+// substituteEnvVars replaces resolved environment variable values with their original env.VAR_NAME references
+func substituteEnvVars(config *ProviderConfig, provider schemas.ModelProvider, envKeys map[string][]EnvKeyInfo) {
+	// Create a map for quick lookup of env vars by provider and key ID
+	envVarMap := make(map[string]string) // key: "provider.keyID.field" -> env var name
+
+	for envVar, keyInfos := range envKeys {
+		for _, keyInfo := range keyInfos {
+			if keyInfo.Provider == provider {
+				// For API keys
+				if keyInfo.KeyType == "api_key" {
+					envVarMap[fmt.Sprintf("%s.%s.value", provider, keyInfo.KeyID)] = envVar
+				}
+				// For Azure config
+				if keyInfo.KeyType == "azure_config" {
+					field := strings.TrimPrefix(keyInfo.ConfigPath, fmt.Sprintf("providers.%s.keys[%s].azure_key_config.", provider, keyInfo.KeyID))
+					envVarMap[fmt.Sprintf("%s.%s.azure.%s", provider, keyInfo.KeyID, field)] = envVar
+				}
+				// For Vertex config
+				if keyInfo.KeyType == "vertex_config" {
+					field := strings.TrimPrefix(keyInfo.ConfigPath, fmt.Sprintf("providers.%s.keys[%s].vertex_key_config.", provider, keyInfo.KeyID))
+					envVarMap[fmt.Sprintf("%s.%s.vertex.%s", provider, keyInfo.KeyID, field)] = envVar
+				}
+				// For Bedrock config
+				if keyInfo.KeyType == "bedrock_config" {
+					field := strings.TrimPrefix(keyInfo.ConfigPath, fmt.Sprintf("providers.%s.keys[%s].bedrock_key_config.", provider, keyInfo.KeyID))
+					envVarMap[fmt.Sprintf("%s.%s.bedrock.%s", provider, keyInfo.KeyID, field)] = envVar
+				}
+			}
+		}
+	}
+
+	// Substitute values in keys
+	for i, key := range config.Keys {
+		keyPrefix := fmt.Sprintf("%s.%s", provider, key.ID)
+
+		// Substitute API key value
+		if envVar, exists := envVarMap[fmt.Sprintf("%s.value", keyPrefix)]; exists {
+			config.Keys[i].Value = fmt.Sprintf("env.%s", envVar)
+		}
+
+		// Substitute Azure config
+		if key.AzureKeyConfig != nil {
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.azure.endpoint", keyPrefix)]; exists {
+				config.Keys[i].AzureKeyConfig.Endpoint = fmt.Sprintf("env.%s", envVar)
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.azure.api_version", keyPrefix)]; exists {
+				apiVersion := fmt.Sprintf("env.%s", envVar)
+				config.Keys[i].AzureKeyConfig.APIVersion = &apiVersion
+			}
+		}
+
+		// Substitute Vertex config
+		if key.VertexKeyConfig != nil {
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.vertex.project_id", keyPrefix)]; exists {
+				config.Keys[i].VertexKeyConfig.ProjectID = fmt.Sprintf("env.%s", envVar)
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.vertex.region", keyPrefix)]; exists {
+				config.Keys[i].VertexKeyConfig.Region = fmt.Sprintf("env.%s", envVar)
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.vertex.auth_credentials", keyPrefix)]; exists {
+				config.Keys[i].VertexKeyConfig.AuthCredentials = fmt.Sprintf("env.%s", envVar)
+			}
+		}
+
+		// Substitute Bedrock config
+		if key.BedrockKeyConfig != nil {
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.bedrock.access_key", keyPrefix)]; exists {
+				config.Keys[i].BedrockKeyConfig.AccessKey = fmt.Sprintf("env.%s", envVar)
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.bedrock.secret_key", keyPrefix)]; exists {
+				config.Keys[i].BedrockKeyConfig.SecretKey = fmt.Sprintf("env.%s", envVar)
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.bedrock.session_token", keyPrefix)]; exists {
+				config.Keys[i].BedrockKeyConfig.SessionToken = &[]string{fmt.Sprintf("env.%s", envVar)}[0]
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.bedrock.region", keyPrefix)]; exists {
+				config.Keys[i].BedrockKeyConfig.Region = &[]string{fmt.Sprintf("env.%s", envVar)}[0]
+			}
+			if envVar, exists := envVarMap[fmt.Sprintf("%s.bedrock.arn", keyPrefix)]; exists {
+				config.Keys[i].BedrockKeyConfig.ARN = &[]string{fmt.Sprintf("env.%s", envVar)}[0]
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Added environment variable support for provider configurations and improved provider CRUD operations in the SQLite config store.

## Changes

- Added `processEnvValue` function to handle environment variable references in configuration values
- Implemented granular provider CRUD operations in SQLite config store:
  - `AddProvider`: Creates a new provider configuration
  - `UpdateProvider`: Updates an existing provider without recreating all providers
  - `DeleteProvider`: Removes a provider and its associated keys
- Updated the HTTP transport to use these new specific methods instead of the generic `UpdateProvidersConfig`
- Added environment variable processing for provider keys and their configurations (Azure, Vertex, Bedrock)

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Test environment variable support
export MY_API_KEY="test-key-value"
# Configure a provider with "env.MY_API_KEY" as the key value
# Verify the key is properly resolved when retrieved

# Test provider CRUD operations
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

## Breaking changes

- [x] No

## Security considerations

This change improves security by allowing API keys and other sensitive configuration to be stored as environment variables rather than directly in the database.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)