### PR TITLE
updates init migration to include max_request_body_size column

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -52,6 +52,10 @@ func migrationInit(db *gorm.DB) error {
 				if err := migrator.CreateTable(&TableClientConfig{}); err != nil {
 					return err
 				}
+			} else if !migrator.HasColumn(&TableClientConfig{}, "max_request_body_size_mb") {
+				if err := migrator.AddColumn(&TableClientConfig{}, "max_request_body_size_mb"); err != nil {
+					return err
+				}
 			}
 			if !migrator.HasTable(&TableEnvKey{}) {
 				if err := migrator.CreateTable(&TableEnvKey{}); err != nil {


### PR DESCRIPTION
## Summary

Added a migration to add the `max_request_body_size_mb` column to the `TableClientConfig` table if it doesn't exist.

## Changes

- Added a conditional check to verify if the `max_request_body_size_mb` column exists in the `TableClientConfig` table
- Implemented logic to add the column if it doesn't exist
- This allows for configuring maximum request body size limits per client

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Core (Go)

## How to test

```sh
# Core/Transports
go version
go test ./framework/configstore/...

# Verify migration runs successfully on database startup
# Check that existing databases get the new column added
```

## Breaking changes

- [x] No

## Security considerations

This change enhances security by allowing configuration of request body size limits, which can help prevent potential DoS attacks through oversized payloads.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)