### PR TITLE
feat: handle common tool types of openai and anthropic in responses api

### DIFF
--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -27,7 +27,7 @@ func (ct *ChatTool) ToResponsesTool() *ResponsesTool {
 	}
 
 	rt := &ResponsesTool{
-		Type: string(ct.Type),
+		Type: ResponsesToolType(ct.Type),
 	}
 
 	// Convert function tools

--- a/core/schemas/providers/anthropic/chat.go
+++ b/core/schemas/providers/anthropic/chat.go
@@ -210,7 +210,7 @@ func (request *AnthropicMessageRequest) ToBifrostChatRequest() *schemas.BifrostC
 				Type: schemas.ChatToolTypeFunction,
 				Function: &schemas.ChatToolFunction{
 					Name:        tool.Name,
-					Description: schemas.Ptr(tool.Description),
+					Description: tool.Description,
 					Parameters:  &params,
 				},
 			})
@@ -407,7 +407,7 @@ func ToAnthropicChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *A
 					Name: tool.Function.Name,
 				}
 				if tool.Function.Description != nil {
-					anthropicTool.Description = *tool.Function.Description
+					anthropicTool.Description = tool.Function.Description
 				}
 
 				// Convert function parameters to input_schema

--- a/core/schemas/providers/openai/responses.go
+++ b/core/schemas/providers/openai/responses.go
@@ -47,7 +47,39 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 
 	if params != nil {
 		req.ResponsesParameters = *params
+		// Filter out tools that OpenAI doesn't support
+		req.filterUnsupportedTools()
 	}
 
 	return req
+}
+
+// filterUnsupportedTools removes tool types that OpenAI doesn't support
+func (req *OpenAIResponsesRequest) filterUnsupportedTools() {
+	if len(req.Tools) == 0 {
+		return
+	}
+
+	// Define OpenAI-supported tool types
+	supportedTypes := map[schemas.ResponsesToolType]bool{
+		schemas.ResponsesToolTypeFunction:           true,
+		schemas.ResponsesToolTypeFileSearch:         true,
+		schemas.ResponsesToolTypeComputerUsePreview: true,
+		schemas.ResponsesToolTypeWebSearch:          true,
+		schemas.ResponsesToolTypeMCP:                true,
+		schemas.ResponsesToolTypeCodeInterpreter:    true,
+		schemas.ResponsesToolTypeImageGeneration:    true,
+		schemas.ResponsesToolTypeLocalShell:         true,
+		schemas.ResponsesToolTypeCustom:             true,
+		schemas.ResponsesToolTypeWebSearchPreview:   true,
+	}
+
+	// Filter tools to only include supported types
+	filteredTools := make([]schemas.ResponsesTool, 0, len(req.Tools))
+	for _, tool := range req.Tools {
+		if supportedTypes[tool.Type] {
+			filteredTools = append(filteredTools, tool)
+		}
+	}
+	req.Tools = filteredTools
 }

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -351,7 +351,7 @@ func getResponsesRequestParams(req *schemas.BifrostResponsesRequest) []*KeyValue
 		if req.Params.Tools != nil {
 			tools := make([]string, len(req.Params.Tools))
 			for i, tool := range req.Params.Tools {
-				tools[i] = tool.Type
+				tools[i] = string(tool.Type)
 			}
 			params = append(params, kvStr("gen_ai.request.tools", strings.Join(tools, ",")))
 		}
@@ -608,7 +608,7 @@ func completeResourceSpan(span *ResourceSpan, timestamp time.Time, resp *schemas
 			if responsesResponse.Tools != nil {
 				tools := make([]string, len(responsesResponse.Tools))
 				for i, tool := range responsesResponse.Tools {
-					tools[i] = tool.Type
+					tools[i] = string(tool.Type)
 				}
 				params = append(params, kvStr("gen_ai.responses.tools", strings.Join(tools, ",")))
 			}


### PR DESCRIPTION
## Summary

Implement proper type handling for Anthropic tools in the schema conversion layer, adding support for specialized tool types like computer use preview, web search, and local shell.

## Changes

- Added `ResponsesToolType` as a proper string type with constants for all supported tool types
- Enhanced Anthropic tool conversion to properly handle specialized tool types:
  - Computer use preview tools
  - Web search tools
  - Local shell (bash) tools
- Added proper type definitions for Anthropic-specific tool structures
- Fixed type conversion in the chat tool mux to use the new type system

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Test with Anthropic API calls that use specialized tools like computer use preview, web search, and local shell to verify proper conversion between Bifrost and Anthropic formats.

## Breaking changes

- [x] No

## Related issues

Improves tool handling for Anthropic provider integration.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)