### PR TITLE
feat: add per-chunk latency tracking to streaming responses

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -444,6 +444,9 @@ func handleAnthropicStreaming(
 		scanner := bufio.NewScanner(resp.Body)
 		chunkIndex := -1
 
+		startTime := time.Now()
+		lastChunkTime := startTime
+
 		// Track minimal state needed for response format
 		var messageID string
 		var modelName string
@@ -527,8 +530,10 @@ func handleAnthropicStreaming(
 								Provider:       providerType,
 								ModelRequested: modelName,
 								ChunkIndex:     chunkIndex,
+								Latency:        time.Since(lastChunkTime).Milliseconds(),
 							},
 						}
+						lastChunkTime = time.Now()
 
 						// Use utility function to process and send response
 						processAndSendResponse(ctx, postHookRunner, streamResponse, responseChan, logger)
@@ -573,8 +578,10 @@ func handleAnthropicStreaming(
 									Provider:       providerType,
 									ModelRequested: modelName,
 									ChunkIndex:     chunkIndex,
+									Latency:        time.Since(lastChunkTime).Milliseconds(),
 								},
 							}
+							lastChunkTime = time.Now()
 
 							// Use utility function to process and send response
 							processAndSendResponse(ctx, postHookRunner, streamResponse, responseChan, logger)
@@ -610,8 +617,10 @@ func handleAnthropicStreaming(
 								Provider:       providerType,
 								ModelRequested: modelName,
 								ChunkIndex:     chunkIndex,
+								Latency:        time.Since(lastChunkTime).Milliseconds(),
 							},
 						}
+						lastChunkTime = time.Now()
 
 						// Use utility function to process and send response
 						processAndSendResponse(ctx, postHookRunner, streamResponse, responseChan, logger)
@@ -646,8 +655,10 @@ func handleAnthropicStreaming(
 									Provider:       providerType,
 									ModelRequested: modelName,
 									ChunkIndex:     chunkIndex,
+									Latency:        time.Since(lastChunkTime).Milliseconds(),
 								},
 							}
+							lastChunkTime = time.Now()
 
 							// Use utility function to process and send response
 							processAndSendResponse(ctx, postHookRunner, streamResponse, responseChan, logger)
@@ -683,8 +694,10 @@ func handleAnthropicStreaming(
 									Provider:       providerType,
 									ModelRequested: modelName,
 									ChunkIndex:     chunkIndex,
+									Latency:        time.Since(lastChunkTime).Milliseconds(),
 								},
 							}
+							lastChunkTime = time.Now()
 
 							// Use utility function to process and send response
 							processAndSendResponse(ctx, postHookRunner, streamResponse, responseChan, logger)
@@ -713,8 +726,10 @@ func handleAnthropicStreaming(
 									Provider:       providerType,
 									ModelRequested: modelName,
 									ChunkIndex:     chunkIndex,
+									Latency:        time.Since(lastChunkTime).Milliseconds(),
 								},
 							}
+							lastChunkTime = time.Now()
 
 							// Use utility function to process and send response
 							processAndSendResponse(ctx, postHookRunner, streamResponse, responseChan, logger)
@@ -774,6 +789,7 @@ func handleAnthropicStreaming(
 			processAndSendError(ctx, postHookRunner, err, responseChan, schemas.ChatCompletionStreamRequest, providerType, modelName, logger)
 		} else {
 			response := createBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.ChatCompletionStreamRequest, providerType, modelName)
+			response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 			handleStreamEndWithSuccess(ctx, response, postHookRunner, responseChan, logger)
 		}
 	}()

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -492,7 +492,7 @@ type BifrostResponseExtraFields struct {
 	RequestType    RequestType        `json:"request_type"`
 	Provider       ModelProvider      `json:"provider"`
 	ModelRequested string             `json:"model_requested"`
-	Latency        int64              `json:"latency,omitempty"` // in milliseconds
+	Latency        int64              `json:"latency,omitempty"` // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
 	BilledUsage    *BilledLLMUsage    `json:"billed_usage,omitempty"`
 	ChunkIndex     int                `json:"chunk_index"` // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
 	RawResponse    interface{}        `json:"raw_response,omitempty"`
@@ -525,6 +525,21 @@ const (
 type BifrostStream struct {
 	*BifrostResponse
 	*BifrostError
+}
+
+// MarshalJSON implements custom JSON marshaling for BifrostStream.
+// This ensures that only the non-nil embedded struct is marshaled,
+// preventing conflicts between BifrostResponse.ExtraFields and BifrostError.ExtraFields.
+func (bs BifrostStream) MarshalJSON() ([]byte, error) {
+	if bs.BifrostResponse != nil {
+		// Marshal the BifrostResponse with its ExtraFields
+		return sonic.Marshal(bs.BifrostResponse)
+	} else if bs.BifrostError != nil {
+		// Marshal the BifrostError with its ExtraFields
+		return sonic.Marshal(bs.BifrostError)
+	}
+	// Return empty object if both are nil (shouldn't happen in practice)
+	return []byte("{}"), nil
 }
 
 // BifrostError represents an error from the Bifrost system.

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -771,11 +771,7 @@ func (h *CompletionHandler) handleStreamingTextCompletion(ctx *fasthttp.RequestC
 		return h.client.TextCompletionStreamRequest(*bifrostCtx, req)
 	}
 
-	extractResponse := func(response *schemas.BifrostStream) (interface{}, bool) {
-		return response, true
-	}
-
-	h.handleStreamingResponse(ctx, getStream, extractResponse)
+	h.handleStreamingResponse(ctx, getStream)
 }
 
 // handleStreamingChatCompletion handles streaming chat completion requests using Server-Sent Events (SSE)
@@ -784,11 +780,7 @@ func (h *CompletionHandler) handleStreamingChatCompletion(ctx *fasthttp.RequestC
 		return h.client.ChatCompletionStreamRequest(*bifrostCtx, req)
 	}
 
-	extractResponse := func(response *schemas.BifrostStream) (interface{}, bool) {
-		return response, true
-	}
-
-	h.handleStreamingResponse(ctx, getStream, extractResponse)
+	h.handleStreamingResponse(ctx, getStream)
 }
 
 // handleStreamingResponses handles streaming responses requests using Server-Sent Events (SSE)
@@ -797,11 +789,7 @@ func (h *CompletionHandler) handleStreamingResponses(ctx *fasthttp.RequestCtx, r
 		return h.client.ResponsesStreamRequest(*bifrostCtx, req)
 	}
 
-	extractResponse := func(response *schemas.BifrostStream) (interface{}, bool) {
-		return response, true
-	}
-
-	h.handleStreamingResponse(ctx, getStream, extractResponse)
+	h.handleStreamingResponse(ctx, getStream)
 }
 
 // handleStreamingSpeech handles streaming speech requests using Server-Sent Events (SSE)
@@ -810,14 +798,7 @@ func (h *CompletionHandler) handleStreamingSpeech(ctx *fasthttp.RequestCtx, req 
 		return h.client.SpeechStreamRequest(*bifrostCtx, req)
 	}
 
-	extractResponse := func(response *schemas.BifrostStream) (interface{}, bool) {
-		if response.Speech == nil || response.Speech.BifrostSpeechStreamResponse == nil {
-			return nil, false
-		}
-		return response.Speech, true
-	}
-
-	h.handleStreamingResponse(ctx, getStream, extractResponse)
+	h.handleStreamingResponse(ctx, getStream)
 }
 
 // handleStreamingTranscriptionRequest handles streaming transcription requests using Server-Sent Events (SSE)
@@ -826,18 +807,11 @@ func (h *CompletionHandler) handleStreamingTranscriptionRequest(ctx *fasthttp.Re
 		return h.client.TranscriptionStreamRequest(*bifrostCtx, req)
 	}
 
-	extractResponse := func(response *schemas.BifrostStream) (interface{}, bool) {
-		if response.Transcribe == nil || response.Transcribe.BifrostTranscribeStreamResponse == nil {
-			return nil, false
-		}
-		return response.Transcribe, true
-	}
-
-	h.handleStreamingResponse(ctx, getStream, extractResponse)
+	h.handleStreamingResponse(ctx, getStream)
 }
 
 // handleStreamingResponse is a generic function to handle streaming responses using Server-Sent Events (SSE)
-func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, getStream func() (chan *schemas.BifrostStream, *schemas.BifrostError), extractResponse func(*schemas.BifrostStream) (interface{}, bool)) {
+func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, getStream func() (chan *schemas.BifrostStream, *schemas.BifrostError)) {
 	// Set SSE headers
 	ctx.SetContentType("text/event-stream")
 	ctx.Response.Header.Set("Cache-Control", "no-cache")
@@ -857,26 +831,24 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, ge
 		defer w.Flush()
 
 		// Process streaming responses
-		for response := range stream {
-			if response == nil {
+		for chunk := range stream {
+			if chunk == nil {
 				continue
 			}
 
-			// Extract and validate the response data
-			data, valid := extractResponse(response)
-			if !valid {
-				continue
+			if chunk.BifrostResponse != nil {
+				h.logger.Info(fmt.Sprintf("Streaming response is a BifrostResponse with type %s, provider %s, model %s and latency %d", chunk.BifrostResponse.ExtraFields.RequestType, chunk.BifrostResponse.ExtraFields.Provider, chunk.BifrostResponse.ExtraFields.ModelRequested, chunk.BifrostResponse.ExtraFields.Latency))
 			}
 
 			// Convert response to JSON
-			responseJSON, err := sonic.Marshal(data)
+			chunkJSON, err := sonic.Marshal(chunk)
 			if err != nil {
 				h.logger.Warn(fmt.Sprintf("Failed to marshal streaming response: %v", err))
 				continue
 			}
 
 			// Send as SSE data
-			if _, err := fmt.Fprintf(w, "data: %s\n\n", responseJSON); err != nil {
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", chunkJSON); err != nil {
 				h.logger.Warn(fmt.Sprintf("Failed to write SSE data: %v", err))
 				break
 			}


### PR DESCRIPTION
## Summary

Added per-chunk latency tracking to all streaming responses, providing more granular performance metrics for streaming operations across all providers.

## Changes

- Added `startTime` and `lastChunkTime` tracking to all streaming handlers
- Implemented per-chunk latency measurements in milliseconds for Anthropic, Bedrock, Cohere, Gemini, and OpenAI providers
- Set total latency on the final chunk of each streaming response
- Improved the HTTP transport to properly handle and forward latency information in SSE responses
- Added custom JSON marshaling for BifrostStream to prevent field conflicts

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with different providers and verify latency metrics are included:

```sh
# Core/Transports
go version
go test ./...

# Test with curl to see latency in streaming responses
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}],
    "stream": true
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves observability for streaming responses, allowing better performance monitoring.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable