### PR TITLE
removes an unncessary replace

### DIFF
--- a/tests/core-chatbot/go.mod
+++ b/tests/core-chatbot/go.mod
@@ -4,8 +4,6 @@ go 1.24
 
 toolchain go1.24.3
 
-replace github.com/maximhq/bifrost/core => ../../core
-
 require github.com/maximhq/bifrost/core v1.1.21
 
 require (

--- a/tests/core-providers/go.mod
+++ b/tests/core-providers/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 )
 
-replace github.com/maximhq/bifrost/core => ../../core
-
 require (
 	cloud.google.com/go/compute/metadata v0.8.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -109,5 +109,3 @@ require (
 	gorm.io/driver/postgres v1.6.0 // indirect
 	gorm.io/driver/sqlite v1.6.0 // indirect
 )
-
-replace github.com/maximhq/bifrost/core => ../core


### PR DESCRIPTION
## Summary

Removed local module replacements in Go module files to use published versions instead of local paths.

## Changes

- Removed `replace github.com/maximhq/bifrost/core => ../../core` directive from `tests/core-chatbot/go.mod`
- Removed `replace github.com/maximhq/bifrost/core => ../../core` directive from `tests/core-providers/go.mod`
- Removed `replace github.com/maximhq/bifrost/core => ../core` directive from `transports/go.mod`

This change ensures that the tests and transports modules use the published version of the core module rather than a local development version, which improves reproducibility and consistency across environments.

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Verify that all modules can still be built and tests pass:

```sh
# Core/Transports
go version
go test ./...

# Test core-chatbot
cd tests/core-chatbot
go test ./...

# Test core-providers
cd tests/core-providers
go test ./...

# Test transports
cd transports
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is a build configuration change.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable