### PR TITLE
refactor: standardize finish reason and single response handling across providers

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -527,7 +527,7 @@ func handleAnthropicChatCompletionStreaming(
 				}
 			}
 			if event.Delta != nil && event.Delta.StopReason != nil {
-				mappedReason := schemas.MapProviderFinishReasonToBifrost(*event.Delta.StopReason, providerType)
+				mappedReason := anthropic.ConvertAnthropicFinishReasonToBifrost(*event.Delta.StopReason)
 				finishReason = &mappedReason
 			}
 			if event.Message != nil {

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/bytedance/sonic"
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/core/schemas/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas/providers/bedrock"
 	cohere "github.com/maximhq/bifrost/core/schemas/providers/cohere"
 )
@@ -699,7 +700,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 				}
 
 				if streamEvent.StopReason != nil {
-					finishReason = schemas.Ptr(schemas.MapProviderFinishReasonToBifrost(*streamEvent.StopReason, providerName))
+					finishReason = schemas.Ptr(anthropic.ConvertAnthropicFinishReasonToBifrost(anthropic.AnthropicStopReason(*streamEvent.StopReason)))
 				}
 
 				response, bifrostErr, _ := streamEvent.ToBifrostChatCompletionStream()

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -538,9 +538,17 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 
 		// Convert content (skip for refusal messages since refusal is already extracted)
 		if rm.Content != nil && (rm.Type == nil || *rm.Type != ResponsesMessageTypeRefusal) {
-			if rm.Content.ContentStr != nil {
-				cm.Content = &ChatMessageContent{
-					ContentStr: rm.Content.ContentStr,
+			if rm.Content.ContentStr != nil ||
+				(len(rm.Content.ContentBlocks) == 1 &&
+					(rm.Content.ContentBlocks[0].Type == ResponsesInputMessageContentBlockTypeText || rm.Content.ContentBlocks[0].Type == ResponsesOutputMessageContentTypeText)) {
+				if rm.Content.ContentStr != nil {
+					cm.Content = &ChatMessageContent{
+						ContentStr: rm.Content.ContentStr,
+					}
+				} else {
+					cm.Content = &ChatMessageContent{
+						ContentStr: rm.Content.ContentBlocks[0].Text,
+					}
 				}
 			} else if rm.Content.ContentBlocks != nil {
 				chatBlocks := make([]ChatContentBlock, len(rm.Content.ContentBlocks))

--- a/core/schemas/providers/anthropic/types.go
+++ b/core/schemas/providers/anthropic/types.go
@@ -190,6 +190,18 @@ type AnthropicToolContent struct {
 
 // ==================== RESPONSE TYPES ====================
 
+type AnthropicStopReason string
+
+const (
+	AnthropicStopReasonEndTurn                    AnthropicStopReason = "end_turn"
+	AnthropicStopReasonMaxTokens                  AnthropicStopReason = "max_tokens"
+	AnthropicStopReasonStopSequence               AnthropicStopReason = "stop_sequence"
+	AnthropicStopReasonToolUse                    AnthropicStopReason = "tool_use"
+	AnthropicStopReasonPauseTurn                  AnthropicStopReason = "pause_turn"
+	AnthropicStopReasonRefusal                    AnthropicStopReason = "refusal"
+	AnthropicStopReasonModelContextWindowExceeded AnthropicStopReason = "model_context_window_exceeded"
+)
+
 // AnthropicMessageResponse represents an Anthropic messages API response
 type AnthropicMessageResponse struct {
 	ID           string                  `json:"id"`
@@ -197,7 +209,7 @@ type AnthropicMessageResponse struct {
 	Role         string                  `json:"role"`
 	Content      []AnthropicContentBlock `json:"content"`
 	Model        string                  `json:"model"`
-	StopReason   *string                 `json:"stop_reason,omitempty"`
+	StopReason   AnthropicStopReason     `json:"stop_reason,omitempty"`
 	StopSequence *string                 `json:"stop_sequence,omitempty"`
 	Usage        *AnthropicUsage         `json:"usage,omitempty"`
 }
@@ -265,7 +277,7 @@ type AnthropicStreamDelta struct {
 	PartialJSON  *string                  `json:"partial_json,omitempty"`
 	Thinking     *string                  `json:"thinking,omitempty"`
 	Signature    *string                  `json:"signature,omitempty"`
-	StopReason   *string                  `json:"stop_reason,omitempty"`
+	StopReason   *AnthropicStopReason     `json:"stop_reason,omitempty"` // only not present in "message_start" events
 	StopSequence *string                  `json:"stop_sequence,omitempty"`
 }
 
@@ -280,9 +292,9 @@ type AnthropicModel struct {
 
 type AnthropicListModelsResponse struct {
 	Data    []AnthropicModel `json:"data"`
-	FirstID *string           `json:"first_id,omitempty"`
+	FirstID *string          `json:"first_id,omitempty"`
 	HasMore bool             `json:"has_more"`
-	LastID  *string           `json:"last_id,omitempty"`
+	LastID  *string          `json:"last_id,omitempty"`
 }
 
 // ==================== ERROR TYPES ====================

--- a/core/schemas/providers/anthropic/utils.go
+++ b/core/schemas/providers/anthropic/utils.go
@@ -6,6 +6,39 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+var (
+	// Maps provider-specific finish reasons to Bifrost format
+	anthropicFinishReasonToBifrost = map[AnthropicStopReason]string{
+		AnthropicStopReasonEndTurn:      "stop",
+		AnthropicStopReasonMaxTokens:    "length",
+		AnthropicStopReasonStopSequence: "stop",
+		AnthropicStopReasonToolUse:      "tool_calls",
+	}
+
+	// Maps Bifrost finish reasons to provider-specific format
+	bifrostToAnthropicFinishReason = map[string]AnthropicStopReason{
+		"stop":       AnthropicStopReasonEndTurn, // canonical default
+		"length":     AnthropicStopReasonMaxTokens,
+		"tool_calls": AnthropicStopReasonToolUse,
+	}
+)
+
+// ConvertAnthropicFinishReasonToBifrost converts provider finish reasons to Bifrost format
+func ConvertAnthropicFinishReasonToBifrost(providerReason AnthropicStopReason) string {
+	if bifrostReason, ok := anthropicFinishReasonToBifrost[providerReason]; ok {
+		return bifrostReason
+	}
+	return string(providerReason)
+}
+
+// ConvertBifrostFinishReasonToAnthropic converts Bifrost finish reasons to provider format
+func ConvertBifrostFinishReasonToAnthropic(bifrostReason string) AnthropicStopReason {
+	if providerReason, ok := bifrostToAnthropicFinishReason[bifrostReason]; ok {
+		return providerReason
+	}
+	return AnthropicStopReason(bifrostReason)
+}
+
 // ConvertToAnthropicImageBlock converts a Bifrost image block to Anthropic format
 // Uses the same pattern as the original buildAnthropicImageSourceMap function
 func ConvertToAnthropicImageBlock(block schemas.ChatContentBlock) AnthropicContentBlock {

--- a/core/schemas/providers/cohere/responses.go
+++ b/core/schemas/providers/cohere/responses.go
@@ -41,6 +41,18 @@ func ToCohereResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Cohe
 			if presencePenalty, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["presence_penalty"]); ok {
 				cohereReq.PresencePenalty = presencePenalty
 			}
+			if thinkingParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "thinking"); ok {
+				if thinkingMap, ok := thinkingParam.(map[string]interface{}); ok {
+					thinking := &CohereThinking{}
+					if typeStr, ok := schemas.SafeExtractString(thinkingMap["type"]); ok {
+						thinking.Type = CohereThinkingType(typeStr)
+					}
+					if tokenBudget, ok := schemas.SafeExtractIntPointer(thinkingMap["token_budget"]); ok {
+						thinking.TokenBudget = tokenBudget
+					}
+					cohereReq.Thinking = thinking
+				}
+			}
 		}
 	}
 

--- a/core/schemas/providers/cohere/types.go
+++ b/core/schemas/providers/cohere/types.go
@@ -293,6 +293,7 @@ const (
 	FinishReasonMaxTokens    CohereFinishReason = "MAX_TOKENS"    // Max tokens exceeded
 	FinishReasonToolCall     CohereFinishReason = "TOOL_CALL"     // Model generated tool call
 	FinishReasonError        CohereFinishReason = "ERROR"         // Generation failed due to internal error
+	FinishReasonTimeout      CohereFinishReason = "TIMEOUT"       // Timeout
 )
 
 // CohereUsage represents token usage information

--- a/core/schemas/providers/cohere/utils.go
+++ b/core/schemas/providers/cohere/utils.go
@@ -1,0 +1,19 @@
+package cohere
+
+var (
+	// Maps provider-specific finish reasons to Bifrost format
+	cohereFinishReasonToBifrost = map[CohereFinishReason]string{
+		FinishReasonComplete:     "stop",
+		FinishReasonStopSequence: "stop",
+		FinishReasonMaxTokens:    "length",
+		FinishReasonToolCall:     "tool_calls",
+	}
+)
+
+// ConvertCohereFinishReasonToBifrost converts provider finish reasons to Bifrost format
+func ConvertCohereFinishReasonToBifrost(providerReason CohereFinishReason) string {
+	if bifrostReason, ok := cohereFinishReasonToBifrost[providerReason]; ok {
+		return bifrostReason
+	}
+	return string(providerReason)
+}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -33,62 +33,6 @@ func ParseModelString(model string, defaultProvider ModelProvider) (ModelProvide
 	return defaultProvider, model
 }
 
-// Shared finish reason mappings for Anthropic-compatible providers (Anthropic, Bedrock)
-var (
-	// Maps provider-specific finish reasons to Bifrost format
-	anthropicFinishReasonToBifrost = map[string]string{
-		"end_turn":      "stop",
-		"max_tokens":    "length",
-		"stop_sequence": "stop",
-		"tool_use":      "tool_calls",
-		"content_filtered": "content_filter",
-	}
-
-	// Maps Bifrost finish reasons to provider-specific format
-	bifrostToAnthropicFinishReason = map[string]string{
-		"stop":       "end_turn", // canonical default
-		"length":     "max_tokens",
-		"tool_calls": "tool_use",
-		"content_filter": "content_filtered",
-	}
-)
-
-// ConvertAnthropicFinishReasonToBifrost converts provider finish reasons to Bifrost format
-func ConvertAnthropicFinishReasonToBifrost(providerReason string) string {
-	if bifrostReason, ok := anthropicFinishReasonToBifrost[providerReason]; ok {
-		return bifrostReason
-	}
-	return providerReason
-}
-
-// ConvertBifrostFinishReasonToAnthropic converts Bifrost finish reasons to provider format
-func ConvertBifrostFinishReasonToAnthropic(bifrostReason string) string {
-	if providerReason, ok := bifrostToAnthropicFinishReason[bifrostReason]; ok {
-		return providerReason
-	}
-	return bifrostReason
-}
-
-// MapProviderFinishReasonToBifrost maps provider finish reasons to bifrost finish reasons
-func MapProviderFinishReasonToBifrost(finishReason string, targetProvider ModelProvider) string {
-	switch targetProvider {
-	case Anthropic, Bedrock:
-		return ConvertAnthropicFinishReasonToBifrost(finishReason)
-	default:
-		return finishReason
-	}
-}
-
-// MapBifrostFinishReasonToProvider maps bifrost finish reasons to provider finish reasons
-func MapBifrostFinishReasonToProvider(bifrostReason string, targetProvider ModelProvider) string {
-	switch targetProvider {
-	case Anthropic, Bedrock:
-		return ConvertBifrostFinishReasonToAnthropic(bifrostReason)
-	default:
-		return bifrostReason
-	}
-}
-
 //* IMAGE UTILS *//
 
 // dataURIRegex is a precompiled regex for matching data URI format patterns.

--- a/tests/core-providers/cohere_test.go
+++ b/tests/core-providers/cohere_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestCohere(t *testing.T) {
-	t.Skip("Skipping Cohere tests")
-
 	if os.Getenv("COHERE_API_KEY") == "" {
 		t.Skip("Skipping Cohere tests because COHERE_API_KEY is not set")
 	}


### PR DESCRIPTION
## Summary

Refactored finish reason handling across providers to improve consistency and maintainability by moving provider-specific finish reason mapping logic from the core schemas package to individual provider packages.

## Changes

- Moved Anthropic finish reason mapping from core schemas to the Anthropic provider package
- Added Cohere-specific finish reason mapping in a new utils.go file
- Updated Bedrock provider to use Anthropic's finish reason mapping
- Improved content handling in response conversion to properly handle both string content and content blocks
- Added support for "thinking" parameter in Anthropic and Cohere providers
- Fixed tool call handling in response conversion for better consistency

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# Test specific provider functionality
go test ./tests/core-providers/cohere_test.go
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves provider response handling consistency

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable