### PR TITLE
feat: refactor WebSocket implementation with channel-based subscriptions

### DIFF
--- a/transports/bifrost-http/handlers/server.go
+++ b/transports/bifrost-http/handlers/server.go
@@ -58,8 +58,9 @@ type BifrostHTTPServer struct {
 	Client  *bifrost.Bifrost
 	Config  *lib.Config
 
-	Server *fasthttp.Server
-	Router *router.Router
+	Server           *fasthttp.Server
+	Router           *router.Router
+	WebSocketHandler *WebSocketHandler
 }
 
 // NewBifrostHTTPServer creates a new instance of BifrostHTTPServer.
@@ -395,14 +396,15 @@ func (s *BifrostHTTPServer) RegisterRoutes(ctx context.Context, middlewares ...l
 		cacheHandler = NewCacheHandler(semanticCachePlugin, logger)
 	}
 	// Websocket handler needs to go below UI handler
-	var wsHandler *WebSocketHandler
+	logger.Debug("initializing websocket server")
 	if loggerPlugin != nil {
-		logger.Debug("initializing websocket server")
-		wsHandler = NewWebSocketHandler(ctx, loggerPlugin.GetPluginLogManager(), logger, s.Config.ClientConfig.AllowedOrigins)
-		loggerPlugin.SetLogCallback(wsHandler.BroadcastLogUpdate)
-		// Start WebSocket heartbeat
-		wsHandler.StartHeartbeat()
+		s.WebSocketHandler = NewWebSocketHandler(ctx, loggerPlugin.GetPluginLogManager(), logger, s.Config.ClientConfig.AllowedOrigins)
+		loggerPlugin.SetLogCallback(s.WebSocketHandler.BroadcastLogUpdate)
+	} else {
+		s.WebSocketHandler = NewWebSocketHandler(ctx, nil, logger, s.Config.ClientConfig.AllowedOrigins)
 	}
+	// Start WebSocket heartbeat
+	s.WebSocketHandler.StartHeartbeat()
 	middlewaresWithTelemetry := append(middlewares, telemetry.PrometheusMiddleware)
 	// Chaining all middlewares
 	// lib.ChainMiddlewares chains multiple middlewares together
@@ -429,8 +431,8 @@ func (s *BifrostHTTPServer) RegisterRoutes(ctx context.Context, middlewares ...l
 	if loggingHandler != nil {
 		loggingHandler.RegisterRoutes(s.Router, middlewares...)
 	}
-	if wsHandler != nil {
-		wsHandler.RegisterRoutes(s.Router, middlewares...)
+	if s.WebSocketHandler != nil {
+		s.WebSocketHandler.RegisterRoutes(s.Router, middlewares...)
 	}
 	//
 	// Add Prometheus /metrics endpoint

--- a/ui/app/logs/page.tsx
+++ b/ui/app/logs/page.tsx
@@ -187,12 +187,17 @@ export default function LogsPage() {
 		});
 	}, []);
 
-	const { isConnected: isSocketConnected, setMessageHandler } = useWebSocket();
+	const { isConnected: isSocketConnected, subscribe } = useWebSocket();
 
-	// Set up the message handler when the component mounts
+	// Subscribe to log messages
 	useEffect(() => {
-		setMessageHandler(handleLogMessage);
-	}, [handleLogMessage, setMessageHandler]);
+		const unsubscribe = subscribe("log", (data) => {
+			const { payload, operation } = data;
+			handleLogMessage(payload, operation);
+		});
+
+		return unsubscribe;
+	}, [handleLogMessage, subscribe]);
 
 	// Cleanup timeouts on unmount
 	useEffect(() => {

--- a/ui/hooks/useWebSocket.tsx
+++ b/ui/hooks/useWebSocket.tsx
@@ -1,32 +1,61 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
-import type { LogEntry, WebSocketLogMessage } from "../lib/types/logs";
+import React, { createContext, useContext, useEffect, useRef, useState, useCallback, type ReactNode } from "react";
 import { getWebSocketUrl } from "@/lib/utils/port";
+
+type MessageHandler = (data: any) => void;
 
 interface WebSocketContextType {
 	isConnected: boolean;
 	ws: React.RefObject<WebSocket | null>;
-	setMessageHandler: (handler: (log: LogEntry, operation: "create" | "update") => void) => void;
+	subscribe: (channel: string, handler: MessageHandler) => () => void;
+	send: (data: any) => void;
 }
 
 const WebSocketContext = createContext<WebSocketContextType | null>(null);
 
 interface WebSocketProviderProps {
 	children: ReactNode;
+	path?: string;
 }
 
 // Global reference to maintain state across component remounts
 let globalWsRef: WebSocket | null = null;
-let globalMessageHandler: ((log: LogEntry, operation: "create" | "update") => void) | null = null;
+const messageHandlers = new Map<string, Set<MessageHandler>>();
 
-export function WebSocketProvider({ children }: WebSocketProviderProps) {
+export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderProps) {
 	const wsRef = useRef<WebSocket | null>(globalWsRef);
 	const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const retryCountRef = useRef(0);
 	const [isConnected, setIsConnected] = useState(false);
 
-	const setMessageHandler = (handler: (log: LogEntry, operation: "create" | "update") => void) => {
-		globalMessageHandler = handler;
+	const subscribe = useCallback<(channel: string, handler: MessageHandler) => () => void>((channel, handler) => {
+		if (!messageHandlers.has(channel)) {
+			messageHandlers.set(channel, new Set());
+		}
+		messageHandlers.get(channel)!.add(handler);
+
+		// Return unsubscribe function
+		return () => {
+			const handlers = messageHandlers.get(channel);
+			if (handlers) {
+				handlers.delete(handler);
+				if (handlers.size === 0) {
+					messageHandlers.delete(channel);
+				}
+			}
+		};
+	}, []);
+
+	const send = (data: any) => {
+		if (wsRef.current?.readyState === WebSocket.OPEN) {
+			try {
+				wsRef.current.send(typeof data === "string" ? data : JSON.stringify(data));
+			} catch (error) {
+				console.error("Failed to send WebSocket message:", error);
+			}
+		}
 	};
 
 	useEffect(() => {
@@ -35,7 +64,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				return;
 			}
 
-			const wsUrl = getWebSocketUrl("/ws/logs");
+			const wsUrl = getWebSocketUrl(path);
 
 			const ws = new WebSocket(wsUrl);
 			wsRef.current = ws;
@@ -44,18 +73,44 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			ws.onopen = () => {
 				console.log("WebSocket connected");
 				setIsConnected(true);
+				retryCountRef.current = 0; // Reset retry count on successful connection
+
 				// Clear any pending reconnection attempts
 				if (reconnectTimeoutRef.current) {
 					clearTimeout(reconnectTimeoutRef.current);
 					reconnectTimeoutRef.current = null;
 				}
+
+				// Start heartbeat/ping to keep connection alive
+				if (pingTimerRef.current) {
+					clearInterval(pingTimerRef.current);
+				}
+				pingTimerRef.current = setInterval(() => {
+					if (ws.readyState === WebSocket.OPEN) {
+						try {
+							ws.send("ping");
+						} catch (error) {
+							console.error("Ping failed:", error);
+						}
+					}
+				}, 25000); // Ping every 25 seconds
 			};
 
 			ws.onmessage = (event) => {
 				try {
-					const data: WebSocketLogMessage = JSON.parse(event.data);
-					if (data.type === "log" && globalMessageHandler) {
-						globalMessageHandler(data.payload, data.operation);
+					const data = JSON.parse(event.data);
+					const messageType = data.type || "default";
+
+					// Notify all subscribers for this message type
+					const handlers = messageHandlers.get(messageType);
+					if (handlers) {
+						handlers.forEach((handler) => handler(data));
+					}
+
+					// Also notify wildcard subscribers
+					const wildcardHandlers = messageHandlers.get("*");
+					if (wildcardHandlers) {
+						wildcardHandlers.forEach((handler) => handler(data));
 					}
 				} catch (error) {
 					console.error("Failed to parse WebSocket message:", error);
@@ -65,11 +120,23 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			ws.onclose = () => {
 				console.log("WebSocket disconnected, attempting to reconnect...");
 				setIsConnected(false);
-				// Attempt to reconnect after 5 seconds
-				reconnectTimeoutRef.current = setTimeout(connect, 5000);
+
+				// Clear ping timer
+				if (pingTimerRef.current) {
+					clearInterval(pingTimerRef.current);
+					pingTimerRef.current = null;
+				}
+
+				// Exponential backoff: 0.5s, 1s, 2s, 4s, 8s, 16s, 32s (max)
+				retryCountRef.current = Math.min(retryCountRef.current + 1, 6);
+				const delay = Math.pow(2, retryCountRef.current) * 500;
+				console.log(`Reconnecting in ${delay}ms...`);
+
+				reconnectTimeoutRef.current = setTimeout(connect, delay);
 			};
 
 			ws.onerror = (error) => {
+				console.error("WebSocket error:", error);
 				setIsConnected(false);
 				ws.close();
 			};
@@ -84,10 +151,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				clearTimeout(reconnectTimeoutRef.current);
 				reconnectTimeoutRef.current = null;
 			}
+			if (pingTimerRef.current) {
+				clearInterval(pingTimerRef.current);
+				pingTimerRef.current = null;
+			}
 		};
-	}, []);
+	}, [path]);
 
-	return <WebSocketContext.Provider value={{ isConnected, ws: wsRef, setMessageHandler }}>{children}</WebSocketContext.Provider>;
+	return <WebSocketContext.Provider value={{ isConnected, ws: wsRef, subscribe, send }}>{children}</WebSocketContext.Provider>;
 }
 
 export function useWebSocket() {


### PR DESCRIPTION
## Summary

Refactored WebSocket implementation to support multiple message types and improved connection handling.

## Changes

- Renamed WebSocket endpoint from `/ws/logs` to `/ws` to support multiple message types
- Added WebSocketHandler as a field in BifrostHTTPServer for better access
- Enhanced WebSocket client with channel-based subscription model
- Implemented exponential backoff for reconnection attempts
- Added heartbeat/ping mechanism to keep connections alive
- Created a more robust message handling system with type-based routing
- Updated UI components to use the new subscription model

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Start the server and navigate to the logs page
2. Verify WebSocket connection is established
3. Check that logs are still streaming correctly
4. Test connection resilience by temporarily disabling network or restarting the server
5. Verify reconnection works with exponential backoff

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] Yes
- [ ] No

The WebSocket endpoint has changed from `/ws/logs` to `/ws`. Any custom clients connecting to the old endpoint will need to be updated.

## Security considerations

The WebSocket implementation includes proper origin checking and connection management to prevent unauthorized access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable