### PR TITLE
feat: add Anthropic responses streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Bifrost is a high-performance AI gateway that unifies access to 12+ providers (O
   </tr>
   <tr>
     <td><strong>Pre-release</strong></td>
-    <td>v1.3.0-prerelease5</td>
+    <td>v1.3.0-prerelease7</td>
   </tr>
 </table>
 

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -401,7 +401,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 		}
 
 		// Use shared Anthropic streaming logic
-		return handleAnthropicStreaming(
+		return handleAnthropicChatCompletionStreaming(
 			ctx,
 			client,
 			url,

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -936,7 +936,7 @@ func (br *BifrostResponse) ToResponsesStream() {
 
 	case delta.Thought != nil && *delta.Thought != "":
 		// Reasoning/thought content delta (for models that support reasoning)
-		streamResp.Type = ResponsesStreamResponseTypeOutputTextDelta
+		streamResp.Type = ResponsesStreamResponseTypeReasoningSummaryTextDelta
 		streamResp.Delta = delta.Thought
 
 	case delta.Refusal != nil && *delta.Refusal != "":
@@ -949,7 +949,7 @@ func (br *BifrostResponse) ToResponsesStream() {
 		toolCall := delta.ToolCalls[0] // Take first tool call
 
 		if toolCall.Function.Arguments != "" {
-			streamResp.Type = ResponsesStreamResponseTypeFunctionCallArgumentsAdded
+			streamResp.Type = ResponsesStreamResponseTypeFunctionCallArgumentsDelta
 			streamResp.Arguments = &toolCall.Function.Arguments
 
 			// Set item for function call metadata if this is a new tool call

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -383,14 +383,16 @@ func (l *Log) BuildContentSummary() string {
 
 	// Add output message
 	if l.OutputMessageParsed != nil {
-		if l.OutputMessageParsed.Content.ContentStr != nil && *l.OutputMessageParsed.Content.ContentStr != "" {
-			parts = append(parts, *l.OutputMessageParsed.Content.ContentStr)
-		}
-		// If content blocks exist, extract text from them
-		if l.OutputMessageParsed.Content.ContentBlocks != nil {
-			for _, block := range l.OutputMessageParsed.Content.ContentBlocks {
-				if block.Text != nil && *block.Text != "" {
-					parts = append(parts, *block.Text)
+		if l.OutputMessageParsed.Content != nil {
+			if l.OutputMessageParsed.Content.ContentStr != nil && *l.OutputMessageParsed.Content.ContentStr != "" {
+				parts = append(parts, *l.OutputMessageParsed.Content.ContentStr)
+			}
+			// If content blocks exist, extract text from them
+			if l.OutputMessageParsed.Content.ContentBlocks != nil {
+				for _, block := range l.OutputMessageParsed.Content.ContentBlocks {
+					if block.Text != nil && *block.Text != "" {
+						parts = append(parts, *block.Text)
+					}
 				}
 			}
 		}

--- a/tests/core-providers/scenarios/responses_stream.go
+++ b/tests/core-providers/scenarios/responses_stream.go
@@ -308,7 +308,7 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 
 						// Check for function call events
 						switch streamResp.Type {
-						case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsAdded:
+						case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta:
 							functionCallArgsDetected = true
 							if streamResp.Arguments != nil {
 								t.Logf("🔧 Function call arguments chunk: %q", *streamResp.Arguments)

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -47,23 +47,23 @@ func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if anthropicReq, ok := req.(*anthropic.AnthropicMessageRequest); ok {
 					return &schemas.BifrostRequest{
-						ChatRequest: anthropicReq.ToBifrostRequest(),
+						ResponsesRequest: anthropicReq.ToResponsesBifrostRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid request type")
 			},
 			ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
-				return anthropic.ToAnthropicChatCompletionResponse(resp), nil
+				return anthropic.ToAnthropicResponsesResponse(resp), nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
 				return anthropic.ToAnthropicChatCompletionError(err)
 			},
 			StreamConfig: &StreamConfig{
 				ResponseConverter: func(resp *schemas.BifrostResponse) (interface{}, error) {
-					return anthropic.ToAnthropicChatCompletionStreamResponse(resp), nil
+					return anthropic.ToAnthropicResponsesStreamResponse(resp), nil
 				},
 				ErrorConverter: func(err *schemas.BifrostError) interface{} {
-					return anthropic.ToAnthropicChatCompletionStreamError(err)
+					return anthropic.ToAnthropicResponsesStreamError(err)
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Implements ResponsesStream support for the Anthropic provider, enabling streaming responses for the Responses API endpoint with Anthropic models.

## Changes

- Added `ResponsesStream` implementation for the Anthropic provider
- Renamed `handleAnthropicStreaming` to `handleAnthropicChatCompletionStreaming` for clarity
- Added `ToBifrostResponsesStream` method to convert Anthropic stream events to Bifrost Responses Stream format
- Added constants for Anthropic content block and delta types
- Reorganized code structure to group related functionality together

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Test the Anthropic provider implementation
go test ./core/providers -run TestAnthropicProvider

# Test the ResponsesStream functionality specifically
go test ./core/providers -run TestAnthropicProvider_ResponsesStream

# Run all tests to ensure no regressions
go test ./...
```

## Breaking changes

- [x] No

## Related issues

Implements part of the Responses API streaming support.

## Security considerations

No new security implications. Uses existing authentication mechanisms.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable