### PR TITLE
adds delete option for custom providers

### DIFF
--- a/ui/app/providers/dialogs/addNewCustomProviderDialog.tsx
+++ b/ui/app/providers/dialogs/addNewCustomProviderDialog.tsx
@@ -33,7 +33,7 @@ type FormData = z.infer<typeof formSchema>;
 
 interface Props {
 	show: boolean;
-	onSave: () => void;
+	onSave: (id:string) => void;
 	onClose: () => void;
 }
 
@@ -73,8 +73,8 @@ export default function AddCustomProviderDialog({ show, onClose, onSave }: Props
 			keys: [],
 		})
 			.unwrap()
-			.then(() => {
-				onSave();
+			.then((provider) => {
+				onSave(provider.name);
 				form.reset();
 			})
 			.catch((err) => {

--- a/ui/app/providers/dialogs/confirmDeleteProviderDialog.tsx
+++ b/ui/app/providers/dialogs/confirmDeleteProviderDialog.tsx
@@ -1,0 +1,54 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+} from "@/components/ui/alertDialog";
+import { getErrorMessage, useDeleteProviderMutation } from "@/lib/store";
+import { ModelProvider } from "@/lib/types/config";
+import { AlertDialogTitle } from "@radix-ui/react-alert-dialog";
+import { toast } from "sonner";
+
+interface Props {
+	show: boolean;
+	onCancel: () => void;
+	onDelete: () => void;
+	provider: ModelProvider;
+}
+
+export default function ConfirmDeleteProviderDialog({ show, onCancel, onDelete, provider }: Props) {
+	const [deleteProvider, { isLoading: isDeletingProvider }] = useDeleteProviderMutation();
+
+	const onDeleteHandler = () => {
+		deleteProvider(provider.name)
+			.unwrap()
+			.then(() => {
+				onDelete();
+			})
+			.catch((err) => {
+				toast.error("Failed to delete provider", {
+					description: getErrorMessage(err),
+				});
+			});
+	};
+
+	return (
+		<AlertDialog open={show}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete Provider</AlertDialogTitle>
+					<AlertDialogDescription>Are you sure you want to delete this provider? This action cannot be undone.</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={onCancel}>Cancel</AlertDialogCancel>
+					<AlertDialogAction onClick={onDeleteHandler} disabled={isDeletingProvider}>
+						{isDeletingProvider ? "Deleting..." : "Delete"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/ui/app/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/providers/fragments/allowedRequestsFields.tsx
@@ -39,7 +39,7 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 							control={control}
 							name={`${namePrefix}.${requestType.key}`}
 							render={({ field }) => (
-								<FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+								<FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
 									<div className="space-y-0.5">
 										<FormLabel>{requestType.label}</FormLabel>
 									</div>
@@ -58,7 +58,7 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 							control={control}
 							name={`${namePrefix}.${requestType.key}`}
 							render={({ field }) => (
-								<FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+								<FormItem className="flex flex-row items-center justify-between rounded-lg border p-3">
 									<div className="space-y-0.5">
 										<FormLabel>{requestType.label}</FormLabel>
 									</div>

--- a/ui/app/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/providers/fragments/networkFormFragment.tsx
@@ -6,6 +6,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { DefaultNetworkConfig } from "@/lib/constants/config";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider, isKnownProvider } from "@/lib/types/config";
@@ -73,10 +74,11 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 			network_config: {
 				base_url: provider.network_config?.base_url || "",
 				extra_headers: provider.network_config?.extra_headers,
-				default_request_timeout_in_seconds: provider.network_config?.default_request_timeout_in_seconds || 30,
-				max_retries: provider.network_config?.max_retries || 0,
-				retry_backoff_initial: provider.network_config?.retry_backoff_initial || 500,
-				retry_backoff_max: provider.network_config?.retry_backoff_max || 5000,
+				default_request_timeout_in_seconds:
+					provider.network_config?.default_request_timeout_in_seconds ?? DefaultNetworkConfig.default_request_timeout_in_seconds,
+				max_retries: provider.network_config?.max_retries ?? DefaultNetworkConfig.max_retries,
+				retry_backoff_initial: provider.network_config?.retry_backoff_initial ?? DefaultNetworkConfig.retry_backoff_initial,
+				retry_backoff_max: provider.network_config?.retry_backoff_max ?? DefaultNetworkConfig.retry_backoff_max,
 			},
 		});
 	}, [form, provider.name, provider.network_config]);
@@ -191,7 +193,7 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 									<FormItem className="flex-1">
 										<FormLabel>Initial Backoff (ms)</FormLabel>
 										<FormControl>
-											<Input placeholder="500" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+											<Input placeholder="e.g 500" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -204,7 +206,7 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 									<FormItem className="flex-1">
 										<FormLabel>Max Backoff (ms)</FormLabel>
 										<FormControl>
-											<Input placeholder="5000" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+											<Input placeholder="e.g 5000" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
 										</FormControl>
 										<FormMessage />
 									</FormItem>

--- a/ui/app/providers/views/modelProviderConfig.tsx
+++ b/ui/app/providers/views/modelProviderConfig.tsx
@@ -1,11 +1,11 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ModelProvider } from "@/lib/types/config";
+import { isKnownProvider, ModelProvider } from "@/lib/types/config";
 import { useEffect, useMemo, useState } from "react";
 import { ApiStructureFormFragment, ProxyFormFragment } from "../fragments";
 import { NetworkFormFragment } from "../fragments/networkFormFragment";
 import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
 import ModelProviderKeysTableView from "./modelProviderKeysTableView";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { keysRequired } from "./utils";
 
 interface Props {
@@ -43,7 +43,7 @@ const availableTabs = (provider: ModelProvider) => {
 
 export default function ModelProviderConfig({ provider }: Props) {
 	const [selectedTab, setSelectedTab] = useState<string | undefined>(undefined);
-
+	const isCustomProver = !isKnownProvider(provider.name);
 	const tabs = useMemo(() => {
 		return availableTabs(provider);
 	}, [provider.name]);
@@ -56,7 +56,7 @@ export default function ModelProviderConfig({ provider }: Props) {
 
 	return (
 		<div className="flex w-full flex-col gap-2">
-			<Accordion type="single" collapsible>
+			<Accordion type="single" collapsible={showApiKeys} value={!showApiKeys || isCustomProver ? "item-1" : undefined}>
 				<AccordionItem value="item-1">
 					<AccordionTrigger className="flex cursor-pointer items-center text-[17px] font-semibold">
 						Provider level configuration

--- a/ui/lib/store/slices/providerSlice.ts
+++ b/ui/lib/store/slices/providerSlice.ts
@@ -65,6 +65,8 @@ const providerSlice = createSlice({
 				state.selectedProvider = updatedProvider;
 			}
 		});
+
+		
 	},
 });
 


### PR DESCRIPTION
## Summary

Enhance provider management by adding support for creating providers during update operations and implementing provider deletion in the UI.

## Changes

- Added fallback logic to create a provider if it doesn't exist during an update operation
- Improved error handling for provider operations with proper error type checking
- Added a confirmation dialog for deleting providers in the UI
- Enhanced provider listing with delete functionality (trash icon appears on hover)
- Fixed provider initialization with default values when a provider doesn't exist
- Improved UI components for better user experience

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Try updating a provider that doesn't exist yet - it should be created automatically
2. Test deleting a provider through the UI:
   - Navigate to the providers page
   - Hover over a provider to see the trash icon
   - Click the trash icon and confirm deletion
3. Verify error handling when provider operations fail

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] No

## Related issues

Improves provider management workflow

## Security considerations

No significant security implications as this maintains existing authentication and authorization patterns.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable