### PR TITLE
feat: collapse anthropic single-text replies to string

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -798,6 +798,10 @@ func parseAnthropicResponse(response *AnthropicChatResponse, bifrostResponse *sc
 		}
 	}
 
+	// Build MessageContent based on the type of content blocks
+	messageContent := BuildMessageContent(contentBlocks)
+	defer releaseMessageContent(messageContent)
+
 	// Create a single choice with the collected content
 	bifrostResponse.ID = response.ID
 	bifrostResponse.Choices = []schemas.BifrostResponseChoice{
@@ -805,10 +809,8 @@ func parseAnthropicResponse(response *AnthropicChatResponse, bifrostResponse *sc
 			Index: 0,
 			BifrostNonStreamResponseChoice: &schemas.BifrostNonStreamResponseChoice{
 				Message: schemas.BifrostMessage{
-					Role: schemas.ModelChatMessageRoleAssistant,
-					Content: schemas.MessageContent{
-						ContentBlocks: &contentBlocks,
-					},
+					Role:             schemas.ModelChatMessageRoleAssistant,
+					Content:          *messageContent,
 					AssistantMessage: assistantMessage,
 				},
 				StopString: response.StopSequence,

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -1081,16 +1081,18 @@ func (provider *BedrockProvider) ChatCompletion(ctx context.Context, model strin
 		}
 	}
 
+	// Build MessageContent based on the type of content blocks
+	messageContent := BuildMessageContent(contentBlocks)
+	defer releaseMessageContent(messageContent)
+
 	// Create a single choice with the aggregated content
 	choices := []schemas.BifrostResponseChoice{
 		{
 			Index: 0,
 			BifrostNonStreamResponseChoice: &schemas.BifrostNonStreamResponseChoice{
 				Message: schemas.BifrostMessage{
-					Role: schemas.ModelChatMessageRoleAssistant,
-					Content: schemas.MessageContent{
-						ContentBlocks: &contentBlocks,
-					},
+					Role:             schemas.ModelChatMessageRoleAssistant,
+					Content:          *messageContent,
 					AssistantMessage: assistantMessage,
 				},
 			},


### PR DESCRIPTION
## Summary

In order to ensure consistency in the provider responses, this PR addresses the refactoring discussed as part of [issue #175](https://github.com/maximhq/bifrost/issues/175). 

When the Anthropic response contains exactly one text block, the response is returned as a string instead of list of content blocks. 

**Before**

- openai/gpt-4o-mini

```
"message": {
    "role": "assistant",
    "content": "Hello! It's nice to meet you. How are you doing today?"
}

```
- anthropic/claude-sonnet-4-20250514

```
"message": {
    "role": "assistant",
    "content": [{"type":"text", "text":"Hello! How can I help you today?"}]
}
```

**After**

- openai/gpt-4o-mini
```
"message": {
    "role": "assistant",
    "content": "Hello! It's nice to meet you. How are you doing today?"
}
```

- anthropic/claude-sonnet-4-20250514

```
"message": {
    "role": "assistant",
    "content": "Hello! How can I help you today?"
}
```


## Changes

- If there's only one content block of type text, return as string content otherwise return as content blocks as before.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

# Test Antropic specific tests with

`go test ./tests/core-providers/anthropic_test.go`

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to [issue#175](https://github.com/maximhq/bifrost/issues/175)

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


