### PR TITLE
feat: add chunk ordering by index to ensure correct stream processing

### DIFF
--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -54,6 +54,7 @@ type AudioStreamChunk struct {
 	SemanticCacheDebug *schemas.BifrostCacheDebug           // Semantic cache debug if available
 	Cost               *float64                             // Cost in dollars from pricing plugin
 	ErrorDetails       *schemas.BifrostError                // Error if any
+	ChunkIndex         int                                  // Index of the chunk in the stream
 }
 
 // TranscriptionStreamChunk represents a single transcription streaming chunk
@@ -65,6 +66,7 @@ type TranscriptionStreamChunk struct {
 	SemanticCacheDebug *schemas.BifrostCacheDebug                  // Semantic cache debug if available
 	Cost               *float64                                    // Cost in dollars from pricing plugin
 	ErrorDetails       *schemas.BifrostError                       // Error if any
+	ChunkIndex         int                                         // Index of the chunk in the stream
 }
 
 // ChatStreamChunk represents a single streaming chunk
@@ -76,6 +78,7 @@ type ChatStreamChunk struct {
 	SemanticCacheDebug *schemas.BifrostCacheDebug             // Semantic cache debug if available
 	Cost               *float64                               // Cost in dollars from pricing plugin
 	ErrorDetails       *schemas.BifrostError                  // Error if any
+	ChunkIndex         int                                    // Index of the chunk in the stream
 }
 
 // ResponsesStreamChunk represents a single responses streaming chunk
@@ -87,6 +90,7 @@ type ResponsesStreamChunk struct {
 	SemanticCacheDebug *schemas.BifrostCacheDebug              // Semantic cache debug if available
 	Cost               *float64                                // Cost in dollars from pricing plugin
 	ErrorDetails       *schemas.BifrostError                   // Error if any
+	ChunkIndex         int                                     // Index of the chunk in the stream
 }
 
 // StreamAccumulator manages accumulation of streaming chunks


### PR DESCRIPTION
## Summary

Added chunk ordering to ensure correct processing of streaming responses across all stream types (audio, chat, transcription, responses).

## Changes

- Added `ChunkIndex` field to all stream chunk types to track the order of chunks
- Implemented sorting of chunks by `ChunkIndex` before processing in all stream handlers
- Refactored conditional logic in stream processing functions to be more concise
- Updated the responses stream handler to use `ChunkIndex` instead of `SequenceNumber` for sorting
- Consolidated code blocks to avoid redundant conditionals

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with multiple chunks to verify they are processed in the correct order:

```sh
# Core/Transports
go version
go test ./framework/streaming/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with out-of-order processing of streaming chunks.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable