### PR TITLE
ci: clear changelog after every release

### DIFF
--- a/.github/workflows/scripts/push-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-mintlify-changelog.sh
@@ -30,8 +30,12 @@ append_section () {
   label=$1
   path=$2
   if [ -f "$path" ]; then
-    content=$(get_changelog_content "$path") || return 0
-    CHANGELOG_BODY+=$'\n'"<Update label=\"$label\" description=\"$VERSION\">"$'\n'"$content"$'\n\n'"</Update>"
+    content=$(get_changelog_content "$path")
+    if [ -n "$content" ]; then
+      CHANGELOG_BODY+=$'\n'"<Update label=\"$label\" description=\"$VERSION\">"$'\n'"$content"$'\n\n'"</Update>"
+    fi
+    # Clear the changelog file after processing
+    > "$path"
   fi
 }
 


### PR DESCRIPTION
## Summary

Improve the Mintlify changelog generation script to clear changelog files after processing and handle empty changelog content gracefully.

## Changes

- Modified the `append_section` function to check if the changelog content is empty before adding it to the output
- Added functionality to clear changelog files after they've been processed, preventing duplicate entries in future runs
- Improved error handling by removing the early return when content retrieval fails

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Run the changelog generation script and verify:
1. Empty changelog files are handled properly
2. Changelog files are cleared after processing
3. The generated output contains only non-empty sections

```sh
# Run the changelog generation script
.github/workflows/scripts/push-mintlify-changelog.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects the documentation build process.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified the CI pipeline passes locally if applicable