### PR TITLE
vk fixes

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1205,7 +1205,7 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 	var budgets []TableBudget
 	var rateLimits []TableRateLimit
 
-	if err := s.db.WithContext(ctx).Find(&virtualKeys).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("ProviderConfigs").Find(&virtualKeys).Error; err != nil {
 		return nil, err
 	}
 	if err := s.db.WithContext(ctx).Find(&teams).Error; err != nil {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -291,6 +291,17 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 				}
 				config.Providers = processedProviders
 			}
+			// Loading governance config
+			var governanceConfig *configstore.GovernanceConfig
+			if config.ConfigStore != nil {
+				governanceConfig, err = config.ConfigStore.GetGovernanceConfig(ctx)
+				if err != nil {
+					logger.Warn("failed to get governance config from store: %v", err)
+				}
+			}
+			if governanceConfig != nil {
+				config.GovernanceConfig = governanceConfig
+			}
 			// Checking if MCP config already exists
 			mcpConfig, err := config.ConfigStore.GetMCPConfig(ctx)
 			if err != nil {
@@ -335,6 +346,8 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 					config.Plugins[i] = pluginConfig
 				}
 			}
+			// Loading governance config
+
 			// Load environment variable tracking
 			var dbEnvKeys map[string][]configstore.EnvKeyInfo
 			if dbEnvKeys, err = config.ConfigStore.GetEnvKeys(ctx); err != nil {


### PR DESCRIPTION
## Summary

Optimize virtual key provider routing by preloading provider configurations and caching governance config in memory, eliminating redundant database queries during request processing.

## Changes

- Modified `GetGovernanceConfig` to preload provider configurations with virtual keys using the `Preload("ProviderConfigs")` option
- Refactored the `VKProviderRoutingMiddleware` to use cached governance configuration instead of making database calls for each request
- Added governance config loading to the `LoadConfig` function to ensure it's available in memory
- Improved provider validation when model strings already contain provider prefixes
- Enhanced error handling and added more detailed debug logging

## Type of change

- [x] Feature
- [x] Performance

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# Test with a request using a virtual key
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer vk-your-virtual-key" \
  -d '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Hello"}]}'
```

## Breaking changes

- [x] No

## Related issues

Improves performance for virtual key routing by reducing database queries

## Security considerations

No additional security implications as this is an optimization of existing functionality.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)