### PR TITLE
feat: add logger parameter to maxim plugin and improve response handling

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -217,7 +217,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, key schem
 		return nil, bifrostErr
 	}
 
-	bifrostResponse := response.ToBifrostResponse()
+	bifrostResponse := response.ToBifrostTextCompletionResponse()
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()

--- a/core/schemas/providers/anthropic/chat.go
+++ b/core/schemas/providers/anthropic/chat.go
@@ -247,7 +247,7 @@ func (request *AnthropicMessageRequest) ToBifrostChatRequest() *schemas.BifrostC
 	return bifrostReq
 }
 
-// ToBifrostResponse converts an Anthropic message response to Bifrost format
+// ToBifrostChatResponse converts an Anthropic message response to Bifrost format
 func (response *AnthropicMessageResponse) ToBifrostChatResponse() *schemas.BifrostChatResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/anthropic/text.go
+++ b/core/schemas/providers/anthropic/text.go
@@ -45,8 +45,8 @@ func ToAnthropicTextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionR
 	return anthropicReq
 }
 
-// ToBifrostRequest converts an Anthropic text request back to Bifrost format
-func (request *AnthropicTextRequest) ToBifrostRequest() *schemas.BifrostTextCompletionRequest {
+// ToBifrostTextCompletionRequest converts an Anthropic text request back to Bifrost format
+func (request *AnthropicTextRequest) ToBifrostTextCompletionRequest() *schemas.BifrostTextCompletionRequest {
 	if request == nil {
 		return nil
 	}
@@ -77,7 +77,8 @@ func (request *AnthropicTextRequest) ToBifrostRequest() *schemas.BifrostTextComp
 	return bifrostReq
 }
 
-func (response *AnthropicTextResponse) ToBifrostResponse() *schemas.BifrostTextCompletionResponse {
+// ToBifrostTextCompletionResponse converts an Anthropic text response back to Bifrost format
+func (response *AnthropicTextResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
 	if response == nil {
 		return nil
 	}

--- a/core/schemas/providers/bedrock/chat.go
+++ b/core/schemas/providers/bedrock/chat.go
@@ -40,7 +40,7 @@ func ToBedrockChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Be
 	return bedrockReq, nil
 }
 
-// ToBifrostResponse converts a Bedrock Converse API response to Bifrost format
+// ToBifrostChatResponse converts a Bedrock Converse API response to Bifrost format
 func (response *BedrockConverseResponse) ToBifrostChatResponse() (*schemas.BifrostChatResponse, error) {
 	if response == nil {
 		return nil, fmt.Errorf("bedrock response is nil")

--- a/core/schemas/providers/bedrock/text.go
+++ b/core/schemas/providers/bedrock/text.go
@@ -57,7 +57,7 @@ func ToBedrockTextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionReq
 	return bedrockReq
 }
 
-// ToBifrostResponse converts a Bedrock Anthropic text response to Bifrost format
+// ToBifrostTextCompletionResponse converts a Bedrock Anthropic text response to Bifrost format
 func (response *BedrockAnthropicTextResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
 	if response == nil {
 		return nil
@@ -81,7 +81,7 @@ func (response *BedrockAnthropicTextResponse) ToBifrostTextCompletionResponse() 
 	}
 }
 
-// ToBifrostResponse converts a Bedrock Mistral text response to Bifrost format
+// ToBifrostTextCompletionResponse converts a Bedrock Mistral text response to Bifrost format
 func (response *BedrockMistralTextResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/cohere/chat.go
+++ b/core/schemas/providers/cohere/chat.go
@@ -180,7 +180,7 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Cohe
 	return cohereReq
 }
 
-// ToBifrostResponse converts a Cohere v2 response to Bifrost format
+// ToBifrostChatResponse converts a Cohere v2 response to Bifrost format
 func (response *CohereChatResponse) ToBifrostChatResponse() *schemas.BifrostChatResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/cohere/embedding.go
+++ b/core/schemas/providers/cohere/embedding.go
@@ -61,7 +61,7 @@ func ToCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Cohe
 	return cohereReq
 }
 
-// ToBifrostResponse converts a Cohere embedding response to Bifrost format
+// ToBifrostEmbeddingResponse converts a Cohere embedding response to Bifrost format
 func (response *CohereEmbeddingResponse) ToBifrostEmbeddingResponse() *schemas.BifrostEmbeddingResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/vertex/embedding.go
+++ b/core/schemas/providers/vertex/embedding.go
@@ -66,7 +66,7 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 	return vertexReq
 }
 
-// ToBifrostResponse converts a Vertex AI embedding response to Bifrost format
+// ToBifrostEmbeddingResponse converts a Vertex AI embedding response to Bifrost format
 func (response *VertexEmbeddingResponse) ToBifrostEmbeddingResponse() *schemas.BifrostEmbeddingResponse {
 	if response == nil || len(response.Predictions) == 0 {
 		return nil

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -276,9 +276,9 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *context.Context, re
 	endTimestamp := accumulator.FinalTimestamp
 	accumulator.mu.Unlock()
 
-	// For OpenAI provider, the last chunk already contains the whole accumulated response
+	// For OpenAI-compatible providers, the last chunk already contains the whole accumulated response
 	// so just return it as is
-	if provider == "openai" {
+	if provider == schemas.OpenAI || provider == schemas.OpenRouter || provider == schemas.Azure {
 		isFinalChunk := bifrost.IsFinalChunk(ctx)
 		if isFinalChunk {
 			// For OpenAI, the final chunk contains the complete response

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -195,6 +195,22 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
 		}
+	case StreamTypeResponses:
+		responsesResp := &schemas.BifrostResponsesResponse{}
+
+		if p.Data.OutputMessages != nil {
+			responsesResp.Output = p.Data.OutputMessages
+		}
+		if p.Data.TokenUsage != nil {
+			responsesResp.Usage = p.Data.TokenUsage.ToResponsesResponseUsage()
+		}
+		responsesResp.ExtraFields = schemas.BifrostResponseExtraFields{
+			RequestType:    schemas.ResponsesRequest,
+			Provider:       p.Provider,
+			ModelRequested: p.Model,
+			Latency:        p.Data.Latency,
+		}
+		resp.ResponsesResponse = responsesResp
 	case StreamTypeAudio:
 		speechResp := p.Data.AudioOutput
 		if speechResp == nil {

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -8,16 +8,22 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/streaming"
 
 	"github.com/maximhq/maxim-go"
 	"github.com/maximhq/maxim-go/logging"
 )
 
 // PluginName is the canonical name for the maxim plugin.
-const PluginName = "maxim"
+const (
+	PluginName         string = "maxim"
+	PluginLoggerPrefix string = "[Maxim Plugin]"
+)
 
 // Config is the configuration for the maxim plugin.
 //   - APIKey: API key for Maxim SDK authentication
@@ -25,6 +31,24 @@ const PluginName = "maxim"
 type Config struct {
 	LogRepoID string `json:"log_repo_id,omitempty"` // Optional - can be empty
 	APIKey    string `json:"api_key"`
+}
+
+// Plugin implements the schemas.Plugin interface for Maxim's logger.
+// It provides request and response tracing functionality using Maxim logger,
+// allowing detailed tracking of requests and responses across different log repositories.
+//
+// Fields:
+//   - mx: The Maxim SDK instance for creating new loggers
+//   - defaultLogRepoId: Default log repository ID from config (optional)
+//   - loggers: Map of log repo ID to logger instances
+//   - loggerMutex: RW mutex for thread-safe access to loggers map
+type Plugin struct {
+	mx               *maxim.Maxim
+	defaultLogRepoID string
+	loggers          map[string]*logging.Logger
+	loggerMutex      *sync.RWMutex
+	accumulator      *streaming.Accumulator
+	logger           schemas.Logger
 }
 
 // Init initializes and returns a Plugin instance for Maxim's logger.
@@ -35,7 +59,7 @@ type Config struct {
 // Returns:
 //   - schemas.Plugin: A configured plugin instance for request/response tracing
 //   - error: Any error that occurred during plugin initialization
-func Init(config *Config) (schemas.Plugin, error) {
+func Init(config *Config, logger schemas.Logger) (schemas.Plugin, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -51,6 +75,8 @@ func Init(config *Config) (schemas.Plugin, error) {
 		defaultLogRepoID: config.LogRepoID,
 		loggers:          make(map[string]*logging.Logger),
 		loggerMutex:      &sync.RWMutex{},
+		accumulator:      streaming.NewAccumulator(nil, logger),
+		logger:           logger,
 	}
 
 	// Initialize default logger if LogRepoId is provided
@@ -90,22 +116,6 @@ const (
 //
 // The plugin uses context values to maintain trace and generation IDs throughout the request lifecycle.
 // These IDs can be propagated from external systems through HTTP headers (x-bf-maxim-trace-id and x-bf-maxim-generation-id).
-
-// Plugin implements the schemas.Plugin interface for Maxim's logger.
-// It provides request and response tracing functionality using Maxim logger,
-// allowing detailed tracking of requests and responses across different log repositories.
-//
-// Fields:
-//   - mx: The Maxim SDK instance for creating new loggers
-//   - defaultLogRepoId: Default log repository ID from config (optional)
-//   - loggers: Map of log repo ID to logger instances
-//   - loggerMutex: RW mutex for thread-safe access to loggers map
-type Plugin struct {
-	mx               *maxim.Maxim
-	defaultLogRepoID string
-	loggers          map[string]*logging.Logger
-	loggerMutex      *sync.RWMutex
-}
 
 // GetName returns the name of the plugin.
 func (plugin *Plugin) GetName() string {
@@ -256,7 +266,7 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 	modelParams := make(map[string]interface{})
 
 	switch req.RequestType {
-	case schemas.TextCompletionRequest:
+	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
 		messages = append(messages, logging.CompletionRequest{
 			Role:    string(schemas.ChatMessageRoleUser),
 			Content: req.TextCompletionRequest.Input,
@@ -278,7 +288,7 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 				json.Unmarshal(jsonData, &modelParams)
 			}
 		}
-	case schemas.ChatCompletionRequest:
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
 		for _, message := range req.ChatRequest.Input {
 			messages = append(messages, logging.CompletionRequest{
 				Role:    string(message.Role),
@@ -312,7 +322,7 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 				json.Unmarshal(jsonData, &modelParams)
 			}
 		}
-	case schemas.ResponsesRequest:
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
 		for _, message := range req.ResponsesRequest.Input {
 			if message.Content != nil {
 				role := schemas.ChatMessageRoleUser
@@ -356,8 +366,6 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 			}
 		}
 	}
-
-	tags["action"] = string(req.RequestType)
 
 	if traceID == "" {
 		// If traceID is not set, create a new trace
@@ -412,6 +420,19 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 		*ctx = context.WithValue(*ctx, GenerationIDKey, generationID)
 	}
 
+	// Extract request ID from context
+	requestID, ok := (*ctx).Value(schemas.BifrostContextKeyRequestID).(string)
+	if !ok || requestID == "" {
+		// Log error but don't fail the request
+		plugin.logger.Error("%s request id not found in context or is empty, please set schemas.BifrostContextKeyRequestID in ctx", PluginLoggerPrefix)
+		return req, nil, nil
+	}
+
+	createdTimestamp := time.Now()
+	if bifrost.IsStreamRequestType(req.RequestType) {
+		plugin.accumulator.CreateStreamAccumulator(requestID, createdTimestamp)
+	}
+
 	return req, nil, nil
 }
 
@@ -428,28 +449,46 @@ func (plugin *Plugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest)
 //
 // Parameters:
 //   - ctxRef: Pointer to the context.Context containing trace/generation IDs
-//   - res: The Bifrost response to be traced
+//   - result: The Bifrost response to be traced
 //   - bifrostErr: The BifrostError returned by the request, if any
 //
 // Returns:
 //   - *schemas.BifrostResponse: The original response, unmodified
 //   - *schemas.BifrostError: The original error, unmodified
 //   - error: Never returns an error as it handles missing IDs gracefully
-func (plugin *Plugin) PostHook(ctxRef *context.Context, res *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
-	if ctxRef == nil {
-		return res, bifrostErr, nil
+func (plugin *Plugin) PostHook(ctx *context.Context, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	requestType, _, _ := bifrost.GetResponseFields(result, bifrostErr)
+
+	requestID, ok := (*ctx).Value(schemas.BifrostContextKeyRequestID).(string)
+	if !ok || requestID == "" {
+		return result, bifrostErr, nil
 	}
-	ctx := *ctxRef
+
+	var streamResponse *streaming.ProcessedStreamResponse
+	var err error
+	if bifrost.IsStreamRequestType(requestType) {
+		streamResponse, err = plugin.accumulator.ProcessStreamingResponse(ctx, result, bifrostErr)
+		if err != nil {
+			plugin.logger.Error("%s failed to process streaming response: %v", PluginLoggerPrefix, err)
+			return result, bifrostErr, err
+		}
+
+		// Return the result if it is a delta response
+		if streamResponse == nil || streamResponse.Type == streaming.StreamResponseTypeDelta {
+			return result, bifrostErr, nil
+		}
+	}
+
 	// Get effective log repo ID for this request
-	effectiveLogRepoID := plugin.getEffectiveLogRepoID(ctxRef)
+	effectiveLogRepoID := plugin.getEffectiveLogRepoID(ctx)
 	if effectiveLogRepoID == "" {
-		return res, bifrostErr, nil
+		return result, bifrostErr, nil
 	}
 	logger, err := plugin.getOrCreateLogger(effectiveLogRepoID)
 	if err != nil {
-		return res, bifrostErr, nil
+		return result, bifrostErr, nil
 	}
-	generationID, ok := ctx.Value(GenerationIDKey).(string)
+	generationID, ok := (*ctx).Value(GenerationIDKey).(string)
 	if ok {
 		if bifrostErr != nil {
 			genErr := logging.GenerationError{
@@ -458,21 +497,47 @@ func (plugin *Plugin) PostHook(ctxRef *context.Context, res *schemas.BifrostResp
 				Type:    bifrostErr.Error.Type,
 			}
 			logger.SetGenerationError(generationID, &genErr)
-		} else if res != nil {
-			logger.AddResultToGeneration(generationID, res)
+
+			if bifrost.IsStreamRequestType(requestType) {
+				plugin.accumulator.CleanupStreamAccumulator(requestID)
+			}
+		} else if result != nil {
+			switch requestType {
+			case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
+				if streamResponse != nil {
+					logger.AddResultToGeneration(generationID, streamResponse.ToBifrostResponse().TextCompletionResponse)
+				} else {
+					logger.AddResultToGeneration(generationID, result.TextCompletionResponse)
+				}
+			case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+				if streamResponse != nil {
+					logger.AddResultToGeneration(generationID, streamResponse.ToBifrostResponse().ChatResponse)
+				} else {
+					logger.AddResultToGeneration(generationID, result.ChatResponse)
+				}
+			case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
+				if streamResponse != nil {
+					logger.AddResultToGeneration(generationID, streamResponse.ToBifrostResponse().ResponsesResponse.ToBifrostChatResponse())
+				} else {
+					logger.AddResultToGeneration(generationID, result.ResponsesResponse.ToBifrostChatResponse())
+				}
+			}
 		}
 		logger.EndGeneration(generationID)
 	}
-	traceID, ok := ctx.Value(TraceIDKey).(string)
+	traceID, ok := (*ctx).Value(TraceIDKey).(string)
 	if ok {
 		logger.EndTrace(traceID)
 	}
 	// Flush only the effective logger that was used for this request
 	logger.Flush()
-	return res, bifrostErr, nil
+	return result, bifrostErr, nil
 }
 
 func (plugin *Plugin) Cleanup() error {
+	if plugin.accumulator != nil {
+		plugin.accumulator.Cleanup()
+	}
 	// Flush all loggers
 	plugin.loggerMutex.RLock()
 	for _, logger := range plugin.loggers {

--- a/plugins/maxim/plugin_test.go
+++ b/plugins/maxim/plugin_test.go
@@ -29,10 +29,11 @@ func getPlugin() (schemas.Plugin, error) {
 		return nil, fmt.Errorf("MAXIM_API_KEY is not set, please set it in your environment variables")
 	}
 
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	plugin, err := Init(&Config{
 		APIKey:    os.Getenv("MAXIM_API_KEY"),
 		LogRepoID: os.Getenv("MAXIM_LOG_REPO_ID"),
-	})
+	}, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +195,7 @@ func TestLogRepoIDSelection(t *testing.T) {
 
 // TestPluginInitialization tests plugin initialization with different configs
 func TestPluginInitialization(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	tests := []struct {
 		name        string
 		config      Config
@@ -229,7 +231,7 @@ func TestPluginInitialization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Skip actual Maxim SDK initialization in tests
 			if tt.expectError {
-				_, err := Init(&tt.config)
+				_, err := Init(&tt.config, logger)
 				if err == nil {
 					t.Error("Expected error but got none")
 				}

--- a/transports/bifrost-http/handlers/server.go
+++ b/transports/bifrost-http/handlers/server.go
@@ -211,7 +211,7 @@ func LoadPlugin[T schemas.Plugin](ctx context.Context, name string, pluginConfig
 		if err != nil {
 			return zero, fmt.Errorf("failed to marshal maxim plugin config: %v", err)
 		}
-		plugin, err := maxim.Init(maximConfig)
+		plugin, err := maxim.Init(maximConfig, logger)
 		if err != nil {
 			return zero, err
 		}

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -18,7 +18,7 @@ type AnthropicRouter struct {
 func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 	return []RouteConfig{
 		{
-			Type: RouteConfigTypeAnthropic,
+			Type:   RouteConfigTypeAnthropic,
 			Path:   pathPrefix + "/v1/complete",
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
@@ -27,7 +27,7 @@ func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
 					return &schemas.BifrostRequest{
-						TextCompletionRequest: anthropicReq.ToBifrostRequest(),
+						TextCompletionRequest: anthropicReq.ToBifrostTextCompletionRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid request type")


### PR DESCRIPTION
## Summary

Enhanced the Maxim plugin to properly handle different response types and added logger dependency injection for improved logging capabilities.

## Changes

- Added logger parameter to the `Init` function to enable dependency injection of the logger
- Updated the plugin struct to store the injected logger
- Improved response handling in `PostHook` to properly process different response types:
  - TextCompletionResponse
  - ChatResponse
  - ResponsesResponse (with conversion to BifrostChatResponse)
- Updated all plugin initialization calls to include the required logger parameter

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Test the Maxim plugin
go test ./plugins/maxim/...

# Test the HTTP transport with the updated plugin
go test ./transports/bifrost-http/...

# Run all tests
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

The `Init` function signature for the Maxim plugin has changed to require a logger parameter. All code that initializes this plugin needs to be updated to provide a logger instance.

## Security considerations

No security implications as this change only affects internal logging functionality.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)