### PR TITLE
removes active releases from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,6 @@
 
 Bifrost is a high-performance AI gateway that unifies access to 12+ providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex, and more) through a single OpenAI-compatible API. Deploy in seconds with zero configuration and get automatic failover, load balancing, semantic caching, and enterprise-grade features.
 
-## Active releases
-
-<table style="width: 100%;">
-  <tr>
-    <th>Release Type</th>
-    <th>Version</th>
-  </tr>
-  <tr>
-    <td><strong>Stable</strong></td>
-    <td>v1.2.24</td>
-  </tr>
-  <tr>
-    <td><strong>Pre-release</strong></td>
-    <td>v1.3.0-prerelease7</td>
-  </tr>
-</table>
-
 ## Quick Start
 
 ![Get started](./docs/media/getting-started.png)


### PR DESCRIPTION
## Summary

Remove the "Active releases" section from the README.md file to simplify the documentation.

## Changes

- Removed the "Active releases" table from the README.md that displayed stable (v1.2.24) and pre-release (v1.3.0-prerelease7) version information
- This change streamlines the README by removing version information that requires frequent updates

## Type of change

- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Docs

## How to test

Verify the README.md renders correctly without the version table:

```sh
# View the README in a markdown viewer or on GitHub
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified the CI pipeline passes locally if applicable