### PR TITLE
fixes http releae script

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -54,8 +54,8 @@ for plugin_dir in plugins/*/; do
     if [[ "$VERSION" == *"-"* ]]; then
       # VERSION has prerelease, so include all versions but prefer stable
       ALL_TAGS=$(git tag -l "plugins/${plugin_name}/v*" | sort -V)
-      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-')
-      PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-')
+      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
+      PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
 
       if [ -n "$STABLE_TAGS" ]; then
         # Get the highest stable version
@@ -68,7 +68,7 @@ for plugin_dir in plugins/*/; do
       fi
     else
       # VERSION has no prerelease, so only consider stable releases
-      LATEST_PLUGIN_TAG=$(git tag -l "plugins/${plugin_name}/v*" | grep -v '\-' | sort -V | tail -1)
+      LATEST_PLUGIN_TAG=$(git tag -l "plugins/${plugin_name}/v*" | grep -v '\-' | sort -V | tail -1 || true)
       echo "latest plugin tag (stable only): $LATEST_PLUGIN_TAG"
     fi
 


### PR DESCRIPTION
## Summary

Fix the release script for Bifrost HTTP to handle cases where grep returns no matches, preventing pipeline failures when no tags match the specified patterns.

## Changes

- Added `|| true` to grep commands in `release-bifrost-http.sh` to ensure the script doesn't fail when no matches are found
- This prevents the script from exiting with a non-zero status code when filtering stable and prerelease tags

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script in an environment where some of the grep commands might not find matches:

```sh
# Run the script with a version that has no matching tags
./.github/workflows/scripts/release-bifrost-http.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes CI pipeline failures during release process when no matching tags are found.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable