### PR TITLE
fixes mitlify script to repull before pushing new updates

### DIFF
--- a/.github/workflows/scripts/push-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-mintlify-changelog.sh
@@ -89,8 +89,8 @@ if ! grep -q "\"$route\"" docs/docs.json; then
   ' docs/docs.json > docs/docs.json.tmp && mv docs/docs.json.tmp docs/docs.json
 fi
 
-
-
+# Pulling again before committing
+git pull origin main
 # Commit and push changes
 git add docs/changelogs/$VERSION.mdx
 git add docs/docs.json


### PR DESCRIPTION
## Summary

Add a `git pull` command before committing changes in the Mintlify changelog push script to prevent potential merge conflicts.

## Changes

- Added a `git pull origin main` command before the commit step in the push-mintlify-changelog.sh script
- This ensures the local repository is up-to-date with the remote main branch before committing changelog changes
- Helps prevent merge conflicts when multiple changelog updates happen in parallel

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Run the changelog push script and verify it pulls the latest changes before committing:

```sh
cd .github/workflows/scripts
./push-mintlify-changelog.sh <version>
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Prevents potential merge conflicts when multiple changelog updates are processed simultaneously.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable