### PR TITLE
feat: add context-based header and path overrides with key selection skipping

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2335,6 +2335,10 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *context.Context, requ
 		}
 	}
 
+	if skipKeySelection, ok := (*ctx).Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skipKeySelection && isKeySkippingAllowed(providerKey) {
+		return schemas.Key{}, nil
+	}
+
 	keys, err := bifrost.account.GetKeysForProvider(ctx, providerKey)
 	if err != nil {
 		return schemas.Key{}, err

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -152,7 +152,7 @@ func (provider *AnthropicProvider) completeRequest(ctx context.Context, requestB
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -203,10 +203,10 @@ func (provider *AnthropicProvider) ListModels(ctx context.Context, key schemas.K
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Build URL using centralized URL construction
-	requestURL := anthropic.ToAnthropicListModelsURL(request, provider.networkConfig.BaseURL+"/v1/models")
+	requestURL := anthropic.ToAnthropicListModelsURL(request, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"))
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
@@ -270,7 +270,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, key schem
 	}
 
 	// Use struct directly for JSON marshaling
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, provider.networkConfig.BaseURL+"/v1/complete", key.Value)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/complete"), key.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, key schem
 	}
 
 	// Use struct directly for JSON marshaling
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, provider.networkConfig.BaseURL+"/v1/messages", key.Value)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/messages"), key.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx context.Context, pos
 	return handleAnthropicChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/messages",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/messages"),
 		reqBody,
 		headers,
 		provider.networkConfig.ExtraHeaders,
@@ -436,7 +436,7 @@ func handleAnthropicChatCompletionStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Make the request
 	resp, err := httpClient.Do(req)
@@ -601,7 +601,7 @@ func (provider *AnthropicProvider) Responses(ctx context.Context, key schemas.Ke
 	}
 
 	// Use struct directly for JSON marshaling
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, provider.networkConfig.BaseURL+"/v1/messages", key.Value)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/messages"), key.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -660,7 +660,7 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v1/messages", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/messages"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -684,7 +684,7 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Make the request
 	resp, err := provider.streamClient.Do(req)

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -90,7 +90,7 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -151,7 +151,7 @@ func (provider *AzureProvider) ListModels(ctx context.Context, key schemas.Key, 
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodGet)
@@ -412,7 +412,7 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod("POST")

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -129,7 +129,7 @@ func (provider *BedrockProvider) completeRequest(ctx context.Context, requestBod
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value != "" {
@@ -237,7 +237,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, reque
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value != "" {
@@ -382,7 +382,7 @@ func (provider *BedrockProvider) ListModels(ctx context.Context, key schemas.Key
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value != "" {

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -110,10 +110,10 @@ func (provider *CohereProvider) ListModels(ctx context.Context, key schemas.Key,
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Build URL using centralized URL construction
-	requestURL := cohere.ToCohereListModelsURL(request, provider.networkConfig.BaseURL+"/v1/models")
+	requestURL := cohere.ToCohereListModelsURL(request, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"))
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
@@ -230,9 +230,9 @@ func (provider *CohereProvider) handleCohereChatCompletionRequest(ctx context.Co
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v2/chat")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v2/chat"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -308,7 +308,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v2/chat", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonBody))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -333,7 +333,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	req.Header.Set("Cache-Control", "no-cache")
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Make the request
 	resp, err := provider.streamClient.Do(req)
@@ -590,7 +590,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v2/chat", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonBody))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -615,7 +615,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 	req.Header.Set("Cache-Control", "no-cache")
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Make the request
 	resp, err := provider.streamClient.Do(req)
@@ -782,9 +782,9 @@ func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, 
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v2/embed")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v2/embed"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)

--- a/core/providers/gemini.go
+++ b/core/providers/gemini.go
@@ -86,10 +86,10 @@ func (provider *GeminiProvider) ListModels(ctx context.Context, key schemas.Key,
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Build URL using centralized URL construction
-	requestURL := gemini.ToGeminiListModelsURL(request, provider.networkConfig.BaseURL+"/models")
+	requestURL := gemini.ToGeminiListModelsURL(request, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/models"))
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
@@ -165,9 +165,9 @@ func (provider *GeminiProvider) ChatCompletion(ctx context.Context, key schemas.
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/openai/chat/completions")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/openai/chat/completions"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -244,7 +244,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHo
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/openai/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/openai/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -293,7 +293,7 @@ func (provider *GeminiProvider) Embedding(ctx context.Context, key schemas.Key, 
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/openai/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/openai/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -374,7 +374,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/models/"+request.Model+":streamGenerateContent?alt=sse", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -393,7 +393,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set headers for streaming
 	req.Header.Set("Content-Type", "application/json")
@@ -652,7 +652,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/models/"+request.Model+":streamGenerateContent?alt=sse", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -671,7 +671,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set headers for streaming
 	req.Header.Set("Content-Type", "application/json")
@@ -894,56 +894,6 @@ func extractGeminiUsageMetadata(geminiResponse *gemini.GenerateContentResponse) 
 		totalTokens = int(usageMetadata.TotalTokenCount)
 	}
 	return inputTokens, outputTokens, totalTokens
-}
-
-// completeRequest handles the common HTTP request pattern for Gemini API calls
-func (provider *GeminiProvider) completeRequest(ctx context.Context, model string, key schemas.Key, jsonBody []byte, endpoint string) (*gemini.GenerateContentResponse, interface{}, time.Duration, *schemas.BifrostError) {
-	providerName := provider.GetProviderKey()
-
-	// Create request
-	req := fasthttp.AcquireRequest()
-	resp := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseRequest(req)
-	defer fasthttp.ReleaseResponse(resp)
-
-	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
-
-	// Use Gemini's generateContent endpoint
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/models/" + model + endpoint)
-	req.Header.SetMethod(http.MethodPost)
-	req.Header.SetContentType("application/json")
-	req.Header.Set("x-goog-api-key", key.Value)
-
-	req.SetBody(jsonBody)
-
-	// Make request
-	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
-	if bifrostErr != nil {
-		return nil, nil, latency, bifrostErr
-	}
-
-	// Handle error response
-	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, nil, latency, parseGeminiError(providerName, resp)
-	}
-
-	// Copy the response body before releasing the response
-	// to avoid use-after-free since resp.Body() references fasthttp's internal buffer
-	responseBody := append([]byte(nil), resp.Body()...)
-
-	// Parse Gemini's response
-	var geminiResponse gemini.GenerateContentResponse
-	if err := sonic.Unmarshal(responseBody, &geminiResponse); err != nil {
-		return nil, nil, latency, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, providerName)
-	}
-
-	var rawResponse interface{}
-	if err := sonic.Unmarshal(responseBody, &rawResponse); err != nil {
-		return nil, nil, latency, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, providerName)
-	}
-
-	return &geminiResponse, rawResponse, latency, nil
 }
 
 // parseStreamGeminiError parses Gemini streaming error responses

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -72,7 +72,7 @@ func (provider *GroqProvider) ListModels(ctx context.Context, key schemas.Key, r
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+"/v1/models",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
 		key,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Groq,
@@ -161,7 +161,7 @@ func (provider *GroqProvider) ChatCompletion(ctx context.Context, key schemas.Ke
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -180,7 +180,7 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -76,7 +76,7 @@ func (provider *MistralProvider) ListModels(ctx context.Context, key schemas.Key
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/models")
 	req.Header.SetMethod(http.MethodGet)
@@ -136,7 +136,7 @@ func (provider *MistralProvider) ChatCompletion(ctx context.Context, key schemas
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -155,7 +155,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postH
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -198,7 +198,7 @@ func (provider *MistralProvider) Embedding(ctx context.Context, key schemas.Key,
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -73,7 +73,17 @@ func (provider *OllamaProvider) ListModels(ctx context.Context, key schemas.Key,
 	if provider.networkConfig.BaseURL == "" {
 		return nil, newConfigurationError("base_url is not set", provider.GetProviderKey())
 	}
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", key, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(
+		ctx,
+		provider.client,
+		request,
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
+		key,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		provider.sendBackRawResponse,
+		provider.logger,
+	)
 }
 
 // TextCompletion performs a text completion request to the Ollama API.
@@ -81,7 +91,7 @@ func (provider *OllamaProvider) TextCompletion(ctx context.Context, key schemas.
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -98,7 +108,7 @@ func (provider *OllamaProvider) TextCompletionStream(ctx context.Context, postHo
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -114,7 +124,7 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, key schemas.
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -133,7 +143,7 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -174,7 +184,7 @@ func (provider *OllamaProvider) Embedding(ctx context.Context, key schemas.Key, 
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -84,7 +84,7 @@ func (provider *OpenAIProvider) ListModels(ctx context.Context, key schemas.Key,
 
 	providerName := provider.GetProviderKey()
 
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", key, provider.networkConfig.ExtraHeaders, providerName, provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"), key, provider.networkConfig.ExtraHeaders, providerName, provider.sendBackRawResponse, provider.logger)
 
 }
 
@@ -106,7 +106,7 @@ func handleOpenAIListModelsRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodGet)
@@ -162,7 +162,7 @@ func (provider *OpenAIProvider) TextCompletion(ctx context.Context, key schemas.
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -199,7 +199,7 @@ func handleOpenAITextCompletionRequest(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -254,7 +254,7 @@ func (provider *OpenAIProvider) TextCompletionStream(ctx context.Context, postHo
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -325,7 +325,7 @@ func handleOpenAITextCompletionStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -507,7 +507,7 @@ func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, key schemas.
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -546,7 +546,7 @@ func handleOpenAIChatCompletionRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -609,7 +609,7 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx context.Context, postHo
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -680,7 +680,7 @@ func handleOpenAIChatCompletionStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -864,7 +864,7 @@ func (provider *OpenAIProvider) Responses(ctx context.Context, key schemas.Key, 
 	return handleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/responses"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -903,7 +903,7 @@ func handleOpenAIResponsesRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -964,7 +964,7 @@ func (provider *OpenAIProvider) ResponsesStream(ctx context.Context, postHookRun
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/responses"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -1037,7 +1037,7 @@ func handleOpenAIResponsesStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -1190,7 +1190,7 @@ func (provider *OpenAIProvider) Embedding(ctx context.Context, key schemas.Key, 
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -1231,7 +1231,7 @@ func handleOpenAIEmbeddingRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -1306,9 +1306,9 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/audio/speech")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/audio/speech"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -1377,7 +1377,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v1/audio/speech", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/audio/speech"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -1396,7 +1396,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -1557,9 +1557,9 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/audio/transcriptions")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/audio/transcriptions"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(writer.FormDataContentType()) // This sets multipart/form-data with boundary
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -1640,7 +1640,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v1/audio/transcriptions", &body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/audio/transcriptions"), &body)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -1659,7 +1659,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {

--- a/core/providers/openrouter.go
+++ b/core/providers/openrouter.go
@@ -71,9 +71,9 @@ func (provider *OpenRouterProvider) ListModels(ctx context.Context, key schemas.
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/models")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -120,7 +120,7 @@ func (provider *OpenRouterProvider) TextCompletion(ctx context.Context, key sche
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -137,7 +137,7 @@ func (provider *OpenRouterProvider) TextCompletionStream(ctx context.Context, po
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -153,7 +153,7 @@ func (provider *OpenRouterProvider) ChatCompletion(ctx context.Context, key sche
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -172,7 +172,7 @@ func (provider *OpenRouterProvider) ChatCompletionStream(ctx context.Context, po
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -188,7 +188,7 @@ func (provider *OpenRouterProvider) Responses(ctx context.Context, key schemas.K
 	return handleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/alpha/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/alpha/responses"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -203,7 +203,7 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx context.Context, postHoo
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/alpha/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/alpha/responses"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -72,7 +72,7 @@ func (provider *ParasailProvider) ListModels(ctx context.Context, key schemas.Ke
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+"/v1/models",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
 		key,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
@@ -98,7 +98,7 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schema
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -117,7 +117,7 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, post
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -74,7 +74,7 @@ func (provider *SGLProvider) ListModels(ctx context.Context, key schemas.Key, re
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+"/v1/models",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
 		key,
 		provider.networkConfig.ExtraHeaders,
 		schemas.SGL,
@@ -88,7 +88,7 @@ func (provider *SGLProvider) TextCompletion(ctx context.Context, key schemas.Key
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -105,7 +105,7 @@ func (provider *SGLProvider) TextCompletionStream(ctx context.Context, postHookR
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -121,7 +121,7 @@ func (provider *SGLProvider) ChatCompletion(ctx context.Context, key schemas.Key
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -140,7 +140,7 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -181,7 +181,7 @@ func (provider *SGLProvider) Embedding(ctx context.Context, key schemas.Key, req
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/utils.go
+++ b/core/providers/utils.go
@@ -135,17 +135,37 @@ func configureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	return client
 }
 
+// hopByHopHeaders are HTTP/1.1 headers that must not be forwarded by proxies.
+var hopByHopHeaders = map[string]bool{
+	"connection":          true,
+	"proxy-connection":    true,
+	"keep-alive":          true,
+	"proxy-authenticate":  true,
+	"proxy-authorization": true,
+	"te":                  true,
+	"trailer":             true,
+	"transfer-encoding":   true,
+	"upgrade":             true,
+}
+
+// filterHeaders filters out hop-by-hop headers and returns only the allowed headers.
+func filterHeaders(headers map[string][]string) map[string][]string {
+	filtered := make(map[string][]string, len(headers))
+	for k, v := range headers {
+		if !hopByHopHeaders[strings.ToLower(k)] {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
 // setExtraHeaders sets additional headers from NetworkConfig to the fasthttp request.
 // This allows users to configure custom headers for their provider requests.
 // Header keys are canonicalized using textproto.CanonicalMIMEHeaderKey to avoid duplicates.
 // The Authorization header is excluded for security reasons.
 // It accepts a list of headers (all canonicalized) to skip for security reasons.
 // Headers are only set if they don't already exist on the request to avoid overwriting important headers.
-func setExtraHeaders(req *fasthttp.Request, extraHeaders map[string]string, skipHeaders []string) {
-	if extraHeaders == nil {
-		return
-	}
-
+func setExtraHeaders(ctx context.Context, req *fasthttp.Request, extraHeaders map[string]string, skipHeaders []string) {
 	for key, value := range extraHeaders {
 		canonicalKey := textproto.CanonicalMIMEHeaderKey(key)
 		// Skip Authorization header for security reasons
@@ -162,6 +182,27 @@ func setExtraHeaders(req *fasthttp.Request, extraHeaders map[string]string, skip
 			req.Header.Set(canonicalKey, value)
 		}
 	}
+
+	// Give priority to extra headers in the context
+	if extraHeaders, ok := (ctx).Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+		for k, values := range filterHeaders(extraHeaders) {
+			for i, v := range values {
+				if i == 0 {
+					req.Header.Set(k, v)
+				} else {
+					req.Header.Add(k, v)
+				}
+			}
+		}
+	}
+}
+
+// getPathFromContext gets the path from the context, if it exists, otherwise returns the default path.
+func getPathFromContext(ctx context.Context, defaultPath string) string {
+	if pathInContext, ok := ctx.Value(schemas.BifrostContextKeyURLPath).(string); ok {
+		return pathInContext
+	}
+	return defaultPath
 }
 
 // setExtraHeadersHTTP sets additional headers from NetworkConfig to the standard HTTP request.
@@ -169,11 +210,7 @@ func setExtraHeaders(req *fasthttp.Request, extraHeaders map[string]string, skip
 // Header keys are canonicalized using textproto.CanonicalMIMEHeaderKey to avoid duplicates.
 // It accepts a list of headers (all canonicalized) to skip for security reasons.
 // Headers are only set if they don't already exist on the request to avoid overwriting important headers.
-func setExtraHeadersHTTP(req *http.Request, extraHeaders map[string]string, skipHeaders []string) {
-	if extraHeaders == nil {
-		return
-	}
-
+func setExtraHeadersHTTP(ctx context.Context, req *http.Request, extraHeaders map[string]string, skipHeaders []string) {
 	for key, value := range extraHeaders {
 		canonicalKey := textproto.CanonicalMIMEHeaderKey(key)
 		// Skip Authorization header for security reasons
@@ -188,6 +225,19 @@ func setExtraHeadersHTTP(req *http.Request, extraHeaders map[string]string, skip
 		// Only set the header if it doesn't already exist to avoid overwriting important headers
 		if req.Header.Get(canonicalKey) == "" {
 			req.Header.Set(canonicalKey, value)
+		}
+	}
+
+	// Give priority to extra headers in the context
+	if extraHeaders, ok := (ctx).Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+		for k, values := range filterHeaders(extraHeaders) {
+			for i, v := range values {
+				if i == 0 {
+					req.Header.Set(k, v)
+				} else {
+					req.Header.Add(k, v)
+				}
+			}
 		}
 	}
 }

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -179,7 +179,7 @@ func (provider *VertexProvider) ListModels(ctx context.Context, key schemas.Key,
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.Set("Content-Type", "application/json")
 
@@ -394,7 +394,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, key schemas.
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.Set("Content-Type", "application/json")
 
@@ -701,7 +701,7 @@ func (provider *VertexProvider) handleVertexEmbedding(ctx context.Context, model
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.Set("Content-Type", "application/json")
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -98,12 +98,16 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeyVirtualKey         BifrostContextKey = "x-bf-vk"
-	BifrostContextKeyRequestID          BifrostContextKey = "request-id"
-	BifrostContextKeyFallbackRequestID  BifrostContextKey = "fallback-request-id"
-	BifrostContextKeyDirectKey          BifrostContextKey = "bifrost-direct-key"
-	BifrostContextKeySelectedKey        BifrostContextKey = "bifrost-key-selected" // To store the selected key ID (set by bifrost)
-	BifrostContextKeyStreamEndIndicator BifrostContextKey = "bifrost-stream-end-indicator"
+	BifrostContextKeyVirtualKey         BifrostContextKey = "x-bf-vk"                      // string
+	BifrostContextKeyRequestID          BifrostContextKey = "request-id"                   // string
+	BifrostContextKeyFallbackRequestID  BifrostContextKey = "fallback-request-id"          // string
+	BifrostContextKeyDirectKey          BifrostContextKey = "bifrost-direct-key"           // Key struct
+	BifrostContextKeySelectedKey        BifrostContextKey = "bifrost-key-selected"         // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeyStreamEndIndicator BifrostContextKey = "bifrost-stream-end-indicator" // bool
+	BifrostContextKeySkipKeySelection   BifrostContextKey = "bifrost-skip-key-selection"   // bool (will pass an empty key to the provider)
+	BifrostContextKeyExtraHeaders       BifrostContextKey = "bifrost-extra-headers"        // map[string]string
+	BifrostContextKeyURLPath            BifrostContextKey = "bifrost-extra-url-path"       // string
+	BifrostContextKeyRequestBody        BifrostContextKey = "bifrost-request-body"         // []byte
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,


### PR DESCRIPTION
## Summary

Add support for context-based request customization, allowing dynamic modification of API requests through context values.

## Changes

- Added ability to skip key selection via context flag `BifrostContextKeySkipKeySelection`
- Implemented support for injecting custom HTTP headers from context via `BifrostContextKeyExtraHeaders`
- Added path override capability through `BifrostContextKeyURLPath` to dynamically change API endpoints
- Updated all provider HTTP request methods to use these context-based customizations
- Added filtering for hop-by-hop headers to ensure proper header forwarding

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new context-based customization features:

```sh
# Core/Transports
go version
go test ./...

# Test skipping key selection
ctx := context.WithValue(context.Background(), schemas.BifrostContextKeySkipKeySelection, true)
// Make request with this context

# Test custom headers
headers := map[string][]string{"X-Custom-Header": {"value"}}
ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyExtraHeaders, headers)
// Make request with this context

# Test URL path override
ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyURLPath, "/custom/path")
// Make request with this context
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- Added filtering for hop-by-hop headers to prevent security issues with header forwarding
- Authorization headers are still protected from being overridden

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable