### PR TITLE
fix: added missing openai params in integrations

### DIFF
--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -460,7 +460,8 @@ func DeriveAnthropicFromBifrostResponse(bifrostResp *schemas.BifrostResponse) *A
 		choice := bifrostResp.Choices[0] // Anthropic typically returns one choice
 
 		if choice.FinishReason != nil {
-			anthropicResp.StopReason = choice.FinishReason
+			mappedReason := integrations.MapFinishReasonToProvider(*choice.FinishReason, schemas.Anthropic)
+			anthropicResp.StopReason = &mappedReason
 		}
 		if choice.StopString != nil {
 			anthropicResp.StopSequence = choice.StopString
@@ -577,11 +578,12 @@ func DeriveAnthropicStreamFromBifrostResponse(bifrostResp *schemas.BifrostRespon
 					}
 				}
 			} else if choice.FinishReason != nil && *choice.FinishReason != "" {
-				// Handle finish reason
+				// Handle finish reason - map back to Anthropic format
+				stopReason := integrations.MapFinishReasonToProvider(*choice.FinishReason, schemas.Anthropic)
 				streamResp.Type = "message_delta"
 				streamResp.Delta = &AnthropicStreamDelta{
 					Type:       "message_delta",
-					StopReason: choice.FinishReason,
+					StopReason: &stopReason,
 				}
 			}
 

--- a/transports/bifrost-http/integrations/openai/types.go
+++ b/transports/bifrost-http/integrations/openai/types.go
@@ -25,6 +25,9 @@ type OpenAIChatRequest struct {
 	TopLogProbs      *int                     `json:"top_logprobs,omitempty"`
 	ResponseFormat   interface{}              `json:"response_format,omitempty"`
 	Seed             *int                     `json:"seed,omitempty"`
+	MaxCompletionTokens *int                     `json:"max_completion_tokens,omitempty"`
+	ReasoningEffort *string                     `json:"reasoning_effort,omitempty"`
+	StreamOptions *map[string]interface{}                     `json:"stream_options,omitempty"`
 }
 
 // OpenAISpeechRequest represents an OpenAI speech synthesis request
@@ -339,6 +342,18 @@ func (r *OpenAIChatRequest) convertParameters() *schemas.ModelParameters {
 	}
 	if r.Seed != nil {
 		params.ExtraParams["seed"] = *r.Seed
+	}
+	if r.StreamOptions != nil {
+		params.ExtraParams["stream_options"] = r.StreamOptions
+	}
+	if r.ResponseFormat != nil {
+		params.ExtraParams["response_format"] = r.ResponseFormat
+	}
+	if r.MaxCompletionTokens != nil {
+		params.ExtraParams["max_completion_tokens"] = *r.MaxCompletionTokens
+	}
+	if r.ReasoningEffort != nil {
+		params.ExtraParams["reasoning_effort"] = *r.ReasoningEffort
 	}
 
 	return params

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -313,6 +313,7 @@ func buildProviderSchemas() map[schemas.ModelProvider]ProviderParameterSchema {
 		"timestamp_granularities": true,
 		"encoding_format":         true,
 		"dimensions":              true,
+		"stream_options":          true,
 	}
 
 	anthropicParams := map[string]bool{
@@ -1174,5 +1175,31 @@ func newBifrostError(err error, message string) *schemas.BifrostError {
 			Message: message,
 			Error:   err,
 		},
+	}
+}
+
+// MapFinishReasonToProvider maps OpenAI-compatible finish reasons to provider-specific format
+func MapFinishReasonToProvider(finishReason string, targetProvider schemas.ModelProvider) string {
+	switch targetProvider {
+	case schemas.Anthropic:
+		return mapFinishReasonToAnthropic(finishReason)
+	default:
+		// For OpenAI, Azure, and other providers, pass through as-is
+		return finishReason
+	}
+}
+
+// mapFinishReasonToAnthropic maps OpenAI finish reasons to Anthropic format
+func mapFinishReasonToAnthropic(finishReason string) string {
+	switch finishReason {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	case "tool_calls":
+		return "tool_use"
+	default:
+		// Pass through other reasons like "pause_turn", "refusal", "stop_sequence", etc.
+		return finishReason
 	}
 }


### PR DESCRIPTION
## Summary

Added support for new OpenAI API parameters in the Bifrost HTTP transport layer, including `max_completion_tokens`, `reasoning_effort`, and `stream_options`.

## Changes

- Added new fields to `OpenAIChatRequest` struct: `MaxCompletionTokens`, `ReasoningEffort`, and `StreamOptions`
- Updated the `convertParameters` method to include these new parameters in the `ExtraParams` map
- Added support for passing `response_format` to the model parameters
- Added `stream_options` to the list of allowed parameters for OpenAI models

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new parameters with OpenAI API calls:

```sh
# Test with max_completion_tokens
curl -X POST "http://localhost:8080/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o",
    "messages": [{"role": "user", "content": "Write a short story"}],
    "max_completion_tokens": 100
  }'

# Test with reasoning_effort
curl -X POST "http://localhost:8080/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o",
    "messages": [{"role": "user", "content": "Solve this math problem"}],
    "reasoning_effort": "high"
  }'

# Test with stream_options
curl -X POST "http://localhost:8080/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o",
    "messages": [{"role": "user", "content": "Tell me a joke"}],
    "stream": true,
    "stream_options": {"include_usage": true}
  }'
```

## Breaking changes

- [x] No

## Related issues

Supports the latest OpenAI API parameters for newer model versions.

## Security considerations

No security implications as this only adds support for additional model parameters.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable