### PR TITLE
refactor: optimize Cohere provider with response pooling and standardized request handling

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,4 +1,6 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
-- feat: Adds support for models list for providers
+- feat: Use all keys for list models request
+- refactor: Cohere provider to use completeRequest and response pooling for all requests
+- chore: Added id, object, and model fields to Chat Completion responses from Bedrock and Cohere providers

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -766,6 +766,8 @@ func extractSuccessfulListModelsResponses(
 }
 
 // handleMultipleListModelsRequests handles multiple list models requests concurrently for different keys.
+// It launches concurrent requests for all keys and waits for all goroutines to complete.
+// It returns the aggregated response or an error if the request fails.
 func handleMultipleListModelsRequests(
 	ctx context.Context,
 	keys []schemas.Key,

--- a/core/schemas/providers/anthropic/responses.go
+++ b/core/schemas/providers/anthropic/responses.go
@@ -190,7 +190,7 @@ func ToAnthropicResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *A
 	return anthropicReq
 }
 
-// ToResponsesBifrostResponse converts an Anthropic response to BifrostResponse with Responses structure
+// ToBifrostResponsesResponse converts an Anthropic response to BifrostResponse with Responses structure
 func (response *AnthropicMessageResponse) ToBifrostResponsesResponse() *schemas.BifrostResponsesResponse {
 	if response == nil {
 		return nil

--- a/core/schemas/providers/cohere/responses.go
+++ b/core/schemas/providers/cohere/responses.go
@@ -91,8 +91,8 @@ func ToCohereResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Cohe
 	return cohereReq
 }
 
-// ToResponsesBifrostResponse converts CohereChatResponse to BifrostResponse (Responses structure)
-func (response *CohereChatResponse) ToResponsesBifrostResponsesResponse() *schemas.BifrostResponsesResponse {
+// ToBifrostResponsesResponse converts CohereChatResponse to BifrostResponse (Responses structure)
+func (response *CohereChatResponse) ToBifrostResponsesResponse() *schemas.BifrostResponsesResponse {
 	if response == nil {
 		return nil
 	}

--- a/docs/changelogs/v1.3.13.mdx
+++ b/docs/changelogs/v1.3.13.mdx
@@ -6,11 +6,14 @@ description: "v1.3.13 changelog"
 
 - chore: version update framework to 1.1.18 and core to 1.2.16
 - Adds env variable support for postgres config
+- feat: standardize finish reason and single response handling across providers
+- feat: provider config hot reloading added (no need to restart Bifrost after updating provider configs now)
 
 </Update>
 <Update label="Core" description="v1.3.13">
 
-- feat: Adds support for models list for providers
+- feat: standardize finish reason and single response handling across providers
+- feat: provider config hot reloading added
 
 </Update>
 <Update label="Framework" description="v1.3.13">

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,5 +1,4 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
-- Adds env variable resolution for postgres config
 - chore: Upgrades core to 1.2.16

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,4 +2,6 @@
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
 - chore: version update framework to 1.1.18 and core to 1.2.16
-- Adds env variable support for postgres config
+- feat: Use all keys for list models request
+- fix: handled panic when using gemini models with openai integration responses API requests
+- chore: Added id, object, and model fields to Chat Completion responses from Bedrock and Cohere providers


### PR DESCRIPTION
## Summary

Refactored the Cohere provider to use a unified request handling approach and improved response object pooling for better performance and memory efficiency.

## Changes

- Implemented `completeRequest` method in Cohere provider to centralize API request handling
- Added object pooling for Cohere embedding responses to reduce memory allocations
- Standardized response handling across all Cohere API endpoints
- Added id, object, and model fields to Chat Completion responses from Bedrock and Cohere providers
- Updated list models functionality to use all available keys

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Cohere provider with various request types to ensure proper functionality:

```sh
# Core/Transports
go version
go test ./...

# Test Cohere provider specifically
go test ./core/providers -run TestCohereProvider
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Improves performance and standardizes response handling across providers.

## Security considerations

No security implications as this is an internal refactoring of existing functionality.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable