### PR TITLE
adds health-endpoint for liveness/rediness probe

### DIFF
--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -250,6 +250,37 @@
         }
       }
     },
+    "/health": {
+      "get": {
+        "summary": "Get Health",
+        "description": "Returns the health of the server. This endpoint can be safely used as liveness probe and readiness probe for Kubernetes. It also internally validates connection to config store, log store, vector store",
+        "operationId": "getHealth",
+        "tags": [
+          "Health"
+        ],
+        "responses": {
+          "200": {
+            "description": "Server is healthy and all stores are available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable. One or more required stores (config store, log store, or vector store) are not available."
+          }
+        }
+      }      
+    },
     "/metrics": {
       "get": {
         "summary": "Get Prometheus Metrics",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -108,7 +108,7 @@
             "group": "Enterprise Features",
             "icon": "building",
             "pages": [
-              "enterprise/guardrails",              
+              "enterprise/guardrails",
               "enterprise/clustering",
               "enterprise/governance",
               "enterprise/mcp-with-fa",
@@ -127,17 +127,17 @@
         "icon": "server",
         "pages": [
           {
-            "group":"Common setup instructions",
-            "icon": "book",
-            "pages": [
-              "deployment-guides/how-to/install-make"
-            ]
-          },
-          {
-            "group":"Platform specific guides",
+            "group": "Platform specific guides",
             "icon": "swatchbook",
             "pages": [
               "deployment-guides/fly"
+            ]
+          },
+          {
+            "group": "Common setup instructions",
+            "icon": "book",
+            "pages": [
+              "deployment-guides/how-to/install-make"
             ]
           }
         ]

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -43,6 +43,11 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 	})
 }
 
+// Ping checks if the database is reachable.
+func (s *RDBConfigStore) Ping(ctx context.Context) error {
+	return s.db.WithContext(ctx).Exec("SELECT 1").Error
+}
+
 // DB returns the underlying database connection.
 func (s *RDBConfigStore) DB() *gorm.DB {
 	return s.db

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -15,6 +15,8 @@ import (
 
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
+	// Health check
+	Ping(ctx context.Context) error
 
 	// Client config CRUD
 	UpdateClientConfig(ctx context.Context, config *ClientConfig) error

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/weaviate/weaviate v1.31.5
 	github.com/weaviate/weaviate-go-client/v5 v5.2.0
+	golang.org/x/crypto v0.41.0
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.0
 )
@@ -21,7 +22,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 )
 

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -22,6 +22,11 @@ func (s *RDBLogStore) Create(ctx context.Context, entry *Log) error {
 	return s.db.WithContext(ctx).Create(entry).Error
 }
 
+// Ping checks if the database is reachable.
+func (s *RDBLogStore) Ping(ctx context.Context) error {
+	return s.db.WithContext(ctx).Exec("SELECT 1").Error
+}
+
 // Update updates a log entry in the database.
 func (s *RDBLogStore) Update(ctx context.Context, id string, entry any) error {
 	tx := s.db.WithContext(ctx).Model(&Log{}).Where("id = ?", id).Updates(entry)

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -18,7 +18,8 @@ const (
 )
 
 // LogStore is the interface for the log store.
-type LogStore interface {
+type LogStore interface {	
+	Ping(ctx context.Context) error
 	Create(ctx context.Context, entry *Log) error
 	FindFirst(ctx context.Context, query any, fields ...string) (*Log, error)
 	FindAll(ctx context.Context, query any, fields ...string) ([]*Log, error)

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -46,6 +46,12 @@ type RedisStore struct {
 	logger schemas.Logger
 }
 
+// Ping checks if the Redis server is reachable.
+func (s *RedisStore) Ping(ctx context.Context) error {
+	return s.client.Ping(ctx).Err()
+}
+
+// CreateNamespace creates a new namespace in the Redis vector store.
 func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dimension int, properties map[string]VectorStoreProperties) error {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -105,6 +111,7 @@ func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dime
 	return nil
 }
 
+// GetChunk retrieves a chunk from the Redis vector store.
 func (s *RedisStore) GetChunk(ctx context.Context, namespace string, id string) (SearchResult, error) {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -141,6 +148,7 @@ func (s *RedisStore) GetChunk(ctx context.Context, namespace string, id string) 
 	return searchResult, nil
 }
 
+// GetChunks retrieves multiple chunks from the Redis vector store.
 func (s *RedisStore) GetChunks(ctx context.Context, namespace string, ids []string) ([]SearchResult, error) {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -204,6 +212,7 @@ func (s *RedisStore) GetChunks(ctx context.Context, namespace string, ids []stri
 	return results, nil
 }
 
+// GetAll retrieves all chunks from the Redis vector store.
 func (s *RedisStore) GetAll(ctx context.Context, namespace string, queries []Query, selectFields []string, cursor *string, limit int64) ([]SearchResult, *string, error) {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -460,6 +469,7 @@ func buildRedisQueryCondition(query Query) string {
 	}
 }
 
+// GetNearest retrieves the nearest chunks from the Redis vector store.
 func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []float32, queries []Query, selectFields []string, threshold float64, limit int64) ([]SearchResult, error) {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -565,6 +575,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 	return results, nil
 }
 
+// Add stores a new chunk in the Redis vector store.
 func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embedding []float32, metadata map[string]interface{}) error {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -618,6 +629,7 @@ func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embed
 	return nil
 }
 
+// Delete deletes a chunk from the Redis vector store.
 func (s *RedisStore) Delete(ctx context.Context, namespace string, id string) error {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -643,6 +655,7 @@ func (s *RedisStore) Delete(ctx context.Context, namespace string, id string) er
 	return nil
 }
 
+// DeleteAll deletes all chunks from the Redis vector store.
 func (s *RedisStore) DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error) {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -742,6 +755,7 @@ func (s *RedisStore) deleteAllWithCursor(ctx context.Context, namespace string, 
 	return deleteResults, nil
 }
 
+// DeleteNamespace deletes a namespace from the Redis vector store.
 func (s *RedisStore) DeleteNamespace(ctx context.Context, namespace string) error {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
@@ -758,6 +772,7 @@ func (s *RedisStore) DeleteNamespace(ctx context.Context, namespace string) erro
 	return nil
 }
 
+// Close closes the Redis vector store.
 func (s *RedisStore) Close(ctx context.Context, namespace string) error {
 	// Close the Redis client connection
 	return s.client.Close()

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -76,6 +76,8 @@ const (
 
 // VectorStore represents the interface for the vector store.
 type VectorStore interface {
+	// Health check
+	Ping(ctx context.Context) error
 	CreateNamespace(ctx context.Context, namespace string, dimension int, properties map[string]VectorStoreProperties) error
 	DeleteNamespace(ctx context.Context, namespace string) error
 	GetChunk(ctx context.Context, namespace string, id string) (SearchResult, error)

--- a/framework/vectorstore/weaviate.go
+++ b/framework/vectorstore/weaviate.go
@@ -29,7 +29,7 @@ type WeaviateConfig struct {
 	GrpcConfig *WeaviateGrpcConfig `json:"grpc_config,omitempty"` // grpc config for weaviate (optional)
 
 	// Authentication settings (optional)
-	ApiKey  string            `json:"api_key,omitempty"` // API key for authentication
+	APIKey  string            `json:"api_key,omitempty"` // API key for authentication
 	Headers map[string]string `json:"headers,omitempty"` // Additional headers
 
 	// Connection settings
@@ -49,6 +49,12 @@ type WeaviateStore struct {
 	client *weaviate.Client
 	config *WeaviateConfig
 	logger schemas.Logger
+}
+
+// Ping checks if the Weaviate server is reachable.
+func (s *WeaviateStore) Ping(ctx context.Context) error {
+	_, err := s.client.Misc().MetaGetter().Do(ctx)
+	return err
 }
 
 // Add stores a new object (with or without embedding)
@@ -403,8 +409,8 @@ func newWeaviateStore(ctx context.Context, config *WeaviateConfig, logger schema
 	}
 
 	// Add authentication if provided
-	if config.ApiKey != "" {
-		cfg.AuthConfig = auth.ApiKey{Value: config.ApiKey}
+	if config.APIKey != "" {
+		cfg.AuthConfig = auth.ApiKey{Value: config.APIKey}
 	}
 
 	// Add grpc config if provided

--- a/framework/vectorstore/weaviate_test.go
+++ b/framework/vectorstore/weaviate_test.go
@@ -49,7 +49,7 @@ func NewTestSetup(t *testing.T) *TestSetup {
 	config := WeaviateConfig{
 		Scheme:  scheme,
 		Host:    host,
-		ApiKey:  apiKey,
+		APIKey:  apiKey,
 		Timeout: timeout,
 	}
 
@@ -204,7 +204,7 @@ func TestWeaviateConfig_Validation(t *testing.T) {
 			config: WeaviateConfig{
 				Scheme: "https",
 				Host:   "cluster.weaviate.network",
-				ApiKey: "test-key",
+				APIKey: "test-key",
 			},
 			expectError: false,
 		},
@@ -723,7 +723,7 @@ func TestVectorStoreFactory_Weaviate(t *testing.T) {
 		Config: WeaviateConfig{
 			Scheme: getEnvWithDefault("WEAVIATE_SCHEME", DefaultTestScheme),
 			Host:   getEnvWithDefault("WEAVIATE_HOST", DefaultTestHost),
-			ApiKey: os.Getenv("WEAVIATE_API_KEY"),
+			APIKey: os.Getenv("WEAVIATE_API_KEY"),
 		},
 	}
 

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -38,7 +38,7 @@ func getWeaviateConfigFromEnv() vectorstore.WeaviateConfig {
 	return vectorstore.WeaviateConfig{
 		Scheme:  scheme,
 		Host:    host,
-		ApiKey:  apiKey,
+		APIKey:  apiKey,
 		Timeout: time.Duration(timeout) * time.Second,
 	}
 }

--- a/transports/bifrost-http/handlers/health.go
+++ b/transports/bifrost-http/handlers/health.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// HealthHandler manages HTTP requests for health checks.
+type HealthHandler struct {
+	config *lib.Config
+	logger schemas.Logger
+}
+
+// NewHealthHandler creates a new health handler instance.
+func NewHealthHandler(config *lib.Config, logger schemas.Logger) *HealthHandler {
+	return &HealthHandler{
+		config: config,
+		logger: logger,
+	}
+}
+
+// RegisterRoutes registers the health-related routes.
+func (h *HealthHandler) RegisterRoutes(r *router.Router, middlewares ...lib.BifrostHTTPMiddleware) {
+	r.GET("/health", lib.ChainMiddlewares(h.getHealth, middlewares...))
+}
+
+// getHealth handles GET /api/health - Get the health status of the server.
+func (h *HealthHandler) getHealth(ctx *fasthttp.RequestCtx) {
+	// Pinging config store
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var errors []string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	if h.config.ConfigStore != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := h.config.ConfigStore.Ping(reqCtx); err != nil {
+				mu.Lock()
+				errors = append(errors, "config store not available")
+				mu.Unlock()
+			}
+		}()
+	}
+
+	// Pinging log store
+	if h.config.LogsStore != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := h.config.LogsStore.Ping(reqCtx); err != nil {
+				mu.Lock()
+				errors = append(errors, "log store not available")
+				mu.Unlock()
+			}
+		}()
+	}
+
+	// Pinging vector store
+	if h.config.VectorStore != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := h.config.VectorStore.Ping(reqCtx); err != nil {
+				mu.Lock()
+				errors = append(errors, "vector store not available")
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if len(errors) > 0 {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, errors[0], h.logger)
+		return
+	}
+	SendJSON(ctx, map[string]any{"status": "ok"}, h.logger)
+}

--- a/transports/bifrost-http/handlers/server.go
+++ b/transports/bifrost-http/handlers/server.go
@@ -470,7 +470,8 @@ func (s *BifrostHTTPServer) RegisterRoutes(ctx context.Context, middlewares ...l
 	middlewaresWithTelemetry := append(middlewares, telemetry.PrometheusMiddleware)
 	// Chaining all middlewares
 	// lib.ChainMiddlewares chains multiple middlewares together
-	// Initialize handlers
+	// Initialize 
+	healthHandler := NewHealthHandler(s.Config, logger)
 	providerHandler := NewProviderHandler(s.Config, s.Client, logger)
 	inferenceHandler := NewInferenceHandler(s.Client, s.Config, logger)
 	mcpHandler := NewMCPHandler(s.Client, logger, s.Config)
@@ -478,6 +479,7 @@ func (s *BifrostHTTPServer) RegisterRoutes(ctx context.Context, middlewares ...l
 	configHandler := NewConfigHandler(s.Client, logger, s.Config, s)
 	pluginsHandler := NewPluginsHandler(s, s.Config.ConfigStore, logger)
 	// Register all handler routes
+	healthHandler.RegisterRoutes(s.Router, middlewares...)
 	providerHandler.RegisterRoutes(s.Router, middlewares...)
 	inferenceHandler.RegisterRoutes(s.Router, middlewaresWithTelemetry...)
 	mcpHandler.RegisterRoutes(s.Router, middlewares...)

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2212,8 +2212,8 @@ func (c *Config) GetVectorStoreConfigRedacted(ctx context.Context) (*vectorstore
 		// Create a copy to avoid modifying the original
 		redactedWeaviateConfig := *weaviateConfig
 		// Redact password if it exists
-		if redactedWeaviateConfig.ApiKey != "" {
-			redactedWeaviateConfig.ApiKey = RedactKey(redactedWeaviateConfig.ApiKey)
+		if redactedWeaviateConfig.APIKey != "" {
+			redactedWeaviateConfig.APIKey = RedactKey(redactedWeaviateConfig.APIKey)
 		}
 		redactedVectorStoreConfig := *vectorStoreConfig
 		redactedVectorStoreConfig.Config = &redactedWeaviateConfig


### PR DESCRIPTION
## Summary

Added a health check endpoint that validates connections to the config store, log store, and vector store, making it suitable for Kubernetes liveness and readiness probes.

## Changes

- Added a new `/health` endpoint to the HTTP API
- Implemented `Ping()` methods in all store interfaces (config, log, vector)
- Added implementations for Redis, RDB, and Weaviate stores
- Fixed naming inconsistency from `ApiKey` to `APIKey` in Weaviate config
- Updated OpenAPI documentation to include the new health endpoint

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Docs

## How to test

Test the health endpoint with a running server:

```sh
# Start the server
go run main.go

# Test the health endpoint
curl http://localhost:8000/health

# Expected response:
# {"status":"ok"}

# Test with unavailable stores (by stopping databases)
# Expected response:
# {"error":"config store not available"}
```

## Breaking changes

- [x] No

## Security considerations

The health endpoint doesn't expose sensitive information, only returning a status code and simple message about store availability.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)