### PR TITLE
test: fix provider update test by adding provider after bifrost initialization

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -710,7 +710,6 @@ func TestUpdateProvider(t *testing.T) {
 	t.Run("UpdateInactiveProvider", func(t *testing.T) {
 		// Setup account with provider but don't initialize it in Bifrost
 		account := NewMockAccount()
-		account.AddProvider(schemas.Anthropic, 3, 500)
 
 		ctx := context.Background()
 		bifrost, err := Init(ctx, schemas.BifrostConfig{
@@ -720,6 +719,9 @@ func TestUpdateProvider(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to initialize Bifrost: %v", err)
 		}
+
+		// Add provider to account after bifrost initialization
+		account.AddProvider(schemas.Anthropic, 3, 500)
 
 		// Verify provider doesn't exist initially
 		if bifrost.getProviderByKey(schemas.Anthropic) != nil {


### PR DESCRIPTION
## Summary

Fix test case ordering in `TestUpdateProvider` to properly test inactive provider updates.

## Changes

- Reordered operations in the `UpdateInactiveProvider` test case to add the provider to the account after Bifrost initialization
- This ensures the test correctly verifies that Bifrost can update providers that weren't present during initialization

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the specific test
go test ./core -run TestUpdateProvider

# Run all tests
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the test wasn't properly validating the behavior of updating inactive providers.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)