### PR TITLE
fix: URL decode provider parameters and improve custom provider UI

### DIFF
--- a/ui/app/providers/dialogs/addNewCustomProviderDialog.tsx
+++ b/ui/app/providers/dialogs/addNewCustomProviderDialog.tsx
@@ -44,6 +44,7 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 			.unwrap()
 			.then(() => {
 				onSave();
+				form.reset();
 			})
 			.catch((err) => {
 				toast.error("Failed to add provider", {
@@ -53,12 +54,7 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 	};
 
 	return (
-		<Dialog
-			open={show}
-			onOpenChange={(open) => {
-				if (!open) onClose();
-			}}
-		>
+		<Dialog open={show}>
 			<DialogContent>
 				<DialogHeader>
 					<DialogTitle>Add Custom Provider</DialogTitle>
@@ -110,7 +106,7 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 						/>
 
 						<DialogFooter className="flex flex-row gap-2">
-							<Button variant="outline" onClick={onClose}>
+							<Button type="button" variant="outline" onClick={onClose}>
 								Cancel
 							</Button>
 							<Button type="submit">Add</Button>

--- a/ui/app/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/providers/fragments/apiStructureFormFragment.tsx
@@ -131,7 +131,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Text Completion</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -145,7 +145,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Chat Completion</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -159,7 +159,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Chat Completion Stream</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -173,7 +173,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Embedding</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -189,7 +189,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Speech</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -203,7 +203,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Speech Stream</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -217,7 +217,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Transcription</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}
@@ -231,7 +231,7 @@ export function ApiStructureFormFragment({ provider, showRestartAlert }: Props) 
 											<FormLabel>Transcription Stream</FormLabel>
 										</div>
 										<FormControl>
-											<Switch checked={field.value} onCheckedChange={field.onChange} />
+											<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
 										</FormControl>
 									</FormItem>
 								)}

--- a/ui/app/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/providers/fragments/networkFormFragment.tsx
@@ -12,7 +12,7 @@ import { networkOnlyFormSchema, type NetworkOnlyFormSchema } from "@/lib/types/s
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertTriangle } from "lucide-react";
 import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
 
 interface NetworkFormFragmentProps {
@@ -25,8 +25,8 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
 	const isCustomProvider = !isKnownProvider(provider.name as string);
 
-	const form = useForm<NetworkOnlyFormSchema>({
-		resolver: zodResolver(networkOnlyFormSchema),
+	const form = useForm<NetworkOnlyFormSchema, any, NetworkOnlyFormSchema>({
+		resolver: zodResolver(networkOnlyFormSchema) as Resolver<NetworkOnlyFormSchema, any, NetworkOnlyFormSchema>,
 		mode: "onChange",
 		reValidateMode: "onChange",
 		defaultValues: {

--- a/ui/app/providers/fragments/performanceFormFragment.tsx
+++ b/ui/app/providers/fragments/performanceFormFragment.tsx
@@ -10,7 +10,7 @@ import { ModelProvider } from "@/lib/types/config";
 import { performanceFormSchema, type PerformanceFormSchema } from "@/lib/types/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
 
 interface PerformanceFormFragmentProps {
@@ -21,8 +21,8 @@ interface PerformanceFormFragmentProps {
 export function PerformanceFormFragment({ provider, showRestartAlert = false }: PerformanceFormFragmentProps) {
 	const dispatch = useAppDispatch();
 	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
-	const form = useForm<PerformanceFormSchema>({
-		resolver: zodResolver(performanceFormSchema),
+	const form = useForm<PerformanceFormSchema, any, PerformanceFormSchema>({
+		resolver: zodResolver(performanceFormSchema) as Resolver<PerformanceFormSchema, any, PerformanceFormSchema>,
 		mode: "onChange",
 		reValidateMode: "onChange",
 		defaultValues: {


### PR DESCRIPTION
## Fix Provider Management Issues and Improve UI Form Handling

## Changes

- Fixed URL encoding issue in provider handling by properly decoding provider names in API requests
- Improved custom provider validation logic by removing redundant variable tracking
- Enhanced form handling in the UI:
  - Reset form after successful submission in AddCustomProviderDialog
  - Fixed dialog behavior to properly handle closing
  - Added proper button type attributes
  - Set consistent switch sizes in API structure form
- Fixed TypeScript type errors in form components by properly typing React Hook Form resolvers

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Test adding custom providers with special characters in their names
2. Verify form reset functionality after adding a provider
3. Check that all UI components render correctly with proper sizing
4. Verify TypeScript compilation succeeds:

```sh
# UI
cd ui
pnpm i
pnpm typecheck
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Improved URL handling for provider names enhances security by properly decoding parameters.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable