### PR TITLE
feat: list models with all configured keys for provider

### DIFF
--- a/core/providers/cerebras.go
+++ b/core/providers/cerebras.go
@@ -62,8 +62,8 @@ func (provider *CerebrasProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // ListModels performs a list models request to Cerebras's API.
-func (provider *CerebrasProvider) ListModels(ctx context.Context, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", key, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
+func (provider *CerebrasProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", keys, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
 }
 
 // TextCompletion performs a text completion request to Cerebras's API.

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -67,13 +67,13 @@ func (provider *GroqProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // ListModels performs a list models request to Groq's API.
-func (provider *GroqProvider) ListModels(ctx context.Context, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+func (provider *GroqProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	return handleOpenAIListModelsRequest(
 		ctx,
 		provider.client,
 		request,
 		provider.networkConfig.BaseURL+"/v1/models",
-		key,
+		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Groq,
 		provider.sendBackRawResponse,

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -69,11 +69,11 @@ func (provider *OllamaProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // ListModels performs a list models request to Ollama's API.
-func (provider *OllamaProvider) ListModels(ctx context.Context, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+func (provider *OllamaProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	if provider.networkConfig.BaseURL == "" {
 		return nil, newConfigurationError("base_url is not set", provider.GetProviderKey())
 	}
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", key, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", keys, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
 }
 
 // TextCompletion performs a text completion request to the Ollama API.

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -67,13 +67,13 @@ func (provider *ParasailProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // ListModels performs a list models request to Parasail's API.
-func (provider *ParasailProvider) ListModels(ctx context.Context, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+func (provider *ParasailProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	return handleOpenAIListModelsRequest(
 		ctx,
 		provider.client,
 		request,
 		provider.networkConfig.BaseURL+"/v1/models",
-		key,
+		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
 		provider.sendBackRawResponse,

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -69,13 +69,13 @@ func (provider *SGLProvider) GetProviderKey() schemas.ModelProvider {
 }
 
 // ListModels performs a list models request to SGL's API.
-func (provider *SGLProvider) ListModels(ctx context.Context, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+func (provider *SGLProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	return handleOpenAIListModelsRequest(
 		ctx,
 		provider.client,
 		request,
 		provider.networkConfig.BaseURL+"/v1/models",
-		key,
+		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.SGL,
 		provider.sendBackRawResponse,

--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -9,8 +9,16 @@ import (
 
 // DefaultPageSize is the default page size for listing models
 const DefaultPageSize = 1000
+
 // MaxPaginationRequests is the maximum number of pagination requests to make
 const MaxPaginationRequests = 20
+
+// Structure to collect results from goroutines
+type ListModelsByKeyResult struct {
+	Response *BifrostListModelsResponse
+	Err      *BifrostError
+	KeyID    string
+}
 
 type BifrostListModelsRequest struct {
 	Provider ModelProvider `json:"provider"`
@@ -26,22 +34,24 @@ type BifrostListModelsRequest struct {
 }
 
 type BifrostListModelsResponse struct {
-	Data        []Model                    `json:"data"`
-	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
-	NextPageToken string `json:"next_page_token,omitempty"` // Token to retrieve next page
+	Data          []Model                    `json:"data"`
+	ExtraFields   BifrostResponseExtraFields `json:"extra_fields"`
+	NextPageToken string                     `json:"next_page_token,omitempty"` // Token to retrieve next page
 
 	// Anthropic specific fields
 	FirstID *string `json:"-"`
-	LastID *string `json:"-"`
-	HasMore *bool `json:"-"`
+	LastID  *string `json:"-"`
+	HasMore *bool   `json:"-"`
 }
 
 type Model struct {
 	ID                  string             `json:"id"`
 	CanonicalSlug       *string            `json:"canonical_slug,omitempty"`
 	Name                *string            `json:"name,omitempty"`
-	Created             *int64               `json:"created,omitempty"`
+	Created             *int64             `json:"created,omitempty"`
 	ContextLength       *int               `json:"context_length,omitempty"`
+	MaxInputTokens      *int               `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens     *int               `json:"max_output_tokens,omitempty"`
 	Architecture        *Architecture      `json:"architecture,omitempty"`
 	Pricing             *Pricing           `json:"pricing,omitempty"`
 	TopProvider         *TopProvider       `json:"top_provider,omitempty"`
@@ -75,9 +85,9 @@ type Pricing struct {
 }
 
 type TopProvider struct {
-	IsModerated         *bool    `json:"is_moderated,omitempty"`
-	ContextLength       *int `json:"context_length,omitempty"`
-	MaxCompletionTokens *int `json:"max_completion_tokens,omitempty"`
+	IsModerated         *bool `json:"is_moderated,omitempty"`
+	ContextLength       *int  `json:"context_length,omitempty"`
+	MaxCompletionTokens *int  `json:"max_completion_tokens,omitempty"`
 }
 
 type PerRequestLimits struct {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -198,7 +198,7 @@ type Provider interface {
 	// GetProviderKey returns the provider's identifier
 	GetProviderKey() ModelProvider
 	// ListModels performs a list models request
-	ListModels(ctx context.Context, key Key, request *BifrostListModelsRequest) (*BifrostListModelsResponse, *BifrostError)
+	ListModels(ctx context.Context, keys []Key, request *BifrostListModelsRequest) (*BifrostListModelsResponse, *BifrostError)
 	// TextCompletion performs a text completion request
 	TextCompletion(ctx context.Context, key Key, request *BifrostTextCompletionRequest) (*BifrostTextCompletionResponse, *BifrostError)
 	// TextCompletionStream performs a text completion stream request

--- a/core/schemas/providers/anthropic/models.go
+++ b/core/schemas/providers/anthropic/models.go
@@ -1,46 +1,10 @@
 package anthropic
 
 import (
-	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
-
-func ToAnthropicListModelsURL(request *schemas.BifrostListModelsRequest, baseURL string) string {
-	// Add limit parameter (default to 1000)
-	pageSize := request.PageSize
-	if pageSize <= 0 {
-		pageSize = schemas.DefaultPageSize
-	}
-
-	// Build query parameters
-	params := url.Values{}
-	params.Set("limit", strconv.Itoa(pageSize))
-
-	// Add cursor-based pagination parameters
-	if request.ExtraParams != nil {
-		// before_id for backward pagination
-		if beforeID, ok := request.ExtraParams["before_id"].(string); ok && beforeID != "" {
-			params.Set("before_id", beforeID)
-		}
-		// after_id for forward pagination
-		if afterID, ok := request.ExtraParams["after_id"].(string); ok && afterID != "" {
-			params.Set("after_id", afterID)
-		}
-	}
-	// Use page_token as after_id if not explicitly provided in ExtraParams
-	if request.PageToken != "" {
-		if request.ExtraParams == nil {
-			params.Set("after_id", request.PageToken)
-		} else if _, hasAfterID := request.ExtraParams["after_id"]; !hasAfterID {
-			params.Set("after_id", request.PageToken)
-		}
-	}
-
-	return baseURL + "?" + params.Encode()
-}
 
 func (response *AnthropicListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
 	if response == nil {

--- a/core/schemas/providers/bedrock/chat.go
+++ b/core/schemas/providers/bedrock/chat.go
@@ -2,8 +2,10 @@ package bedrock
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/core/schemas/providers/anthropic"
 )
@@ -42,7 +44,7 @@ func ToBedrockChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Be
 }
 
 // ToBifrostChatResponse converts a Bedrock Converse API response to Bifrost format
-func (response *BedrockConverseResponse) ToBifrostChatResponse() (*schemas.BifrostChatResponse, error) {
+func (response *BedrockConverseResponse) ToBifrostChatResponse(model string) (*schemas.BifrostChatResponse, error) {
 	if response == nil {
 		return nil, fmt.Errorf("bedrock response is nil")
 	}
@@ -136,8 +138,12 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse() (*schemas.Bifro
 
 	// Create the final Bifrost response
 	bifrostResponse := &schemas.BifrostChatResponse{
+		ID:      uuid.New().String(),
+		Model:   model,
+		Object:  "chat.completion",
 		Choices: choices,
 		Usage:   usage,
+		Created: int(time.Now().Unix()),
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType: schemas.ChatCompletionRequest,
 			Provider:    schemas.Bedrock,

--- a/core/schemas/providers/cohere/models.go
+++ b/core/schemas/providers/cohere/models.go
@@ -1,37 +1,6 @@
 package cohere
 
-import (
-	"net/url"
-	"strconv"
-
-	schemas "github.com/maximhq/bifrost/core/schemas"
-)
-
-func ToCohereListModelsURL(request *schemas.BifrostListModelsRequest, baseURL string) string {
-	pageSize := request.PageSize
-	if pageSize <= 0 {
-		pageSize = schemas.DefaultPageSize
-	}
-
-	// Build query parameters
-	params := url.Values{}
-	params.Set("page_size", strconv.Itoa(pageSize))
-
-	if request.PageToken != "" {
-		params.Set("page_token", request.PageToken)
-	}
-
-	if request.ExtraParams != nil {
-		if endpoint, ok := request.ExtraParams["endpoint"].(string); ok && endpoint != "" {
-			params.Set("endpoint", endpoint)
-		}
-		if defaultOnly, ok := request.ExtraParams["default_only"].(bool); ok && defaultOnly {
-			params.Set("default_only", "true")
-		}
-	}
-
-	return baseURL + "?" + params.Encode()
-}
+import "github.com/maximhq/bifrost/core/schemas"
 
 func (response *CohereListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
 	if response == nil {
@@ -40,7 +9,6 @@ func (response *CohereListModelsResponse) ToBifrostListModelsResponse(providerKe
 
 	bifrostResponse := &schemas.BifrostListModelsResponse{
 		Data:          make([]schemas.Model, 0, len(response.Models)),
-		NextPageToken: response.NextPageToken,
 	}
 
 	for _, model := range response.Models {

--- a/core/schemas/providers/gemini/models.go
+++ b/core/schemas/providers/gemini/models.go
@@ -1,30 +1,10 @@
 package gemini
 
 import (
-	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
-
-func ToGeminiListModelsURL(request *schemas.BifrostListModelsRequest, baseURL string) string {
-	// Add limit parameter (default to 1000)
-	pageSize := request.PageSize
-	if pageSize <= 0 {
-		pageSize = schemas.DefaultPageSize
-	}	
-
-	// Build query parameters
-	params := url.Values{}
-	params.Set("pageSize", strconv.Itoa(pageSize))
-
-	if request.PageToken != "" {
-		params.Set("pageToken", request.PageToken)
-	}
-
-	return baseURL + "?" + params.Encode()
-}
 
 func (response *GeminiListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
 	if response == nil {
@@ -33,7 +13,6 @@ func (response *GeminiListModelsResponse) ToBifrostListModelsResponse(providerKe
 
 	bifrostResponse := &schemas.BifrostListModelsResponse{
 		Data:          make([]schemas.Model, 0, len(response.Models)),
-		NextPageToken: response.NextPageToken,
 	}
 
 	for _, model := range response.Models {
@@ -45,6 +24,8 @@ func (response *GeminiListModelsResponse) ToBifrostListModelsResponse(providerKe
 			Name:             schemas.Ptr(model.DisplayName),
 			Description:      schemas.Ptr(model.Description),
 			ContextLength:    schemas.Ptr(int(contextLength)),
+			MaxInputTokens:   schemas.Ptr(model.InputTokenLimit),
+			MaxOutputTokens:  schemas.Ptr(model.OutputTokenLimit),
 			SupportedMethods: model.SupportedGenerationMethods,
 		})
 	}
@@ -72,6 +53,12 @@ func ToGeminiListModelsResponse(resp *schemas.BifrostListModelsResponse) *Gemini
 		}
 		if model.Description != nil {
 			geminiModel.Description = *model.Description
+		}
+		if model.MaxInputTokens != nil {
+			geminiModel.InputTokenLimit = *model.MaxInputTokens
+		}
+		if model.MaxOutputTokens != nil {
+			geminiModel.OutputTokenLimit = *model.MaxOutputTokens
 		}
 
 		geminiResponse.Models = append(geminiResponse.Models, geminiModel)

--- a/core/schemas/providers/vertex/models.go
+++ b/core/schemas/providers/vertex/models.go
@@ -1,29 +1,6 @@
 package vertex
 
-import (
-	"net/url"
-	"strconv"
-
-	"github.com/maximhq/bifrost/core/schemas"
-)
-
-func ToVertexListModelsURL(request *schemas.BifrostListModelsRequest, baseURL string) string {
-	// Add limit parameter (default to 100 for Vertex)
-	pageSize := request.PageSize
-	if pageSize <= 0 || pageSize > MaxPageSize {
-		pageSize = MaxPageSize
-	}
-
-	// Build query parameters
-	params := url.Values{}
-	params.Set("pageSize", strconv.Itoa(pageSize))
-
-	if request.PageToken != "" {
-		params.Set("pageToken", request.PageToken)
-	}
-
-	return baseURL + "?" + params.Encode()
-}
+import "github.com/maximhq/bifrost/core/schemas"
 
 func (response *VertexListModelsResponse) ToBifrostListModelsResponse() *schemas.BifrostListModelsResponse {
 	if response == nil {
@@ -32,7 +9,6 @@ func (response *VertexListModelsResponse) ToBifrostListModelsResponse() *schemas
 
 	bifrostResponse := &schemas.BifrostListModelsResponse{
 		Data:          make([]schemas.Model, 0, len(response.Models)),
-		NextPageToken: response.NextPageToken,
 	}
 
 	for _, model := range response.Models {

--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -6632,6 +6632,16 @@
             "example": 128000,
             "nullable": true
           },
+          "max_input_tokens": {
+            "type": "integer",
+            "description": "Maximum input tokens",
+            "nullable": true
+          },
+          "max_output_tokens": {
+            "type": "integer",
+            "description": "Maximum output tokens",
+            "nullable": true
+          },
           "architecture": {
             "$ref": "#/components/schemas/ModelArchitecture",
             "description": "Object describing the model's technical capabilities",


### PR DESCRIPTION
## Summary

Enhance the ListModels functionality to aggregate results from multiple API keys, improving model discovery and availability.

## Changes

- Modified `ListModels` interface to accept multiple keys instead of a single key
- Implemented key aggregation logic that combines model lists from multiple API keys
- Added deduplication of models based on model ID when aggregating results
- Created a best-effort approach that continues processing remaining keys even if some fail
- Added a new helper function `getAllSupportedKeys` to retrieve all valid keys for a provider
- Updated all provider implementations to support the multi-key approach

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the ListModels endpoint with multiple API keys configured for the same provider:

```sh
# Core/Transports
go version
go test ./...

# Test with multiple keys for a provider (e.g., OpenAI)
curl -X GET "http://localhost:8000/v1/models?provider=openai" -H "Authorization: Bearer your-bifrost-token"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves model discovery by aggregating results from multiple API keys.

## Security considerations

The implementation maintains the same security model as before, with proper error handling to avoid leaking sensitive information.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable