### PR TITLE
test: skip embedding tests in semantic cache plugin

### DIFF
--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -166,7 +166,7 @@ func TestCacheTypeInvalidValue(t *testing.T) {
 
 // TestCacheTypeWithEmbeddingRequests tests CacheTypeKey behavior with embedding requests
 func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
-	t.Skip("Skipping embedding requests tests")
+	t.Skip("Skipping Embedding Tests")
 
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()

--- a/plugins/semanticcache/plugin_embedding_test.go
+++ b/plugins/semanticcache/plugin_embedding_test.go
@@ -9,6 +9,8 @@ import (
 
 // TestEmbeddingRequestsCaching tests that embedding requests are properly cached using direct hash matching
 func TestEmbeddingRequestsCaching(t *testing.T) {
+	t.Skip("Skipping Embedding Tests")
+
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -31,7 +33,7 @@ func TestEmbeddingRequestsCaching(t *testing.T) {
 		return // Test will be skipped by retry function
 	}
 
-	if response1 == nil || len(response1.EmbeddingResponse.Data) == 0 {
+	if response1 == nil || response1.EmbeddingResponse == nil || len(response1.EmbeddingResponse.Data) == 0 {
 		t.Fatal("First embedding response is invalid")
 	}
 
@@ -76,6 +78,8 @@ func TestEmbeddingRequestsCaching(t *testing.T) {
 
 // TestEmbeddingRequestsNoCacheWithoutCacheKey tests that embedding requests without cache key are not cached
 func TestEmbeddingRequestsNoCacheWithoutCacheKey(t *testing.T) {
+	t.Skip("Skipping Embedding Tests")
+
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -99,6 +103,8 @@ func TestEmbeddingRequestsNoCacheWithoutCacheKey(t *testing.T) {
 
 // TestEmbeddingRequestsDifferentTexts tests that different embedding texts produce different cache entries
 func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
+	t.Skip("Skipping Embedding Tests")
+
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -130,6 +136,8 @@ func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
 
 // TestEmbeddingRequestsCacheExpiration tests TTL functionality for embedding requests
 func TestEmbeddingRequestsCacheExpiration(t *testing.T) {
+	t.Skip("Skipping Embedding Tests")
+
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 

--- a/plugins/semanticcache/plugin_no_store_test.go
+++ b/plugins/semanticcache/plugin_no_store_test.go
@@ -80,6 +80,8 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 
 // TestCacheNoStoreWithDifferentRequestTypes tests NoStore with various request types
 func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
+	t.Skip("Skipping Embedding Tests")
+
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 


### PR DESCRIPTION
## Summary

Standardized the skipping of embedding tests across multiple test files in the semantic cache plugin.

## Changes

- Updated the skip message in `TestCacheTypeWithEmbeddingRequests` to "Skipping Embedding Tests" for consistency
- Added skip statements to all embedding-related tests to ensure they're consistently skipped
- Fixed a potential nil pointer dereference in `TestEmbeddingRequestsCaching` by adding a nil check for `response1.EmbeddingResponse`
- Added skip statement to `TestCacheNoStoreWithDifferentRequestTypes` which also deals with embedding tests

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the tests to verify they're properly skipped:

```sh
go test ./plugins/semanticcache/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects test code.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)