### PR TITLE
feat: add retry count tracking and metrics for Bifrost requests

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1234,6 +1234,9 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			}
 		}
 
+		// Save retry count into context
+		req.Context = context.WithValue(req.Context, schemas.BifrostContextKeyRetryCount, attempts)
+
 		if bifrostError != nil {
 			// Add retry information to error
 			if attempts > 0 {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -105,6 +105,7 @@ const (
 	BifrostContextKeyRequestType        BifrostContextKey = "bifrost-request-type"
 	BifrostContextKeyRequestProvider    BifrostContextKey = "bifrost-request-provider"
 	BifrostContextKeyRequestModel       BifrostContextKey = "bifrost-request-model"
+	BifrostContextKeyRetryCount         BifrostContextKey = "bifrost-retry-count"
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -49,6 +49,7 @@ These metrics track requests forwarded to AI providers:
 | `bifrost_output_tokens_total` | Counter | Total output tokens received from upstream providers | `provider`, `model`, `method`, custom labels |
 | `bifrost_cache_hits_total` | Counter | Total cache hits by type (direct/semantic) | `provider`, `model`, `method`, `cache_type`, custom labels |
 | `bifrost_cost_total` | Counter | Total cost in USD for upstream provider requests | `provider`, `model`, `method`, custom labels |
+| `bifrost_retries_total` | Counter | Total number of retries performed before a successful request or fallback | `provider`, `model`, `method`, custom labels |
 
 **Label Definitions:**
 - `provider`: AI provider name (e.g., `openai`, `anthropic`, `azure`)
@@ -57,6 +58,7 @@ These metrics track requests forwarded to AI providers:
 - `cache_type`: Cache hit type (`direct`, `semantic`) - only for cache hits metric
 - `path`: HTTP endpoint path
 - `status`: HTTP status code
+- `retries`: Number of retry attempts (recorded as metric value, not label)
 
 ---
 
@@ -123,6 +125,19 @@ rate(bifrost_upstream_requests_total[5m]) * 100
 
 # Errors by model
 sum by (model) (rate(bifrost_error_requests_total[5m]))
+
+### Retry Analysis
+Track how often retries are happening per provider and model:
+
+```promql
+# Retry rate per provider
+rate(bifrost_retries_total[5m])
+
+# Retries per request ratio
+rate(bifrost_retries_total[5m]) / rate(bifrost_upstream_requests_total[5m])
+
+# High retry detection (e.g. >1 retry/request on average)
+rate(bifrost_retries_total[5m]) / rate(bifrost_upstream_requests_total[5m]) > 1
 ```
 
 ---

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -42,6 +42,7 @@ type PrometheusPlugin struct {
 	OutputTokensTotal     *prometheus.CounterVec
 	CacheHitsTotal        *prometheus.CounterVec
 	CostTotal             *prometheus.CounterVec
+	RetriesTotal          *prometheus.CounterVec
 }
 
 // NewPrometheusPlugin creates a new PrometheusPlugin with initialized metrics.
@@ -170,6 +171,11 @@ func (p *PrometheusPlugin) PostHook(ctx *context.Context, result *schemas.Bifros
 			p.ErrorRequestsTotal.WithLabelValues(promLabelValues...).Inc()
 		} else {
 			p.SuccessRequestsTotal.WithLabelValues(promLabelValues...).Inc()
+		}
+
+		// Record retries if available in context
+		if retries, ok := (*ctx).Value(schemas.BifrostContextKeyRetryCount).(int); ok && retries > 0 {
+			p.RetriesTotal.WithLabelValues(promLabelValues...).Add(float64(retries))
 		}
 
 		// Record input and output tokens

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -61,6 +61,7 @@ func Init(pricingManager *pricing.PricingManager, logger schemas.Logger) *Promet
 		OutputTokensTotal:     bifrostOutputTokensTotal,
 		CacheHitsTotal:        bifrostCacheHitsTotal,
 		CostTotal:             bifrostCostTotal,
+		RetriesTotal:          bifrostRetriesTotal,
 	}
 }
 

--- a/plugins/telemetry/setup.go
+++ b/plugins/telemetry/setup.go
@@ -49,6 +49,9 @@ var (
 	// bifrostCostTotal tracks the total cost in USD for requests to upstream providers
 	bifrostCostTotal *prometheus.CounterVec
 
+	// bifrostRetriesTotal tracks the total number of retries performed by Bifrost.
+	bifrostRetriesTotal *prometheus.CounterVec
+
 	// customLabels stores the expected label names in order
 	customLabels  []string
 	isInitialized bool
@@ -167,6 +170,14 @@ func InitPrometheusMetrics(labels []string) {
 		prometheus.CounterOpts{
 			Name: "bifrost_cost_total",
 			Help: "Total cost in USD for requests to upstream providers.",
+		},
+		append(bifrostDefaultLabels, labels...),
+	)
+	
+	bifrostRetriesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "bifrost_retries_total",
+			Help: "Total number of retries performed by Bifrost.",
 		},
 		append(bifrostDefaultLabels, labels...),
 	)

--- a/transports/bifrost-http/handlers/completions.go
+++ b/transports/bifrost-http/handlers/completions.go
@@ -592,7 +592,11 @@ func (h *CompletionHandler) handleRequest(ctx *fasthttp.RequestCtx, completionTy
 		ctx.Response.SetBody(resp.Speech.Audio)
 		return
 	}
-
+	
+	// // getting (handlers)
+	if retries, ok := (*bifrostCtx).Value(schemas.BifrostContextKeyRetryCount).(int); ok {
+		ctx.Response.Header.Set("x-bf-retries", strconv.Itoa(retries))
+	}
 	// Send successful response
 	SendJSON(ctx, resp, h.logger)
 }

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -112,9 +112,9 @@ func ParseModel(model string) (string, string, error) {
 	return provider, name, nil
 }
 
-func getRetryCount(bctx *context.Context) int {
-	if bctx != nil {
-		if v, ok := (*bctx).Value(schemas.BifrostContextKeyRetryCount).(int); ok {
+func getRetryCount(ctx *context.Context) int {
+	if ctx != nil {
+		if v, ok := (*ctx).Value(schemas.BifrostContextKeyRetryCount).(int); ok {
 			return v
 		}
 	}

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -3,6 +3,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -109,4 +110,13 @@ func ParseModel(model string) (string, string, error) {
 		return "", "", fmt.Errorf("model must be in the format 'provider/model' with non-empty provider and model")
 	}
 	return provider, name, nil
+}
+
+func getRetryCount(bctx *context.Context) int {
+	if bctx != nil {
+		if v, ok := (*bctx).Value(schemas.BifrostContextKeyRetryCount).(int); ok {
+			return v
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Summary

Currently, there’s no way to know how many retries were performed before a request succeeded or failed. This PR adds retry count tracking and exposes it to consumers.

Changes

Populated retry counts in requestWorker after retry loops.

Exposed retry count via x-bf-retries HTTP header in the gateway.

Saved retry count in context for telemetry and plugin access.

Type of change

 Feature

Affected areas

 Core (Go)

 Transports (HTTP)

 Plugins

 Docs

How to test

Run go test ./... to verify core functionality.

Send a request through a provider that triggers retries.

Check Retries in BifrostResponse or BifrostError.

Check x-bf-retries HTTP header.

Related issues

Closes #459