### PR TITLE
fix: handle panic in gemini responses stream

### DIFF
--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1057,6 +1057,8 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse() *BifrostRespon
 		}
 	}
 
+	streamResp.ExtraFields.RequestType = ResponsesStreamRequest
+
 	// Return the created stream response
 	return streamResp
 }

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -722,10 +722,10 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, config RouteCo
 				switch {
 				case chunk.BifrostTextCompletionResponse != nil:
 					convertedResponse, err = config.StreamConfig.TextStreamResponseConverter(chunk.BifrostTextCompletionResponse)
-				case chunk.BifrostChatResponse != nil:
-					convertedResponse, err = config.StreamConfig.ChatStreamResponseConverter(chunk.BifrostChatResponse)
 				case chunk.BifrostResponsesStreamResponse != nil:
 					convertedResponse, err = config.StreamConfig.ResponsesStreamResponseConverter(chunk.BifrostResponsesStreamResponse)
+				case chunk.BifrostChatResponse != nil:
+					convertedResponse, err = config.StreamConfig.ChatStreamResponseConverter(chunk.BifrostChatResponse)
 				case chunk.BifrostSpeechStreamResponse != nil:
 					convertedResponse, err = config.StreamConfig.SpeechStreamResponseConverter(chunk.BifrostSpeechStreamResponse)
 				case chunk.BifrostTranscriptionStreamResponse != nil:


### PR DESCRIPTION
## Summary

Fix the request type assignment in responses stream and prioritize responses stream handling over chat responses in the streaming handler.

Closes #721

## Changes

- Added `RequestType` assignment in `ToBifrostResponsesStreamResponse()` to properly set the request type to `ResponsesStreamRequest`
- Reordered the switch case in `handleStreaming()` to check for `BifrostResponsesStreamResponse` before `BifrostChatResponse` to ensure proper handling priority

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses to verify the correct handling order:

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where responses stream requests were not properly identified and could be incorrectly handled as chat responses.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable