### PR TITLE
fix: minor logs ui and api reference fixes

### DIFF
--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -1581,7 +1581,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogSearchResult"
+                  "$ref": "#/components/schemas/SearchResult"
                 }
               }
             }
@@ -4889,31 +4889,6 @@
           }
         }
       },
-      "SearchStats": {
-        "type": "object",
-        "properties": {
-          "total_requests": {
-            "type": "integer",
-            "description": "Total number of requests"
-          },
-          "success_rate": {
-            "type": "number",
-            "description": "Percentage of successful requests"
-          },
-          "average_latency": {
-            "type": "number",
-            "description": "Average latency in milliseconds"
-          },
-          "total_tokens": {
-            "type": "integer",
-            "description": "Total tokens used"
-          },
-          "total_cost": {
-            "type": "number",
-            "description": "Total cost in dollars"
-          }
-        }
-      },
       "EmbeddingRequest": {
         "type": "object",
         "required": [
@@ -6148,109 +6123,186 @@
       "Log": {
         "type": "object",
         "properties": {
-          "ID": {
-            "type": "integer"
+          "id": { "type": "string" },
+          "parent_request_id": { "type": "string", "nullable": true },
+          "timestamp": { "type": "string", "format": "date-time" },
+          "object": { "type": "string" },
+          "provider": { "type": "string" },
+          "model": { "type": "string" },
+          "latency": { "type": "number", "format": "double", "nullable": true },
+          "cost": { "type": "number", "format": "double", "nullable": true },
+          "status": { "type": "string" },
+          "stream": { "type": "boolean" },
+          "raw_response": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "input_history": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ChatMessage" }
           },
-          "CreatedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "UpdatedAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "DeletedAt": {
-            "type": "string",
-            "format": "date-time",
+          "output_message": {
+            "type": "object",
+            "$ref": "#/components/schemas/ChatMessage",
             "nullable": true
           },
-          "request_id": {
-            "type": "string"
+          "responses_output": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ResponsesMessage" }
           },
-          "provider": {
-            "type": "string"
+          "embedding_output": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/EmbeddingData" }
           },
-          "model": {
-            "type": "string"
+          "params": { "type": "object", "nullable": true },
+          "tools": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ChatTool" }
           },
-          "object": {
-            "type": "string"
+          "tool_calls": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ChatAssistantMessageToolCall" }
           },
-          "status": {
-            "type": "string"
-          },
-          "request_body": {
-            "type": "string"
-          },
-          "response_body": {
-            "type": "string"
-          },
-          "latency": {
-            "type": "integer",
-            "description": "in nanoseconds"
-          },
-          "is_streaming": {
-            "type": "boolean"
-          },
-          "stream_channel": {
-            "type": "string"
-          },
-          "prompt_tokens": {
-            "type": "integer"
-          },
-          "completion_tokens": {
-            "type": "integer"
-          },
-          "total_tokens": {
-            "type": "integer"
-          },
-          "cost": {
-            "type": "number"
-          },
-          "billed_tokens": {
-            "type": "integer"
-          },
-          "billed_cost": {
-            "type": "number"
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "virtual_key": {
-            "type": "string"
-          },
-          "key": {
-            "type": "string"
-          },
-          "custom_id": {
-            "type": "string"
-          },
-          "user": {
-            "type": "string"
-          },
-          "is_fallback": {
-            "type": "boolean"
-          },
-          "retry_count": {
-            "type": "integer"
-          },
-          "target": {
-            "type": "string"
-          },
-          "plugin_execution": {
-            "type": "string"
-          },
-          "plugin_short_circuit": {
-            "type": "boolean"
-          },
-          "semantic_cache_hit": {
-            "type": "boolean"
-          },
-          "metadata": {
+          "token_usage": {
             "type": "object",
-            "additionalProperties": true
+            "$ref": "#/components/schemas/BifrostLLMUsage",
+            "nullable": true
+          },
+          "error_details": {
+            "type": "object",
+            "$ref": "#/components/schemas/BifrostError",
+            "nullable": true
+          },
+          "speech_input": {
+            "type": "object",
+            "$ref": "#/components/schemas/SpeechInput",
+            "nullable": true
+          },
+          "transcription_input": {
+            "type": "object",
+            "$ref": "#/components/schemas/TranscriptionInput",
+            "nullable": true
+          },
+          "speech_output": {
+            "type": "object",
+            "$ref": "#/components/schemas/BifrostSpeechResponse",
+            "nullable": true
+          },
+          "transcription_output": {
+            "type": "object",
+            "$ref": "#/components/schemas/BifrostTranscriptionResponse",
+            "nullable": true
+          },
+          "cache_debug": {
+            "type": "object",
+            "$ref": "#/components/schemas/BifrostCacheDebug",
+            "nullable": true
           }
+        }
+      },
+      "EmbeddingData": {
+        "type": "object",
+        "properties": {
+          "index": { "type": "integer" },
+          "object": { "type": "string", "example": "embedding" },
+          "embedding": { "$ref": "#/components/schemas/EmbeddingStruct" }
+        }
+      },
+      "EmbeddingStruct": {
+        "oneOf": [
+          { "type": "string" },
+          { "type": "array", "items": { "type": "number", "format": "float" } },
+          { "type": "array", "items": { "type": "array", "items": { "type": "number", "format": "float" } } }
+        ],
+        "description": "The embedding vector, which can be a string, a list of floats, or a list of lists of floats."
+      },
+      "BifrostLLMUsage": {
+        "type": "object",
+        "properties": {
+          "prompt_tokens": { "type": "integer" },
+          "completion_tokens": { "type": "integer" },
+          "total_tokens": { "type": "integer" }
+        }
+      },
+      "SpeechInput": {
+        "type": "object",
+        "properties": {
+          "input": { "type": "string" }
+        }
+      },
+      "TranscriptionInput": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "byte",
+            "description": "The audio file to transcribe."
+          }
+        }
+      },
+      "BifrostSpeechResponse": {
+        "type": "object",
+        "properties": {
+          "audio": { "type": "string", "format": "byte", "description": "The generated audio file." },
+          "usage": { "$ref": "#/components/schemas/SpeechUsage", "nullable": true }
+        }
+      },
+      "SpeechUsage": {
+        "type": "object",
+        "properties": {
+          "input_tokens": { "type": "integer" },
+          "output_tokens": { "type": "integer" },
+          "total_tokens": { "type": "integer" }
+        }
+      },
+      "BifrostTranscriptionResponse": {
+        "type": "object",
+        "properties": {
+          "duration": { "type": "number", "format": "double", "nullable": true },
+          "language": { "type": "string", "nullable": true },
+          "text": { "type": "string" },
+          "words": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TranscriptionWord" }
+          },
+          "segments": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TranscriptionSegment" }
+          }
+        }
+      },
+      "TranscriptionWord": {
+        "type": "object",
+        "properties": {
+          "word": { "type": "string" },
+          "start": { "type": "number", "format": "double" },
+          "end": { "type": "number", "format": "double" }
+        }
+      },
+      "TranscriptionSegment": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "seek": { "type": "integer" },
+          "start": { "type": "number", "format": "double" },
+          "end": { "type": "number", "format": "double" },
+          "text": { "type": "string" },
+          "tokens": { "type": "array", "items": { "type": "integer" } },
+          "temperature": { "type": "number", "format": "float" },
+          "avg_logprob": { "type": "number", "format": "double" },
+          "compression_ratio": { "type": "number", "format": "double" },
+          "no_speech_prob": { "type": "number", "format": "double" }
+        }
+      },
+      "BifrostCacheDebug": {
+        "type": "object",
+        "properties": {
+          "cache_hit": { "type": "boolean" },
+          "cache_id": { "type": "string", "nullable": true },
+          "hit_type": { "type": "string", "nullable": true },
+          "provider_used": { "type": "string", "nullable": true },
+          "model_used": { "type": "string", "nullable": true },
+          "input_tokens": { "type": "integer", "nullable": true },
+          "threshold": { "type": "number", "format": "double", "nullable": true },
+          "similarity": { "type": "number", "format": "double", "nullable": true }
         }
       },
       "LogSearchResult": {
@@ -6262,9 +6314,24 @@
               "$ref": "#/components/schemas/Log"
             }
           },
-          "total": {
-            "type": "integer",
-            "format": "int64"
+          "pagination": {
+            "type": "object",
+            "properties": {
+              "limit": { "type": "integer" },
+              "offset": { "type": "integer" },
+              "sort_by": { "type": "string" },
+              "order": { "type": "string" }
+            }
+          },
+          "stats": {
+            "type": "object",
+            "properties": {
+              "total_requests": { "type": "integer", "format": "int64" },
+              "success_rate": { "type": "number", "format": "double" },
+              "average_latency": { "type": "number", "format": "double" },
+              "total_tokens": { "type": "integer", "format": "int64" },
+              "total_cost": { "type": "number", "format": "double" }
+            }
           }
         }
       },
@@ -6365,6 +6432,65 @@
           "tool",
           "developer"
         ]
+      },
+      "PaginationOptions": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "sort_by": {
+            "type": "string"
+          },
+          "order": {
+            "type": "string"
+          }
+        }
+      },
+      "SearchStats": {
+        "type": "object",
+        "properties": {
+          "total_requests": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "success_rate": {
+            "type": "number",
+            "format": "double"
+          },
+          "average_latency": {
+            "type": "number",
+            "format": "double"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "total_cost": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "properties": {
+          "logs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Log"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationOptions"
+          },
+          "stats": {
+            "$ref": "#/components/schemas/SearchStats"
+          }
+        }
       }
     },
     "responses": {

--- a/ui/app/logs/views/logDetailsSheet.tsx
+++ b/ui/app/logs/views/logDetailsSheet.tsx
@@ -76,7 +76,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 					<DottedSeparator />
 					<div className="space-y-4">
 						<BlockHeader title="Request Details" icon={<FileText className="h-5 w-5 text-gray-600" />} />
-						<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
+						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
 							<LogEntryDetailsView
 								className="w-full"
 								label="Provider"
@@ -323,19 +323,19 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 								</div>
 							</>
 						)}
-					{log.error_details?.error.error && (
-						<>
-							<div className="mt-4 w-full text-left text-sm font-medium">Error Details</div>
-							<div className="w-full rounded-sm border">
-								<div className="border-b px-6 py-2 text-sm font-medium">Details</div>
-								<div className="px-6 py-2 font-mono text-xs whitespace-pre-wrap break-words">
-									{typeof log.error_details?.error.error === "string"
-										? (log.error_details.error.error)
-										: JSON.stringify(log.error_details?.error.error, null, 2)}
+						{log.error_details?.error.error && (
+							<>
+								<div className="mt-4 w-full text-left text-sm font-medium">Error Details</div>
+								<div className="w-full rounded-sm border">
+									<div className="border-b px-6 py-2 text-sm font-medium">Details</div>
+									<div className="px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap">
+										{typeof log.error_details?.error.error === "string"
+											? log.error_details.error.error
+											: JSON.stringify(log.error_details?.error.error, null, 2)}
+									</div>
 								</div>
-							</div>
-						</>
-					)}
+							</>
+						)}
 					</>
 				)}
 			</SheetContent>

--- a/ui/app/logs/views/logEntryDetailsView.tsx
+++ b/ui/app/logs/views/logEntryDetailsView.tsx
@@ -28,7 +28,7 @@ export default function LogEntryDetailsView(props: Props) {
 			<div className={props.containerClassName}>
 				{props.label !== "" && (
 					<div className="text-muted-foreground flex shrink-0 flex-row items-center gap-2 pb-2 text-xs font-medium">
-						{props.label.toUpperCase()}
+						{props.label.toUpperCase().replace(/_/g, " ")}
 					</div>
 				)}
 				<div
@@ -39,7 +39,7 @@ export default function LogEntryDetailsView(props: Props) {
 						"text-end": props.align === "right",
 					})}
 				>
-					{props.value}
+					<div className="text-bifrost-gray-300 flex-1 text-sm">{typeof props.value === "boolean" ? String(props.value) : props.value}</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

Updated the OpenAPI schema to use a unified `SearchResult` type instead of `LogSearchResult` and enhanced the Log schema with more detailed properties. Also improved the UI components for log details display.

## Changes

- Replaced `LogSearchResult` reference with `SearchResult` in the OpenAPI schema
- Expanded the `Log` schema with more detailed properties including embedding output, token usage, and cache debug information
- Added new schemas for embedding data, speech input/output, transcription, and cache debugging
- Removed the standalone `SearchStats` schema and integrated it into the `SearchResult` schema
- Added `PaginationOptions` schema for better pagination support
- Fixed UI alignment in log details sheet from `items-center` to `items-start`
- Improved error details display formatting in the log details sheet
- Enhanced `LogEntryDetailsView` to properly format labels and handle boolean values

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

```sh
# UI
cd ui
pnpm i
pnpm build

# Verify API documentation is correct
# Check that log details display properly in the UI
```

## Breaking changes

- [x] Yes
- [ ] No

The schema changes from `LogSearchResult` to `SearchResult` may require updates to client code that depends on the previous schema structure.

## Security considerations

No security implications as this is primarily a schema and UI update.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)