### PR TITLE
enhancement: base_url input in create custom provider modal

### DIFF
--- a/ui/app/providers/dialogs/addNewCustomProviderDialog.tsx
+++ b/ui/app/providers/dialogs/addNewCustomProviderDialog.tsx
@@ -26,6 +26,7 @@ const allowedRequestsSchema = z.object({
 const formSchema = z.object({
 	name: z.string().min(1),
 	baseFormat: z.string().min(1),
+	base_url: z.string().min(1, "Base URL is required").url("Must be a valid URL"),
 	allowed_requests: allowedRequestsSchema,
 });
 
@@ -44,6 +45,7 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 		defaultValues: {
 			name: "",
 			baseFormat: "",
+			base_url: "",
 			allowed_requests: {
 				text_completion: true,
 				chat_completion: true,
@@ -69,6 +71,13 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 			custom_provider_config: {
 				base_provider_type: data.baseFormat as KnownProvider,
 				allowed_requests: data.allowed_requests,
+			},
+			network_config: {
+				base_url: data.base_url,
+				default_request_timeout_in_seconds: 30,
+				max_retries: 0,
+				retry_backoff_initial: 500,
+				retry_backoff_max: 5000,
 			},
 			keys: [],
 		})
@@ -128,6 +137,25 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 													<SelectItem value="bedrock">AWS Bedrock</SelectItem>
 												</SelectContent>
 											</Select>
+										</FormControl>
+										<FormMessage />
+									</div>
+								</FormItem>
+							)}
+						/>
+						<FormField
+							control={form.control}
+							name="base_url"
+							render={({ field }) => (
+								<FormItem className="flex flex-col gap-3">
+									<FormLabel>Base URL</FormLabel>
+									<div>
+										<FormControl>
+										<Input
+											placeholder={"https://api.your-provider.com"}
+											{...field}
+											value={field.value || ""}
+										/>
 										</FormControl>
 										<FormMessage />
 									</div>


### PR DESCRIPTION
## Summary

Added Base URL field to the custom provider creation dialog, enabling users to specify the API endpoint when adding a new custom provider.

## Changes

- Added `base_url` field to the form schema with validation for required input and URL format
- Added form field UI component with appropriate label and placeholder
- Included the base URL in the network configuration when creating a new custom provider
- Set default network configuration values for timeout and retry settings

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the providers section
2. Click "Add Custom Provider"
3. Fill out the form including the new Base URL field
4. Verify validation works (requires URL format)
5. Submit the form and confirm the provider is created with the correct base URL

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The base URL is stored as part of the provider configuration and used for API requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable