### PR TITLE
refactor: remove redundant heading and unused Redis cluster test code

### DIFF
--- a/docs/features/observability.mdx
+++ b/docs/features/observability.mdx
@@ -78,8 +78,6 @@ For HTTP transport, configure via environment variables:
 
 ## Configuration
 
-### Plugin Configuration
-
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `ApiKey` | `string` | ✅ Yes | Your Maxim API key for authentication |


### PR DESCRIPTION
## Summary

Refine observability documentation and update network configuration in semantic cache test utilities.

## Changes

- Removed redundant "Plugin Configuration" header in observability documentation
- Removed unused `NewRedisClusterTestSetup` function that was no longer needed
- Replaced generic `schemas.DefaultNetworkConfig` with explicit network configuration in test utilities
- Fixed whitespace in Redis config function

## Type of change

- [x] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./plugins/semanticcache/...

# Documentation
# Verify the observability.mdx file renders correctly
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is primarily cleanup and documentation improvements.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)