### PR TITLE
refactor: simplify semantic cache tests by removing retry helper functions

### DIFF
--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -18,11 +18,11 @@ func TestCacheTypeDirectOnly(t *testing.T) {
 	testRequest := CreateBasicChatRequest("What is Bifrost?", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx1, testRequest)
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache()
 
@@ -51,11 +51,11 @@ func TestCacheTypeSemanticOnly(t *testing.T) {
 	testRequest := CreateBasicChatRequest("Explain machine learning concepts", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx1, testRequest)
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache()
 
@@ -98,11 +98,11 @@ func TestCacheTypeDirectWithSemanticFallback(t *testing.T) {
 	testRequest := CreateBasicChatRequest("Define artificial intelligence", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx1, testRequest)
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache()
 
@@ -153,21 +153,19 @@ func TestCacheTypeInvalidValue(t *testing.T) {
 	testRequest := CreateBasicChatRequest("Test invalid cache type", 0.7, 50)
 
 	t.Log("Making request with invalid CacheTypeKey value...")
-	response, err := ChatRequestWithRetries(t, setup.Client, ctx, testRequest)
+	response, err := setup.Client.ChatCompletionRequest(ctx, testRequest)
 	if err != nil {
 		return // Test will be skipped by retry function
 	}
 
 	// Should fall back to default behavior (both direct and semantic)
-	AssertNoCacheHit(t, response)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response})
 
 	t.Log("✅ Invalid CacheTypeKey value falls back to default behavior")
 }
 
 // TestCacheTypeWithEmbeddingRequests tests CacheTypeKey behavior with embedding requests
 func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
-	t.Skip("Skipping Embedding Tests")
-
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -176,11 +174,11 @@ func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
 	// Cache first request
 	ctx1 := CreateContextWithCacheKey("test-embedding-cache-type")
 	t.Log("Making first embedding request...")
-	response1, err1 := EmbeddingRequestWithRetries(t, setup.Client, ctx1, embeddingRequest)
+	response1, err1 := setup.Client.EmbeddingRequest(ctx1, embeddingRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
 	WaitForCache()
 
@@ -220,11 +218,11 @@ func TestCacheTypePerformanceCharacteristics(t *testing.T) {
 	// Cache first request
 	ctx1 := CreateContextWithCacheKey("test-cache-performance")
 	t.Log("Making first request to populate cache...")
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx1, testRequest)
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache()
 

--- a/plugins/semanticcache/plugin_normalization_test.go
+++ b/plugins/semanticcache/plugin_normalization_test.go
@@ -91,16 +91,16 @@ func testChatCompletionNormalization(t *testing.T, setup *TestSetup) {
 
 	// Make first request (should miss cache and be stored)
 	t.Logf("Making first request with user: '%s', system: '%s'", testCases[0].userMsg, testCases[0].systemMsg)
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx, requests[0])
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx, requests[0])
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	if response1 == nil || len(response1.ChatResponse.Choices) == 0 {
+	if response1 == nil || len(response1.Choices) == 0 {
 		t.Fatal("First response is invalid")
 	}
 
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 	WaitForCache()
 
 	// Test all other variations should hit cache due to normalization
@@ -243,16 +243,16 @@ func TestChatCompletionContentBlocksNormalization(t *testing.T) {
 
 	// Make first request (should miss cache and be stored)
 	t.Logf("Making first request with content blocks: %v", testCases[0].textBlocks)
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx, requests[0])
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx, requests[0])
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	if response1 == nil || len(response1.ChatResponse.Choices) == 0 {
+	if response1 == nil || len(response1.Choices) == 0 {
 		t.Fatal("First response is invalid")
 	}
 
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 	WaitForCache()
 
 	// Test all other variations should hit cache due to normalization
@@ -285,12 +285,12 @@ func TestNormalizationWithSemanticCache(t *testing.T) {
 	// Make first request with original text
 	originalRequest := CreateBasicChatRequest("What is Machine Learning?", 0.5, 50)
 	t.Log("Making first request with original text...")
-	response1, err1 := ChatRequestWithRetries(t, setup.Client, ctx, originalRequest)
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx, originalRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 	WaitForCache()
 
 	// Test semantic match with different case (should hit semantic cache after normalization)

--- a/plugins/semanticcache/plugin_responses_test.go
+++ b/plugins/semanticcache/plugin_responses_test.go
@@ -25,20 +25,20 @@ func TestResponsesAPIBasicFunctionality(t *testing.T) {
 
 	// Make first request (will go to OpenAI and be cached) - with retries
 	start1 := time.Now()
-	response1, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, testRequest)
+	response1, err1 := setup.Client.ResponsesRequest(ctx, testRequest)
 	duration1 := time.Since(start1)
 
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	if response1 == nil || len(response1.ResponsesResponse.Output) == 0 {
+	if response1 == nil || len(response1.Output) == 0 {
 		t.Fatal("First Responses response is invalid")
 	}
 
 	t.Logf("First request completed in %v", duration1)
-	t.Logf("Response contains %d output messages", len(response1.ResponsesResponse.Output))
-	if c := response1.ResponsesResponse.Output[0].Content; c != nil && c.ContentStr != nil {
+	t.Logf("Response contains %d output messages", len(response1.Output))
+	if c := response1.Output[0].Content; c != nil && c.ContentStr != nil {
 		t.Logf("Response: %s", *c.ContentStr)
 	} else if c != nil && len(c.ContentBlocks) > 0 && c.ContentBlocks[0].Text != nil {
 		t.Logf("Response: %s", *c.ContentBlocks[0].Text)
@@ -138,7 +138,7 @@ func TestResponsesAPIDifferentParameters(t *testing.T) {
 			clearTestKeysWithStore(t, setup.Store)
 
 			// Make first request
-			_, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, tt.request1)
+			_, err1 := setup.Client.ResponsesRequest(ctx, tt.request1)
 			if err1 != nil {
 				return // Test will be skipped by retry function
 			}
@@ -176,12 +176,12 @@ func TestResponsesAPISemanticMatching(t *testing.T) {
 	// First request
 	originalRequest := CreateBasicResponsesRequest("What is machine learning?", 0.5, 500)
 	t.Log("Making first Responses request with original text...")
-	response1, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, originalRequest)
+	response1, err1 := setup.Client.ResponsesRequest(ctx, originalRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 	WaitForCache()
 
 	// Test semantic match with similar but different text
@@ -217,12 +217,12 @@ func TestResponsesAPIWithInstructions(t *testing.T) {
 	)
 
 	t.Log("Making first Responses request with instructions...")
-	response1, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, request1)
+	response1, err1 := setup.Client.ResponsesRequest(ctx, request1)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 	WaitForCache()
 
 	// Make identical request
@@ -260,11 +260,11 @@ func TestResponsesAPICacheExpiration(t *testing.T) {
 	responsesRequest := CreateBasicResponsesRequest("TTL test for Responses API", 0.5, 500)
 
 	t.Log("Making first Responses request with short TTL...")
-	response1, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, responsesRequest)
+	response1, err1 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
 	WaitForCache()
 
@@ -283,12 +283,12 @@ func TestResponsesAPICacheExpiration(t *testing.T) {
 	time.Sleep(shortTTL + 2*time.Second) // Wait for TTL to expire
 
 	t.Log("Making third Responses request after TTL expiration...")
-	response3, err3 := ResponsesRequestWithRetries(t, setup.Client, ctx, responsesRequest)
+	response3, err3 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err3 != nil {
 		return // Test will be skipped by retry function
 	}
 	// Should not be a cache hit since TTL expired
-	AssertNoCacheHit(t, response3)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response3})
 
 	t.Log("✅ Responses API requests properly handle TTL expiration")
 }
@@ -305,13 +305,13 @@ func TestResponsesAPIWithoutCacheKey(t *testing.T) {
 
 	t.Log("Making Responses request without cache key...")
 
-	response, err := ResponsesRequestWithRetries(t, setup.Client, ctx, responsesRequest)
+	response, err := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err != nil {
 		return // Test will be skipped by retry function
 	}
 
 	// Should not be cached
-	AssertNoCacheHit(t, response)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response})
 
 	t.Log("✅ Responses requests without cache key are properly not cached")
 }
@@ -325,20 +325,20 @@ func TestResponsesAPINoStoreFlag(t *testing.T) {
 	ctx := CreateContextWithCacheKeyAndNoStore("test-no-store-responses", true)
 
 	t.Log("Testing no-store with Responses API...")
-	response1, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, responsesRequest)
+	response1, err1 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
 	WaitForCache()
 
 	// Verify not cached
-	response2, err2 := ResponsesRequestWithRetries(t, setup.Client, ctx, responsesRequest)
+	response2, err2 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err2 != nil {
 		return // Test will be skipped by retry function
 	}
-	AssertNoCacheHit(t, response2) // Should not be cached
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response2}) // Should not be cached
 
 	t.Log("✅ Responses API no-store flag working correctly")
 }
@@ -356,7 +356,7 @@ func TestResponsesAPIStreaming(t *testing.T) {
 	// Make non-streaming request first
 	t.Log("Making non-streaming Responses request...")
 	nonStreamRequest := CreateBasicResponsesRequest(prompt, 0.5, 500)
-	_, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, nonStreamRequest)
+	_, err1 := setup.Client.ResponsesRequest(ctx, nonStreamRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
@@ -417,12 +417,12 @@ func TestResponsesAPIComplexParameters(t *testing.T) {
 	request.Params.Store = &[]bool{true}[0]
 
 	t.Log("Making first Responses request with complex parameters...")
-	response1, err1 := ResponsesRequestWithRetries(t, setup.Client, ctx, request)
+	response1, err1 := setup.Client.ResponsesRequest(ctx, request)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
 
-	AssertNoCacheHit(t, response1)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 	WaitForCache()
 
 	// Create identical request

--- a/plugins/semanticcache/plugin_streaming_test.go
+++ b/plugins/semanticcache/plugin_streaming_test.go
@@ -25,7 +25,7 @@ func TestStreamingCacheBasicFunctionality(t *testing.T) {
 
 	// Make first streaming request
 	start1 := time.Now()
-	stream1, err1 := ChatStreamingRequestWithRetries(t, setup.Client, ctx, testRequest)
+	stream1, err1 := setup.Client.ChatCompletionStreamRequest(ctx, testRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
@@ -125,7 +125,7 @@ func TestStreamingVsNonStreaming(t *testing.T) {
 	// Make non-streaming request first
 	t.Log("Making non-streaming request...")
 	nonStreamRequest := CreateBasicChatRequest(prompt, 0.5, 50)
-	nonStreamResponse, err1 := ChatRequestWithRetries(t, setup.Client, ctx, nonStreamRequest)
+	nonStreamResponse, err1 := setup.Client.ChatCompletionRequest(ctx, nonStreamRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
@@ -177,7 +177,7 @@ func TestStreamingVsNonStreaming(t *testing.T) {
 	}
 
 	// Verify non-streaming response was not affected
-	AssertNoCacheHit(t, nonStreamResponse)
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: nonStreamResponse})
 
 	t.Log("✅ Streaming vs non-streaming test completed!")
 }
@@ -197,7 +197,7 @@ func TestStreamingChunkOrdering(t *testing.T) {
 	)
 
 	t.Log("Making first streaming request to establish cache...")
-	stream1, err1 := ChatStreamingRequestWithRetries(t, setup.Client, ctx, testRequest)
+	stream1, err1 := setup.Client.ChatCompletionStreamRequest(ctx, testRequest)
 	if err1 != nil {
 		return // Test will be skipped by retry function
 	}
@@ -286,7 +286,7 @@ func TestSpeechSynthesisStreaming(t *testing.T) {
 
 	t.Log("Making first speech synthesis request...")
 	start1 := time.Now()
-	response1, err1 := SpeechRequestWithRetries(t, setup.Client, ctx, speechRequest)
+	response1, err1 := setup.Client.SpeechRequest(ctx, speechRequest)
 	duration1 := time.Since(start1)
 
 	if err1 != nil {


### PR DESCRIPTION
## Summary

Refactored semantic cache plugin tests to directly use client methods instead of using retry wrapper functions, simplifying the test code and making it more maintainable.

## Changes

- Removed `WithRetries` helper functions and their specialized wrappers (`ChatRequestWithRetries`, `EmbeddingRequestWithRetries`, etc.)
- Updated all test calls to directly use the client methods (`setup.Client.ChatCompletionRequest`, etc.)
- Fixed response handling by wrapping raw responses in `BifrostResponse` objects when needed
- Re-enabled embedding tests that were previously skipped
- Adjusted retry configuration parameters for better test stability

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache plugin tests to verify they still pass with the refactored code:

```sh
cd plugins/semanticcache
go test -v ./...
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable