### PR TITLE
Add responses streaming support to OTEL accumulator

### DIFF
--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -1,0 +1,212 @@
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// processResponsesStreamingResponse processes a responses streaming response
+func (a *Accumulator) processResponsesStreamingResponse(ctx *context.Context, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*ProcessedStreamResponse, error) {
+	requestID, ok := (*ctx).Value(schemas.BifrostContextKeyRequestID).(string)
+	if !ok || requestID == "" {
+		return nil, fmt.Errorf("request-id not found in context or is empty")
+	}
+
+	requestType, provider, model := bifrost.GetRequestFields(result, bifrostErr)
+	if requestType != schemas.ResponsesStreamRequest {
+		return nil, fmt.Errorf("invalid request type for responses streaming: %s", requestType)
+	}
+
+	isFinalChunk := bifrost.IsFinalChunk(ctx)
+	chunk := a.getResponsesStreamChunk()
+	chunk.Timestamp = time.Now()
+	chunk.ErrorDetails = bifrostErr
+
+	if result != nil && result.ResponsesStreamResponse != nil {
+		if cloned, err := cloneResponsesStreamResponse(result.ResponsesStreamResponse); err != nil {
+			a.logger.Warn("[streaming] failed to clone responses stream event: %v", err)
+			chunk.Event = result.ResponsesStreamResponse
+		} else {
+			chunk.Event = cloned
+		}
+
+		if usage := extractResponsesUsage(result, chunk.Event); usage != nil {
+			chunk.TokenUsage = usage
+		}
+	}
+
+	if result != nil && isFinalChunk {
+		if a.pricingManager != nil {
+			cost := a.pricingManager.CalculateCostWithCacheDebug(result)
+			chunk.Cost = bifrost.Ptr(cost)
+		}
+		chunk.SemanticCacheDebug = result.ExtraFields.CacheDebug
+	}
+
+	object := string(StreamTypeResponses)
+	if result != nil && result.Object != "" {
+		object = result.Object
+	}
+
+	if err := a.addResponsesStreamChunk(requestID, chunk, object, isFinalChunk); err != nil {
+		return nil, fmt.Errorf("failed to add responses stream chunk for request %s: %w", requestID, err)
+	}
+
+	if !isFinalChunk {
+		return nil, nil
+	}
+
+	shouldProcess := false
+	accumulator := a.getOrCreateStreamAccumulator(requestID)
+	accumulator.mu.Lock()
+	if !accumulator.IsComplete {
+		accumulator.IsComplete = true
+		shouldProcess = true
+	}
+	accumulator.mu.Unlock()
+
+	if !shouldProcess {
+		return nil, nil
+	}
+
+	data, err := a.processAccumulatedResponsesStreamingChunks(requestID, model, bifrostErr, isFinalChunk)
+	if err != nil {
+		a.logger.Error("failed to process accumulated responses chunks for request %s: %v", requestID, err)
+		return nil, err
+	}
+
+	return &ProcessedStreamResponse{
+		Type:       StreamResponseTypeFinal,
+		RequestID:  requestID,
+		StreamType: StreamTypeResponses,
+		Provider:   provider,
+		Model:      model,
+		Data:       data,
+	}, nil
+}
+
+func (a *Accumulator) processAccumulatedResponsesStreamingChunks(requestID, model string, respErr *schemas.BifrostError, isFinalChunk bool) (*AccumulatedData, error) {
+	accumulator := a.getOrCreateStreamAccumulator(requestID)
+	accumulator.mu.Lock()
+	defer accumulator.mu.Unlock()
+	if isFinalChunk {
+		defer a.cleanupStreamAccumulator(requestID)
+	}
+
+	data := &AccumulatedData{
+		RequestID:      requestID,
+		Model:          model,
+		Status:         "success",
+		Stream:         true,
+		StartTimestamp: accumulator.StartTimestamp,
+		EndTimestamp:   accumulator.FinalTimestamp,
+		ErrorDetails:   respErr,
+		Object:         accumulator.Object,
+	}
+
+	if data.Object == "" {
+		data.Object = string(StreamTypeResponses)
+	}
+
+	if respErr != nil {
+		data.Status = "error"
+	}
+
+	if !accumulator.StartTimestamp.IsZero() && !accumulator.FinalTimestamp.IsZero() {
+		data.Latency = accumulator.FinalTimestamp.Sub(accumulator.StartTimestamp).Nanoseconds() / 1e6
+	}
+
+	if len(accumulator.ResponsesStreamChunks) == 0 {
+		return data, nil
+	}
+
+	lastChunk := accumulator.ResponsesStreamChunks[len(accumulator.ResponsesStreamChunks)-1]
+	if lastChunk.TokenUsage != nil {
+		data.TokenUsage = lastChunk.TokenUsage
+	}
+	if lastChunk.SemanticCacheDebug != nil {
+		data.CacheDebug = lastChunk.SemanticCacheDebug
+	}
+	if lastChunk.Cost != nil {
+		data.Cost = lastChunk.Cost
+	}
+
+	if lastChunk.Event != nil && lastChunk.Event.Response != nil {
+		data.ResponsesOutput = lastChunk.Event.Response.ResponsesResponse
+		if data.TokenUsage == nil {
+			data.TokenUsage = convertResponsesUsage(lastChunk.Event.Response.Usage)
+		}
+	}
+
+	// Derive output message/tool calls for logging convenience
+	if data.ResponsesOutput != nil && len(data.ResponsesOutput.Output) > 0 {
+		chatMessages := schemas.ToChatMessages(data.ResponsesOutput.Output)
+		if len(chatMessages) > 0 {
+			lastMessage := chatMessages[len(chatMessages)-1]
+			data.OutputMessage = &lastMessage
+			if lastMessage.ChatAssistantMessage != nil && lastMessage.ChatAssistantMessage.ToolCalls != nil {
+				data.ToolCalls = lastMessage.ChatAssistantMessage.ToolCalls
+			}
+		}
+	}
+
+	return data, nil
+}
+
+func cloneResponsesStreamResponse(event *schemas.ResponsesStreamResponse) (*schemas.ResponsesStreamResponse, error) {
+	if event == nil {
+		return nil, nil
+	}
+
+	payload, err := sonic.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+
+	var cloned schemas.ResponsesStreamResponse
+	if err := sonic.Unmarshal(payload, &cloned); err != nil {
+		return nil, err
+	}
+
+	return &cloned, nil
+}
+
+func extractResponsesUsage(result *schemas.BifrostResponse, event *schemas.ResponsesStreamResponse) *schemas.LLMUsage {
+	if result != nil && result.Usage != nil && result.Usage.TotalTokens > 0 {
+		return result.Usage
+	}
+
+	if event != nil && event.Response != nil {
+		return convertResponsesUsage(event.Response.Usage)
+	}
+	return nil
+}
+
+func convertResponsesUsage(usage *schemas.ResponsesResponseUsage) *schemas.LLMUsage {
+	if usage == nil {
+		return nil
+	}
+
+	llmUsage := &schemas.LLMUsage{
+		ResponsesExtendedResponseUsage: usage.ResponsesExtendedResponseUsage,
+	}
+
+	if usage.ResponsesExtendedResponseUsage != nil {
+		llmUsage.PromptTokens = usage.ResponsesExtendedResponseUsage.InputTokens
+		llmUsage.CompletionTokens = usage.ResponsesExtendedResponseUsage.OutputTokens
+	}
+
+	if usage.TotalTokens != 0 {
+		llmUsage.TotalTokens = usage.TotalTokens
+	} else {
+		llmUsage.TotalTokens = llmUsage.PromptTokens + llmUsage.CompletionTokens
+	}
+
+	return llmUsage
+}

--- a/framework/streaming/responses_test.go
+++ b/framework/streaming/responses_test.go
@@ -1,0 +1,114 @@
+package streaming
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestProcessResponsesStreamingResponse_FinalChunkProducesUsage(t *testing.T) {
+	acc := NewAccumulator(nil, bifrost.NewDefaultLogger(schemas.LogLevelInfo))
+
+	baseCtx := context.Background()
+	baseCtx = context.WithValue(baseCtx, schemas.BifrostContextKeyRequestID, "req-123")
+
+	// Simulate a non-final chunk
+	nonFinalCtx := baseCtx
+	resultChunk := &schemas.BifrostResponse{
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType:    schemas.ResponsesStreamRequest,
+			Provider:       schemas.OpenAI,
+			ModelRequested: "gpt-4.1",
+			ChunkIndex:     1,
+		},
+		ResponsesStreamResponse: &schemas.ResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
+			SequenceNumber: 1,
+			Response:       &schemas.ResponsesStreamResponseStruct{},
+		},
+	}
+
+	if resp, err := acc.processResponsesStreamingResponse(&nonFinalCtx, resultChunk, nil); err != nil {
+		t.Fatalf("processResponsesStreamingResponse (non-final) returned error: %v", err)
+	} else if resp != nil {
+		t.Fatalf("expected nil response for non-final chunk, got %#v", resp)
+	}
+
+	// Simulate the final chunk with usage information
+	finalCtx := context.WithValue(baseCtx, schemas.BifrostContextKeyStreamEndIndicator, true)
+	finalUsage := &schemas.ResponsesResponseUsage{
+		ResponsesExtendedResponseUsage: &schemas.ResponsesExtendedResponseUsage{
+			InputTokens:  5,
+			OutputTokens: 7,
+		},
+		TotalTokens: 12,
+	}
+	finalResponse := &schemas.ResponsesResponse{
+		Output: []schemas.ResponsesMessage{
+			{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("final answer"),
+				},
+			},
+		},
+		CreatedAt: int(time.Now().Unix()),
+	}
+
+	finalChunk := &schemas.BifrostResponse{
+		Model: "gpt-4.1",
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType:    schemas.ResponsesStreamRequest,
+			Provider:       schemas.OpenAI,
+			ModelRequested: "gpt-4.1",
+			ChunkIndex:     2,
+		},
+		ResponsesStreamResponse: &schemas.ResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeCompleted,
+			SequenceNumber: 2,
+			Response: &schemas.ResponsesStreamResponseStruct{
+				ResponsesResponse: finalResponse,
+				Usage:             finalUsage,
+			},
+		},
+	}
+
+	streamResp, err := acc.processResponsesStreamingResponse(&finalCtx, finalChunk, nil)
+	if err != nil {
+		t.Fatalf("processResponsesStreamingResponse (final) returned error: %v", err)
+	}
+	if streamResp == nil {
+		t.Fatalf("expected processed stream response for final chunk, got nil")
+	}
+	if streamResp.Type != StreamResponseTypeFinal {
+		t.Fatalf("expected final stream response type, got %s", streamResp.Type)
+	}
+	if streamResp.Data == nil {
+		t.Fatalf("expected accumulated data in stream response")
+	}
+	if streamResp.Data.ResponsesOutput == nil {
+		t.Fatalf("expected responses output in accumulated data")
+	}
+	if streamResp.Data.TokenUsage == nil {
+		t.Fatalf("expected token usage in accumulated data")
+	}
+	if streamResp.Data.TokenUsage.TotalTokens != 12 {
+		t.Fatalf("expected total tokens 12, got %d", streamResp.Data.TokenUsage.TotalTokens)
+	}
+	if streamResp.Data.OutputMessage == nil || streamResp.Data.OutputMessage.Content == nil || streamResp.Data.OutputMessage.Content.ContentStr == nil {
+		t.Fatalf("expected output message to be derived from responses output")
+	}
+
+	// Ensure ToBifrostResponse materialises usage and responses payload
+	bifrostResp := streamResp.ToBifrostResponse()
+	if bifrostResp.Usage == nil || bifrostResp.Usage.TotalTokens != 12 {
+		t.Fatalf("expected bifrost response usage total tokens to be 12")
+	}
+	if bifrostResp.ResponsesResponse == nil || len(bifrostResp.ResponsesResponse.Output) == 0 {
+		t.Fatalf("expected bifrost response to contain responses output")
+	}
+}


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [X] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

## How to test

```sh
  # Make sure framework resolves the in-repo core module
  go work init ./core ./framework

  # Run the streaming unit tests that cover the new accumulator path
  cd framework
  go test ./streaming
  go test ./streaming -run TestProcessResponsesStreamingResponse_FinalChunkProducesUsage

  # (Optional) remove the temporary workspace file once you’re done
  rm ../go.work
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [X] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [X] I read `docs/contributing/README.md` and followed the guidelines
- [X] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [X] I verified builds succeed (Go and UI)
- [X] I verified the CI pipeline passes locally if applicable


