### PR TITLE
feat: add API key authentication support for Bedrock provider

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -1198,7 +1198,7 @@ func handleAnthropicStreaming(
 			logger.Warn(fmt.Sprintf("Error reading %s stream: %v", providerType, err))
 			processAndSendError(ctx, postHookRunner, err, responseChan, logger)
 		} else {
-			response := createBifrostChatCompletionChunkResponse(usage, finishReason, chunkIndex, params, providerType)
+			response := createBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, params, providerType)
 			handleStreamEndWithSuccess(ctx, response, postHookRunner, responseChan, logger)
 		}
 	}()

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -438,6 +438,7 @@ func handleOpenAIStreaming(
 		usage := &schemas.LLMUsage{}
 
 		var finishReason *string
+		var id string
 
 		for scanner.Scan() {
 			line := scanner.Text()
@@ -513,6 +514,10 @@ func handleOpenAIStreaming(
 				response.Choices[0].FinishReason = nil
 			}
 
+			if response.ID != "" && id == "" {
+				id = response.ID
+			}
+
 			// Handle regular content chunks
 			if choice.BifrostStreamResponseChoice != nil && (choice.BifrostStreamResponseChoice.Delta.Content != nil || len(choice.BifrostStreamResponseChoice.Delta.ToolCalls) > 0) {
 				chunkIndex++
@@ -529,7 +534,7 @@ func handleOpenAIStreaming(
 			logger.Warn(fmt.Sprintf("Error reading stream: %v", err))
 			processAndSendError(ctx, postHookRunner, err, responseChan, logger)
 		} else {
-			response := createBifrostChatCompletionChunkResponse(usage, finishReason, chunkIndex, params, providerName)
+			response := createBifrostChatCompletionChunkResponse(id, usage, finishReason, chunkIndex, params, providerName)
 			handleStreamEndWithSuccess(ctx, response, postHookRunner, responseChan, logger)
 		}
 	}()

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -804,6 +804,7 @@ func processAndSendError(
 }
 
 func createBifrostChatCompletionChunkResponse(
+	id string,
 	usage *schemas.LLMUsage,
 	finishReason *string,
 	currentChunkIndex int,
@@ -811,6 +812,7 @@ func createBifrostChatCompletionChunkResponse(
 	providerName schemas.ModelProvider,
 ) *schemas.BifrostResponse {
 	response := &schemas.BifrostResponse{
+		ID:     id,
 		Object: "chat.completion.chunk",
 		Usage:  usage,
 		Choices: []schemas.BifrostResponseChoice{

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -31,6 +31,8 @@ type VertexKeyConfig struct {
 	AuthCredentials string `json:"auth_credentials,omitempty"`
 }
 
+// NOTE: To use Vertex IAM role authentication, set AuthCredentials to empty string.
+
 // BedrockKeyConfig represents the AWS Bedrock-specific configuration.
 // It contains AWS-specific settings required for authentication and service access.
 type BedrockKeyConfig struct {
@@ -41,6 +43,9 @@ type BedrockKeyConfig struct {
 	ARN          *string           `json:"arn,omitempty"`           // Amazon Resource Name for resource identification
 	Deployments  map[string]string `json:"deployments,omitempty"`   // Mapping of model identifiers to inference profiles
 }
+
+// NOTE: To use Bedrock IAM role authentication, set both AccessKey and SecretKey to empty strings.
+// To use Bedrock API Key authentication, set Value in Key struct instead.
 
 // Account defines the interface for managing provider accounts and their configurations.
 // It provides methods to access provider-specific settings, API keys, and configurations.

--- a/core/utils.go
+++ b/core/utils.go
@@ -2,7 +2,6 @@ package bifrost
 
 import (
 	"context"
-	"encoding/json"
 	"math/rand"
 	"time"
 
@@ -12,30 +11,6 @@ import (
 // Ptr returns a pointer to the given value.
 func Ptr[T any](v T) *T {
 	return &v
-}
-
-// MarshalToString marshals the given value to a JSON string.
-func MarshalToString(v any) (string, error) {
-	if v == nil {
-		return "", nil
-	}
-	data, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-// MarshalToStringPtr marshals the given value to a JSON string and returns a pointer to the string.
-func MarshalToStringPtr(v any) (*string, error) {
-	if v == nil {
-		return nil, nil
-	}
-	data, err := MarshalToString(v)
-	if err != nil {
-		return nil, err
-	}
-	return &data, nil
 }
 
 func attachContextKeys(ctx context.Context, req *schemas.BifrostRequest, requestType schemas.RequestType) context.Context {

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -764,12 +764,13 @@ AWS Bedrock supports both explicit credentials and IAM role authentication:
 ![AWS Bedrock Configuration Interface](../../media/ui-bedrock-config.png)
 
 1. Navigate to **"Providers"** → **"AWS Bedrock"**
-2. Set **Access Key**: AWS Access Key ID (or leave empty for IAM)
-3. Set **Secret Key**: AWS Secret Access Key (or leave empty for IAM)
-4. Set **Region**: e.g., `us-east-1`
-5. Configure **Deployments**: Map model names to inference profiles
-6. Set **ARN**: Required for deployments mapping
-7. Save configuration
+2. Set **API Key**: AWS API Key (or leave empty if using IAM role authentication)
+3. Set **Access Key**: AWS Access Key ID (or leave empty to use IAM in environment)
+4. Set **Secret Key**: AWS Secret Access Key (or leave empty to use IAM in environment)
+5. Set **Region**: e.g., `us-east-1`
+6. Configure **Deployments**: Map model names to inference profiles
+7. Set **ARN**: Required for deployments mapping
+8. Save configuration
 
 </Tab>
 
@@ -833,9 +834,10 @@ curl --location 'http://localhost:8080/api/providers' \
 </Tabs>
 
 **Notes:**
-- If both `access_key` and `secret_key` are empty, Bifrost uses IAM role authentication from environment
-- `arn` is required for URL formation - `deployments` mapping is ignored without it
-- When using `arn` + `deployments`, Bifrost uses model profiles; otherwise forms path with incoming model name directly
+- If using API Key authentication, set `value` field to the API key, else leave it empty for IAM role authentication.
+- In IAM role authentication, if both `access_key` and `secret_key` are empty, Bifrost uses IAM role authentication from the environment.
+- `arn` is required for URL formation - `deployments` mapping is ignored without it.
+- When using `arn` + `deployments`, Bifrost uses model profiles; otherwise forms path with incoming model name directly.
 
 ### Google Vertex
 

--- a/docs/quickstart/go-sdk/provider-configuration.mdx
+++ b/docs/quickstart/go-sdk/provider-configuration.mdx
@@ -307,9 +307,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
             {
                 Models: []string{"anthropic.claude-3-sonnet-20240229-v1:0", "anthropic.claude-v2:1"},
                 Weight: 1.0,
+                Value:  os.Getenv("AWS_API_KEY"), // Leave empty for IAM role authentication
                 BedrockKeyConfig: &schemas.BedrockKeyConfig{
-                    AccessKey:    os.Getenv("AWS_ACCESS_KEY_ID"),     // Leave empty for IAM role
-                    SecretKey:    os.Getenv("AWS_SECRET_ACCESS_KEY"), // Leave empty for IAM role
+                    AccessKey:    os.Getenv("AWS_ACCESS_KEY_ID"),     // Leave empty for API Key authentication or system's IAM pickup
+                    SecretKey:    os.Getenv("AWS_SECRET_ACCESS_KEY"), // Leave empty for API Key authentication or system's IAM pickup
                     SessionToken: bifrost.Ptr(os.Getenv("AWS_SESSION_TOKEN")), // Optional
                     Region:       bifrost.Ptr("us-east-1"),
                     // For model profiles (inference profiles)
@@ -327,9 +328,10 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
 ```
 
 **Notes:**
-- If both `AccessKey` and `SecretKey` are empty, Bifrost uses IAM role authentication from environment
-- `ARN` is required for URL formation - `Deployments` mapping is ignored without it
-- When using `ARN` + `Deployments`, Bifrost uses model profiles; otherwise forms path with incoming model name directly
+- If using API Key authentication, set `Value` field to the API key, else leave it empty for IAM role authentication.
+- In IAM role authentication, if both `AccessKey` and `SecretKey` are empty, Bifrost uses IAM from the environment.
+- `ARN` is required for URL formation - `Deployments` mapping is ignored without it.
+- When using `ARN` + `Deployments`, Bifrost uses model profiles; otherwise forms path with incoming model name directly.
 
 </Tab>
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -9,9 +9,7 @@ import (
 
 // Migrate performs the necessary database migrations.
 func triggerMigrations(db *gorm.DB) error {
-	var err error
-	err = migrationInit(db)
-	if err != nil {
+	if err := migrationInit(db); err != nil {
 		return err
 	}
 	return nil

--- a/framework/configstore/sqlite.go
+++ b/framework/configstore/sqlite.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/vectorstore"
@@ -603,7 +602,7 @@ func (s *SQLiteConfigStore) UpdateVectorStoreConfig(config *vectorstore.Config) 
 		if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&TableVectorStoreConfig{}).Error; err != nil {
 			return err
 		}
-		jsonConfig, err := bifrost.MarshalToStringPtr(config.Config)
+		jsonConfig, err := marshalToStringPtr(config.Config)
 		if err != nil {
 			return err
 		}
@@ -642,7 +641,7 @@ func (s *SQLiteConfigStore) UpdateLogsStoreConfig(config *logstore.Config) error
 		if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&TableLogStoreConfig{}).Error; err != nil {
 			return err
 		}
-		jsonConfig, err := bifrost.MarshalToStringPtr(config)
+		jsonConfig, err := marshalToStringPtr(config)
 		if err != nil {
 			return err
 		}

--- a/framework/configstore/utils.go
+++ b/framework/configstore/utils.go
@@ -8,6 +8,30 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+// marshalToString marshals the given value to a JSON string.
+func marshalToString(v any) (string, error) {
+	if v == nil {
+		return "", nil
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// marshalToStringPtr marshals the given value to a JSON string and returns a pointer to the string.
+func marshalToStringPtr(v any) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	data, err := marshalToString(v)
+	if err != nil {
+		return nil, err
+	}
+	return &data, nil
+}
+
 // deepCopy creates a deep copy of a given type
 func deepCopy[T any](in T) (T, error) {
 	var out T

--- a/ui/app/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/providers/fragments/apiKeysFormFragment.tsx
@@ -3,6 +3,7 @@
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import { TagInput } from "@/components/ui/tagInput";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -20,7 +21,7 @@ const MODEL_PLACEHOLDERS = {
 	default: "e.g. gpt-4, gpt-3.5-turbo. Leave blank for all models.",
 	openai: "e.g. gpt-4, gpt-3.5-turbo, gpt-4-turbo, gpt-4o",
 	azure: "e.g. gpt-4, gpt-3.5-turbo (must match deployment mappings)",
-	bedrock: "e.g. anthropic.claude-v2, amazon.titan-text-express-v1",
+	bedrock: "e.g. claude-v2, titan-text-express-v1",
 	vertex: "e.g. gemini-pro, text-bison, chat-bison",
 };
 
@@ -41,15 +42,15 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 			{isBedrock && (
 				<Alert variant="default" className="-z-10">
 					<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600" />
-					<AlertTitle>IAM Role Authentication</AlertTitle>
+					<AlertTitle>Authentication Methods</AlertTitle>
 					<AlertDescription>
-						Leave both Access Key and Secret Key empty to use IAM roles attached to your environment (EC2, Lambda, ECS, EKS). This is the
-						recommended approach for production deployments.
+						You can either use IAM role authentication or API key authentication. Please leave API Key empty when using IAM role
+						authentication.
 					</AlertDescription>
 				</Alert>
 			)}
 			<div className="flex gap-4">
-				{!isVertex && !isBedrock && (
+				{!isVertex && (
 					<div className="flex-1">
 						<FormField
 							control={control}
@@ -273,19 +274,14 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 			)}
 			{isBedrock && (
 				<div className="space-y-4">
-					<FormField
-						control={control}
-						name={`key.bedrock_key_config.arn`}
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>ARN</FormLabel>
-								<FormControl>
-									<Input placeholder="ARN" {...field} />
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
+					<Separator className="my-6" />
+					<Alert variant="default" className="-z-10">
+						<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600" />
+						<AlertTitle>IAM Role Authentication</AlertTitle>
+						<AlertDescription>
+							Leave both Access Key and Secret Key empty to use IAM roles attached to your environment (EC2, Lambda, ECS, EKS).
+						</AlertDescription>
+					</Alert>
 					<FormField
 						control={control}
 						name={`key.bedrock_key_config.access_key`}
@@ -293,7 +289,14 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 							<FormItem>
 								<FormLabel>Access Key</FormLabel>
 								<FormControl>
-									<Input placeholder="your-aws-access-key or env.AWS_ACCESS_KEY_ID" {...field} />
+									<Input
+										placeholder="your-aws-access-key or env.AWS_ACCESS_KEY_ID"
+										value={field.value ?? ""}
+										onChange={field.onChange}
+										onBlur={field.onBlur}
+										name={field.name}
+										ref={field.ref}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>
@@ -306,7 +309,14 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 							<FormItem>
 								<FormLabel>Secret Key</FormLabel>
 								<FormControl>
-									<Input placeholder="your-aws-secret-key or env.AWS_SECRET_ACCESS_KEY" {...field} />
+									<Input
+										placeholder="your-aws-secret-key or env.AWS_SECRET_ACCESS_KEY"
+										value={field.value ?? ""}
+										onChange={field.onChange}
+										onBlur={field.onBlur}
+										name={field.name}
+										ref={field.ref}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>
@@ -319,12 +329,20 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 							<FormItem>
 								<FormLabel>Session Token (Optional)</FormLabel>
 								<FormControl>
-									<Input placeholder="your-aws-session-token or env.AWS_SESSION_TOKEN" {...field} />
+									<Input
+										placeholder="your-aws-session-token or env.AWS_SESSION_TOKEN"
+										value={field.value ?? ""}
+										onChange={field.onChange}
+										onBlur={field.onBlur}
+										name={field.name}
+										ref={field.ref}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>
 						)}
 					/>
+					<Separator className="my-6" />
 					<FormField
 						control={control}
 						name={`key.bedrock_key_config.region`}
@@ -332,7 +350,34 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 							<FormItem>
 								<FormLabel>Region (Required)</FormLabel>
 								<FormControl>
-									<Input placeholder="us-east-1 or env.AWS_REGION" {...field} />
+									<Input
+										placeholder="us-east-1 or env.AWS_REGION"
+										value={field.value ?? ""}
+										onChange={field.onChange}
+										onBlur={field.onBlur}
+										name={field.name}
+										ref={field.ref}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`key.bedrock_key_config.arn`}
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>ARN</FormLabel>
+								<FormControl>
+									<Input
+										placeholder="arn:aws:bedrock:us-east-1:123:inference-profile or env.AWS_ARN"
+										value={field.value ?? ""}
+										onChange={field.onChange}
+										onBlur={field.onBlur}
+										name={field.name}
+										ref={field.ref}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>
@@ -347,7 +392,7 @@ export function ApiKeyFormFragment({ control, providerName }: Props) {
 								<FormDescription>JSON object mapping model names to inference profile names</FormDescription>
 								<FormControl>
 									<Textarea
-										placeholder='{"gpt-4": "my-gpt4-deployment", "gpt-3.5-turbo": "my-gpt35-deployment"}'
+										placeholder='{"claude-3-sonnet": "us.anthropic.claude-3-sonnet-20240229-v1:0", "claude-v2": "us.anthropic.claude-v2:1"}'
 										value={typeof field.value === "string" ? field.value : JSON.stringify(field.value || {}, null, 2)}
 										onChange={(e) => {
 											// Store as string during editing to allow intermediate invalid states

--- a/ui/app/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/providers/views/modelProviderKeysTableView.tsx
@@ -42,7 +42,7 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 			case KnownProvidersNames[5]:
 				return key.vertex_key_config?.auth_credentials || "unknown";
 			case KnownProvidersNames[3]:
-				return key.bedrock_key_config?.access_key || "unknown";
+				return key.value || key.bedrock_key_config?.access_key || "system IAM";
 			default:
 				return key.value;
 		}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -44,8 +44,8 @@ export const DefaultVertexKeyConfig: VertexKeyConfig = {
 
 // BedrockKeyConfig matching Go's schemas.BedrockKeyConfig
 export interface BedrockKeyConfig {
-	access_key: string;
-	secret_key: string;
+	access_key?: string;
+	secret_key?: string;
 	session_token?: string;
 	region: string;
 	arn?: string;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -28,8 +28,8 @@ export const vertexKeyConfigSchema = z.object({
 
 // Bedrock key config schema
 export const bedrockKeyConfigSchema = z.object({
-	access_key: z.string().min(1, "Access key is required"),
-	secret_key: z.string().min(1, "Secret key is required"),
+	access_key: z.string().min(1, "Access key is required").optional(),
+	secret_key: z.string().min(1, "Secret key is required").optional(),
 	session_token: z.string().optional(),
 	region: z.string().min(1, "Region is required"),
 	arn: z.string().optional(),


### PR DESCRIPTION
## Add API Key Authentication Support for AWS Bedrock

This PR adds support for API Key authentication with AWS Bedrock, allowing users to authenticate using either IAM roles or API keys. Previously, only IAM role authentication was supported.

Solves #479

## Changes

- Modified `completeRequest` function to accept the entire `schemas.Key` instead of just the Bedrock config
- Added conditional logic to use API Key authentication when `key.Value` is set
- Updated the UI to support both authentication methods with clear separation
- Added explanatory notes in the schema documentation about authentication options
- Moved utility functions `MarshalToString` and `MarshalToStringPtr` from core to configstore package
- Updated UI form to include proper placeholders and descriptions for Bedrock authentication

## Type of change

- [x] Feature
- [x] Refactor
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

1. Configure a Bedrock provider with API Key authentication:
   - Add a new Bedrock key in the UI
   - Enter your API key in the "API Key" field
   - Leave the IAM credentials (Access Key, Secret Key) empty
   - Set the required Region

2. Configure a Bedrock provider with IAM role authentication:
   - Add a new Bedrock key in the UI
   - Leave the API Key field empty
   - Either provide Access Key and Secret Key or leave both empty to use the instance IAM role
   - Set the required Region

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] No

## Security considerations

This PR enhances authentication options for AWS Bedrock but doesn't change the security model. API keys are handled with the same security considerations as other provider keys.