### PR TITLE
feat: add latency tracking and enhanced token usage details

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -545,7 +545,21 @@ type ContentLogProb struct {
 
 // BifrostLLMUsage represents token usage information
 type BifrostLLMUsage struct {
-	PromptTokens     int `json:"prompt_tokens,omitempty"`
-	CompletionTokens int `json:"completion_tokens,omitempty"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens            int                          `json:"prompt_tokens,omitempty"`
+	PromptTokensDetails     *ChatPromptTokensDetails     `json:"prompt_tokens_details,omitempty"`
+	CompletionTokens        int                          `json:"completion_tokens,omitempty"`
+	CompletionTokensDetails *ChatCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+	TotalTokens             int                          `json:"total_tokens"`
+}
+
+type ChatPromptTokensDetails struct {
+	AudioTokens  int `json:"audio_tokens,omitempty"`
+	CachedTokens int `json:"cached_tokens,omitempty"`
+}
+
+type ChatCompletionTokensDetails struct {
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
+	AudioTokens              int `json:"audio_tokens,omitempty"`
+	ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
 }

--- a/core/schemas/providers/cohere/chat.go
+++ b/core/schemas/providers/cohere/chat.go
@@ -298,6 +298,11 @@ func (response *CohereChatResponse) ToBifrostChatResponse() *schemas.BifrostChat
 			if response.Usage.Tokens.OutputTokens != nil {
 				usage.CompletionTokens = int(*response.Usage.Tokens.OutputTokens)
 			}
+			if response.Usage.CachedTokens != nil {
+				usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+					CachedTokens: int(*response.Usage.CachedTokens),
+				}
+			}
 			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 		}
 

--- a/core/schemas/providers/cohere/types.go
+++ b/core/schemas/providers/cohere/types.go
@@ -500,14 +500,13 @@ func (c *CohereStreamCitationStruct) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("citations field is neither array nor object")
 }
 
-
 // CohereStreamMessage represents the message part of streaming deltas
 type CohereStreamMessage struct {
-	Role      *string                    `json:"role,omitempty"`       // For message-start
-	Content   *CohereStreamContentStruct `json:"content,omitempty"`    // For content events (object)
-	ToolPlan  *string                    `json:"tool_plan,omitempty"`  // For tool-plan-delta
-	ToolCalls *CohereStreamToolCallStruct      `json:"tool_calls,omitempty"` // For tool-call events (flexible)
-	Citations *CohereStreamCitationStruct            `json:"citations,omitempty"`  // For citation events
+	Role      *string                     `json:"role,omitempty"`       // For message-start
+	Content   *CohereStreamContentStruct  `json:"content,omitempty"`    // For content events (object)
+	ToolPlan  *string                     `json:"tool_plan,omitempty"`  // For tool-plan-delta
+	ToolCalls *CohereStreamToolCallStruct `json:"tool_calls,omitempty"` // For tool-call events (flexible)
+	Citations *CohereStreamCitationStruct `json:"citations,omitempty"`  // For citation events
 }
 
 // CohereStreamContent represents content in streaming events

--- a/core/schemas/providers/gemini/chat.go
+++ b/core/schemas/providers/gemini/chat.go
@@ -335,7 +335,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	}
 
 	// Extract usage metadata
-	inputTokens, outputTokens, totalTokens := response.extractUsageMetadata()
+	inputTokens, outputTokens, totalTokens, cachedTokens, reasoningTokens := response.extractUsageMetadata()
 
 	// Process candidates to extract text content
 	if len(response.Candidates) > 0 {
@@ -380,6 +380,12 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 		PromptTokens:     inputTokens,
 		CompletionTokens: outputTokens,
 		TotalTokens:      totalTokens,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedTokens: cachedTokens,
+		},
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+			ReasoningTokens: reasoningTokens,
+		},
 	}
 
 	return bifrostResp
@@ -468,6 +474,12 @@ func ToGeminiChatResponse(bifrostResp *schemas.BifrostChatResponse) *GenerateCon
 			PromptTokenCount:     int32(bifrostResp.Usage.PromptTokens),
 			CandidatesTokenCount: int32(bifrostResp.Usage.CompletionTokens),
 			TotalTokenCount:      int32(bifrostResp.Usage.TotalTokens),
+		}
+		if bifrostResp.Usage.PromptTokensDetails != nil {
+			genaiResp.UsageMetadata.CachedContentTokenCount = int32(bifrostResp.Usage.PromptTokensDetails.CachedTokens)
+		}
+		if bifrostResp.Usage.CompletionTokensDetails != nil {
+			genaiResp.UsageMetadata.ThoughtsTokenCount = int32(bifrostResp.Usage.CompletionTokensDetails.ReasoningTokens)
 		}
 	}
 

--- a/core/schemas/providers/gemini/transcription.go
+++ b/core/schemas/providers/gemini/transcription.go
@@ -77,7 +77,7 @@ func (response *GenerateContentResponse) ToBifrostTranscriptionResponse() *schem
 	bifrostResp := &schemas.BifrostTranscriptionResponse{}
 
 	// Extract usage metadata
-	inputTokens, outputTokens, totalTokens := response.extractUsageMetadata()
+	inputTokens, outputTokens, totalTokens, _, _ := response.extractUsageMetadata()
 
 	// Process candidates to extract text content
 	if len(response.Candidates) > 0 {

--- a/core/schemas/providers/gemini/types.go
+++ b/core/schemas/providers/gemini/types.go
@@ -1335,3 +1335,17 @@ type GeminiChatRequestErrorStruct struct {
 	Message string `json:"message"` // Error message
 	Status  string `json:"status"`  // Error status string (e.g., "INVALID_REQUEST")
 }
+
+type GeminiGenerationError struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+		Details []struct {
+			Type            string `json:"@type"`
+			FieldViolations []struct {
+				Description string `json:"description"`
+			} `json:"fieldViolations"`
+		} `json:"details"`
+	} `json:"error"`
+}

--- a/core/schemas/providers/gemini/utils.go
+++ b/core/schemas/providers/gemini/utils.go
@@ -153,14 +153,16 @@ func ensureExtraParams(bifrostReq *schemas.BifrostChatRequest) {
 }
 
 // extractUsageMetadata extracts usage metadata from the Gemini response
-func (r *GenerateContentResponse) extractUsageMetadata() (int, int, int) {
-	var inputTokens, outputTokens, totalTokens int
+func (r *GenerateContentResponse) extractUsageMetadata() (int, int, int, int, int) {
+	var inputTokens, outputTokens, totalTokens, cachedTokens, reasoningTokens int
 	if r.UsageMetadata != nil {
 		inputTokens = int(r.UsageMetadata.PromptTokenCount)
 		outputTokens = int(r.UsageMetadata.CandidatesTokenCount)
 		totalTokens = int(r.UsageMetadata.TotalTokenCount)
+		cachedTokens = int(r.UsageMetadata.CachedContentTokenCount)
+		reasoningTokens = int(r.UsageMetadata.ThoughtsTokenCount)
 	}
-	return inputTokens, outputTokens, totalTokens
+	return inputTokens, outputTokens, totalTokens, cachedTokens, reasoningTokens
 }
 
 // convertParamsToGenerationConfig converts Bifrost parameters to Gemini GenerationConfig

--- a/core/schemas/providers/openai/chat.go
+++ b/core/schemas/providers/openai/chat.go
@@ -43,7 +43,6 @@ func ToOpenAIChatRequest(bifrostReq *schemas.BifrostChatRequest) *OpenAIChatRequ
 		openaiReq.filterOpenAISpecificParameters()
 		return openaiReq
 	}
-
 }
 
 // Filter OpenAI Specific Parameters

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -246,11 +246,15 @@ type ResponsesResponseUsage struct {
 }
 
 type ResponsesResponseInputTokens struct {
+	AudioTokens  int `json:"audio_tokens"`  // Tokens for audio input
 	CachedTokens int `json:"cached_tokens"` // Tokens retrieved from cache
 }
 
 type ResponsesResponseOutputTokens struct {
-	ReasoningTokens int `json:"reasoning_tokens"` // Number of reasoning tokens
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
+	AudioTokens              int `json:"audio_tokens,omitempty"`
+	ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
 }
 
 // =============================================================================

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -2,3 +2,4 @@
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
 - chore: version update core to 1.2.12
+- feat: added support for vertex provider/model format in pricing lookup

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -387,11 +387,7 @@ func (p *LoggerPlugin) PostHook(ctx *context.Context, result *schemas.BifrostRes
 			case result.ChatResponse != nil && result.ChatResponse.Usage != nil:
 				usage = result.ChatResponse.Usage
 			case result.ResponsesResponse != nil && result.ResponsesResponse.Usage != nil:
-				usage = &schemas.BifrostLLMUsage{
-					PromptTokens:     result.ResponsesResponse.Usage.InputTokens,
-					CompletionTokens: result.ResponsesResponse.Usage.OutputTokens,
-					TotalTokens:      result.ResponsesResponse.Usage.TotalTokens,
-				}
+				usage = result.ResponsesResponse.Usage.ToBifrostLLMUsage()
 			case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
 				usage = result.EmbeddingResponse.Usage
 			case result.TranscriptionResponse != nil && result.TranscriptionResponse.Usage != nil:

--- a/ui/app/logs/views/logDetailsSheet.tsx
+++ b/ui/app/logs/views/logDetailsSheet.tsx
@@ -119,6 +119,56 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 									<LogEntryDetailsView className="w-full" label="Prompt Tokens" value={log.token_usage?.prompt_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Completion Tokens" value={log.token_usage?.completion_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Total Tokens" value={log.token_usage?.total_tokens || "-"} />
+									{log.token_usage?.prompt_tokens_details && (
+										<>
+											{log.token_usage.prompt_tokens_details.cached_tokens && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Cached Tokens"
+													value={log.token_usage.prompt_tokens_details.cached_tokens || "-"}
+												/>
+											)}
+											{log.token_usage.prompt_tokens_details.audio_tokens && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Input Audio Tokens"
+													value={log.token_usage.prompt_tokens_details.audio_tokens || "-"}
+												/>
+											)}
+										</>
+									)}
+									{log.token_usage?.completion_tokens_details && (
+										<>
+											{log.token_usage.completion_tokens_details.reasoning_tokens && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Reasoning Tokens"
+													value={log.token_usage.completion_tokens_details.reasoning_tokens || "-"}
+												/>
+											)}
+											{log.token_usage.completion_tokens_details.audio_tokens && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Output Audio Tokens"
+													value={log.token_usage.completion_tokens_details.audio_tokens || "-"}
+												/>
+											)}
+											{log.token_usage.completion_tokens_details.accepted_prediction_tokens && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Accepted Prediction Tokens"
+													value={log.token_usage.completion_tokens_details.accepted_prediction_tokens || "-"}
+												/>
+											)}
+											{log.token_usage.completion_tokens_details.rejected_prediction_tokens && (
+												<LogEntryDetailsView
+													className="w-full"
+													label="Rejected Prediction Tokens"
+													value={log.token_usage.completion_tokens_details.rejected_prediction_tokens || "-"}
+												/>
+											)}
+										</>
+									)}
 								</div>
 							</div>
 							{log.cache_debug && (


### PR DESCRIPTION
## Summary

Added latency tracking and enhanced token usage details for LLM responses, providing more granular metrics for performance monitoring and cost analysis.

## Changes

- Added latency tracking to Vertex provider responses, measuring and reporting API call duration in milliseconds
- Enhanced `BifrostLLMUsage` structure with detailed token usage fields for both prompt and completion tokens
- Added support for specialized token types like cached tokens, reasoning tokens, audio tokens, and prediction tokens
- Implemented conversion methods between different response formats to preserve token usage details
- Updated UI to display detailed token usage information when available
- Added support for vertex provider/model format in pricing lookup
- Removed commented-out code related to response pooling in Vertex provider

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test the latency tracking and enhanced token usage details with various providers:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

Verify that latency is reported in milliseconds in the response and that detailed token usage information is displayed in the UI when available.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this PR only enhances metrics reporting.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable