### PR TITLE
adds v while injecting version in the binary

### DIFF
--- a/.github/workflows/scripts/build-executables.sh
+++ b/.github/workflows/scripts/build-executables.sh
@@ -64,7 +64,7 @@ for platform in "${platforms[@]}"; do
 
     env GOWORK=off CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" CC="$CC_COMPILER" CXX="$CXX_COMPILER" \
       go build -trimpath -tags "netgo,osusergo,sqlite_static" \
-      -ldflags "-s -w -buildid= -extldflags '-static' -X main.Version=${VERSION}" \
+      -ldflags "-s -w -buildid= -extldflags '-static' -X main.Version=v${VERSION}" \
       -o "$PROJECT_ROOT/dist/$PLATFORM_DIR/$GOARCH/$output_name" .
 
   elif [[ "$GOOS" = "windows" ]]; then
@@ -74,7 +74,7 @@ for platform in "${platforms[@]}"; do
     fi
 
     env GOWORK=off CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" CC="$CC_COMPILER" CXX="$CXX_COMPILER" \
-      go build -trimpath -ldflags "-s -w -buildid= -X main.Version=${VERSION}" \
+      go build -trimpath -ldflags "-s -w -buildid= -X main.Version=v${VERSION}" \
       -o "$PROJECT_ROOT/dist/$PLATFORM_DIR/$GOARCH/$output_name" .
 
    else # Darwin (macOS)
@@ -87,7 +87,7 @@ for platform in "${platforms[@]}"; do
     fi
 
     env GOWORK=off CGO_ENABLED=1 GOOS="$GOOS" GOARCH="$GOARCH" CC="$CC_COMPILER" CXX="$CXX_COMPILER" \
-      go build -trimpath -ldflags "-s -w -buildid= -X main.Version=${VERSION}" \
+      go build -trimpath -ldflags "-s -w -buildid= -X main.Version=v${VERSION}" \
       -o "$PROJECT_ROOT/dist/$PLATFORM_DIR/$GOARCH/$output_name" .
   fi
 

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -38,7 +38,7 @@ COPY --from=ui-builder /app/out ./bifrost-http/ui
 ENV GOWORK=off
 ARG VERSION=unknown
 RUN go build \
-    -ldflags="-w -s -extldflags '-static' -X main.Version=${VERSION}" \
+    -ldflags="-w -s -extldflags '-static' -X main.Version=v${VERSION}" \
     -a -trimpath \
     -tags "sqlite_static" \
     -o /app/main \


### PR DESCRIPTION
## Summary

Prepend 'v' to version numbers in build scripts to ensure consistent version formatting across all build environments.

## Changes

- Modified build scripts to prepend 'v' to the VERSION variable in ldflags
- Updated both the main build-executables.sh script and the Docker build process
- Ensures version strings are consistently formatted as "v1.2.3" rather than "1.2.3"

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that built binaries and Docker images show the correct version format:

```sh
# Build and check version
./build-executables.sh
./dist/linux/amd64/bifrost version
# Should show v1.2.3 instead of 1.2.3

# Build Docker image and check version
docker build -t bifrost:test -f transports/Dockerfile .
docker run --rm bifrost:test version
# Should show v1.2.3 instead of 1.2.3
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Standardizes version formatting across all build outputs.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable