### PR TITLE
fixes access your service section for ecs documentation

### DIFF
--- a/docs/deployment-guides/ecs.mdx
+++ b/docs/deployment-guides/ecs.mdx
@@ -1370,19 +1370,26 @@ The Makefile automatically creates the CloudWatch log group `/ecs/bifrost-task`,
 
 ### Without Load Balancer
 
-When deployed without a load balancer, the ECS task gets a public IP address. Use the Makefile to find it:
+When deployed without a load balancer, the ECS task gets a public IP address. You can find it using AWS CLI:
 
 ```bash
-# Get the service URL
-make get-ecs-url
+# Get the public IP address of your running task
+aws ec2 describe-network-interfaces \
+  --network-interface-ids $(aws ecs describe-tasks \
+    --cluster bifrost-cluster \
+    --tasks $(aws ecs list-tasks \
+      --cluster bifrost-cluster \
+      --service-name bifrost-service \
+      --region us-east-1 \
+      --query 'taskArns[0]' \
+      --output text) \
+    --region us-east-1 \
+    --query 'tasks[0].attachments[0].details[?name==`networkInterfaceId`].value' \
+    --output text) \
+  --region us-east-1 \
+  --query 'NetworkInterfaces[0].Association.PublicIp' \
+  --output text
 ```
-
-This will show you:
-- The public IP address of your running task
-- The full URL to access your service (e.g., `http://1.2.3.4:8080`)
-- The health check endpoint URL
-
-The `deploy-ecs` command also automatically displays the public IP at the end of deployment.
 
 <Warning>
 **Important Notes:**
@@ -1394,10 +1401,7 @@ The `deploy-ecs` command also automatically displays the public IP at the end of
 **Testing your deployment:**
 
 ```bash
-# Get the URL
-make get-ecs-url
-
-# Test health endpoint (replace IP with your actual IP)
+# Test health endpoint (replace YOUR_PUBLIC_IP with the IP from above)
 curl http://YOUR_PUBLIC_IP:8080/health
 
 # Expected response
@@ -1409,10 +1413,18 @@ curl http://YOUR_PUBLIC_IP:8080/health
 If you deployed with `TARGET_GROUP_ARN`, your service is accessible via the load balancer's DNS name:
 
 ```bash
-# Get the load balancer URL
-make get-ecs-url
+# Get the load balancer DNS name (replace YOUR_TARGET_GROUP_ARN with your actual ARN)
+aws elbv2 describe-load-balancers \
+  --load-balancer-arns $(aws elbv2 describe-target-groups \
+    --target-group-arns YOUR_TARGET_GROUP_ARN \
+    --region us-east-1 \
+    --query 'TargetGroups[0].LoadBalancerArns[0]' \
+    --output text) \
+  --region us-east-1 \
+  --query 'LoadBalancers[0].DNSName' \
+  --output text
 
-# Test via load balancer
+# Test via load balancer (replace YOUR_ALB_DNS with the DNS from above)
 curl http://YOUR_ALB_DNS/health
 ```
 


### PR DESCRIPTION
## Summary

Replace Makefile commands with direct AWS CLI commands for retrieving ECS task public IP addresses and load balancer DNS names in the ECS deployment documentation.

## Changes

- Replaced `make get-ecs-url` command with explicit AWS CLI commands to retrieve the public IP address of ECS tasks
- Added detailed AWS CLI commands to get the load balancer DNS name when using a target group
- Updated testing instructions to use the retrieved IP/DNS values directly
- Removed references to the Makefile automatically displaying the public IP at the end of deployment

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Follow the AWS CLI commands in the updated documentation to retrieve the public IP of an ECS task:

```sh
aws ec2 describe-network-interfaces \
  --network-interface-ids $(aws ecs describe-tasks \
    --cluster bifrost-cluster \
    --tasks $(aws ecs list-tasks \
      --cluster bifrost-cluster \
      --service-name bifrost-service \
      --region us-east-1 \
      --query 'taskArns[0]' \
      --output text) \
    --region us-east-1 \
    --query 'tasks[0].attachments[0].details[?name==`networkInterfaceId`].value' \
    --output text) \
  --region us-east-1 \
  --query 'NetworkInterfaces[0].Association.PublicIp' \
  --output text
```

2. Verify the load balancer DNS retrieval command works:

```sh
aws elbv2 describe-load-balancers \
  --load-balancer-arns $(aws elbv2 describe-target-groups \
    --target-group-arns YOUR_TARGET_GROUP_ARN \
    --region us-east-1 \
    --query 'TargetGroups[0].LoadBalancerArns[0]' \
    --output text) \
  --region us-east-1 \
  --query 'LoadBalancers[0].DNSName' \
  --output text
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only updates documentation with direct AWS CLI commands.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable