### PR TITLE
build fix

### DIFF
--- a/docs/architecture/framework/vector-store.mdx
+++ b/docs/architecture/framework/vector-store.mdx
@@ -176,7 +176,7 @@ vectorConfig := &vectorstore.Config{
     Config: vectorstore.WeaviateConfig{
         Scheme: "http",           // "http" for local, "https" for cloud
         Host:   "localhost:8080", // Your Weaviate host
-        ApiKey: "your-weaviate-api-key", // Required for Weaviate Cloud; optional for local/self-hosted
+        APIKey: "your-weaviate-api-key", // Required for Weaviate Cloud; optional for local/self-hosted
 
         // Enable gRPC for improved performance (optional)
         GrpcConfig: &vectorstore.WeaviateGrpcConfig{
@@ -249,7 +249,7 @@ vectorConfig := &vectorstore.Config{
     Config: vectorstore.WeaviateConfig{
         Scheme: "https",
         Host:   "your-weaviate-host",
-        ApiKey: "your-api-key",
+        APIKey: "your-api-key",
         
         // Enable gRPC for better performance
         GrpcConfig: &vectorstore.WeaviateGrpcConfig{

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/fasthttp/router v1.5.4
 	github.com/fasthttp/websocket v1.5.12
 	github.com/google/uuid v1.6.0
-	github.com/maximhq/bifrost/core v1.2.7
-	github.com/maximhq/bifrost/framework v1.1.7
+	github.com/maximhq/bifrost/core v1.2.8
+	github.com/maximhq/bifrost/framework v1.1.8
 	github.com/maximhq/bifrost/plugins/governance v1.3.7
 	github.com/maximhq/bifrost/plugins/logging v1.3.7
 	github.com/maximhq/bifrost/plugins/maxim v1.4.7

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -10,7 +10,9 @@ github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:W
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.39.2 h1:EJLg8IdbzgeD7xgvZ+I8M1e0fL0ptn/M47lianzth0I=
+github.com/aws/aws-sdk-go-v2 v1.39.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 h1:i8p8P4diljCr60PpJp6qZXNlgX4m2yQFpYk+9ZT+J4E=
+github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1/go.mod h1:ddqbooRZYNoJ2dsTwOty16rM+/Aqmk/GOXrK8cg7V00=
 github.com/aws/aws-sdk-go-v2/config v1.31.0 h1:9yH0xiY5fUnVNLRWO0AtayqwU1ndriZdN78LlhruJR4=
 github.com/aws/aws-sdk-go-v2/config v1.31.0/go.mod h1:VeV3K72nXnhbe4EuxxhzsDc/ByrCSlZwUnWH52Nde/I=
 github.com/aws/aws-sdk-go-v2/credentials v1.18.4 h1:IPd0Algf1b+Qy9BcDp0sCUcIWdCQPSzDoMK3a8pcbUM=
@@ -18,7 +20,9 @@ github.com/aws/aws-sdk-go-v2/credentials v1.18.4/go.mod h1:nwg78FjH2qvsRM1EVZlX9
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.3 h1:GicIdnekoJsjq9wqnvyi2elW6CGMSYKhdozE7/Svh78=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.3/go.mod h1:R7BIi6WNC5mc1kfRM7XM/VHC3uRWkjc396sfabq4iOo=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9 h1:se2vOWGD3dWQUtfn4wEjRQJb1HK1XsNIt825gskZ970=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.9/go.mod h1:hijCGH2VfbZQxqCDN7bwz/4dzxV+hkyhjawAtdPWKZA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9 h1:6RBnKZLkJM4hQ+kN6E7yWFveOTg8NLPHAkqrs4ZPlTU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.9/go.mod h1:V9rQKRmK7AWuEsOMnHzKj8WyrIir1yUJbZxDuZLFvXI=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 h1:6+lZi2JeGKtCraAj1rpoZfKqnQ9SptseRZioejfUOLM=
@@ -32,6 +36,7 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.33.0/go.mod h1:59qHWaY5B+Rs7HGTu
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0 h1:MG9VFW43M4A8BYeAfaJJZWrroinxeTi2r3+SnmLQfSA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.37.0/go.mod h1:JdeBDPgpJfuS6rU/hNglmOigKhyEZtBmbraLE4GK1J8=
 github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
+github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -198,10 +203,10 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/maximhq/bifrost/core v1.2.7 h1:GuVxkdPlko3Bu/29w/EWVinwC6BdVYRpfYMVarTLYzY=
-github.com/maximhq/bifrost/core v1.2.7/go.mod h1:+XuS+bhOBxyOimr6iIMKLJJTC0syNfP3+WGV0xishRU=
-github.com/maximhq/bifrost/framework v1.1.7 h1:O8oyhPNnTCkRPz6SmGkhU7iTqCvF/5QKoZ2cE8ivME0=
-github.com/maximhq/bifrost/framework v1.1.7/go.mod h1:JbMHkf53L6tCYmn9kR4q0oWRryFfiL78wEapf3JoA8Q=
+github.com/maximhq/bifrost/core v1.2.8 h1:n0izWBhovdO4UtLjfWtJi0Lr7UWEHtHx9zewpqP+Ksg=
+github.com/maximhq/bifrost/core v1.2.8/go.mod h1:RCyChXNiw50vP6nf4NBAHxKs9NFOIXo7L7XTONR6fy4=
+github.com/maximhq/bifrost/framework v1.1.8 h1:01IrrrZ4ytS5/RyKPnGeDssdl+UhHkVXNvSpJuOQ4I0=
+github.com/maximhq/bifrost/framework v1.1.8/go.mod h1:B2T6YoZEaHqWqBt414UjqKTJLVgSvlKDVCaSySgNrxg=
 github.com/maximhq/bifrost/plugins/governance v1.3.7 h1:EunkstvJZfVzXN0DDE7eKFu3t6J259wkpppVmYv1Gug=
 github.com/maximhq/bifrost/plugins/governance v1.3.7/go.mod h1:2MmkxNqZt9srgMHlEX+uw1P6urowcTfpyqDun27LeD4=
 github.com/maximhq/bifrost/plugins/logging v1.3.7 h1:f5C5ZL3vQYpAJlPKnzdKbHSmtezJq8WgPb7vDDToxgM=

--- a/ui/app/_fallbacks/enterprise/components/guardrails/guardrailsProviderView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/guardrails/guardrailsProviderView.tsx
@@ -2,7 +2,7 @@ import { Construction } from "lucide-react";
 import ContactUsView from "../views/contactUsView";
 
 
-export default function GuardrailsProviderView() {
+export default function guardrailsProviderView() {
     return (
         <div className="h-full w-full">
             <ContactUsView

--- a/ui/app/guardrails/page.tsx
+++ b/ui/app/guardrails/page.tsx
@@ -1,6 +1,4 @@
-import GuardrailsView from "@/app/enterprise/components/guardrails/guardrailsProviderView";
-
-
+import GuardrailsView from "@enterprise/components/guardrails/guardrailsProviderView";
 
 export default function GuardrailsPage() {
 	return <GuardrailsView />;


### PR DESCRIPTION
## Summary

Fix Weaviate API field naming convention and update import paths for guardrails component.

## Changes

- Renamed `ApiKey` to `APIKey` in Weaviate configuration examples to follow Go naming conventions
- Updated dependencies for core and framework packages to latest versions (v1.2.8 and v1.1.8)
- Fixed casing in guardrails component export function name
- Updated import path for guardrails component to use the enterprise alias

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is primarily a naming convention fix and import path update.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable