### PR TITLE
feat: add key name field and remove OpenAI responses API config

### DIFF
--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -6,20 +6,14 @@ import "context"
 // Key represents an API key and its associated configuration for a provider.
 // It contains the key value, supported models, and a weight for load balancing.
 type Key struct {
-	ID               string            `json:"id"`                           // The unique identifier for the key (not used by bifrost, but can be used by users to identify the key)
+	ID               string            `json:"id"`                           // The unique identifier for the key (used by bifrost to identify the key)
+	Name             string            `json:"name"`                         // The name of the key (used by users to identify the key, not used by bifrost)
 	Value            string            `json:"value"`                        // The actual API key value
 	Models           []string          `json:"models"`                       // List of models this key can access
 	Weight           float64           `json:"weight"`                       // Weight for load balancing between multiple keys
-	OpenAIKeyConfig  *OpenAIKeyConfig  `json:"openai_key_config,omitempty"`  // OpenAI-specific key configuration
 	AzureKeyConfig   *AzureKeyConfig   `json:"azure_key_config,omitempty"`   // Azure-specific key configuration
 	VertexKeyConfig  *VertexKeyConfig  `json:"vertex_key_config,omitempty"`  // Vertex-specific key configuration
 	BedrockKeyConfig *BedrockKeyConfig `json:"bedrock_key_config,omitempty"` // AWS Bedrock-specific key configuration
-}
-
-// OpenAIKeyConfig represents the OpenAI-specific configuration.
-// It contains OpenAI-specific settings required for which endpoint to use. (chat completion or responses api)
-type OpenAIKeyConfig struct {
-	UseResponsesAPI bool `json:"use_responses_api,omitempty"`
 }
 
 // AzureKeyConfig represents the Azure-specific configuration.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -133,6 +133,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 					Provider:         dbProvider.Name,
 					ProviderID:       dbProvider.ID,
 					KeyID:            key.ID,
+					Name:             key.Name,
 					Value:            key.Value,
 					Models:           key.Models,
 					Weight:           key.Weight,
@@ -243,6 +244,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 				Provider:         dbProvider.Name,
 				ProviderID:       dbProvider.ID,
 				KeyID:            key.ID,
+				Name:             key.Name,
 				Value:            key.Value,
 				Models:           key.Models,
 				Weight:           key.Weight,
@@ -341,6 +343,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 				Provider:         dbProvider.Name,
 				ProviderID:       dbProvider.ID,
 				KeyID:            key.ID,
+				Name:             key.Name,
 				Value:            key.Value,
 				Models:           key.Models,
 				Weight:           key.Weight,
@@ -489,6 +492,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 
 			keys[i] = schemas.Key{
 				ID:               dbKey.KeyID,
+				Name:             dbKey.Name,
 				Value:            processedValue,
 				Models:           dbKey.Models,
 				Weight:           dbKey.Weight,
@@ -858,7 +862,7 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 		Preload("RateLimit").
 		Preload("ProviderConfigs").
 		Preload("Keys", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id, key_id, models_json")
+			return db.Select("id, name, key_id, models_json, provider")
 		}).Find(&virtualKeys).Error; err != nil {
 		return nil, err
 	}
@@ -875,7 +879,7 @@ func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.
 		Preload("RateLimit").
 		Preload("ProviderConfigs").
 		Preload("Keys", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id, key_id, models_json")
+			return db.Select("id, name, key_id, models_json, provider")
 		}).First(&virtualKey, "id = ?", id).Error; err != nil {
 		return nil, err
 	}
@@ -1014,7 +1018,7 @@ func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string)
 		Preload("RateLimit").
 		Preload("ProviderConfigs").
 		Preload("Keys", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id, key_id, models_json")
+			return db.Select("id, name, key_id, models_json, provider")
 		}).First(&virtualKey, "value = ?", value).Error; err != nil {
 		return nil, err
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -312,10 +312,10 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 					for i, dbKey := range dbProvider.Keys {
 						keys[i] = schemas.Key{
 							ID:               dbKey.ID, // Key ID is passed in dbKey, not ID
+							Name:             dbKey.Name,
 							Value:            dbKey.Value,
 							Models:           dbKey.Models,
 							Weight:           dbKey.Weight,
-							OpenAIKeyConfig:  dbKey.OpenAIKeyConfig,
 							AzureKeyConfig:   dbKey.AzureKeyConfig,
 							VertexKeyConfig:  dbKey.VertexKeyConfig,
 							BedrockKeyConfig: dbKey.BedrockKeyConfig,
@@ -1034,10 +1034,10 @@ func (c *Config) GetProviderConfigRedacted(provider schemas.ModelProvider) (*con
 	redactedConfig.Keys = make([]schemas.Key, len(config.Keys))
 	for i, key := range config.Keys {
 		redactedConfig.Keys[i] = schemas.Key{
-			ID:              key.ID,
-			Models:          key.Models, // Copy slice reference - read-only so safe
-			Weight:          key.Weight,
-			OpenAIKeyConfig: key.OpenAIKeyConfig,
+			ID:     key.ID,
+			Name:   key.Name,
+			Models: key.Models, // Copy slice reference - read-only so safe
+			Weight: key.Weight,
 		}
 
 		// Redact API key value
@@ -1402,6 +1402,7 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 		for _, key := range provider.Keys {
 			keys = append(keys, configstoreTables.TableKey{
 				KeyID:    key.ID,
+				Name:     key.Name,
 				Value:    "",
 				Models:   key.Models,
 				Weight:   key.Weight,

--- a/ui/app/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/providers/fragments/apiKeysFormFragment.tsx
@@ -4,7 +4,6 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { Switch } from "@/components/ui/switch";
 import { TagInput } from "@/components/ui/tagInput";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -30,7 +29,6 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 			: isVertex
 				? ModelPlaceholders.vertex
 				: ModelPlaceholders.openai;
-	const isOpenAI = providerName === "openai";
 
 	return (
 		<div data-tab="api-keys" className="space-y-4 overflow-hidden">
@@ -44,79 +42,90 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 					</AlertDescription>
 				</Alert>
 			)}
-			<div className="flex gap-4">
-				{!isVertex && (
-					<div className="flex-1">
-						<FormField
-							control={control}
-							name={`key.value`}
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel>API Key</FormLabel>
-									<FormControl>
-										<Input placeholder="API Key or env.MY_KEY" type="text" {...field} />
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-					</div>
-				)}
-				<div className="h-[80px]">
+			<div className="flex items-start gap-4">
+				<div className="flex-1">
 					<FormField
 						control={control}
-						name={`key.weight`}
+						name={`key.name`}
 						render={({ field }) => (
 							<FormItem>
-								<div className="flex items-center gap-2">
-									<FormLabel>Weight</FormLabel>
-									<TooltipProvider>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<span>
-													<Info className="text-muted-foreground h-3 w-3" />
-												</span>
-											</TooltipTrigger>
-											<TooltipContent>
-												<p>Determines traffic distribution between keys. Higher weights receive more requests.</p>
-											</TooltipContent>
-										</Tooltip>
-									</TooltipProvider>
-								</div>
+								<FormLabel>Name</FormLabel>
 								<FormControl>
-									<Input
-										placeholder="1.0"
-										className="w-[220px]"
-										value={field.value === undefined || field.value === null ? "" : String(field.value)}
-										onChange={(e) => {
-											// Clear error while typing
-											form.clearErrors("key.weight");
-											// Keep as string during typing to allow partial input
-											field.onChange(e.target.value === "" ? "" : e.target.value);
-										}}
-										onBlur={(e) => {
-											const v = e.target.value.trim();
-											if (v !== "") {
-												const num = parseFloat(v);
-												if (!isNaN(num)) {
-													field.onChange(num);
-												} else {
-													form.setError("key.weight", { message: "Weight must be a valid number" });
-												}
-											}
-											field.onBlur();
-										}}
-										name={field.name}
-										ref={field.ref}
-										type="text"
-									/>
+									<Input placeholder="Production Key" type="text" {...field} />
 								</FormControl>
 								<FormMessage />
 							</FormItem>
 						)}
 					/>
 				</div>
+				<FormField
+					control={control}
+					name={`key.weight`}
+					render={({ field }) => (
+						<FormItem>
+							<div className="flex items-center gap-2">
+								<FormLabel>Weight</FormLabel>
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span>
+												<Info className="text-muted-foreground h-3 w-3" />
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>
+											<p>Determines traffic distribution between keys. Higher weights receive more requests.</p>
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+							</div>
+							<FormControl>
+								<Input
+									placeholder="1.0"
+									className="w-[220px]"
+									value={field.value === undefined || field.value === null ? "" : String(field.value)}
+									onChange={(e) => {
+										// Clear error while typing
+										form.clearErrors("key.weight");
+										// Keep as string during typing to allow partial input
+										field.onChange(e.target.value === "" ? "" : e.target.value);
+									}}
+									onBlur={(e) => {
+										const v = e.target.value.trim();
+										if (v !== "") {
+											const num = parseFloat(v);
+											if (!isNaN(num)) {
+												field.onChange(num);
+											} else {
+												form.setError("key.weight", { message: "Weight must be a valid number" });
+											}
+										}
+										field.onBlur();
+									}}
+									name={field.name}
+									ref={field.ref}
+									type="text"
+								/>
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
 			</div>
+			{!isVertex && (
+				<FormField
+					control={control}
+					name={`key.value`}
+					render={({ field }) => (
+						<FormItem>
+							<FormLabel>API Key</FormLabel>
+							<FormControl>
+								<Input placeholder="API Key or env.MY_KEY" type="text" {...field} />
+							</FormControl>
+							<FormMessage />
+						</FormItem>
+					)}
+				/>
+			)}
 			<FormField
 				control={control}
 				name={`key.models`}
@@ -144,30 +153,6 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 					</FormItem>
 				)}
 			/>
-			{isOpenAI && (
-				<div className="space-y-4">
-					<FormField
-						control={control}
-						name={`key.openai_key_config.use_responses_api`}
-						render={({ field }) => (
-							<FormItem>
-								<FormControl>
-									<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
-										<div className="space-y-0.5">
-											<label htmlFor="enforce-governance" className="text-sm font-medium">
-												Use Responses API
-											</label>
-											<p className="text-muted-foreground text-sm">Use the Responses API instead of the Chat Completion API.</p>
-										</div>
-										<Switch id="enforce-governance" size="md" checked={field.value} onCheckedChange={field.onChange} />
-									</div>
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-				</div>
-			)}
 			{isAzure && (
 				<div className="space-y-4">
 					<FormField

--- a/ui/app/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/providers/fragments/networkFormFragment.tsx
@@ -154,6 +154,34 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 								)}
 							/>
 						</div>
+						<div className="flex w-full flex-row items-start gap-4">
+							<FormField
+								control={form.control}
+								name="network_config.retry_backoff_initial"
+								render={({ field }) => (
+									<FormItem className="flex-1">
+										<FormLabel>Initial Backoff (ms)</FormLabel>
+										<FormControl>
+											<Input placeholder="e.g 500" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="network_config.retry_backoff_max"
+								render={({ field }) => (
+									<FormItem className="flex-1">
+										<FormLabel>Max Backoff (ms)</FormLabel>
+										<FormControl>
+											<Input placeholder="e.g 10000" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 						<FormField
 							control={form.control}
 							name="network_config.extra_headers"
@@ -193,34 +221,6 @@ export function NetworkFormFragment({ provider, showRestartAlert = false }: Netw
 								</FormItem>
 							)}
 						/>
-						<div className="flex w-full flex-row items-start gap-4">
-							<FormField
-								control={form.control}
-								name="network_config.retry_backoff_initial"
-								render={({ field }) => (
-									<FormItem className="flex-1">
-										<FormLabel>Initial Backoff (ms)</FormLabel>
-										<FormControl>
-											<Input placeholder="e.g 500" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-							<FormField
-								control={form.control}
-								name="network_config.retry_backoff_max"
-								render={({ field }) => (
-									<FormItem className="flex-1">
-										<FormLabel>Max Backoff (ms)</FormLabel>
-										<FormControl>
-											<Input placeholder="e.g 5000" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
 					</div>
 				</div>
 

--- a/ui/app/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/providers/views/modelProviderKeysTableView.tsx
@@ -37,17 +37,6 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 		setShowAddNewKeyDialog({ show: true, keyIndex: keyIndex });
 	}
 
-	function getKey(provider: ModelProvider, key: ModelProviderKey) {
-		switch (provider.name) {
-			case KnownProvidersNames[5]:
-				return key.vertex_key_config?.auth_credentials || "unknown";
-			case KnownProvidersNames[3]:
-				return key.value || key.bedrock_key_config?.access_key || "system IAM";
-			default:
-				return key.value;
-		}
-	}
-
 	return (
 		<div className={cn("w-full", className)}>
 			{showDeleteKeyDialog && (
@@ -127,7 +116,7 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 								<TableRow key={index} className="text-sm transition-colors hover:bg-white" onClick={() => {}}>
 									<TableCell>
 										<div className="flex items-center space-x-2">
-											<span className="font-mono text-sm">{getKey(provider, key)}</span>
+											<span className="font-mono text-sm">{key.name}</span>
 										</div>
 									</TableCell>
 									<TableCell>

--- a/ui/app/providers/views/providerKeyForm.tsx
+++ b/ui/app/providers/views/providerKeyForm.tsx
@@ -23,8 +23,6 @@ const providerKeyFormSchema = z.object({
 	key: modelProviderKeySchema,
 });
 
-type ProviderKeyFormData = z.infer<typeof providerKeyFormSchema>;
-
 export default function ProviderKeyForm({ provider, keyIndex, onCancel, onSave }: Props) {
 	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
 	const form = useForm({
@@ -34,6 +32,7 @@ export default function ProviderKeyForm({ provider, keyIndex, onCancel, onSave }
 		defaultValues: {
 			key: provider?.keys?.[keyIndex] ?? {
 				id: uuid(),
+				name: "",
 				value: "",
 				models: [],
 				weight: 1.0,

--- a/ui/app/virtual-keys/views/virtualKeyDetailsDialog.tsx
+++ b/ui/app/virtual-keys/views/virtualKeyDetailsDialog.tsx
@@ -99,15 +99,18 @@ export default function VirtualKeyDetailDialog({ virtualKey, onClose }: VirtualK
 									<Table>
 										<TableHeader>
 											<TableRow>
-												<TableHead>Key ID</TableHead>
+												<TableHead>Name</TableHead>
 												<TableHead>Allowed Models</TableHead>
 											</TableRow>
 										</TableHeader>
 										<TableBody>
 											{virtualKey.keys.map((key) => (
 												<TableRow key={key.key_id}>
-													<TableCell className="max-w-[200px] truncate">
-														<span className="font-mono text-sm">{key.key_id}</span>
+													<TableCell className="max-w-[200px]">
+														<span className="flex items-center font-mono text-sm">
+															<RenderProviderIcon provider={key.provider as ProviderIconType} size="sm" className="mr-2 h-4 w-4 shrink-0" />
+															<span className="truncate">{key.name}</span>
+														</span>
 													</TableCell>
 													<TableCell>
 														{key.models && key.models.length > 0 ? (

--- a/ui/app/virtual-keys/views/virtualKeyDialog.tsx
+++ b/ui/app/virtual-keys/views/virtualKeyDialog.tsx
@@ -349,9 +349,16 @@ export default function VirtualKeyDialog({ virtualKey, teams, customers, onSave,
 											<FormControl>
 												<MultiSelect
 													options={availableKeys.map((key) => ({
-														label: key.key_id,
+														label: key.name,
 														value: key.key_id,
 														description: key.models.join(", "),
+														icon: ({ className }: { className?: string }) => (
+															<RenderProviderIcon
+																provider={key.provider as ProviderIconType}
+																size="sm"
+																className={className || "h-4 w-4"}
+															/>
+														),
 													}))}
 													defaultValue={field.value || []}
 													onValueChange={field.onChange}

--- a/ui/app/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/virtual-keys/views/virtualKeysTable.tsx
@@ -128,7 +128,7 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefr
 							<TableRow>
 								<TableHead>Name</TableHead>
 								<TableHead>Key</TableHead>
-								<TableHead>DB Keys</TableHead>
+								<TableHead>Allowed Keys</TableHead>
 								<TableHead>Budget</TableHead>
 								<TableHead>Status</TableHead>
 								<TableHead className="text-right">Actions</TableHead>
@@ -170,31 +170,9 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefr
 												</div>
 											</TableCell>
 											<TableCell>
-												<div className="flex flex-wrap gap-1">
-													{vk.keys && vk.keys.length > 0 ? (
-														vk.keys.slice(0, 2).map((dbKey) => (
-															<Badge
-																key={dbKey.key_id}
-																variant="outline"
-																className="text-xs"
-																title={`${dbKey.key_id} — ${dbKey.provider_id}`}
-															>
-																{dbKey.key_id.substring(0, 8)}...
-															</Badge>
-														))
-													) : (
-														<span className="text-muted-foreground text-sm">All keys</span>
-													)}
-													{vk.keys && vk.keys.length > 2 && (
-														<Badge
-															variant="outline"
-															className="text-xs"
-															title={`${vk.keys.length} total keys — Providers: ${[...new Set(vk.keys.map((k) => k.provider_id))].join(", ")}`}
-														>
-															+{vk.keys.length - 2} more
-														</Badge>
-													)}
-												</div>
+												<Badge variant="outline" className="text-xs">
+													{vk.keys && vk.keys.length > 0 ? vk.keys.length : "All"} keys
+												</Badge>
 											</TableCell>
 											<TableCell>
 												{vk.budget ? (

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -64,10 +64,6 @@ const AllowedRequestsSchema = z.object({
 });
 
 // Key configuration schemas
-const OpenAIKeyConfigSchema = z.object({
-	use_responses_api: z.boolean(),
-});
-
 const AzureKeyConfigSchema = z.object({
 	endpoint: z.string().min(1, "Endpoint is required for Azure keys"),
 	deployments: z
@@ -127,10 +123,10 @@ const BedrockKeyConfigSchema = z
 
 const KeySchema = z.object({
 	id: z.string(),
+	name: z.string().min(1, "Name is required for the key"),
 	value: z.string(),
 	models: z.array(z.string()),
 	weight: z.number().min(0.1, "Key weights must be between 0.1 and 1").max(1, "Key weights must be between 0.1 and 1"),
-	openai_key_config: OpenAIKeyConfigSchema.optional(),
 	azure_key_config: AzureKeyConfigSchema.optional(),
 	vertex_key_config: VertexKeyConfigSchema.optional(),
 	bedrock_key_config: BedrockKeyConfigSchema.optional(),

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -16,14 +16,6 @@ export const isKnownProvider = (provider: string): provider is KnownProvider => 
 	return KnownProvidersNames.includes(provider.toLowerCase() as KnownProvider);
 };
 
-export interface OpenAIKeyConfig {
-	use_responses_api: boolean;
-}
-
-export const DefaultOpenAIKeyConfig: OpenAIKeyConfig = {
-	use_responses_api: false,
-} as const satisfies Required<OpenAIKeyConfig>;
-
 // AzureKeyConfig matching Go's schemas.AzureKeyConfig
 export interface AzureKeyConfig {
 	endpoint: string;
@@ -73,10 +65,10 @@ export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
 // Key structure matching Go's schemas.Key
 export interface ModelProviderKey {
 	id: string;
+	name: string;
 	value?: string;
 	models?: string[];
 	weight: number;
-	openai_key_config?: OpenAIKeyConfig;
 	azure_key_config?: AzureKeyConfig;
 	vertex_key_config?: VertexKeyConfig;
 	bedrock_key_config?: BedrockKeyConfig;
@@ -85,6 +77,7 @@ export interface ModelProviderKey {
 // Default ModelProviderKey
 export const DefaultModelProviderKey: ModelProviderKey = {
 	id: "",
+	name: "",
 	value: "",
 	models: [],
 	weight: 1.0,

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -1,5 +1,7 @@
 // Governance types that match the Go backend structures
 
+import { ModelProviderName } from "./config";
+
 export interface Budget {
 	id: string;
 	max_limit: number; // In dollars
@@ -43,8 +45,10 @@ export interface Customer {
 
 export interface DBKey {
 	key_id: string; // UUID identifier for the key
+	name: string; // Name of the key
 	provider_id: string; // identifier for the provider
 	models: string[]; // List of models this key can access
+	provider: ModelProviderName; // Provider name
 }
 
 export interface VirtualKey {

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -12,11 +12,6 @@ export const customProviderNameSchema = z.string().min(1, "Custom provider name 
 // Model provider name schema (union of known and custom providers)
 export const modelProviderNameSchema = z.union([knownProviderSchema, customProviderNameSchema]);
 
-// OpenAI key config schema
-export const openaiKeyConfigSchema = z.object({
-	use_responses_api: z.boolean(),
-});
-
 // Azure key config schema
 export const azureKeyConfigSchema = z.object({
 	endpoint: z.url("Must be a valid URL"),
@@ -45,6 +40,7 @@ export const bedrockKeyConfigSchema = z.object({
 export const modelProviderKeySchema = z
 	.object({
 		id: z.string().min(1, "Id is required"),
+		name: z.string().min(1, "Name is required"),
 		value: z.string().optional(),
 		models: z.array(z.string()).default([]).optional(),
 		weight: z.union([
@@ -67,7 +63,6 @@ export const modelProviderKeySchema = z
 				})
 				.pipe(z.number().min(0.1, "Weight must be greater than 0.1").max(1, "Weight must be less than 1")),
 		]),
-		openai_key_config: openaiKeyConfigSchema.optional(),
 		azure_key_config: azureKeyConfigSchema.optional(),
 		vertex_key_config: vertexKeyConfigSchema.optional(),
 		bedrock_key_config: bedrockKeyConfigSchema.optional(),


### PR DESCRIPTION
## Summary

Add a human-friendly name field to API keys and remove OpenAI-specific response API configuration.

## Changes

- Added a new `name` field to API keys to provide a human-readable identifier
- Removed the OpenAI-specific `use_responses_api` configuration and related fields
- Updated the UI to display key names instead of key IDs or values
- Added database migration to create and populate the name field for existing keys
- Reorganized the API key form in the UI for better usability

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)

## How to test

1. Start the application with existing keys
2. Verify that existing keys have automatically generated names
3. Create a new key and provide a custom name
4. Verify the name appears in the UI instead of the key ID

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

The removal of the OpenAI `use_responses_api` configuration is a breaking change. Any code that relied on this configuration will need to be updated.

## Security considerations

This change improves security by reducing the exposure of sensitive key IDs and values in the UI, replacing them with human-readable names.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)