### PR TITLE
feat: add custom provider config JSON column and require base URL for specific providers

### DIFF
--- a/ui/app/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/providers/fragments/networkFormFragment.tsx
@@ -40,8 +40,9 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 	}, [form.formState.isDirty]);
 
 	const onSubmit = (data: NetworkOnlyFormSchema) => {
-		if (isCustomProvider && !(data.network_config?.base_url || "").trim()) {
-			toast.error("Base URL is required for custom providers.");
+		const requiresBaseUrl = isCustomProvider || provider.name === "ollama" || provider.name === "sgl";
+		if (requiresBaseUrl && !(data.network_config?.base_url || "").trim()) {
+			toast.error("Base URL is required for this provider.");
 			return;
 		}
 		// Create updated provider configuration
@@ -80,6 +81,8 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 		});
 	}, [form, provider.name, provider.network_config]);
 
+	const baseURLRequired = provider.name === "ollama" || provider.name === "sgl" || isCustomProvider;
+
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
@@ -101,7 +104,7 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 							name="network_config.base_url"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Base URL {isCustomProvider ? "(Required for Custom Providers)" : "(Optional)"}</FormLabel>
+									<FormLabel>Base URL {baseURLRequired ? "(Required)" : "(Optional)"}</FormLabel>
 									<FormControl>
 										<Input
 											placeholder={isCustomProvider ? "https://api.your-provider.com" : "https://api.example.com"}

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -188,7 +188,7 @@ export const ProviderFormSchema = z
 		}
 
 		// Base URL validation for specific providers
-		const baseURLRequired = data.selectedProvider === "ollama" || data.selectedProvider === "sgl";
+		const baseURLRequired = data.selectedProvider === "ollama" || data.selectedProvider === "sgl" || isCustomProvider;
 		if (baseURLRequired) {
 			if (!data.networkConfig?.base_url) {
 				ctx.addIssue({

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -81,33 +81,27 @@ export const networkConfigSchema = z
 	});
 
 // Network form schema - more lenient for form inputs
-export const networkFormConfigSchema = z.object({
-	base_url: z
-		.url("Must be a valid URL")
-		.refine((url) => url.startsWith("https://"), {
-			message: "Only HTTPS URLs are supported",
-		})
-		.optional(),
-	extra_headers: z.record(z.string(), z.string()).optional(),
-	default_request_timeout_in_seconds: z.coerce
-		.number("Timeout must be a number")
-		.min(1, "Timeout must be greater than 0 seconds")
-		.max(300, "Timeout must be less than 300 seconds"),
-	max_retries: z.coerce
-		.number("Max retries must be a number")
-		.min(0, "Max retries must be greater than 0")
-		.max(10, "Max retries must be less than 10"),
-	retry_backoff_initial: z.coerce
-		.number("Retry backoff initial must be a number")
-		.min(0, "Retry backoff initial must be greater than 0"),
-	retry_backoff_max: z.coerce
-		.number("Retry backoff max must be a number")
-		.min(0, "Retry backoff max must be greater than 0"),
-})
-.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
-	message: "Initial backoff must be less than or equal to max backoff",
-	path: ["retry_backoff_initial"],
-});
+export const networkFormConfigSchema = z
+	.object({
+		base_url: z.preprocess((v) => (v === "" ? undefined : v), z.string().url("Must be a valid URL").optional()),
+		extra_headers: z.record(z.string(), z.string()).optional(),
+		default_request_timeout_in_seconds: z.coerce
+			.number("Timeout must be a number")
+			.min(1, "Timeout must be greater than 0 seconds")
+			.max(300, "Timeout must be less than 300 seconds"),
+		max_retries: z.coerce
+			.number("Max retries must be a number")
+			.min(0, "Max retries must be greater than 0")
+			.max(10, "Max retries must be less than 10"),
+		retry_backoff_initial: z.coerce
+			.number("Retry backoff initial must be a number")
+			.min(100, "Retry backoff initial must be at least 100ms"),
+		retry_backoff_max: z.coerce.number("Retry backoff max must be a number").min(1000, "Retry backoff max must be at least 1000ms"),
+	})
+	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
+		message: "Initial backoff must be less than or equal to max backoff",
+		path: ["retry_backoff_initial"],
+	});
 
 // Concurrency and buffer size schema
 export const concurrencyAndBufferSizeSchema = z.object({


### PR DESCRIPTION
## Summary

Added support for custom provider configuration by implementing a database migration to add a JSON column for storing provider-specific configuration data. Also updated the UI to make base URL required for Ollama, SGL, and custom providers, and removed the HTTPS-only restriction for base URLs.

Solves #504

## Changes

- Added a database migration to create a `custom_provider_config_json` column in the provider table
- Updated the UI to make base URL required for Ollama, SGL, and custom providers
- Removed the HTTPS-only validation requirement for base URLs to support local development and on-prem deployments
- Incremented version numbers across framework, plugins, and transports

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

1. Run the application to trigger the database migration
2. Verify the new column exists in the provider table
3. Test creating/updating providers with custom configurations
4. Verify base URL is required for Ollama, SGL, and custom providers
5. Verify non-HTTPS URLs are now accepted

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] No

## Related issues

Enables better support for custom provider configurations and local development environments.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)