### PR TITLE
feat: add virtual key provider config table with weighted routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Variables
 HOST ?= localhost
 PORT ?= 8080
-APP_DIR ?=
+APP_DIR ?= 
 PROMETHEUS_LABELS ?=
 LOG_STYLE ?= json
 LOG_LEVEL ?= info

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1583,7 +1583,7 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *context.Context, prov
 	}
 
 	if len(keys) == 0 {
-		return schemas.Key{}, fmt.Errorf("no keys found for provider: %v", providerKey)
+		return schemas.Key{}, fmt.Errorf("no keys found for provider: %v and model: %s", providerKey, model)
 	}
 
 	// filter out keys which dont support the model, if the key has no models, it is supported for all models

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -88,7 +88,7 @@ type BedrockMistralContent struct {
 type BedrockMistralChatMessage struct {
 	Role       schemas.ModelChatMessageRole `json:"role"`                   // Role of the message sender
 	Content    []BedrockMistralContent      `json:"content"`                // Array of message content
-	ToolCalls  []BedrockAnthropicToolCall  `json:"tool_calls,omitempty"`   // Optional tool calls
+	ToolCalls  []BedrockAnthropicToolCall   `json:"tool_calls,omitempty"`   // Optional tool calls
 	ToolCallID *string                      `json:"tool_call_id,omitempty"` // Optional tool call ID
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -118,7 +118,7 @@ const (
 // a text completion, a chat completion, an embedding request, a speech request, or a transcription request.
 type RequestInput struct {
 	TextCompletionInput *string             `json:"text_completion_input,omitempty"`
-	ChatCompletionInput []BifrostMessage   `json:"chat_completion_input,omitempty"`
+	ChatCompletionInput []BifrostMessage    `json:"chat_completion_input,omitempty"`
 	EmbeddingInput      *EmbeddingInput     `json:"embedding_input,omitempty"`
 	SpeechInput         *SpeechInput        `json:"speech_input,omitempty"`
 	TranscriptionInput  *TranscriptionInput `json:"transcription_input,omitempty"`
@@ -295,12 +295,12 @@ type Fallback struct {
 // mapped to the provider's parameters.
 type ModelParameters struct {
 	ToolChoice        *ToolChoice `json:"tool_choice,omitempty"`         // Whether to call a tool
-	Tools             []Tool     `json:"tools,omitempty"`               // Tools to use
+	Tools             []Tool      `json:"tools,omitempty"`               // Tools to use
 	Temperature       *float64    `json:"temperature,omitempty"`         // Controls randomness in the output
 	TopP              *float64    `json:"top_p,omitempty"`               // Controls diversity via nucleus sampling
 	TopK              *int        `json:"top_k,omitempty"`               // Controls diversity via top-k sampling
 	MaxTokens         *int        `json:"max_tokens,omitempty"`          // Maximum number of tokens to generate
-	StopSequences     []string   `json:"stop_sequences,omitempty"`      // Sequences that stop generation
+	StopSequences     []string    `json:"stop_sequences,omitempty"`      // Sequences that stop generation
 	PresencePenalty   *float64    `json:"presence_penalty,omitempty"`    // Penalizes repeated tokens
 	FrequencyPenalty  *float64    `json:"frequency_penalty,omitempty"`   // Penalizes frequent tokens
 	ParallelToolCalls *bool       `json:"parallel_tool_calls,omitempty"` // Enables parallel tool calls
@@ -318,7 +318,7 @@ type FunctionParameters struct {
 	Description *string                `json:"description,omitempty"` // Description of the parameters
 	Required    []string               `json:"required,omitempty"`    // Required parameter names
 	Properties  map[string]interface{} `json:"properties,omitempty"`  // Parameter properties
-	Enum        []string              `json:"enum,omitempty"`        // Enum values for the parameters
+	Enum        []string               `json:"enum,omitempty"`        // Enum values for the parameters
 }
 
 // Function represents a function that can be called by the model.
@@ -492,7 +492,7 @@ type ToolMessage struct {
 type AssistantMessage struct {
 	Refusal     *string      `json:"refusal,omitempty"`
 	Annotations []Annotation `json:"annotations,omitempty"`
-	ToolCalls   []ToolCall  `json:"tool_calls,omitempty"`
+	ToolCalls   []ToolCall   `json:"tool_calls,omitempty"`
 	Thought     *string      `json:"thought,omitempty"`
 }
 
@@ -795,7 +795,7 @@ type BifrostResponseExtraFields struct {
 	Provider    ModelProvider      `json:"provider"`
 	Params      ModelParameters    `json:"model_params"`
 	Latency     *int64             `json:"latency,omitempty"`
-	ChatHistory []BifrostMessage  `json:"chat_history,omitempty"`
+	ChatHistory []BifrostMessage   `json:"chat_history,omitempty"`
 	BilledUsage *BilledLLMUsage    `json:"billed_usage,omitempty"`
 	ChunkIndex  int                `json:"chunk_index"` // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
 	RawResponse interface{}        `json:"raw_response,omitempty"`

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -19,6 +19,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddCustomProviderConfigJSONColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddVirtualKeyProviderConfigTable(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -237,6 +240,38 @@ func migrationAddCustomProviderConfigJSONColumn(ctx context.Context, db *gorm.DB
 				if err := migrator.AddColumn(&TableProvider{}, "custom_provider_config_json"); err != nil {
 					return err
 				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while running db migration: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddVirtualKeyProviderConfigTable(ctx context.Context, db *gorm.DB) error {
+	m := migration.New(db, migration.DefaultOptions, []*migration.Migration{{
+		ID: "addvirtualkeyproviderconfig",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			if !migrator.HasTable(&TableVirtualKeyProviderConfig{}) {
+				if err := migrator.CreateTable(&TableVirtualKeyProviderConfig{}); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			if err := migrator.DropTable(&TableVirtualKeyProviderConfig{}); err != nil {
+				return err
 			}
 			return nil
 		},

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -55,9 +55,16 @@ type ConfigStore interface {
 	// Governance config CRUD
 	GetVirtualKeys(ctx context.Context) ([]TableVirtualKey, error)
 	GetVirtualKey(ctx context.Context, id string) (*TableVirtualKey, error)
+	GetVirtualKeyByValue(ctx context.Context, value string) (*TableVirtualKey, error)
 	CreateVirtualKey(ctx context.Context, virtualKey *TableVirtualKey, tx ...*gorm.DB) error
 	UpdateVirtualKey(ctx context.Context, virtualKey *TableVirtualKey, tx ...*gorm.DB) error
 	DeleteVirtualKey(ctx context.Context, id string) error
+
+	// Virtual key provider config CRUD
+	GetVirtualKeyProviderConfigs(ctx context.Context, virtualKeyID string) ([]TableVirtualKeyProviderConfig, error)
+	CreateVirtualKeyProviderConfig(ctx context.Context, virtualKeyProviderConfig *TableVirtualKeyProviderConfig, tx ...*gorm.DB) error
+	UpdateVirtualKeyProviderConfig(ctx context.Context, virtualKeyProviderConfig *TableVirtualKeyProviderConfig, tx ...*gorm.DB) error
+	DeleteVirtualKeyProviderConfig(ctx context.Context, id uint, tx ...*gorm.DB) error
 
 	// Team CRUD
 	GetTeams(ctx context.Context, customerID string) ([]TableTeam, error)

--- a/framework/configstore/tables.go
+++ b/framework/configstore/tables.go
@@ -616,13 +616,12 @@ type TableTeam struct {
 
 // TableVirtualKey represents a virtual key with budget, rate limits, and team/customer association
 type TableVirtualKey struct {
-	ID               string   `gorm:"primaryKey;type:varchar(255)" json:"id"`
-	Name             string   `gorm:"uniqueIndex:idx_virtual_key_name;type:varchar(255);not null" json:"name"`
-	Description      string   `gorm:"type:text" json:"description,omitempty"`
-	Value            string   `gorm:"uniqueIndex:idx_virtual_key_value;type:varchar(255);not null" json:"value"` // The virtual key value
-	IsActive         bool     `gorm:"default:true" json:"is_active"`
-	AllowedModels    []string `gorm:"type:text;serializer:json" json:"allowed_models"`    // Empty means all models allowed
-	AllowedProviders []string `gorm:"type:text;serializer:json" json:"allowed_providers"` // Empty means all providers allowed
+	ID              string                          `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	Name            string                          `gorm:"uniqueIndex:idx_virtual_key_name;type:varchar(255);not null" json:"name"`
+	Description     string                          `gorm:"type:text" json:"description,omitempty"`
+	Value           string                          `gorm:"uniqueIndex:idx_virtual_key_value;type:varchar(255);not null" json:"value"` // The virtual key value
+	IsActive        bool                            `gorm:"default:true" json:"is_active"`
+	ProviderConfigs []TableVirtualKeyProviderConfig `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"provider_configs"` // Empty means all providers allowed
 
 	// Foreign key relationships (mutually exclusive: either TeamID or CustomerID, not both)
 	TeamID      *string    `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
@@ -639,6 +638,15 @@ type TableVirtualKey struct {
 
 	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+// TableVirtualKeyProviderConfig represents a provider configuration for a virtual key
+type TableVirtualKeyProviderConfig struct {
+	ID            uint     `gorm:"primaryKey;autoIncrement" json:"id"`
+	VirtualKeyID  string   `gorm:"type:varchar(255);not null" json:"virtual_key_id"`
+	Provider      string   `gorm:"type:varchar(50);not null" json:"provider"`
+	Weight        float64  `gorm:"default:1.0" json:"weight"`
+	AllowedModels []string `gorm:"type:text;serializer:json" json:"allowed_models"` // Empty means all models allowed
 }
 
 // TableModelPricing represents pricing information for AI models
@@ -675,11 +683,14 @@ type TableModelPricing struct {
 }
 
 // Table names
-func (TableBudget) TableName() string       { return "governance_budgets" }
-func (TableRateLimit) TableName() string    { return "governance_rate_limits" }
-func (TableCustomer) TableName() string     { return "governance_customers" }
-func (TableTeam) TableName() string         { return "governance_teams" }
-func (TableVirtualKey) TableName() string   { return "governance_virtual_keys" }
+func (TableBudget) TableName() string     { return "governance_budgets" }
+func (TableRateLimit) TableName() string  { return "governance_rate_limits" }
+func (TableCustomer) TableName() string   { return "governance_customers" }
+func (TableTeam) TableName() string       { return "governance_teams" }
+func (TableVirtualKey) TableName() string { return "governance_virtual_keys" }
+func (TableVirtualKeyProviderConfig) TableName() string {
+	return "governance_virtual_key_provider_configs"
+}
 func (TableConfig) TableName() string       { return "governance_config" }
 func (TableModelPricing) TableName() string { return "governance_model_pricing" }
 

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -102,10 +102,10 @@ type Log struct {
 	// Virtual fields for JSON output - these will be populated when needed
 	InputHistoryParsed        []schemas.BifrostMessage    `gorm:"-" json:"input_history,omitempty"`
 	OutputMessageParsed       *schemas.BifrostMessage     `gorm:"-" json:"output_message,omitempty"`
-	EmbeddingOutputParsed     []schemas.BifrostEmbedding `gorm:"-" json:"embedding_output,omitempty"`
+	EmbeddingOutputParsed     []schemas.BifrostEmbedding  `gorm:"-" json:"embedding_output,omitempty"`
 	ParamsParsed              *schemas.ModelParameters    `gorm:"-" json:"params,omitempty"`
-	ToolsParsed               []schemas.Tool             `gorm:"-" json:"tools,omitempty"`
-	ToolCallsParsed           []schemas.ToolCall         `gorm:"-" json:"tool_calls,omitempty"`
+	ToolsParsed               []schemas.Tool              `gorm:"-" json:"tools,omitempty"`
+	ToolCallsParsed           []schemas.ToolCall          `gorm:"-" json:"tool_calls,omitempty"`
 	TokenUsageParsed          *schemas.LLMUsage           `gorm:"-" json:"token_usage,omitempty"`
 	ErrorDetailsParsed        *schemas.BifrostError       `gorm:"-" json:"error_details,omitempty"`
 	SpeechInputParsed         *schemas.SpeechInput        `gorm:"-" json:"speech_input,omitempty"`

--- a/framework/pricing/main.go
+++ b/framework/pricing/main.go
@@ -3,6 +3,7 @@ package pricing
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -25,6 +26,8 @@ type PricingManager struct {
 	// In-memory cache for fast access - direct map for O(1) lookups
 	pricingData map[string]configstore.TableModelPricing
 	mu          sync.RWMutex
+
+	modelPool map[schemas.ModelProvider][]string
 
 	// Background sync worker
 	syncTicker *time.Ticker
@@ -75,8 +78,11 @@ func Init(ctx context.Context, configStore configstore.ConfigStore, logger schem
 		configStore: configStore,
 		logger:      logger,
 		pricingData: make(map[string]configstore.TableModelPricing),
+		modelPool:   make(map[schemas.ModelProvider][]string),
 		done:        make(chan struct{}),
 	}
+
+	logger.Info("initializing pricing manager...")
 
 	if configStore != nil {
 		// Load initial pricing data
@@ -88,13 +94,15 @@ func Init(ctx context.Context, configStore configstore.ConfigStore, logger schem
 		if err := pm.syncPricing(ctx); err != nil {
 			return nil, fmt.Errorf("failed to sync pricing data: %w", err)
 		}
-		
 	} else {
 		// Load pricing data from config memory
 		if err := pm.loadPricingIntoMemory(ctx); err != nil {
 			return nil, fmt.Errorf("failed to load pricing data from config memory: %w", err)
 		}
 	}
+
+	// Populate model pool with normalized providers
+	pm.populateModelPool()
 
 	// Start background sync worker
 	pm.syncCtx, pm.syncCancel = context.WithCancel(ctx)
@@ -331,6 +339,80 @@ func (pm *PricingManager) CalculateCostFromUsage(provider string, model string, 
 	totalCost := inputCost + outputCost
 
 	return totalCost
+}
+
+// populateModelPool populates the model pool with all available models per provider (thread-safe)
+func (pm *PricingManager) populateModelPool() {
+	// Acquire write lock for the entire rebuild operation
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	// Clear existing model pool
+	pm.modelPool = make(map[schemas.ModelProvider][]string)
+
+	// Map to track unique models per provider
+	providerModels := make(map[schemas.ModelProvider]map[string]bool)
+
+	// Iterate through all pricing data to collect models per provider
+	for _, pricing := range pm.pricingData {
+		// Normalize provider before adding to model pool
+		normalizedProvider := schemas.ModelProvider(normalizeProvider(pricing.Provider))
+
+		// Initialize map for this provider if not exists
+		if providerModels[normalizedProvider] == nil {
+			providerModels[normalizedProvider] = make(map[string]bool)
+		}
+
+		// Add model to the provider's model set (using map for deduplication)
+		providerModels[normalizedProvider][pricing.Model] = true
+	}
+
+	// Convert sets to slices and assign to modelPool
+	for provider, modelSet := range providerModels {
+		models := make([]string, 0, len(modelSet))
+		for model := range modelSet {
+			models = append(models, model)
+		}
+		pm.modelPool[provider] = models
+	}
+
+	// Log the populated model pool for debugging
+	totalModels := 0
+	for provider, models := range pm.modelPool {
+		totalModels += len(models)
+		pm.logger.Debug("populated %d models for provider %s", len(models), string(provider))
+	}
+	pm.logger.Info("populated model pool with %d models across %d providers", totalModels, len(pm.modelPool))
+}
+
+// GetModelsForProvider returns all available models for a given provider (thread-safe)
+func (pm *PricingManager) GetModelsForProvider(provider schemas.ModelProvider) []string {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	models, exists := pm.modelPool[provider]
+	if !exists {
+		return []string{}
+	}
+
+	// Return a copy to prevent external modification
+	result := make([]string, len(models))
+	copy(result, models)
+	return result
+}
+
+// GetProvidersForModel returns all providers for a given model (thread-safe)
+func (pm *PricingManager) GetProvidersForModel(model string) []schemas.ModelProvider {
+	pm.mu.RLock()
+	defer pm.mu.RUnlock()
+
+	providers := make([]schemas.ModelProvider, 0)
+	for provider, models := range pm.modelPool {
+		if slices.Contains(models, model) {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
 }
 
 // getPricing returns pricing information for a model (thread-safe)

--- a/framework/pricing/sync.go
+++ b/framework/pricing/sync.go
@@ -62,9 +62,9 @@ func (pm *PricingManager) syncPricing(ctx context.Context) error {
 	pricingData, err := pm.loadPricingFromURL(ctx)
 	if err != nil {
 		// Check if we have existing data in database
-		pricingRecords, err := pm.configStore.GetModelPrices(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to get pricing records: %w", err)
+		pricingRecords, pricingErr := pm.configStore.GetModelPrices(ctx)
+		if pricingErr != nil {
+			return fmt.Errorf("failed to get pricing records: %w", pricingErr)
 		}
 		if len(pricingRecords) > 0 {
 			pm.logger.Error("failed to load pricing data from URL, but existing data found in database: %v", err)

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -93,20 +93,20 @@ func (r *BudgetResolver) EvaluateRequest(ctx *context.Context, evaluationRequest
 		}
 	}
 
-	// 2. Check model filtering
-	if !r.isModelAllowed(vk, evaluationRequest.Model) {
-		return &EvaluationResult{
-			Decision:   DecisionModelBlocked,
-			Reason:     fmt.Sprintf("Model '%s' is not allowed for this virtual key", evaluationRequest.Model),
-			VirtualKey: vk,
-		}
-	}
-
-	// 3. Check provider filtering
+	// 2. Check provider filtering
 	if !r.isProviderAllowed(vk, evaluationRequest.Provider) {
 		return &EvaluationResult{
 			Decision:   DecisionProviderBlocked,
 			Reason:     fmt.Sprintf("Provider '%s' is not allowed for this virtual key", evaluationRequest.Provider),
+			VirtualKey: vk,
+		}
+	}
+
+	// 3. Check model filtering
+	if !r.isModelAllowed(vk, evaluationRequest.Provider, evaluationRequest.Model) {
+		return &EvaluationResult{
+			Decision:   DecisionModelBlocked,
+			Reason:     fmt.Sprintf("Model '%s' is not allowed for this virtual key", evaluationRequest.Model),
 			VirtualKey: vk,
 		}
 	}
@@ -141,23 +141,38 @@ func (r *BudgetResolver) EvaluateRequest(ctx *context.Context, evaluationRequest
 }
 
 // isModelAllowed checks if the requested model is allowed for this VK
-func (r *BudgetResolver) isModelAllowed(vk *configstore.TableVirtualKey, model string) bool {
+func (r *BudgetResolver) isModelAllowed(vk *configstore.TableVirtualKey, provider schemas.ModelProvider, model string) bool {
 	// Empty AllowedModels means all models are allowed
-	if len(vk.AllowedModels) == 0 {
+	if len(vk.ProviderConfigs) == 0 {
 		return true
 	}
 
-	return slices.Contains(vk.AllowedModels, model)
+	for _, pc := range vk.ProviderConfigs {
+		if pc.Provider == string(provider) {
+			if len(pc.AllowedModels) == 0 {
+				return true
+			}
+			return slices.Contains(pc.AllowedModels, model)
+		}
+	}
+
+	return false
 }
 
 // isProviderAllowed checks if the requested provider is allowed for this VK
 func (r *BudgetResolver) isProviderAllowed(vk *configstore.TableVirtualKey, provider schemas.ModelProvider) bool {
 	// Empty AllowedProviders means all providers are allowed
-	if len(vk.AllowedProviders) == 0 {
+	if len(vk.ProviderConfigs) == 0 {
 		return true
 	}
 
-	return slices.Contains(vk.AllowedProviders, string(provider))
+	for _, pc := range vk.ProviderConfigs {
+		if pc.Provider == string(provider) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // checkRateLimits checks the VK's rate limits using flexible approach

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -223,7 +223,6 @@ func (t *UsageTracker) PerformStartupResets(ctx context.Context) error {
 			}
 		}
 	}
-	t.logger.Info("startup reset summary: VKs with RL=%d, without RL=%d, RL resets=%d", vksWithRateLimits, vksWithoutRateLimits, len(resetRateLimits))
 	if len(errs) > 0 {
 		t.logger.Error("startup reset encountered %d errors: %v", len(errs), errs)
 		return fmt.Errorf("startup reset completed with %d errors", len(errs))

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -392,7 +392,7 @@ func (plugin *Plugin) PostHook(ctxRef *context.Context, res *schemas.BifrostResp
 	}
 	generationID, ok := ctx.Value(GenerationIDKey).(string)
 	if ok {
-		if bifrostErr != nil  {
+		if bifrostErr != nil {
 			genErr := logging.GenerationError{
 				Message: bifrostErr.Error.Message,
 				Code:    bifrostErr.Error.Code,

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -122,9 +122,9 @@ func NewTestSetup(t *testing.T) *TestSetup {
 	}
 
 	return NewTestSetupWithConfig(t, &Config{
-		Provider:       schemas.OpenAI,
-		EmbeddingModel: "text-embedding-3-small",
-		Threshold:      0.8,
+		Provider:          schemas.OpenAI,
+		EmbeddingModel:    "text-embedding-3-small",
+		Threshold:         0.8,
 		CleanUpOnShutdown: true,
 		Keys: []schemas.Key{
 			{

--- a/transports/bifrost-http/handlers/completions.go
+++ b/transports/bifrost-http/handlers/completions.go
@@ -81,12 +81,12 @@ type CompletionRequest struct {
 	StreamFormat   *string                  `json:"stream_format,omitempty"`
 
 	ToolChoice        *schemas.ToolChoice `json:"tool_choice,omitempty"`         // Whether to call a tool
-	Tools             []schemas.Tool     `json:"tools,omitempty"`               // Tools to use
+	Tools             []schemas.Tool      `json:"tools,omitempty"`               // Tools to use
 	Temperature       *float64            `json:"temperature,omitempty"`         // Controls randomness in the output
 	TopP              *float64            `json:"top_p,omitempty"`               // Controls diversity via nucleus sampling
 	TopK              *int                `json:"top_k,omitempty"`               // Controls diversity via top-k sampling
 	MaxTokens         *int                `json:"max_tokens,omitempty"`          // Maximum number of tokens to generate
-	StopSequences     []string           `json:"stop_sequences,omitempty"`      // Sequences that stop generation
+	StopSequences     []string            `json:"stop_sequences,omitempty"`      // Sequences that stop generation
 	PresencePenalty   *float64            `json:"presence_penalty,omitempty"`    // Penalizes repeated tokens
 	FrequencyPenalty  *float64            `json:"frequency_penalty,omitempty"`   // Penalizes frequent tokens
 	ParallelToolCalls *bool               `json:"parallel_tool_calls,omitempty"` // Enables parallel tool calls

--- a/transports/bifrost-http/integrations/anthropic/types.go
+++ b/transports/bifrost-http/integrations/anthropic/types.go
@@ -69,9 +69,9 @@ type AnthropicMessageRequest struct {
 	Temperature   *float64             `json:"temperature,omitempty"`
 	TopP          *float64             `json:"top_p,omitempty"`
 	TopK          *int                 `json:"top_k,omitempty"`
-	StopSequences []string            `json:"stop_sequences,omitempty"`
+	StopSequences []string             `json:"stop_sequences,omitempty"`
 	Stream        *bool                `json:"stream,omitempty"`
-	Tools         []AnthropicTool     `json:"tools,omitempty"`
+	Tools         []AnthropicTool      `json:"tools,omitempty"`
 	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
 }
 

--- a/transports/bifrost-http/integrations/openai/types.go
+++ b/transports/bifrost-http/integrations/openai/types.go
@@ -19,7 +19,7 @@ type OpenAIChatRequest struct {
 	FrequencyPenalty    *float64                 `json:"frequency_penalty,omitempty"`
 	LogitBias           map[string]float64       `json:"logit_bias,omitempty"`
 	User                *string                  `json:"user,omitempty"`
-	Tools               []schemas.Tool          `json:"tools,omitempty"` // Reuse schema type
+	Tools               []schemas.Tool           `json:"tools,omitempty"` // Reuse schema type
 	ToolChoice          *schemas.ToolChoice      `json:"tool_choice,omitempty"`
 	Stream              *bool                    `json:"stream,omitempty"`
 	LogProbs            *bool                    `json:"logprobs,omitempty"`
@@ -140,8 +140,8 @@ type OpenAIStreamChoice struct {
 
 // OpenAIStreamDelta represents the incremental content in a streaming chunk
 type OpenAIStreamDelta struct {
-	Role      *string             `json:"role,omitempty"`
-	Content   *string             `json:"content,omitempty"`
+	Role      *string            `json:"role,omitempty"`
+	Content   *string            `json:"content,omitempty"`
 	ToolCalls []schemas.ToolCall `json:"tool_calls,omitempty"`
 }
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -134,7 +134,8 @@ type Config struct {
 	EnvKeys map[string][]configstore.EnvKeyInfo
 
 	// Plugin configs
-	Plugins []*schemas.PluginConfig
+	Plugins       []*schemas.PluginConfig
+	LoadedPlugins map[string]bool
 
 	// Pricing manager
 	PricingManager *pricing.PricingManager
@@ -223,7 +224,6 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to get logs store config: %w", err)
 			}
-			logger.Debug("log store config from DB: %v", logStoreConfig)
 			if logStoreConfig == nil {
 				logStoreConfig = &logstore.Config{
 					Enabled: true,
@@ -238,6 +238,7 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize logs store: %v", err)
 			}
+			logger.Info("logs store initialized.")
 			err = config.ConfigStore.UpdateLogsStoreConfig(ctx, logStoreConfig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to update logs store config: %w", err)
@@ -602,7 +603,7 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 
 		if config.ConfigStore != nil {
 			logger.Debug("updating governance config in store")
-			if err := config.ConfigStore.ExecuteTransaction(ctx,func(tx *gorm.DB) error {
+			if err := config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 				// Create budgets
 				for _, budget := range config.GovernanceConfig.Budgets {
 					if err := config.ConfigStore.CreateBudget(ctx, &budget, tx); err != nil {
@@ -1472,7 +1473,7 @@ func (s *Config) EditMCPClientTools(ctx context.Context, name string, toolsToAdd
 		if err := s.ConfigStore.UpdateMCPConfig(ctx, s.MCPConfig, s.EnvKeys); err != nil {
 			return fmt.Errorf("failed to update MCP config in store: %w", err)
 		}
-		if err := s.ConfigStore.UpdateEnvKeys(ctx, 	s.EnvKeys); err != nil {
+		if err := s.ConfigStore.UpdateEnvKeys(ctx, s.EnvKeys); err != nil {
 			logger.Warn("failed to update env keys: %v", err)
 		}
 	}

--- a/ui/app/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/providers/fragments/apiKeysFormFragment.tsx
@@ -7,6 +7,7 @@ import { Separator } from "@/components/ui/separator";
 import { TagInput } from "@/components/ui/tagInput";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { MODEL_PLACEHOLDERS } from "@/lib/constants/config";
 import { isRedacted } from "@/lib/utils/validation";
 import { Info } from "lucide-react";
 import { Control, UseFormReturn } from "react-hook-form";
@@ -17,16 +18,7 @@ interface Props {
 	form: UseFormReturn<any>;
 }
 
-// Model placeholders based on provider type
-const MODEL_PLACEHOLDERS = {
-	default: "e.g. gpt-4, gpt-3.5-turbo. Leave blank for all models.",
-	openai: "e.g. gpt-4, gpt-3.5-turbo, gpt-4-turbo, gpt-4o",
-	azure: "e.g. gpt-4, gpt-3.5-turbo (must match deployment mappings)",
-	bedrock: "e.g. claude-v2, titan-text-express-v1",
-	vertex: "e.g. gemini-pro, text-bison, chat-bison",
-};
-
-export function ApiKeyFormFragment({ control, providerName, form }: Props) {
+export function ApiKeyFormFragment({ control, providerName }: Props) {
 	const isBedrock = providerName === "bedrock";
 	const isVertex = providerName === "vertex";
 	const isAzure = providerName === "azure";

--- a/ui/app/teams-customers/views/customerTable.tsx
+++ b/ui/app/teams-customers/views/customerTable.tsx
@@ -18,10 +18,11 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { getErrorMessage, useDeleteCustomerMutation } from "@/lib/store";
 import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { formatCurrency, parseResetPeriod } from "@/lib/utils/governance";
-import { DollarSign, Edit, Key, Plus, Trash2, Users } from "lucide-react";
+import { Edit, Key, Plus, Trash2, Users } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import CustomerDialog from "./customerDialog";
+import { cn } from "@/lib/utils";
 
 interface CustomersTableProps {
 	customers: Customer[];
@@ -94,6 +95,7 @@ export default function CustomersTable({ customers, teams, virtualKeys, onRefres
 								<TableHead>Name</TableHead>
 								<TableHead>Teams</TableHead>
 								<TableHead>Budget</TableHead>
+								<TableHead>Reset Period</TableHead>
 								<TableHead>Virtual Keys</TableHead>
 								<TableHead className="text-right">Actions</TableHead>
 							</TableRow>
@@ -136,18 +138,21 @@ export default function CustomersTable({ customers, teams, virtualKeys, onRefres
 											</TableCell>
 											<TableCell>
 												{customer.budget ? (
-													<div className="flex items-center gap-1">
-														<DollarSign className="h-3 w-3" />
-														<span className="text-sm">
-															{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
-														</span>
-														<Badge
-															variant={customer.budget.current_usage >= customer.budget.max_limit ? "destructive" : "secondary"}
-															className="text-xs"
-														>
-															{parseResetPeriod(customer.budget.reset_duration)}
-														</Badge>
-													</div>
+													<span
+														className={cn(
+															"font-mono text-sm",
+															customer.budget.current_usage >= customer.budget.max_limit && "text-destructive",
+														)}
+													>
+														{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
+													</span>
+												) : (
+													<span className="text-muted-foreground text-sm">-</span>
+												)}
+											</TableCell>
+											<TableCell>
+												{customer.budget ? (
+													parseResetPeriod(customer.budget.reset_duration)
 												) : (
 													<span className="text-muted-foreground text-sm">-</span>
 												)}

--- a/ui/app/teams-customers/views/teamDialog.tsx
+++ b/ui/app/teams-customers/views/teamDialog.tsx
@@ -14,7 +14,7 @@ import { formatCurrency } from "@/lib/utils/governance";
 import { Validator } from "@/lib/utils/validation";
 import { formatDistanceToNow } from "date-fns";
 import isEqual from "lodash.isequal";
-import { User } from "lucide-react";
+import { Building } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -185,7 +185,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 											{customers.map((customer) => (
 												<SelectItem key={customer.id} value={customer.id}>
 													<div className="flex items-center gap-2">
-														<User className="h-4 w-4" />
+														<Building className="h-4 w-4" />
 														{customer.name}
 													</div>
 												</SelectItem>
@@ -214,7 +214,8 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 									<span className="text-sm">Current Usage:</span>
 									<div className="flex items-center gap-2">
 										<span className="text-sm">
-											<span className="font-mono">{formatCurrency(team.budget.current_usage)}</span> / <span className="font-mono">{formatCurrency(team.budget.max_limit)}</span>
+											<span className="font-mono">{formatCurrency(team.budget.current_usage)}</span> /{" "}
+											<span className="font-mono">{formatCurrency(team.budget.max_limit)}</span>
 										</span>
 										<Badge
 											variant={team.budget.current_usage >= team.budget.max_limit ? "destructive" : "default"}

--- a/ui/app/virtual-keys/views/virtualKeyDetailsDialog.tsx
+++ b/ui/app/virtual-keys/views/virtualKeyDetailsDialog.tsx
@@ -3,6 +3,9 @@
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { VirtualKey } from "@/lib/types/governance";
 import { calculateUsagePercentage, formatCurrency, getUsageVariant, parseResetPeriod } from "@/lib/utils/governance";
 import { formatDistanceToNow } from "date-fns";
@@ -36,8 +39,8 @@ export default function VirtualKeyDetailDialog({ virtualKey, onClose }: VirtualK
 
 	return (
 		<Dialog open onOpenChange={onClose}>
-			<DialogContent className="max-h-[80vh] w-full max-w-2xl overflow-y-auto p-0" showCloseButton={true}>
-				<DialogHeader className="z-10 border-b px-6 pt-6 bg-transparent">
+			<DialogContent className="max-h-[80vh] max-w-4xl overflow-y-auto p-0" showCloseButton={true}>
+				<DialogHeader className="z-10 border-b bg-transparent px-6 pt-6">
 					<DialogTitle>{virtualKey.name}</DialogTitle>
 					<DialogDescription>{virtualKey.description || "Virtual key details and usage information"}</DialogDescription>
 				</DialogHeader>
@@ -86,56 +89,99 @@ export default function VirtualKeyDetailDialog({ virtualKey, onClose }: VirtualK
 
 					<Separator />
 
-					{/* Model & Provider Restrictions */}
+					{/* Allowed Keys */}
 					<div className="space-y-4">
-						<h3 className="font-semibold">Allowed Models & Providers</h3>
+						<h3 className="font-semibold">Allowed Keys</h3>
 
 						<div className="space-y-3">
-							{!virtualKey.allowed_models && !virtualKey.allowed_providers ? (
-								<span className="text-muted-foreground text-sm">All models and providers allowed</span>
+							{virtualKey.keys && virtualKey.keys.length > 0 ? (
+								<div className="rounded-md border">
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Key ID</TableHead>
+												<TableHead>Allowed Models</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{virtualKey.keys.map((key) => (
+												<TableRow key={key.key_id}>
+													<TableCell className="max-w-[200px] truncate">
+														<span className="font-mono text-sm">{key.key_id}</span>
+													</TableCell>
+													<TableCell>
+														{key.models && key.models.length > 0 ? (
+															<div className="flex flex-wrap gap-1">
+																{key.models.map((model: string) => (
+																	<Badge key={model} variant="secondary" className="text-xs">
+																		{model}
+																	</Badge>
+																))}
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">All models allowed</span>
+														)}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								</div>
 							) : (
-								<>
-									{virtualKey.allowed_models && virtualKey.allowed_models.length > 0 ? (
-										<div>
-											<span className="text-muted-foreground text-sm font-medium">Models</span>
-											<div className="mt-2">
-												{virtualKey.allowed_models && virtualKey.allowed_models.length > 0 ? (
-													<div className="flex flex-wrap gap-2">
-														{virtualKey.allowed_models.map((model) => (
-															<Badge key={model} variant="secondary" className="text-xs">
-																{model}
-															</Badge>
-														))}
-													</div>
-												) : (
-													<span className="text-muted-foreground text-sm">All models allowed</span>
-												)}
-											</div>
-										</div>
-									) : (
-										<span className="text-muted-foreground text-sm">All models allowed</span>
-									)}
-									{virtualKey.allowed_providers && virtualKey.allowed_providers.length > 0 ? (
-										<div>
-											<span className="text-muted-foreground text-sm font-medium">Providers</span>
-											<div className="mt-2">
-												{virtualKey.allowed_providers && virtualKey.allowed_providers.length > 0 ? (
-													<div className="flex flex-wrap gap-2">
-														{virtualKey.allowed_providers.map((provider) => (
-															<Badge key={provider} variant="secondary" className="text-xs">
-																{provider}
-															</Badge>
-														))}
-													</div>
-												) : (
-													<span className="text-muted-foreground text-sm">All providers allowed</span>
-												)}
-											</div>
-										</div>
-									) : (
-										<span className="text-muted-foreground text-sm">All providers allowed</span>
-									)}
-								</>
+								<span className="text-muted-foreground text-sm">No specific keys assigned - all keys allowed</span>
+							)}
+						</div>
+					</div>
+
+					<Separator />
+
+					{/* Provider Configurations */}
+					<div className="space-y-4">
+						<h3 className="font-semibold">Provider Configurations</h3>
+
+						<div className="space-y-3">
+							{!virtualKey.provider_configs || virtualKey.provider_configs.length === 0 ? (
+								<span className="text-muted-foreground text-sm">All providers allowed with default settings</span>
+							) : (
+								<div className="rounded-md border">
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Provider</TableHead>
+												<TableHead>Weight</TableHead>
+												<TableHead>Allowed Models</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{virtualKey.provider_configs.map((config, index) => (
+												<TableRow key={`${config.provider}-${index}`}>
+													<TableCell>
+														<div className="flex items-center gap-2">
+															<RenderProviderIcon provider={config.provider as ProviderIconType} size="sm" className="h-4 w-4" />
+															{ProviderLabels[config.provider as ProviderName] || config.provider}
+														</div>
+													</TableCell>
+													<TableCell>
+														<span className="font-mono text-sm">{config.weight}</span>
+													</TableCell>
+													<TableCell>
+														{config.allowed_models && config.allowed_models.length > 0 ? (
+															<div className="flex flex-wrap gap-1">
+																{config.allowed_models.map((model) => (
+																	<Badge key={model} variant="secondary" className="text-xs">
+																		{model}
+																	</Badge>
+																))}
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">All models allowed</span>
+														)}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+								</div>
 							)}
 						</div>
 					</div>

--- a/ui/app/virtual-keys/views/virtualKeyDialog.tsx
+++ b/ui/app/virtual-keys/views/virtualKeyDialog.tsx
@@ -1,25 +1,38 @@
 "use client";
 
-import FormFooter from "@/components/formFooter";
+import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { TagInput } from "@/components/ui/tagInput";
 import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { MODEL_PLACEHOLDERS as ModelPlaceholders } from "@/lib/constants/config";
 import { resetDurationOptions } from "@/lib/constants/governance";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName, ProviderNames } from "@/lib/constants/logs";
 import { getErrorMessage, useCreateVirtualKeyMutation, useGetAllKeysQuery, useUpdateVirtualKeyMutation } from "@/lib/store";
-import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
-import { Validator } from "@/lib/utils/validation";
-import isEqual from "lodash.isequal";
-import { Info, User, Users } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+	CreateVirtualKeyRequest,
+	Customer,
+	Team,
+	UpdateVirtualKeyRequest,
+	VirtualKey,
+	VirtualKeyProviderConfig,
+} from "@/lib/types/governance";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Building, Info, Trash2, Users } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
+import { z } from "zod";
 
 interface VirtualKeyDialogProps {
 	virtualKey?: VirtualKey | null;
@@ -29,59 +42,57 @@ interface VirtualKeyDialogProps {
 	onCancel: () => void;
 }
 
-interface VirtualKeyFormData {
-	name: string;
-	description: string;
-	allowedModels: string[];
-	allowedProviders: string[];
-	entityType: "team" | "customer" | "none";
-	teamId: string;
-	customerId: string;
-	isActive: boolean;
-	selectedDBKeys: string[]; // Array of selected DBKey IDs
-	// Budget
-	budgetMaxLimit: number | undefined;
-	budgetResetDuration: string;
-	// Token limits
-	tokenMaxLimit: number | undefined;
-	tokenResetDuration: string;
-	// Request limits
-	requestMaxLimit: number | undefined;
-	requestResetDuration: string;
-	isDirty: boolean;
-}
+// Provider configuration schema
+const providerConfigSchema = z.object({
+	id: z.number().optional(),
+	provider: z.string().min(1, "Provider is required"),
+	weight: z.union([z.number().min(0, "Weight must be at least 0").max(1, "Weight must be at most 1"), z.string()]),
+	allowed_models: z.array(z.string()).optional(),
+});
 
-// Helper function to create initial state
-const createInitialState = (virtualKey?: VirtualKey | null): Omit<VirtualKeyFormData, "isDirty"> => {
-	return {
-		name: virtualKey?.name || "",
-		description: virtualKey?.description || "",
-		allowedModels: virtualKey?.allowed_models || [],
-		allowedProviders: virtualKey?.allowed_providers || [],
-		entityType: virtualKey?.team_id ? "team" : virtualKey?.customer_id ? "customer" : "none",
-		teamId: virtualKey?.team_id || "",
-		customerId: virtualKey?.customer_id || "",
-		isActive: virtualKey?.is_active ?? true,
-		selectedDBKeys: virtualKey?.keys?.map((key) => key.key_id) || [], // Extract key IDs
+// Main form schema
+const formSchema = z
+	.object({
+		name: z.string().min(1, "Virtual key name is required"),
+		description: z.string().optional(),
+		providerConfigs: z.array(providerConfigSchema).optional(),
+		entityType: z.enum(["team", "customer", "none"]),
+		teamId: z.string().optional(),
+		customerId: z.string().optional(),
+		isActive: z.boolean(),
+		selectedDBKeys: z.array(z.string()).optional(),
 		// Budget
-		budgetMaxLimit: virtualKey?.budget ? virtualKey.budget.max_limit : undefined, // Already in dollars
-		budgetResetDuration: virtualKey?.budget?.reset_duration || "1M",
+		budgetMaxLimit: z.string().optional(),
+		budgetResetDuration: z.string().optional(),
 		// Token limits
-		tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit || undefined,
-		tokenResetDuration: virtualKey?.rate_limit?.token_reset_duration || "1h",
+		tokenMaxLimit: z.string().optional(),
+		tokenResetDuration: z.string().optional(),
 		// Request limits
-		requestMaxLimit: virtualKey?.rate_limit?.request_max_limit || undefined,
-		requestResetDuration: virtualKey?.rate_limit?.request_reset_duration || "1h",
-	};
-};
+		requestMaxLimit: z.string().optional(),
+		requestResetDuration: z.string().optional(),
+	})
+	.refine(
+		(data) => {
+			// Validate that sum of provider weights equals 1 (only when there are multiple providers)
+			if (data.providerConfigs && data.providerConfigs.length > 1) {
+				const totalWeight = data.providerConfigs.reduce((sum, config) => {
+					const weight = typeof config.weight === "string" ? parseFloat(config.weight) : config.weight;
+					return sum + (isNaN(weight) ? 0 : weight);
+				}, 0);
+				return Math.abs(totalWeight - 1) < 0.001; // Allow small floating point errors
+			}
+			return true;
+		},
+		{
+			message: "Sum of all provider weights must equal 1 when multiple providers are configured",
+			path: ["providerConfigs"],
+		},
+	);
+
+type FormData = z.infer<typeof formSchema>;
 
 export default function VirtualKeyDialog({ virtualKey, teams, customers, onSave, onCancel }: VirtualKeyDialogProps) {
 	const isEditing = !!virtualKey;
-	const [initialState] = useState<Omit<VirtualKeyFormData, "isDirty">>(createInitialState(virtualKey));
-	const [formData, setFormData] = useState<VirtualKeyFormData>({
-		...initialState,
-		isDirty: false,
-	});
 
 	// RTK Query hooks
 	const { data: keysData, error: keysError, isLoading: keysLoading } = useGetAllKeysQuery();
@@ -91,6 +102,27 @@ export default function VirtualKeyDialog({ virtualKey, teams, customers, onSave,
 
 	const availableKeys = keysData || [];
 
+	// Form setup
+	const form = useForm<FormData>({
+		resolver: zodResolver(formSchema),
+		defaultValues: {
+			name: virtualKey?.name || "",
+			description: virtualKey?.description || "",
+			providerConfigs: virtualKey?.provider_configs || [],
+			entityType: virtualKey?.team_id ? "team" : virtualKey?.customer_id ? "customer" : "none",
+			teamId: virtualKey?.team_id || "",
+			customerId: virtualKey?.customer_id || "",
+			isActive: virtualKey?.is_active ?? true,
+			selectedDBKeys: virtualKey?.keys?.map((key) => key.key_id) || [],
+			budgetMaxLimit: virtualKey?.budget ? String(virtualKey.budget.max_limit) : "",
+			budgetResetDuration: virtualKey?.budget?.reset_duration || "1M",
+			tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit ? String(virtualKey.rate_limit.token_max_limit) : "",
+			tokenResetDuration: virtualKey?.rate_limit?.token_reset_duration || "1h",
+			requestMaxLimit: virtualKey?.rate_limit?.request_max_limit ? String(virtualKey.rate_limit.request_max_limit) : "",
+			requestResetDuration: virtualKey?.rate_limit?.request_reset_duration || "1h",
+		},
+	});
+
 	// Handle keys loading error
 	useEffect(() => {
 		if (keysError) {
@@ -98,139 +130,94 @@ export default function VirtualKeyDialog({ virtualKey, teams, customers, onSave,
 		}
 	}, [keysError]);
 
-	// Track isDirty state
-	useEffect(() => {
-		const currentData = {
-			name: formData.name,
-			description: formData.description,
-			allowedModels: formData.allowedModels,
-			allowedProviders: formData.allowedProviders,
-			entityType: formData.entityType,
-			teamId: formData.teamId,
-			customerId: formData.customerId,
-			isActive: formData.isActive,
-			selectedDBKeys: formData.selectedDBKeys,
-			budgetMaxLimit: formData.budgetMaxLimit,
-			budgetResetDuration: formData.budgetResetDuration,
-			tokenMaxLimit: formData.tokenMaxLimit,
-			tokenResetDuration: formData.tokenResetDuration,
-			requestMaxLimit: formData.requestMaxLimit,
-			requestResetDuration: formData.requestResetDuration,
-		};
-		setFormData((prev) => ({
-			...prev,
-			isDirty: !isEqual(initialState, currentData),
-		}));
-	}, [
-		formData.name,
-		formData.description,
-		formData.allowedModels,
-		formData.allowedProviders,
-		formData.entityType,
-		formData.teamId,
-		formData.customerId,
-		formData.isActive,
-		formData.selectedDBKeys,
-		formData.budgetMaxLimit,
-		formData.budgetResetDuration,
-		formData.tokenMaxLimit,
-		formData.tokenResetDuration,
-		formData.requestMaxLimit,
-		formData.requestResetDuration,
-		initialState,
-	]);
+	// Provider configuration state
+	const [selectedProvider, setSelectedProvider] = useState<string>("");
 
-	// Validation
-	const validator = useMemo(
-		() =>
-			new Validator([
-				// Basic validation
-				Validator.required(formData.name.trim(), "Virtual key name is required"),
+	// Get current provider configs from form
+	const providerConfigs = form.watch("providerConfigs") || [];
 
-				// Check if anything is dirty
-				Validator.custom(formData.isDirty, "No changes to save"),
-
-				// Entity validation
-				Validator.custom(
-					formData.entityType === "none" ||
-						(formData.entityType === "team" && !!formData.teamId) ||
-						(formData.entityType === "customer" && !!formData.customerId),
-					"Please select a valid team or customer assignment",
-				),
-
-				// Budget validation
-				...(formData.budgetMaxLimit
-					? [
-							Validator.minValue(formData.budgetMaxLimit, 0.01, "Budget max limit must be greater than $0.01"),
-							Validator.required(formData.budgetResetDuration, "Budget reset duration is required"),
-						]
-					: []),
-
-				// Rate limit validation - at least one limit must be set if rate limiting is enabled
-				...(formData.tokenMaxLimit || formData.requestMaxLimit
-					? [
-							// Token limit validation
-							...(formData.tokenMaxLimit
-								? [
-										Validator.required(formData.tokenMaxLimit, "Token max limit is required when token limiting is enabled"),
-										Validator.minValue(formData.tokenMaxLimit || 0, 1, "Token max limit must be at least 1"),
-										Validator.required(formData.tokenResetDuration, "Token reset duration is required"),
-									]
-								: []),
-							// Request limit validation
-							...(formData.requestMaxLimit
-								? [
-										Validator.required(formData.requestMaxLimit, "Request max limit is required when request limiting is enabled"),
-										Validator.minValue(formData.requestMaxLimit || 0, 1, "Request max limit must be at least 1"),
-										Validator.required(formData.requestResetDuration, "Request reset duration is required"),
-									]
-								: []),
-						]
-					: []),
-			]),
-		[formData],
-	);
-
-	const updateField = <K extends keyof VirtualKeyFormData>(field: K, value: VirtualKeyFormData[K]) => {
-		setFormData((prev) => ({ ...prev, [field]: value }));
-	};
-
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
-
-		if (!validator.isValid()) {
-			toast.error(validator.getFirstError());
+	// Handle adding a new provider configuration
+	const handleAddProvider = (provider: string) => {
+		const existingConfig = providerConfigs.find((config) => config.provider === provider);
+		if (existingConfig) {
+			toast.error("This provider is already configured");
 			return;
 		}
 
+		const newConfig: VirtualKeyProviderConfig = {
+			provider: provider,
+			weight: 0.5, // Default weight, user can adjust
+			allowed_models: [],
+		};
+
+		form.setValue("providerConfigs", [...providerConfigs, newConfig], { shouldDirty: true });
+	};
+
+	// Handle removing a provider configuration
+	const handleRemoveProvider = (index: number) => {
+		const updatedConfigs = providerConfigs.filter((_, i) => i !== index);
+		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
+	};
+
+	// Handle updating provider configuration
+	const handleUpdateProviderConfig = (index: number, field: keyof VirtualKeyProviderConfig, value: any) => {
+		const updatedConfigs = [...providerConfigs];
+		updatedConfigs[index] = { ...updatedConfigs[index], [field]: value };
+		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
+	};
+
+	// Helper function to convert string weights to numbers
+	const normalizeProviderConfigs = (configs: (VirtualKeyProviderConfig & { weight: string | number })[]): VirtualKeyProviderConfig[] => {
+		return configs.map((config) => ({
+			...config,
+			weight: typeof config.weight === "string" ? parseFloat(config.weight) || 0 : config.weight,
+		}));
+	};
+
+	// Normalize numeric fields to ensure they are numbers or undefined
+	const normalizeNumericField = (value: string | undefined): number | undefined => {
+		if (value === undefined || value === "") return undefined;
+		const num = parseFloat(value);
+		return isNaN(num) ? undefined : num;
+	};
+
+	// Handle form submission
+	const onSubmit = async (data: FormData) => {
 		try {
+			// Normalize provider configs to ensure weights are numbers
+			const normalizedProviderConfigs = data.providerConfigs
+				? normalizeProviderConfigs(data.providerConfigs as (VirtualKeyProviderConfig & { weight: string | number })[])
+				: [];
+
 			if (isEditing && virtualKey) {
 				// Update existing virtual key
 				const updateData: UpdateVirtualKeyRequest = {
-					description: formData.description || undefined,
-					allowed_models: formData.allowedModels,
-					allowed_providers: formData.allowedProviders,
-					team_id: formData.entityType === "team" ? formData.teamId : undefined,
-					customer_id: formData.entityType === "customer" ? formData.customerId : undefined,
-					key_ids: !isEqual(formData.selectedDBKeys, initialState.selectedDBKeys) ? formData.selectedDBKeys : undefined, // Only send if changed
-					is_active: formData.isActive,
+					description: data.description || undefined,
+					provider_configs: normalizedProviderConfigs,
+					team_id: data.entityType === "team" ? data.teamId : undefined,
+					customer_id: data.entityType === "customer" ? data.customerId : undefined,
+					key_ids: data.selectedDBKeys,
+					is_active: data.isActive,
 				};
 
 				// Add budget if enabled
-				if (formData.budgetMaxLimit) {
+				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
+				if (budgetMaxLimit) {
 					updateData.budget = {
-						max_limit: formData.budgetMaxLimit, // Already in dollars
-						reset_duration: formData.budgetResetDuration,
+						max_limit: budgetMaxLimit,
+						reset_duration: data.budgetResetDuration || "1M",
 					};
 				}
 
 				// Add rate limit if enabled
-				if (formData.tokenMaxLimit || formData.requestMaxLimit) {
+				const tokenMaxLimit = normalizeNumericField(data.tokenMaxLimit);
+				const requestMaxLimit = normalizeNumericField(data.requestMaxLimit);
+				if (tokenMaxLimit || requestMaxLimit) {
 					updateData.rate_limit = {
-						token_max_limit: formData.tokenMaxLimit,
-						token_reset_duration: formData.tokenResetDuration,
-						request_max_limit: formData.requestMaxLimit,
-						request_reset_duration: formData.requestResetDuration,
+						token_max_limit: tokenMaxLimit,
+						token_reset_duration: data.tokenResetDuration || "1h",
+						request_max_limit: requestMaxLimit,
+						request_reset_duration: data.requestResetDuration || "1h",
 					};
 				}
 
@@ -239,31 +226,33 @@ export default function VirtualKeyDialog({ virtualKey, teams, customers, onSave,
 			} else {
 				// Create new virtual key
 				const createData: CreateVirtualKeyRequest = {
-					name: formData.name,
-					description: formData.description || undefined,
-					allowed_models: formData.allowedModels.length > 0 ? formData.allowedModels : undefined,
-					allowed_providers: formData.allowedProviders.length > 0 ? formData.allowedProviders : undefined,
-					team_id: formData.entityType === "team" ? formData.teamId : undefined,
-					customer_id: formData.entityType === "customer" ? formData.customerId : undefined,
-					key_ids: formData.selectedDBKeys.length > 0 ? formData.selectedDBKeys : undefined, // Empty means all keys
-					is_active: formData.isActive,
+					name: data.name,
+					description: data.description || undefined,
+					provider_configs: normalizedProviderConfigs,
+					team_id: data.entityType === "team" ? data.teamId : undefined,
+					customer_id: data.entityType === "customer" ? data.customerId : undefined,
+					key_ids: data.selectedDBKeys,
+					is_active: data.isActive,
 				};
 
 				// Add budget if enabled
-				if (formData.budgetMaxLimit) {
+				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
+				if (budgetMaxLimit) {
 					createData.budget = {
-						max_limit: formData.budgetMaxLimit, // Already in dollars
-						reset_duration: formData.budgetResetDuration,
+						max_limit: budgetMaxLimit,
+						reset_duration: data.budgetResetDuration || "1M",
 					};
 				}
 
 				// Add rate limit if enabled
-				if (formData.tokenMaxLimit || formData.requestMaxLimit) {
+				const tokenMaxLimit = normalizeNumericField(data.tokenMaxLimit);
+				const requestMaxLimit = normalizeNumericField(data.requestMaxLimit);
+				if (tokenMaxLimit || requestMaxLimit) {
 					createData.rate_limit = {
-						token_max_limit: formData.tokenMaxLimit,
-						token_reset_duration: formData.tokenResetDuration,
-						request_max_limit: formData.requestMaxLimit,
-						request_reset_duration: formData.requestResetDuration,
+						token_max_limit: tokenMaxLimit,
+						token_reset_duration: data.tokenResetDuration || "1h",
+						request_max_limit: requestMaxLimit,
+						request_reset_duration: data.requestResetDuration || "1h",
 					};
 				}
 
@@ -289,217 +278,439 @@ export default function VirtualKeyDialog({ virtualKey, teams, customers, onSave,
 					</DialogDescription>
 				</DialogHeader>
 
-				<form onSubmit={handleSubmit} className="px-6">
-					<div className="space-y-4">
-						<div className="space-y-2">
-							<Label htmlFor="name">Name *</Label>
-							<Input
-								id="name"
-								placeholder="e.g., Production API Key"
-								value={formData.name}
-								onChange={(e) => updateField("name", e.target.value)}
-								maxLength={50}
-								disabled={isEditing} // Can't change name when editing
-							/>
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="description">Description</Label>
-							<Textarea
-								id="description"
-								placeholder="This key is used for..."
-								value={formData.description}
-								onChange={(e) => updateField("description", e.target.value)}
-								rows={3}
-							/>
-						</div>
-
-						<Toggle label="Is this key active?" val={formData.isActive} setVal={(val: boolean) => updateField("isActive", val)} />
-
-						<DottedSeparator className="mt-6 mb-5" />
-
-						{/* DBKey Selection */}
-						<div className="space-y-2">
-							<div className="flex items-center gap-2">
-								<label className="text-sm font-medium">Allowed Keys</label>
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span>
-												<Info className="text-muted-foreground h-3 w-3" />
-											</span>
-										</TooltipTrigger>
-										<TooltipContent>
-											<p>Select specific database keys to associate with this virtual key. Leave empty to allow all keys.</p>
-										</TooltipContent>
-									</Tooltip>
-								</TooltipProvider>
-							</div>
-							<MultiSelect
-								options={availableKeys.map((key) => ({
-									label: key.key_id,
-									value: key.key_id,
-									description: key.models.join(", "),
-								}))}
-								defaultValue={formData.selectedDBKeys}
-								onValueChange={(value) => updateField("selectedDBKeys", value)}
-								placeholder="Select keys..."
-								variant="inverted"
-								className="hover:bg-accent bg-white dark:bg-zinc-800"
-							/>
-						</div>
-
-						<div className="space-y-2">
-							<div className="flex items-center gap-2">
-								<label className="text-sm font-medium">Allowed Models</label>
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span>
-												<Info className="text-muted-foreground h-3 w-3" />
-											</span>
-										</TooltipTrigger>
-										<TooltipContent>
-											<p>Comma-separated list of models this key applies to. Leave blank for all models.</p>
-										</TooltipContent>
-									</Tooltip>
-								</TooltipProvider>
-							</div>
-							<TagInput
-								placeholder="e.g. gpt-4, gpt-3.5-turbo"
-								value={formData.allowedModels}
-								onValueChange={(value) => updateField("allowedModels", value)}
-							/>
-						</div>
-
-						<div className="space-y-2">
-							<div className="flex items-center gap-2">
-								<label className="text-sm font-medium">Allowed Providers</label>
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span>
-												<Info className="text-muted-foreground h-3 w-3" />
-											</span>
-										</TooltipTrigger>
-										<TooltipContent>
-											<p>Comma-separated list of providers this key applies to. Leave blank for all providers.</p>
-										</TooltipContent>
-									</Tooltip>
-								</TooltipProvider>
-							</div>
-							<TagInput
-								placeholder="e.g. openai, anthropic"
-								value={formData.allowedProviders}
-								onValueChange={(value) => updateField("allowedProviders", value)}
-							/>
-						</div>
-
-						<DottedSeparator className="mt-6 mb-5" />
-
-						{/* Budget Configuration */}
-						<NumberAndSelect
-							id="budgetMaxLimit"
-							label="Maximum Spend (USD)"
-							value={formData.budgetMaxLimit?.toString() || ""}
-							selectValue={formData.budgetResetDuration}
-							onChangeNumber={(value) => updateField("budgetMaxLimit", parseFloat(value) || 0)}
-							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
-							options={resetDurationOptions}
-						/>
-
-						{/* Rate Limiting Configuration */}
+				<Form {...form}>
+					<form onSubmit={form.handleSubmit(onSubmit)} className="px-6">
 						<div className="space-y-4">
-							<NumberAndSelect
-								id="tokenMaxLimit"
-								label="Maximum Tokens"
-								value={formData.tokenMaxLimit?.toString() || ""}
-								selectValue={formData.tokenResetDuration}
-								onChangeNumber={(value) => updateField("tokenMaxLimit", parseInt(value) || 0)}
-								onChangeSelect={(value) => updateField("tokenResetDuration", value)}
-								options={resetDurationOptions}
-							/>
+							{/* Basic Information */}
+							<div className="space-y-4">
+								<FormField
+									control={form.control}
+									name="name"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Name *</FormLabel>
+											<FormControl>
+												<Input placeholder="e.g., Production API Key" {...field} disabled={isEditing} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 
-							<NumberAndSelect
-								id="requestMaxLimit"
-								label="Maximum Requests"
-								value={formData.requestMaxLimit?.toString() || ""}
-								selectValue={formData.requestResetDuration}
-								onChangeNumber={(value) => updateField("requestMaxLimit", parseInt(value) || 0)}
-								onChangeSelect={(value) => updateField("requestResetDuration", value)}
-								options={resetDurationOptions}
-							/>
-						</div>
+								<FormField
+									control={form.control}
+									name="description"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Description</FormLabel>
+											<FormControl>
+												<Textarea placeholder="This key is used for..." {...field} rows={3} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 
-						<DottedSeparator className="my-6" />
+								<FormField
+									control={form.control}
+									name="isActive"
+									render={({ field }) => (
+										<FormItem>
+											<Toggle label="Is this key active?" val={field.value} setVal={field.onChange} />
+										</FormItem>
+									)}
+								/>
+							</div>
 
-						{/* Entity Assignment */}
-						<div className="space-y-4">
+							<DottedSeparator className="mt-6 mb-5" />
+
+							{/* DBKey Selection */}
 							<div className="space-y-2">
-								<Label>Assignment Type</Label>
-								<Select
-									value={formData.entityType}
-									onValueChange={(value: "team" | "customer" | "none") => updateField("entityType", value)}
-								>
-									<SelectTrigger className="w-full">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent className="w-full">
-										<SelectItem value="none">No Assignment</SelectItem>
-										{teams?.length > 0 && <SelectItem value="team">Assign to Team</SelectItem>}
-										{customers?.length > 0 && <SelectItem value="customer">Assign to Customer</SelectItem>}
-									</SelectContent>
-								</Select>
+								<div className="flex items-center gap-2">
+									<Label className="text-sm font-medium">Allowed Keys</Label>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span>
+													<Info className="text-muted-foreground h-3 w-3" />
+												</span>
+											</TooltipTrigger>
+											<TooltipContent>
+												<p>Select specific database keys to associate with this virtual key. Leave empty to allow all keys.</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								</div>
+								<FormField
+									control={form.control}
+									name="selectedDBKeys"
+									render={({ field }) => (
+										<FormItem>
+											<FormControl>
+												<MultiSelect
+													options={availableKeys.map((key) => ({
+														label: key.key_id,
+														value: key.key_id,
+														description: key.models.join(", "),
+													}))}
+													defaultValue={field.value || []}
+													onValueChange={field.onChange}
+													placeholder="Select keys..."
+													variant="inverted"
+													className="hover:bg-accent bg-white dark:bg-zinc-800"
+													animationConfig={{
+														badgeAnimation: "none",
+														popoverAnimation: "none",
+														optionHoverAnimation: "none",
+													}}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 							</div>
 
-							{formData.entityType === "team" && teams?.length > 0 && (
-								<div className="space-y-2">
-									<Label>Select Team</Label>
-									<Select value={formData.teamId} onValueChange={(value) => updateField("teamId", value)}>
-										<SelectTrigger className="w-full">
-											<SelectValue placeholder="Select a team" />
-										</SelectTrigger>
-										<SelectContent className="w-full">
-											{teams.map((team) => (
-												<SelectItem key={team.id} value={team.id}>
-													<div className="flex items-center gap-2">
-														<Users className="h-4 w-4" />
-														{team.name}
-														{team.customer && <span className="text-muted-foreground">({team.customer.name})</span>}
-													</div>
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+							{/* Provider Configurations */}
+							<div className="space-y-2">
+								<div className="flex items-center gap-2">
+									<Label className="text-sm font-medium">Provider Configurations</Label>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span>
+													<Info className="text-muted-foreground h-3 w-3" />
+												</span>
+											</TooltipTrigger>
+											<TooltipContent>
+												<p>
+													Configure which providers this virtual key can use and their specific settings. Leave empty to allow all
+													providers.
+												</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
 								</div>
-							)}
 
-							{formData.entityType === "customer" && customers?.length > 0 && (
-								<div className="space-y-2">
-									<Label>Select Customer</Label>
-									<Select value={formData.customerId} onValueChange={(value) => updateField("customerId", value)}>
-										<SelectTrigger className="w-full">
-											<SelectValue placeholder="Select a customer" />
+								{/* Add Provider Dropdown */}
+								<div className="flex gap-2">
+									<Select
+										value={selectedProvider}
+										onValueChange={(provider) => {
+											handleAddProvider(provider);
+											setSelectedProvider(""); // Reset to placeholder state
+										}}
+									>
+										<SelectTrigger className="flex-1">
+											<SelectValue placeholder="Select a provider to add" />
 										</SelectTrigger>
-										<SelectContent className="w-full">
-											{customers.map((customer) => (
-												<SelectItem key={customer.id} value={customer.id}>
-													<div className="flex items-center gap-2">
-														<User className="h-4 w-4" />
-														{customer.name}
-													</div>
-												</SelectItem>
-											))}
+										<SelectContent>
+											{ProviderNames.filter((provider) => !providerConfigs.some((config) => config.provider === provider)).length > 0 ? (
+												ProviderNames.filter((provider) => !providerConfigs.some((config) => config.provider === provider)).map(
+													(provider) => (
+														<SelectItem key={provider} value={provider}>
+															<RenderProviderIcon provider={provider as ProviderIconType} size="sm" className="h-4 w-4" />
+															{ProviderLabels[provider]}
+														</SelectItem>
+													),
+												)
+											) : (
+												<div className="text-muted-foreground px-2 py-1.5 text-sm">All providers configured</div>
+											)}
 										</SelectContent>
 									</Select>
 								</div>
+
+								{/* Provider Configurations Table */}
+								{providerConfigs.length > 0 && (
+									<div className="rounded-md border">
+										<Table>
+											<TableHeader>
+												<TableRow>
+													<TableHead>Provider</TableHead>
+													<TableHead>Weight</TableHead>
+													<TableHead>Allowed Models</TableHead>
+													<TableHead className="w-[50px]"></TableHead>
+												</TableRow>
+											</TableHeader>
+											<TableBody>
+												{providerConfigs.map((config, index) => (
+													<TableRow key={`${config.provider}-${index}`}>
+														<TableCell>
+															<div className="flex items-center gap-2">
+																<RenderProviderIcon provider={config.provider as ProviderIconType} size="sm" className="h-4 w-4" />
+																{ProviderLabels[config.provider as ProviderName]}
+															</div>
+														</TableCell>
+														<TableCell className="max-w-[100px]">
+															<Input
+																placeholder="0.5"
+																className="w-full border-none"
+																value={config.weight}
+																onChange={(e) => {
+																	const inputValue = e.target.value;
+																	// Allow empty string, numbers, and partial decimal inputs like "0."
+																	if (inputValue === "" || !isNaN(parseFloat(inputValue)) || inputValue.endsWith(".")) {
+																		handleUpdateProviderConfig(index, "weight", inputValue);
+																	}
+																}}
+																onBlur={(e) => {
+																	const inputValue = e.target.value.trim();
+																	if (inputValue === "") {
+																		handleUpdateProviderConfig(index, "weight", "");
+																	} else {
+																		const num = parseFloat(inputValue);
+																		if (!isNaN(num)) {
+																			handleUpdateProviderConfig(index, "weight", String(num));
+																		} else {
+																			handleUpdateProviderConfig(index, "weight", "");
+																		}
+																	}
+																}}
+																type="text"
+															/>
+														</TableCell>
+														<TableCell className="max-w-[500px]">
+															<TagInput
+																placeholder={
+																	config.provider
+																		? ModelPlaceholders[config.provider as keyof typeof ModelPlaceholders]
+																		: ModelPlaceholders.openai
+																}
+																value={config.allowed_models || []}
+																onValueChange={(models: string[]) => handleUpdateProviderConfig(index, "allowed_models", models)}
+																className="max-w-[500px] min-w-[200px] border-none"
+															/>
+														</TableCell>
+														<TableCell>
+															<Button type="button" variant="ghost" size="sm" onClick={() => handleRemoveProvider(index)}>
+																<Trash2 className="h-4 w-4" />
+															</Button>
+														</TableCell>
+													</TableRow>
+												))}
+											</TableBody>
+										</Table>
+									</div>
+								)}
+
+								{/* Display validation errors for provider configurations */}
+								{form.formState.errors.providerConfigs && (
+									<div className="text-destructive text-sm">{form.formState.errors.providerConfigs.message}</div>
+								)}
+							</div>
+
+							<DottedSeparator className="mt-6 mb-5" />
+
+							{/* Budget Configuration */}
+							<div className="space-y-4">
+								<Label className="text-sm font-medium">Budget Configuration</Label>
+								<FormField
+									control={form.control}
+									name="budgetMaxLimit"
+									render={({ field }) => (
+										<FormItem>
+											<NumberAndSelect
+												id="budgetMaxLimit"
+												labelClassName="font-normal"
+												label="Maximum Spend (USD)"
+												value={field.value || ""}
+												selectValue={form.watch("budgetResetDuration") || "1M"}
+												onChangeNumber={(value) => {
+													field.onChange(value);
+												}}
+												onChangeSelect={(value) => form.setValue("budgetResetDuration", value)}
+												options={resetDurationOptions}
+											/>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+
+							{/* Rate Limiting Configuration */}
+							<div className="space-y-4">
+								<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
+
+								<FormField
+									control={form.control}
+									name="tokenMaxLimit"
+									render={({ field }) => (
+										<FormItem>
+											<NumberAndSelect
+												id="tokenMaxLimit"
+												labelClassName="font-normal"
+												label="Maximum Tokens"
+												value={field.value || ""}
+												selectValue={form.watch("tokenResetDuration") || "1h"}
+												onChangeNumber={(value) => {
+													field.onChange(value);
+												}}
+												onChangeSelect={(value) => form.setValue("tokenResetDuration", value)}
+												options={resetDurationOptions}
+											/>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={form.control}
+									name="requestMaxLimit"
+									render={({ field }) => (
+										<FormItem>
+											<NumberAndSelect
+												id="requestMaxLimit"
+												labelClassName="font-normal"
+												label="Maximum Requests"
+												value={field.value || ""}
+												selectValue={form.watch("requestResetDuration") || "1h"}
+												onChangeNumber={(value) => {
+													field.onChange(value);
+												}}
+												onChangeSelect={(value) => form.setValue("requestResetDuration", value)}
+												options={resetDurationOptions}
+											/>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+
+							{(teams?.length > 0 || customers?.length > 0) && (
+								<>
+									<DottedSeparator className="my-6" />
+
+									{/* Entity Assignment */}
+									<div className="space-y-4">
+										<Label className="text-sm font-medium">Entity Assignment</Label>
+
+										<div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
+											<FormField
+												control={form.control}
+												name="entityType"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel className="font-normal">Assignment Type</FormLabel>
+														<Select onValueChange={field.onChange} defaultValue={field.value}>
+															<FormControl className="w-full">
+																<SelectTrigger>
+																	<SelectValue />
+																</SelectTrigger>
+															</FormControl>
+															<SelectContent>
+																<SelectItem value="none">No Assignment</SelectItem>
+																{teams?.length > 0 && <SelectItem value="team">Assign to Team</SelectItem>}
+																{customers?.length > 0 && <SelectItem value="customer">Assign to Customer</SelectItem>}
+															</SelectContent>
+														</Select>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+											{form.watch("entityType") === "team" && teams?.length > 0 && (
+												<FormField
+													control={form.control}
+													name="teamId"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel className="font-normal">Select Team</FormLabel>
+															<Select onValueChange={field.onChange} defaultValue={field.value}>
+																<FormControl className="w-full">
+																	<SelectTrigger>
+																		<SelectValue placeholder="Select a team" />
+																	</SelectTrigger>
+																</FormControl>
+																<SelectContent>
+																	{teams.map((team) => (
+																		<SelectItem key={team.id} value={team.id}>
+																			<div className="flex items-center gap-2">
+																				<Users className="h-4 w-4" />
+																				{team.name}
+																				{team.customer && (
+																					<span className="text-muted-foreground flex items-center gap-1">
+																						<Building className="h-2 w-2" />
+																						{team.customer.name}
+																					</span>
+																				)}
+																			</div>
+																		</SelectItem>
+																	))}
+																</SelectContent>
+															</Select>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+											)}
+
+											{form.watch("entityType") === "customer" && customers?.length > 0 && (
+												<FormField
+													control={form.control}
+													name="customerId"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel className="font-normal">Select Customer</FormLabel>
+															<Select onValueChange={field.onChange} defaultValue={field.value}>
+																<FormControl className="w-full">
+																	<SelectTrigger>
+																		<SelectValue placeholder="Select a customer" />
+																	</SelectTrigger>
+																</FormControl>
+																<SelectContent>
+																	{customers.map((customer) => (
+																		<SelectItem key={customer.id} value={customer.id}>
+																			<div className="flex items-center gap-2">
+																				<Building className="h-4 w-4" />
+																				{customer.name}
+																			</div>
+																		</SelectItem>
+																	))}
+																</SelectContent>
+															</Select>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+											)}
+										</div>
+									</div>
+								</>
 							)}
 						</div>
-					</div>
-					<div className="dark:bg-card border-border  bg-white pb-6">
-						<FormFooter validator={validator} label="Virtual Key" onCancel={onCancel} isLoading={isLoading} isEditing={isEditing} />
-					</div>
-				</form>
+
+						{/* Form Footer */}
+						<div className="dark:bg-card border-border bg-white py-6">
+							<div className="flex justify-end gap-2">
+								<Button type="button" variant="outline" onClick={onCancel}>
+									Cancel
+								</Button>
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<Button type="submit" disabled={isLoading || !form.formState.isDirty || !form.formState.isValid}>
+												{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+											</Button>
+										</TooltipTrigger>
+										{(isLoading || !form.formState.isDirty || !form.formState.isValid) && (
+											<TooltipContent>
+												<p>
+													{isLoading
+														? "Saving..."
+														: !form.formState.isDirty && !form.formState.isValid
+															? "No changes made and validation errors present"
+															: !form.formState.isDirty
+																? "No changes made"
+																: "Please fix validation errors"}
+												</p>
+											</TooltipContent>
+										)}
+									</Tooltip>
+								</TooltipProvider>
+							</div>
+						</div>
+					</form>
+				</Form>
 			</DialogContent>
 		</Dialog>
 	);

--- a/ui/app/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/virtual-keys/views/virtualKeysTable.tsx
@@ -156,10 +156,7 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefr
 									return (
 										<TableRow key={vk.id} className="hover:bg-muted/50 cursor-pointer transition-colors" onClick={() => handleRowClick(vk)}>
 											<TableCell className="max-w-[200px]">
-												<div className="truncate">
-													<div className="truncate font-medium">{vk.name}</div>
-													{vk.description && <div className="text-muted-foreground truncate text-sm">{vk.description}</div>}
-												</div>
+												<div className="truncate font-medium">{vk.name}</div>
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<div className="flex items-center gap-2">

--- a/ui/components/ui/dialog.tsx
+++ b/ui/components/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
 				{showCloseButton && (
 					<DialogPrimitive.Close
 						data-slot="dialog-close"
-						className="ring-offset-background data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-6 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 z-10"
+						className="ring-offset-background data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-6 right-4 z-10 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
 					>
 						<XIcon />
 						<span className="sr-only">Close</span>
@@ -74,11 +74,7 @@ function DialogContent({
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
 	return (
-		<div
-			data-slot="dialog-header"
-			className={cn("dark:bg-card flex flex-col gap-2 pb-4 text-center sm:text-left", className)}
-			{...props}
-		/>
+		<div data-slot="dialog-header" className={cn("dark:bg-card flex flex-col gap-2 pb-4 text-center sm:text-left", className)} {...props} />
 	);
 }
 

--- a/ui/components/ui/multiSelect.tsx
+++ b/ui/components/ui/multiSelect.tsx
@@ -810,7 +810,7 @@ export const MultiSelect = React.forwardRef<MultiSelectRef, MultiSelectProps>(
 																}
 															}}
 															aria-label={`Remove ${option.label} from selection`}
-															className="ring-none -m-0.5 ml-2 h-4 w-4 cursor-pointer rounded-sm p-0.5 hover:bg-white/20 focus:outline-none"
+															className="ring-none -m-0.5 ml-2 h-4 w-4 cursor-pointer rounded-sm focus:outline-none"
 														>
 															<XCircle className={cn("h-3 w-3", responsiveSettings.compactMode && "h-2.5 w-2.5")} />
 														</div>

--- a/ui/components/ui/numberAndSelect.tsx
+++ b/ui/components/ui/numberAndSelect.tsx
@@ -1,6 +1,6 @@
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
 import React from "react";
 
 const NumberAndSelect = ({
@@ -11,6 +11,7 @@ const NumberAndSelect = ({
 	onChangeNumber,
 	onChangeSelect,
 	options,
+	labelClassName,
 }: {
 	id: string;
 	label: string;
@@ -19,15 +20,45 @@ const NumberAndSelect = ({
 	onChangeNumber: (value: string) => void;
 	onChangeSelect: (value: string) => void;
 	options: { label: string; value: string }[];
+	labelClassName?: string;
 }) => {
 	return (
 		<div className="flex w-full items-center justify-between gap-4">
 			<div className="grow space-y-2">
-				<Label htmlFor={id}>{label}</Label>
-				<Input id={id} type="number" min="1" step="1" placeholder="100" value={value} onChange={(e) => onChangeNumber(e.target.value)} />
+				<Label htmlFor={id} className={labelClassName}>
+					{label}
+				</Label>
+				<Input
+					id={id}
+					placeholder="100"
+					value={value}
+					onChange={(e) => {
+						const inputValue = e.target.value;
+						// Allow empty string, numbers, and partial decimal inputs like "0."
+						if (inputValue === "" || !isNaN(parseFloat(inputValue)) || inputValue.endsWith(".")) {
+							onChangeNumber(inputValue);
+						}
+					}}
+					onBlur={(e) => {
+						const inputValue = e.target.value.trim();
+						if (inputValue === "") {
+							onChangeNumber("");
+						} else {
+							const num = parseFloat(inputValue);
+							if (!isNaN(num)) {
+								onChangeNumber(String(num));
+							} else {
+								onChangeNumber("");
+							}
+						}
+					}}
+					type="text"
+				/>
 			</div>
 			<div className="w-40 space-y-2">
-				<Label htmlFor={`${id}-select`}>Reset Period</Label>
+				<Label htmlFor={`${id}-select`} className={labelClassName}>
+					Reset Period
+				</Label>
 				<Select value={selectValue} onValueChange={(value) => onChangeSelect(value as string)}>
 					<SelectTrigger className="m-0 w-full">
 						<SelectValue />

--- a/ui/components/ui/tagInput.tsx
+++ b/ui/components/ui/tagInput.tsx
@@ -46,21 +46,19 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(({ cla
 	};
 
 	return (
-		<div className={cn("border-input dark:bg-accent flex flex-wrap items-center gap-2 rounded-sm border", className)}>
-			<div className={cn("flex flex-row gap-2", value.length > 0 && "pl-2")}>
-				{value.map((tag) => (
-					<Badge key={tag} variant="secondary" className="bg-accent dark:bg-card flex items-center gap-1">
-						{tag}
-						<button
-							type="button"
-							className="ring-offset-background focus:ring-ring cursor-pointer rounded-full outline-none focus:ring-2 focus:ring-offset-2"
-							onClick={() => removeTag(tag)}
-						>
-							<X className="h-3 w-3" />
-						</button>
-					</Badge>
-				))}
-			</div>
+		<div className={cn("border-input dark:bg-accent flex flex-wrap items-center gap-2 rounded-sm border p-1", className)}>
+			{value.map((tag) => (
+				<Badge key={tag} variant="secondary" className="bg-accent dark:bg-card flex items-center gap-1">
+					{tag}
+					<button
+						type="button"
+						className="ring-offset-background focus:ring-ring cursor-pointer rounded-full outline-none focus:ring-2 focus:ring-offset-2"
+						onClick={() => removeTag(tag)}
+					>
+						<X className="h-3 w-3" />
+					</button>
+				</Badge>
+			))}
 			<Input
 				ref={ref}
 				type="text"
@@ -68,7 +66,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(({ cla
 				onChange={handleInputChange}
 				onKeyDown={handleKeyDown}
 				onBlur={handleBlur}
-				className={cn("dark:bg-accent min-w-32 flex-1 border-0 shadow-none focus-visible:ring-0", value.length > 0 ? "px-0" : "px-1")}
+				className={cn("dark:bg-accent h-6 min-w-32 flex-1 border-0 p-0 text-xs shadow-none focus-visible:ring-0")}
 				{...props}
 			/>
 		</div>

--- a/ui/hooks/useDebounce.ts
+++ b/ui/hooks/useDebounce.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useDebouncedValue(value: any, delay: number): any {
+	const [debouncedValue, setDebouncedValue] = useState(value);
+
+	useEffect(() => {
+		const handler = setTimeout(() => {
+			setDebouncedValue(value);
+		}, delay);
+
+		return () => {
+			clearTimeout(handler);
+		};
+	}, [value, delay]);
+
+	return debouncedValue;
+}
+
+export const useDebouncedFunction = <T extends (...args: any[]) => any>(func: T, delay: number): ((...args: Parameters<T>) => void) => {
+	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+	const debouncedFunction = useCallback(
+		(...args: Parameters<T>) => {
+			if (timeoutRef.current) {
+				clearTimeout(timeoutRef.current);
+			}
+			timeoutRef.current = setTimeout(() => func(...args), delay);
+		},
+		[func, delay],
+	);
+
+	return debouncedFunction;
+};

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -1,4 +1,41 @@
 import { AllowedRequests, ConcurrencyAndBufferSize, NetworkConfig } from "@/lib/types/config";
+import { ProviderName } from "./logs";
+
+// Model placeholders based on provider type
+export const MODEL_PLACEHOLDERS = {
+	default: "e.g. gpt-4, gpt-3.5-turbo. Leave blank for all models.",
+	anthropic: "e.g. claude-3-haiku, claude-2.1",
+	azure: "e.g. gpt-4, gpt-35-turbo (must match deployment names)",
+	bedrock: "e.g. claude-v2, titan-text-express-v1, ai21-j2-mid",
+	cerebras: "e.g. cerebras-2, cerebras-2-vision",
+	cohere: "e.g. command-r, command-r-plus",
+	gemini: "e.g. gemini-1.5-pro, gemini-1.5-flash",
+	groq: "e.g. llama3-70b-8192, mixtral-8x7b-32768",
+	mistral: "e.g. mistral-7b-instruct, mixtral-8x7b",
+	openrouter: "e.g. openai/gpt-4, anthropic/claude-3-haiku",
+	sgl: "e.g. sgl-2, sgl-vision",
+	parasail: "e.g. parasail-2, parasail-vision",
+	ollama: "e.g. llama3.1, llama2",
+	openai: "e.g. gpt-4, gpt-4o, gpt-4o-mini, gpt-3.5-turbo",
+	vertex: "e.g. gemini-1.5-pro, text-bison, chat-bison",
+};
+
+export const isKeyRequiredByProvider: Record<ProviderName, boolean> = {
+	anthropic: true,
+	azure: true,
+	bedrock: true,
+	cerebras: true,
+	cohere: true,
+	gemini: true,
+	groq: true,
+	mistral: true,
+	openrouter: true,
+	sgl: false,
+	parasail: true,
+	ollama: false,
+	openai: true,
+	vertex: true,
+};
 
 export const DefaultNetworkConfig = {
 	base_url: "",

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -1,19 +1,19 @@
 // Known provider names array - centralized definition
 export const KnownProvidersNames = [
-	"openai",
 	"anthropic",
 	"azure",
 	"bedrock",
+	"cerebras",
 	"cohere",
-	"vertex",
+	"gemini",
+	"groq",
 	"mistral",
 	"ollama",
-	"groq",
+	"openai",
+	"openrouter",
 	"parasail",
 	"sgl",
-	"cerebras",
-	"gemini",
-	"openrouter",
+	"vertex",
 ] as const;
 
 // Local Provider type derived from KNOWN_PROVIDERS constant

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -52,8 +52,7 @@ export interface VirtualKey {
 	name: string;
 	value: string; // The actual key value
 	description?: string;
-	allowed_models?: string[];
-	allowed_providers?: string[];
+	provider_configs?: VirtualKeyProviderConfig[];
 	team_id?: string;
 	customer_id?: string;
 	budget_id?: string;
@@ -67,6 +66,13 @@ export interface VirtualKey {
 	budget?: Budget;
 	rate_limit?: RateLimit;
 	keys?: DBKey[]; // Associated database keys
+}
+
+export interface VirtualKeyProviderConfig {
+	id?: number;
+	provider: string;
+	weight: number;
+	allowed_models: string[];
 }
 
 export interface UsageStats {
@@ -83,8 +89,7 @@ export interface UsageStats {
 export interface CreateVirtualKeyRequest {
 	name: string;
 	description?: string;
-	allowed_models?: string[];
-	allowed_providers?: string[];
+	provider_configs?: VirtualKeyProviderConfig[];
 	team_id?: string;
 	customer_id?: string;
 	budget?: CreateBudgetRequest;
@@ -95,8 +100,7 @@ export interface CreateVirtualKeyRequest {
 
 export interface UpdateVirtualKeyRequest {
 	description?: string;
-	allowed_models?: string[];
-	allowed_providers?: string[];
+	provider_configs?: VirtualKeyProviderConfig[];
 	team_id?: string;
 	customer_id?: string;
 	budget?: UpdateBudgetRequest;


### PR DESCRIPTION
## Summary

Add weighted provider routing for virtual keys, allowing for load balancing between different providers that support the same model.

## Changes

- Added a new `TableVirtualKeyProviderConfig` table to store provider configurations for virtual keys
- Replaced `AllowedProviders` field with `ProviderConfigs` in virtual keys to support weighted routing
- Implemented weighted random selection algorithm for provider routing
- Added middleware to handle provider routing for requests with virtual keys
- Enhanced the pricing manager to track which models are available for each provider
- Updated governance handlers to support CRUD operations for provider configs

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the weighted provider routing by creating a virtual key with multiple provider configurations:

```sh
# Create a virtual key with provider configs
curl -X POST http://localhost:8000/api/governance/virtual-keys \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test VK with Routing",
    "provider_configs": [
      {"provider": "openai", "weight": 0.7},
      {"provider": "anthropic", "weight": 0.3}
    ]
  }'

# Use the virtual key to make requests without specifying provider
curl -X POST http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -H "X-BF-VK: your-vk-value" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}]
  }'
```

The system should automatically route to the appropriate provider based on the weights.

## Breaking changes

- [x] Yes
- [ ] No

This change replaces the `AllowedProviders` field with `ProviderConfigs` in virtual keys. Existing virtual keys will need to be updated to use the new provider configuration system.

## Security considerations

The weighted routing system maintains the same security model as the previous implementation, with provider access still controlled by virtual key permissions.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable