### PR TITLE
refactor: stream end indicator added to context

### DIFF
--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -42,12 +42,6 @@ type BedrockKeyConfig struct {
 	Deployments  map[string]string `json:"deployments,omitempty"`   // Mapping of model identifiers to inference profiles
 }
 
-type BifrostContext string
-
-const (
-	BifrostContextKey BifrostContext = "bifrost-key"
-)
-
 // Account defines the interface for managing provider accounts and their configurations.
 // It provides methods to access provider-specific settings, API keys, and configurations.
 type Account interface {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -79,6 +79,30 @@ var StandardProviders = []ModelProvider{
 	Vertex,
 }
 
+// RequestType represents the type of request being made to a provider.
+type RequestType string
+
+const (
+	TextCompletionRequest       RequestType = "text_completion"
+	ChatCompletionRequest       RequestType = "chat_completion"
+	ChatCompletionStreamRequest RequestType = "chat_completion_stream"
+	EmbeddingRequest            RequestType = "embedding"
+	SpeechRequest               RequestType = "speech"
+	SpeechStreamRequest         RequestType = "speech_stream"
+	TranscriptionRequest        RequestType = "transcription"
+	TranscriptionStreamRequest  RequestType = "transcription_stream"
+)
+
+// BifrostContextKey is a type for context keys used in Bifrost.
+type BifrostContextKey string
+
+// BifrostContextKeyRequestType is a context key for the request type.
+const (
+	BifrostContextKeyDirectKey          BifrostContextKey = "bifrost-direct-key"
+	BifrostContextKeyStreamEndIndicator BifrostContextKey = "bifrost-stream-end-indicator"
+	BifrostContextKeyRequestType        BifrostContextKey = "bifrost-request-type"
+)
+
 //* Request Structs
 
 // RequestInput represents the input for a model request, which can be either
@@ -164,7 +188,7 @@ type TranscriptionInput struct {
 	Language       *string `json:"language,omitempty"`
 	Prompt         *string `json:"prompt,omitempty"`
 	ResponseFormat *string `json:"response_format,omitempty"` // Default is "json"
-	Format     *string `json:"file_format,omitempty"`// Type of file, not required in openai, but required in gemini
+	Format         *string `json:"file_format,omitempty"`     // Type of file, not required in openai, but required in gemini
 }
 
 // BifrostRequest represents a request to be processed by Bifrost.
@@ -369,17 +393,16 @@ func (mc *MessageContent) UnmarshalJSON(data []byte) error {
 type ContentBlockType string
 
 const (
-	ContentBlockTypeText  ContentBlockType = "text"
-	ContentBlockTypeImage ContentBlockType = "image_url"
+	ContentBlockTypeText       ContentBlockType = "text"
+	ContentBlockTypeImage      ContentBlockType = "image_url"
 	ContentBlockTypeInputAudio ContentBlockType = "input_audio"
 )
 
 type ContentBlock struct {
-	Type     ContentBlockType `json:"type"`
-	Text     *string          `json:"text,omitempty"`
-	ImageURL *ImageURLStruct  `json:"image_url,omitempty"`
-	InputAudio *InputAudioStruct  `json:"input_audio,omitempty"`
-
+	Type       ContentBlockType  `json:"type"`
+	Text       *string           `json:"text,omitempty"`
+	ImageURL   *ImageURLStruct   `json:"image_url,omitempty"`
+	InputAudio *InputAudioStruct `json:"input_audio,omitempty"`
 }
 
 // ToolMessage represents a message from a tool
@@ -405,7 +428,7 @@ type ImageURLStruct struct {
 // Data carries the audio payload as a string (e.g., data URL or provider-accepted encoded content).
 // Format is optional (e.g., "wav", "mp3"); when nil, providers may attempt auto-detection.
 type InputAudioStruct struct {
-	Data string `json:"data"`
+	Data   string  `json:"data"`
 	Format *string `json:"format,omitempty"`
 }
 

--- a/core/utils.go
+++ b/core/utils.go
@@ -50,8 +50,8 @@ func canProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
 }
 
 // isStreamRequestType returns true if the given request type is a stream request.
-func isStreamRequestType(reqType RequestType) bool {
-	return reqType == ChatCompletionStreamRequest || reqType == SpeechStreamRequest || reqType == TranscriptionStreamRequest
+func isStreamRequestType(reqType schemas.RequestType) bool {
+	return reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionStreamRequest
 }
 
 // calculateBackoff implements exponential backoff with jitter for retry attempts.

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -116,7 +116,7 @@ func makeRequestWithDirectKey() {
         Value:  "sk-direct-api-key",
         Weight: 1.0,
     }
-    ctx = context.WithValue(ctx, schemas.BifrostContextKey, directKey)
+    ctx = context.WithValue(ctx, schemas.BifrostContextKeyDirectKey, directKey)
     
     response, err := client.ChatCompletion(ctx, &schemas.BifrostRequest{
         Provider: schemas.OpenAI,
@@ -212,7 +212,7 @@ For cloud providers with deployment-based routing, Bifrost validates deployment 
 For scenarios requiring explicit key control, Bifrost supports bypassing the entire key management system:
 
 **Go SDK Context Override:**
-Pass a key directly in the request context using `schemas.BifrostContextKey`. This completely bypasses provider key lookup and selection.
+Pass a key directly in the request context using `schemas.BifrostContextKeyDirectKey`. This completely bypasses provider key lookup and selection.
 
 **Gateway Header-based Keys:**
 Send API keys in `Authorization` (Bearer) or `x-api-key` headers. Requires `allow_direct_keys` setting to be enabled.

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -101,7 +101,7 @@ func (p *GovernancePlugin) PreHook(ctx *context.Context, req *schemas.BifrostReq
 	// Extract governance headers and virtual key using utility functions
 	headers := extractHeadersFromContext(*ctx)
 	virtualKey := getStringFromContext(*ctx, ContextKey("x-bf-vk"))
-	requestID := getStringFromContext(*ctx, bifrost.BifrostContextKey("request-id"))
+	requestID := getStringFromContext(*ctx, schemas.BifrostContextKey("request-id"))
 
 	if virtualKey == "" {
 		if p.isVkMandatory != nil && *p.isVkMandatory {
@@ -215,7 +215,7 @@ func (p *GovernancePlugin) PostHook(ctx *context.Context, result *schemas.Bifros
 	// Extract governance information
 	headers := extractHeadersFromContext(*ctx)
 	virtualKey := getStringFromContext(*ctx, ContextKey("x-bf-vk"))
-	requestID := getStringFromContext(*ctx, bifrost.BifrostContextKey("request-id"))
+	requestID := getStringFromContext(*ctx, schemas.BifrostContextKey("request-id"))
 
 	// Skip if no virtual key
 	if virtualKey == "" {

--- a/plugins/jsonparser/main.go
+++ b/plugins/jsonparser/main.go
@@ -165,7 +165,7 @@ func (p *JsonParserPlugin) getRequestID(ctx *context.Context, result *schemas.Bi
 
 	// Try to get from context if not available in result
 	if ctx != nil {
-		if requestID, ok := (*ctx).Value(bifrost.BifrostContextKey("request-id")).(string); ok && requestID != "" {
+		if requestID, ok := (*ctx).Value(schemas.BifrostContextKey("request-id")).(string); ok && requestID != "" {
 			return requestID
 		}
 	}

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 )
@@ -255,7 +254,7 @@ func (p *LoggerPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest
 	}
 
 	// Extract request ID from context
-	requestID, ok := (*ctx).Value(bifrost.BifrostContextKey("request-id")).(string)
+	requestID, ok := (*ctx).Value(schemas.BifrostContextKey("request-id")).(string)
 	if !ok || requestID == "" {
 		// Log error but don't fail the request
 		p.logger.Error("request-id not found in context or is empty")
@@ -337,7 +336,7 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 	}
 
 	// Extract request ID from context
-	requestID, ok := (*ctx).Value(bifrost.BifrostContextKey("request-id")).(string)
+	requestID, ok := (*ctx).Value(schemas.BifrostContextKey("request-id")).(string)
 	if !ok || requestID == "" {
 		// Log error but don't fail the request
 		p.logger.Error("request-id not found in context or is empty")
@@ -345,13 +344,13 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 	}
 
 	// Check if this is a streaming response
-	requestType, ok := (*ctx).Value(bifrost.BifrostContextKeyRequestType).(bifrost.RequestType)
+	requestType, ok := (*ctx).Value(schemas.BifrostContextKeyRequestType).(schemas.RequestType)
 	if !ok {
 		p.logger.Error("request type missing/invalid in PostHook for request %s", requestID)
 		return result, err, nil
 	}
-	isAudioStreaming := requestType == bifrost.SpeechStreamRequest || requestType == bifrost.TranscriptionStreamRequest
-	isChatStreaming := requestType == bifrost.ChatCompletionStreamRequest
+	isAudioStreaming := requestType == schemas.SpeechStreamRequest || requestType == schemas.TranscriptionStreamRequest
+	isChatStreaming := requestType == schemas.ChatCompletionStreamRequest
 
 	// Queue the log update message (non-blocking) - use same pattern for both streaming and regular
 	logMsg := p.getLogMessage()

--- a/plugins/logging/streaming.go
+++ b/plugins/logging/streaming.go
@@ -295,7 +295,7 @@ func (p *LoggerPlugin) cleanupOldStreamAccumulators() {
 
 // handleStreamingResponse handles streaming responses with ordered accumulation
 func (p *LoggerPlugin) handleStreamingResponse(ctx *context.Context, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
-	requestID, ok := (*ctx).Value(bifrost.BifrostContextKey("request-id")).(string)
+	requestID, ok := (*ctx).Value(schemas.BifrostContextKey("request-id")).(string)
 	if !ok || requestID == "" {
 		p.logger.Error("request-id not found in context or is empty")
 		return result, err, nil

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -349,7 +349,7 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 	*ctx = context.WithValue(*ctx, requestModelKey, req.Model)
 	*ctx = context.WithValue(*ctx, requestProviderKey, req.Provider)
 
-	requestType, ok := (*ctx).Value(bifrost.BifrostContextKeyRequestType).(bifrost.RequestType)
+	requestType, ok := (*ctx).Value(schemas.BifrostContextKeyRequestType).(schemas.RequestType)
 	if !ok {
 		return req, nil, nil
 	}
@@ -445,7 +445,7 @@ func (plugin *Plugin) PostHook(ctx *context.Context, res *schemas.BifrostRespons
 	}
 
 	// Get the request type from context
-	requestType, ok := (*ctx).Value(bifrost.BifrostContextKeyRequestType).(bifrost.RequestType)
+	requestType, ok := (*ctx).Value(schemas.BifrostContextKeyRequestType).(schemas.RequestType)
 	if !ok {
 		return res, nil, nil
 	}
@@ -483,7 +483,7 @@ func (plugin *Plugin) PostHook(ctx *context.Context, res *schemas.BifrostRespons
 	}
 
 	// Get embedding from context if available and needed
-	if shouldStoreEmbeddings && requestType != bifrost.EmbeddingRequest && requestType != bifrost.TranscriptionRequest {
+	if shouldStoreEmbeddings && requestType != schemas.EmbeddingRequest && requestType != schemas.TranscriptionRequest {
 		embeddingValue := (*ctx).Value(requestEmbeddingKey)
 		if embeddingValue != nil {
 			embedding, ok = embeddingValue.([]float32)

--- a/plugins/semanticcache/plugin_integration_test.go
+++ b/plugins/semanticcache/plugin_integration_test.go
@@ -20,7 +20,7 @@ func TestSemanticCacheBasicFlow(t *testing.T) {
 
 	// Add cache key to context
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	// Test request
 	request := &schemas.BifrostRequest{
@@ -107,7 +107,7 @@ func TestSemanticCacheBasicFlow(t *testing.T) {
 	// Reset context for second request
 	ctx2 := context.Background()
 	ctx2 = context.WithValue(ctx2, CacheKey, "test-cache-enabled")
-	ctx2 = context.WithValue(ctx2, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx2 = context.WithValue(ctx2, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	modifiedReq2, shortCircuit2, err := setup.Plugin.PreHook(&ctx2, request)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	// Base request
 	baseRequest := &schemas.BifrostRequest{
@@ -229,7 +229,7 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 
 	ctx2 := context.Background()
 	ctx2 = context.WithValue(ctx2, CacheKey, "test-cache-enabled")
-	ctx2 = context.WithValue(ctx2, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx2 = context.WithValue(ctx2, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	modifiedRequest := *baseRequest
 	modifiedRequest.Params = &schemas.ModelParameters{
@@ -253,7 +253,7 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 
 	ctx3 := context.Background()
 	ctx3 = context.WithValue(ctx3, CacheKey, "test-cache-enabled")
-	ctx3 = context.WithValue(ctx3, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx3 = context.WithValue(ctx3, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	modifiedRequest2 := *baseRequest
 	modifiedRequest2.Model = "gpt-3.5-turbo" // Different model
@@ -278,7 +278,7 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionStreamRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionStreamRequest)
 
 	request := &schemas.BifrostRequest{
 		Provider: schemas.OpenAI,
@@ -360,7 +360,7 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 
 	ctx2 := context.Background()
 	ctx2 = context.WithValue(ctx2, CacheKey, "test-cache-enabled")
-	ctx2 = context.WithValue(ctx2, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionStreamRequest)
+	ctx2 = context.WithValue(ctx2, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionStreamRequest)
 
 	_, shortCircuit2, err := setup.Plugin.PreHook(&ctx2, request)
 	if err != nil {
@@ -405,7 +405,7 @@ func TestSemanticCache_NoCacheWhenKeyMissing(t *testing.T) {
 
 	ctx := context.Background()
 	// Don't set the cache key - cache should be disabled
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	request := &schemas.BifrostRequest{
 		Provider: schemas.OpenAI,
@@ -444,7 +444,7 @@ func TestSemanticCache_CustomTTLHandling(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
 	ctx = context.WithValue(ctx, CacheTTLKey, 1*time.Minute) // Custom TTL
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	request := &schemas.BifrostRequest{
 		Provider: schemas.OpenAI,
@@ -510,7 +510,7 @@ func TestSemanticCache_CustomThresholdHandling(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
 	ctx = context.WithValue(ctx, CacheThresholdKey, 0.95) // Very high threshold
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	request := &schemas.BifrostRequest{
 		Provider: schemas.OpenAI,
@@ -551,7 +551,7 @@ func TestSemanticCache_ProviderModelCachingFlags(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	request1 := &schemas.BifrostRequest{
 		Provider: schemas.OpenAI,
@@ -623,7 +623,7 @@ func TestSemanticCache_ProviderModelCachingFlags(t *testing.T) {
 
 	ctx2 := context.Background()
 	ctx2 = context.WithValue(ctx2, CacheKey, "test-cache-enabled")
-	ctx2 = context.WithValue(ctx2, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx2 = context.WithValue(ctx2, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	_, shortCircuit2, err := setup.Plugin.PreHook(&ctx2, request2)
 	if err != nil {
@@ -646,7 +646,7 @@ func TestSemanticCache_ConfigurationEdgeCases(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, CacheKey, "test-cache-enabled")
 	ctx = context.WithValue(ctx, CacheTTLKey, "not-a-duration") // Invalid TTL type
-	ctx = context.WithValue(ctx, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	request := &schemas.BifrostRequest{
 		Provider: schemas.OpenAI,
@@ -677,7 +677,7 @@ func TestSemanticCache_ConfigurationEdgeCases(t *testing.T) {
 	ctx2 := context.Background()
 	ctx2 = context.WithValue(ctx2, CacheKey, "test-cache-enabled")
 	ctx2 = context.WithValue(ctx2, CacheThresholdKey, "not-a-float") // Invalid threshold type
-	ctx2 = context.WithValue(ctx2, bifrost.BifrostContextKeyRequestType, bifrost.ChatCompletionRequest)
+	ctx2 = context.WithValue(ctx2, schemas.BifrostContextKeyRequestType, schemas.ChatCompletionRequest)
 
 	// Should handle invalid threshold gracefully
 	_, shortCircuit2, err := setup.Plugin.PreHook(&ctx2, request)

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -7,12 +7,11 @@ import (
 	"fmt"
 	"time"
 
-	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
-func (plugin *Plugin) performDirectSearch(ctx *context.Context, req *schemas.BifrostRequest, requestType bifrost.RequestType, cacheKey string) (*schemas.PluginShortCircuit, error) {
+func (plugin *Plugin) performDirectSearch(ctx *context.Context, req *schemas.BifrostRequest, requestType schemas.RequestType, cacheKey string) (*schemas.PluginShortCircuit, error) {
 	// Generate hash for the request
 	hash, err := plugin.generateRequestHash(req, requestType)
 	if err != nil {
@@ -80,7 +79,7 @@ func (plugin *Plugin) performDirectSearch(ctx *context.Context, req *schemas.Bif
 }
 
 // performSemanticSearch performs semantic similarity search and returns matching response if found.
-func (plugin *Plugin) performSemanticSearch(ctx *context.Context, req *schemas.BifrostRequest, requestType bifrost.RequestType, cacheKey string) (*schemas.PluginShortCircuit, error) {
+func (plugin *Plugin) performSemanticSearch(ctx *context.Context, req *schemas.BifrostRequest, requestType schemas.RequestType, cacheKey string) (*schemas.PluginShortCircuit, error) {
 	// Extract text and metadata for embedding
 	text, paramsHash, err := plugin.extractTextForEmbedding(req, requestType)
 	if err != nil {

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -76,7 +76,7 @@ func (plugin *Plugin) generateEmbedding(ctx context.Context, text string) ([]flo
 // Returns:
 //   - string: Hexadecimal representation of the xxhash
 //   - error: Any error that occurred during request normalization or hashing
-func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest, requestType bifrost.RequestType) (string, error) {
+func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest, requestType schemas.RequestType) (string, error) {
 	// Create a hash input structure that includes both input and parameters
 	hashInput := struct {
 		Input  schemas.RequestInput     `json:"input"`
@@ -101,7 +101,7 @@ func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest, requestTy
 
 // extractTextForEmbedding extracts meaningful text from different input types for embedding generation.
 // Returns the text to embed and metadata for storage.
-func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest, requestType bifrost.RequestType) (string, string, error) {
+func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest, requestType schemas.RequestType) (string, string, error) {
 	metadata := map[string]interface{}{}
 
 	attachments := []string{}
@@ -258,10 +258,10 @@ func getMetadataHash(metadata map[string]interface{}) (string, error) {
 }
 
 // isStreamingRequest checks if the request is a streaming request
-func (plugin *Plugin) isStreamingRequest(requestType bifrost.RequestType) bool {
-	return requestType == bifrost.ChatCompletionStreamRequest ||
-		requestType == bifrost.SpeechStreamRequest ||
-		requestType == bifrost.TranscriptionStreamRequest
+func (plugin *Plugin) isStreamingRequest(requestType schemas.RequestType) bool {
+	return requestType == schemas.ChatCompletionStreamRequest ||
+		requestType == schemas.SpeechStreamRequest ||
+		requestType == schemas.TranscriptionStreamRequest
 }
 
 // buildUnifiedMetadata constructs the unified metadata structure for VectorEntry

--- a/transports/bifrost-http/integrations/openai/router.go
+++ b/transports/bifrost-http/integrations/openai/router.go
@@ -79,7 +79,7 @@ func AzureEndpointPreHook(handlerStore lib.HandlerStore) func(ctx *fasthttp.Requ
 				key.AzureKeyConfig.APIVersion = &apiVersionStr
 			}
 
-			ctx.SetUserValue(string(schemas.BifrostContextKey), key)
+			ctx.SetUserValue(string(schemas.BifrostContextKeyDirectKey), key)
 
 			return nil
 		}

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -611,10 +611,10 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 		// Execute the request through Bifrost
 		bifrostCtx := lib.ConvertToBifrostContext(ctx, g.handlerStore.ShouldAllowDirectKeys())
 
-		if ctx.UserValue(string(schemas.BifrostContextKey)) != nil {
-			key, ok := ctx.UserValue(string(schemas.BifrostContextKey)).(schemas.Key)
+		if ctx.UserValue(string(schemas.BifrostContextKeyDirectKey)) != nil {
+			key, ok := ctx.UserValue(string(schemas.BifrostContextKeyDirectKey)).(schemas.Key)
 			if ok {
-				*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKey, key)
+				*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyDirectKey, key)
 			}
 		}
 

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/plugins/maxim"
@@ -76,7 +75,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool) *co
 	if requestID == "" {
 		requestID = uuid.New().String()
 	}
-	bifrostCtx = context.WithValue(bifrostCtx, bifrost.BifrostContextKey("request-id"), requestID)
+	bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey("request-id"), requestID)
 
 	// Then process other headers
 	ctx.Request.Header.VisitAll(func(key, value []byte) {
@@ -208,7 +207,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool) *co
 				Models: []string{}, // Empty models list - will be validated by provider
 				Weight: 1.0,        // Default weight
 			}
-			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey, key)
+			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKeyDirectKey, key)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Refactored request type constants and context keys by moving them from the core package to the schemas package for better organization and reusability across the codebase.

## Changes

- Moved `RequestType` enum and constants from `core/bifrost.go` to `schemas/bifrost.go`
- Moved `BifrostContextKey` type and constants from `core/bifrost.go` to `schemas/bifrost.go`
- Renamed `BifrostContextKey` to `BifrostContextKeyDirectKey` for clarity
- Added new context key `BifrostContextKeyStreamEndIndicator` to better handle stream termination
- Updated all references throughout the codebase to use the new schema-based constants
- Improved stream handling in providers (OpenAI, Gemini) to properly handle end-of-stream indicators
- Fixed audio and transcription streaming to properly send usage information at the end of streams

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Run the test suite to ensure all functionality works as expected:

```sh
# Core/Transports
go version
go test ./...
```

Additionally, test streaming endpoints with various providers to ensure proper stream termination and usage information:

```sh
# Test chat completion streaming
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello"}],"stream":true}'

# Test speech streaming
curl -X POST http://localhost:8080/v1/audio/speech \
  -H "Content-Type: application/json" \
  -d '{"model":"tts-1","input":"Hello world","voice":"alloy","stream":true}'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves stream handling and organization of context keys.

## Security considerations

No security implications as this is a refactoring of internal constants and stream handling.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)