### PR TITLE
fix: improve error handling for missing pricing manager

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -50,7 +50,7 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, store conf
 		logger.Warn("governance plugin requires config store to persist data, running in memory only mode")
 	}
 	if pricingManager == nil {
-		logger.Warn("governance plugin requires pricing manager to calculate cost, running in cost-free mode")
+		logger.Warn("governance plugin requires pricing manager to calculate cost, all cost calculations will be skipped.")
 	}
 
 	governanceStore, err := NewGovernanceStore(logger, store, governanceConfig)

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -170,7 +170,7 @@ func Init(logger schemas.Logger, logsStore logstore.LogStore, pricingManager *pr
 		return nil, fmt.Errorf("logs store cannot be nil")
 	}
 	if pricingManager == nil {
-		logger.Warn("logging plugin requires pricing manager to calculate cost, running in cost-free mode")
+		logger.Warn("logging plugin requires pricing manager to calculate cost, all cost calculations will be skipped.")
 	}
 
 	plugin := &LoggerPlugin{

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -45,7 +45,11 @@ type PrometheusPlugin struct {
 }
 
 // NewPrometheusPlugin creates a new PrometheusPlugin with initialized metrics.
-func Init(pricingManager *pricing.PricingManager) *PrometheusPlugin {
+func Init(pricingManager *pricing.PricingManager, logger schemas.Logger) *PrometheusPlugin {
+	if pricingManager == nil {
+		logger.Warn("telemetry plugin requires pricing manager to calculate cost, all cost calculations will be skipped.")
+	}
+
 	return &PrometheusPlugin{
 		pricingManager:        pricingManager,
 		UpstreamRequestsTotal: bifrostUpstreamRequestsTotal,

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -363,7 +363,6 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 
 	// Initializing log store
 	if configData.LogsStoreConfig != nil && configData.LogsStoreConfig.Enabled {
-		logger.Info("initializing log store: %v", configData.LogsStoreConfig)
 		config.LogsStore, err = logstore.NewLogStore(configData.LogsStoreConfig, logger)
 		if err != nil {
 			return nil, err

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -336,7 +336,7 @@ func main() {
 	// Initialize pricing manager
 	pricingManager, err := pricing.Init(config.ConfigStore, logger)
 	if err != nil {
-		logger.Fatal("failed to initialize pricing manager: %v", err)
+		logger.Error("failed to initialize pricing manager: %v", err)
 	}
 
 	// Create account backed by the high-performance store (all processing is done in LoadFromDatabase)
@@ -349,7 +349,7 @@ func main() {
 	telemetry.InitPrometheusMetrics(config.ClientConfig.PrometheusLabels)
 	logger.Debug("prometheus Go/Process collectors registered.")
 
-	promPlugin := telemetry.Init(pricingManager)
+	promPlugin := telemetry.Init(pricingManager, logger)
 
 	loadedPlugins = append(loadedPlugins, promPlugin)
 


### PR DESCRIPTION
## Summary

Improved error handling for pricing manager initialization and standardized warning messages across plugins when pricing manager is unavailable.

solves issue #451

## Changes

- Updated warning message in governance plugin to clarify that cost calculations will be skipped
- Updated warning message in logging plugin to match the governance plugin's wording
- Added missing logger parameter to telemetry plugin's Init function
- Added warning message in telemetry plugin when pricing manager is nil
- Changed fatal error to regular error when failing to initialize pricing manager
- Removed unnecessary log message when initializing log store

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/governance/...
go test ./plugins/logging/...
go test ./plugins/telemetry/...
go test ./transports/bifrost-http/...

# Start the server without pricing manager configuration
# Verify warning messages appear in logs but service continues to run
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. This PR only improves error handling and messaging.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)