### PR TITLE
feat: add TransportInterceptor to Plugin interface for HTTP request modification

### DIFF
--- a/plugins/jsonparser/main.go
+++ b/plugins/jsonparser/main.go
@@ -87,6 +87,11 @@ func (p *JsonParserPlugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (p *JsonParserPlugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // PreHook is not used for this plugin as we only process responses
 func (p *JsonParserPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
 	return req, nil, nil

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -211,6 +211,11 @@ func (p *LoggerPlugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (p *LoggerPlugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // PreHook is called before a request is processed - FULLY ASYNC, NO DATABASE I/O
 func (p *LoggerPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
 	if ctx == nil {

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -117,6 +117,11 @@ func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (plugin *Plugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // getEffectiveLogRepoID determines which single log repo ID to use based on priority:
 // 1. Header log repo ID (if provided)
 // 2. Default log repo ID from config (if configured)

--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -478,6 +478,11 @@ func (p *MockerPlugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (p *MockerPlugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // PreHook intercepts requests and applies mocking rules based on configuration
 // This is called before the actual provider request and can short-circuit the flow
 func (p *MockerPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -110,6 +110,11 @@ func (p *OtelPlugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (p *OtelPlugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // ValidateConfig function for the OTEL plugin
 func (p *OtelPlugin) ValidateConfig(config any) (*Config, error) {
 	var otelConfig Config

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -335,6 +335,11 @@ func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (plugin *Plugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // PreHook is called before a request is processed by Bifrost.
 // It performs a two-stage cache lookup: first direct hash matching, then semantic similarity search.
 // Uses UUID-based keys for entries stored in the VectorStore.

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -68,6 +68,11 @@ func (p *PrometheusPlugin) GetName() string {
 	return PluginName
 }
 
+// TransportInterceptor is not used for this plugin
+func (p *PrometheusPlugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	return headers, body, nil
+}
+
 // PreHook records the start time of the request in the context.
 // This time is used later in PostHook to calculate request duration.
 func (p *PrometheusPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -3,13 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
-	"slices"
-	"sort"
-	"strings"
 
-	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -47,149 +41,68 @@ func CorsMiddleware(config *lib.Config) BifrostHTTPMiddleware {
 	}
 }
 
-// VKProviderRoutingMiddleware routes requests to the appropriate provider based on the virtual key
-func VKProviderRoutingMiddleware(config *lib.Config, logger schemas.Logger) BifrostHTTPMiddleware {
-	isGovernanceEnabled := config.LoadedPlugins[governance.PluginName]
+func TransportInterceptorMiddleware(config *lib.Config) BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
-			if !isGovernanceEnabled {
-				next(ctx)
-				return
-			}
-			var virtualKeyValue string
-			// Extract x-bf-vk header
-			ctx.Request.Header.All()(func(key, value []byte) bool {
-				if strings.ToLower(string(key)) == "x-bf-vk" {
-					virtualKeyValue = string(value)
-				}
-				return true
-			})
-			// If no virtual key, continue to next handler
-			if virtualKeyValue == "" {
-				next(ctx)
-				return
-			}
-			// Only process POST requests with a body
-			if string(ctx.Method()) != "POST" {
-				next(ctx)
-				return
-			}
-			// Get the request body
-			body := ctx.Request.Body()
-			if len(body) == 0 {
-				next(ctx)
-				return
-			}
-			// Parse the request body to extract the model field
-			var requestBody map[string]interface{}
-			if err := json.Unmarshal(body, &requestBody); err != nil {
-				// If we can't parse as JSON, continue without modification
+			// Get plugins from config
+			plugins := config.LoadedPlugins
+			if len(plugins) == 0 {
 				next(ctx)
 				return
 			}
 
-			// Check if the request has a model field
-			modelValue, hasModel := requestBody["model"]
-			if !hasModel {
+			// If governance plugin is not loaded, skip interception
+			if !config.LoadedPluginsMap[governance.PluginName] {
 				next(ctx)
 				return
 			}
-			modelStr, ok := modelValue.(string)
-			if !ok || modelStr == "" {
-				next(ctx)
-				return
-			}
-			// Check if model already has provider prefix (contains "/")
-			if strings.Contains(modelStr, "/") {
-				provider, _ := schemas.ParseModelString(modelStr, "")
-				// Checking valid provider
-				if _, ok := config.Providers[provider]; ok {
+
+			// Parse headers
+			headers := make(map[string]string)
+			ctx.Request.Header.VisitAll(func(key, value []byte) {
+				headers[string(key)] = string(value)
+			})
+
+			// Unmarshal request body
+			requestBody := make(map[string]any)
+			bodyBytes := ctx.Request.Body()
+			if len(bodyBytes) > 0 {
+				if err := json.Unmarshal(bodyBytes, &requestBody); err != nil {
+					// If body is not valid JSON, log warning and continue without interception
+					logger.Warn(fmt.Sprintf("TransportInterceptor: Failed to unmarshal request body: %v", err))
 					next(ctx)
 					return
 				}
 			}
-			var virtualKey *configstore.TableVirtualKey
-			var err error
-			for _, vk := range config.GovernanceConfig.VirtualKeys {
-				if vk.Value == virtualKeyValue {
-					virtualKey = &vk
-					break
-				}
-			}
-			if virtualKey == nil {
-				SendError(ctx, fasthttp.StatusBadRequest, "Invalid virtual key", logger)
-				return
-			}
-			if !virtualKey.IsActive {
-				SendError(ctx, fasthttp.StatusBadRequest, "Virtual key is not active", logger)
-				next(ctx)
-				return
-			}
-			// Get provider configs for this virtual key			
-			providerConfigs := virtualKey.ProviderConfigs
-			if len(providerConfigs) == 0 {
-				// No provider configs, continue without modification
-				next(ctx)
-				return
-			}
-			allowedProviderConfigs := make([]configstore.TableVirtualKeyProviderConfig, 0)
-			for _, config := range providerConfigs {
-				if len(config.AllowedModels) == 0 || slices.Contains(config.AllowedModels, modelStr) {
-					allowedProviderConfigs = append(allowedProviderConfigs, config)
-				}
-			}
-			if len(allowedProviderConfigs) == 0 {
-				// No allowed provider configs, continue without modification
-				next(ctx)
-				return
-			}
-			// Weighted random selection from allowed providers for the main model
-			totalWeight := 0.0
-			for _, config := range allowedProviderConfigs {
-				totalWeight += config.Weight
-			}
-			// Generate random number between 0 and totalWeight
-			randomValue := rand.Float64() * totalWeight
-			// Select provider based on weighted random selection
-			var selectedProvider schemas.ModelProvider
-			currentWeight := 0.0
-			for _, config := range allowedProviderConfigs {
-				currentWeight += config.Weight
-				if randomValue <= currentWeight {
-					selectedProvider = schemas.ModelProvider(config.Provider)
-					break
-				}
-			}
-			// Update the model field in the request body
-			requestBody["model"] = string(selectedProvider) + "/" + modelStr
-			// Check if fallbacks field is already present
-			_, hasFallbacks := requestBody["fallbacks"]
-			if !hasFallbacks && len(allowedProviderConfigs) > 1 {
-				// Sort allowed provider configs by weight (descending)
-				sort.Slice(allowedProviderConfigs, func(i, j int) bool {
-					return allowedProviderConfigs[i].Weight > allowedProviderConfigs[j].Weight
-				})
 
-				// Filter out the selected provider and create fallbacks array
-				fallbacks := make([]string, 0, len(allowedProviderConfigs)-1)
-				for _, config := range allowedProviderConfigs {
-					if config.Provider != string(selectedProvider) {
-						fallbacks = append(fallbacks, string(schemas.ModelProvider(config.Provider))+"/"+modelStr)
-					}
+			// Call TransportInterceptor on all plugins
+			for _, plugin := range plugins {
+				modifiedHeaders, modifiedBody, err := plugin.TransportInterceptor(string(ctx.Request.URI().RequestURI()), headers, requestBody)
+				if err != nil {
+					logger.Warn(fmt.Sprintf("TransportInterceptor: Plugin '%s' returned error: %v", plugin.GetName(), err))
+					// Continue with unmodified headers/body
+					continue
 				}
-
-				// Add fallbacks to request body
-				requestBody["fallbacks"] = fallbacks
+				// Update headers and body with modifications
+				headers = modifiedHeaders
+				requestBody = modifiedBody
 			}
 
-			// Marshal the updated request body back to JSON
-			updatedBody, err := json.Marshal(requestBody)
-			if err != nil {
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to marshal updated request body: %v", err), logger)
-				return
+			// Marshal the body back to JSON
+			if len(requestBody) > 0 {
+				updatedBody, err := json.Marshal(requestBody)
+				if err != nil {
+					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("TransportInterceptor: Failed to marshal request body: %v", err), logger)
+					return
+				}
+				ctx.Request.SetBody(updatedBody)
 			}
-			// Replace the request body with the updated one
-			ctx.Request.SetBody(updatedBody)
+
+			// Set modified headers back on the request
+			for key, value := range headers {
+				ctx.Request.Header.Set(key, value)
+			}
+
 			next(ctx)
 		}
 	}


### PR DESCRIPTION
## Summary

Added a new `TransportInterceptor` plugin hook that allows plugins to modify HTTP requests before they enter the Bifrost core processing pipeline. This enables earlier intervention in the request lifecycle, particularly for governance and routing decisions.

## Changes

- Added a new `TransportInterceptor` method to the Plugin interface that operates at the HTTP transport layer
- Implemented the interceptor in the Governance plugin to handle provider routing based on virtual keys
- Moved virtual key provider routing logic from middleware to the Governance plugin
- Updated plugin execution documentation to clarify the order of operations
- Added implementation of the required method to all plugins (with no-op implementations where not needed)
- Created a new middleware that applies all plugin transport interceptors

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins

## How to test

```sh
# Core/Transports
go test ./...

# Test with HTTP requests containing virtual keys
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-bf-vk: your-virtual-key" \
  -d '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Hello"}]}'
```

## Breaking changes

- [x] No

## Security considerations

The TransportInterceptor provides plugins with access to raw HTTP headers and request bodies, which could contain sensitive information. Plugin implementations should handle this data securely.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)