### PR TITLE
refactor: standardize request body handling and error messages across providers

### DIFF
--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -138,13 +138,7 @@ func parseStreamAnthropicError(resp *http.Response, providerType schemas.ModelPr
 // completeRequest sends a request to Anthropic's API and handles the response.
 // It constructs the API URL, sets up authentication, and processes the response.
 // Returns the response body or an error if the request fails.
-func (provider *AnthropicProvider) completeRequest(ctx context.Context, requestBody interface{}, url string, key string) ([]byte, time.Duration, *schemas.BifrostError) {
-	// Marshal the request body
-	jsonData, err := sonic.Marshal(requestBody)
-	if err != nil {
-		return nil, 0, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, provider.GetProviderKey())
-	}
-
+func (provider *AnthropicProvider) completeRequest(ctx context.Context, jsonData []byte, url string, key string) ([]byte, time.Duration, *schemas.BifrostError) {
 	// Create the request with the JSON body
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -184,11 +178,16 @@ func (provider *AnthropicProvider) completeRequest(ctx context.Context, requestB
 		return nil, latency, bifrostErr
 	}
 
+	respBody, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, latency, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, provider.GetProviderKey())
+	}
+
 	// Read the response body and copy it before releasing the response
 	// to avoid use-after-free since resp.Body() references fasthttp's internal buffer
-	bodyCopy := append([]byte(nil), resp.Body()...)
+	// bodyCopy := append([]byte(nil), resp.Body()...)
 
-	return bodyCopy, latency, nil
+	return respBody, latency, nil
 }
 
 // ListModels performs a list models request to Anthropic's API.
@@ -213,7 +212,9 @@ func (provider *AnthropicProvider) ListModels(ctx context.Context, key schemas.K
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("x-api-key", key.Value)
+	if key.Value != "" {
+		req.Header.Set("x-api-key", key.Value)
+	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
 
 	// Make request
@@ -224,8 +225,6 @@ func (provider *AnthropicProvider) ListModels(ctx context.Context, key schemas.K
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", provider.GetProviderKey(), string(resp.Body())))
-
 		var errorResp anthropic.AnthropicError
 
 		bifrostErr := handleProviderAPIError(resp, &errorResp)
@@ -235,9 +234,14 @@ func (provider *AnthropicProvider) ListModels(ctx context.Context, key schemas.K
 		return nil, bifrostErr
 	}
 
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, provider.GetProviderKey())
+	}
+
 	// Parse Anthropic's response
 	var anthropicResponse anthropic.AnthropicListModelsResponse
-	rawResponse, bifrostErr := handleProviderResponse(resp.Body(), &anthropicResponse, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, &anthropicResponse, provider.sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -267,9 +271,11 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, key schem
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	reqBody := anthropic.ToAnthropicTextCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("text completion input is not provided", nil, provider.GetProviderKey())
+	jsonData, err := checkContextAndGetRequestBody(ctx,
+		func() (any, error) { return anthropic.ToAnthropicTextCompletionRequest(request), nil },
+		provider.GetProviderKey())
+	if err != nil {
+		return nil, err
 	}
 
 	// Use struct directly for JSON marshaling
@@ -307,7 +313,7 @@ func (provider *AnthropicProvider) TextCompletion(ctx context.Context, key schem
 // It formats the request, sends it to Anthropic, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *AnthropicProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "anthropic")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
 }
 
 // ChatCompletion performs a chat completion request to Anthropic's API.
@@ -319,9 +325,11 @@ func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, key schem
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	reqBody := anthropic.ToAnthropicChatCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, provider.GetProviderKey())
+	jsonData, err := checkContextAndGetRequestBody(ctx,
+		func() (any, error) { return anthropic.ToAnthropicChatCompletionRequest(request), nil },
+		provider.GetProviderKey())
+	if err != nil {
+		return nil, err
 	}
 
 	// Use struct directly for JSON marshaling
@@ -365,19 +373,28 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx context.Context, pos
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	reqBody := anthropic.ToAnthropicChatCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("failed to convert request", fmt.Errorf("conversion returned nil"), provider.GetProviderKey())
+	jsonData, err := checkContextAndGetRequestBody(ctx,
+		func() (any, error) {
+			reqBody := anthropic.ToAnthropicChatCompletionRequest(request)
+			if reqBody != nil {
+				reqBody.Stream = schemas.Ptr(true)
+			}
+			return reqBody, nil
+		},
+		provider.GetProviderKey())
+	if err != nil {
+		return nil, err
 	}
-	reqBody.Stream = schemas.Ptr(true)
 
 	// Prepare Anthropic headers
 	headers := map[string]string{
 		"Content-Type":      "application/json",
-		"x-api-key":         key.Value,
 		"anthropic-version": provider.apiVersion,
 		"Accept":            "text/event-stream",
 		"Cache-Control":     "no-cache",
+	}
+	if key.Value != "" {
+		headers["x-api-key"] = key.Value
 	}
 
 	// Use shared Anthropic streaming logic
@@ -385,7 +402,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx context.Context, pos
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/messages"),
-		reqBody,
+		jsonData,
 		headers,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
@@ -401,7 +418,7 @@ func handleAnthropicChatCompletionStreaming(
 	ctx context.Context,
 	httpClient *http.Client,
 	url string,
-	requestBody interface{},
+	jsonData []byte,
 	headers map[string]string,
 	extraHeaders map[string]string,
 	sendBackRawResponse bool,
@@ -409,13 +426,8 @@ func handleAnthropicChatCompletionStreaming(
 	postHookRunner schemas.PostHookRunner,
 	logger schemas.Logger,
 ) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	jsonBody, err := sonic.Marshal(requestBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerType)
-	}
-
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -598,9 +610,11 @@ func (provider *AnthropicProvider) Responses(ctx context.Context, key schemas.Ke
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	reqBody := anthropic.ToAnthropicResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, provider.GetProviderKey())
+	jsonData, err := checkContextAndGetRequestBody(ctx,
+		func() (any, error) { return anthropic.ToAnthropicResponsesRequest(request), nil },
+		provider.GetProviderKey())
+	if err != nil {
+		return nil, err
 	}
 
 	// Use struct directly for JSON marshaling
@@ -642,24 +656,17 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	reqBody := anthropic.ToAnthropicResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("failed to convert request", fmt.Errorf("conversion returned nil"), provider.GetProviderKey())
-	}
-	reqBody.Stream = schemas.Ptr(true)
-
-	// Prepare Anthropic headers
-	headers := map[string]string{
-		"Content-Type":      "application/json",
-		"x-api-key":         key.Value,
-		"anthropic-version": provider.apiVersion,
-		"Accept":            "text/event-stream",
-		"Cache-Control":     "no-cache",
-	}
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, provider.GetProviderKey())
+	jsonData, bifrostErr := checkContextAndGetRequestBody(ctx,
+		func() (any, error) {
+			reqBody := anthropic.ToAnthropicResponsesRequest(request)
+			if reqBody != nil {
+				reqBody.Stream = schemas.Ptr(true)
+			}
+			return reqBody, nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create HTTP request for streaming
@@ -679,6 +686,17 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, provider.GetProviderKey())
 		}
 		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, provider.GetProviderKey())
+	}
+
+	// Prepare Anthropic headers
+	headers := map[string]string{
+		"Content-Type":      "application/json",
+		"anthropic-version": provider.apiVersion,
+		"Accept":            "text/event-stream",
+		"Cache-Control":     "no-cache",
+	}
+	if key.Value != "" {
+		headers["x-api-key"] = key.Value
 	}
 
 	// Set headers
@@ -833,25 +851,25 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 
 // Embedding is not supported by the Anthropic provider.
 func (provider *AnthropicProvider) Embedding(ctx context.Context, key schemas.Key, input *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "anthropic")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the Anthropic provider.
 func (provider *AnthropicProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "anthropic")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Anthropic provider.
 func (provider *AnthropicProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "anthropic")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Anthropic provider.
 func (provider *AnthropicProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "anthropic")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Anthropic provider.
 func (provider *AnthropicProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "anthropic")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/bytedance/sonic"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/core/schemas/providers/azure"
 	"github.com/maximhq/bifrost/core/schemas/providers/openai"
@@ -64,13 +63,7 @@ func (provider *AzureProvider) GetProviderKey() schemas.ModelProvider {
 // completeRequest sends a request to Azure's API and handles the response.
 // It constructs the API URL, sets up authentication, and processes the response.
 // Returns the response body, request latency, or an error if the request fails.
-func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody interface{}, path string, key schemas.Key, model string, requestType schemas.RequestType) ([]byte, time.Duration, *schemas.BifrostError) {
-	// Marshal the request body
-	jsonData, err := sonic.Marshal(requestBody)
-	if err != nil {
-		return nil, 0, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, provider.GetProviderKey())
-	}
-
+func (provider *AzureProvider) completeRequest(ctx context.Context, jsonData []byte, path string, key schemas.Key, model string, requestType schemas.RequestType) ([]byte, time.Duration, *schemas.BifrostError) {
 	deployment := key.AzureKeyConfig.Deployments[model]
 	if deployment == "" {
 		return nil, 0, newConfigurationError(fmt.Sprintf("deployment not found for model %s", model), provider.GetProviderKey())
@@ -96,6 +89,7 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if authToken, ok := ctx.Value(AzureAuthorizationTokenKey).(string); ok {
+		// TODO: Shift this to key.Value like in bedrock and vertex
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 		// Ensure api-key is not accidentally present (from extra headers, etc.)
 		req.Header.Del("api-key")
@@ -116,9 +110,14 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 		return nil, latency, parseOpenAIError(resp, requestType, provider.GetProviderKey(), model)
 	}
 
+	respBody, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, latency, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, provider.GetProviderKey())
+	}
+
 	// Read the response body and copy it before releasing the response
-	// to avoid use-after-free since resp.Body() references fasthttp's internal buffer
-	bodyCopy := append([]byte(nil), resp.Body()...)
+	// to avoid use-after-free since respBody references fasthttp's internal buffer
+	bodyCopy := append([]byte(nil), respBody...)
 
 	return bodyCopy, latency, nil
 }
@@ -141,9 +140,6 @@ func (provider *AzureProvider) ListModels(ctx context.Context, key schemas.Key, 
 		apiVersion = schemas.Ptr(azure.DefaultAzureAPIVersion)
 	}
 
-	// Construct URL - list models is a resource-level operation, doesn't require deployment
-	url := fmt.Sprintf("%s/openai/models?api-version=%s", key.AzureKeyConfig.Endpoint, *apiVersion)
-
 	// Create the request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -153,7 +149,7 @@ func (provider *AzureProvider) ListModels(ctx context.Context, key schemas.Key, 
 	// Set any extra headers from network config
 	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(url)
+	req.SetRequestURI(key.AzureKeyConfig.Endpoint + getPathFromContext(ctx, fmt.Sprintf("/openai/models?api-version=%s", *apiVersion)))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 
@@ -174,13 +170,17 @@ func (provider *AzureProvider) ListModels(ctx context.Context, key schemas.Key, 
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		provider.logger.Debug(fmt.Sprintf("error from azure provider: %s", string(resp.Body())))
 		return nil, parseOpenAIError(resp, schemas.ListModelsRequest, provider.GetProviderKey(), "")
+	}
+
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, provider.GetProviderKey())
 	}
 
 	// Read the response body and copy it before releasing the response
 	// to avoid use-after-free since resp.Body() references fasthttp's internal buffer
-	responseBody := append([]byte(nil), resp.Body()...)
+	responseBody := append([]byte(nil), body...)
 
 	// Parse Azure-specific response
 	azureResponse := &azure.AzureListModelsResponse{}
@@ -217,12 +217,14 @@ func (provider *AzureProvider) TextCompletion(ctx context.Context, key schemas.K
 	}
 
 	// Use centralized OpenAI text converter (Azure is OpenAI-compatible)
-	reqBody := openai.ToOpenAITextCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("text completion input is not provided", nil, provider.GetProviderKey())
+	jsonData, bifrostErr := checkContextAndGetRequestBody(ctx,
+		func() (any, error) { return openai.ToOpenAITextCompletionRequest(request), nil },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, "completions", key, request.Model, schemas.TextCompletionRequest)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, "completions", key, request.Model, schemas.TextCompletionRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -300,12 +302,14 @@ func (provider *AzureProvider) ChatCompletion(ctx context.Context, key schemas.K
 	}
 
 	// Use centralized OpenAI converter since Azure is OpenAI-compatible
-	reqBody := openai.ToOpenAIChatRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, provider.GetProviderKey())
+	jsonData, bifrostErr := checkContextAndGetRequestBody(ctx,
+		func() (any, error) { return openai.ToOpenAIChatRequest(request), nil },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, "chat/completions", key, request.Model, schemas.ChatCompletionRequest)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, "chat/completions", key, request.Model, schemas.ChatCompletionRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -389,20 +393,18 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 		return nil, newConfigurationError(fmt.Sprintf("deployment not found for model %s", request.Model), provider.GetProviderKey())
 	}
 
-	url := fmt.Sprintf("%s/openai/v1/responses?api-version=preview", key.AzureKeyConfig.Endpoint)
-
 	// Use centralized OpenAI converter since Azure is OpenAI-compatible
-	reqBody := openai.ToOpenAIResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, provider.GetProviderKey())
-	}
-
-	reqBody.Model = deployment
-
-	// Marshal the request body
-	jsonData, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, provider.GetProviderKey())
+	jsonData, bifrostErr := checkContextAndGetRequestBody(ctx,
+		func() (any, error) {
+			reqBody := openai.ToOpenAIResponsesRequest(request)
+			if reqBody != nil {
+				reqBody.Model = deployment
+			}
+			return reqBody, nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create the request with the JSON body
@@ -414,7 +416,7 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 	// Set any extra headers from network config
 	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(url)
+	req.SetRequestURI(key.AzureKeyConfig.Endpoint + getPathFromContext(ctx, "/openai/v1/responses?api-version=preview"))
 	req.Header.SetMethod("POST")
 	req.Header.SetContentType("application/json")
 	if authToken, ok := ctx.Value(AzureAuthorizationTokenKey).(string); ok {
@@ -438,9 +440,14 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 		return nil, parseOpenAIError(resp, schemas.ResponsesRequest, provider.GetProviderKey(), request.Model)
 	}
 
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, provider.GetProviderKey())
+	}
+
 	response := &schemas.BifrostResponsesResponse{}
 
-	rawResponse, bifrostErr := handleProviderResponse(resp.Body(), response, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, response, provider.sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -469,8 +476,6 @@ func (provider *AzureProvider) ResponsesStream(ctx context.Context, postHookRunn
 		return nil, newConfigurationError(fmt.Sprintf("deployment not found for model %s", request.Model), provider.GetProviderKey())
 	}
 
-	url := fmt.Sprintf("%s/openai/v1/responses?api-version=preview", key.AzureKeyConfig.Endpoint)
-
 	// Prepare Azure-specific headers
 	authHeader := make(map[string]string)
 
@@ -490,7 +495,7 @@ func (provider *AzureProvider) ResponsesStream(ctx context.Context, postHookRunn
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
-		url,
+		key.AzureKeyConfig.Endpoint+getPathFromContext(ctx, "/openai/v1/responses?api-version=preview"),
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
@@ -511,12 +516,14 @@ func (provider *AzureProvider) Embedding(ctx context.Context, key schemas.Key, r
 	}
 
 	// Use centralized converter
-	reqBody := openai.ToOpenAIEmbeddingRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("embedding input is not provided", nil, provider.GetProviderKey())
+	jsonData, bifrostErr := checkContextAndGetRequestBody(ctx,
+		func() (any, error) { return openai.ToOpenAIEmbeddingRequest(request), nil },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, "embeddings", key, request.Model, schemas.EmbeddingRequest)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, "embeddings", key, request.Model, schemas.EmbeddingRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -543,22 +550,22 @@ func (provider *AzureProvider) Embedding(ctx context.Context, key schemas.Key, r
 
 // Speech is not supported by the Azure provider.
 func (provider *AzureProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "azure")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Azure provider.
 func (provider *AzureProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "azure")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Azure provider.
 func (provider *AzureProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "azure")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Azure provider.
 func (provider *AzureProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "azure")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }
 
 // validateKeyConfig validates the key configuration.

--- a/core/providers/cerebras.go
+++ b/core/providers/cerebras.go
@@ -63,7 +63,17 @@ func (provider *CerebrasProvider) GetProviderKey() schemas.ModelProvider {
 
 // ListModels performs a list models request to Cerebras's API.
 func (provider *CerebrasProvider) ListModels(ctx context.Context, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", key, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(
+		ctx,
+		provider.client,
+		request,
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
+		key,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		provider.sendBackRawResponse,
+		provider.logger,
+	)
 }
 
 // TextCompletion performs a text completion request to Cerebras's API.
@@ -73,7 +83,7 @@ func (provider *CerebrasProvider) TextCompletion(ctx context.Context, key schema
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -87,12 +97,17 @@ func (provider *CerebrasProvider) TextCompletion(ctx context.Context, key schema
 // It formats the request, sends it to Cerebras, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *CerebrasProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
+	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		provider.GetProviderKey(),
@@ -106,7 +121,7 @@ func (provider *CerebrasProvider) ChatCompletion(ctx context.Context, key schema
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -121,13 +136,17 @@ func (provider *CerebrasProvider) ChatCompletion(ctx context.Context, key schema
 // Uses Cerebras's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *CerebrasProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		schemas.Cerebras,
@@ -162,25 +181,25 @@ func (provider *CerebrasProvider) ResponsesStream(ctx context.Context, postHookR
 
 // Embedding is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -176,13 +176,17 @@ func (provider *GroqProvider) ChatCompletion(ctx context.Context, key schemas.Ke
 // Uses Groq's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		schemas.Groq,
@@ -218,25 +222,25 @@ func (provider *GroqProvider) ResponsesStream(ctx context.Context, postHookRunne
 
 // Embedding is not supported by the Groq provider.
 func (provider *GroqProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "groq")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the Groq provider.
 func (provider *GroqProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "groq")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Groq provider.
 func (provider *GroqProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "groq")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Groq provider.
 func (provider *GroqProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "groq")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Groq provider.
 func (provider *GroqProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "groq")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -78,10 +78,12 @@ func (provider *MistralProvider) ListModels(ctx context.Context, key schemas.Key
 	// Set any extra headers from network config
 	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/models")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
@@ -121,14 +123,14 @@ func (provider *MistralProvider) ListModels(ctx context.Context, key schemas.Key
 
 // TextCompletion is not supported by the Mistral provider.
 func (provider *MistralProvider) TextCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
 }
 
 // TextCompletionStream performs a streaming text completion request to Mistral's API.
 // It formats the request, sends it to Mistral, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *MistralProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
 }
 
 // ChatCompletion performs a chat completion request to the Mistral API.
@@ -151,13 +153,17 @@ func (provider *MistralProvider) ChatCompletion(ctx context.Context, key schemas
 // Uses Mistral's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		schemas.Mistral,
@@ -210,20 +216,20 @@ func (provider *MistralProvider) Embedding(ctx context.Context, key schemas.Key,
 
 // Speech is not supported by the Mistral provider.
 func (provider *MistralProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "mistral")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Mistral provider.
 func (provider *MistralProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "mistral")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Mistral provider.
 func (provider *MistralProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Mistral provider.
 func (provider *MistralProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -196,20 +196,20 @@ func (provider *OllamaProvider) Embedding(ctx context.Context, key schemas.Key, 
 
 // Speech is not supported by the Ollama provider.
 func (provider *OllamaProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "ollama")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Ollama provider.
 func (provider *OllamaProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "ollama")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Ollama provider.
 func (provider *OllamaProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "ollama")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Ollama provider.
 func (provider *OllamaProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "ollama")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/openrouter.go
+++ b/core/providers/openrouter.go
@@ -76,7 +76,9 @@ func (provider *OpenRouterProvider) ListModels(ctx context.Context, key schemas.
 	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
@@ -134,12 +136,16 @@ func (provider *OpenRouterProvider) TextCompletion(ctx context.Context, key sche
 // It formats the request, sends it to OpenRouter, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *OpenRouterProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		provider.GetProviderKey(),
@@ -168,13 +174,17 @@ func (provider *OpenRouterProvider) ChatCompletion(ctx context.Context, key sche
 // Uses OpenRouter's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *OpenRouterProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		schemas.OpenRouter,
@@ -200,12 +210,16 @@ func (provider *OpenRouterProvider) Responses(ctx context.Context, key schemas.K
 
 // ResponsesStream performs a streaming responses request to the OpenRouter API.
 func (provider *OpenRouterProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/alpha/responses"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		provider.GetProviderKey(),
@@ -217,25 +231,25 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx context.Context, postHoo
 
 // Embedding is not supported by the OpenRouter provider.
 func (provider *OpenRouterProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "openrouter")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the OpenRouter provider.
 func (provider *OpenRouterProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "openrouter")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the OpenRouter provider.
 func (provider *OpenRouterProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "openrouter")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the OpenRouter provider.
 func (provider *OpenRouterProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "openrouter")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the OpenRouter provider.
 func (provider *OpenRouterProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "openrouter")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -83,14 +83,14 @@ func (provider *ParasailProvider) ListModels(ctx context.Context, key schemas.Ke
 
 // TextCompletion is not supported by the Parasail provider.
 func (provider *ParasailProvider) TextCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
 }
 
 // TextCompletionStream performs a streaming text completion request to Parasail's API.
 // It formats the request, sends it to Parasail, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *ParasailProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
 }
 
 // ChatCompletion performs a chat completion request to the Parasail API.
@@ -113,13 +113,17 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schema
 // Uses Parasail's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		provider.sendBackRawResponse,
 		schemas.Parasail,
@@ -155,25 +159,25 @@ func (provider *ParasailProvider) ResponsesStream(ctx context.Context, postHookR
 
 // Embedding is not supported by the Parasail provider.
 func (provider *ParasailProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "parasail")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the Parasail provider.
 func (provider *ParasailProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "parasail")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Parasail provider.
 func (provider *ParasailProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "parasail")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Parasail provider.
 func (provider *ParasailProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Parasail provider.
 func (provider *ParasailProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -193,20 +193,20 @@ func (provider *SGLProvider) Embedding(ctx context.Context, key schemas.Key, req
 
 // Speech is not supported by the SGL provider.
 func (provider *SGLProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "sgl")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the SGL provider.
 func (provider *SGLProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "sgl")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the SGL provider.
 func (provider *SGLProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "sgl")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the SGL provider.
 func (provider *SGLProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "sgl")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/schemas/providers/anthropic/responses.go
+++ b/core/schemas/providers/anthropic/responses.go
@@ -32,6 +32,9 @@ func (request *AnthropicMessageRequest) ToBifrostResponsesRequest() *schemas.Bif
 	if request.TopP != nil {
 		params.TopP = request.TopP
 	}
+	if request.Metadata != nil && request.Metadata.UserID != nil {
+		params.User = request.Metadata.UserID
+	}
 	if request.TopK != nil {
 		params.ExtraParams["top_k"] = *request.TopK
 	}
@@ -127,6 +130,11 @@ func ToAnthropicResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *A
 		}
 		if bifrostReq.Params.TopP != nil {
 			anthropicReq.TopP = bifrostReq.Params.TopP
+		}
+		if bifrostReq.Params.User != nil {
+			anthropicReq.Metadata = &AnthropicMetaData{
+				UserID: bifrostReq.Params.User,
+			}
 		}
 		if bifrostReq.Params.ExtraParams != nil {
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
@@ -1161,6 +1169,15 @@ func convertAnthropicContentBlocksToResponsesMessages(content []AnthropicContent
 							},
 						},
 					},
+					ResponsesReasoning: &schemas.ResponsesReasoning{
+						Summary: []schemas.ResponsesReasoningContent{
+							{
+								Text: *block.Thinking,
+								Type: schemas.ResponsesReasoningContentBlockTypeSummaryText,
+							},
+						},
+						EncryptedContent: block.Signature,
+					},
 				})
 			}
 
@@ -1326,10 +1343,12 @@ func convertBifrostMessagesToAnthropicContent(messages []schemas.ResponsesMessag
 			case schemas.ResponsesMessageTypeReasoning:
 				// Build thinking from ResponsesReasoning summary, else from reasoning content blocks
 				var thinking string
+				var signature *string
 				if msg.ResponsesReasoning != nil && msg.ResponsesReasoning.Summary != nil {
 					for _, b := range msg.ResponsesReasoning.Summary {
 						thinking += b.Text
 					}
+					signature = msg.ResponsesReasoning.EncryptedContent
 				} else if msg.Content != nil && msg.Content.ContentBlocks != nil {
 					for _, b := range msg.Content.ContentBlocks {
 						if b.Type == schemas.ResponsesOutputMessageContentTypeReasoning && b.Text != nil {
@@ -1339,8 +1358,9 @@ func convertBifrostMessagesToAnthropicContent(messages []schemas.ResponsesMessag
 				}
 				if thinking != "" {
 					contentBlocks = append(contentBlocks, AnthropicContentBlock{
-						Type:     AnthropicContentBlockTypeThinking,
-						Thinking: &thinking,
+						Type:      AnthropicContentBlockTypeThinking,
+						Thinking:  &thinking,
+						Signature: signature,
 					})
 				}
 

--- a/core/schemas/providers/anthropic/types.go
+++ b/core/schemas/providers/anthropic/types.go
@@ -37,6 +37,7 @@ type AnthropicMessageRequest struct {
 	Model         string               `json:"model"`
 	MaxTokens     int                  `json:"max_tokens"`
 	Messages      []AnthropicMessage   `json:"messages"`
+	Metadata      *AnthropicMetaData   `json:"metadata,omitempty"`
 	System        *AnthropicContent    `json:"system,omitempty"`
 	Temperature   *float64             `json:"temperature,omitempty"`
 	TopP          *float64             `json:"top_p,omitempty"`
@@ -46,6 +47,10 @@ type AnthropicMessageRequest struct {
 	Tools         []AnthropicTool      `json:"tools,omitempty"`
 	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
 	Thinking      *AnthropicThinking   `json:"thinking,omitempty"`
+}
+
+type AnthropicMetaData struct {
+	UserID *string `json:"user_id"`
 }
 
 type AnthropicThinking struct {
@@ -130,6 +135,7 @@ type AnthropicContentBlock struct {
 	Type      AnthropicContentBlockType `json:"type"`                  // "text", "image", "tool_use", "tool_result", "thinking"
 	Text      *string                   `json:"text,omitempty"`        // For text content
 	Thinking  *string                   `json:"thinking,omitempty"`    // For thinking content
+	Signature *string                   `json:"signature,omitempty"`   // For signature content
 	ToolUseID *string                   `json:"tool_use_id,omitempty"` // For tool_result content
 	ID        *string                   `json:"id,omitempty"`          // For tool_use content
 	Name      *string                   `json:"name,omitempty"`        // For tool_use content

--- a/core/schemas/providers/gemini/speech.go
+++ b/core/schemas/providers/gemini/speech.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest, responseModalities []string) *GeminiGenerationRequest {
+func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest) *GeminiGenerationRequest {
 	if bifrostReq == nil {
 		return nil
 	}
@@ -17,13 +17,7 @@ func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest, responseMod
 	}
 
 	// Convert parameters to generation config
-	if len(responseModalities) > 0 {
-		var modalities []Modality
-		for _, mod := range responseModalities {
-			modalities = append(modalities, Modality(mod))
-		}
-		geminiReq.GenerationConfig.ResponseModalities = modalities
-	}
+	geminiReq.GenerationConfig.ResponseModalities = []Modality{ModalityAudio}
 
 	// Convert speech input to Gemini format
 	if bifrostReq.Input.Input != "" {

--- a/core/schemas/providers/vertex/types.go
+++ b/core/schemas/providers/vertex/types.go
@@ -4,6 +4,10 @@ import "time"
 
 // Vertex AI Embedding API types
 
+const (
+	DefaultVertexAnthropicVersion = "vertex-2023-10-16"
+)
+
 // VertexEmbeddingInstance represents a single embedding instance in the request
 type VertexEmbeddingInstance struct {
 	Content  string  `json:"content"`             // The text to generate embeddings for

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -94,7 +94,7 @@ type ResponsesParameters struct {
 	ToolChoice         *ResponsesToolChoice          `json:"tool_choice,omitempty"` // Whether to call a tool
 	Tools              []ResponsesTool               `json:"tools,omitempty"`       // Tools to use
 	Truncation         *string                       `json:"truncation,omitempty"`
-
+	User               *string                       `json:"user,omitempty"`
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`

--- a/core/utils.go
+++ b/core/utils.go
@@ -59,6 +59,10 @@ func canProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
 	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock
 }
 
+func isKeySkippingAllowed(providerKey schemas.ModelProvider) bool {
+	return providerKey != schemas.Azure && providerKey != schemas.Bedrock && providerKey != schemas.Vertex
+}
+
 // calculateBackoff implements exponential backoff with jitter for retry attempts.
 func calculateBackoff(attempt int, config *schemas.ProviderConfig) time.Duration {
 	// Calculate an exponential backoff: initial * 2^attempt

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -219,6 +219,9 @@ func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvid
 }
 
 func (mc *ModelCatalog) AddModelDataToPool(modelData *schemas.BifrostListModelsResponse) {
+	if modelData == nil {
+		return
+	}
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 

--- a/transports/bifrost-http/handlers/server.go
+++ b/transports/bifrost-http/handlers/server.go
@@ -579,11 +579,13 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	modelData, listModelsErr := s.Client.ListAllModels(ctx, nil)
 	if listModelsErr != nil {
 		if listModelsErr.Error != nil {
-			return fmt.Errorf("failed to list all models: %s", listModelsErr.Error.Message)
+			logger.Error("failed to list all models: %s", listModelsErr.Error.Message)
+		} else {
+			logger.Error("failed to list all models: %v", listModelsErr)
 		}
-		return fmt.Errorf("failed to list all models: %v", listModelsErr)
+	} else {
+		s.Config.PricingManager.AddModelDataToPool(modelData)
 	}
-	s.Config.PricingManager.AddModelDataToPool(modelData)
 	logger.Info("models added to catalog")
 	s.Config.SetBifrostClient(s.Client)
 	// Initialize routes

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -68,6 +68,11 @@ func createAnthropicMessagesRouteConfig(pathPrefix string) []RouteConfig {
 				return nil, errors.New("invalid request type")
 			},
 			ResponsesResponseConverter: func(resp *schemas.BifrostResponsesResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.Anthropic {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return anthropic.ToAnthropicResponsesResponse(resp), nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -46,9 +46,19 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			return nil, errors.New("invalid request type")
 		},
 		EmbeddingResponseConverter: func(resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini {
+				if resp.ExtraFields.RawResponse != nil {
+					return resp.ExtraFields.RawResponse, nil
+				}
+			}
 			return gemini.ToGeminiEmbeddingResponse(resp), nil
 		},
 		ChatResponseConverter: func(resp *schemas.BifrostChatResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini {
+				if resp.ExtraFields.RawResponse != nil {
+					return resp.ExtraFields.RawResponse, nil
+				}
+			}
 			return gemini.ToGeminiChatResponse(resp), nil
 		},
 		ErrorConverter: func(err *schemas.BifrostError) interface{} {

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -119,6 +119,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid request type")
 			},
 			TextResponseConverter: func(resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -158,6 +163,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid request type")
 			},
 			ChatResponseConverter: func(resp *schemas.BifrostChatResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -198,6 +208,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid request type")
 			},
 			ResponsesResponseConverter: func(resp *schemas.BifrostResponsesResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -237,6 +252,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid embedding request type")
 			},
 			EmbeddingResponseConverter: func(resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -305,6 +325,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid transcription request type")
 			},
 			TranscriptionResponseConverter: func(resp *schemas.BifrostTranscriptionResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {


### PR DESCRIPTION
## Summary

Refactored provider request handling to improve error handling, support gzip responses, and standardize unsupported operation errors across providers.

## Changes

- Added `checkContextAndGetRequestBody` utility to centralize request body preparation and error handling
- Implemented `checkAndDecodeBody` to properly handle gzipped responses
- Standardized unsupported operation error messages using request types instead of hardcoded strings
- Improved empty API key handling to make it consistent across providers
- Enhanced error handling in streaming operations
- Fixed response body handling to avoid potential use-after-free issues
- Added support for user ID in Anthropic requests via metadata field
- Added support for reasoning content in Anthropic responses

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test various provider API calls with and without API keys:

```sh
# Core/Transports
go test ./core/providers/...
go test ./transports/bifrost-http/...

# Test with gzipped responses
curl -H "Accept-Encoding: gzip" http://localhost:8000/v1/models
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves error handling and response processing across all providers.

## Security considerations

Improved handling of API keys and authentication headers.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable