### PR TITLE
refactor: simplify vertex provider normalization logic

### DIFF
--- a/framework/pricing/utils.go
+++ b/framework/pricing/utils.go
@@ -38,10 +38,9 @@ func isCacheReadRequest(req *schemas.BifrostRequest, headers map[string]string) 
 
 // normalizeProvider normalizes the provider name to a consistent format
 func normalizeProvider(p string) string {
-	switch p {
-	case "vertex_ai-language-models", "vertex_ai", "google-vertex":
-		return "vertex"
-	default:
+	if strings.Contains(p, "vertex_ai") || p == "google-vertex" {
+		return string(schemas.Vertex)
+	} else {
 		return p
 	}
 }


### PR DESCRIPTION
## Summary

Refactored the `normalizeProvider` function in the pricing package to use string comparison instead of a switch statement for better maintainability.

## Changes

- Replaced the switch statement in `normalizeProvider` with a conditional check using `strings.Contains`
- Updated the return value to use the constant `schemas.Vertex` for better type safety
- Simplified the logic to handle all vertex-related provider names in a single condition

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./framework/pricing/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a refactoring of internal provider name normalization logic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable