### PR TITLE
refactor: improve Azure provider error handling and responses API support

### DIFF
--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -91,7 +91,7 @@ func (provider *MistralProvider) ListModels(ctx context.Context, key schemas.Key
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, parseOpenAIError(resp)
+		return nil, parseOpenAIError(resp, schemas.ListModelsRequest, provider.GetProviderKey(), "")
 	}
 
 	// Parse Mistral's response

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -199,12 +199,13 @@ func handleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.Bif
 	statusCode := resp.StatusCode()
 
 	if err := sonic.Unmarshal(resp.Body(), &errorResp); err != nil {
+		rawResponse := resp.Body()
+		message := fmt.Sprintf("provider API error: %s", string(rawResponse))
 		return &schemas.BifrostError{
-			IsBifrostError: true,
+			IsBifrostError: false,
 			StatusCode:     &statusCode,
 			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderResponseUnmarshal,
-				Error:   err,
+				Message: message,
 			},
 		}
 	}
@@ -307,6 +308,9 @@ func newConfigurationError(message string, providerType schemas.ModelProvider) *
 		Error: &schemas.ErrorField{
 			Message: message,
 		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			Provider: providerType,
+		},
 	}
 }
 
@@ -318,6 +322,9 @@ func newBifrostOperationError(message string, err error, providerType schemas.Mo
 		Error: &schemas.ErrorField{
 			Message: message,
 			Error:   err,
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			Provider: providerType,
 		},
 	}
 }
@@ -334,6 +341,9 @@ func newProviderAPIError(message string, err error, statusCode int, providerType
 			Message: message,
 			Error:   err,
 			Type:    errorType,
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			Provider: providerType,
 		},
 	}
 }

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -890,7 +890,7 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, ge
 		return
 	}
 
-	var requestType schemas.RequestType
+	var includeEventType bool
 
 	// Use streaming response writer
 	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
@@ -902,7 +902,7 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, ge
 				continue
 			}
 
-			includeEventType := false
+			includeEventType = false
 			if chunk.BifrostResponsesStreamResponse != nil ||
 				(chunk.BifrostError != nil && chunk.BifrostError.ExtraFields.RequestType == schemas.ResponsesStreamRequest) {
 				includeEventType = true
@@ -951,10 +951,10 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, ge
 			}
 		}
 
-		if requestType != schemas.ResponsesStreamRequest {
+		if !includeEventType {
 			// Send the [DONE] marker to indicate the end of the stream (only for non-responses APIs)
 			if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
-				h.logger.Warn(fmt.Sprintf("Failed to write SSE done marker: %v", err))
+				h.logger.Warn(fmt.Sprintf("Failed to write SSE [DONE] marker: %v", err))
 			}
 		}
 		// Note: OpenAI responses API doesn't use [DONE] marker, it ends when the stream closes

--- a/ui/app/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/providers/fragments/apiKeysFormFragment.tsx
@@ -158,7 +158,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							<FormItem>
 								<FormLabel>Endpoint (Required)</FormLabel>
 								<FormControl>
-									<Input placeholder="https://your-resource.openai.azure.com or env.AZURE_ENDPOINT" {...field} />
+									<Input placeholder="https://your-resource.openai.azure.com or env.AZURE_ENDPOINT" {...field} value={field.value ?? ""} />
 								</FormControl>
 								<FormMessage />
 							</FormItem>
@@ -171,7 +171,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							<FormItem>
 								<FormLabel>API Version (Optional)</FormLabel>
 								<FormControl>
-									<Input placeholder="2024-02-01 or env.AZURE_API_VERSION" {...field} />
+									<Input placeholder="2024-02-01 or env.AZURE_API_VERSION" {...field} value={field.value ?? ""} />
 								</FormControl>
 								<FormMessage />
 							</FormItem>


### PR DESCRIPTION
## Summary

Refactors the Azure provider to improve error handling, reduce code duplication, and add native support for the Responses API.

## Changes

- Added native implementation of the Responses API for Azure instead of converting to chat requests
- Refactored error handling to use a consistent approach across all providers
- Extracted common validation logic into a dedicated `validateKeyConfig` method
- Simplified URL construction by removing redundant conditionals
- Standardized error messages to include provider information
- Fixed stream error handling to properly parse and propagate errors

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Azure provider functionality with various request types:

```sh
# Core/Transports
go version
go test ./core/providers/...

# Test with actual Azure endpoints
# Set up Azure credentials in your environment and run:
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer YOUR_TOKEN" \
  -d '{
    "model": "your-azure-model",
    "messages": [{"role": "user", "content": "Hello"}],
    "provider": "azure"
  }'

# Test the Responses API
curl -X POST http://localhost:8000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer YOUR_TOKEN" \
  -d '{
    "model": "your-azure-model",
    "system": "You are a helpful assistant",
    "prompt": "Hello",
    "provider": "azure"
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves error handling and reduces code duplication in the Azure provider.

## Security considerations

No security implications. This refactor maintains the same authentication mechanisms.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable