### PR TITLE
feat: added responses stream in cohere

### DIFF
--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -108,44 +108,6 @@ func (provider *CohereProvider) TextCompletionStream(ctx context.Context, postHo
 	return nil, newUnsupportedOperationError("text completion stream", "cohere")
 }
 
-// ChatCompletion performs a chat completion request to the Cohere API using v2 converter.
-// It formats the request, sends it to Cohere, and processes the response.
-// Returns a BifrostResponse containing the completion results or an error if the request fails.
-func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	// Check if chat completion is allowed
-	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
-		return nil, err
-	}
-
-	providerName := provider.GetProviderKey()
-
-	// Convert to Cohere v2 request
-	reqBody := cohere.ToCohereChatCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, providerName)
-	}
-
-	cohereResponse, rawResponse, latency, err := provider.handleCohereChatCompletionRequest(ctx, reqBody, key)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Cohere v2 response to Bifrost response
-	bifrostResponse := cohereResponse.ToBifrostResponse()
-
-	bifrostResponse.Model = request.Model
-	bifrostResponse.ExtraFields.Provider = providerName
-	bifrostResponse.ExtraFields.ModelRequested = request.Model
-	bifrostResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	if provider.sendBackRawResponse {
-		bifrostResponse.ExtraFields.RawResponse = rawResponse
-	}
-
-	return bifrostResponse, nil
-}
-
 func (provider *CohereProvider) handleCohereChatCompletionRequest(ctx context.Context, reqBody *cohere.CohereChatRequest, key schemas.Key) (*cohere.CohereChatResponse, interface{}, time.Duration, *schemas.BifrostError) {
 	providerName := provider.GetProviderKey()
 
@@ -223,18 +185,21 @@ func (provider *CohereProvider) handleCohereChatCompletionRequest(ctx context.Co
 	return &cohereResponse, rawResponse, latency, nil
 }
 
-func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+// ChatCompletion performs a chat completion request to the Cohere API using v2 converter.
+// It formats the request, sends it to Cohere, and processes the response.
+// Returns a BifrostResponse containing the completion results or an error if the request fails.
+func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if chat completion is allowed
-	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
 		return nil, err
 	}
 
 	providerName := provider.GetProviderKey()
 
 	// Convert to Cohere v2 request
-	reqBody := cohere.ToCohereResponsesRequest(request)
+	reqBody := cohere.ToCohereChatCompletionRequest(request)
 	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
+		return nil, newBifrostOperationError("chat completion input is not provided", nil, providerName)
 	}
 
 	cohereResponse, rawResponse, latency, err := provider.handleCohereChatCompletionRequest(ctx, reqBody, key)
@@ -243,98 +208,14 @@ func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, 
 	}
 
 	// Convert Cohere v2 response to Bifrost response
-	bifrostResponse := cohereResponse.ToResponsesBifrostResponse()
+	bifrostResponse := cohereResponse.ToBifrostResponse()
 
 	bifrostResponse.Model = request.Model
 	bifrostResponse.ExtraFields.Provider = providerName
 	bifrostResponse.ExtraFields.ModelRequested = request.Model
-	bifrostResponse.ExtraFields.RequestType = schemas.ResponsesRequest
+	bifrostResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
-	if provider.sendBackRawResponse {
-		bifrostResponse.ExtraFields.RawResponse = rawResponse
-	}
-
-	return bifrostResponse, nil
-}
-
-// Embedding generates embeddings for the given input text(s) using the Cohere API.
-// Supports Cohere's embedding models and returns a BifrostResponse containing the embedding(s).
-func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	// Check if embedding is allowed
-	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.EmbeddingRequest); err != nil {
-		return nil, err
-	}
-
-	providerName := provider.GetProviderKey()
-
-	// Create Bifrost request for conversion
-	reqBody := cohere.ToCohereEmbeddingRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("embedding input is not provided", nil, providerName)
-	}
-
-	// Marshal request body
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
-	// Create request
-	req := fasthttp.AcquireRequest()
-	resp := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseRequest(req)
-	defer fasthttp.ReleaseResponse(resp)
-
-	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
-
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v2/embed")
-	req.Header.SetMethod("POST")
-	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
-
-	req.SetBody(jsonBody)
-
-	// Make request
-	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
-	if bifrostErr != nil {
-		return nil, bifrostErr
-	}
-
-	// Handle error response
-	if resp.StatusCode() != fasthttp.StatusOK {
-		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-
-		var errorResp cohere.CohereError
-		bifrostErr := handleProviderAPIError(resp, &errorResp)
-		bifrostErr.Error.Message = errorResp.Message
-
-		return nil, bifrostErr
-	}
-
-	// Parse response
-	var cohereResp cohere.CohereEmbeddingResponse
-	if err := sonic.Unmarshal(resp.Body(), &cohereResp); err != nil {
-		return nil, newBifrostOperationError("error parsing embedding response", err, providerName)
-	}
-
-	// Parse raw response for consistent format
-	var rawResponse interface{}
-	if err := sonic.Unmarshal(resp.Body(), &rawResponse); err != nil {
-		return nil, newBifrostOperationError("error parsing raw response for embedding", err, providerName)
-	}
-
-	// Create BifrostResponse
-	bifrostResponse := cohereResp.ToBifrostResponse()
-
-	bifrostResponse.Model = request.Model
-	bifrostResponse.ExtraFields.Provider = providerName
-	bifrostResponse.ExtraFields.ModelRequested = request.Model
-	bifrostResponse.ExtraFields.RequestType = schemas.EmbeddingRequest
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	// Only include RawResponse if sendBackRawResponse is enabled
 	if provider.sendBackRawResponse {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
@@ -501,13 +382,9 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 					}
 
 				case cohere.StreamEventContentDelta:
-					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.Content != nil {
+					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.Content != nil && event.Delta.Message.Content.Text != nil {
 						// Try to cast content to CohereStreamContent
-						if contentObj, ok := event.Delta.Message.Content.(map[string]interface{}); ok {
-							if text, exists := contentObj["text"].(string); exists {
-								response.Choices[0].BifrostStreamResponseChoice.Delta.Content = &text
-							}
-						}
+						response.Choices[0].BifrostStreamResponseChoice.Delta.Content = event.Delta.Message.Content.Text
 					}
 
 				case cohere.StreamEventToolPlanDelta:
@@ -519,9 +396,9 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 					// Content start event - just continue, actual content comes in content-delta
 
 				case cohere.StreamEventToolCallStart, cohere.StreamEventToolCallDelta:
-					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.ToolCalls != nil && event.Delta.Message.ToolCalls.ToolCall != nil {
+					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.ToolCalls != nil {
 						// Handle single tool call object (tool-call-start/delta events)
-						cohereToolCall := event.Delta.Message.ToolCalls.ToolCall
+						cohereToolCall := event.Delta.Message.ToolCalls
 						toolCall := schemas.ChatAssistantMessageToolCall{}
 
 						if cohereToolCall.ID != nil {
@@ -606,6 +483,322 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	return responseChan, nil
 }
 
+func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	// Check if chat completion is allowed
+	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+		return nil, err
+	}
+
+	providerName := provider.GetProviderKey()
+
+	// Convert to Cohere v2 request
+	reqBody := cohere.ToCohereResponsesRequest(request)
+	if reqBody == nil {
+		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
+	}
+
+	cohereResponse, rawResponse, latency, err := provider.handleCohereChatCompletionRequest(ctx, reqBody, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Cohere v2 response to Bifrost response
+	bifrostResponse := cohereResponse.ToResponsesBifrostResponse()
+
+	bifrostResponse.Model = request.Model
+	bifrostResponse.ExtraFields.Provider = providerName
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.ResponsesRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if provider.sendBackRawResponse {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
+func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	// Check if responses stream is allowed
+	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
+		return nil, err
+	}
+
+	providerName := provider.GetProviderKey()
+	// Convert to Cohere v2 request and add streaming
+	reqBody := cohere.ToCohereResponsesRequest(request)
+	if reqBody == nil {
+		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
+	}
+	reqBody.Stream = schemas.Ptr(true)
+
+	jsonBody, err := sonic.Marshal(reqBody)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
+	}
+
+	// Create HTTP request for streaming
+	req, err := http.NewRequestWithContext(ctx, "POST", provider.networkConfig.BaseURL+"/v2/chat", bytes.NewReader(jsonBody))
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
+		}
+		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+	}
+
+	// Set headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+key.Value)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	// Set any extra headers from network config
+	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+
+	// Make the request
+	resp, err := provider.streamClient.Do(req)
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
+		}
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderRequest,
+				Error:   err,
+			},
+		}
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, newProviderAPIError(fmt.Sprintf("HTTP error from %s: %d", providerName, resp.StatusCode), fmt.Errorf("%s", string(body)), resp.StatusCode, providerName, nil, nil)
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStream, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer close(responseChan)
+		defer resp.Body.Close()
+
+		scanner := bufio.NewScanner(resp.Body)
+		chunkIndex := 0
+
+		startTime := time.Now()
+		lastChunkTime := startTime
+
+		// Track SSE event parsing state
+		var eventData string
+
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			// Skip empty lines and comments
+			if line == "" || strings.HasPrefix(line, ":") {
+				continue
+			}
+
+			// Parse SSE event - track event data
+			if after, ok := strings.CutPrefix(line, "data: "); ok {
+				eventData = after
+			} else {
+				continue
+			}
+
+			// Skip if we don't have event data
+			if eventData == "" {
+				continue
+			}
+
+			// Handle [DONE] marker
+			if strings.TrimSpace(eventData) == "[DONE]" {
+				provider.logger.Debug("Received [DONE] marker, ending stream")
+				return
+			}
+
+			// Parse the unified streaming event
+			var event cohere.CohereStreamEvent
+			if err := sonic.Unmarshal([]byte(eventData), &event); err != nil {
+				provider.logger.Warn(fmt.Sprintf("Failed to parse stream event: %v", err))
+				continue
+			}
+
+			if chunkIndex == 0 {
+				sendCreatedEventResponsesChunk(ctx, postHookRunner, providerName, request.Model, startTime, responseChan, provider.logger)
+				sendInProgressEventResponsesChunk(ctx, postHookRunner, providerName, request.Model, startTime, responseChan, provider.logger)
+				chunkIndex = 2
+			}
+
+			response, bifrostErr, isLastChunk := event.ToBifrostResponsesStream(chunkIndex)
+			if response != nil {
+				response.ExtraFields = schemas.BifrostResponseExtraFields{
+					RequestType:    schemas.ResponsesStreamRequest,
+					Provider:       providerName,
+					ModelRequested: request.Model,
+					ChunkIndex:     chunkIndex,
+					Latency:        time.Since(lastChunkTime).Milliseconds(),
+				}
+
+				if event.Type == cohere.StreamEventMessageEnd && event.Delta != nil && event.Delta.Usage != nil && event.Delta.Usage.BilledUnits != nil {
+					response.ExtraFields.BilledUsage = &schemas.BilledLLMUsage{}
+					if event.Delta.Usage.BilledUnits.InputTokens != nil {
+						response.ExtraFields.BilledUsage.PromptTokens = event.Delta.Usage.BilledUnits.InputTokens
+					}
+					if event.Delta.Usage.BilledUnits.OutputTokens != nil {
+						response.ExtraFields.BilledUsage.CompletionTokens = event.Delta.Usage.BilledUnits.OutputTokens
+					}
+				}
+				
+				lastChunkTime = time.Now()
+				chunkIndex++
+
+				if provider.sendBackRawResponse {
+					response.ExtraFields.RawResponse = eventData
+				}
+
+				if isLastChunk {
+					if response.ResponsesStreamResponse == nil {
+						response.ResponsesStreamResponse = &schemas.ResponsesStreamResponse{
+							Response: &schemas.ResponsesStreamResponseStruct{},
+						}
+					} else if response.ResponsesStreamResponse.Response == nil {
+						response.ResponsesStreamResponse.Response = &schemas.ResponsesStreamResponseStruct{}
+					}
+					response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+					handleStreamEndWithSuccess(ctx, response, postHookRunner, responseChan, provider.logger)
+					break
+				}
+				processAndSendResponse(ctx, postHookRunner, response, responseChan, provider.logger)
+			}
+			if bifrostErr != nil {
+				bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+					RequestType:    schemas.ResponsesStreamRequest,
+					Provider:       providerName,
+					ModelRequested: request.Model,
+				}
+
+				processAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+				break
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			provider.logger.Warn(fmt.Sprintf("Error reading %s stream: %v", providerName, err))
+			processAndSendError(ctx, postHookRunner, err, responseChan, schemas.ResponsesStreamRequest, providerName, request.Model, provider.logger)
+		}
+	}()
+
+	return responseChan, nil
+}
+
+// Embedding generates embeddings for the given input text(s) using the Cohere API.
+// Supports Cohere's embedding models and returns a BifrostResponse containing the embedding(s).
+func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	// Check if embedding is allowed
+	if err := checkOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.EmbeddingRequest); err != nil {
+		return nil, err
+	}
+
+	providerName := provider.GetProviderKey()
+
+	// Create Bifrost request for conversion
+	reqBody := cohere.ToCohereEmbeddingRequest(request)
+	if reqBody == nil {
+		return nil, newBifrostOperationError("embedding input is not provided", nil, providerName)
+	}
+
+	// Marshal request body
+	jsonBody, err := sonic.Marshal(reqBody)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
+	}
+
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set any extra headers from network config
+	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + "/v2/embed")
+	req.Header.SetMethod("POST")
+	req.Header.SetContentType("application/json")
+	req.Header.Set("Authorization", "Bearer "+key.Value)
+
+	req.SetBody(jsonBody)
+
+	// Make request
+	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
+
+		var errorResp cohere.CohereError
+		bifrostErr := handleProviderAPIError(resp, &errorResp)
+		bifrostErr.Error.Message = errorResp.Message
+
+		return nil, bifrostErr
+	}
+
+	// Parse response
+	var cohereResp cohere.CohereEmbeddingResponse
+	if err := sonic.Unmarshal(resp.Body(), &cohereResp); err != nil {
+		return nil, newBifrostOperationError("error parsing embedding response", err, providerName)
+	}
+
+	// Parse raw response for consistent format
+	var rawResponse interface{}
+	if err := sonic.Unmarshal(resp.Body(), &rawResponse); err != nil {
+		return nil, newBifrostOperationError("error parsing raw response for embedding", err, providerName)
+	}
+
+	// Create BifrostResponse
+	bifrostResponse := cohereResp.ToBifrostResponse()
+
+	bifrostResponse.Model = request.Model
+	bifrostResponse.ExtraFields.Provider = providerName
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.EmbeddingRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	// Only include RawResponse if sendBackRawResponse is enabled
+	if provider.sendBackRawResponse {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
 func (provider *CohereProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("speech", "cohere")
 }
@@ -620,8 +813,4 @@ func (provider *CohereProvider) Transcription(ctx context.Context, key schemas.K
 
 func (provider *CohereProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, newUnsupportedOperationError("transcription stream", "cohere")
-}
-
-func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("responses stream", "cohere")
 }

--- a/core/providers/gemini.go
+++ b/core/providers/gemini.go
@@ -208,6 +208,15 @@ func (provider *GeminiProvider) Responses(ctx context.Context, key schemas.Key, 
 	return response, nil
 }
 
+func (provider *GeminiProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return provider.ChatCompletionStream(
+		ctx,
+		getResponsesChunkConverterCombinedPostHookRunner(postHookRunner),
+		key,
+		request.ToChatRequest(),
+	)
+}
+
 // Embedding performs an embedding request to the Gemini API.
 func (provider *GeminiProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
 	// Check if embedding is allowed for this provider
@@ -914,8 +923,4 @@ func parseGeminiError(providerName schemas.ModelProvider, resp *fasthttp.Respons
 	}
 
 	return newBifrostOperationError(fmt.Sprintf("Gemini error: %v", errorResp), fmt.Errorf("HTTP %d", resp.StatusCode()), providerName)
-}
-
-func (provider *GeminiProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("responses stream", "gemini")
 }

--- a/core/schemas/providers/cohere/embedding.go
+++ b/core/schemas/providers/cohere/embedding.go
@@ -110,15 +110,14 @@ func (cohereResp *CohereEmbeddingResponse) ToBifrostResponse() *schemas.BifrostR
 	// Convert usage information
 	if cohereResp.Meta != nil {
 		if cohereResp.Meta.Tokens != nil {
-			usage := &schemas.LLMUsage{}
+			bifrostResponse.Usage = &schemas.LLMUsage{}
 			if cohereResp.Meta.Tokens.InputTokens != nil {
-				usage.PromptTokens = int(*cohereResp.Meta.Tokens.InputTokens)
+				bifrostResponse.Usage.PromptTokens = int(*cohereResp.Meta.Tokens.InputTokens)
 			}
 			if cohereResp.Meta.Tokens.OutputTokens != nil {
-				usage.CompletionTokens = int(*cohereResp.Meta.Tokens.OutputTokens)
+				bifrostResponse.Usage.CompletionTokens = int(*cohereResp.Meta.Tokens.OutputTokens)
 			}
-			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
-			bifrostResponse.Usage = usage
+			bifrostResponse.Usage.TotalTokens = bifrostResponse.Usage.PromptTokens + bifrostResponse.Usage.CompletionTokens
 		}
 
 		// Convert billed usage

--- a/core/schemas/providers/cohere/types.go
+++ b/core/schemas/providers/cohere/types.go
@@ -9,22 +9,22 @@ import (
 
 // CohereChatRequest represents a Cohere  chat completion request
 type CohereChatRequest struct {
-	Model            string                   `json:"model"`                        // Required: Model to use for chat completion
-	Messages         []CohereMessage          `json:"messages"`                     // Required: Array of message objects
+	Model            string                  `json:"model"`                        // Required: Model to use for chat completion
+	Messages         []CohereMessage         `json:"messages"`                     // Required: Array of message objects
 	Tools            []CohereChatRequestTool `json:"tools,omitempty"`              // Optional: Tools available for the model
-	ToolChoice       *CohereToolChoice        `json:"tool_choice,omitempty"`        // Optional: Tool choice configuration
-	Temperature      *float64                 `json:"temperature,omitempty"`        // Optional: Sampling temperature
-	P                *float64                 `json:"p,omitempty"`                  // Optional: Top-p sampling
-	K                *int                     `json:"k,omitempty"`                  // Optional: Top-k sampling
-	MaxTokens        *int                     `json:"max_tokens,omitempty"`         // Optional: Maximum tokens to generate
+	ToolChoice       *CohereToolChoice       `json:"tool_choice,omitempty"`        // Optional: Tool choice configuration
+	Temperature      *float64                `json:"temperature,omitempty"`        // Optional: Sampling temperature
+	P                *float64                `json:"p,omitempty"`                  // Optional: Top-p sampling
+	K                *int                    `json:"k,omitempty"`                  // Optional: Top-k sampling
+	MaxTokens        *int                    `json:"max_tokens,omitempty"`         // Optional: Maximum tokens to generate
 	StopSequences    []string                `json:"stop_sequences,omitempty"`     // Optional: Stop sequences
-	FrequencyPenalty *float64                 `json:"frequency_penalty,omitempty"`  // Optional: Frequency penalty
-	PresencePenalty  *float64                 `json:"presence_penalty,omitempty"`   // Optional: Presence penalty
-	Stream           *bool                    `json:"stream,omitempty"`             // Optional: Enable streaming
-	SafetyMode       *string                  `json:"safety_mode,omitempty"`        // Optional: Safety mode
-	LogProbs         *bool                    `json:"log_probs,omitempty"`          // Optional: Log probabilities
-	StrictToolChoice *bool                    `json:"strict_tool_choice,omitempty"` // Optional: Strict tool choice
-	Thinking         *CohereThinking          `json:"thinking,omitempty"`           // Optional: Reasoning configuration
+	FrequencyPenalty *float64                `json:"frequency_penalty,omitempty"`  // Optional: Frequency penalty
+	PresencePenalty  *float64                `json:"presence_penalty,omitempty"`   // Optional: Presence penalty
+	Stream           *bool                   `json:"stream,omitempty"`             // Optional: Enable streaming
+	SafetyMode       *string                 `json:"safety_mode,omitempty"`        // Optional: Safety mode
+	LogProbs         *bool                   `json:"log_probs,omitempty"`          // Optional: Log probabilities
+	StrictToolChoice *bool                   `json:"strict_tool_choice,omitempty"` // Optional: Strict tool choice
+	Thinking         *CohereThinking         `json:"thinking,omitempty"`           // Optional: Reasoning configuration
 }
 
 type CohereChatRequestTool struct {
@@ -42,7 +42,7 @@ type CohereChatRequestFunction struct {
 type CohereMessage struct {
 	Role       string                `json:"role"`                   // Required: Message role (system, user, assistant, tool)
 	Content    *CohereMessageContent `json:"content,omitempty"`      // Optional: Message content (string or array of content blocks)
-	ToolCalls  []CohereToolCall     `json:"tool_calls,omitempty"`   // Optional: Tool calls (for assistant messages)
+	ToolCalls  []CohereToolCall      `json:"tool_calls,omitempty"`   // Optional: Tool calls (for assistant messages)
 	ToolCallID *string               `json:"tool_call_id,omitempty"` // Optional: Tool call ID (for tool messages)
 	ToolPlan   *string               `json:"tool_plan,omitempty"`    // Optional: Chain-of-thought style reflection (assistant only)
 }
@@ -50,7 +50,7 @@ type CohereMessage struct {
 // CohereMessageContent represents flexible content that can be string or content blocks
 type CohereMessageContent struct {
 	// Use custom marshaling to handle string or []CohereContentBlock
-	StringContent *string               `json:"-"`
+	StringContent *string              `json:"-"`
 	BlocksContent []CohereContentBlock `json:"-"`
 }
 
@@ -212,15 +212,15 @@ type CohereTool struct {
 
 // CohereEmbeddingRequest represents a Cohere embedding request
 type CohereEmbeddingRequest struct {
-	Model           string                  `json:"model"`                      // Required: ID of embedding model
-	InputType       string                  `json:"input_type"`                 // Required: Type of input for v3+ models
+	Model           string                 `json:"model"`                      // Required: ID of embedding model
+	InputType       string                 `json:"input_type"`                 // Required: Type of input for v3+ models
 	Texts           []string               `json:"texts,omitempty"`            // Optional: Array of strings to embed (max 96)
 	Images          []string               `json:"images,omitempty"`           // Optional: Array of image data URIs (max 1)
 	Inputs          []CohereEmbeddingInput `json:"inputs,omitempty"`           // Optional: Array of mixed text/image inputs (max 96)
-	MaxTokens       *int                    `json:"max_tokens,omitempty"`       // Optional: Max tokens to embed per input
-	OutputDimension *int                    `json:"output_dimension,omitempty"` // Optional: Embedding dimensions (256, 512, 1024, 1536)
+	MaxTokens       *int                   `json:"max_tokens,omitempty"`       // Optional: Max tokens to embed per input
+	OutputDimension *int                   `json:"output_dimension,omitempty"` // Optional: Embedding dimensions (256, 512, 1024, 1536)
 	EmbeddingTypes  []string               `json:"embedding_types,omitempty"`  // Optional: Types of embeddings to return
-	Truncate        *string                 `json:"truncate,omitempty"`         // Optional: How to handle long inputs
+	Truncate        *string                `json:"truncate,omitempty"`         // Optional: How to handle long inputs
 }
 
 // CohereEmbeddingInput represents a mixed text/image input
@@ -230,12 +230,12 @@ type CohereEmbeddingInput struct {
 
 // CohereEmbeddingResponse represents a Cohere embedding response
 type CohereEmbeddingResponse struct {
-	ID           string                      `json:"id"`                      // Response ID
-	Embeddings   *CohereEmbeddingData        `json:"embeddings,omitempty"`    // Embedding data object
-	ResponseType *string                     `json:"response_type,omitempty"` // Response type (embeddings_floats, embeddings_by_type)
+	ID           string                     `json:"id"`                      // Response ID
+	Embeddings   *CohereEmbeddingData       `json:"embeddings,omitempty"`    // Embedding data object
+	ResponseType *string                    `json:"response_type,omitempty"` // Response type (embeddings_floats, embeddings_by_type)
 	Texts        []string                   `json:"texts,omitempty"`         // Original text entries
 	Images       []CohereEmbeddingImageInfo `json:"images,omitempty"`        // Original image entries
-	Meta         *CohereEmbeddingMeta        `json:"meta,omitempty"`          // Response metadata
+	Meta         *CohereEmbeddingMeta       `json:"meta,omitempty"`          // Response metadata
 }
 
 // CohereEmbeddingData represents the embeddings object with different types
@@ -261,7 +261,7 @@ type CohereEmbeddingMeta struct {
 	APIVersion  *CohereEmbeddingAPIVersion `json:"api_version,omitempty"`  // API version info
 	BilledUnits *CohereBilledUnits         `json:"billed_units,omitempty"` // Billing information
 	Tokens      *CohereTokenUsage          `json:"tokens,omitempty"`       // Token usage
-	Warnings    []string                  `json:"warnings,omitempty"`     // Any warnings
+	Warnings    []string                   `json:"warnings,omitempty"`     // Any warnings
 }
 
 // CohereEmbeddingAPIVersion represents API version information
@@ -279,7 +279,7 @@ type CohereChatResponse struct {
 	FinishReason *CohereFinishReason `json:"finish_reason,omitempty"` // Reason for completion
 	Message      *CohereMessage      `json:"message,omitempty"`       // Generated message from assistant
 	Usage        *CohereUsage        `json:"usage,omitempty"`         // Token usage information
-	LogProbs     []CohereLogProb    `json:"logprobs,omitempty"`      // Log probabilities (if requested)
+	LogProbs     []CohereLogProb     `json:"logprobs,omitempty"`      // Log probabilities (if requested)
 }
 
 // CohereFinishReason represents the reason a chat request has finished
@@ -295,8 +295,9 @@ const (
 
 // CohereUsage represents token usage information
 type CohereUsage struct {
-	BilledUnits *CohereBilledUnits `json:"billed_units,omitempty"` // Billed usage information
-	Tokens      *CohereTokenUsage  `json:"tokens,omitempty"`       // Token usage details
+	BilledUnits  *CohereBilledUnits `json:"billed_units,omitempty"`  // Billed usage information
+	Tokens       *CohereTokenUsage  `json:"tokens,omitempty"`        // Token usage details
+	CachedTokens *float64           `json:"cached_tokens,omitempty"` // Cached tokens
 }
 
 // CohereBilledUnits represents billed usage information
@@ -309,30 +310,49 @@ type CohereBilledUnits struct {
 
 // CohereTokenUsage represents detailed token usage
 type CohereTokenUsage struct {
-	InputTokens  *float64 `json:"input_tokens,omitempty"`  // Number of input tokens used
-	OutputTokens *float64 `json:"output_tokens,omitempty"` // Number of output tokens produced
+	InputTokens  *float64 `json:"input_tokens"`  // Number of input tokens used
+	OutputTokens *float64 `json:"output_tokens"` // Number of output tokens produced
 }
 
 // CohereLogProb represents log probability information
 type CohereLogProb struct {
-	TokenIDs []int      `json:"token_ids"`          // Token IDs of each token in text chunk
-	Text     *string    `json:"text,omitempty"`     // Text chunk for log probabilities
+	TokenIDs []int     `json:"token_ids"`          // Token IDs of each token in text chunk
+	Text     *string   `json:"text,omitempty"`     // Text chunk for log probabilities
 	LogProbs []float64 `json:"logprobs,omitempty"` // Log probability of each token
 }
 
+type CohereCitationType string
+
+const (
+	CitationTypeTextContent     CohereCitationType = "TEXT_CONTENT"
+	CitationTypeThinkingContent CohereCitationType = "THINKING_CONTENT"
+	CitationTypePlan            CohereCitationType = "PLAN"
+)
+
+type CohereSourceType string
+
+const (
+	SourceTypeTool     CohereSourceType = "tool"
+	SourceTypeDocument CohereSourceType = "document"
+)
+
+
 // CohereCitation represents a citation in the response
 type CohereCitation struct {
-	Start   int             `json:"start"`             // Start position of cited text
-	End     int             `json:"end"`               // End position of cited text
-	Text    string          `json:"text"`              // Cited text
-	Sources []CohereSource `json:"sources,omitempty"` // Citation sources
+	Start        int                `json:"start"`             // Start position of cited text
+	End          int                `json:"end"`               // End position of cited text
+	Text         string             `json:"text"`              // Cited text
+	Sources      []CohereSource     `json:"sources,omitempty"` // Citation sources
+	ContentIndex int                `json:"content_index"`     // Content index of the citation
+	Type         CohereCitationType `json:"type"`              // Type of citation
 }
 
 // CohereSource represents a citation source
 type CohereSource struct {
-	Type       string      `json:"type"`                  // Source type (tool, document)
-	ID         string      `json:"id"`                    // Source ID
-	ToolOutput interface{} `json:"tool_output,omitempty"` // Tool output (for tool sources)
+	Type       CohereSourceType       `json:"type"`                  // Source type ("tool" or "document")
+	ID         *string                `json:"id,omitempty"`          // Source ID (nullable)
+	ToolOutput *map[string]any 		  `json:"tool_output,omitempty"` // Tool output (for tool sources)
+	Document   *map[string]any        `json:"document,omitempty"`    // Document data (for document sources)
 }
 
 // ==================== STREAMING TYPES ====================
@@ -372,41 +392,17 @@ type CohereStreamDelta struct {
 
 // CohereStreamMessage represents the message part of streaming deltas
 type CohereStreamMessage struct {
-	Role      *string          `json:"role,omitempty"`       // For message-start
-	Content   interface{}      `json:"content,omitempty"`    // For content events (can be array [] or object)
-	ToolPlan  *string          `json:"tool_plan,omitempty"`  // For tool-plan-delta
-	ToolCalls *CohereToolCalls `json:"tool_calls,omitempty"` // For tool-call events (flexible)
-}
-
-// CohereFlexibleToolCalls handles both array and single object tool calls
-type CohereToolCalls struct {
-	ToolCall      *CohereToolCall  // For tool-call-start/delta (single object)
-	ToolCallArray []CohereToolCall // For message-start (array)
-}
-
-// UnmarshalJSON handles both array [] and single object {} for tool calls
-func (tc *CohereToolCalls) UnmarshalJSON(data []byte) error {
-	// Try array first (message-start case)
-	var array []CohereToolCall
-	if err := json.Unmarshal(data, &array); err == nil {
-		tc.ToolCallArray = array
-		return nil
-	}
-
-	// Try single object (tool-call-start/delta case)
-	var single CohereToolCall
-	if err := json.Unmarshal(data, &single); err == nil {
-		tc.ToolCall = &single
-		return nil
-	}
-
-	return fmt.Errorf("tool_calls must be array or object")
+	Role      *string              `json:"role,omitempty"`       // For message-start
+	Content   *CohereStreamContent `json:"content,omitempty"`    // For content events (object)
+	ToolPlan  *string              `json:"tool_plan,omitempty"`  // For tool-plan-delta
+	ToolCalls *CohereToolCall      `json:"tool_calls,omitempty"` // For tool-call events (flexible)
+	Citations *CohereCitation      `json:"citations,omitempty"`  // For citation events
 }
 
 // CohereStreamContent represents content in streaming events
 type CohereStreamContent struct {
-	Type *string `json:"type,omitempty"` // For content-start
-	Text *string `json:"text,omitempty"` // For content deltas
+	Type CohereContentBlockType `json:"type,omitempty"` // For content-start
+	Text *string                `json:"text,omitempty"` // For content deltas
 }
 
 // ==================== ERROR TYPES ====================

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -670,6 +670,7 @@ type ResponsesOutputMessageContentTextAnnotation struct {
 	Type        string  `json:"type"`                  // "file_citation" | "url_citation" | "container_file_citation" | "file_path"
 	Index       *int    `json:"index,omitempty"`       // Common index field (FileCitation, FilePath)
 	FileID      *string `json:"file_id,omitempty"`     // Common file ID field (FileCitation, ContainerFileCitation, FilePath)
+	Text        *string `json:"text,omitempty"`        // Text of the citation
 	StartIndex  *int    `json:"start_index,omitempty"` // Common start index field (URLCitation, ContainerFileCitation)
 	EndIndex    *int    `json:"end_index,omitempty"`   // Common end index field (URLCitation, ContainerFileCitation)
 	Filename    *string `json:"filename,omitempty"`


### PR DESCRIPTION
## Summary

Implement Cohere ResponsesStream support and refactor token usage handling to improve reliability and reduce code duplication.

## Changes

- Added ResponsesStream implementation for Cohere provider
- Refactored token usage handling to use non-pointer float64 values
- Fixed content and tool call handling in streaming responses
- Simplified delta message content handling in stream events
- Reorganized code structure for better readability and maintainability

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Cohere provider with ResponsesStream functionality:

```sh
# Core/Transports
go version
go test ./...

# Test ResponsesStream with Cohere
curl -X POST "http://localhost:8000/v1/providers/cohere/responses-stream" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -d '{
    "model": "command",
    "messages": [
      {"role": "user", "content": "Tell me about quantum computing"}
    ]
  }'
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Implements ResponsesStream support for Cohere provider

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable