### PR TITLE
fix: Fix regex validation for connection string in MCP client form

### DIFF
--- a/ui/app/config/views/mcpClientForm.tsx
+++ b/ui/app/config/views/mcpClientForm.tsx
@@ -113,7 +113,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ client, open, onClose, onSaved 
 					Validator.required(form.connection_string?.trim(), "Connection URL is required"),
 					Validator.pattern(
 						form.connection_string || "",
-						/^(?:http:?\/\/.+|env\.[A-Z_]+)$/,
+						/^(?:https?:\/\/.+|env\.[A-Z_]+)$/,
 						"Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)",
 					),
 				]

--- a/ui/app/config/views/mcpClientForm.tsx
+++ b/ui/app/config/views/mcpClientForm.tsx
@@ -113,7 +113,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ client, open, onClose, onSaved 
 					Validator.required(form.connection_string?.trim(), "Connection URL is required"),
 					Validator.pattern(
 						form.connection_string || "",
-						/^(?:http:\/\/|https:\/\/|env\.[A-Z_]+)$/,
+						/^(?:http:?\/\/.+|env\.[A-Z_]+)$/,
 						"Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)",
 					),
 				]

--- a/ui/app/config/views/mcpClientForm.tsx
+++ b/ui/app/config/views/mcpClientForm.tsx
@@ -113,7 +113,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ client, open, onClose, onSaved 
 					Validator.required(form.connection_string?.trim(), "Connection URL is required"),
 					Validator.pattern(
 						form.connection_string || "",
-						/^(http:\/\/|https:\/\/|env\.[A-Z_]+$)/,
+						/^(?:http:\/\/|https:\/\/|env\.[A-Z_]+)$/,
 						"Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)",
 					),
 				]


### PR DESCRIPTION
FIxes : #165 

## Summary

This PR fixes the regex pattern for validating connection strings in the MCP client form component has incorrect anchoring that allows invalid URLs to pass validation.

## Changes

Made changes in the bifrost\ui\app\config\views\mcpClientForm.tsx file
In the line 116, changed : /^(http:\/\/|https:\/\/|env\.[A-Z_]+$)/ to /^(?:http:\/\/|https:\/\/|env\.[A-Z_]+)$/ so that the URL is properly anchored.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1) Open the MCP Client Form in your application UI.
2) Try entering various values in the "Connection URL" field:
   
> Valid examples:

- http://example.com
- https://example.com
- env.MY_ENV_VAR

> Invalid examples (should show a validation error):

- ftp://example.com
- http://garbageEXTRA
- env.my_env_var (lowercase letters)
- example.com
- http:// (with nothing after)

3) Submit the form and confirm:

- Valid values are accepted.
- Invalid values show the error:
- "Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)"

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Closes #165 

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


