### PR TITLE
fix: finish reason mapping for bedrock

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -444,7 +444,7 @@ func handleAnthropicChatCompletionStreaming(
 				}
 			}
 			if event.Delta != nil && event.Delta.StopReason != nil {
-				mappedReason := anthropic.MapAnthropicFinishReasonToBifrost(*event.Delta.StopReason)
+				mappedReason := schemas.MapProviderFinishReasonToBifrost(*event.Delta.StopReason, providerType)
 				finishReason = &mappedReason
 			}
 			if event.Message != nil {

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -563,7 +563,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 				}
 
 				if streamEvent.StopReason != nil {
-					finishReason = streamEvent.StopReason
+					finishReason = schemas.Ptr(schemas.MapProviderFinishReasonToBifrost(*streamEvent.StopReason, providerName))
 				}
 
 				response, bifrostErr, _ := streamEvent.ToBifrostChatCompletionStream()

--- a/core/schemas/providers/anthropic/chat.go
+++ b/core/schemas/providers/anthropic/chat.go
@@ -339,7 +339,7 @@ func (response *AnthropicMessageResponse) ToBifrostResponse() *schemas.BifrostRe
 		},
 		FinishReason: func() *string {
 			if response.StopReason != nil && *response.StopReason != "" {
-				mapped := MapAnthropicFinishReasonToBifrost(*response.StopReason)
+				mapped := schemas.MapProviderFinishReasonToBifrost(*response.StopReason, schemas.Anthropic)
 				return &mapped
 			}
 			return nil
@@ -622,7 +622,7 @@ func ToAnthropicChatCompletionResponse(bifrostResp *schemas.BifrostResponse) *An
 		choice := bifrostResp.Choices[0] // Anthropic typically returns one choice
 
 		if choice.FinishReason != nil {
-			mappedReason := schemas.MapFinishReasonToProvider(*choice.FinishReason, schemas.Anthropic)
+			mappedReason := schemas.MapBifrostFinishReasonToProvider(*choice.FinishReason, schemas.Anthropic)
 			anthropicResp.StopReason = &mappedReason
 		}
 		if choice.StopString != nil {
@@ -883,7 +883,7 @@ func ToAnthropicChatCompletionStreamResponse(bifrostResp *schemas.BifrostRespons
 				}
 			} else if choice.FinishReason != nil && *choice.FinishReason != "" {
 				// Handle finish reason - map back to Anthropic format
-				stopReason := schemas.MapFinishReasonToProvider(*choice.FinishReason, schemas.Anthropic)
+				stopReason := schemas.MapBifrostFinishReasonToProvider(*choice.FinishReason, schemas.Anthropic)
 				streamResp.Type = "message_delta"
 				streamResp.Delta = &AnthropicStreamDelta{
 					Type:       "message_delta",

--- a/core/schemas/providers/anthropic/utils.go
+++ b/core/schemas/providers/anthropic/utils.go
@@ -4,45 +4,6 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-var (
-	finishReasonMap = map[string]string{
-		"end_turn":      "stop",
-		"max_tokens":    "length",
-		"stop_sequence": "stop",
-		"tool_use":      "tool_calls",
-	}
-
-	// reverseFinishReasonMap = func() map[string]string {
-	// 	m := make(map[string]string, len(finishReasonMap))
-	// 	for k, v := range finishReasonMap {
-	// 		m[v] = k
-	// 	}
-	// 	return m
-	// }()
-
-	reverseFinishReasonMap = map[string]string{
-		"stop":       "end_turn", // canonical default
-		"length":     "max_tokens",
-		"tool_calls": "tool_use",
-	}
-)
-
-// MapAnthropicFinishReasonToOpenAI maps Anthropic finish reasons to OpenAI-compatible ones
-func MapAnthropicFinishReasonToBifrost(anthropicReason string) string {
-	if _, ok := finishReasonMap[anthropicReason]; ok {
-		return finishReasonMap[anthropicReason]
-	}
-	return anthropicReason
-}
-
-// MapBifrostFinishReasonToAnthropic maps Bifrost finish reasons back to Anthropic
-func MapBifrostFinishReasonToAnthropic(bifrostReason string) string {
-	if mapped, ok := reverseFinishReasonMap[bifrostReason]; ok {
-		return mapped
-	}
-	return bifrostReason
-}
-
 // ConvertToAnthropicImageBlock converts a Bifrost image block to Anthropic format
 // Uses the same pattern as the original buildAnthropicImageSourceMap function
 func ConvertToAnthropicImageBlock(block schemas.ChatContentBlock) AnthropicContentBlock {

--- a/core/schemas/providers/bedrock/chat.go
+++ b/core/schemas/providers/bedrock/chat.go
@@ -115,7 +115,7 @@ func (bedrockResp *BedrockConverseResponse) ToBifrostResponse() (*schemas.Bifros
 					ChatAssistantMessage: assistantMessage,
 				},
 			},
-			FinishReason: &bedrockResp.StopReason,
+			FinishReason: schemas.Ptr(schemas.MapProviderFinishReasonToBifrost(bedrockResp.StopReason, schemas.Bedrock)),
 		},
 	}
 	var usage *schemas.LLMUsage


### PR DESCRIPTION
## Summary

Refactored finish reason mapping to standardize how completion stop reasons are handled across different providers, particularly focusing on Anthropic and Bedrock. Closes #617 

## Changes

- Centralized finish reason mapping logic in `schemas/utils.go` with shared maps and conversion functions
- Replaced provider-specific mapping functions with unified `MapProviderFinishReasonToBifrost` and `MapBifrostFinishReasonToProvider` functions
- Removed duplicated mapping logic from Anthropic provider and moved it to the central schemas package
- Updated Bedrock provider to use the standardized mapping functions
- Ensured consistent handling of finish reasons in both streaming and non-streaming responses

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test that finish reasons are correctly mapped between provider-specific formats and Bifrost's standardized format:

```sh
# Core/Transports
go version
go test ./...

# Test specific providers
go test ./core/providers/anthropic_test.go
go test ./core/providers/bedrock_test.go
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves consistency in handling completion stop reasons across providers.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable