### PR TITLE
fix: restructured core-provider test cases

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -436,6 +436,10 @@ func handleAnthropicChatCompletionStreaming(
 				continue
 			}
 
+			if event.Type == anthropic.AnthropicStreamEventTypeMessageStart && event.Message != nil && event.Message.ID != "" {
+				messageID = event.Message.ID
+			}
+
 			if event.Usage != nil {
 				usage = &schemas.BifrostLLMUsage{
 					PromptTokens:     event.Usage.InputTokens,
@@ -449,12 +453,12 @@ func handleAnthropicChatCompletionStreaming(
 			}
 			if event.Message != nil {
 				// Handle different event types
-				messageID = event.Message.ID
 				modelName = event.Message.Model
 			}
 
 			response, bifrostErr, isLastChunk := event.ToBifrostChatCompletionStream()
 			if response != nil {
+				response.ID = messageID
 				response.ExtraFields = schemas.BifrostResponseExtraFields{
 					RequestType:    schemas.ChatCompletionStreamRequest,
 					Provider:       providerType,

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -382,23 +382,23 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 					}
 
 				case cohere.StreamEventContentDelta:
-					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.Content != nil && event.Delta.Message.Content.Text != nil {
+					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.Content != nil && event.Delta.Message.Content.CohereStreamContentObject != nil && event.Delta.Message.Content.CohereStreamContentObject.Text != nil {
 						// Try to cast content to CohereStreamContent
-						response.Choices[0].ChatStreamResponseChoice.Delta.Content = event.Delta.Message.Content.Text
+						response.Choices[0].ChatStreamResponseChoice.Delta.Content = event.Delta.Message.Content.CohereStreamContentObject.Text
 					}
 
 				case cohere.StreamEventToolPlanDelta:
 					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.ToolPlan != nil {
-						response.Choices[0].ChatStreamResponseChoice.Delta.Content = event.Delta.Message.ToolPlan
+						response.Choices[0].ChatStreamResponseChoice.Delta.Thought = event.Delta.Message.ToolPlan
 					}
 
 				case cohere.StreamEventContentStart:
 					// Content start event - just continue, actual content comes in content-delta
 
 				case cohere.StreamEventToolCallStart, cohere.StreamEventToolCallDelta:
-					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.ToolCalls != nil {
+					if event.Delta != nil && event.Delta.Message != nil && event.Delta.Message.ToolCalls != nil && event.Delta.Message.ToolCalls.CohereToolCallObject != nil {
 						// Handle single tool call object (tool-call-start/delta events)
-						cohereToolCall := event.Delta.Message.ToolCalls
+						cohereToolCall := event.Delta.Message.ToolCalls.CohereToolCallObject
 						toolCall := schemas.ChatAssistantMessageToolCall{}
 
 						if cohereToolCall.ID != nil {

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -599,6 +599,9 @@ func getResponsesChunkConverterCombinedPostHookRunner(postHookRunner schemas.Pos
 		if result != nil {
 			if result.ChatResponse != nil {
 				result.ResponsesStreamResponse = result.ChatResponse.ToBifrostResponsesStreamResponse()
+				if result.ResponsesResponse == nil {
+					result.ResponsesResponse = &schemas.BifrostResponsesResponse{}
+				}
 				result.ResponsesResponse.ExtraFields = result.ResponsesStreamResponse.ExtraFields
 				result.ResponsesResponse.ExtraFields.RequestType = schemas.ResponsesRequest
 			}

--- a/core/schemas/providers/anthropic/chat.go
+++ b/core/schemas/providers/anthropic/chat.go
@@ -3,7 +3,7 @@ package anthropic
 import (
 	"encoding/json"
 	"fmt"
-
+	"time"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -260,6 +260,7 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse() *schemas.Bifro
 			RequestType: schemas.ChatCompletionRequest,
 			Provider:    schemas.Anthropic,
 		},
+		Created: int(time.Now().Unix()),
 	}
 
 	// Collect all content and tool calls into a single message
@@ -838,7 +839,7 @@ func ToAnthropicChatCompletionStreamResponse(bifrostResp *schemas.BifrostChatRes
 		choice := bifrostResp.Choices[0] // Anthropic typically returns one choice
 
 		// Handle streaming responses
-		if choice.ChatStreamResponseChoice != nil {
+		if choice.ChatStreamResponseChoice != nil && choice.ChatStreamResponseChoice.Delta != nil {
 			delta := choice.ChatStreamResponseChoice.Delta
 
 			// Handle text content deltas

--- a/core/schemas/providers/cohere/chat.go
+++ b/core/schemas/providers/cohere/chat.go
@@ -1,6 +1,8 @@
 package cohere
 
 import (
+	"time"
+
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -23,9 +25,9 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Cohe
 		}
 
 		// Convert content
-		if msg.Content.ContentStr != nil {
+		if msg.Content != nil && msg.Content.ContentStr != nil {
 			cohereMsg.Content = NewStringContent(*msg.Content.ContentStr)
-		} else if msg.Content.ContentBlocks != nil {
+		} else if msg.Content != nil && msg.Content.ContentBlocks != nil {
 			var contentBlocks []CohereContentBlock
 			for _, block := range msg.Content.ContentBlocks {
 				if block.Text != nil {
@@ -197,6 +199,7 @@ func (response *CohereChatResponse) ToBifrostChatResponse() *schemas.BifrostChat
 				},
 			},
 		},
+		Created: int(time.Now().Unix()),
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType: schemas.ChatCompletionRequest,
 			Provider:    schemas.Cohere,

--- a/core/schemas/providers/cohere/responses.go
+++ b/core/schemas/providers/cohere/responses.go
@@ -447,11 +447,11 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int) (*s
 		}, nil, false
 	case StreamEventContentStart:
 		// Content block start - create content part added event
-		if chunk.Delta != nil && chunk.Index != nil && chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil {
+		if chunk.Delta != nil && chunk.Index != nil && chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil && chunk.Delta.Message.Content.CohereStreamContentObject != nil {
 			var contentType schemas.ResponsesMessageContentBlockType
 			var part *schemas.ResponsesMessageContentBlock
 
-			switch chunk.Delta.Message.Content.Type {
+			switch chunk.Delta.Message.Content.CohereStreamContentObject.Type {
 			case CohereContentBlockTypeText:
 				contentType = schemas.ResponsesOutputMessageContentTypeText
 				part = &schemas.ResponsesMessageContentBlock{
@@ -480,13 +480,13 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int) (*s
 	case StreamEventContentDelta:
 		if chunk.Index != nil && chunk.Delta != nil {
 			// Handle text content delta
-			if chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil && chunk.Delta.Message.Content.Text != nil && *chunk.Delta.Message.Content.Text != "" {
+			if chunk.Delta.Message != nil && chunk.Delta.Message.Content != nil && chunk.Delta.Message.Content.CohereStreamContentObject != nil && chunk.Delta.Message.Content.CohereStreamContentObject.Text != nil && *chunk.Delta.Message.Content.CohereStreamContentObject.Text != "" {
 				return &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
 					SequenceNumber: sequenceNumber,
 					OutputIndex:    schemas.Ptr(0),
 					ContentIndex:   chunk.Index,
-					Delta:          chunk.Delta.Message.Content.Text,
+					Delta:          chunk.Delta.Message.Content.CohereStreamContentObject.Text,
 				}, nil, false
 			}
 		}
@@ -514,9 +514,9 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int) (*s
 		}
 		return nil, nil, false
 	case StreamEventToolCallStart:
-		if chunk.Index != nil && chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolCalls != nil {
+		if chunk.Index != nil && chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolCalls != nil && chunk.Delta.Message.ToolCalls.CohereToolCallObject != nil {
 			// Tool call start - create function call message
-			toolCall := chunk.Delta.Message.ToolCalls
+			toolCall := chunk.Delta.Message.ToolCalls.CohereToolCallObject
 			if toolCall.Function != nil && toolCall.Function.Name != nil {
 				messageType := schemas.ResponsesMessageTypeFunctionCall
 
@@ -540,9 +540,9 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int) (*s
 		}
 		return nil, nil, false
 	case StreamEventToolCallDelta:
-		if chunk.Index != nil && chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolCalls != nil {
+		if chunk.Index != nil && chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.ToolCalls != nil && chunk.Delta.Message.ToolCalls.CohereToolCallObject != nil {
 			// Tool call delta - handle function arguments streaming
-			toolCall := chunk.Delta.Message.ToolCalls
+			toolCall := chunk.Delta.Message.ToolCalls.CohereToolCallObject
 			if toolCall.Function != nil {
 				return &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
@@ -568,7 +568,7 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int) (*s
 	case StreamEventCitationStart:
 		if chunk.Index != nil && chunk.Delta != nil && chunk.Delta.Message != nil && chunk.Delta.Message.Citations != nil {
 			// Citation start - create annotation for the citation
-			citation := chunk.Delta.Message.Citations
+			citation := chunk.Delta.Message.Citations.CohereStreamCitationObject
 
 			// Map Cohere citation to ResponsesOutputMessageContentTextAnnotation
 			annotation := &schemas.ResponsesOutputMessageContentTextAnnotation{

--- a/core/schemas/providers/gemini/chat.go
+++ b/core/schemas/providers/gemini/chat.go
@@ -212,12 +212,6 @@ func (request *GeminiGenerationRequest) ToBifrostChatRequest() *schemas.BifrostC
 		bifrostReq.Params.ExtraParams["cached_content"] = request.CachedContent
 	}
 
-	// Convert response modalities
-	if len(request.ResponseModalities) > 0 {
-		ensureExtraParams(bifrostReq)
-		bifrostReq.Params.ExtraParams["response_modalities"] = request.ResponseModalities
-	}
-
 	// Convert labels
 	if len(request.Labels) > 0 {
 		ensureExtraParams(bifrostReq)
@@ -310,11 +304,6 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest, respo
 			// Cached content
 			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
 				geminiReq.CachedContent = cachedContent
-			}
-
-			// Response modalities
-			if modalities, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["response_modalities"]); ok {
-				geminiReq.ResponseModalities = modalities
 			}
 
 			// Labels

--- a/core/schemas/providers/gemini/embedding.go
+++ b/core/schemas/providers/gemini/embedding.go
@@ -120,44 +120,42 @@ func (request *GeminiGenerationRequest) ToBifrostEmbeddingRequest() *schemas.Bif
 		Model:    model,
 	}
 
-	// Convert contents to embedding input
-	if len(request.Contents) > 0 {
-		// Extract text from all contents
-		var texts []string
-		for _, content := range request.Contents {
-			for _, part := range content.Parts {
+	if len(request.Requests) > 0 {
+		embeddingRequest := request.Requests[0]
+		if embeddingRequest.Content != nil {
+			var texts []string
+			for _, part := range embeddingRequest.Content.Parts {
 				if part != nil && part.Text != "" {
 					texts = append(texts, part.Text)
 				}
 			}
-		}
-
-		if len(texts) > 0 {
-			bifrostReq.Input = &schemas.EmbeddingInput{}
-			if len(texts) == 1 {
-				bifrostReq.Input.Text = &texts[0]
-			} else {
-				bifrostReq.Input.Texts = texts
+			if len(texts) > 0 {
+				bifrostReq.Input = &schemas.EmbeddingInput{}
+				if len(texts) == 1 {
+					bifrostReq.Input.Text = &texts[0]
+				} else {
+					bifrostReq.Input.Texts = texts
+				}
 			}
 		}
-	}
 
-	// Convert parameters
-	if request.OutputDimensionality != nil || request.TaskType != nil || request.Title != nil {
-		bifrostReq.Params = &schemas.EmbeddingParameters{}
+		// Convert parameters
+		if embeddingRequest.OutputDimensionality != nil || embeddingRequest.TaskType != nil || embeddingRequest.Title != nil {
+			bifrostReq.Params = &schemas.EmbeddingParameters{}
 
-		if request.OutputDimensionality != nil {
-			bifrostReq.Params.Dimensions = request.OutputDimensionality
-		}
-
-		// Handle extra parameters
-		if request.TaskType != nil || request.Title != nil {
-			bifrostReq.Params.ExtraParams = make(map[string]interface{})
-			if request.TaskType != nil {
-				bifrostReq.Params.ExtraParams["taskType"] = request.TaskType
+			if embeddingRequest.OutputDimensionality != nil {
+				bifrostReq.Params.Dimensions = embeddingRequest.OutputDimensionality
 			}
-			if request.Title != nil {
-				bifrostReq.Params.ExtraParams["title"] = request.Title
+
+			// Handle extra parameters
+			if embeddingRequest.TaskType != nil || embeddingRequest.Title != nil {
+				bifrostReq.Params.ExtraParams = make(map[string]interface{})
+				if embeddingRequest.TaskType != nil {
+					bifrostReq.Params.ExtraParams["taskType"] = embeddingRequest.TaskType
+				}
+				if embeddingRequest.Title != nil {
+					bifrostReq.Params.ExtraParams["title"] = embeddingRequest.Title
+				}
 			}
 		}
 	}

--- a/core/schemas/providers/gemini/speech.go
+++ b/core/schemas/providers/gemini/speech.go
@@ -16,11 +16,6 @@ func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest, responseMod
 		Model: bifrostReq.Model,
 	}
 
-	// Set response modalities for speech generation
-	if len(responseModalities) > 0 {
-		geminiReq.ResponseModalities = responseModalities
-	}
-
 	// Convert parameters to generation config
 	if len(responseModalities) > 0 {
 		var modalities []Modality
@@ -94,7 +89,7 @@ func ToGeminiSpeechResponse(bifrostResp *schemas.BifrostSpeechResponse) *Generat
 				{
 					InlineData: &Blob{
 						Data:     bifrostResp.Audio,
-						MIMEType: "audio/wav", // Default audio MIME type
+						MIMEType: detectAudioMimeType(bifrostResp.Audio),
 					},
 				},
 			},

--- a/core/schemas/providers/gemini/types.go
+++ b/core/schemas/providers/gemini/types.go
@@ -52,24 +52,18 @@ const (
 )
 
 type GeminiGenerationRequest struct {
-	Model              string                   `json:"model,omitempty"`    // Model field for explicit model specification
-	Contents           []CustomContent          `json:"contents,omitempty"` // For chat completion requests
-	Requests           []GeminiEmbeddingRequest `json:"requests,omitempty"` // For batch embedding requests
-	SystemInstruction  *CustomContent           `json:"systemInstruction,omitempty"`
-	GenerationConfig   GenerationConfig         `json:"generationConfig,omitempty"`
-	SafetySettings     []SafetySetting          `json:"safetySettings,omitempty"`
-	Tools              []Tool                   `json:"tools,omitempty"`
-	ToolConfig         ToolConfig               `json:"toolConfig,omitempty"`
-	Labels             map[string]string        `json:"labels,omitempty"`
-	CachedContent      string                   `json:"cachedContent,omitempty"`
-	ResponseModalities []string                 `json:"responseModalities,omitempty"`
-	Stream             bool                     `json:"-"` // Internal field to track streaming requests
-	IsEmbedding        bool                     `json:"-"` // Internal field to track if this is an embedding request
-
-	// Embedding-specific parameters
-	TaskType             *string `json:"taskType,omitempty"`
-	Title                *string `json:"title,omitempty"`
-	OutputDimensionality *int    `json:"outputDimensionality,omitempty"`
+	Model             string                   `json:"model,omitempty"`    // Model field for explicit model specification
+	Contents          []CustomContent          `json:"contents,omitempty"` // For chat completion requests
+	Requests          []GeminiEmbeddingRequest `json:"requests,omitempty"` // For batch embedding requests
+	SystemInstruction *CustomContent           `json:"systemInstruction,omitempty"`
+	GenerationConfig  GenerationConfig         `json:"generationConfig,omitempty"`
+	SafetySettings    []SafetySetting          `json:"safetySettings,omitempty"`
+	Tools             []Tool                   `json:"tools,omitempty"`
+	ToolConfig        ToolConfig               `json:"toolConfig,omitempty"`
+	Labels            map[string]string        `json:"labels,omitempty"`
+	CachedContent     string                   `json:"cachedContent,omitempty"`
+	Stream            bool                     `json:"-"` // Internal field to track streaming requests
+	IsEmbedding       bool                     `json:"-"` // Internal field to track if this is an embedding request
 }
 
 // IsStreamingRequested implements the StreamingRequest interface

--- a/tests/core-providers/scenarios/embedding.go
+++ b/tests/core-providers/scenarios/embedding.go
@@ -67,22 +67,6 @@ func RunEmbeddingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 			Fallbacks: testConfig.Fallbacks,
 		}
 
-		// Use embedding-specific retry configuration
-		retryConfig := EmbeddingRetryConfig()
-		retryContext := TestRetryContext{
-			ScenarioName: "Embedding",
-			ExpectedBehavior: map[string]interface{}{
-				"expected_embedding_count": len(testTexts),
-				"should_have_vectors":      true,
-				"expected_texts":           testTexts,
-			},
-			TestMetadata: map[string]interface{}{
-				"provider":   testConfig.Provider,
-				"model":      testConfig.EmbeddingModel,
-				"text_count": len(testTexts),
-			},
-		}
-
 		// Enhanced embedding validation
 		expectations := EmbeddingExpectations(testTexts)
 		expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
@@ -117,7 +101,7 @@ func validateEmbeddingSemantics(t *testing.T, response *schemas.BifrostEmbedding
 	}
 
 	for i := range response.Data {
-		vec, extractErr := getEmbeddingVector(response.Data[i].Embedding)
+		vec, extractErr := getEmbeddingVector(response.Data[i])
 		if extractErr != nil {
 			t.Fatalf("Failed to extract embedding vector for text '%s': %v", testTexts[i], extractErr)
 		}

--- a/tests/core-providers/scenarios/end_to_end_tool_calling.go
+++ b/tests/core-providers/scenarios/end_to_end_tool_calling.go
@@ -54,7 +54,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		}
 
 		// Create operations for both APIs
-		chatOperation := func() (*schemas.BifrostResponse, *schemas.BifrostError) {
+		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -68,7 +68,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			return client.ChatCompletionRequest(ctx, chatReq)
 		}
 
-		responsesOperation := func() (*schemas.BifrostResponse, *schemas.BifrostError) {
+		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -105,8 +105,8 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		}
 
 		// Extract tool calls from both APIs
-		chatToolCalls := ExtractToolCalls(result1.ChatCompletionsResponse)
-		responsesToolCalls := ExtractToolCalls(result1.ResponsesAPIResponse)
+		chatToolCalls := ExtractChatToolCalls(result1.ChatCompletionsResponse)
+		responsesToolCalls := ExtractResponsesToolCalls(result1.ResponsesAPIResponse)
 
 		if len(chatToolCalls) == 0 {
 			t.Fatal("Expected at least one tool call in Chat Completions API response for 'weather'")
@@ -138,8 +138,8 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 
 		// Build conversation history for Responses API
 		responsesConversationMessages := []schemas.ResponsesMessage{responsesUserMessage}
-		if result1.ResponsesAPIResponse.ResponsesResponse != nil {
-			for _, output := range result1.ResponsesAPIResponse.ResponsesResponse.Output {
+		if result1.ResponsesAPIResponse.Output != nil {
+			for _, output := range result1.ResponsesAPIResponse.Output {
 				responsesConversationMessages = append(responsesConversationMessages, output)
 			}
 		}
@@ -171,7 +171,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		expectations2.MinContentLength = 30                                            // Should be a substantial response
 
 		// Create operations for both APIs - Step 2
-		chatOperation2 := func() (*schemas.BifrostResponse, *schemas.BifrostError) {
+		chatOperation2 := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -184,7 +184,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			return client.ChatCompletionRequest(ctx, chatReq)
 		}
 
-		responsesOperation2 := func() (*schemas.BifrostResponse, *schemas.BifrostError) {
+		responsesOperation2 := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -222,7 +222,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 
 		// Log results from both APIs
 		if result2.ChatCompletionsResponse != nil {
-			chatContent := GetResultContent(result2.ChatCompletionsResponse)
+			chatContent := GetChatContent(result2.ChatCompletionsResponse)
 			t.Logf("✅ Chat Completions API result: %s", chatContent)
 
 			// Additional validation for Chat Completions API
@@ -239,7 +239,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		}
 
 		if result2.ResponsesAPIResponse != nil {
-			responsesContent := GetResultContent(result2.ResponsesAPIResponse)
+			responsesContent := GetResponsesContent(result2.ResponsesAPIResponse)
 			t.Logf("✅ Responses API result: %s", responsesContent)
 
 			// Additional validation for Responses API

--- a/tests/core-providers/scenarios/multiple_images.go
+++ b/tests/core-providers/scenarios/multiple_images.go
@@ -79,6 +79,14 @@ func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 				"expected_keywords": []string{"different", "differences", "contrast", "unlike", "comparison", "compare", "both", "two"}, // 🎯 Comparison-specific terms
 			},
 		}
+		chatRetryConfig := ChatRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []ChatRetryCondition{}, // Add specific chat retry conditions as needed
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
 
 		// Enhanced validation for multiple image comparison (ant vs lion)
 		expectations := VisionExpectations([]string{"ant", "lion"}) // Basic expectation - should identify both as animals with differences
@@ -90,7 +98,7 @@ func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 			"single image", "unable to view the second",
 		}...) // Failure to process multiple images indicators
 
-		response, bifrostError := WithTestRetry(t, retryConfig, retryContext, expectations, "MultipleImages", func() (*schemas.BifrostResponse, *schemas.BifrostError) {
+		response, bifrostError := WithChatTestRetry(t, chatRetryConfig, retryContext, expectations, "MultipleImages", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 			return client.ChatCompletionRequest(ctx, request)
 		})
 
@@ -99,7 +107,7 @@ func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 			t.Fatalf("❌ Multiple images request failed after retries: %v", GetErrorMessage(bifrostError))
 		}
 
-		content := GetResultContent(response)
+		content := GetChatContent(response)
 
 		// Additional validation for ant vs lion comparison
 		contentLower := strings.ToLower(content)

--- a/tests/core-providers/scenarios/responses_stream.go
+++ b/tests/core-providers/scenarios/responses_stream.go
@@ -100,17 +100,13 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				lastResponse = response
 
 				// Basic validation of streaming response structure
-				if response.BifrostResponse != nil {
-					if response.BifrostResponse.ExtraFields.Provider != testConfig.Provider {
-						t.Logf("⚠️ Warning: Provider mismatch - expected %s, got %s", testConfig.Provider, response.BifrostResponse.ExtraFields.Provider)
-					}
-					// Validate ResponsesStreamResponse is present
-					if response.BifrostResponse.ResponsesStreamResponse == nil {
-						t.Fatal("ResponsesStreamResponse should not be nil in responses streaming")
+				if response.BifrostResponsesStreamResponse != nil {
+					if response.BifrostResponsesStreamResponse.ExtraFields.Provider != testConfig.Provider {
+						t.Logf("⚠️ Warning: Provider mismatch - expected %s, got %s", testConfig.Provider, response.BifrostResponsesStreamResponse.ExtraFields.Provider)
 					}
 
 					// Process the streaming response
-					streamResp := response.BifrostResponse.ResponsesStreamResponse
+					streamResp := response.BifrostResponsesStreamResponse
 
 					// Track event types
 					eventTypes[streamResp.Type]++
@@ -303,8 +299,8 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 					}
 					responseCount++
 
-					if response.BifrostResponse != nil && response.BifrostResponse.ResponsesStreamResponse != nil {
-						streamResp := response.BifrostResponse.ResponsesStreamResponse
+					if response.BifrostResponsesStreamResponse != nil {
+						streamResp := response.BifrostResponsesStreamResponse
 
 						// Check for function call events
 						switch streamResp.Type {
@@ -412,8 +408,8 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 					}
 					responseCount++
 
-					if response.BifrostResponse != nil && response.BifrostResponse.ResponsesStreamResponse != nil {
-						streamResp := response.BifrostResponse.ResponsesStreamResponse
+					if response.BifrostResponsesStreamResponse != nil {
+						streamResp := response.BifrostResponsesStreamResponse
 
 						// Check for reasoning-specific events
 						switch streamResp.Type {
@@ -507,35 +503,6 @@ func validateResponsesStreamingStructure(t *testing.T, eventTypes map[schemas.Re
 	}
 }
 
-// createConsolidatedResponsesResponse creates a consolidated response for validation
-func createConsolidatedResponsesResponse(finalContent string, lastResponse *schemas.BifrostStream, provider schemas.ModelProvider) *schemas.BifrostResponse {
-	consolidatedResponse := &schemas.BifrostResponse{
-		ResponsesResponse: &schemas.ResponsesResponse{
-			Output: []schemas.ResponsesMessage{
-				{
-					Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
-					Content: &schemas.ResponsesMessageContent{
-						ContentStr: &finalContent,
-					},
-				},
-			},
-		},
-		ExtraFields: schemas.BifrostResponseExtraFields{
-			Provider: provider,
-		},
-	}
-
-	// Copy usage and other metadata from last response if available
-	if lastResponse != nil && lastResponse.BifrostResponse != nil {
-		consolidatedResponse.Usage = lastResponse.Usage
-		consolidatedResponse.Model = lastResponse.Model
-		consolidatedResponse.ID = lastResponse.ID
-		consolidatedResponse.Created = lastResponse.Created
-	}
-
-	return consolidatedResponse
-}
 
 // StreamingValidationResult represents the result of streaming validation
 type StreamingValidationResult struct {
@@ -602,15 +569,11 @@ func validateResponsesStreamingResponse(t *testing.T, eventTypes map[schemas.Res
 	if lastResponse == nil {
 		errors = append(errors, "Should have at least one streaming response")
 	} else {
-		if lastResponse.BifrostResponse == nil {
-			errors = append(errors, "Last streaming response should have BifrostResponse")
+		if lastResponse.BifrostResponsesStreamResponse == nil {
+			errors = append(errors, "Last streaming response should have BifrostResponsesStreamResponse")
 		} else {
-			if lastResponse.BifrostResponse.ResponsesStreamResponse == nil {
-				errors = append(errors, "Streaming response should have ResponsesStreamResponse")
-			}
-
-			if lastResponse.BifrostResponse.ExtraFields.Provider != testConfig.Provider {
-				errors = append(errors, fmt.Sprintf("Provider mismatch: expected %s, got %s", testConfig.Provider, lastResponse.BifrostResponse.ExtraFields.Provider))
+			if lastResponse.BifrostResponsesStreamResponse.ExtraFields.Provider != testConfig.Provider {
+				errors = append(errors, fmt.Sprintf("Provider mismatch: expected %s, got %s", testConfig.Provider, lastResponse.BifrostResponsesStreamResponse.ExtraFields.Provider))
 			}
 		}
 	}

--- a/tests/core-providers/scenarios/text_completion.go
+++ b/tests/core-providers/scenarios/text_completion.go
@@ -50,7 +50,11 @@ func RunTextCompletionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 		expectations.ShouldNotContainWords = append(expectations.ShouldNotContainWords, []string{"error", "failed", "invalid"}...) // Should not contain error terms
 
 		response, bifrostErr := WithTestRetry(t, retryConfig, retryContext, expectations, "TextCompletion", func() (*schemas.BifrostResponse, *schemas.BifrostError) {
-			return client.TextCompletionRequest(ctx, request)
+			c, err := client.TextCompletionRequest(ctx, request)
+			if err != nil {
+				return nil, err
+			}
+			return &schemas.BifrostResponse{TextCompletionResponse: c}, nil
 		})
 
 		if bifrostErr != nil {

--- a/tests/core-providers/scenarios/transcription.go
+++ b/tests/core-providers/scenarios/transcription.go
@@ -75,7 +75,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 
 				ttsResponse, err := client.SpeechRequest(ctx, ttsRequest)
 				RequireNoError(t, err, "TTS generation failed for round-trip test")
-				if ttsResponse.Audio == nil || len(ttsResponse.Audio) == 0 {
+				if ttsResponse == nil || len(ttsResponse.Audio) == 0 {
 					t.Fatal("TTS returned invalid or empty audio for round-trip test")
 				}
 
@@ -105,21 +105,6 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 						ResponseFormat: tc.responseFormat,
 					},
 					Fallbacks: testConfig.Fallbacks,
-				}
-
-				retryConfig := GetTestRetryConfigForScenario("Transcription_RoundTrip", testConfig)
-				retryContext := TestRetryContext{
-					ScenarioName: "Transcription_RoundTrip_" + tc.name,
-					ExpectedBehavior: map[string]interface{}{
-						"transcribe_audio": true,
-						"round_trip_test":  true,
-						"original_text":    tc.text,
-					},
-					TestMetadata: map[string]interface{}{
-						"provider":     testConfig.Provider,
-						"model":        testConfig.TranscriptionModel,
-						"audio_format": tc.format,
-					},
 				}
 
 				// Enhanced validation for transcription
@@ -187,10 +172,10 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 
 					response, err := client.TranscriptionRequest(ctx, request)
 					require.Nilf(t, err, "Custom transcription failed: %v", err)
-					require.NotNil(t, response.Transcribe)
-					assert.NotEmpty(t, response.Transcribe.Text)
+					require.NotNil(t, response, "Custom transcription returned nil response")
+					assert.NotEmpty(t, response.Text)
 
-					t.Logf("✅ Custom transcription successful: '%s' → '%s'", tc.text, response.Transcribe.Text)
+					t.Logf("✅ Custom transcription successful: '%s' → '%s'", tc.text, response.Text)
 				})
 			}
 		})
@@ -230,13 +215,12 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 
 					response, err := client.TranscriptionRequest(ctx, request)
 					require.Nilf(t, err, "Transcription failed for format %s: %v", format, err)
-					require.NotNil(t, response)
-					require.NotNil(t, response.Transcribe)
+					require.NotNil(t, response, "Transcription returned nil response for format %s", format)
 
 					// All formats should return some text
-					assert.NotEmpty(t, response.Transcribe.Text)
+					assert.NotEmpty(t, response.Text)
 
-					t.Logf("✅ Format %s successful: '%s'", format, response.Transcribe.Text)
+					t.Logf("✅ Format %s successful: '%s'", format, response.Text)
 				})
 			}
 		})
@@ -263,11 +247,10 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 
 			response, err := client.TranscriptionRequest(ctx, request)
 			require.Nilf(t, err, "Advanced transcription failed: %v", err)
-			require.NotNil(t, response)
-			require.NotNil(t, response.Transcribe)
-			assert.NotEmpty(t, response.Transcribe.Text)
+			require.NotNil(t, response, "Advanced transcription returned nil response")
+			assert.NotEmpty(t, response.Text)
 
-			t.Logf("✅ Advanced transcription successful: '%s'", response.Transcribe.Text)
+			t.Logf("✅ Advanced transcription successful: '%s'", response.Text)
 		})
 
 		t.Run("MultipleLanguages", func(t *testing.T) {
@@ -295,11 +278,9 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 
 					response, err := client.TranscriptionRequest(ctx, request)
 					require.Nilf(t, err, "Transcription failed for language %s: %v", lang, err)
-					require.NotNil(t, response)
-					require.NotNil(t, response.Transcribe)
-
-					assert.NotEmpty(t, response.Transcribe.Text)
-					t.Logf("✅ Language %s transcription successful: '%s'", lang, response.Transcribe.Text)
+					require.NotNil(t, response, "Transcription returned nil response for language %s", lang)
+					assert.NotEmpty(t, response.Text)
+					t.Logf("✅ Language %s transcription successful: '%s'", lang, response.Text)
 				})
 			}
 		})

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -18,6 +18,7 @@ type AnthropicRouter struct {
 func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 	return []RouteConfig{
 		{
+			Type: RouteConfigTypeAnthropic,
 			Path:   pathPrefix + "/v1/complete",
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -23,6 +23,7 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 
 	// Chat completions endpoint
 	routes = append(routes, RouteConfig{
+		Type: RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/v1beta/models/{model:*}",
 		Method: "POST",
 		GetRequestTypeInstance: func() interface{} {

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -101,6 +101,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 		"/openai/deployments/{deployment-id}/completions",
 	} {
 		routes = append(routes, RouteConfig{
+			Type: RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
@@ -139,6 +140,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 		"/openai/deployments/{deployment-id}/chat/completions",
 	} {
 		routes = append(routes, RouteConfig{
+			Type: RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
@@ -177,6 +179,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 		"/openai/deployments/{deployment-id}/responses",
 	} {
 		routes = append(routes, RouteConfig{
+			Type: RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
@@ -216,6 +219,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 		"/openai/deployments/{deployment-id}/embeddings",
 	} {
 		routes = append(routes, RouteConfig{
+			Type: RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
@@ -246,6 +250,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 		"/openai/deployments/{deployment-id}/audio/speech",
 	} {
 		routes = append(routes, RouteConfig{
+			Type: RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
@@ -281,6 +286,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 		"/openai/deployments/{deployment-id}/audio/transcriptions",
 	} {
 		routes = append(routes, RouteConfig{
+			Type: RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {


### PR DESCRIPTION
## Summary

Refactored the response types in the testing framework to use specific response types instead of the generic `BifrostResponse` type, improving type safety and clarity.

## Changes

- Split the generic `BifrostResponse` into specific response types for each API (Chat, Responses, Embedding, Speech, etc.)
- Updated helper functions to extract content and tool calls from specific response types
- Created dedicated validation functions for each response type
- Refactored stream handling to use the appropriate response types
- Extracted common validation logic into reusable helper functions

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the core provider tests to ensure they still pass with the refactored response types:

```sh
# Core/Transports
go version
go test ./tests/core-providers/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves type safety in the testing framework, making it easier to maintain and extend.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable