### PR TITLE
fix: added responses input history column and fixed chunk conversion

### DIFF
--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -616,11 +616,7 @@ func getResponsesChunkConverterCombinedPostHookRunner(postHookRunner schemas.Pos
 		if result != nil {
 			if result.ChatResponse != nil {
 				result.ResponsesStreamResponse = result.ChatResponse.ToBifrostResponsesStreamResponse()
-				if result.ResponsesResponse == nil {
-					result.ResponsesResponse = &schemas.BifrostResponsesResponse{}
-				}
-				result.ResponsesResponse.ExtraFields = result.ResponsesStreamResponse.ExtraFields
-				result.ResponsesResponse.ExtraFields.RequestType = schemas.ResponsesRequest
+				result.ChatResponse = nil
 			}
 		} else if err != nil {
 			// Ensure downstream knows this is a Responses stream even on errors

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -24,11 +24,12 @@ func (p *LoggerPlugin) insertInitialLogEntry(ctx context.Context, requestID stri
 		Stream:    false,
 		CreatedAt: timestamp,
 		// Set parsed fields for serialization
-		InputHistoryParsed:       data.InputHistory,
-		ParamsParsed:             data.Params,
-		ToolsParsed:              data.Tools,
-		SpeechInputParsed:        data.SpeechInput,
-		TranscriptionInputParsed: data.TranscriptionInput,
+		InputHistoryParsed:          data.InputHistory,
+		ResponsesInputHistoryParsed: data.ResponsesInputHistory,
+		ParamsParsed:                data.Params,
+		ToolsParsed:                 data.Tools,
+		SpeechInputParsed:           data.SpeechInput,
+		TranscriptionInputParsed:    data.TranscriptionInput,
 	}
 
 	if parentRequestID != "" {

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -86,15 +86,12 @@ func retryOnNotFound(ctx context.Context, operation func() error) error {
 }
 
 // extractInputHistory extracts input history from request input
-func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) []schemas.ChatMessage {
+func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) ([]schemas.ChatMessage, []schemas.ResponsesMessage) {
 	if request.ChatRequest != nil {
-		return request.ChatRequest.Input
+		return request.ChatRequest.Input, []schemas.ResponsesMessage{}
 	}
-	if request.ResponsesRequest != nil {
-		messages := schemas.ToChatMessages(request.ResponsesRequest.Input)
-		if len(messages) > 0 {
-			return messages
-		}
+	if request.ResponsesRequest != nil && len(request.ResponsesRequest.Input) > 0 {
+		return []schemas.ChatMessage{}, request.ResponsesRequest.Input
 	}
 	if request.TextCompletionRequest != nil {
 		var text string
@@ -114,7 +111,7 @@ func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) []sc
 					ContentStr: &text,
 				},
 			},
-		}
+		}, []schemas.ResponsesMessage{}
 	}
 	if request.EmbeddingRequest != nil {
 		texts := request.EmbeddingRequest.Input.Texts
@@ -139,7 +136,7 @@ func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) []sc
 					ContentBlocks: contentBlocks,
 				},
 			},
-		}
+		}, []schemas.ResponsesMessage{}
 	}
-	return []schemas.ChatMessage{}
+	return []schemas.ChatMessage{}, []schemas.ResponsesMessage{}
 }

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -722,10 +722,10 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, config RouteCo
 				switch {
 				case chunk.BifrostTextCompletionResponse != nil:
 					convertedResponse, err = config.StreamConfig.TextStreamResponseConverter(chunk.BifrostTextCompletionResponse)
-				case chunk.BifrostResponsesStreamResponse != nil:
-					convertedResponse, err = config.StreamConfig.ResponsesStreamResponseConverter(chunk.BifrostResponsesStreamResponse)
 				case chunk.BifrostChatResponse != nil:
 					convertedResponse, err = config.StreamConfig.ChatStreamResponseConverter(chunk.BifrostChatResponse)
+				case chunk.BifrostResponsesStreamResponse != nil:
+					convertedResponse, err = config.StreamConfig.ResponsesStreamResponseConverter(chunk.BifrostResponsesStreamResponse)
 				case chunk.BifrostSpeechStreamResponse != nil:
 					convertedResponse, err = config.StreamConfig.SpeechStreamResponseConverter(chunk.BifrostSpeechStreamResponse)
 				case chunk.BifrostTranscriptionStreamResponse != nil:

--- a/ui/app/logs/views/logDetailsSheet.tsx
+++ b/ui/app/logs/views/logDetailsSheet.tsx
@@ -13,7 +13,7 @@ import LogEntryDetailsView from "./logEntryDetailsView";
 import LogChatMessageView from "./logChatMessageView";
 import SpeechView from "./speechView";
 import TranscriptionView from "./transcriptionView";
-import LogResponsesOutputView from "./logResponsesOutputView";
+import LogResponsesMessageView from "./logResponsesMessageView";
 
 interface LogDetailSheetProps {
 	log: LogEntry | null;
@@ -300,15 +300,23 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 					</>
 				)}
 
-				{/* Show input for chat/text completions */}
-				{log.input_history && log.input_history.length > 0 && (
-					<>
-						<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
-						<LogChatMessageView message={log.input_history[log.input_history.length - 1]} />
-					</>
-				)}
+			{/* Show input for chat/text completions */}
+			{log.input_history && log.input_history.length > 0 && (
+				<>
+					<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
+					<LogChatMessageView message={log.input_history[log.input_history.length - 1]} />
+				</>
+			)}
 
-				{log.status !== "processing" && (
+			{/* Show input history for responses API */}
+			{log.responses_input_history && log.responses_input_history.length > 0 && (
+				<>
+					<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
+					<LogResponsesMessageView messages={log.responses_input_history} />
+				</>
+			)}
+
+			{log.status !== "processing" && (
 					<>
 						{log.output_message && !log.error_details?.error.message && (
 							<>
@@ -321,7 +329,7 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 						{log.responses_output && log.responses_output.length > 0 && !log.error_details?.error.message && (
 							<>
 								<div className="mt-4 w-full text-left text-sm font-medium">Response</div>
-								<LogResponsesOutputView messages={log.responses_output} />
+								<LogResponsesMessageView messages={log.responses_output} />
 							</>
 						)}
 						{log.embedding_output && log.embedding_output.length > 0 && !log.error_details?.error.message && (

--- a/ui/app/logs/views/logResponsesMessageView.tsx
+++ b/ui/app/logs/views/logResponsesMessageView.tsx
@@ -2,7 +2,7 @@ import { ResponsesMessage, ResponsesMessageContentBlock } from "@/lib/types/logs
 import { CodeEditor } from "./codeEditor";
 import { isJson, cleanJson } from "@/lib/utils/validation";
 
-interface LogResponsesOutputViewProps {
+interface LogResponsesMessageViewProps {
 	messages: ResponsesMessage[];
 }
 
@@ -334,11 +334,11 @@ const renderMessage = (message: ResponsesMessage, index: number) => {
 	);
 };
 
-export default function LogResponsesOutputView({ messages }: LogResponsesOutputViewProps) {
+export default function LogResponsesMessageView({ messages }: LogResponsesMessageViewProps) {
 	if (!messages || messages.length === 0) {
 		return (
 			<div className="w-full rounded-sm border">
-				<div className="text-muted-foreground px-6 py-4 text-center text-sm">No responses output available</div>
+				<div className="text-muted-foreground px-6 py-4 text-center text-sm">No responses messages available</div>
 			</div>
 		);
 	}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -248,6 +248,7 @@ export interface LogEntry {
 	provider: string;
 	model: string;
 	input_history: ChatMessage[];
+	responses_input_history: ResponsesMessage[];
 	output_message?: ChatMessage;
 	responses_output?: ResponsesMessage[];
 	embedding_output?: BifrostEmbedding[];


### PR DESCRIPTION
## Summary

Add support for storing and displaying Responses API input history in logs, enabling better tracking and debugging of Responses API requests.

## Changes

- Added a new `responses_input_history` column to the logs database table
- Created a database migration to add the new column
- Modified the logging plugin to extract and store Responses API input messages
- Updated the UI to display Responses input history in log details
- Renamed `LogResponsesOutputView` to `LogResponsesMessageView` for reuse with both input and output
- Fixed an issue in the post-hook runner by clearing `ChatResponse` after converting to `ResponsesStreamResponse`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Make Responses API requests
2. Check logs to verify input history is properly stored and displayed
3. Verify that both input and output messages are properly displayed in the UI

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] Yes
- [ ] No

The database schema has been updated with a new column. Users should run the application to trigger the migration.

## Security considerations

No new security implications. The implementation follows the same patterns as existing log storage.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable