### PR TITLE
simplify changelog on each release on Github

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -255,14 +255,8 @@ fi
 
 BODY="## Bifrost HTTP Transport Release v$VERSION
 
-### 🚀 Bifrost HTTP Transport v$VERSION
-
 $CHANGELOG_BODY
 
-### Dependencies
-- **Core**: \`$CORE_VERSION\`
-- **Framework**: \`$FRAMEWORK_VERSION\`
-$PLUGIN_UPDATES
 ### Installation
 
 #### Docker

--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -88,8 +88,6 @@ fi
 
 BODY="## Core Release v$VERSION
 
-### 🔧 Core Library v$VERSION
-
 $CHANGELOG_BODY
 
 ### Installation
@@ -97,11 +95,6 @@ $CHANGELOG_BODY
 \`\`\`bash
 go get github.com/maximhq/bifrost/core@v$VERSION
 \`\`\`
-
-### Next Steps
-1. Framework will be updated automatically if needed
-2. Plugins will be updated automatically if needed
-3. Bifrost HTTP will be updated automatically if needed
 
 ---
 _This release was automatically created from version file: \`core/version\`_"

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -150,12 +150,7 @@ fi
 
 BODY="## Framework Release $VERSION
 
-### 📦 Framework Library $VERSION
-
 $CHANGELOG_BODY
-
-### Dependencies
-- **Core**: \`$CORE_VERSION\`
 
 ### Installation
 

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -161,13 +161,7 @@ fi
 
 BODY="## Plugin Release: $PLUGIN_NAME v$PLUGIN_VERSION
 
-### 🔌 Plugin: $PLUGIN_NAME v$PLUGIN_VERSION
-
 $CHANGELOG_BODY
-
-### Dependencies
-- **Core**: \`$CORE_VERSION\`
-- **Framework**: \`$FRAMEWORK_VERSION\`
 
 ### Installation
 
@@ -175,12 +169,6 @@ $CHANGELOG_BODY
 # Update your go.mod to use the new plugin version
 go get github.com/maximhq/bifrost/plugins/$PLUGIN_NAME@v$PLUGIN_VERSION
 \`\`\`
-
-### Plugin Details
-- **Name**: $PLUGIN_NAME
-- **Version**: $PLUGIN_VERSION
-- **Core Dependency**: $CORE_VERSION
-- **Framework Dependency**: $FRAMEWORK_VERSION
 
 ---
 _This release was automatically created from version file: \`plugins/$PLUGIN_NAME/version\`_"


### PR DESCRIPTION
## Summary

Simplify release notes templates by removing redundant headers and dependency information from all release scripts.

## Changes

- Removed duplicate title headers (with emojis) from all release scripts
- Removed dependency information sections from all release scripts
- Removed "Next Steps" section from core release script
- Removed "Plugin Details" section from single plugin release script

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins

## How to test

Verify that the release scripts generate cleaner release notes without redundant information:

```sh
# Test core release script
.github/workflows/scripts/release-core.sh

# Test framework release script
.github/workflows/scripts/release-framework.sh

# Test HTTP transport release script
.github/workflows/scripts/release-bifrost-http.sh

# Test plugin release script
.github/workflows/scripts/release-single-plugin.sh
```

## Breaking changes

- [x] No

## Related issues

Improves release notes readability by removing duplicate information.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable