### PR TITLE
ui-build-fix-prerelease6

### DIFF
--- a/ui/app/logs/page.tsx
+++ b/ui/app/logs/page.tsx
@@ -8,7 +8,7 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
 import { useWebSocket } from "@/hooks/useWebSocket";
-import { getErrorMessage, useAppSelector, useLazyGetLogsQuery } from "@/lib/store";
+import { getErrorMessage, useLazyGetLogsQuery } from "@/lib/store";
 import type { ChatMessage, ChatMessageContent, ContentBlock, LogEntry, LogFilters, LogStats, Pagination } from "@/lib/types/logs";
 import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -21,9 +21,6 @@ export default function LogsPage() {
 	const [fetchingLogs, setFetchingLogs] = useState(false); // on pagination/filters change
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
-	const user = useAppSelector((state) => state.user?.currentUser);
-
-	console.log("user", user);
 
 	// RTK Query lazy hook for manual triggering
 	const [triggerGetLogs] = useLazyGetLogsQuery();


### PR DESCRIPTION
## Summary

Remove unused imports and console.log statement from the logs page component.

## Changes

- Removed the unused `useAppSelector` import from the store
- Removed unused `user` variable that was retrieving the current user from the store
- Removed a console.log statement that was logging the user object

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the logs page still functions correctly without the removed code:

```sh
# UI
cd ui
pnpm i || npm i
pnpm dev || npm run dev
# Navigate to the logs page and verify it loads correctly
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable