### PR TITLE
mintlify push will always run with check for existance

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -371,7 +371,7 @@ jobs:
   # Push Mintlify changelog
   push-mintlify-changelog:
     needs: [check-skip, detect-changes, bifrost-http-release]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && needs.bifrost-http-release.result == 'success'"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' &&  (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
         contents: write

--- a/.github/workflows/scripts/push-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-mintlify-changelog.sh
@@ -10,6 +10,12 @@ fi
 
 VERSION="v$VERSION"
 
+# Check if this page already exists in docs/changelogs/
+if [ -f "docs/changelogs/$VERSION.mdx" ]; then
+  echo "✅ Changelog for $VERSION already exists"
+  exit 0
+fi
+
 # Source changelog utilities
 source "$(dirname "$0")/changelog-utils.sh"
 


### PR DESCRIPTION
## Summary

Fix the Mintlify changelog generation workflow to prevent failures and avoid duplicate changelog files.

## Changes

- Modified the condition in `release-pipeline.yml` to run the Mintlify changelog job even when bifrost-http doesn't need a release or when the release job is skipped
- Added a check in `push-mintlify-changelog.sh` to skip changelog generation if the file for the current version already exists

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

The changes can be tested by running the release pipeline workflow:

```sh
# Trigger the workflow manually or by creating a new tag
# Verify that the Mintlify changelog job runs correctly even when bifrost-http doesn't need a release
# Verify that the script exits gracefully when a changelog file already exists
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with the Mintlify changelog generation process in the CI pipeline.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable