### PR TITLE
refactor: moved bifrost middleware to lib and added prom middleware to inferance and integration routes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1100,7 +1100,7 @@ func (bifrost *Bifrost) shouldTryFallbacks(req *schemas.BifrostRequest, primaryE
 	}
 
 	// Handle request cancellation
-	if primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
+	if primaryErr.Error != nil && primaryErr.Error.Type != nil && *primaryErr.Error.Type == schemas.RequestCancelled {
 		return false
 	}
 

--- a/transports/bifrost-http/handlers/cache.go
+++ b/transports/bifrost-http/handlers/cache.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/plugins/semanticcache"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -24,9 +25,9 @@ func NewCacheHandler(plugin schemas.Plugin, logger schemas.Logger) *CacheHandler
 	}
 }
 
-func (h *CacheHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
-	r.DELETE("/api/cache/clear/{requestId}", ChainMiddlewares(h.clearCache, middlewares...))
-	r.DELETE("/api/cache/clear-by-key/{cacheKey}", ChainMiddlewares(h.clearCacheByKey, middlewares...))
+func (h *CacheHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
+	r.DELETE("/api/cache/clear/{requestId}", lib.ChainMiddlewares(h.clearCache, middlewares...))
+	r.DELETE("/api/cache/clear-by-key/{cacheKey}", lib.ChainMiddlewares(h.clearCacheByKey, middlewares...))
 }
 
 func (h *CacheHandler) clearCache(ctx *fasthttp.RequestCtx) {

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -21,9 +21,9 @@ type ConfigManager interface {
 // ConfigHandler manages runtime configuration updates for Bifrost.
 // It provides endpoints to update and retrieve settings persisted via the ConfigStore backed by sql database.
 type ConfigHandler struct {
-	client *bifrost.Bifrost
-	logger schemas.Logger
-	store  *lib.Config
+	client        *bifrost.Bifrost
+	logger        schemas.Logger
+	store         *lib.Config
 	configManager ConfigManager
 }
 
@@ -31,19 +31,19 @@ type ConfigHandler struct {
 // It requires the Bifrost client, a logger, and the config store.
 func NewConfigHandler(client *bifrost.Bifrost, logger schemas.Logger, store *lib.Config, configManager ConfigManager) *ConfigHandler {
 	return &ConfigHandler{
-		client: client,
-		logger: logger,
-		store:  store,
+		client:        client,
+		logger:        logger,
+		store:         store,
 		configManager: configManager,
 	}
 }
 
 // RegisterRoutes registers the configuration-related routes.
 // It adds the `PUT /api/config` endpoint.
-func (h *ConfigHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
-	r.GET("/api/config", ChainMiddlewares(h.getConfig, middlewares...))
-	r.PUT("/api/config", ChainMiddlewares(h.updateConfig, middlewares...))
-	r.GET("/api/version", ChainMiddlewares(h.getVersion, middlewares...))
+func (h *ConfigHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
+	r.GET("/api/config", lib.ChainMiddlewares(h.getConfig, middlewares...))
+	r.PUT("/api/config", lib.ChainMiddlewares(h.updateConfig, middlewares...))
+	r.GET("/api/version", lib.ChainMiddlewares(h.getVersion, middlewares...))
 }
 
 // getVersion handles GET /api/version - Get the current version

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/plugins/governance"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
 )
@@ -129,27 +130,27 @@ type UpdateCustomerRequest struct {
 }
 
 // RegisterRoutes registers all governance-related routes for the new hierarchical system
-func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
+func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
 	// Virtual Key CRUD operations
-	r.GET("/api/governance/virtual-keys", ChainMiddlewares(h.getVirtualKeys, middlewares...))
-	r.POST("/api/governance/virtual-keys", ChainMiddlewares(h.createVirtualKey, middlewares...))
-	r.GET("/api/governance/virtual-keys/{vk_id}", ChainMiddlewares(h.getVirtualKey, middlewares...))
-	r.PUT("/api/governance/virtual-keys/{vk_id}", ChainMiddlewares(h.updateVirtualKey, middlewares...))
-	r.DELETE("/api/governance/virtual-keys/{vk_id}", ChainMiddlewares(h.deleteVirtualKey, middlewares...))
+	r.GET("/api/governance/virtual-keys", lib.ChainMiddlewares(h.getVirtualKeys, middlewares...))
+	r.POST("/api/governance/virtual-keys", lib.ChainMiddlewares(h.createVirtualKey, middlewares...))
+	r.GET("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.getVirtualKey, middlewares...))
+	r.PUT("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.updateVirtualKey, middlewares...))
+	r.DELETE("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.deleteVirtualKey, middlewares...))
 
 	// Team CRUD operations
-	r.GET("/api/governance/teams", ChainMiddlewares(h.getTeams, middlewares...))
-	r.POST("/api/governance/teams", ChainMiddlewares(h.createTeam, middlewares...))
-	r.GET("/api/governance/teams/{team_id}", ChainMiddlewares(h.getTeam, middlewares...))
-	r.PUT("/api/governance/teams/{team_id}", ChainMiddlewares(h.updateTeam, middlewares...))
-	r.DELETE("/api/governance/teams/{team_id}", ChainMiddlewares(h.deleteTeam, middlewares...))
+	r.GET("/api/governance/teams", lib.ChainMiddlewares(h.getTeams, middlewares...))
+	r.POST("/api/governance/teams", lib.ChainMiddlewares(h.createTeam, middlewares...))
+	r.GET("/api/governance/teams/{team_id}", lib.ChainMiddlewares(h.getTeam, middlewares...))
+	r.PUT("/api/governance/teams/{team_id}", lib.ChainMiddlewares(h.updateTeam, middlewares...))
+	r.DELETE("/api/governance/teams/{team_id}", lib.ChainMiddlewares(h.deleteTeam, middlewares...))
 
 	// Customer CRUD operations
-	r.GET("/api/governance/customers", ChainMiddlewares(h.getCustomers, middlewares...))
-	r.POST("/api/governance/customers", ChainMiddlewares(h.createCustomer, middlewares...))
-	r.GET("/api/governance/customers/{customer_id}", ChainMiddlewares(h.getCustomer, middlewares...))
-	r.PUT("/api/governance/customers/{customer_id}", ChainMiddlewares(h.updateCustomer, middlewares...))
-	r.DELETE("/api/governance/customers/{customer_id}", ChainMiddlewares(h.deleteCustomer, middlewares...))
+	r.GET("/api/governance/customers", lib.ChainMiddlewares(h.getCustomers, middlewares...))
+	r.POST("/api/governance/customers", lib.ChainMiddlewares(h.createCustomer, middlewares...))
+	r.GET("/api/governance/customers/{customer_id}", lib.ChainMiddlewares(h.getCustomer, middlewares...))
+	r.PUT("/api/governance/customers/{customer_id}", lib.ChainMiddlewares(h.updateCustomer, middlewares...))
+	r.DELETE("/api/governance/customers/{customer_id}", lib.ChainMiddlewares(h.deleteCustomer, middlewares...))
 }
 
 // Virtual Key CRUD Operations

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -273,14 +273,14 @@ const (
 )
 
 // RegisterRoutes registers all completion-related routes
-func (h *CompletionHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
+func (h *CompletionHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
 	// Completion endpoints
-	r.POST("/v1/completions", ChainMiddlewares(h.textCompletion, middlewares...))
-	r.POST("/v1/chat/completions", ChainMiddlewares(h.chatCompletion, middlewares...))
-	r.POST("/v1/responses", ChainMiddlewares(h.responses, middlewares...))
-	r.POST("/v1/embeddings", ChainMiddlewares(h.embeddings, middlewares...))
-	r.POST("/v1/audio/speech", ChainMiddlewares(h.speech, middlewares...))
-	r.POST("/v1/audio/transcriptions", ChainMiddlewares(h.transcription, middlewares...))
+	r.POST("/v1/completions", lib.ChainMiddlewares(h.textCompletion, middlewares...))
+	r.POST("/v1/chat/completions", lib.ChainMiddlewares(h.chatCompletion, middlewares...))
+	r.POST("/v1/responses", lib.ChainMiddlewares(h.responses, middlewares...))
+	r.POST("/v1/embeddings", lib.ChainMiddlewares(h.embeddings, middlewares...))
+	r.POST("/v1/audio/speech", lib.ChainMiddlewares(h.speech, middlewares...))
+	r.POST("/v1/audio/transcriptions", lib.ChainMiddlewares(h.transcription, middlewares...))
 }
 
 // textCompletion handles POST /v1/completions - Process text completion requests

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -31,9 +31,9 @@ func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStor
 }
 
 // RegisterRoutes registers all integration routes for AI provider compatibility endpoints
-func (h *IntegrationHandler) RegisterRoutes(r *router.Router) {
+func (h *IntegrationHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
 	// Register routes for each integration extension
 	for _, extension := range h.extensions {
-		extension.RegisterRoutes(r)
+		extension.RegisterRoutes(r, middlewares...)
 	}
 }

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -12,6 +12,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/plugins/logging"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -30,11 +31,11 @@ func NewLoggingHandler(logManager logging.LogManager, logger schemas.Logger) *Lo
 }
 
 // RegisterRoutes registers all logging-related routes
-func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
+func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
 	// Log retrieval with filtering, search, and pagination
-	r.GET("/api/logs", ChainMiddlewares(h.getLogs, middlewares...))
-	r.GET("/api/logs/dropped", ChainMiddlewares(h.getDroppedRequests, middlewares...))
-	r.GET("/api/logs/models", ChainMiddlewares(h.getAvailableModels, middlewares...))
+	r.GET("/api/logs", lib.ChainMiddlewares(h.getLogs, middlewares...))
+	r.GET("/api/logs/dropped", lib.ChainMiddlewares(h.getDroppedRequests, middlewares...))
+	r.GET("/api/logs/models", lib.ChainMiddlewares(h.getAvailableModels, middlewares...))
 }
 
 // getLogs handles GET /api/logs - Get logs with filtering, search, and pagination via query parameters
@@ -147,7 +148,7 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 		h.logger.Error("failed to search logs: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Search failed: %v", err), h.logger)
 		return
-	}	
+	}
 	SendJSON(ctx, result, h.logger)
 }
 

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -30,14 +30,14 @@ func NewMCPHandler(client *bifrost.Bifrost, logger schemas.Logger, store *lib.Co
 }
 
 // RegisterRoutes registers all MCP-related routes
-func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
+func (h *MCPHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
 	// MCP tool execution endpoint
-	r.POST("/v1/mcp/tool/execute", ChainMiddlewares(h.executeTool, middlewares...))
-	r.GET("/api/mcp/clients", ChainMiddlewares(h.getMCPClients, middlewares...))
-	r.POST("/api/mcp/client", ChainMiddlewares(h.addMCPClient, middlewares...))
-	r.PUT("/api/mcp/client/{name}", ChainMiddlewares(h.editMCPClientTools, middlewares...))
-	r.DELETE("/api/mcp/client/{name}", ChainMiddlewares(h.removeMCPClient, middlewares...))
-	r.POST("/api/mcp/client/{name}/reconnect", ChainMiddlewares(h.reconnectMCPClient, middlewares...))
+	r.POST("/v1/mcp/tool/execute", lib.ChainMiddlewares(h.executeTool, middlewares...))
+	r.GET("/api/mcp/clients", lib.ChainMiddlewares(h.getMCPClients, middlewares...))
+	r.POST("/api/mcp/client", lib.ChainMiddlewares(h.addMCPClient, middlewares...))
+	r.PUT("/api/mcp/client/{name}", lib.ChainMiddlewares(h.editMCPClientTools, middlewares...))
+	r.DELETE("/api/mcp/client/{name}", lib.ChainMiddlewares(h.removeMCPClient, middlewares...))
+	r.POST("/api/mcp/client/{name}/reconnect", lib.ChainMiddlewares(h.reconnectMCPClient, middlewares...))
 }
 
 // executeTool handles POST /v1/mcp/tool/execute - Execute MCP tool

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -268,7 +268,7 @@ func TestCorsMiddleware_NoOriginHeader(t *testing.T) {
 	}
 }
 
-// TestChainMiddlewares_NoMiddlewares tests chaining with no middlewares
+// Testlib.ChainMiddlewares_NoMiddlewares tests chaining with no middlewares
 func TestChainMiddlewares_NoMiddlewares(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	handlerCalled := false
@@ -277,7 +277,7 @@ func TestChainMiddlewares_NoMiddlewares(t *testing.T) {
 		handlerCalled = true
 	}
 
-	chained := ChainMiddlewares(handler)
+	chained := lib.ChainMiddlewares(handler)
 	chained(ctx)
 
 	if !handlerCalled {
@@ -285,13 +285,13 @@ func TestChainMiddlewares_NoMiddlewares(t *testing.T) {
 	}
 }
 
-// TestChainMiddlewares_SingleMiddleware tests chaining with a single middleware
+// Testlib.ChainMiddlewares_SingleMiddleware tests chaining with a single middleware
 func TestChainMiddlewares_SingleMiddleware(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	middlewareCalled := false
 	handlerCalled := false
 
-	middleware := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			middlewareCalled = true
 			next(ctx)
@@ -302,7 +302,7 @@ func TestChainMiddlewares_SingleMiddleware(t *testing.T) {
 		handlerCalled = true
 	}
 
-	chained := ChainMiddlewares(handler, middleware)
+	chained := lib.ChainMiddlewares(handler, middleware)
 	chained(ctx)
 
 	if !middlewareCalled {
@@ -313,26 +313,26 @@ func TestChainMiddlewares_SingleMiddleware(t *testing.T) {
 	}
 }
 
-// TestChainMiddlewares_MultipleMiddlewares tests chaining with multiple middlewares
+// Testlib.ChainMiddlewares_MultipleMiddlewares tests chaining with multiple middlewares
 func TestChainMiddlewares_MultipleMiddlewares(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	executionOrder := []int{}
 
-	middleware1 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware1 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 1)
 			next(ctx)
 		}
 	})
 
-	middleware2 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware2 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 2)
 			next(ctx)
 		}
 	})
 
-	middleware3 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware3 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 3)
 			next(ctx)
@@ -343,7 +343,7 @@ func TestChainMiddlewares_MultipleMiddlewares(t *testing.T) {
 		executionOrder = append(executionOrder, 4)
 	}
 
-	chained := ChainMiddlewares(handler, middleware1, middleware2, middleware3)
+	chained := lib.ChainMiddlewares(handler, middleware1, middleware2, middleware3)
 	chained(ctx)
 
 	// Check execution order: middlewares should execute in order, then handler
@@ -360,11 +360,11 @@ func TestChainMiddlewares_MultipleMiddlewares(t *testing.T) {
 	}
 }
 
-// TestChainMiddlewares_MiddlewareCanModifyContext tests that middlewares can modify the context
+// Testlib.ChainMiddlewares_MiddlewareCanModifyContext tests that middlewares can modify the context
 func TestChainMiddlewares_MiddlewareCanModifyContext(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 
-	middleware := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			ctx.SetUserValue("test-key", "test-value")
 			next(ctx)
@@ -380,18 +380,18 @@ func TestChainMiddlewares_MiddlewareCanModifyContext(t *testing.T) {
 		}
 	}
 
-	chained := ChainMiddlewares(handler, middleware)
+	chained := lib.ChainMiddlewares(handler, middleware)
 	chained(ctx)
 }
 
-// TestChainMiddlewares_ShortCircuit tests that when a middleware writes a response
+// Testlib.ChainMiddlewares_ShortCircuit tests that when a middleware writes a response
 // and does not call next, subsequent middlewares and handler do not execute.
 func TestChainMiddlewares_ShortCircuit(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	executionOrder := []int{}
 
 	// First middleware - writes response and short-circuits by not calling next
-	middleware1 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware1 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 1)
 			ctx.SetStatusCode(fasthttp.StatusUnauthorized)
@@ -401,7 +401,7 @@ func TestChainMiddlewares_ShortCircuit(t *testing.T) {
 	})
 
 	// Second middleware - should NOT execute when middleware1 short-circuits
-	middleware2 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware2 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 2)
 			next(ctx)
@@ -409,7 +409,7 @@ func TestChainMiddlewares_ShortCircuit(t *testing.T) {
 	})
 
 	// Third middleware - should NOT execute when middleware1 short-circuits
-	middleware3 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware3 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 3)
 			next(ctx)
@@ -423,7 +423,7 @@ func TestChainMiddlewares_ShortCircuit(t *testing.T) {
 		ctx.SetBodyString("Success")
 	}
 
-	chained := ChainMiddlewares(handler, middleware1, middleware2, middleware3)
+	chained := lib.ChainMiddlewares(handler, middleware1, middleware2, middleware3)
 	chained(ctx)
 
 	// Verify only middleware1 executed
@@ -448,14 +448,14 @@ func TestChainMiddlewares_ShortCircuit(t *testing.T) {
 	}
 }
 
-// TestChainMiddlewares_ShortCircuitMiddlePosition tests that middleware in the middle
+// Testlib.ChainMiddlewares_ShortCircuitMiddlePosition tests that middleware in the middle
 // can short-circuit, preventing later middlewares and handler from executing.
 func TestChainMiddlewares_ShortCircuitMiddlePosition(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	executionOrder := []int{}
 
 	// First middleware - executes and calls next
-	middleware1 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware1 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 1)
 			next(ctx)
@@ -463,7 +463,7 @@ func TestChainMiddlewares_ShortCircuitMiddlePosition(t *testing.T) {
 	})
 
 	// Second middleware - writes response and short-circuits
-	middleware2 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware2 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 2)
 			ctx.SetStatusCode(fasthttp.StatusUnauthorized)
@@ -473,7 +473,7 @@ func TestChainMiddlewares_ShortCircuitMiddlePosition(t *testing.T) {
 	})
 
 	// Third middleware - should NOT execute
-	middleware3 := BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	middleware3 := lib.BifrostHTTPMiddleware(func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			executionOrder = append(executionOrder, 3)
 			next(ctx)
@@ -487,7 +487,7 @@ func TestChainMiddlewares_ShortCircuitMiddlePosition(t *testing.T) {
 		ctx.SetBodyString("Success")
 	}
 
-	chained := ChainMiddlewares(handler, middleware1, middleware2, middleware3)
+	chained := lib.ChainMiddlewares(handler, middleware1, middleware2, middleware3)
 	chained(ctx)
 
 	// Verify only middleware1 and middleware2 executed

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
 )
@@ -48,12 +49,12 @@ type UpdatePluginRequest struct {
 }
 
 // RegisterRoutes registers the routes for the PluginsHandler
-func (h *PluginsHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
-	r.GET("/api/plugins", ChainMiddlewares(h.getPlugins, middlewares...))
-	r.GET("/api/plugins/{name}", ChainMiddlewares(h.getPlugin, middlewares...))
-	r.POST("/api/plugins", ChainMiddlewares(h.createPlugin, middlewares...))
-	r.PUT("/api/plugins/{name}", ChainMiddlewares(h.updatePlugin, middlewares...))
-	r.DELETE("/api/plugins/{name}", ChainMiddlewares(h.deletePlugin, middlewares...))
+func (h *PluginsHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
+	r.GET("/api/plugins", lib.ChainMiddlewares(h.getPlugins, middlewares...))
+	r.GET("/api/plugins/{name}", lib.ChainMiddlewares(h.getPlugin, middlewares...))
+	r.POST("/api/plugins", lib.ChainMiddlewares(h.createPlugin, middlewares...))
+	r.PUT("/api/plugins/{name}", lib.ChainMiddlewares(h.updatePlugin, middlewares...))
+	r.DELETE("/api/plugins/{name}", lib.ChainMiddlewares(h.deletePlugin, middlewares...))
 }
 
 // getPlugins gets all plugins

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -59,14 +59,14 @@ type ErrorResponse struct {
 }
 
 // RegisterRoutes registers all provider management routes
-func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
+func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
 	// Provider CRUD operations
-	r.GET("/api/providers", ChainMiddlewares(h.listProviders, middlewares...))
-	r.GET("/api/providers/{provider}", ChainMiddlewares(h.getProvider, middlewares...))
-	r.POST("/api/providers", ChainMiddlewares(h.addProvider, middlewares...))
-	r.PUT("/api/providers/{provider}", ChainMiddlewares(h.updateProvider, middlewares...))
-	r.DELETE("/api/providers/{provider}", ChainMiddlewares(h.deleteProvider, middlewares...))
-	r.GET("/api/keys", ChainMiddlewares(h.listKeys, middlewares...))
+	r.GET("/api/providers", lib.ChainMiddlewares(h.listProviders, middlewares...))
+	r.GET("/api/providers/{provider}", lib.ChainMiddlewares(h.getProvider, middlewares...))
+	r.POST("/api/providers", lib.ChainMiddlewares(h.addProvider, middlewares...))
+	r.PUT("/api/providers/{provider}", lib.ChainMiddlewares(h.updateProvider, middlewares...))
+	r.DELETE("/api/providers/{provider}", lib.ChainMiddlewares(h.deleteProvider, middlewares...))
+	r.GET("/api/keys", lib.ChainMiddlewares(h.listKeys, middlewares...))
 }
 
 // listProviders handles GET /api/providers - List all providers

--- a/transports/bifrost-http/handlers/ui.go
+++ b/transports/bifrost-http/handlers/ui.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -24,9 +25,9 @@ func NewUIHandler(uiContent embed.FS) *UIHandler {
 }
 
 // RegisterRoutes registers the UI routes with the provided router.
-func (h *UIHandler) RegisterRoutes(router *router.Router, middlewares ...BifrostHTTPMiddleware) {
-	router.GET("/", ChainMiddlewares(h.serveDashboard, middlewares...))
-	router.GET("/{filepath:*}", ChainMiddlewares(h.serveDashboard, middlewares...))
+func (h *UIHandler) RegisterRoutes(router *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
+	router.GET("/", lib.ChainMiddlewares(h.serveDashboard, middlewares...))
+	router.GET("/{filepath:*}", lib.ChainMiddlewares(h.serveDashboard, middlewares...))
 }
 
 // ServeDashboard serves the dashboard UI.

--- a/transports/bifrost-http/handlers/websocket.go
+++ b/transports/bifrost-http/handlers/websocket.go
@@ -14,6 +14,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/plugins/logging"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
@@ -49,8 +50,8 @@ func NewWebSocketHandler(ctx context.Context, logManager logging.LogManager, log
 }
 
 // RegisterRoutes registers all WebSocket-related routes
-func (h *WebSocketHandler) RegisterRoutes(r *router.Router, middlewares ...BifrostHTTPMiddleware) {
-	r.GET("/ws/logs", ChainMiddlewares(h.connectLogStream, middlewares...))
+func (h *WebSocketHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
+	r.GET("/ws/logs", lib.ChainMiddlewares(h.connectLogStream, middlewares...))
 }
 
 // getUpgrader returns a WebSocket upgrader configured with the current allowed origins

--- a/transports/bifrost-http/lib/middleware.go
+++ b/transports/bifrost-http/lib/middleware.go
@@ -1,0 +1,24 @@
+package lib
+
+import "github.com/valyala/fasthttp"
+
+// BifrostHTTPMiddleware is a middleware function for the Bifrost HTTP transport
+// It follows the standard pattern: receives the next handler and returns a new handler
+type BifrostHTTPMiddleware func(next fasthttp.RequestHandler) fasthttp.RequestHandler
+
+// lib.ChainMiddlewares chains multiple middlewares together
+// Middlewares are applied in order: the first middleware wraps the second, etc.
+// This allows earlier middlewares to short-circuit by not calling next(ctx)
+func ChainMiddlewares(handler fasthttp.RequestHandler, middlewares ...BifrostHTTPMiddleware) fasthttp.RequestHandler {
+	// If no middlewares, return the original handler
+	if len(middlewares) == 0 {
+		return handler
+	}
+	// Build the chain from right to left (last middleware wraps the handler)
+	// This ensures execution order is left to right (first middleware executes first)
+	chained := handler
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		chained = middlewares[i](chained)
+	}
+	return chained
+}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -109,10 +109,15 @@ export const networkConfigSchema = z
 export const networkFormConfigSchema = z
 	.object({
 		base_url: z
-			.url("Must be a valid URL")
-			.refine((url) => url.startsWith("https://") || url.startsWith("http://"), {
-				message: "Must be a valid HTTP or HTTPS URL",
-			})
+			.union([
+				z
+					.string()
+					.url("Must be a valid URL")
+					.refine((url) => url.startsWith("https://") || url.startsWith("http://"), {
+						message: "Must be a valid HTTP or HTTPS URL",
+					}),
+				z.string().length(0),
+			])
 			.optional(),
 		extra_headers: z.record(z.string(), z.string()).optional(),
 		default_request_timeout_in_seconds: z.coerce


### PR DESCRIPTION
## Summary

Refactors HTTP middleware handling in the Bifrost HTTP transport to improve code organization and fix a memory allocation issue in the telemetry plugin.

## Changes

- Moved middleware types and chain function from handlers to a dedicated lib package
- Fixed a memory allocation issue in the telemetry plugin's error handling by pre-allocating slices
- Applied telemetry middleware specifically to inference and integration routes
- Updated all handler RegisterRoutes methods to use the new middleware location
- Fixed URL validation in the UI network form config schema to allow empty strings

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is primarily a refactoring change.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable