### PR TITLE
docs fixes

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -371,7 +371,7 @@ jobs:
   # Push Mintlify changelog
   push-mintlify-changelog:
     needs: [check-skip, detect-changes, bifrost-http-release]
-    if: "needs.check-skip.outputs.should-skip != 'true' &&  (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' &&  (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
         contents: write

--- a/docs/changelogs/v1.3.10.mdx
+++ b/docs/changelogs/v1.3.10.mdx
@@ -5,7 +5,7 @@ description: "v1.3.10 changelog"
 <Update label="Bifrost(HTTP)" description="v1.3.10">
 
 - chore: version update core to 1.2.13 and framework to 1.1.15
-- feat: added headers support for OTel configuration. Value prefixed with env will be fetched from environment variables (env.<ENV_VAR_NAME>)
+- feat: added headers support for OTel configuration. Value prefixed with env will be fetched from environment variables (`env.ENV_VAR_NAME`)
 - feat: emission of OTel resource spans is completely async - this brings down inference overhead to < 1µsecond
 - fix: added latency calculation for vertex native requests
 - feat: added cached tokens and reasoning tokens to the usage in ui
@@ -62,7 +62,7 @@ description: "v1.3.10 changelog"
 <Update label="otel" description="v1.3.10">
 
 - chore: version update core to 1.2.13 and framework to 1.1.15
-- feat: added headers support for OTel configuration. Value prefixed with env will be fetched from environment variables (env.<ENV_VAR_NAME>)
+- feat: added headers support for OTel configuration. Value prefixed with env will be fetched from environment variables (`env.ENV_VAR_NAME`)
 - feat: emission of OTel resource spans is completely async - this brings down inference overhead to < 1µsecond
 
 </Update>


### PR DESCRIPTION
## Summary

Improve the release pipeline workflow and update changelog formatting for better readability.

## Changes

- Added `always()` condition to the `push-mintlify-changelog` job to ensure it runs even if previous jobs fail
- Fixed the formatting in changelog files for the OTel configuration headers documentation:
  - Changed `(env.<ENV_VAR_NAME>)` to use proper code formatting with backticks: ``(`env.ENV_VAR_NAME`)``
  - Applied this formatting fix in both Bifrost(HTTP) and otel sections of the changelog

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the GitHub workflow runs correctly:

```sh
# Trigger the workflow manually or through a release
# Check that the push-mintlify-changelog job runs even if other jobs fail
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable