### PR TITLE
fix-provider-selection-from-url params

### DIFF
--- a/ui/app/providers/page.tsx
+++ b/ui/app/providers/page.tsx
@@ -78,7 +78,7 @@ export default function Providers() {
 				});
 			});
 		return;
-	}, [provider]);
+	}, [provider, isLoadingProviders]);
 
 	useEffect(() => {
 		if (selectedProvider || !allProviders || allProviders.length === 0 || provider) return;


### PR DESCRIPTION
## Summary

Added `isLoadingProviders` to the dependency array of a useEffect hook to ensure proper re-rendering when the loading state changes.

## Changes

- Added `isLoadingProviders` to the dependency array of a useEffect hook in the Providers component
- This ensures the effect runs when the loading state changes, preventing potential stale state issues

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the providers page properly updates when the loading state changes:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Navigate to the providers page and verify that the component behaves correctly during loading states.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the effect might not run when the loading state changes.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable