### PR TITLE
fix: add always() condition to framework-release workflow

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -97,7 +97,7 @@ jobs:
 
   framework-release:
     needs: [check-skip, detect-changes, core-release]
-    if: "needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Added `always()` condition to the framework-release job in the GitHub Actions workflow to ensure it runs regardless of the status of dependent jobs.

## Changes

- Modified the conditional statement for the `framework-release` job by adding `always()` to ensure the job runs even if previous jobs fail
- This ensures the framework release process continues independently of other job statuses while still respecting the other required conditions

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the framework release job runs properly in the CI pipeline:

```sh
# Trigger the release pipeline and observe that the framework-release job
# runs even if other jobs have non-success statuses (as long as other conditions are met)
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only affects the CI/CD pipeline execution flow.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable