### PR TITLE
feat: add Anthropic OAuth passthrough support and gzip response decoding in all providers

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -157,7 +157,10 @@ func (provider *AnthropicProvider) completeRequest(ctx context.Context, requestB
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("x-api-key", key)
+	// Can be empty in case of passthrough
+	if key != "" {
+		req.Header.Set("x-api-key", key)
+	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
 
 	req.SetBody(jsonData)

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -18,33 +19,42 @@ type AnthropicRouter struct {
 	*GenericRouter
 }
 
-// CreateAnthropicRouteConfigs creates route configurations for Anthropic endpoints.
-func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
-	return []RouteConfig{
-		{
-			Type:   RouteConfigTypeAnthropic,
-			Path:   pathPrefix + "/v1/complete",
-			Method: "POST",
-			GetRequestTypeInstance: func() interface{} {
-				return &anthropic.AnthropicTextRequest{}
-			},
-			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
-				if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
-					return &schemas.BifrostRequest{
-						TextCompletionRequest: anthropicReq.ToBifrostTextCompletionRequest(),
-					}, nil
-				}
-				return nil, errors.New("invalid request type")
-			},
-			TextResponseConverter: func(resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
-				return anthropic.ToAnthropicTextCompletionResponse(resp), nil
-			},
-			ErrorConverter: func(err *schemas.BifrostError) interface{} {
-				return anthropic.ToAnthropicChatCompletionError(err)
-			},
+// createAnthropicCompleteRouteConfig creates a route configuration for the `/v1/complete` endpoint.
+func createAnthropicCompleteRouteConfig(pathPrefix string) RouteConfig {
+	return RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   pathPrefix + "/v1/complete",
+		Method: "POST",
+		GetRequestTypeInstance: func() interface{} {
+			return &anthropic.AnthropicTextRequest{}
 		},
-		{
-			Path:   pathPrefix + "/v1/messages",
+		RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
+			if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
+				return &schemas.BifrostRequest{
+					TextCompletionRequest: anthropicReq.ToBifrostTextCompletionRequest(),
+				}, nil
+			}
+			return nil, errors.New("invalid request type")
+		},
+		TextResponseConverter: func(resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
+			return anthropic.ToAnthropicTextCompletionResponse(resp), nil
+		},
+		ErrorConverter: func(err *schemas.BifrostError) interface{} {
+			return anthropic.ToAnthropicChatCompletionError(err)
+		},
+	}
+}
+
+// createAnthropicMessagesRouteConfig creates a route configuration for the `/v1/messages` endpoint.
+func createAnthropicMessagesRouteConfig(pathPrefix string) []RouteConfig {
+	var routes []RouteConfig
+	for _, path := range []string{
+		"/v1/messages",
+		"/v1/messages/{path:*}",
+	} {
+		routes = append(routes, RouteConfig{
+			Type:   RouteConfigTypeAnthropic,
+			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
 				return &anthropic.AnthropicMessageRequest{}
@@ -71,8 +81,17 @@ func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 					return anthropic.ToAnthropicResponsesStreamError(err)
 				},
 			},
-		},
+			PreCallback: checkAnthropicPassthrough,
+		})
 	}
+	return routes
+}
+
+// CreateAnthropicRouteConfigs creates route configurations for Anthropic endpoints.
+func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
+	return append([]RouteConfig{
+		createAnthropicCompleteRouteConfig(pathPrefix),
+	}, createAnthropicMessagesRouteConfig(pathPrefix)...)
 }
 
 func CreateAnthropicListModelsRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) []RouteConfig {
@@ -101,6 +120,52 @@ func CreateAnthropicListModelsRouteConfigs(pathPrefix string, handlerStore lib.H
 			PreCallback: extractAnthropicListModelsParams,
 		},
 	}
+}
+
+// checkAnthropicPassthrough pre-callback checks if the request is for a claude model.
+// If it is, it attaches the raw request body for direct use by the provider.
+// It also checks for anthropic oauth headers and sets the bifrost context.
+func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
+	var provider schemas.ModelProvider
+	var model string
+
+	switch r := req.(type) {
+	case *anthropic.AnthropicTextRequest:
+		provider, model = schemas.ParseModelString(r.Model, "")
+		// Check if model parameter explicitly has `anthropic/` prefix
+		if after, ok := strings.CutPrefix(model, "anthropic/"); ok {
+			r.Model = after
+		}
+
+	case *anthropic.AnthropicMessageRequest:
+		provider, model = schemas.ParseModelString(r.Model, "")
+		// Check if model parameter explicitly has `anthropic/` prefix
+		if after, ok := strings.CutPrefix(model, "anthropic/"); ok {
+			r.Model = after
+		}
+	}
+
+	if !strings.Contains(model, "claude") || (provider != schemas.Anthropic && provider != "") {
+		// Not a Claude model or not an Anthropic model, so we can continue
+		return nil
+	}
+
+	// Check if anthropic oauth headers are present
+	if !isAnthropicAPIKeyAuth(ctx) {
+		headers := extractHeadersFromRequest(ctx)
+		url := extractExactPath(ctx)
+		if !strings.HasPrefix(url, "/") {
+			url = "/" + url
+		}
+
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyExtraHeaders, headers)
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyURLPath, url)
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeySkipKeySelection, true)
+	}
+
+	// Set the request body in the context
+	*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRequestBody, rawBody)
+	return nil
 }
 
 // extractAnthropicListModelsParams extracts query parameters for list models request

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -86,13 +87,13 @@ func extractHeadersFromRequest(ctx *fasthttp.RequestCtx) map[string][]string {
 	return headers
 }
 
-// getExactPath returns the request path *after* the integration prefix,
+// extractExactPath returns the request path *after* the integration prefix,
 // preserving the original query string exactly as sent by the client.
 //
 // Example:
 //
 //	/openai/v1/chat/completions?model=gpt-4o  ->  /chat/completions?model=gpt-4o
-func getExactPath(ctx *fasthttp.RequestCtx) string {
+func extractExactPath(ctx *fasthttp.RequestCtx) string {
 	// ctx.Path() returns only the path (no query) as a []byte backed by fasthttp’s internal buffers.
 	// Treat it as read-only; don’t append to it directly.
 	path := ctx.Path() // e.g. "/openai/v1/chat/completions"
@@ -298,4 +299,23 @@ func (g *GenericRouter) extractFallbacksFromRequest(req interface{}) ([]string, 
 	}
 
 	return nil, nil
+}
+
+// isAnthropicAPIKeyAuth checks if the request uses standard API key authentication.
+// Returns true for API key auth (x-api-key header), false for OAuth (Bearer sk-ant-oat*).
+// This is required for Claude Code specifically, which may use OAuth authentication.
+// Default behavior is to assume API mode when neither x-api-key nor OAuth token is present.
+func isAnthropicAPIKeyAuth(ctx *fasthttp.RequestCtx) bool {
+	// If x-api-key header is present - this is definitely API mode
+	if apiKey := string(ctx.Request.Header.Peek("x-api-key")); apiKey != "" {
+		return true
+	}
+	// Check for OAuth token in Authorization header
+	if authHeader := string(ctx.Request.Header.Peek("Authorization")); authHeader != "" {
+		if strings.HasPrefix(strings.ToLower(authHeader), "bearer sk-ant-oat") {
+			return false // OAuth mode, NOT API
+		}
+	}
+	// Default to API mode
+	return true
 }


### PR DESCRIPTION
## Summary

Add support for Anthropic OAuth authentication to enable Claude Code integration. This PR allows Bifrost to handle both API key and OAuth authentication methods for Anthropic models.

## Changes

- Added support for Anthropic OAuth authentication (Bearer tokens starting with `sk-ant-oat`)
- Made API key header optional when using passthrough mode
- Added path wildcard support for Anthropic messages endpoint to handle subpaths
- Implemented a pre-callback function to detect Anthropic models and set appropriate context values
- Refactored Anthropic route configuration creation for better maintainability

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

1. Test with standard Anthropic API key:
```sh
curl -X POST http://localhost:8000/anthropic/v1/messages \
  -H "x-api-key: your-api-key" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-3-opus-20240229","messages":[{"role":"user","content":"Hello"}]}'
```

2. Test with Anthropic OAuth token:
```sh
curl -X POST http://localhost:8000/anthropic/v1/messages \
  -H "Authorization: Bearer sk-ant-oat-your-token" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-3-opus-20240229","messages":[{"role":"user","content":"Hello"}]}'
```

3. Test Claude Code endpoint:
```sh
curl -X POST http://localhost:8000/anthropic/v1/messages/code \
  -H "Authorization: Bearer sk-ant-oat-your-token" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-3-opus-20240229","messages":[{"role":"user","content":"Write a Python function to sort a list"}]}'
```

## Breaking changes

- [x] No

## Related issues

Enables Claude Code integration

## Security considerations

This PR handles authentication tokens securely by passing them through to the Anthropic API without modification.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)