### PR TITLE
feat: added redis stack in docker compose for tests --skip-pipeline

### DIFF
--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -141,10 +141,9 @@ func (ts *RedisTestSetup) ensureNamespaceExists(t *testing.T) {
 
 	err := ts.Store.CreateNamespace(ts.ctx, TestNamespace, RedisTestDimension, properties)
 	if err != nil {
-		t.Skipf("RediSearch not available or schema creation failed for namespace %q: %v", TestNamespace, err)
-	} else {
-		t.Logf("Created test namespace: %s", TestNamespace)
+		t.Fatalf("Failed to create namespace %q: %v", TestNamespace, err)
 	}
+	t.Logf("Created test namespace: %s", TestNamespace)
 }
 
 // cleanupTestData removes all test objects from the namespace

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -28,6 +28,24 @@ services:
             bifrost_network:
                 ipv4_address: 172.38.0.12
 
+    # Redis Stack instance for vector store tests
+    redis-stack:
+        image: redis/redis-stack:7.4.0-v6
+        command: redis-stack-server --protected-mode no
+        ports:
+            - "6379:6379"
+            - "8001:8001"  # RedisInsight web UI
+        volumes:
+            - redis_data:/data
+        networks:
+            bifrost_network:
+                ipv4_address: 172.38.0.13
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+
 networks:
     bifrost_network:
         driver: bridge
@@ -38,3 +56,4 @@ networks:
 
 volumes:
     weaviate_data:
+    redis_data:


### PR DESCRIPTION
## Summary

Add Redis Stack to the Docker Compose configuration for vector store testing.

## Changes

- Added Redis Stack service (version 7.4.0-v6) to the Docker Compose configuration
- Configured Redis to run with protected mode disabled
- Exposed ports 6379 (Redis) and 8001 (RedisInsight web UI)
- Added persistent volume for Redis data
- Configured network settings with a static IP (172.38.0.13)
- Added health check to ensure Redis is running properly

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Providers/Integrations
- [x] Core (Go)

## How to test

Run the Docker Compose setup and verify Redis is accessible:

```sh
cd tests
docker-compose up -d redis-stack
docker-compose ps  # Verify redis-stack is running
redis-cli -h localhost -p 6379 ping  # Should return PONG
```

You can also access the RedisInsight web UI at http://localhost:8001

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

Redis is configured with protected mode disabled to allow connections from any host. This is appropriate for testing but should be reviewed for production deployments.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable