### PR TITLE
feat: added go sdk setup in custom providers doc

### DIFF
--- a/docs/features/custom-providers.mdx
+++ b/docs/features/custom-providers.mdx
@@ -109,6 +109,94 @@ curl --location 'http://localhost:8080/api/providers' \
 
 </Tab>
 
+<Tab title="Go SDK">
+
+Create a custom provider using the Go SDK by implementing the Account interface with custom provider configuration:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    "time"
+
+    "github.com/maximhq/bifrost/core/schemas"
+)
+
+// Define custom provider name
+const ProviderOpenAICustom = schemas.ModelProvider("openai-custom")
+
+type MyAccount struct{}
+
+func (a *MyAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
+    return []schemas.ModelProvider{
+        schemas.OpenAI,
+        ProviderOpenAICustom, // Include your custom provider
+    }, nil
+}
+
+func (a *MyAccount) GetKeysForProvider(ctx context.Context, provider schemas.ModelProvider) ([]schemas.Key, error) {
+    switch provider {
+    case schemas.OpenAI:
+        return []schemas.Key{{
+            Value:  os.Getenv("OPENAI_API_KEY"),
+            Models: []string{},
+            Weight: 1.0,
+        }}, nil
+    case ProviderOpenAICustom:
+        return []schemas.Key{{
+            Value:  os.Getenv("OPENAI_CUSTOM_API_KEY"), // API key for OpenAI-compatible endpoint
+            Models: []string{},
+            Weight: 1.0,
+        }}, nil
+    }
+    return nil, fmt.Errorf("provider %s not supported", provider)
+}
+
+func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+    switch provider {
+    case schemas.OpenAI:
+        return &schemas.ProviderConfig{
+            NetworkConfig:            schemas.DefaultNetworkConfig,
+            ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
+        }, nil
+    case ProviderOpenAICustom:
+        return &schemas.ProviderConfig{
+            NetworkConfig: schemas.NetworkConfig{
+                BaseURL:                        "https://your-openai-compatible-endpoint.com", // Custom base URL
+                DefaultRequestTimeoutInSeconds: 60,
+                MaxRetries:                     1,
+                RetryBackoffInitial:            100 * time.Millisecond,
+                RetryBackoffMax:                2 * time.Second,
+            },
+            ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+                Concurrency: 3,
+                BufferSize:  10,
+            },
+            CustomProviderConfig: &schemas.CustomProviderConfig{
+                BaseProviderType: schemas.OpenAI, // Use OpenAI protocol
+                AllowedRequests: &schemas.AllowedRequests{
+                    TextCompletion:       false,
+                    ChatCompletion:       true,  // Enable chat completion
+                    ChatCompletionStream: true,  // Enable streaming
+                    Embedding:            false,
+                    Speech:               false,
+                    SpeechStream:         false,
+                    Transcription:        false,
+                    TranscriptionStream:  false,
+                },
+            },
+        }, nil
+    }
+    return nil, fmt.Errorf("provider %s not supported", provider)
+}
+
+```
+
+</Tab>
+
 </Tabs>
 
 ## Configuration Options


### PR DESCRIPTION
## Summary

Added Go SDK example for creating custom providers in the documentation, showing how to implement the Account interface with custom provider configuration.

## Changes

- Added a Go SDK code example in the custom-providers.mdx documentation
- Demonstrated how to implement the Account interface with custom provider support
- Included example configuration for an OpenAI-compatible custom provider
- Showed how to set custom base URLs, network configurations, and allowed request types

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. View the updated documentation page at `/docs/features/custom-providers.mdx`
2. Verify the Go SDK tab appears alongside existing examples
3. Ensure the code example is properly formatted and syntax highlighted

## Breaking changes

- [x] No

## Related issues

Improves developer experience by providing Go SDK examples for custom provider implementation.

## Checklist

- [x] I updated documentation where needed