### PR TITLE
refactor: pass input as bifrost request for requests

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1286,15 +1286,15 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 func handleProviderRequest(provider schemas.Provider, req *ChannelMessage, key schemas.Key, reqType schemas.RequestType) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	switch reqType {
 	case schemas.TextCompletionRequest:
-		return provider.TextCompletion(req.Context, req.Model, key, *req.Input.TextCompletionInput, req.Params)
+		return provider.TextCompletion(req.Context, key, &req.BifrostRequest)
 	case schemas.ChatCompletionRequest:
-		return provider.ChatCompletion(req.Context, req.Model, key, *req.Input.ChatCompletionInput, req.Params)
+		return provider.ChatCompletion(req.Context, key, &req.BifrostRequest)
 	case schemas.EmbeddingRequest:
-		return provider.Embedding(req.Context, req.Model, key, req.Input.EmbeddingInput, req.Params)
+		return provider.Embedding(req.Context, key, &req.BifrostRequest)
 	case schemas.SpeechRequest:
-		return provider.Speech(req.Context, req.Model, key, req.Input.SpeechInput, req.Params)
+		return provider.Speech(req.Context, key, &req.BifrostRequest)
 	case schemas.TranscriptionRequest:
-		return provider.Transcription(req.Context, req.Model, key, req.Input.TranscriptionInput, req.Params)
+		return provider.Transcription(req.Context, key, &req.BifrostRequest)
 	default:
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
@@ -1309,11 +1309,11 @@ func handleProviderRequest(provider schemas.Provider, req *ChannelMessage, key s
 func handleProviderStreamRequest(provider schemas.Provider, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner, reqType schemas.RequestType) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	switch reqType {
 	case schemas.ChatCompletionStreamRequest:
-		return provider.ChatCompletionStream(req.Context, postHookRunner, req.Model, key, *req.Input.ChatCompletionInput, req.Params)
+		return provider.ChatCompletionStream(req.Context, postHookRunner, key, &req.BifrostRequest)
 	case schemas.SpeechStreamRequest:
-		return provider.SpeechStream(req.Context, postHookRunner, req.Model, key, req.Input.SpeechInput, req.Params)
+		return provider.SpeechStream(req.Context, postHookRunner, key, &req.BifrostRequest)
 	case schemas.TranscriptionStreamRequest:
-		return provider.TranscriptionStream(req.Context, postHookRunner, req.Model, key, req.Input.TranscriptionInput, req.Params)
+		return provider.TranscriptionStream(req.Context, postHookRunner, key, &req.BifrostRequest)
 	default:
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -197,16 +197,16 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 // TextCompletion performs a text completion request to Azure's API.
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *AzureProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	preparedParams := prepareParams(params)
+func (provider *AzureProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	preparedParams := prepareParams(input.Params)
 
 	// Merge additional parameters
 	requestBody := mergeConfig(map[string]interface{}{
-		"model":  model,
-		"prompt": text,
+		"model":  input.Model,
+		"prompt": *input.Input.TextCompletionInput,
 	}, preparedParams)
 
-	responseBody, err := provider.completeRequest(ctx, requestBody, "completions", key, model)
+	responseBody, err := provider.completeRequest(ctx, requestBody, "completions", key, input.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -259,8 +259,8 @@ func (provider *AzureProvider) TextCompletion(ctx context.Context, model string,
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		bifrostResponse.ExtraFields.Params = *params
+	if input.Params != nil {
+		bifrostResponse.ExtraFields.Params = *input.Params
 	}
 
 	return bifrostResponse, nil
@@ -269,19 +269,13 @@ func (provider *AzureProvider) TextCompletion(ctx context.Context, model string,
 // ChatCompletion performs a chat completion request to Azure's API.
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *AzureProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *AzureProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Azure is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Azure,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 	requestBody := openaiReq
 
-	responseBody, err := provider.completeRequest(ctx, requestBody, "chat/completions", key, model)
+	responseBody, err := provider.completeRequest(ctx, requestBody, "chat/completions", key, input.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -304,8 +298,8 @@ func (provider *AzureProvider) ChatCompletion(ctx context.Context, model string,
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	return response, nil
@@ -314,18 +308,11 @@ func (provider *AzureProvider) ChatCompletion(ctx context.Context, model string,
 // Embedding generates embeddings for the given input text(s) using Azure OpenAI.
 // The input can be either a single string or a slice of strings for batch embedding.
 // Returns a BifrostResponse containing the embedding(s) and any error that occurred.
-func (provider *AzureProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *AzureProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 
 	// Use centralized converter
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.OpenAI,
-		Model:    model,
-		Input:    schemas.RequestInput{EmbeddingInput: input},
-		Params:   params,
-	}
-
-	azureReq := openai.ConvertEmbeddingRequestToOpenAI(bifrostReq)
-	responseBody, err := provider.completeRequest(ctx, azureReq, "embeddings", key, model)
+	azureReq := openai.ConvertEmbeddingRequestToOpenAI(input)
+	responseBody, err := provider.completeRequest(ctx, azureReq, "embeddings", key, input.Model)
 	if err != nil {
 		return nil, err
 	}
@@ -344,8 +331,8 @@ func (provider *AzureProvider) Embedding(ctx context.Context, model string, key 
 
 	response.ExtraFields.Provider = schemas.Azure
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	if provider.sendBackRawResponse {
@@ -359,15 +346,9 @@ func (provider *AzureProvider) Embedding(ctx context.Context, model string, key 
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Uses Azure-specific URL construction with deployments and supports both api-key and Bearer token authentication.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	// Use centralized OpenAI converter since Azure is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Azure,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	if key.AzureKeyConfig == nil {
@@ -383,9 +364,9 @@ func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHoo
 	var fullURL string
 
 	if key.AzureKeyConfig.Deployments != nil {
-		deployment := key.AzureKeyConfig.Deployments[model]
+		deployment := key.AzureKeyConfig.Deployments[input.Model]
 		if deployment == "" {
-			return nil, newConfigurationError(fmt.Sprintf("deployment not found for model %s", model), schemas.Azure)
+			return nil, newConfigurationError(fmt.Sprintf("deployment not found for model %s", input.Model), schemas.Azure)
 		}
 
 		apiVersion := key.AzureKeyConfig.APIVersion
@@ -420,24 +401,24 @@ func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHoo
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Azure, // Provider type
-		params,
+		input.Params,
 		postHookRunner,
 		provider.logger,
 	)
 }
 
-func (provider *AzureProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *AzureProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "azure")
 }
 
-func (provider *AzureProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *AzureProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "azure")
 }
 
-func (provider *AzureProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *AzureProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "azure")
 }
 
-func (provider *AzureProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *AzureProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "azure")
 }

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -96,14 +96,14 @@ func (provider *CohereProvider) GetProviderKey() schemas.ModelProvider {
 
 // TextCompletion is not supported by the Cohere provider.
 // Returns an error indicating that text completion is not supported.
-func (provider *CohereProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *CohereProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", "cohere")
 }
 
 // ChatCompletion performs a chat completion request to the Cohere API using v2 converter.
 // It formats the request, sends it to Cohere, and processes the response.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *CohereProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if chat completion is allowed
 	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.OperationChatCompletion); err != nil {
 		return nil, err
@@ -111,17 +111,8 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, model string
 
 	providerName := provider.GetProviderKey()
 
-	// Create Bifrost request for conversion
-	bifrostRequest := &schemas.BifrostRequest{
-		Model: model,
-		Input: schemas.RequestInput{
-			ChatCompletionInput: &messages,
-		},
-		Params: params,
-	}
-
 	// Convert to Cohere v2 request
-	cohereRequest := cohere.ConvertChatRequestToCohere(bifrostRequest)
+	cohereRequest := cohere.ConvertChatRequestToCohere(input)
 
 	// Marshal request body
 	jsonBody, err := sonic.Marshal(cohereRequest)
@@ -196,15 +187,15 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, model string
 
 	// Convert Cohere v2 response to Bifrost response
 	bifrostResponse := cohere.ConvertChatResponseToBifrost(&cohereResponse)
-	bifrostResponse.Model = model
+	bifrostResponse.Model = input.Model
 	bifrostResponse.ExtraFields.Provider = providerName
 
 	if provider.sendBackRawResponse {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		bifrostResponse.ExtraFields.Params = *params
+	if input.Params != nil {
+		bifrostResponse.ExtraFields.Params = *input.Params
 	}
 
 	return bifrostResponse, nil
@@ -212,7 +203,7 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, model string
 
 // Embedding generates embeddings for the given input text(s) using the Cohere API.
 // Supports Cohere's embedding models and returns a BifrostResponse containing the embedding(s).
-func (provider *CohereProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if embedding is allowed
 	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.OperationEmbedding); err != nil {
 		return nil, err
@@ -221,15 +212,7 @@ func (provider *CohereProvider) Embedding(ctx context.Context, model string, key
 	providerName := provider.GetProviderKey()
 
 	// Create Bifrost request for conversion
-	bifrostRequest := &schemas.BifrostRequest{
-		Model: model,
-		Input: schemas.RequestInput{
-			EmbeddingInput: input,
-		},
-		Params: params,
-	}
-
-	cohereRequest := cohere.ConvertEmbeddingRequestToCohere(bifrostRequest)
+	cohereRequest := cohere.ConvertEmbeddingRequestToCohere(input)
 
 	// Marshal request body
 	jsonBody, err := sonic.Marshal(cohereRequest)
@@ -284,7 +267,7 @@ func (provider *CohereProvider) Embedding(ctx context.Context, model string, key
 
 	// Create BifrostResponse
 	bifrostResponse := cohere.ConvertEmbeddingResponseToBifrost(&cohereResp)
-	bifrostResponse.Model = model
+	bifrostResponse.Model = input.Model
 	bifrostResponse.ExtraFields.Provider = providerName
 
 	// Only include RawResponse if sendBackRawResponse is enabled
@@ -292,8 +275,8 @@ func (provider *CohereProvider) Embedding(ctx context.Context, model string, key
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		bifrostResponse.ExtraFields.Params = *params
+	if input.Params != nil {
+		bifrostResponse.ExtraFields.Params = *input.Params
 	}
 
 	return bifrostResponse, nil
@@ -302,25 +285,15 @@ func (provider *CohereProvider) Embedding(ctx context.Context, model string, key
 // ChatCompletionStream performs a streaming chat completion request to the Cohere API.
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Check if chat completion stream is allowed
 	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.OperationChatCompletionStream); err != nil {
 		return nil, err
 	}
 
 	providerName := provider.GetProviderKey()
-
-	// Create Bifrost request for conversion
-	bifrostRequest := &schemas.BifrostRequest{
-		Model: model,
-		Input: schemas.RequestInput{
-			ChatCompletionInput: &messages,
-		},
-		Params: params,
-	}
-
 	// Convert to Cohere v2 request and add streaming
-	cohereRequest := cohere.ConvertChatRequestToCohere(bifrostRequest)
+	cohereRequest := cohere.ConvertChatRequestToCohere(input)
 	cohereRequest.Stream = schemas.Ptr(true)
 
 	jsonBody, err := sonic.Marshal(cohereRequest)
@@ -411,7 +384,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 				response := &schemas.BifrostResponse{
 					ID:     responseID,
 					Object: "chat.completion.chunk",
-					Model:  model,
+					Model:  input.Model,
 					Choices: []schemas.BifrostResponseChoice{
 						{
 							Index: 0,
@@ -504,8 +477,8 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 							}
 						}
 
-						if params != nil {
-							response.ExtraFields.Params = *params
+						if input.Params != nil {
+							response.ExtraFields.Params = *input.Params
 						}
 
 						ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
@@ -537,18 +510,18 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	return responseChan, nil
 }
 
-func (provider *CohereProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *CohereProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "cohere")
 }
 
-func (provider *CohereProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *CohereProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "cohere")
 }
 
-func (provider *CohereProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *CohereProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "cohere")
 }
 
-func (provider *CohereProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *CohereProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "cohere")
 }

--- a/core/providers/gemini.go
+++ b/core/providers/gemini.go
@@ -127,12 +127,12 @@ func (provider *GeminiProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // TextCompletion is not supported by the Gemini provider.
-func (provider *GeminiProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GeminiProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", string(provider.GetProviderKey()))
 }
 
 // ChatCompletion performs a chat completion request to the Gemini API.
-func (provider *GeminiProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GeminiProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if chat completion is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationChatCompletion); err != nil {
 		return nil, err
@@ -141,13 +141,7 @@ func (provider *GeminiProvider) ChatCompletion(ctx context.Context, model string
 	providerName := provider.GetProviderKey()
 
 	// Use centralized OpenAI converter since Gemini uses OpenAI-compatible endpoints
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Gemini,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 	jsonBody, err := sonic.Marshal(openaiReq)
 	if err != nil {
@@ -215,8 +209,8 @@ func (provider *GeminiProvider) ChatCompletion(ctx context.Context, model string
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	return response, nil
@@ -226,7 +220,7 @@ func (provider *GeminiProvider) ChatCompletion(ctx context.Context, model string
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Uses Gemini's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Check if chat completion stream is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationChatCompletionStream); err != nil {
 		return nil, err
@@ -235,13 +229,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHo
 	providerName := provider.GetProviderKey()
 
 	// Use centralized OpenAI converter since Gemini uses OpenAI-compatible endpoints
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Gemini,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	// Prepare Gemini headers
@@ -261,47 +249,48 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHo
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		providerName,
-		params,
+		input.Params,
 		postHookRunner,
 		provider.logger,
 	)
 }
 
 // Embedding performs an embedding request to the Gemini API.
-func (provider *GeminiProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GeminiProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if embedding is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationEmbedding); err != nil {
 		return nil, err
 	}
 
 	providerName := provider.GetProviderKey()
+	embeddingInput := input.Input.EmbeddingInput
 
-	if input == nil || len(input.Texts) == 0 {
+	if input == nil || len(embeddingInput.Texts) == 0 {
 		return nil, newBifrostOperationError("invalid embedding input: at least one text is required", nil, providerName)
 	}
 
 	// Prepare request body with base parameters
 	requestBody := map[string]interface{}{
-		"model": model,
-		"input": input.Texts,
+		"model": input.Model,
+		"input": embeddingInput.Texts,
 	}
 
 	// Merge any additional parameters
-	if params != nil {
+	if input.Params != nil {
 		// Map standard parameters
-		if params.EncodingFormat != nil {
-			requestBody["encoding_format"] = *params.EncodingFormat
+		if input.Params.EncodingFormat != nil {
+			requestBody["encoding_format"] = *input.Params.EncodingFormat
 		}
-		if params.Dimensions != nil {
-			requestBody["dimensions"] = *params.Dimensions
+		if input.Params.Dimensions != nil {
+			requestBody["dimensions"] = *input.Params.Dimensions
 		}
-		if params.User != nil {
-			requestBody["user"] = *params.User
+		if input.Params.User != nil {
+			requestBody["user"] = *input.Params.User
 		}
 
 		// Merge any extra parameters
-		if params.ExtraParams != nil {
-			requestBody = mergeConfig(requestBody, params.ExtraParams)
+		if input.Params.ExtraParams != nil {
+			requestBody = mergeConfig(requestBody, input.Params.ExtraParams)
 		}
 	}
 
@@ -312,7 +301,7 @@ func (provider *GeminiProvider) Embedding(ctx context.Context, model string, key
 		provider.networkConfig.BaseURL+"/openai/embeddings",
 		requestBody,
 		key,
-		params,
+		input.Params,
 		provider.networkConfig.ExtraHeaders,
 		providerName,
 		provider.sendBackRawResponse,
@@ -320,7 +309,7 @@ func (provider *GeminiProvider) Embedding(ctx context.Context, model string, key
 	)
 }
 
-func (provider *GeminiProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GeminiProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if speech is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationSpeech); err != nil {
 		return nil, err
@@ -329,15 +318,15 @@ func (provider *GeminiProvider) Speech(ctx context.Context, model string, key sc
 	providerName := provider.GetProviderKey()
 
 	// Validate input
-	if input == nil || input.Input == "" {
+	if input == nil || input.Input.SpeechInput == nil || input.Input.SpeechInput.Input == "" {
 		return nil, newBifrostOperationError("invalid speech input: no text provided", fmt.Errorf("empty text input"), providerName)
 	}
 
 	// Prepare request body using shared function
-	requestBody := prepareGeminiGenerationRequest(input, params, []string{"AUDIO"})
+	requestBody := prepareGeminiGenerationRequest(input.Input.SpeechInput, input.Params, []string{"AUDIO"})
 
 	// Use common request function
-	bifrostResponse, geminiResponse, bifrostErr := provider.completeRequest(ctx, model, key, requestBody, ":generateContent", params)
+	bifrostResponse, geminiResponse, bifrostErr := provider.completeRequest(ctx, input.Model, key, requestBody, ":generateContent", input.Params)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -370,14 +359,14 @@ func (provider *GeminiProvider) Speech(ctx context.Context, model string, key sc
 		},
 	}
 
-	if params != nil {
-		bifrostResponse.ExtraFields.Params = *params
+	if input.Params != nil {
+		bifrostResponse.ExtraFields.Params = *input.Params
 	}
 
 	return bifrostResponse, nil
 }
 
-func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Check if speech stream is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationSpeechStream); err != nil {
 		return nil, err
@@ -386,12 +375,12 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 	providerName := provider.GetProviderKey()
 
 	// Validate input
-	if input == nil || input.Input == "" {
+	if input == nil || input.Input.SpeechInput == nil || input.Input.SpeechInput.Input == "" {
 		return nil, newBifrostOperationError("invalid speech input: no text provided", fmt.Errorf("empty text input"), providerName)
 	}
 
 	// Prepare request body using shared function
-	requestBody := prepareGeminiGenerationRequest(input, params, []string{"AUDIO"})
+	requestBody := prepareGeminiGenerationRequest(input.Input.SpeechInput, input.Params, []string{"AUDIO"})
 
 	jsonBody, err := sonic.Marshal(requestBody)
 	if err != nil {
@@ -399,7 +388,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/models/"+model+":streamGenerateContent?alt=sse", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/models/"+input.Model+":streamGenerateContent?alt=sse", bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
 	}
@@ -516,7 +505,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 				// Create Bifrost speech response for streaming
 				response := &schemas.BifrostResponse{
 					Object: "audio.speech.chunk",
-					Model:  model,
+					Model:  input.Model,
 					Speech: &schemas.BifrostSpeech{
 						Audio: audioChunk,
 						BifrostSpeechStreamResponse: &schemas.BifrostSpeechStreamResponse{
@@ -550,8 +539,8 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 				},
 			}
 
-			if params != nil {
-				response.ExtraFields.Params = *params
+			if input.Params != nil {
+				response.ExtraFields.Params = *input.Params
 			}
 			handleStreamEndWithSuccess(ctx, response, postHookRunner, responseChan, provider.logger)
 		}
@@ -560,7 +549,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 	return responseChan, nil
 }
 
-func (provider *GeminiProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GeminiProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if transcription is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationTranscription); err != nil {
 		return nil, err
@@ -568,21 +557,23 @@ func (provider *GeminiProvider) Transcription(ctx context.Context, model string,
 
 	providerName := provider.GetProviderKey()
 
+	transcriptionInput := input.Input.TranscriptionInput
+
 	// Check file size limit (Gemini has a 20MB limit for inline data)
 	const maxFileSize = 20 * 1024 * 1024 // 20MB
-	if len(input.File) > maxFileSize {
-		return nil, newBifrostOperationError("audio file too large for inline transcription", fmt.Errorf("file size %d bytes exceeds 20MB limit", len(input.File)), providerName)
+	if len(transcriptionInput.File) > maxFileSize {
+		return nil, newBifrostOperationError("audio file too large for inline transcription", fmt.Errorf("file size %d bytes exceeds 20MB limit", len(transcriptionInput.File)), providerName)
 	}
 
-	if input.Prompt == nil {
-		input.Prompt = Ptr("Generate a transcript of the speech.")
+	if transcriptionInput.Prompt == nil {
+		input.Input.TranscriptionInput.Prompt = Ptr("Generate a transcript of the speech.")
 	}
 
 	// Prepare request body using shared function
-	requestBody := prepareGeminiGenerationRequest(input, params, nil)
+	requestBody := prepareGeminiGenerationRequest(transcriptionInput, input.Params, nil)
 
 	// Use common request function
-	bifrostResponse, geminiResponse, bifrostErr := provider.completeRequest(ctx, model, key, requestBody, ":generateContent", params)
+	bifrostResponse, geminiResponse, bifrostErr := provider.completeRequest(ctx, input.Model, key, requestBody, ":generateContent", input.Params)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -617,39 +608,40 @@ func (provider *GeminiProvider) Transcription(ctx context.Context, model string,
 		},
 		BifrostTranscribeNonStreamResponse: &schemas.BifrostTranscribeNonStreamResponse{
 			Task:     Ptr("transcribe"),
-			Language: input.Language,
+			Language: transcriptionInput.Language,
 		},
 	}
 
-	if params != nil {
-		bifrostResponse.ExtraFields.Params = *params
+	if input.Params != nil {
+		bifrostResponse.ExtraFields.Params = *input.Params
 	}
 
 	return bifrostResponse, nil
 }
 
-func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Check if transcription stream is allowed for this provider
 	if err := checkOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.OperationTranscriptionStream); err != nil {
 		return nil, err
 	}
 
 	providerName := provider.GetProviderKey()
+	transcriptionInput := input.Input.TranscriptionInput
 
 	// Check file size limit (Gemini has a 20MB limit for inline data)
-	if input.File != nil {
+	if transcriptionInput.File != nil {
 		const maxFileSize = 20 * 1024 * 1024 // 20MB
-		if len(input.File) > maxFileSize {
-			return nil, newBifrostOperationError("audio file too large for inline transcription", fmt.Errorf("file size %d bytes exceeds 20MB limit", len(input.File)), providerName)
+		if len(transcriptionInput.File) > maxFileSize {
+			return nil, newBifrostOperationError("audio file too large for inline transcription", fmt.Errorf("file size %d bytes exceeds 20MB limit", len(transcriptionInput.File)), providerName)
 		}
 	}
 
-	if input.Prompt == nil {
-		input.Prompt = Ptr("Generate a transcript of the speech.")
+	if transcriptionInput.Prompt == nil {
+		transcriptionInput.Prompt = Ptr("Generate a transcript of the speech.")
 	}
 
 	// Prepare request body using shared function
-	requestBody := prepareGeminiGenerationRequest(input, params, nil)
+	requestBody := prepareGeminiGenerationRequest(transcriptionInput, input.Params, nil)
 
 	jsonBody, err := sonic.Marshal(requestBody)
 	if err != nil {
@@ -657,7 +649,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/models/"+model+":streamGenerateContent?alt=sse", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/models/"+input.Model+":streamGenerateContent?alt=sse", bytes.NewReader(jsonBody))
 	if err != nil {
 		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
 	}
@@ -786,7 +778,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHoo
 							Delta: &deltaText, // Delta text for this chunk
 						},
 					},
-					Model: model,
+					Model: input.Model,
 					ExtraFields: schemas.BifrostResponseExtraFields{
 						Provider:   providerName,
 						ChunkIndex: chunkIndex,
@@ -820,8 +812,8 @@ func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHoo
 				},
 			}
 
-			if params != nil {
-				response.ExtraFields.Params = *params
+			if input.Params != nil {
+				response.ExtraFields.Params = *input.Params
 			}
 			handleStreamEndWithSuccess(ctx, response, postHookRunner, responseChan, provider.logger)
 		}

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -91,20 +91,14 @@ func (provider *GroqProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // TextCompletion is not supported by the Groq provider.
-func (provider *GroqProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GroqProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", "groq")
 }
 
 // ChatCompletion performs a chat completion request to the Groq API.
-func (provider *GroqProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GroqProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Groq is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Groq,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 
 	jsonBody, err := sonic.Marshal(openaiReq)
@@ -164,15 +158,15 @@ func (provider *GroqProvider) ChatCompletion(ctx context.Context, model string, 
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	return response, nil
 }
 
 // Embedding is not supported by the Groq provider.
-func (provider *GroqProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GroqProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("embedding", "groq")
 }
 
@@ -180,15 +174,9 @@ func (provider *GroqProvider) Embedding(ctx context.Context, model string, key s
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Uses Groq's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Groq is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Groq,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	// Prepare Groq headers
@@ -209,24 +197,24 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Groq,
-		params,
+		input.Params,
 		postHookRunner,
 		provider.logger,
 	)
 }
 
-func (provider *GroqProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GroqProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "groq")
 }
 
-func (provider *GroqProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *GroqProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "groq")
 }
 
-func (provider *GroqProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *GroqProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "groq")
 }
 
-func (provider *GroqProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *GroqProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "groq")
 }

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -92,20 +92,14 @@ func (provider *OllamaProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // TextCompletion is not supported by the Ollama provider.
-func (provider *OllamaProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *OllamaProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", "ollama")
 }
 
 // ChatCompletion performs a chat completion request to the Ollama API.
-func (provider *OllamaProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *OllamaProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Ollama is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Ollama,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 	jsonBody, err := sonic.Marshal(openaiReq)
 	if err != nil {
@@ -165,15 +159,15 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, model string
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	return response, nil
 }
 
 // Embedding is not supported by the Ollama provider.
-func (provider *OllamaProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *OllamaProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("embedding", "ollama")
 }
 
@@ -181,15 +175,9 @@ func (provider *OllamaProvider) Embedding(ctx context.Context, model string, key
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Uses Ollama's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Ollama is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Ollama,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	// Prepare Ollama headers (Ollama typically doesn't require authorization, but we include it if provided)
@@ -213,24 +201,24 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Ollama,
-		params,
+		input.Params,
 		postHookRunner,
 		provider.logger,
 	)
 }
 
-func (provider *OllamaProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *OllamaProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "ollama")
 }
 
-func (provider *OllamaProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *OllamaProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "ollama")
 }
 
-func (provider *OllamaProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *OllamaProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "ollama")
 }
 
-func (provider *OllamaProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *OllamaProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "ollama")
 }

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -91,20 +91,14 @@ func (provider *ParasailProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // TextCompletion is not supported by the Parasail provider.
-func (provider *ParasailProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *ParasailProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", "parasail")
 }
 
 // ChatCompletion performs a chat completion request to the Parasail API.
-func (provider *ParasailProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Parasail is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Parasail,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 	jsonBody, err := sonic.Marshal(openaiReq)
 	if err != nil {
@@ -163,15 +157,15 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, model stri
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	return response, nil
 }
 
 // Embedding is not supported by the Parasail provider.
-func (provider *ParasailProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *ParasailProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("embedding", "parasail")
 }
 
@@ -179,15 +173,9 @@ func (provider *ParasailProvider) Embedding(ctx context.Context, model string, k
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Uses Parasail's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since Parasail is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.Parasail,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	// Prepare Parasail headers
@@ -208,28 +196,28 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, post
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
-		params,
+		input.Params,
 		postHookRunner,
 		provider.logger,
 	)
 }
 
 // Speech is not supported by the Parasail provider.
-func (provider *ParasailProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *ParasailProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "parasail")
 }
 
 // SpeechStream is not supported by the Parasail provider.
-func (provider *ParasailProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *ParasailProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "parasail")
 }
 
 // Transcription is not supported by the Parasail provider.
-func (provider *ParasailProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *ParasailProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "parasail")
 }
 
 // TranscriptionStream is not supported by the Parasail provider.
-func (provider *ParasailProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *ParasailProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "parasail")
 }

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -92,20 +92,14 @@ func (provider *SGLProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // TextCompletion is not supported by the SGL provider.
-func (provider *SGLProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *SGLProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", "sgl")
 }
 
 // ChatCompletion performs a chat completion request to the SGL API.
-func (provider *SGLProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *SGLProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since SGL is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.SGL,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 	jsonBody, err := sonic.Marshal(openaiReq)
 	if err != nil {
@@ -171,15 +165,15 @@ func (provider *SGLProvider) ChatCompletion(ctx context.Context, model string, k
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
-	if params != nil {
-		response.ExtraFields.Params = *params
+	if input.Params != nil {
+		response.ExtraFields.Params = *input.Params
 	}
 
 	return response, nil
 }
 
 // Embedding is not supported by the SGL provider.
-func (provider *SGLProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *SGLProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("embedding", "sgl")
 }
 
@@ -187,15 +181,9 @@ func (provider *SGLProvider) Embedding(ctx context.Context, model string, key sc
 // It supports real-time streaming of responses using Server-Sent Events (SSE).
 // Uses SGL's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
-func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Use centralized OpenAI converter since SGL is OpenAI-compatible
-	bifrostReq := &schemas.BifrostRequest{
-		Provider: schemas.SGL,
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-	openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+	openaiReq := openai.ConvertChatRequestToOpenAI(input)
 	openaiReq.Stream = schemas.Ptr(true)
 
 	// Prepare SGL headers (SGL typically doesn't require authorization, but we include it if provided)
@@ -219,24 +207,24 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		schemas.SGL,
-		params,
+		input.Params,
 		postHookRunner,
 		provider.logger,
 	)
 }
 
-func (provider *SGLProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *SGLProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "sgl")
 }
 
-func (provider *SGLProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *SGLProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "sgl")
 }
 
-func (provider *SGLProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *SGLProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "sgl")
 }
 
-func (provider *SGLProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *SGLProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "sgl")
 }

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -132,14 +132,14 @@ func (provider *VertexProvider) GetProviderKey() schemas.ModelProvider {
 
 // TextCompletion is not supported by the Vertex provider.
 // Returns an error indicating that text completion is not available.
-func (provider *VertexProvider) TextCompletion(ctx context.Context, model string, key schemas.Key, text string, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *VertexProvider) TextCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("text completion", "vertex")
 }
 
 // ChatCompletion performs a chat completion request to the Vertex API.
 // It supports both text and image content in messages.
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *VertexProvider) ChatCompletion(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if key.VertexKeyConfig == nil {
 		return nil, newConfigurationError("vertex key config is not set", schemas.Vertex)
 	}
@@ -147,31 +147,24 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 	// Format messages for Vertex API
 
 	var requestBody map[string]interface{}
-	bifrostReq := &schemas.BifrostRequest{
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
 
-	if strings.Contains(model, "claude") {
+	if strings.Contains(input.Model, "claude") {
 		// Use centralized Anthropic converter
-		bifrostReq.Provider = schemas.Anthropic
-		anthropicReq := anthropic.ConvertChatRequestToAnthropic(bifrostReq)
+		anthropicReq := anthropic.ConvertChatRequestToAnthropic(input)
 
 		// Convert struct to map for Vertex API
 		reqBytes, _ := sonic.Marshal(anthropicReq)
 		sonic.Unmarshal(reqBytes, &requestBody)
 	} else {
 		// Use centralized OpenAI converter for non-Claude models
-		bifrostReq.Provider = schemas.OpenAI
-		openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+		openaiReq := openai.ConvertChatRequestToOpenAI(input)
 
 		// Convert struct to map for Vertex API
 		reqBytes, _ := sonic.Marshal(openaiReq)
 		sonic.Unmarshal(reqBytes, &requestBody)
 	}
 
-	if strings.Contains(model, "claude") {
+	if strings.Contains(input.Model, "claude") {
 		if _, exists := requestBody["anthropic_version"]; !exists {
 			requestBody["anthropic_version"] = "vertex-2023-10-16"
 		}
@@ -198,8 +191,8 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 
 	url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/openapi/chat/completions", region, projectID, region)
 
-	if strings.Contains(model, "claude") {
-		url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", region, projectID, region, model)
+	if strings.Contains(input.Model, "claude") {
+		url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", region, projectID, region, input.Model)
 	}
 
 	// Create request
@@ -275,7 +268,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 		return nil, newProviderAPIError(openAIErr.Error.Message, nil, resp.StatusCode, schemas.Vertex, nil, nil)
 	}
 
-	if strings.Contains(model, "claude") {
+	if strings.Contains(input.Model, "claude") {
 		// Create response object from pool
 		response := acquireAnthropicChatResponse()
 		defer releaseAnthropicChatResponse(response)
@@ -301,8 +294,8 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 			bifrostResponse.ExtraFields.RawResponse = rawResponse
 		}
 
-		if params != nil {
-			bifrostResponse.ExtraFields.Params = *params
+		if input.Params != nil {
+			bifrostResponse.ExtraFields.Params = *input.Params
 		}
 
 		return bifrostResponse, nil
@@ -324,8 +317,8 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 			response.ExtraFields.RawResponse = rawResponse
 		}
 
-		if params != nil {
-			response.ExtraFields.Params = *params
+		if input.Params != nil {
+			response.ExtraFields.Params = *input.Params
 		}
 
 		return response, nil
@@ -335,7 +328,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, model string
 // Embedding generates embeddings for the given input text(s) using Vertex AI.
 // All Vertex AI embedding models use the same response format regardless of the model type.
 // Returns a BifrostResponse containing the embedding(s) and any error that occurred.
-func (provider *VertexProvider) Embedding(ctx context.Context, model string, key schemas.Key, input *schemas.EmbeddingInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *VertexProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	if key.VertexKeyConfig == nil {
 		return nil, newConfigurationError("vertex key config is not set", schemas.Vertex)
 	}
@@ -351,12 +344,12 @@ func (provider *VertexProvider) Embedding(ctx context.Context, model string, key
 	}
 
 	// Validate input
-	if input == nil || len(input.Texts) == 0 {
+	if input.Input.EmbeddingInput == nil || len(input.Input.EmbeddingInput.Texts) == 0 {
 		return nil, newConfigurationError("embedding input texts are empty", schemas.Vertex)
 	}
 
 	// All Vertex AI embedding models use the same native Vertex embedding API
-	return provider.handleVertexEmbedding(ctx, model, key, input, params)
+	return provider.handleVertexEmbedding(ctx, input.Model, key, input.Input.EmbeddingInput, input.Params)
 }
 
 // handleVertexEmbedding handles embedding requests using Vertex's native embedding API
@@ -616,7 +609,7 @@ func (provider *VertexProvider) convertVertexEmbeddingResponse(vertexResponse ma
 // ChatCompletionStream performs a streaming chat completion request to the Vertex API.
 // It supports both OpenAI-style streaming (for non-Claude models) and Anthropic-style streaming (for Claude models).
 // Returns a channel of BifrostResponse objects for streaming results or an error if the request fails.
-func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, messages []schemas.BifrostMessage, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	if key.VertexKeyConfig == nil {
 		return nil, newConfigurationError("vertex key config is not set", schemas.Vertex)
 	}
@@ -638,16 +631,9 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 		return nil, newBifrostOperationError("error creating auth client", err, schemas.Vertex)
 	}
 
-	bifrostReq := &schemas.BifrostRequest{
-		Model:    model,
-		Input:    schemas.RequestInput{ChatCompletionInput: &messages},
-		Params:   params,
-	}
-
-	if strings.Contains(model, "claude") {
-		bifrostReq.Provider = schemas.Anthropic
+	if strings.Contains(input.Model, "claude") {
 		// Use Anthropic-style streaming for Claude models
-		anthropicReq := anthropic.ConvertChatRequestToAnthropic(bifrostReq)
+		anthropicReq := anthropic.ConvertChatRequestToAnthropic(input)
 		anthropicReq.Stream = schemas.Ptr(true)
 
 		// Convert struct to map for Vertex API
@@ -662,7 +648,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 		delete(requestBody, "model")
 		delete(requestBody, "region")
 
-		url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", region, projectID, region, model)
+		url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", region, projectID, region, input.Model)
 
 		// Prepare headers for Vertex Anthropic
 		headers := map[string]string{
@@ -680,14 +666,13 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 			headers,
 			provider.networkConfig.ExtraHeaders,
 			schemas.Vertex,
-			params,
+			input.Params,
 			postHookRunner,
 			provider.logger,
 		)
 	} else {
 		// Use OpenAI-style streaming for non-Claude models
-		bifrostReq.Provider = schemas.OpenAI
-		openaiReq := openai.ConvertChatRequestToOpenAI(bifrostReq)
+		openaiReq := openai.ConvertChatRequestToOpenAI(input)
 		openaiReq.Stream = schemas.Ptr(true)
 
 		// Convert struct to map for Vertex API
@@ -715,25 +700,25 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 			headers,
 			provider.networkConfig.ExtraHeaders,
 			schemas.Vertex,
-			params,
+			input.Params,
 			postHookRunner,
 			provider.logger,
 		)
 	}
 }
 
-func (provider *VertexProvider) Speech(ctx context.Context, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *VertexProvider) Speech(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "vertex")
 }
 
-func (provider *VertexProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.SpeechInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *VertexProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech stream", "vertex")
 }
 
-func (provider *VertexProvider) Transcription(ctx context.Context, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (*schemas.BifrostResponse, *schemas.BifrostError) {
+func (provider *VertexProvider) Transcription(ctx context.Context, key schemas.Key, input *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription", "vertex")
 }
 
-func (provider *VertexProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, model string, key schemas.Key, input *schemas.TranscriptionInput, params *schemas.ModelParameters) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+func (provider *VertexProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, input *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "vertex")
 }

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -203,19 +203,19 @@ type Provider interface {
 	// GetProviderKey returns the provider's identifier
 	GetProviderKey() ModelProvider
 	// TextCompletion performs a text completion request
-	TextCompletion(ctx context.Context, model string, key Key, text string, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	TextCompletion(ctx context.Context, key Key, input *BifrostRequest) (*BifrostResponse, *BifrostError)
 	// ChatCompletion performs a chat completion request
-	ChatCompletion(ctx context.Context, model string, key Key, messages []BifrostMessage, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	ChatCompletion(ctx context.Context, key Key, input *BifrostRequest) (*BifrostResponse, *BifrostError)
 	// ChatCompletionStream performs a chat completion stream request
-	ChatCompletionStream(ctx context.Context, postHookRunner PostHookRunner, model string, key Key, messages []BifrostMessage, params *ModelParameters) (chan *BifrostStream, *BifrostError)
+	ChatCompletionStream(ctx context.Context, postHookRunner PostHookRunner, key Key, input *BifrostRequest) (chan *BifrostStream, *BifrostError)
 	// Embedding performs an embedding request
-	Embedding(ctx context.Context, model string, key Key, input *EmbeddingInput, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	Embedding(ctx context.Context, key Key, input *BifrostRequest) (*BifrostResponse, *BifrostError)
 	// Speech performs a text to speech request
-	Speech(ctx context.Context, model string, key Key, input *SpeechInput, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	Speech(ctx context.Context, key Key, input *BifrostRequest) (*BifrostResponse, *BifrostError)
 	// SpeechStream performs a text to speech stream request
-	SpeechStream(ctx context.Context, postHookRunner PostHookRunner, model string, key Key, input *SpeechInput, params *ModelParameters) (chan *BifrostStream, *BifrostError)
+	SpeechStream(ctx context.Context, postHookRunner PostHookRunner, key Key, input *BifrostRequest) (chan *BifrostStream, *BifrostError)
 	// Transcription performs a transcription request
-	Transcription(ctx context.Context, model string, key Key, input *TranscriptionInput, params *ModelParameters) (*BifrostResponse, *BifrostError)
+	Transcription(ctx context.Context, key Key, input *BifrostRequest) (*BifrostResponse, *BifrostError)
 	// TranscriptionStream performs a transcription stream request
-	TranscriptionStream(ctx context.Context, postHookRunner PostHookRunner, model string, key Key, input *TranscriptionInput, params *ModelParameters) (chan *BifrostStream, *BifrostError)
+	TranscriptionStream(ctx context.Context, postHookRunner PostHookRunner, key Key, input *BifrostRequest) (chan *BifrostStream, *BifrostError)
 }

--- a/core/schemas/providers/anthropic/converters.go
+++ b/core/schemas/providers/anthropic/converters.go
@@ -773,22 +773,22 @@ func convertImageBlock(block schemas.ContentBlock) AnthropicContentBlock {
 }
 
 // ConvertTextRequestToAnthropic converts a Bifrost text completion request to Anthropic format
-func ConvertTextRequestToAnthropic(model string, text string, params *schemas.ModelParameters) *AnthropicTextRequest {
+func ConvertTextRequestToAnthropic(bifrostReq *schemas.BifrostRequest) *AnthropicTextRequest {
 	anthropicReq := &AnthropicTextRequest{
-		Model:             model,
-		Prompt:            fmt.Sprintf("\n\nHuman: %s\n\nAssistant:", text),
+		Model:             bifrostReq.Model,
+		Prompt:            fmt.Sprintf("\n\nHuman: %s\n\nAssistant:", *bifrostReq.Input.TextCompletionInput),
 		MaxTokensToSample: 4096, // Default value
 	}
 
 	// Convert parameters
-	if params != nil {
-		if params.MaxTokens != nil {
-			anthropicReq.MaxTokensToSample = *params.MaxTokens
+	if bifrostReq.Params != nil {
+		if bifrostReq.Params.MaxTokens != nil {
+			anthropicReq.MaxTokensToSample = *bifrostReq.Params.MaxTokens
 		}
-		anthropicReq.Temperature = params.Temperature
-		anthropicReq.TopP = params.TopP
-		anthropicReq.TopK = params.TopK
-		anthropicReq.StopSequences = params.StopSequences
+		anthropicReq.Temperature = bifrostReq.Params.Temperature
+		anthropicReq.TopP = bifrostReq.Params.TopP
+		anthropicReq.TopK = bifrostReq.Params.TopK
+		anthropicReq.StopSequences = bifrostReq.Params.StopSequences
 	}
 
 	return anthropicReq

--- a/core/schemas/providers/cohere/converters.go
+++ b/core/schemas/providers/cohere/converters.go
@@ -311,60 +311,6 @@ func ConvertEmbeddingRequestToCohere(bifrostReq *schemas.BifrostRequest) *Cohere
 		if truncate, ok := bifrostReq.Params.ExtraParams["truncate"].(string); ok {
 			cohereReq.Truncate = &truncate
 		}
-
-		// Images (if provided)
-		if images, ok := bifrostReq.Params.ExtraParams["images"].([]interface{}); ok {
-			var imageStrs []string
-			for _, img := range images {
-				if imgStr, ok := img.(string); ok {
-					imageStrs = append(imageStrs, imgStr)
-				}
-			}
-			if len(imageStrs) > 0 {
-				cohereReq.Images = &imageStrs
-			}
-		}
-
-		// Mixed inputs (if provided)
-		if inputs, ok := bifrostReq.Params.ExtraParams["inputs"].([]interface{}); ok {
-			var cohereInputs []CohereEmbeddingInput
-			for _, input := range inputs {
-				if inputMap, ok := input.(map[string]interface{}); ok {
-					if content, ok := inputMap["content"].([]interface{}); ok {
-						var contentBlocks []CohereContentBlock
-						for _, block := range content {
-							if blockMap, ok := block.(map[string]interface{}); ok {
-								contentBlock := CohereContentBlock{}
-
-								if blockType, ok := blockMap["type"].(string); ok {
-									contentBlock.Type = blockType
-								}
-
-								if text, ok := blockMap["text"].(string); ok {
-									contentBlock.Text = &text
-								}
-
-								if imageURL, ok := blockMap["image_url"].(map[string]interface{}); ok {
-									if url, ok := imageURL["url"].(string); ok {
-										contentBlock.ImageURL = &CohereImageURL{URL: url}
-									}
-								}
-
-								contentBlocks = append(contentBlocks, contentBlock)
-							}
-						}
-						if len(contentBlocks) > 0 {
-							cohereInputs = append(cohereInputs, CohereEmbeddingInput{
-								Content: contentBlocks,
-							})
-						}
-					}
-				}
-			}
-			if len(cohereInputs) > 0 {
-				cohereReq.Inputs = &cohereInputs
-			}
-		}
 	}
 
 	return cohereReq


### PR DESCRIPTION
## Summary

Simplified provider interfaces by consolidating request parameters into a single `BifrostRequest` object, reducing function parameter complexity and improving code maintainability.

## Changes

- Refactored all provider interfaces to accept a single `BifrostRequest` parameter instead of separate model, messages, and parameter arguments
- Updated all provider implementations to use the consolidated parameter approach
- Modified request handling in the core Bifrost service to pass the complete request object to providers
- Updated converters to work with the consolidated request format

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the test suite to ensure all provider functionality continues to work as expected:

```sh
# Core/Transports
go version
go test ./...
```

Additionally, test various provider requests to verify they work correctly with the new interface:

```sh
# Example: Test OpenAI chat completion
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}]
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves code maintainability and reduces function parameter complexity.

## Security considerations

No security implications as this is an internal refactoring of the provider interfaces.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable