### PR TITLE
feat: add custom key selector and request latency tracking

### DIFF
--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -133,7 +133,7 @@ func handleOpenAITextCompletionRequest(
 	req.SetBody(jsonBody)
 
 	// Make request
-	bifrostErr := makeRequestWithContext(ctx, client, req, resp)
+	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -160,6 +160,7 @@ func handleOpenAITextCompletionRequest(
 	response.ExtraFields.Provider = providerName
 	response.ExtraFields.ModelRequested = request.Model
 	response.ExtraFields.RequestType = schemas.TextCompletionRequest
+	response.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
 	if sendBackRawResponse {
@@ -459,7 +460,7 @@ func handleOpenAIChatCompletionRequest(
 	req.SetBody(jsonBody)
 
 	// Make request
-	bifrostErr := makeRequestWithContext(ctx, client, req, resp)
+	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -491,6 +492,7 @@ func handleOpenAIChatCompletionRequest(
 	response.ExtraFields.Provider = providerName
 	response.ExtraFields.ModelRequested = request.Model
 	response.ExtraFields.RequestType = schemas.ChatCompletionRequest
+	response.ExtraFields.Latency = latency.Milliseconds()
 
 	return response, nil
 }
@@ -553,7 +555,7 @@ func handleOpenAIResponsesRequest(
 	req.SetBody(jsonBody)
 
 	// Make request
-	bifrostErr := makeRequestWithContext(ctx, client, req, resp)
+	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -585,6 +587,7 @@ func handleOpenAIResponsesRequest(
 	response.ExtraFields.Provider = providerName
 	response.ExtraFields.ModelRequested = request.Model
 	response.ExtraFields.RequestType = schemas.ResponsesRequest
+	response.ExtraFields.Latency = latency.Milliseconds()
 
 	return response, nil
 }
@@ -653,7 +656,7 @@ func handleOpenAIEmbeddingRequest(
 	req.SetBody(jsonBody)
 
 	// Make request
-	bifrostErr := makeRequestWithContext(ctx, client, req, resp)
+	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -678,6 +681,7 @@ func handleOpenAIEmbeddingRequest(
 	response.ExtraFields.Provider = providerName
 	response.ExtraFields.ModelRequested = request.Model
 	response.ExtraFields.RequestType = schemas.EmbeddingRequest
+	response.ExtraFields.Latency = latency.Milliseconds()
 
 	if sendBackRawResponse {
 		response.ExtraFields.RawResponse = rawResponse
@@ -969,7 +973,7 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 	req.SetBody(jsonBody)
 
 	// Make request
-	bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
+	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -996,6 +1000,7 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 			RequestType:    schemas.SpeechRequest,
 			Provider:       providerName,
 			ModelRequested: request.Model,
+			Latency:        latency.Milliseconds(),
 		},
 	}
 
@@ -1223,7 +1228,7 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 	req.SetBody(body.Bytes())
 
 	// Make request
-	bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
+	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -1260,6 +1265,7 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 			RequestType:    schemas.TranscriptionRequest,
 			Provider:       providerName,
 			ModelRequested: request.Model,
+			Latency:        latency.Milliseconds(),
 		},
 	}
 

--- a/core/schemas/providers/bedrock/chat.go
+++ b/core/schemas/providers/bedrock/chat.go
@@ -128,19 +128,12 @@ func (bedrockResp *BedrockConverseResponse) ToBifrostResponse() (*schemas.Bifros
 		}
 	}
 
-	// Calculate latency
-	var latency float64
-	if bedrockResp.Metrics != nil {
-		latency = float64(bedrockResp.Metrics.LatencyMs)
-	}
-
 	// Create the final Bifrost response
 	bifrostResponse := &schemas.BifrostResponse{
 		Choices: choices,
 		Usage:   usage,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType: schemas.ChatCompletionRequest,
-			Latency:     &latency,
 			Provider:    schemas.Bedrock,
 		},
 	}

--- a/framework/streaming/audio.go
+++ b/framework/streaming/audio.go
@@ -67,7 +67,7 @@ func (a *Accumulator) processAccumulatedAudioStreamingChunks(requestID string, b
 	if accumulator.StartTimestamp.IsZero() || accumulator.FinalTimestamp.IsZero() {
 		data.Latency = 0
 	} else {
-		data.Latency = float64(accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds()) / 1e6
+		data.Latency = accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds() / 1e6
 	}
 	data.EndTimestamp = accumulator.FinalTimestamp
 	data.AudioOutput = completeMessage

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -88,7 +88,7 @@ func (a *Accumulator) processAccumulatedChatStreamingChunks(requestID string, re
 	if accumulator.StartTimestamp.IsZero() || accumulator.FinalTimestamp.IsZero() {
 		data.Latency = 0
 	} else {
-		data.Latency = float64(accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds()) / 1e6
+		data.Latency = accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds() / 1e6
 	}
 	data.EndTimestamp = accumulator.FinalTimestamp
 	data.OutputMessage = completeMessage

--- a/framework/streaming/transcription.go
+++ b/framework/streaming/transcription.go
@@ -66,7 +66,7 @@ func (a *Accumulator) processAccumulatedTranscriptionStreamingChunks(requestID s
 	if accumulator.StartTimestamp.IsZero() || accumulator.FinalTimestamp.IsZero() {
 		data.Latency = 0
 	} else {
-		data.Latency = float64(accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds()) / 1e6
+		data.Latency = accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds() / 1e6
 	}
 	data.EndTimestamp = accumulator.FinalTimestamp
 	data.TranscriptionOutput = completeMessage

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 	"time"
 
-	bifrost "github.com/maximhq/bifrost/core"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -30,7 +29,7 @@ type AccumulatedData struct {
 	Model               string
 	Status              string
 	Stream              bool
-	Latency             float64
+	Latency             int64 // in milliseconds
 	StartTimestamp      time.Time
 	EndTimestamp        time.Time
 	OutputMessage       *schemas.ChatMessage
@@ -153,7 +152,7 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 		Provider:   p.Provider,
 	}
 	if p.Data.Latency != 0 {
-		resp.ExtraFields.Latency = bifrost.Ptr(p.Data.Latency)
+		resp.ExtraFields.Latency = p.Data.Latency
 	}
 	return resp
 }

--- a/tests/core-providers/custom_test.go
+++ b/tests/core-providers/custom_test.go
@@ -105,7 +105,7 @@ func TestCustomProvider_MismatchedIdentity(t *testing.T) {
 		Input: []schemas.ChatMessage{
 			{
 				Role: schemas.ChatMessageRoleUser,
-				Content: schemas.ChatMessageContent{
+				Content: &schemas.ChatMessageContent{
 					ContentStr: bifrost.Ptr("Hello! What's the capital of France?"),
 				},
 			},

--- a/tests/core-providers/scenarios/chat_completion_stream.go
+++ b/tests/core-providers/scenarios/chat_completion_stream.go
@@ -147,9 +147,9 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 				{
 					Index: 0,
 					BifrostNonStreamResponseChoice: &schemas.BifrostNonStreamResponseChoice{
-						Message: schemas.ChatMessage{
+						Message: &schemas.ChatMessage{
 							Role: schemas.ChatMessageRoleAssistant,
-							Content: schemas.ChatMessageContent{
+							Content: &schemas.ChatMessageContent{
 								ContentStr: &finalContent,
 							},
 						},

--- a/tests/core-providers/scenarios/complete_end_to_end.go
+++ b/tests/core-providers/scenarios/complete_end_to_end.go
@@ -119,7 +119,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 		// Add all choice messages to Chat Completions conversation history
 		if result1.ChatCompletionsResponse.Choices != nil {
 			for _, choice := range result1.ChatCompletionsResponse.Choices {
-				chatConversationHistory = append(chatConversationHistory, choice.Message)
+				chatConversationHistory = append(chatConversationHistory, *choice.Message)
 			}
 		}
 

--- a/tests/core-providers/scenarios/cross_provider_scenarios.go
+++ b/tests/core-providers/scenarios/cross_provider_scenarios.go
@@ -696,7 +696,7 @@ func RunCrossProviderScenarioTest(t *testing.T, client *bifrost.Bifrost, ctx con
 		} else {
 			// Use Chat API choices
 			for _, choice := range response.Choices {
-				conversationHistory = append(conversationHistory, choice.Message)
+				conversationHistory = append(conversationHistory, *choice.Message)
 			}
 		}
 

--- a/tests/core-providers/scenarios/end_to_end_tool_calling.go
+++ b/tests/core-providers/scenarios/end_to_end_tool_calling.go
@@ -131,7 +131,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		chatConversationMessages := []schemas.ChatMessage{chatUserMessage}
 		if result1.ChatCompletionsResponse.Choices != nil {
 			for _, choice := range result1.ChatCompletionsResponse.Choices {
-				chatConversationMessages = append(chatConversationMessages, choice.Message)
+				chatConversationMessages = append(chatConversationMessages, *choice.Message)
 			}
 		}
 		chatConversationMessages = append(chatConversationMessages, CreateToolChatMessage(toolResult, chatToolCall.ID))

--- a/tests/core-providers/scenarios/multi_turn_conversation.go
+++ b/tests/core-providers/scenarios/multi_turn_conversation.go
@@ -74,7 +74,7 @@ func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx con
 		// Add all choice messages from the first response
 		if response1.Choices != nil {
 			for _, choice := range response1.Choices {
-				messages2 = append(messages2, choice.Message)
+				messages2 = append(messages2, *choice.Message)
 			}
 		}
 

--- a/tests/core-providers/scenarios/multiple_images.go
+++ b/tests/core-providers/scenarios/multiple_images.go
@@ -28,7 +28,7 @@ func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 		messages := []schemas.ChatMessage{
 			{
 				Role: schemas.ChatMessageRoleUser,
-				Content: schemas.ChatMessageContent{
+				Content: &schemas.ChatMessageContent{
 					ContentBlocks: []schemas.ChatContentBlock{
 						{
 							Type: schemas.ChatContentBlockTypeText,

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -125,7 +125,7 @@ func init() {
 	logger.SetLevel(schemas.LogLevel(server.LogLevel))
 	// Setting up logger
 	handlers.SetLogger(logger)
-	
+
 }
 
 // main is the entry point of the application.


### PR DESCRIPTION
## Summary

Implement a customizable key selection strategy for Bifrost by introducing a KeySelector interface that allows users to define their own logic for selecting API keys.

## Changes

- Added a `KeySelector` function type in schemas to allow custom key selection strategies
- Added a `keySelector` field to the Bifrost struct to store the custom selector
- Extracted the default weighted random selection logic into a standalone `WeightedRandomKeySelector` function
- Added the selected key ID to the request context for tracking and debugging purposes
- Made the key selection configurable through the BifrostConfig

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

You can test by implementing a custom key selector and passing it to the BifrostConfig:

```go
customSelector := func(ctx *context.Context, keys []schemas.Key, providerKey schemas.ModelProvider, model string) (schemas.Key, error) {
    // Your custom selection logic here
    return keys[0], nil
}

config := schemas.BifrostConfig{
    // Other config...
    KeySelector: customSelector,
}

bifrost, err := core.Init(context.Background(), config)
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enables more flexible key selection strategies for different use cases like round-robin, least-used, or priority-based selection.

## Security considerations

The key selection strategy could potentially impact rate limiting and usage patterns across API keys, but doesn't introduce new security concerns.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)