### PR TITLE
fix: removed timeouts

### DIFF
--- a/core/providers/gemini.go
+++ b/core/providers/gemini.go
@@ -372,7 +372,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 
 		scanner := bufio.NewScanner(resp.Body)
 		// Increase buffer size to handle large chunks (especially for audio data)
-		buf := make([]byte, 0, 64*1024) // 64KB buffer
+		buf := make([]byte, 0, 256*1024) // 256KB buffer
 		scanner.Buffer(buf, 1024*1024)  // Allow up to 1MB tokens
 		chunkIndex := -1
 		usage := &schemas.SpeechUsage{}

--- a/tests/core-providers/scenarios/speech_synthesis_stream.go
+++ b/tests/core-providers/scenarios/speech_synthesis_stream.go
@@ -98,9 +98,7 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				}
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-					defer cancel()
-					return client.SpeechStreamRequest(streamCtx, request)
+					return client.SpeechStreamRequest(ctx, request)
 				})
 
 				// Enhanced validation for streaming speech synthesis
@@ -116,7 +114,7 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				var lastResponse *schemas.BifrostStream
 				var streamErrors []string
 
-				readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 				defer cancel()
 
 				// Read streaming chunks with enhanced validation
@@ -171,7 +169,7 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx con
 
 						lastResponse = response
 
-					case <-readCtx.Done():
+					case <-streamCtx.Done():
 						streamErrors = append(streamErrors, "Stream reading timed out")
 						goto streamComplete
 					}
@@ -262,9 +260,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 			}
 
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				streamCtx, cancel := context.WithTimeout(ctx, 60*time.Second) // Longer timeout for HD model
-				defer cancel()
-				return client.SpeechStreamRequest(streamCtx, request)
+				return client.SpeechStreamRequest(ctx, request)
 			})
 
 			RequireNoError(t, err, "HD streaming speech synthesis failed")
@@ -273,7 +269,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 			var chunkCount int
 			var streamErrors []string
 
-			readCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			streamCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 
 			for {
@@ -308,7 +304,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 						t.Logf("⚠️ Unexpected HD model: %s", response.BifrostSpeechStreamResponse.ExtraFields.ModelRequested)
 					}
 
-				case <-readCtx.Done():
+				case <-streamCtx.Done():
 					streamErrors = append(streamErrors, "HD stream reading timed out")
 					goto hdStreamComplete
 				}
@@ -367,9 +363,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 					}
 
 					responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-						streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-						defer cancel()
-						return client.SpeechStreamRequest(streamCtx, request)
+						return client.SpeechStreamRequest(ctx, request)
 					})
 
 					RequireNoError(t, err, fmt.Sprintf("Streaming failed for voice %s", voice))
@@ -377,7 +371,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 					var receivedData bool
 					var streamErrors []string
 
-					readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+					streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 					defer cancel()
 
 					for {
@@ -402,7 +396,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 								t.Logf("✅ Received data for voice %s: %d bytes", voice, len(response.BifrostSpeechStreamResponse.Audio))
 							}
 
-						case <-readCtx.Done():
+						case <-streamCtx.Done():
 							streamErrors = append(streamErrors, fmt.Sprintf("Stream timed out for voice %s", voice))
 							goto voiceStreamComplete
 						}

--- a/tests/core-providers/scenarios/transcription_stream.go
+++ b/tests/core-providers/scenarios/transcription_stream.go
@@ -132,17 +132,15 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 				}
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-					defer cancel()
-					return client.TranscriptionStreamRequest(streamCtx, streamRequest)
+					return client.TranscriptionStreamRequest(ctx, streamRequest)
 				})
 
 				RequireNoError(t, err, "Transcription stream initiation failed")
 				if responseChannel == nil {
 					t.Fatal("Response channel should not be nil")
 				}
-				
-				readCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+
+				streamCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 				defer cancel()
 
 				var fullTranscriptionText string
@@ -209,7 +207,7 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 
 						lastResponse = response
 
-					case <-readCtx.Done():
+					case <-streamCtx.Done():
 						streamErrors = append(streamErrors, "Stream reading timed out")
 						goto streamComplete
 					}
@@ -335,11 +333,8 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 				},
 			}
 
-
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				defer cancel()
-				return client.TranscriptionStreamRequest(streamCtx, request)
+				return client.TranscriptionStreamRequest(ctx, request)
 			})
 
 			RequireNoError(t, err, "JSON streaming failed")
@@ -347,7 +342,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			var receivedResponse bool
 			var streamErrors []string
 
-			readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 
 			for {
@@ -384,7 +379,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 						}
 					}
 
-				case <-readCtx.Done():
+				case <-streamCtx.Done():
 					streamErrors = append(streamErrors, "JSON stream reading timed out")
 					goto verboseStreamComplete
 				}
@@ -436,9 +431,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 					}
 
 					responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-						streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-						defer cancel()
-						return client.TranscriptionStreamRequest(streamCtx, request)
+						return client.TranscriptionStreamRequest(ctx, request)
 					})
 
 					RequireNoError(t, err, fmt.Sprintf("Streaming failed for language %s", lang))
@@ -446,7 +439,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 					var receivedData bool
 					var streamErrors []string
 
-					readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+					streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 					defer cancel()
 
 					for {
@@ -471,7 +464,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 								t.Logf("✅ Received transcription data for language %s", lang)
 							}
 
-						case <-readCtx.Done():
+						case <-streamCtx.Done():
 							streamErrors = append(streamErrors, fmt.Sprintf("Stream timed out for language %s", lang))
 							goto langStreamComplete
 						}
@@ -524,9 +517,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			}
 
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-				defer cancel()
-				return client.TranscriptionStreamRequest(streamCtx, request)
+				return client.TranscriptionStreamRequest(ctx, request)
 			})
 
 			RequireNoError(t, err, "Custom prompt streaming failed")
@@ -535,7 +526,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			var streamErrors []string
 			var receivedText string
 
-			readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			streamCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 
 			for {
@@ -562,7 +553,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 						t.Logf("✅ Custom prompt chunk %d: '%s'", chunkCount, chunkText)
 					}
 
-				case <-readCtx.Done():
+				case <-streamCtx.Done():
 					streamErrors = append(streamErrors, "Custom prompt stream reading timed out")
 					goto promptStreamComplete
 				}


### PR DESCRIPTION
## Improve Speech Stream Buffer Size and Context Management

This PR enhances the speech streaming functionality by increasing the buffer size for Gemini provider and improving context management in tests.

## Changes

- Increased the Gemini provider's speech stream buffer size from 64KB to 256KB to better handle large audio chunks
- Refactored stream context handling in tests:
  - Renamed variables from `readCtx` to `streamCtx` for clarity
  - Removed redundant context creation in stream request functions
  - Simplified context flow by using the parent context for requests and dedicated timeout contexts for stream reading

## Type of change

- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Run the speech synthesis and transcription stream tests to verify the changes:

```sh
go test ./tests/core-providers/scenarios/speech_synthesis_stream.go
go test ./tests/core-providers/scenarios/transcription_stream.go
```

The tests should complete successfully with improved buffer handling and cleaner context management.

## Breaking changes

- [x] No

## Security considerations

No security implications. This change only affects buffer sizes and context management.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally