### PR TITLE
feat: enhance WebSocket implementation with unified endpoint and subscription model

### DIFF
--- a/transports/bifrost-http/handlers/websocket.go
+++ b/transports/bifrost-http/handlers/websocket.go
@@ -50,7 +50,7 @@ func NewWebSocketHandler(ctx context.Context, logManager logging.LogManager, log
 
 // RegisterRoutes registers all WebSocket-related routes
 func (h *WebSocketHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
-	r.GET("/ws/logs", ChainMiddlewares(h.connectLogStream, middlewares...))
+	r.GET("/ws", ChainMiddlewares(h.connectStream, middlewares...))
 }
 
 // getUpgrader returns a WebSocket upgrader configured with the current allowed origins
@@ -85,8 +85,8 @@ func isLocalhost(host string) bool {
 		host == ""
 }
 
-// connectLogStream handles WebSocket connections for real-time log streaming
-func (h *WebSocketHandler) connectLogStream(ctx *fasthttp.RequestCtx) {
+// connectStream handles WebSocket connections for real-time streaming
+func (h *WebSocketHandler) connectStream(ctx *fasthttp.RequestCtx) {
 	upgrader := h.getUpgrader()
 	err := upgrader.Upgrade(ctx, func(ws *websocket.Conn) {
 		// Read safety & liveness
@@ -160,6 +160,7 @@ func (h *WebSocketHandler) sendMessageSafely(client *WebSocketClient, messageTyp
 			client.conn.Close()
 		}()
 	}
+
 	return err
 }
 
@@ -194,6 +195,11 @@ func (h *WebSocketHandler) BroadcastLogUpdate(logEntry *logstore.Log) {
 		return
 	}
 
+	h.BroadcastMarshaledMessage(data)
+}
+
+// BroadcastMarshaledMessage sends an adaptive routing update to all connected WebSocket clients
+func (h *WebSocketHandler) BroadcastMarshaledMessage(data []byte) {
 	// Get a snapshot of clients to avoid holding the lock during writes
 	h.mu.RLock()
 	clients := make([]*WebSocketClient, 0, len(h.clients))

--- a/ui/app/logs/page.tsx
+++ b/ui/app/logs/page.tsx
@@ -187,12 +187,17 @@ export default function LogsPage() {
 		});
 	}, []);
 
-	const { isConnected: isSocketConnected, setMessageHandler } = useWebSocket();
+	const { isConnected: isSocketConnected, subscribe } = useWebSocket();
 
-	// Set up the message handler when the component mounts
+	// Subscribe to log messages
 	useEffect(() => {
-		setMessageHandler(handleLogMessage);
-	}, [handleLogMessage, setMessageHandler]);
+		const unsubscribe = subscribe("log", (data) => {
+			const { payload, operation } = data;
+			handleLogMessage(payload, operation);
+		});
+
+		return unsubscribe;
+	}, [handleLogMessage, subscribe]);
 
 	// Cleanup timeouts on unmount
 	useEffect(() => {

--- a/ui/hooks/useWebSocket.tsx
+++ b/ui/hooks/useWebSocket.tsx
@@ -1,32 +1,61 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
-import type { LogEntry, WebSocketLogMessage } from "../lib/types/logs";
 import { getWebSocketUrl } from "@/lib/utils/port";
+
+type MessageHandler = (data: any) => void;
 
 interface WebSocketContextType {
 	isConnected: boolean;
 	ws: React.RefObject<WebSocket | null>;
-	setMessageHandler: (handler: (log: LogEntry, operation: "create" | "update") => void) => void;
+	subscribe: (channel: string, handler: MessageHandler) => () => void;
+	send: (data: any) => void;
 }
 
 const WebSocketContext = createContext<WebSocketContextType | null>(null);
 
 interface WebSocketProviderProps {
 	children: ReactNode;
+	path?: string;
 }
 
 // Global reference to maintain state across component remounts
 let globalWsRef: WebSocket | null = null;
-let globalMessageHandler: ((log: LogEntry, operation: "create" | "update") => void) | null = null;
+const messageHandlers = new Map<string, Set<MessageHandler>>();
 
-export function WebSocketProvider({ children }: WebSocketProviderProps) {
+export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderProps) {
 	const wsRef = useRef<WebSocket | null>(globalWsRef);
 	const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const retryCountRef = useRef(0);
 	const [isConnected, setIsConnected] = useState(false);
 
-	const setMessageHandler = (handler: (log: LogEntry, operation: "create" | "update") => void) => {
-		globalMessageHandler = handler;
+	const subscribe = (channel: string, handler: MessageHandler) => {
+		if (!messageHandlers.has(channel)) {
+			messageHandlers.set(channel, new Set());
+		}
+		messageHandlers.get(channel)!.add(handler);
+
+		// Return unsubscribe function
+		return () => {
+			const handlers = messageHandlers.get(channel);
+			if (handlers) {
+				handlers.delete(handler);
+				if (handlers.size === 0) {
+					messageHandlers.delete(channel);
+				}
+			}
+		};
+	};
+
+	const send = (data: any) => {
+		if (wsRef.current?.readyState === WebSocket.OPEN) {
+			try {
+				wsRef.current.send(typeof data === "string" ? data : JSON.stringify(data));
+			} catch (error) {
+				console.error("Failed to send WebSocket message:", error);
+			}
+		}
 	};
 
 	useEffect(() => {
@@ -35,7 +64,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				return;
 			}
 
-			const wsUrl = getWebSocketUrl("/ws/logs");
+			const wsUrl = getWebSocketUrl(path);
 
 			const ws = new WebSocket(wsUrl);
 			wsRef.current = ws;
@@ -44,18 +73,44 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			ws.onopen = () => {
 				console.log("WebSocket connected");
 				setIsConnected(true);
+				retryCountRef.current = 0; // Reset retry count on successful connection
+
 				// Clear any pending reconnection attempts
 				if (reconnectTimeoutRef.current) {
 					clearTimeout(reconnectTimeoutRef.current);
 					reconnectTimeoutRef.current = null;
 				}
+
+				// Start heartbeat/ping to keep connection alive
+				if (pingTimerRef.current) {
+					clearInterval(pingTimerRef.current);
+				}
+				pingTimerRef.current = setInterval(() => {
+					if (ws.readyState === WebSocket.OPEN) {
+						try {
+							ws.send("ping");
+						} catch (error) {
+							console.error("Ping failed:", error);
+						}
+					}
+				}, 25000); // Ping every 25 seconds
 			};
 
 			ws.onmessage = (event) => {
 				try {
-					const data: WebSocketLogMessage = JSON.parse(event.data);
-					if (data.type === "log" && globalMessageHandler) {
-						globalMessageHandler(data.payload, data.operation);
+					const data = JSON.parse(event.data);
+					const messageType = data.type || "default";
+
+					// Notify all subscribers for this message type
+					const handlers = messageHandlers.get(messageType);
+					if (handlers) {
+						handlers.forEach((handler) => handler(data));
+					}
+
+					// Also notify wildcard subscribers
+					const wildcardHandlers = messageHandlers.get("*");
+					if (wildcardHandlers) {
+						wildcardHandlers.forEach((handler) => handler(data));
 					}
 				} catch (error) {
 					console.error("Failed to parse WebSocket message:", error);
@@ -65,11 +120,23 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			ws.onclose = () => {
 				console.log("WebSocket disconnected, attempting to reconnect...");
 				setIsConnected(false);
-				// Attempt to reconnect after 5 seconds
-				reconnectTimeoutRef.current = setTimeout(connect, 5000);
+
+				// Clear ping timer
+				if (pingTimerRef.current) {
+					clearInterval(pingTimerRef.current);
+					pingTimerRef.current = null;
+				}
+
+				// Exponential backoff: 0.5s, 1s, 2s, 4s, 8s, 16s, 32s (max)
+				retryCountRef.current = Math.min(retryCountRef.current + 1, 6);
+				const delay = Math.pow(2, retryCountRef.current) * 500;
+				console.log(`Reconnecting in ${delay}ms...`);
+
+				reconnectTimeoutRef.current = setTimeout(connect, delay);
 			};
 
 			ws.onerror = (error) => {
+				console.error("WebSocket error:", error);
 				setIsConnected(false);
 				ws.close();
 			};
@@ -84,10 +151,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				clearTimeout(reconnectTimeoutRef.current);
 				reconnectTimeoutRef.current = null;
 			}
+			if (pingTimerRef.current) {
+				clearInterval(pingTimerRef.current);
+				pingTimerRef.current = null;
+			}
 		};
-	}, []);
+	}, [path]);
 
-	return <WebSocketContext.Provider value={{ isConnected, ws: wsRef, setMessageHandler }}>{children}</WebSocketContext.Provider>;
+	return <WebSocketContext.Provider value={{ isConnected, ws: wsRef, subscribe, send }}>{children}</WebSocketContext.Provider>;
 }
 
 export function useWebSocket() {


### PR DESCRIPTION
## Summary

Enhance WebSocket functionality by implementing a more robust and flexible WebSocket system that supports multiple message types and channels.

## Changes

- Refactored WebSocket handler to use a single `/ws` endpoint instead of the specific `/ws/logs` endpoint
- Added WebSocketHandler as a field in BifrostHTTPServer for better access and management
- Implemented a more robust WebSocket client with reconnection logic and exponential backoff
- Added heartbeat/ping mechanism to keep connections alive
- Created a pub/sub pattern for WebSocket messages with channel-based subscriptions
- Enhanced error handling and connection management
- Updated UI components to use the new subscription-based WebSocket API

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Start the application and navigate to the logs page
2. Verify that logs are still streaming correctly
3. Check browser console for WebSocket connection messages
4. Test reconnection by temporarily stopping and restarting the server

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm dev
```

## Breaking changes

- [x] Yes
- [ ] No

The WebSocket endpoint has changed from `/ws/logs` to `/ws`. Any external clients connecting to the old endpoint will need to update their connection URLs.

## Security considerations

The WebSocket implementation includes origin validation to prevent unauthorized connections.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)