### PR TITLE
fix: correct input validation conditions in Bifrost requests

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -373,7 +373,7 @@ func (bifrost *Bifrost) SpeechRequest(ctx context.Context, req *schemas.BifrostS
 			},
 		}
 	}
-	if req.Input != nil || req.Input.Input == "" {
+	if req.Input == nil || req.Input.Input == "" {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
@@ -402,7 +402,7 @@ func (bifrost *Bifrost) SpeechStreamRequest(ctx context.Context, req *schemas.Bi
 			},
 		}
 	}
-	if req.Input != nil || req.Input.Input == "" {
+	if req.Input == nil || req.Input.Input == "" {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
@@ -431,7 +431,7 @@ func (bifrost *Bifrost) TranscriptionRequest(ctx context.Context, req *schemas.B
 			},
 		}
 	}
-	if req.Input != nil || req.Input.File == nil {
+	if req.Input == nil || req.Input.File == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
@@ -460,7 +460,7 @@ func (bifrost *Bifrost) TranscriptionStreamRequest(ctx context.Context, req *sch
 			},
 		}
 	}
-	if req.Input != nil || req.Input.File == nil {
+	if req.Input == nil || req.Input.File == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -851,12 +851,6 @@ func (provider *BedrockProvider) processEventBuffer(ctx context.Context, postHoo
 			// Handle tool use delta
 			toolUseDelta := streamEvent.Delta.ToolUse
 
-			// Parse the incremental input JSON
-			var inputData interface{}
-			if err := sonic.Unmarshal([]byte(toolUseDelta.Input), &inputData); err != nil {
-				inputData = map[string]interface{}{}
-			}
-
 			// Create tool call structure
 			var toolCall schemas.ChatAssistantMessageToolCall
 			toolCall.Type = schemas.Ptr("function")

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -339,7 +339,7 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 		rm.Content = &ResponsesMessageContent{
 			ContentBlocks: []ResponsesMessageContentBlock{refusalBlock},
 		}
-	}  else if cm.Content.ContentStr != nil {
+	} else if cm.Content.ContentStr != nil {
 		// Convert regular string content
 		rm.Content = &ResponsesMessageContent{
 			ContentStr: cm.Content.ContentStr,
@@ -348,10 +348,28 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 		// Convert content blocks
 		responseBlocks := make([]ResponsesMessageContentBlock, len(cm.Content.ContentBlocks))
 		for i, block := range cm.Content.ContentBlocks {
+			blockType := ResponsesMessageContentBlockType(block.Type)
+
+			switch block.Type {
+			case ChatContentBlockTypeText:
+				if cm.Role == ChatMessageRoleAssistant {
+					blockType = ResponsesOutputMessageContentTypeText
+				} else {
+					blockType = ResponsesInputMessageContentBlockTypeText
+				}
+			case ChatContentBlockTypeImage:
+				blockType = ResponsesInputMessageContentBlockTypeImage
+			case ChatContentBlockTypeFile:
+				blockType = ResponsesInputMessageContentBlockTypeFile
+			case ChatContentBlockTypeInputAudio:
+				blockType = ResponsesInputMessageContentBlockTypeAudio
+			}
+
 			responseBlocks[i] = ResponsesMessageContentBlock{
-				Type: ResponsesMessageContentBlockType(block.Type),
+				Type: blockType,
 				Text: block.Text,
 			}
+
 			// Convert specific block types
 			if block.ImageURLStruct != nil {
 				responseBlocks[i].ResponsesInputMessageContentBlockImage = &ResponsesInputMessageContentBlockImage{

--- a/core/schemas/providers/gemini/embedding.go
+++ b/core/schemas/providers/gemini/embedding.go
@@ -8,7 +8,7 @@ import (
 
 // ToGeminiEmbeddingRequest converts a BifrostRequest with embedding input to Gemini's embedding request format
 func ToGeminiEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *GeminiEmbeddingRequest {
-	if bifrostReq == nil || (bifrostReq.Input.Text == nil && bifrostReq.Input.Texts == nil) {
+	if bifrostReq == nil || bifrostReq.Input == nil || (bifrostReq.Input.Text == nil && bifrostReq.Input.Texts == nil) {
 		return nil
 	}
 	embeddingInput := bifrostReq.Input

--- a/core/schemas/providers/vertex/embedding.go
+++ b/core/schemas/providers/vertex/embedding.go
@@ -6,7 +6,7 @@ import (
 
 // ToVertexEmbeddingRequest converts a Bifrost embedding request to Vertex AI format
 func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *VertexEmbeddingRequest {
-	if bifrostReq == nil || (bifrostReq.Input.Text == nil && bifrostReq.Input.Texts == nil) {
+	if bifrostReq == nil || bifrostReq.Input == nil || (bifrostReq.Input.Text == nil && bifrostReq.Input.Texts == nil) {
 		return nil
 	}
 

--- a/tests/core-providers/custom_test.go
+++ b/tests/core-providers/custom_test.go
@@ -63,11 +63,11 @@ func TestCustomProvider_DisallowedOperation(t *testing.T) {
 	request := &schemas.BifrostSpeechRequest{
 		Provider: config.ProviderOpenAICustom, // Use the custom provider
 		Model:    "llama-3.3-70b-versatile",   // Use a model that exists for this provider
-		Input: schemas.SpeechInput{
+		Input: &schemas.SpeechInput{
 			Input: prompt,
 		},
 		Params: &schemas.SpeechParameters{
-			VoiceConfig: schemas.SpeechVoiceInput{
+			VoiceConfig: &schemas.SpeechVoiceInput{
 				Voice: bifrost.Ptr("alloy"),
 			},
 			ResponseFormat: "mp3",

--- a/tests/core-providers/scenarios/embedding.go
+++ b/tests/core-providers/scenarios/embedding.go
@@ -58,7 +58,7 @@ func RunEmbeddingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 		request := &schemas.BifrostEmbeddingRequest{
 			Provider: testConfig.Provider,
 			Model:    testConfig.EmbeddingModel,
-			Input: schemas.EmbeddingInput{
+			Input: &schemas.EmbeddingInput{
 				Texts: testTexts,
 			},
 			Params: &schemas.EmbeddingParameters{

--- a/tests/core-providers/scenarios/speech_synthesis.go
+++ b/tests/core-providers/scenarios/speech_synthesis.go
@@ -62,11 +62,11 @@ func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				request := &schemas.BifrostSpeechRequest{
 					Provider: testConfig.Provider,
 					Model:    testConfig.SpeechSynthesisModel, // Use configured model
-					Input: schemas.SpeechInput{
+					Input: &schemas.SpeechInput{
 						Input: tc.text,
 					},
 					Params: &schemas.SpeechParameters{
-						VoiceConfig: schemas.SpeechVoiceInput{
+						VoiceConfig: &schemas.SpeechVoiceInput{
 							Voice: &voice,
 						},
 						ResponseFormat: tc.format,
@@ -165,11 +165,11 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 			request := &schemas.BifrostSpeechRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.SpeechSynthesisModel,
-				Input: schemas.SpeechInput{
+				Input: &schemas.SpeechInput{
 					Input: longText,
 				},
 				Params: &schemas.SpeechParameters{
-					VoiceConfig: schemas.SpeechVoiceInput{
+					VoiceConfig: &schemas.SpeechVoiceInput{
 						Voice: &voice,
 					},
 					ResponseFormat: "mp3",
@@ -230,11 +230,11 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 					request := &schemas.BifrostSpeechRequest{
 						Provider: testConfig.Provider,
 						Model:    testConfig.SpeechSynthesisModel,
-						Input: schemas.SpeechInput{
+						Input: &schemas.SpeechInput{
 							Input: testText,
 						},
 						Params: &schemas.SpeechParameters{
-							VoiceConfig: schemas.SpeechVoiceInput{
+							VoiceConfig: &schemas.SpeechVoiceInput{
 								Voice: &voice,
 							},
 							ResponseFormat: "mp3",

--- a/tests/core-providers/scenarios/speech_synthesis_stream.go
+++ b/tests/core-providers/scenarios/speech_synthesis_stream.go
@@ -65,11 +65,11 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				request := &schemas.BifrostSpeechRequest{
 					Provider: testConfig.Provider,
 					Model:    testConfig.SpeechSynthesisModel,
-					Input: schemas.SpeechInput{
+					Input: &schemas.SpeechInput{
 						Input: tc.text,
 					},
 					Params: &schemas.SpeechParameters{
-						VoiceConfig: schemas.SpeechVoiceInput{
+						VoiceConfig: &schemas.SpeechVoiceInput{
 							Voice: &voice,
 						},
 						ResponseFormat: tc.format,
@@ -226,11 +226,11 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 			request := &schemas.BifrostSpeechRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.SpeechSynthesisModel,
-				Input: schemas.SpeechInput{
+				Input: &schemas.SpeechInput{
 					Input: finalText,
 				},
 				Params: &schemas.SpeechParameters{
-					VoiceConfig: schemas.SpeechVoiceInput{
+					VoiceConfig: &schemas.SpeechVoiceInput{
 						Voice: &voice,
 					},
 					ResponseFormat: "mp3",
@@ -329,11 +329,11 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 					request := &schemas.BifrostSpeechRequest{
 						Provider: testConfig.Provider,
 						Model:    testConfig.SpeechSynthesisModel,
-						Input: schemas.SpeechInput{
+						Input: &schemas.SpeechInput{
 							Input: testText,
 						},
 						Params: &schemas.SpeechParameters{
-							VoiceConfig: schemas.SpeechVoiceInput{
+							VoiceConfig: &schemas.SpeechVoiceInput{
 								Voice: &voiceCopy,
 							},
 							ResponseFormat: "mp3",

--- a/tests/core-providers/scenarios/test_retry_framework.go
+++ b/tests/core-providers/scenarios/test_retry_framework.go
@@ -120,7 +120,7 @@ func WithTestRetry(
 
 			// Return nil response + BifrostError so calling test fails
 			testFailureError := &schemas.BifrostError{
-				Error: schemas.ErrorField{
+				Error: &schemas.ErrorField{
 					Message: fmt.Sprintf("Test validation failed after %d attempts - %s", attempt, validationErrors),
 					Type:    bifrost.Ptr("validation_failure"),
 					Code:    bifrost.Ptr("TEST_VALIDATION_FAILED"),

--- a/tests/core-providers/scenarios/text_completion.go
+++ b/tests/core-providers/scenarios/text_completion.go
@@ -22,7 +22,7 @@ func RunTextCompletionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 		request := &schemas.BifrostTextCompletionRequest{
 			Provider: testConfig.Provider,
 			Model:    testConfig.TextModel,
-			Input: schemas.TextCompletionInput{
+			Input: &schemas.TextCompletionInput{
 				PromptStr: &prompt,
 			},
 			Fallbacks: testConfig.Fallbacks,

--- a/tests/core-providers/scenarios/transcription.go
+++ b/tests/core-providers/scenarios/transcription.go
@@ -61,11 +61,11 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 				ttsRequest := &schemas.BifrostSpeechRequest{
 					Provider: testConfig.Provider,
 					Model:    testConfig.SpeechSynthesisModel,
-					Input: schemas.SpeechInput{
+					Input: &schemas.SpeechInput{
 						Input: tc.text,
 					},
 					Params: &schemas.SpeechParameters{
-						VoiceConfig: schemas.SpeechVoiceInput{
+						VoiceConfig: &schemas.SpeechVoiceInput{
 							Voice: &voice,
 						},
 						ResponseFormat: tc.format,
@@ -96,7 +96,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 				transcriptionRequest := &schemas.BifrostTranscriptionRequest{
 					Provider: testConfig.Provider,
 					Model:    testConfig.TranscriptionModel,
-					Input: schemas.TranscriptionInput{
+					Input: &schemas.TranscriptionInput{
 						File: ttsResponse.Speech.Audio,
 					},
 					Params: &schemas.TranscriptionParameters{
@@ -224,7 +224,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 					request := &schemas.BifrostTranscriptionRequest{
 						Provider: testConfig.Provider,
 						Model:    testConfig.TranscriptionModel,
-						Input: schemas.TranscriptionInput{
+						Input: &schemas.TranscriptionInput{
 							File: audioData,
 						},
 						Params: &schemas.TranscriptionParameters{
@@ -268,7 +268,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 					request := &schemas.BifrostTranscriptionRequest{
 						Provider: testConfig.Provider,
 						Model:    testConfig.TranscriptionModel,
-						Input: schemas.TranscriptionInput{
+						Input: &schemas.TranscriptionInput{
 							File: audioData,
 						},
 						Params: &schemas.TranscriptionParameters{
@@ -299,7 +299,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 			request := &schemas.BifrostTranscriptionRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.TranscriptionModel,
-				Input: schemas.TranscriptionInput{
+				Input: &schemas.TranscriptionInput{
 					File: audioData,
 				},
 				Params: &schemas.TranscriptionParameters{
@@ -333,7 +333,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 					request := &schemas.BifrostTranscriptionRequest{
 						Provider: testConfig.Provider,
 						Model:    testConfig.TranscriptionModel,
-						Input: schemas.TranscriptionInput{
+						Input: &schemas.TranscriptionInput{
 							File: audioData,
 						},
 						Params: &schemas.TranscriptionParameters{

--- a/tests/core-providers/scenarios/transcription_stream.go
+++ b/tests/core-providers/scenarios/transcription_stream.go
@@ -65,11 +65,11 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 				ttsRequest := &schemas.BifrostSpeechRequest{
 					Provider: testConfig.Provider,
 					Model:    testConfig.SpeechSynthesisModel,
-					Input: schemas.SpeechInput{
+					Input: &schemas.SpeechInput{
 						Input: tc.text,
 					},
 					Params: &schemas.SpeechParameters{
-						VoiceConfig: schemas.SpeechVoiceInput{
+						VoiceConfig: &schemas.SpeechVoiceInput{
 							Voice: &voice,
 						},
 						ResponseFormat: tc.format,
@@ -102,7 +102,7 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 				streamRequest := &schemas.BifrostTranscriptionRequest{
 					Provider: testConfig.Provider,
 					Model:    testConfig.TranscriptionModel,
-					Input: schemas.TranscriptionInput{
+					Input: &schemas.TranscriptionInput{
 						File: ttsResponse.Speech.Audio,
 					},
 					Params: &schemas.TranscriptionParameters{
@@ -310,7 +310,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			request := &schemas.BifrostTranscriptionRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.TranscriptionModel,
-				Input: schemas.TranscriptionInput{
+				Input: &schemas.TranscriptionInput{
 					File: audioData,
 				},
 				Params: &schemas.TranscriptionParameters{
@@ -409,7 +409,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 					request := &schemas.BifrostTranscriptionRequest{
 						Provider: testConfig.Provider,
 						Model:    testConfig.TranscriptionModel,
-						Input: schemas.TranscriptionInput{
+						Input: &schemas.TranscriptionInput{
 							File: audioData,
 						},
 						Params: &schemas.TranscriptionParameters{
@@ -491,7 +491,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			request := &schemas.BifrostTranscriptionRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.TranscriptionModel,
-				Input: schemas.TranscriptionInput{
+				Input: &schemas.TranscriptionInput{
 					File: audioData,
 				},
 				Params: &schemas.TranscriptionParameters{

--- a/tests/core-providers/scenarios/utils.go
+++ b/tests/core-providers/scenarios/utils.go
@@ -189,11 +189,11 @@ func GetLionBase64Image() (string, error) {
 // CreateSpeechInput creates a basic speech input for testing
 func CreateSpeechRequest(text, voice, format string) *schemas.BifrostSpeechRequest {
 	return &schemas.BifrostSpeechRequest{
-		Input: schemas.SpeechInput{
+		Input: &schemas.SpeechInput{
 			Input: text,
 		},
 		Params: &schemas.SpeechParameters{
-			VoiceConfig: schemas.SpeechVoiceInput{
+			VoiceConfig: &schemas.SpeechVoiceInput{
 				Voice: &voice,
 			},
 			ResponseFormat: format,
@@ -204,7 +204,7 @@ func CreateSpeechRequest(text, voice, format string) *schemas.BifrostSpeechReque
 // CreateTranscriptionInput creates a basic transcription input for testing
 func CreateTranscriptionInput(audioData []byte, language, responseFormat *string) *schemas.BifrostTranscriptionRequest {
 	return &schemas.BifrostTranscriptionRequest{
-		Input: schemas.TranscriptionInput{
+		Input: &schemas.TranscriptionInput{
 			File: audioData,
 		},
 		Params: &schemas.TranscriptionParameters{
@@ -481,9 +481,9 @@ func GenerateTTSAudioForTest(ctx context.Context, t *testing.T, client *bifrost.
 	req := &schemas.BifrostSpeechRequest{
 		Provider: provider,
 		Model:    ttsModel,
-		Input:    schemas.SpeechInput{Input: text},
+		Input:    &schemas.SpeechInput{Input: text},
 		Params: &schemas.SpeechParameters{
-			VoiceConfig: schemas.SpeechVoiceInput{
+			VoiceConfig: &schemas.SpeechVoiceInput{
 				Voice: &voice,
 			},
 			ResponseFormat: format,


### PR DESCRIPTION
## Summary

Fixed critical input validation logic in Bifrost's speech, transcription, and embedding requests by correcting conditional checks and updating pointer types in request structures.

## Changes

- Fixed incorrect input validation conditions in `SpeechRequest`, `SpeechStreamRequest`, `TranscriptionRequest`, and `TranscriptionStreamRequest` methods by changing `req.Input != nil || req.Input.X == ""` to `req.Input == nil || req.Input.X == ""` 
- Updated embedding request validation in Gemini and Vertex providers to properly check for nil input
- Changed input fields in request structs from value types to pointer types in test scenarios
- Fixed content block type mapping in `ToResponsesMessages()` to ensure proper content type assignment
- Removed unused JSON parsing code in Bedrock provider's `processEventBuffer` function

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the test suite to verify the fixed input validation logic:

```sh
# Core/Transports
go version
go test ./...
```

Specifically test speech, transcription, and embedding requests to ensure proper input validation.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This PR fixes input validation logic that could have led to unexpected behavior or potential crashes when processing requests with missing or invalid inputs.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable