### PR TITLE
feat: plugins async fixes and added streaming to maxim plugin

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -284,7 +284,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, key schem
 		return nil, bifrostErr
 	}
 
-	bifrostResponse := response.ToBifrostResponse()
+	bifrostResponse := response.ToBifrostTextCompletionResponse()
 
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()

--- a/core/schemas/providers/anthropic/chat.go
+++ b/core/schemas/providers/anthropic/chat.go
@@ -247,7 +247,7 @@ func (request *AnthropicMessageRequest) ToBifrostChatRequest() *schemas.BifrostC
 	return bifrostReq
 }
 
-// ToBifrostResponse converts an Anthropic message response to Bifrost format
+// ToBifrostChatResponse converts an Anthropic message response to Bifrost format
 func (response *AnthropicMessageResponse) ToBifrostChatResponse() *schemas.BifrostChatResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/anthropic/text.go
+++ b/core/schemas/providers/anthropic/text.go
@@ -45,8 +45,8 @@ func ToAnthropicTextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionR
 	return anthropicReq
 }
 
-// ToBifrostRequest converts an Anthropic text request back to Bifrost format
-func (request *AnthropicTextRequest) ToBifrostRequest() *schemas.BifrostTextCompletionRequest {
+// ToBifrostTextCompletionRequest converts an Anthropic text request back to Bifrost format
+func (request *AnthropicTextRequest) ToBifrostTextCompletionRequest() *schemas.BifrostTextCompletionRequest {
 	if request == nil {
 		return nil
 	}
@@ -77,7 +77,8 @@ func (request *AnthropicTextRequest) ToBifrostRequest() *schemas.BifrostTextComp
 	return bifrostReq
 }
 
-func (response *AnthropicTextResponse) ToBifrostResponse() *schemas.BifrostTextCompletionResponse {
+// ToBifrostTextCompletionResponse converts an Anthropic text response back to Bifrost format
+func (response *AnthropicTextResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
 	if response == nil {
 		return nil
 	}

--- a/core/schemas/providers/bedrock/chat.go
+++ b/core/schemas/providers/bedrock/chat.go
@@ -40,7 +40,7 @@ func ToBedrockChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Be
 	return bedrockReq, nil
 }
 
-// ToBifrostResponse converts a Bedrock Converse API response to Bifrost format
+// ToBifrostChatResponse converts a Bedrock Converse API response to Bifrost format
 func (response *BedrockConverseResponse) ToBifrostChatResponse() (*schemas.BifrostChatResponse, error) {
 	if response == nil {
 		return nil, fmt.Errorf("bedrock response is nil")

--- a/core/schemas/providers/bedrock/text.go
+++ b/core/schemas/providers/bedrock/text.go
@@ -57,7 +57,7 @@ func ToBedrockTextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionReq
 	return bedrockReq
 }
 
-// ToBifrostResponse converts a Bedrock Anthropic text response to Bifrost format
+// ToBifrostTextCompletionResponse converts a Bedrock Anthropic text response to Bifrost format
 func (response *BedrockAnthropicTextResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
 	if response == nil {
 		return nil
@@ -81,7 +81,7 @@ func (response *BedrockAnthropicTextResponse) ToBifrostTextCompletionResponse() 
 	}
 }
 
-// ToBifrostResponse converts a Bedrock Mistral text response to Bifrost format
+// ToBifrostTextCompletionResponse converts a Bedrock Mistral text response to Bifrost format
 func (response *BedrockMistralTextResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/cohere/chat.go
+++ b/core/schemas/providers/cohere/chat.go
@@ -180,7 +180,7 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Cohe
 	return cohereReq
 }
 
-// ToBifrostResponse converts a Cohere v2 response to Bifrost format
+// ToBifrostChatResponse converts a Cohere v2 response to Bifrost format
 func (response *CohereChatResponse) ToBifrostChatResponse() *schemas.BifrostChatResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/cohere/embedding.go
+++ b/core/schemas/providers/cohere/embedding.go
@@ -61,7 +61,7 @@ func ToCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Cohe
 	return cohereReq
 }
 
-// ToBifrostResponse converts a Cohere embedding response to Bifrost format
+// ToBifrostEmbeddingResponse converts a Cohere embedding response to Bifrost format
 func (response *CohereEmbeddingResponse) ToBifrostEmbeddingResponse() *schemas.BifrostEmbeddingResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/openai/chat.go
+++ b/core/schemas/providers/openai/chat.go
@@ -2,8 +2,8 @@ package openai
 
 import "github.com/maximhq/bifrost/core/schemas"
 
-// ToBifrostRequest converts an OpenAI chat request to Bifrost format
-func (request *OpenAIChatRequest) ToBifrostRequest() *schemas.BifrostChatRequest {
+// ToBifrostChatRequest converts an OpenAI chat request to Bifrost format
+func (request *OpenAIChatRequest) ToBifrostChatRequest() *schemas.BifrostChatRequest {
 	provider, model := schemas.ParseModelString(request.Model, schemas.OpenAI)
 
 	bifrostReq := &schemas.BifrostChatRequest{

--- a/core/schemas/providers/openai/embedding.go
+++ b/core/schemas/providers/openai/embedding.go
@@ -4,8 +4,8 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// ToBifrostRequest converts an OpenAI embedding request to Bifrost format
-func (request *OpenAIEmbeddingRequest) ToBifrostRequest() *schemas.BifrostEmbeddingRequest {
+// ToBifrostEmbeddingRequest converts an OpenAI embedding request to Bifrost format
+func (request *OpenAIEmbeddingRequest) ToBifrostEmbeddingRequest() *schemas.BifrostEmbeddingRequest {
 	provider, model := schemas.ParseModelString(request.Model, schemas.OpenAI)
 
 	bifrostReq := &schemas.BifrostEmbeddingRequest{

--- a/core/schemas/providers/openai/responses.go
+++ b/core/schemas/providers/openai/responses.go
@@ -2,7 +2,8 @@ package openai
 
 import "github.com/maximhq/bifrost/core/schemas"
 
-func (request *OpenAIResponsesRequest) ToBifrostRequest() *schemas.BifrostResponsesRequest {
+// ToBifrostResponsesRequest converts an OpenAI responses request to Bifrost format
+func (request *OpenAIResponsesRequest) ToBifrostResponsesRequest() *schemas.BifrostResponsesRequest {
 	if request == nil {
 		return nil
 	}
@@ -27,6 +28,7 @@ func (request *OpenAIResponsesRequest) ToBifrostRequest() *schemas.BifrostRespon
 	}
 }
 
+// ToOpenAIResponsesRequest converts a Bifrost responses request to OpenAI format
 func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
 		return nil

--- a/core/schemas/providers/openai/speech.go
+++ b/core/schemas/providers/openai/speech.go
@@ -2,8 +2,8 @@ package openai
 
 import "github.com/maximhq/bifrost/core/schemas"
 
-// ToBifrostRequest converts an OpenAI speech request to Bifrost format
-func (request *OpenAISpeechRequest) ToBifrostRequest() *schemas.BifrostSpeechRequest {
+// ToBifrostSpeechRequest converts an OpenAI speech request to Bifrost format
+func (request *OpenAISpeechRequest) ToBifrostSpeechRequest() *schemas.BifrostSpeechRequest {
 	provider, model := schemas.ParseModelString(request.Model, schemas.OpenAI)
 
 	bifrostReq := &schemas.BifrostSpeechRequest{

--- a/core/schemas/providers/openai/text.go
+++ b/core/schemas/providers/openai/text.go
@@ -24,7 +24,8 @@ func ToOpenAITextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionRequ
 	return openaiReq
 }
 
-func (request *OpenAITextCompletionRequest) ToBifrostRequest() *schemas.BifrostTextCompletionRequest {
+// ToBifrostTextCompletionRequest converts an OpenAI text completion request to Bifrost format
+func (request *OpenAITextCompletionRequest) ToBifrostTextCompletionRequest() *schemas.BifrostTextCompletionRequest {
 	if request == nil {
 		return nil
 	}

--- a/core/schemas/providers/openai/transcription.go
+++ b/core/schemas/providers/openai/transcription.go
@@ -2,8 +2,8 @@ package openai
 
 import "github.com/maximhq/bifrost/core/schemas"
 
-// ToBifrostRequest converts an OpenAI transcription request to Bifrost format
-func (request *OpenAITranscriptionRequest) ToBifrostRequest() *schemas.BifrostTranscriptionRequest {
+// ToBifrostTranscriptionRequest converts an OpenAI transcription request to Bifrost format
+func (request *OpenAITranscriptionRequest) ToBifrostTranscriptionRequest() *schemas.BifrostTranscriptionRequest {
 	provider, model := schemas.ParseModelString(request.Model, schemas.OpenAI)
 
 	bifrostReq := &schemas.BifrostTranscriptionRequest{

--- a/core/schemas/providers/vertex/embedding.go
+++ b/core/schemas/providers/vertex/embedding.go
@@ -66,7 +66,7 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 	return vertexReq
 }
 
-// ToBifrostResponse converts a Vertex AI embedding response to Bifrost format
+// ToBifrostEmbeddingResponse converts a Vertex AI embedding response to Bifrost format
 func (response *VertexEmbeddingResponse) ToBifrostEmbeddingResponse() *schemas.BifrostEmbeddingResponse {
 	if response == nil || len(response.Predictions) == 0 {
 		return nil

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -10,6 +10,420 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+// deepCopyResponsesStreamResponse creates a deep copy of BifrostResponsesStreamResponse
+// to prevent shared data mutation between different plugin accumulators
+func deepCopyResponsesStreamResponse(original *schemas.BifrostResponsesStreamResponse) *schemas.BifrostResponsesStreamResponse {
+	if original == nil {
+		return nil
+	}
+
+	copy := &schemas.BifrostResponsesStreamResponse{
+		Type:           original.Type,
+		SequenceNumber: original.SequenceNumber,
+		ExtraFields:    original.ExtraFields, // ExtraFields can be safely shared as they're typically read-only
+	}
+
+	// Deep copy Response if present
+	if original.Response != nil {
+		copy.Response = &schemas.BifrostResponsesResponse{}
+		*copy.Response = *original.Response // Shallow copy the struct
+
+		// Deep copy the Output slice if present
+		if original.Response.Output != nil {
+			copy.Response.Output = make([]schemas.ResponsesMessage, len(original.Response.Output))
+			for i, msg := range original.Response.Output {
+				copy.Response.Output[i] = deepCopyResponsesMessage(msg)
+			}
+		}
+
+		// Copy Usage if present (Usage can be shallow copied as it's typically immutable)
+		if original.Response.Usage != nil {
+			copyUsage := *original.Response.Usage
+			copy.Response.Usage = &copyUsage
+		}
+	}
+
+	// Copy pointer fields
+	if original.OutputIndex != nil {
+		copyOutputIndex := *original.OutputIndex
+		copy.OutputIndex = &copyOutputIndex
+	}
+
+	if original.Item != nil {
+		copyItem := deepCopyResponsesMessage(*original.Item)
+		copy.Item = &copyItem
+	}
+
+	if original.ContentIndex != nil {
+		copyContentIndex := *original.ContentIndex
+		copy.ContentIndex = &copyContentIndex
+	}
+
+	if original.ItemID != nil {
+		copyItemID := *original.ItemID
+		copy.ItemID = &copyItemID
+	}
+
+	if original.Part != nil {
+		copyPart := deepCopyResponsesMessageContentBlock(*original.Part)
+		copy.Part = &copyPart
+	}
+
+	if original.Delta != nil {
+		copyDelta := *original.Delta
+		copy.Delta = &copyDelta
+	}
+
+	// Deep copy LogProbs slice if present
+	if original.LogProbs != nil {
+		copy.LogProbs = make([]schemas.ResponsesOutputMessageContentTextLogProb, len(original.LogProbs))
+		for i, logProb := range original.LogProbs {
+			copiedLogProb := schemas.ResponsesOutputMessageContentTextLogProb{
+				LogProb: logProb.LogProb,
+				Token:   logProb.Token,
+			}
+			// Deep copy Bytes slice
+			if logProb.Bytes != nil {
+				copiedLogProb.Bytes = make([]int, len(logProb.Bytes))
+				for j, byteValue := range logProb.Bytes {
+					copiedLogProb.Bytes[j] = byteValue
+				}
+			}
+			// Deep copy TopLogProbs slice
+			if logProb.TopLogProbs != nil {
+				copiedLogProb.TopLogProbs = make([]schemas.LogProb, len(logProb.TopLogProbs))
+				for j, topLogProb := range logProb.TopLogProbs {
+					copiedLogProb.TopLogProbs[j] = schemas.LogProb{
+						Bytes:   topLogProb.Bytes,
+						LogProb: topLogProb.LogProb,
+						Token:   topLogProb.Token,
+					}
+				}
+			}
+			copy.LogProbs[i] = copiedLogProb
+		}
+	}
+
+	if original.Text != nil {
+		copyText := *original.Text
+		copy.Text = &copyText
+	}
+
+	if original.Refusal != nil {
+		copyRefusal := *original.Refusal
+		copy.Refusal = &copyRefusal
+	}
+
+	if original.Arguments != nil {
+		copyArguments := *original.Arguments
+		copy.Arguments = &copyArguments
+	}
+
+	if original.PartialImageB64 != nil {
+		copyPartialImageB64 := *original.PartialImageB64
+		copy.PartialImageB64 = &copyPartialImageB64
+	}
+
+	if original.PartialImageIndex != nil {
+		copyPartialImageIndex := *original.PartialImageIndex
+		copy.PartialImageIndex = &copyPartialImageIndex
+	}
+
+	if original.Annotation != nil {
+		copyAnnotation := *original.Annotation
+		copy.Annotation = &copyAnnotation
+	}
+
+	if original.AnnotationIndex != nil {
+		copyAnnotationIndex := *original.AnnotationIndex
+		copy.AnnotationIndex = &copyAnnotationIndex
+	}
+
+	if original.Code != nil {
+		copyCode := *original.Code
+		copy.Code = &copyCode
+	}
+
+	if original.Message != nil {
+		copyMessage := *original.Message
+		copy.Message = &copyMessage
+	}
+
+	if original.Param != nil {
+		copyParam := *original.Param
+		copy.Param = &copyParam
+	}
+
+	return copy
+}
+
+// deepCopyResponsesMessage creates a deep copy of a ResponsesMessage
+func deepCopyResponsesMessage(original schemas.ResponsesMessage) schemas.ResponsesMessage {
+	copy := schemas.ResponsesMessage{}
+
+	if original.ID != nil {
+		copyID := *original.ID
+		copy.ID = &copyID
+	}
+
+	if original.Type != nil {
+		copyType := *original.Type
+		copy.Type = &copyType
+	}
+
+	if original.Role != nil {
+		copyRole := *original.Role
+		copy.Role = &copyRole
+	}
+
+	if original.Content != nil {
+		copy.Content = &schemas.ResponsesMessageContent{}
+
+		if original.Content.ContentStr != nil {
+			copyContentStr := *original.Content.ContentStr
+			copy.Content.ContentStr = &copyContentStr
+		}
+
+		if original.Content.ContentBlocks != nil {
+			copy.Content.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, len(original.Content.ContentBlocks))
+			for i, block := range original.Content.ContentBlocks {
+				copy.Content.ContentBlocks[i] = deepCopyResponsesMessageContentBlock(block)
+			}
+		}
+	}
+
+	if original.ResponsesToolMessage != nil {
+		copy.ResponsesToolMessage = &schemas.ResponsesToolMessage{}
+
+		// Deep copy primitive fields
+		if original.ResponsesToolMessage.CallID != nil {
+			copyCallID := *original.ResponsesToolMessage.CallID
+			copy.ResponsesToolMessage.CallID = &copyCallID
+		}
+
+		if original.ResponsesToolMessage.Name != nil {
+			copyName := *original.ResponsesToolMessage.Name
+			copy.ResponsesToolMessage.Name = &copyName
+		}
+
+		if original.ResponsesToolMessage.Arguments != nil {
+			copyArguments := *original.ResponsesToolMessage.Arguments
+			copy.ResponsesToolMessage.Arguments = &copyArguments
+		}
+
+		if original.ResponsesToolMessage.Error != nil {
+			copyError := *original.ResponsesToolMessage.Error
+			copy.ResponsesToolMessage.Error = &copyError
+		}
+
+		// Deep copy Output
+		if original.ResponsesToolMessage.Output != nil {
+			copy.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
+
+			if original.ResponsesToolMessage.Output.ResponsesToolCallOutputStr != nil {
+				copyStr := *original.ResponsesToolMessage.Output.ResponsesToolCallOutputStr
+				copy.ResponsesToolMessage.Output.ResponsesToolCallOutputStr = &copyStr
+			}
+
+			if original.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
+				copy.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks = make([]schemas.ResponsesMessageContentBlock, len(original.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks))
+				for i, block := range original.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
+					copy.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks[i] = deepCopyResponsesMessageContentBlock(block)
+				}
+			}
+
+			if original.ResponsesToolMessage.Output.ResponsesComputerToolCallOutput != nil {
+				copyOutput := *original.ResponsesToolMessage.Output.ResponsesComputerToolCallOutput
+				copy.ResponsesToolMessage.Output.ResponsesComputerToolCallOutput = &copyOutput
+			}
+		}
+
+		// Deep copy Action
+		if original.ResponsesToolMessage.Action != nil {
+			copy.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{}
+
+			if original.ResponsesToolMessage.Action.ResponsesComputerToolCallAction != nil {
+				copyAction := *original.ResponsesToolMessage.Action.ResponsesComputerToolCallAction
+				// Deep copy Path slice
+				if copyAction.Path != nil {
+					copyAction.Path = make([]schemas.ResponsesComputerToolCallActionPath, len(copyAction.Path))
+					for i, path := range original.ResponsesToolMessage.Action.ResponsesComputerToolCallAction.Path {
+						copyAction.Path[i] = path // struct copy is fine for simple structs
+					}
+				}
+				// Deep copy Keys slice
+				if copyAction.Keys != nil {
+					copyAction.Keys = make([]string, len(copyAction.Keys))
+					for i, key := range original.ResponsesToolMessage.Action.ResponsesComputerToolCallAction.Keys {
+						copyAction.Keys[i] = key
+					}
+				}
+				copy.ResponsesToolMessage.Action.ResponsesComputerToolCallAction = &copyAction
+			}
+
+			if original.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction != nil {
+				copyAction := *original.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction
+				copy.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction = &copyAction
+			}
+
+			if original.ResponsesToolMessage.Action.ResponsesLocalShellToolCallAction != nil {
+				copyAction := *original.ResponsesToolMessage.Action.ResponsesLocalShellToolCallAction
+				copy.ResponsesToolMessage.Action.ResponsesLocalShellToolCallAction = &copyAction
+			}
+
+			if original.ResponsesToolMessage.Action.ResponsesMCPApprovalRequestAction != nil {
+				copyAction := *original.ResponsesToolMessage.Action.ResponsesMCPApprovalRequestAction
+				copy.ResponsesToolMessage.Action.ResponsesMCPApprovalRequestAction = &copyAction
+			}
+		}
+
+		// Deep copy embedded tool call structs
+		if original.ResponsesToolMessage.ResponsesFileSearchToolCall != nil {
+			copyToolCall := *original.ResponsesToolMessage.ResponsesFileSearchToolCall
+			// Deep copy Queries slice
+			if copyToolCall.Queries != nil {
+				copyToolCall.Queries = make([]string, len(copyToolCall.Queries))
+				for i, query := range original.ResponsesToolMessage.ResponsesFileSearchToolCall.Queries {
+					copyToolCall.Queries[i] = query
+				}
+			}
+			// Deep copy Results slice
+			if copyToolCall.Results != nil {
+				copyToolCall.Results = make([]schemas.ResponsesFileSearchToolCallResult, len(copyToolCall.Results))
+				for i, result := range original.ResponsesToolMessage.ResponsesFileSearchToolCall.Results {
+					copyResult := result
+					// Deep copy Attributes map if present
+					if result.Attributes != nil {
+						copyAttrs := make(map[string]any, len(*result.Attributes))
+						for k, v := range *result.Attributes {
+							copyAttrs[k] = v
+						}
+						copyResult.Attributes = &copyAttrs
+					}
+					copyToolCall.Results[i] = copyResult
+				}
+			}
+			copy.ResponsesToolMessage.ResponsesFileSearchToolCall = &copyToolCall
+		}
+
+		if original.ResponsesToolMessage.ResponsesComputerToolCall != nil {
+			copyToolCall := *original.ResponsesToolMessage.ResponsesComputerToolCall
+			// Deep copy PendingSafetyChecks slice
+			if copyToolCall.PendingSafetyChecks != nil {
+				copyToolCall.PendingSafetyChecks = make([]schemas.ResponsesComputerToolCallPendingSafetyCheck, len(copyToolCall.PendingSafetyChecks))
+				for i, check := range original.ResponsesToolMessage.ResponsesComputerToolCall.PendingSafetyChecks {
+					copyToolCall.PendingSafetyChecks[i] = check
+				}
+			}
+			copy.ResponsesToolMessage.ResponsesComputerToolCall = &copyToolCall
+		}
+
+		if original.ResponsesToolMessage.ResponsesComputerToolCallOutput != nil {
+			copyOutput := *original.ResponsesToolMessage.ResponsesComputerToolCallOutput
+			// Deep copy AcknowledgedSafetyChecks slice
+			if copyOutput.AcknowledgedSafetyChecks != nil {
+				copyOutput.AcknowledgedSafetyChecks = make([]schemas.ResponsesComputerToolCallAcknowledgedSafetyCheck, len(copyOutput.AcknowledgedSafetyChecks))
+				for i, check := range original.ResponsesToolMessage.ResponsesComputerToolCallOutput.AcknowledgedSafetyChecks {
+					copyOutput.AcknowledgedSafetyChecks[i] = check
+				}
+			}
+			copy.ResponsesToolMessage.ResponsesComputerToolCallOutput = &copyOutput
+		}
+
+		if original.ResponsesToolMessage.ResponsesCodeInterpreterToolCall != nil {
+			copyToolCall := *original.ResponsesToolMessage.ResponsesCodeInterpreterToolCall
+			// Deep copy Outputs slice
+			if copyToolCall.Outputs != nil {
+				copyToolCall.Outputs = make([]schemas.ResponsesCodeInterpreterOutput, len(copyToolCall.Outputs))
+				for i, output := range original.ResponsesToolMessage.ResponsesCodeInterpreterToolCall.Outputs {
+					copyToolCall.Outputs[i] = output
+				}
+			}
+			copy.ResponsesToolMessage.ResponsesCodeInterpreterToolCall = &copyToolCall
+		}
+
+		if original.ResponsesToolMessage.ResponsesMCPToolCall != nil {
+			copyToolCall := *original.ResponsesToolMessage.ResponsesMCPToolCall
+			copy.ResponsesToolMessage.ResponsesMCPToolCall = &copyToolCall
+		}
+
+		if original.ResponsesToolMessage.ResponsesCustomToolCall != nil {
+			copyToolCall := *original.ResponsesToolMessage.ResponsesCustomToolCall
+			copy.ResponsesToolMessage.ResponsesCustomToolCall = &copyToolCall
+		}
+
+		if original.ResponsesToolMessage.ResponsesImageGenerationCall != nil {
+			copyCall := *original.ResponsesToolMessage.ResponsesImageGenerationCall
+			copy.ResponsesToolMessage.ResponsesImageGenerationCall = &copyCall
+		}
+
+		if original.ResponsesToolMessage.ResponsesMCPListTools != nil {
+			copyListTools := *original.ResponsesToolMessage.ResponsesMCPListTools
+			// Deep copy Tools slice
+			if copyListTools.Tools != nil {
+				copyListTools.Tools = make([]schemas.ResponsesMCPTool, len(copyListTools.Tools))
+				for i, tool := range original.ResponsesToolMessage.ResponsesMCPListTools.Tools {
+					copyListTools.Tools[i] = tool
+				}
+			}
+			copy.ResponsesToolMessage.ResponsesMCPListTools = &copyListTools
+		}
+
+		if original.ResponsesToolMessage.ResponsesMCPApprovalResponse != nil {
+			copyApproval := *original.ResponsesToolMessage.ResponsesMCPApprovalResponse
+			copy.ResponsesToolMessage.ResponsesMCPApprovalResponse = &copyApproval
+		}
+	}
+
+	return copy
+}
+
+// deepCopyResponsesMessageContentBlock creates a deep copy of a ResponsesMessageContentBlock
+func deepCopyResponsesMessageContentBlock(original schemas.ResponsesMessageContentBlock) schemas.ResponsesMessageContentBlock {
+	copy := schemas.ResponsesMessageContentBlock{
+		Type: original.Type,
+	}
+
+	if original.Text != nil {
+		copyText := *original.Text
+		copy.Text = &copyText
+	}
+
+	// Copy other specific content type fields as needed
+	if original.ResponsesOutputMessageContentText != nil {
+		t := *original.ResponsesOutputMessageContentText
+		// Annotations
+		if t.Annotations != nil {
+			t.Annotations = append([]schemas.ResponsesOutputMessageContentTextAnnotation(nil), t.Annotations...)
+		}
+		// LogProbs (and their inner slices)
+		if t.LogProbs != nil {
+			newLP := make([]schemas.ResponsesOutputMessageContentTextLogProb, len(t.LogProbs))
+			for i := range t.LogProbs {
+				lp := t.LogProbs[i]
+				if lp.Bytes != nil {
+					lp.Bytes = append([]int(nil), lp.Bytes...)
+				}
+				if lp.TopLogProbs != nil {
+					lp.TopLogProbs = append([]schemas.LogProb(nil), lp.TopLogProbs...)
+				}
+				newLP[i] = lp
+			}
+			t.LogProbs = newLP
+		}
+		copy.ResponsesOutputMessageContentText = &t
+	}
+
+	if original.ResponsesOutputMessageContentRefusal != nil {
+		copyRefusal := schemas.ResponsesOutputMessageContentRefusal{
+			Refusal: original.ResponsesOutputMessageContentRefusal.Refusal,
+		}
+		copy.ResponsesOutputMessageContentRefusal = &copyRefusal
+	}
+
+	return copy
+}
+
 // buildCompleteMessageFromResponsesStreamChunks builds complete messages from accumulated responses stream chunks
 func (a *Accumulator) buildCompleteMessageFromResponsesStreamChunks(chunks []*ResponsesStreamChunk) []schemas.ResponsesMessage {
 	var messages []schemas.ResponsesMessage
@@ -276,9 +690,9 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *context.Context, re
 	endTimestamp := accumulator.FinalTimestamp
 	accumulator.mu.Unlock()
 
-	// For OpenAI provider, the last chunk already contains the whole accumulated response
+	// For OpenAI-compatible providers, the last chunk already contains the whole accumulated response
 	// so just return it as is
-	if provider == "openai" {
+	if provider == schemas.OpenAI || provider == schemas.OpenRouter || provider == schemas.Azure {
 		isFinalChunk := bifrost.IsFinalChunk(ctx)
 		if isFinalChunk {
 			// For OpenAI, the final chunk contains the complete response
@@ -348,8 +762,8 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *context.Context, re
 	if bifrostErr != nil {
 		chunk.FinishReason = bifrost.Ptr("error")
 	} else if result != nil && result.ResponsesStreamResponse != nil {
-		// Store the stream response
-		chunk.StreamResponse = result.ResponsesStreamResponse
+		// Store a deep copy of the stream response to prevent shared data mutation between plugins
+		chunk.StreamResponse = deepCopyResponsesStreamResponse(result.ResponsesStreamResponse)
 
 		// Extract token usage from stream response if available
 		if result.ResponsesStreamResponse.Response != nil &&

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -195,6 +195,22 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
 		}
+	case StreamTypeResponses:
+		responsesResp := &schemas.BifrostResponsesResponse{}
+
+		if p.Data.OutputMessages != nil {
+			responsesResp.Output = p.Data.OutputMessages
+		}
+		if p.Data.TokenUsage != nil {
+			responsesResp.Usage = p.Data.TokenUsage.ToResponsesResponseUsage()
+		}
+		responsesResp.ExtraFields = schemas.BifrostResponseExtraFields{
+			RequestType:    schemas.ResponsesRequest,
+			Provider:       p.Provider,
+			ModelRequested: p.Model,
+			Latency:        p.Data.Latency,
+		}
+		resp.ResponsesResponse = responsesResp
 	case StreamTypeAudio:
 		speechResp := p.Data.AudioOutput
 		if speechResp == nil {

--- a/plugins/maxim/plugin_test.go
+++ b/plugins/maxim/plugin_test.go
@@ -29,10 +29,11 @@ func getPlugin() (schemas.Plugin, error) {
 		return nil, fmt.Errorf("MAXIM_API_KEY is not set, please set it in your environment variables")
 	}
 
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	plugin, err := Init(&Config{
 		APIKey:    os.Getenv("MAXIM_API_KEY"),
 		LogRepoID: os.Getenv("MAXIM_LOG_REPO_ID"),
-	})
+	}, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -194,6 +195,7 @@ func TestLogRepoIDSelection(t *testing.T) {
 
 // TestPluginInitialization tests plugin initialization with different configs
 func TestPluginInitialization(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	tests := []struct {
 		name        string
 		config      Config
@@ -229,7 +231,7 @@ func TestPluginInitialization(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Skip actual Maxim SDK initialization in tests
 			if tt.expectError {
-				_, err := Init(&tt.config)
+				_, err := Init(&tt.config, logger)
 				if err == nil {
 					t.Error("Expected error but got none")
 				}

--- a/plugins/otel/docker-compose.yml
+++ b/plugins/otel/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       - source: otel-collector-config
         target: /etc/otelcol/config.yaml
     ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP
-      - "8888:8888"   # Collector /metrics
-      - "9464:9464"   # Prometheus scrape endpoint
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+      - "8888:8888" # Collector /metrics
+      - "9464:9464" # Prometheus scrape endpoint
       - "13133:13133" # Health check
-      - "1777:1777"   # pprof
+      - "1777:1777" # pprof
       - "55679:55679" # zpages
     restart: unless-stopped
     depends_on:
@@ -21,14 +21,14 @@ services:
   tempo:
     image: grafana/tempo:latest
     container_name: tempo
-    command: [ "-config.file=/etc/tempo.yaml" ]
+    command: ["-config.file=/etc/tempo.yaml"]
     configs:
       - source: tempo-config
         target: /etc/tempo.yaml
     ports:
-      - "3200:3200"   # tempo HTTP/gRPC API (multiplexed)
+      - "3200:3200" # tempo HTTP/gRPC API (multiplexed)
     expose:
-      - "4317"        # OTLP gRPC (internal)
+      - "4317" # OTLP gRPC (internal)
     volumes:
       - tempo-data:/var/tempo
     restart: unless-stopped

--- a/transports/bifrost-http/handlers/server.go
+++ b/transports/bifrost-http/handlers/server.go
@@ -211,7 +211,7 @@ func LoadPlugin[T schemas.Plugin](ctx context.Context, name string, pluginConfig
 		if err != nil {
 			return zero, fmt.Errorf("failed to marshal maxim plugin config: %v", err)
 		}
-		plugin, err := maxim.Init(maximConfig)
+		plugin, err := maxim.Init(maximConfig, logger)
 		if err != nil {
 			return zero, err
 		}

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -30,7 +30,7 @@ func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
 					return &schemas.BifrostRequest{
-						TextCompletionRequest: anthropicReq.ToBifrostRequest(),
+						TextCompletionRequest: anthropicReq.ToBifrostTextCompletionRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid request type")

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -112,7 +112,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if openaiReq, ok := req.(*openai.OpenAITextCompletionRequest); ok {
 					return &schemas.BifrostRequest{
-						TextCompletionRequest: openaiReq.ToBifrostRequest(),
+						TextCompletionRequest: openaiReq.ToBifrostTextCompletionRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid request type")
@@ -151,7 +151,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if openaiReq, ok := req.(*openai.OpenAIChatRequest); ok {
 					return &schemas.BifrostRequest{
-						ChatRequest: openaiReq.ToBifrostRequest(),
+						ChatRequest: openaiReq.ToBifrostChatRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid request type")
@@ -190,7 +190,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if openaiReq, ok := req.(*openai.OpenAIResponsesRequest); ok {
 					return &schemas.BifrostRequest{
-						ResponsesRequest: openaiReq.ToBifrostRequest(),
+						ResponsesRequest: openaiReq.ToBifrostResponsesRequest(),
 					}, nil
 
 				}
@@ -230,7 +230,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if embeddingReq, ok := req.(*openai.OpenAIEmbeddingRequest); ok {
 					return &schemas.BifrostRequest{
-						EmbeddingRequest: embeddingReq.ToBifrostRequest(),
+						EmbeddingRequest: embeddingReq.ToBifrostEmbeddingRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid embedding request type")
@@ -261,7 +261,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if speechReq, ok := req.(*openai.OpenAISpeechRequest); ok {
 					return &schemas.BifrostRequest{
-						SpeechRequest: speechReq.ToBifrostRequest(),
+						SpeechRequest: speechReq.ToBifrostSpeechRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid speech request type")
@@ -298,7 +298,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
 				if transcriptionReq, ok := req.(*openai.OpenAITranscriptionRequest); ok {
 					return &schemas.BifrostRequest{
-						TranscriptionRequest: transcriptionReq.ToBifrostRequest(),
+						TranscriptionRequest: transcriptionReq.ToBifrostTranscriptionRequest(),
 					}, nil
 				}
 				return nil, errors.New("invalid transcription request type")


### PR DESCRIPTION
## Summary

Improved method naming consistency and implemented deep copying for streaming responses to prevent data mutation between plugin accumulators.

## Changes

- Renamed conversion methods in provider schemas to be more specific and consistent (e.g., `ToBifrostResponse` → `ToBifrostTextCompletionResponse`)
- Added deep copy functionality for `ResponsesStreamResponse` to prevent shared data mutation between different plugin accumulators
- Fixed streaming response handling in the Maxim plugin to properly support streaming requests
- Improved concurrency handling in plugins (Logging, Governance, OTEL) by moving response processing to goroutines
- Updated the Anthropic provider to use the renamed conversion method

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with multiple plugins enabled:

```sh
# Core/Transports
go version
go test ./...

# Test with streaming requests
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $API_KEY" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}],
    "stream": true
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with data mutation between plugin accumulators during streaming responses.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable