### PR TITLE
feat: add Anthropic thinking parameter and text completion integration support

### DIFF
--- a/core/schemas/providers/anthropic/responses.go
+++ b/core/schemas/providers/anthropic/responses.go
@@ -133,6 +133,28 @@ func ToAnthropicResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *A
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
 				anthropicReq.StopSequences = stop
 			}
+			if thinking, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "thinking"); ok {
+				if thinkingMap, ok := thinking.(map[string]interface{}); ok {
+					anthropicThinking := &AnthropicThinking{}
+					if thinkingType, ok := thinkingMap["type"].(string); ok {
+						anthropicThinking.Type = thinkingType
+					}
+					// Handle budget_tokens - JSON numbers can be float64 or int
+					if budgetTokensVal, exists := thinkingMap["budget_tokens"]; exists && budgetTokensVal != nil {
+						switch v := budgetTokensVal.(type) {
+						case float64:
+							budgetInt := int(v)
+							anthropicThinking.BudgetTokens = &budgetInt
+						case int:
+							anthropicThinking.BudgetTokens = &v
+						case int64:
+							budgetInt := int(v)
+							anthropicThinking.BudgetTokens = &budgetInt
+						}
+					}
+					anthropicReq.Thinking = anthropicThinking
+				}
+			}
 		}
 
 		// Convert tools

--- a/core/schemas/providers/anthropic/types.go
+++ b/core/schemas/providers/anthropic/types.go
@@ -44,6 +44,12 @@ type AnthropicMessageRequest struct {
 	Stream        *bool                `json:"stream,omitempty"`
 	Tools         []AnthropicTool      `json:"tools,omitempty"`
 	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
+	Thinking      *AnthropicThinking   `json:"thinking,omitempty"`
+}
+
+type AnthropicThinking struct {
+	Type         string `json:"type"` // "enabled" or "disabled"
+	BudgetTokens *int   `json:"budget_tokens,omitempty"`
 }
 
 // IsStreamingRequested implements the StreamingRequest interface

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -18,6 +18,27 @@ type AnthropicRouter struct {
 func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 	return []RouteConfig{
 		{
+			Path:   pathPrefix + "/v1/complete",
+			Method: "POST",
+			GetRequestTypeInstance: func() interface{} {
+				return &anthropic.AnthropicTextRequest{}
+			},
+			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
+				if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
+					return &schemas.BifrostRequest{
+						TextCompletionRequest: anthropicReq.ToBifrostRequest(),
+					}, nil
+				}
+				return nil, errors.New("invalid request type")
+			},
+			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
+				return anthropic.ToAnthropicTextCompletionResponse(resp), nil
+			},
+			ErrorConverter: func(err *schemas.BifrostError) interface{} {
+				return anthropic.ToAnthropicChatCompletionError(err)
+			},
+		},
+		{
 			Path:   pathPrefix + "/v1/messages",
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {


### PR DESCRIPTION
## Summary

Added support for Anthropic's "thinking" parameter and implemented bidirectional conversion between Anthropic and Bifrost text completion formats.

## Changes

- Added support for the Anthropic "thinking" parameter in message requests, allowing control over the model's thinking process with type and budget_tokens options
- Implemented ToBifrostRequest method for AnthropicTextRequest to convert Anthropic requests to Bifrost format
- Added ToAnthropicTextCompletionResponse function to convert Bifrost responses back to Anthropic format
- Created a new route handler for Anthropic's v1/complete endpoint in the HTTP transport

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new Anthropic thinking parameter and text completion conversions:

```sh
# Test the core functionality
go test ./core/schemas/providers/anthropic/...

# Test the HTTP transport integration
go test ./transports/bifrost-http/integrations/...

# Test the complete endpoint with a request containing the thinking parameter
curl -X POST http://localhost:8000/anthropic/v1/complete \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude-3-opus-20240229",
    "prompt": "Tell me a joke",
    "max_tokens_to_sample": 100,
    "temperature": 0.7
  }'
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Adds support for Anthropic's thinking parameter as described in their API documentation.

## Security considerations

No additional security implications. The implementation follows existing patterns for parameter handling.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable