### PR TITLE
fix: function properties type in semantic cache test --skip-pipeline

### DIFF
--- a/plugins/semanticcache/plugin_edge_cases_test.go
+++ b/plugins/semanticcache/plugin_edge_cases_test.go
@@ -124,7 +124,7 @@ func TestToolVariations(t *testing.T) {
 						Description: bifrost.Ptr("Get the current weather"),
 						Parameters: &schemas.ToolFunctionParameters{
 							Type: "object",
-							Properties: map[string]interface{}{
+							Properties: &map[string]interface{}{
 								"location": map[string]interface{}{
 									"type":        "string",
 									"description": "The city and state",
@@ -161,7 +161,7 @@ func TestToolVariations(t *testing.T) {
 						Description: bifrost.Ptr("Get current weather information"),
 						Parameters: &schemas.ToolFunctionParameters{
 							Type: "object",
-							Properties: map[string]interface{}{
+							Properties: &map[string]interface{}{
 								"city": map[string]interface{}{ // Different parameter name
 									"type":        "string",
 									"description": "The city name",


### PR DESCRIPTION
## Summary

Fix type mismatch in semantic cache plugin tests by changing `Properties` field type from `map[string]interface{}` to `&map[string]interface{}` to match the schema definition.

## Changes

- Updated the `Properties` field in `TestToolVariations` test to use a pointer to a map (`&map[string]interface{}`) instead of a direct map
- This change ensures the test correctly matches the expected schema structure defined in the `schemas.ToolFunctionParameters` type

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache plugin tests to verify they pass with the updated type:

```sh
go test ./plugins/semanticcache/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a test-only change that fixes a type mismatch.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable