### PR TITLE
feat: added request level support for skippping keys, extra headers, raw request passthrough and response gzip decompression and anthropic integration passthrough

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2397,6 +2397,10 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *context.Context, requ
 		}
 	}
 
+	if skipKeySelection, ok := (*ctx).Value(schemas.BifrostContextKeySkipKeySelection).(bool); ok && skipKeySelection && isKeySkippingAllowed(providerKey) {
+		return schemas.Key{}, nil
+	}
+
 	keys, err := bifrost.account.GetKeysForProvider(ctx, providerKey)
 	if err != nil {
 		return schemas.Key{}, err

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -327,10 +327,10 @@ func (bifrost *Bifrost) ListAllModels(ctx context.Context, request *schemas.Bifr
 			for {
 				// check for context cancellation
 				select {
-					case <-ctx.Done():
-						bifrost.logger.Warn(fmt.Sprintf("context cancelled for provider %s", providerKey))
-						return
-					default:
+				case <-ctx.Done():
+					bifrost.logger.Warn(fmt.Sprintf("context cancelled for provider %s", providerKey))
+					return
+				default:
 				}
 
 				iterations++
@@ -1963,7 +1963,7 @@ func executeRequestWithRetries[T any](
 		// Check if we should retry based on status code or error message
 		shouldRetry := false
 
-		if bifrostError.Error != nil && bifrostError.Error.Message == schemas.ErrProviderRequest {
+		if bifrostError.Error != nil && bifrostError.Error.Message == schemas.ErrProviderDoRequest {
 			shouldRetry = true
 			logger.Debug("detected request HTTP error, will retry: %s", bifrostError.Error.Message)
 		}

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -233,8 +233,8 @@ func TestExecuteRequestWithRetries_RetryableConditions(t *testing.T) {
 			error: createBifrostError("too many requests", Ptr(429), nil, false),
 		},
 		{
-			name:  "ErrProviderRequest",
-			error: createBifrostError(schemas.ErrProviderRequest, nil, nil, false),
+			name:  "ErrProviderDoRequest",
+			error: createBifrostError(schemas.ErrProviderDoRequest, nil, nil, false),
 		},
 		{
 			name:  "RateLimitMessage",

--- a/core/providers/anthropic.go
+++ b/core/providers/anthropic.go
@@ -143,7 +143,10 @@ func (provider *AnthropicProvider) completeRequest(ctx context.Context, requestB
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("x-api-key", key)
+	// Can be empty in case of passthrough
+	if key != "" {
+		req.Header.Set("x-api-key", key)
+	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
 
 	req.SetBody(jsonData)

--- a/core/providers/azure.go
+++ b/core/providers/azure.go
@@ -90,7 +90,7 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, requestBody 
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -152,7 +152,7 @@ func (provider *AzureProvider) listModelsByKey(ctx context.Context, key schemas.
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodGet)
@@ -420,7 +420,7 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod("POST")

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -87,7 +87,7 @@ func (provider *BedrockProvider) GetProviderKey() schemas.ModelProvider {
 // completeRequest sends a request to Bedrock's API and handles the response.
 // It constructs the API URL, sets up AWS authentication, and processes the response.
 // Returns the response body, request latency, or an error if the request fails.
-func (provider *BedrockProvider) completeRequest(ctx context.Context, requestBody interface{}, path string, key schemas.Key) ([]byte, time.Duration, *schemas.BifrostError) {
+func (provider *BedrockProvider) completeRequest(ctx context.Context, jsonData []byte, path string, key schemas.Key) ([]byte, time.Duration, *schemas.BifrostError) {
 	config := key.BedrockKeyConfig
 
 	region := bedrock.DefaultBedrockRegion
@@ -95,29 +95,8 @@ func (provider *BedrockProvider) completeRequest(ctx context.Context, requestBod
 		region = *config.Region
 	}
 
-	jsonBody, err := sonic.Marshal(requestBody)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, 0, &schemas.BifrostError{
-				IsBifrostError: false,
-				Error: &schemas.ErrorField{
-					Type:    schemas.Ptr(schemas.RequestCancelled),
-					Message: fmt.Sprintf("Request cancelled or timed out by context: %v", ctx.Err()),
-					Error:   err,
-				},
-			}
-		}
-		return nil, 0, &schemas.BifrostError{
-			IsBifrostError: true,
-			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderJSONMarshaling,
-				Error:   err,
-			},
-		}
-	}
-
 	// Create the request with the JSON body
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path), bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path), bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, 0, &schemas.BifrostError{
 			IsBifrostError: true,
@@ -162,7 +141,7 @@ func (provider *BedrockProvider) completeRequest(ctx context.Context, requestBod
 		return nil, latency, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderRequest,
+				Message: schemas.ErrProviderDoRequest,
 				Error:   err,
 			},
 		}
@@ -209,7 +188,7 @@ func (provider *BedrockProvider) completeRequest(ctx context.Context, requestBod
 // makeStreamingRequest creates a streaming request to Bedrock's API.
 // It formats the request, sends it to Bedrock, and returns the response.
 // Returns the response body and an error if the request fails.
-func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, requestBody interface{}, key schemas.Key, model string) (*http.Response, *schemas.BifrostError) {
+func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, jsonData []byte, key schemas.Key, model string) (*http.Response, *schemas.BifrostError) {
 	providerName := provider.GetProviderKey()
 
 	if key.BedrockKeyConfig == nil {
@@ -224,14 +203,8 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, reque
 		region = *key.BedrockKeyConfig.Region
 	}
 
-	// Create the streaming request
-	jsonBody, jsonErr := sonic.Marshal(requestBody)
-	if jsonErr != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, jsonErr, providerName)
-	}
-
 	// Create HTTP request for streaming
-	req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path), bytes.NewReader(jsonBody))
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path), bytes.NewReader(jsonData))
 	if reqErr != nil {
 		return nil, newBifrostOperationError("error creating request", reqErr, providerName)
 	}
@@ -257,7 +230,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, reque
 		if errors.Is(respErr, http.ErrHandlerTimeout) || errors.Is(respErr, context.Canceled) || errors.Is(respErr, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, respErr, provider.GetProviderKey())
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, respErr, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderDoRequest, respErr, providerName)
 	}
 
 	// Check for HTTP errors
@@ -427,7 +400,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx context.Context, key schema
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderRequest,
+				Message: schemas.ErrProviderDoRequest,
 				Error:   err,
 			},
 		}
@@ -469,7 +442,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx context.Context, key schema
 
 	// Parse Bedrock-specific response
 	bedrockResponse := &bedrock.BedrockListModelsResponse{}
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, bedrockResponse, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(responseBody, bedrockResponse, shouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -482,7 +455,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx context.Context, key schema
 
 	response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -519,13 +492,17 @@ func (provider *BedrockProvider) TextCompletion(ctx context.Context, key schemas
 		return nil, newConfigurationError("bedrock key config is not provided", providerName)
 	}
 
-	requestBody := bedrock.ToBedrockTextCompletionRequest(request)
-	if requestBody == nil {
-		return nil, newBifrostOperationError("text completion input is not provided", nil, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return bedrock.ToBedrockTextCompletionRequest(request), nil },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	path := provider.getModelPath("invoke", request.Model, key)
-	body, latency, err := provider.completeRequest(ctx, requestBody, path, key)
+	body, latency, err := provider.completeRequest(ctx, jsonData, path, key)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +535,7 @@ func (provider *BedrockProvider) TextCompletion(ctx context.Context, key schemas
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Parse raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		var rawResponse interface{}
 		if err := sonic.Unmarshal(body, &rawResponse); err != nil {
 			return nil, newBifrostOperationError("error parsing raw response", err, providerName)
@@ -573,7 +550,7 @@ func (provider *BedrockProvider) TextCompletion(ctx context.Context, key schemas
 // It formats the request, sends it to Bedrock, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *BedrockProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "bedrock")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, schemas.Bedrock)
 }
 
 // ChatCompletion performs a chat completion request to Bedrock's API.
@@ -590,17 +567,21 @@ func (provider *BedrockProvider) ChatCompletion(ctx context.Context, key schemas
 		return nil, newConfigurationError("bedrock key config is not provided", providerName)
 	}
 
-	// pool the request
-	reqBody, err := bedrock.ToBedrockChatCompletionRequest(request)
-	if err != nil {
-		return nil, newBifrostOperationError("failed to convert request", err, providerName)
+	// Use centralized Bedrock converter
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return bedrock.ToBedrockChatCompletionRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Format the path with proper model identifier
 	path := provider.getModelPath("converse", request.Model, key)
 
 	// Create the signed request
-	responseBody, latency, bifrostErr := provider.completeRequest(ctx, reqBody, path, key)
+	responseBody, latency, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -627,7 +608,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx context.Context, key schemas
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		var rawResponse interface{}
 		if err := sonic.Unmarshal(responseBody, &rawResponse); err == nil {
 			bifrostResponse.ExtraFields.RawResponse = rawResponse
@@ -647,12 +628,16 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 
 	providerName := provider.GetProviderKey()
 
-	reqBody, err := bedrock.ToBedrockChatCompletionRequest(request)
-	if err != nil {
-		return nil, newBifrostOperationError("failed to convert request", err, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return bedrock.ToBedrockChatCompletionRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	resp, bifrostErr := provider.makeStreamingRequest(ctx, reqBody, key, request.Model)
+	resp, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -740,7 +725,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 					chunkIndex++
 					lastChunkTime = time.Now()
 
-					if provider.sendBackRawResponse {
+					if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 						response.ExtraFields.RawResponse = string(message.Payload)
 					}
 
@@ -781,17 +766,21 @@ func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key,
 		return nil, newConfigurationError("bedrock key config is not provided", providerName)
 	}
 
-	// pool the request
-	reqBody, err := bedrock.ToBedrockResponsesRequest(request)
-	if err != nil {
-		return nil, newBifrostOperationError("failed to convert request", err, providerName)
+	// Use centralized Bedrock converter
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return bedrock.ToBedrockResponsesRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Format the path with proper model identifier
 	path := provider.getModelPath("converse", request.Model, key)
 
 	// Create the signed request
-	responseBody, latency, bifrostErr := provider.completeRequest(ctx, reqBody, path, key)
+	responseBody, latency, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -818,7 +807,7 @@ func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key,
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		var rawResponse interface{}
 		if err := sonic.Unmarshal(responseBody, &rawResponse); err == nil {
 			bifrostResponse.ExtraFields.RawResponse = rawResponse
@@ -838,12 +827,16 @@ func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRu
 
 	providerName := provider.GetProviderKey()
 
-	reqBody, err := bedrock.ToBedrockResponsesRequest(request)
-	if err != nil {
-		return nil, newBifrostOperationError("failed to convert request", err, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return bedrock.ToBedrockResponsesRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	resp, bifrostErr := provider.makeStreamingRequest(ctx, reqBody, key, request.Model)
+	resp, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -930,7 +923,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRu
 					chunkIndex++
 					lastChunkTime = time.Now()
 
-					if provider.sendBackRawResponse {
+					if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 						response.ExtraFields.RawResponse = string(message.Payload)
 					}
 
@@ -994,20 +987,28 @@ func (provider *BedrockProvider) Embedding(ctx context.Context, key schemas.Key,
 
 	switch modelType {
 	case "titan":
-		titanReq, err := bedrock.ToBedrockTitanEmbeddingRequest(request)
-		if err != nil {
-			return nil, newBifrostOperationError("failed to convert Titan request", err, providerName)
+		jsonData, bifrostErr := checkContextAndGetRequestBody(
+			ctx,
+			request,
+			func() (any, error) { return bedrock.ToBedrockTitanEmbeddingRequest(request) },
+			provider.GetProviderKey())
+		if bifrostErr != nil {
+			return nil, bifrostErr
 		}
 		path := provider.getModelPath("invoke", request.Model, key)
-		rawResponse, latency, bifrostError = provider.completeRequest(ctx, titanReq, path, key)
+		rawResponse, latency, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
 
 	case "cohere":
-		cohereReq, err := bedrock.ToBedrockCohereEmbeddingRequest(request)
-		if err != nil {
-			return nil, newBifrostOperationError("failed to convert Cohere request", err, providerName)
+		jsonData, bifrostErr := checkContextAndGetRequestBody(
+			ctx,
+			request,
+			func() (any, error) { return bedrock.ToBedrockCohereEmbeddingRequest(request) },
+			provider.GetProviderKey())
+		if bifrostErr != nil {
+			return nil, bifrostErr
 		}
 		path := provider.getModelPath("invoke", request.Model, key)
-		rawResponse, latency, bifrostError = provider.completeRequest(ctx, cohereReq, path, key)
+		rawResponse, latency, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
 
 	default:
 		return nil, newConfigurationError("unsupported embedding model type", providerName)
@@ -1044,7 +1045,7 @@ func (provider *BedrockProvider) Embedding(ctx context.Context, key schemas.Key,
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		var rawResponseData interface{}
 		if err := sonic.Unmarshal(rawResponse, &rawResponseData); err == nil {
 			bifrostResponse.ExtraFields.RawResponse = rawResponseData
@@ -1056,22 +1057,22 @@ func (provider *BedrockProvider) Embedding(ctx context.Context, key schemas.Key,
 
 // Speech is not supported by the Bedrock provider.
 func (provider *BedrockProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "bedrock")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, schemas.Bedrock)
 }
 
 // SpeechStream is not supported by the Bedrock provider.
 func (provider *BedrockProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "bedrock")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, schemas.Bedrock)
 }
 
 // Transcription is not supported by the Bedrock provider.
 func (provider *BedrockProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "bedrock")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, schemas.Bedrock)
 }
 
 // TranscriptionStream is not supported by the Bedrock provider.
 func (provider *BedrockProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "bedrock")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, schemas.Bedrock)
 }
 
 func (provider *BedrockProvider) getModelPath(basePath string, model string, key schemas.Key) string {

--- a/core/providers/bedrock.go
+++ b/core/providers/bedrock.go
@@ -129,7 +129,7 @@ func (provider *BedrockProvider) completeRequest(ctx context.Context, requestBod
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value != "" {
@@ -237,7 +237,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, reque
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value != "" {
@@ -395,7 +395,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx context.Context, key schema
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value != "" {

--- a/core/providers/cerebras.go
+++ b/core/providers/cerebras.go
@@ -63,7 +63,17 @@ func (provider *CerebrasProvider) GetProviderKey() schemas.ModelProvider {
 
 // ListModels performs a list models request to Cerebras's API.
 func (provider *CerebrasProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", keys, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(
+		ctx,
+		provider.client,
+		request,
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
+		keys,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.logger,
+	)
 }
 
 // TextCompletion performs a text completion request to Cerebras's API.
@@ -73,12 +83,12 @@ func (provider *CerebrasProvider) TextCompletion(ctx context.Context, key schema
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -87,14 +97,19 @@ func (provider *CerebrasProvider) TextCompletion(ctx context.Context, key schema
 // It formats the request, sends it to Cerebras, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *CerebrasProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
+	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
 		provider.logger,
@@ -106,11 +121,11 @@ func (provider *CerebrasProvider) ChatCompletion(ctx context.Context, key schema
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -121,15 +136,19 @@ func (provider *CerebrasProvider) ChatCompletion(ctx context.Context, key schema
 // Uses Cerebras's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *CerebrasProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Cerebras,
 		postHookRunner,
 		provider.logger,
@@ -162,25 +181,25 @@ func (provider *CerebrasProvider) ResponsesStream(ctx context.Context, postHookR
 
 // Embedding is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "cerebras")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -122,13 +122,7 @@ func (provider *CohereProvider) GetProviderKey() schemas.ModelProvider {
 // completeRequest sends a request to Cohere's API and handles the response.
 // It constructs the API URL, sets up authentication, and processes the response.
 // Returns the response body or an error if the request fails.
-func (provider *CohereProvider) completeRequest(ctx context.Context, requestBody interface{}, url string, key string) ([]byte, time.Duration, *schemas.BifrostError) {
-	// Marshal the request body
-	jsonData, err := sonic.Marshal(requestBody)
-	if err != nil {
-		return nil, 0, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, provider.GetProviderKey())
-	}
-
+func (provider *CohereProvider) completeRequest(ctx context.Context, jsonData []byte, url string, key string) ([]byte, time.Duration, *schemas.BifrostError) {
 	// Create the request with the JSON body
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -141,7 +135,9 @@ func (provider *CohereProvider) completeRequest(ctx context.Context, requestBody
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key)
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
 
 	req.SetBody(jsonData)
 
@@ -170,9 +166,14 @@ func (provider *CohereProvider) completeRequest(ctx context.Context, requestBody
 		return nil, latency, bifrostErr
 	}
 
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, latency, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, provider.GetProviderKey())
+	}
+
 	// Read the response body and copy it before releasing the response
 	// to avoid use-after-free since resp.Body() references fasthttp's internal buffer
-	bodyCopy := append([]byte(nil), resp.Body()...)
+	bodyCopy := append([]byte(nil), body...)
 
 	return bodyCopy, latency, nil
 }
@@ -207,7 +208,9 @@ func (provider *CohereProvider) listModelsByKey(ctx context.Context, key schemas
 	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, fmt.Sprintf("/v1/models?%s", params.Encode())))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
@@ -223,12 +226,14 @@ func (provider *CohereProvider) listModelsByKey(ctx context.Context, key schemas
 		return nil, bifrostErr
 	}
 
-	// Copy response body before releasing
-	responseBody := append([]byte(nil), resp.Body()...)
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
 	// Parse Cohere list models response
 	var cohereResponse cohere.CohereListModelsResponse
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, &cohereResponse, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, &cohereResponse, shouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -238,7 +243,7 @@ func (provider *CohereProvider) listModelsByKey(ctx context.Context, key schemas
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -263,14 +268,14 @@ func (provider *CohereProvider) ListModels(ctx context.Context, keys []schemas.K
 // TextCompletion is not supported by the Cohere provider.
 // Returns an error indicating that text completion is not supported.
 func (provider *CohereProvider) TextCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion", "cohere")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
 }
 
 // TextCompletionStream performs a streaming text completion request to Cohere's API.
 // It formats the request, sends it to Cohere, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *CohereProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "cohere")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
 }
 
 // ChatCompletion performs a chat completion request to the Cohere API using v2 converter.
@@ -282,15 +287,17 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.
 		return nil, err
 	}
 
-	providerName := provider.GetProviderKey()
-
 	// Convert to Cohere v2 request
-	reqBody := cohere.ToCohereChatCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, providerName)
+	jsonData, err := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return cohere.ToCohereChatCompletionRequest(request), nil },
+		provider.GetProviderKey())
+	if err != nil {
+		return nil, err
 	}
 
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, provider.networkConfig.BaseURL+"/v2/chat", key.Value)
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), key.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +306,7 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.
 	response := acquireCohereResponse()
 	defer releaseCohereResponse(response)
 
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, shouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -313,7 +320,7 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -330,20 +337,22 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	}
 
 	providerName := provider.GetProviderKey()
-	// Convert to Cohere v2 request and add streaming
-	reqBody := cohere.ToCohereChatCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) {
+			reqBody := cohere.ToCohereChatCompletionRequest(request)
+			if reqBody != nil {
+				reqBody.Stream = schemas.Ptr(true)
+			}
+			return reqBody, nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
-	reqBody.Stream = schemas.Ptr(true)
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -358,12 +367,14 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
@@ -389,7 +400,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderRequest,
+				Message: schemas.ErrProviderDoRequest,
 				Error:   err,
 			},
 		}
@@ -463,7 +474,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 					lastChunkTime = time.Now()
 					chunkIndex++
 
-					if provider.sendBackRawResponse {
+					if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 						response.ExtraFields.RawResponse = jsonData
 					}
 
@@ -501,15 +512,17 @@ func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, 
 		return nil, err
 	}
 
-	providerName := provider.GetProviderKey()
-
-	// Convert to Cohere v2 request
-	reqBody := cohere.ToCohereResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return cohere.ToCohereResponsesRequest(request), nil },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, provider.networkConfig.BaseURL+"/v2/chat", key.Value)
+	// Convert to Cohere v2 request
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), key.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -518,7 +531,7 @@ func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, 
 	response := acquireCohereResponse()
 	defer releaseCohereResponse(response)
 
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, shouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -532,7 +545,7 @@ func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, 
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -548,19 +561,23 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 
 	providerName := provider.GetProviderKey()
 	// Convert to Cohere v2 request and add streaming
-	reqBody := cohere.ToCohereResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
-	}
-	reqBody.Stream = schemas.Ptr(true)
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) {
+			reqBody := cohere.ToCohereResponsesRequest(request)
+			if reqBody != nil {
+				reqBody.Stream = schemas.Ptr(true)
+			}
+			return reqBody, nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -575,12 +592,14 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 
@@ -606,7 +625,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderRequest,
+				Message: schemas.ErrProviderDoRequest,
 				Error:   err,
 			},
 		}
@@ -688,7 +707,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 				lastChunkTime = time.Now()
 				chunkIndex++
 
-				if provider.sendBackRawResponse {
+				if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 					response.ExtraFields.RawResponse = eventData
 				}
 
@@ -731,15 +750,17 @@ func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, 
 		return nil, err
 	}
 
-	providerName := provider.GetProviderKey()
-
-	// Create Bifrost request for conversion
-	reqBody := cohere.ToCohereEmbeddingRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("embedding input is not provided", nil, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return cohere.ToCohereEmbeddingRequest(request), nil },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
-	responseBody, latency, err := provider.completeRequest(ctx, reqBody, provider.networkConfig.BaseURL+"/v2/embed", key.Value)
+	// Create Bifrost request for conversion
+	responseBody, latency, err := provider.completeRequest(ctx, jsonData, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/embed"), key.Value)
 	if err != nil {
 		return nil, err
 	}
@@ -748,7 +769,7 @@ func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, 
 	response := acquireCohereEmbeddingResponse()
 	defer releaseCohereEmbeddingResponse(response)
 
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, shouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -762,7 +783,7 @@ func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, 
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		bifrostResponse.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -771,20 +792,20 @@ func (provider *CohereProvider) Embedding(ctx context.Context, key schemas.Key, 
 
 // Speech is not supported by the Cohere provider.
 func (provider *CohereProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "cohere")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Cohere provider.
 func (provider *CohereProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "cohere")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Cohere provider.
 func (provider *CohereProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "cohere")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Cohere provider.
 func (provider *CohereProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "cohere")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/cohere.go
+++ b/core/providers/cohere.go
@@ -136,7 +136,7 @@ func (provider *CohereProvider) completeRequest(ctx context.Context, requestBody
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -189,7 +189,7 @@ func (provider *CohereProvider) listModelsByKey(ctx context.Context, key schemas
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Build query parameters
 	params := url.Values{}
@@ -204,7 +204,7 @@ func (provider *CohereProvider) listModelsByKey(ctx context.Context, key schemas
 	}
 
 	// Build URL
-	req.SetRequestURI(fmt.Sprintf("%s/v1/models?%s", provider.networkConfig.BaseURL, params.Encode()))
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, fmt.Sprintf("/v1/models?%s", params.Encode())))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -343,7 +343,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v2/chat", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonBody))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -368,7 +368,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 	req.Header.Set("Cache-Control", "no-cache")
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Make the request
 	resp, err := provider.streamClient.Do(req)
@@ -560,7 +560,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v2/chat", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v2/chat"), bytes.NewReader(jsonBody))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -585,7 +585,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 	req.Header.Set("Cache-Control", "no-cache")
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Make the request
 	resp, err := provider.streamClient.Do(req)

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -72,7 +72,7 @@ func (provider *GroqProvider) ListModels(ctx context.Context, keys []schemas.Key
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+"/v1/models",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Groq,
@@ -161,7 +161,7 @@ func (provider *GroqProvider) ChatCompletion(ctx context.Context, key schemas.Ke
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -180,7 +180,7 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -81,10 +81,12 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 	// Set any extra headers from network config
 	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/models")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
@@ -103,7 +105,7 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 
 	// Parse Mistral's response
 	var mistralResponse mistral.MistralListModelsResponse
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, &mistralResponse, provider.sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(responseBody, &mistralResponse, shouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -114,7 +116,7 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 	response.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -135,14 +137,14 @@ func (provider *MistralProvider) ListModels(ctx context.Context, keys []schemas.
 
 // TextCompletion is not supported by the Mistral provider.
 func (provider *MistralProvider) TextCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
 }
 
 // TextCompletionStream performs a streaming text completion request to Mistral's API.
 // It formats the request, sends it to Mistral, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *MistralProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
 }
 
 // ChatCompletion performs a chat completion request to the Mistral API.
@@ -154,7 +156,7 @@ func (provider *MistralProvider) ChatCompletion(ctx context.Context, key schemas
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -165,15 +167,19 @@ func (provider *MistralProvider) ChatCompletion(ctx context.Context, key schemas
 // Uses Mistral's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Mistral,
 		postHookRunner,
 		provider.logger,
@@ -217,27 +223,27 @@ func (provider *MistralProvider) Embedding(ctx context.Context, key schemas.Key,
 		key,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Mistral,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
 
 // Speech is not supported by the Mistral provider.
 func (provider *MistralProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "mistral")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Mistral provider.
 func (provider *MistralProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "mistral")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Mistral provider.
 func (provider *MistralProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Mistral provider.
 func (provider *MistralProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "mistral")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/mistral.go
+++ b/core/providers/mistral.go
@@ -79,7 +79,7 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/models")
 	req.Header.SetMethod(http.MethodGet)
@@ -150,7 +150,7 @@ func (provider *MistralProvider) ChatCompletion(ctx context.Context, key schemas
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -169,7 +169,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postH
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -212,7 +212,7 @@ func (provider *MistralProvider) Embedding(ctx context.Context, key schemas.Key,
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -73,7 +73,17 @@ func (provider *OllamaProvider) ListModels(ctx context.Context, keys []schemas.K
 	if provider.networkConfig.BaseURL == "" {
 		return nil, newConfigurationError("base_url is not set", provider.GetProviderKey())
 	}
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", keys, provider.networkConfig.ExtraHeaders, provider.GetProviderKey(), provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(
+		ctx,
+		provider.client,
+		request,
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
+		keys,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		provider.sendBackRawResponse,
+		provider.logger,
+	)
 }
 
 // TextCompletion performs a text completion request to the Ollama API.
@@ -81,7 +91,7 @@ func (provider *OllamaProvider) TextCompletion(ctx context.Context, key schemas.
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -98,7 +108,7 @@ func (provider *OllamaProvider) TextCompletionStream(ctx context.Context, postHo
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -114,7 +124,7 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, key schemas.
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -133,7 +143,7 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -174,7 +184,7 @@ func (provider *OllamaProvider) Embedding(ctx context.Context, key schemas.Key, 
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -81,7 +81,7 @@ func (provider *OllamaProvider) ListModels(ctx context.Context, keys []schemas.K
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -96,7 +96,7 @@ func (provider *OllamaProvider) TextCompletion(ctx context.Context, key schemas.
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -112,7 +112,7 @@ func (provider *OllamaProvider) TextCompletionStream(ctx context.Context, postHo
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
 		provider.logger,
@@ -128,7 +128,7 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, key schemas.
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -147,7 +147,7 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Ollama,
 		postHookRunner,
 		provider.logger,
@@ -189,27 +189,27 @@ func (provider *OllamaProvider) Embedding(ctx context.Context, key schemas.Key, 
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
 
 // Speech is not supported by the Ollama provider.
 func (provider *OllamaProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "ollama")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Ollama provider.
 func (provider *OllamaProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "ollama")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Ollama provider.
 func (provider *OllamaProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "ollama")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Ollama provider.
 func (provider *OllamaProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "ollama")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -84,7 +84,16 @@ func (provider *OpenAIProvider) ListModels(ctx context.Context, keys []schemas.K
 
 	providerName := provider.GetProviderKey()
 
-	return handleOpenAIListModelsRequest(ctx, provider.client, request, provider.networkConfig.BaseURL+"/v1/models", keys, provider.networkConfig.ExtraHeaders, providerName, provider.sendBackRawResponse, provider.logger)
+	return handleOpenAIListModelsRequest(ctx,
+		provider.client,
+		request,
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
+		keys,
+		provider.networkConfig.ExtraHeaders,
+		providerName,
+		provider.sendBackRawResponse,
+		provider.logger,
+	)
 }
 
 // listModelsByKeyOpenAI performs a list models request for a single key.
@@ -105,7 +114,7 @@ func listModelsByKeyOpenAI(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodGet)
@@ -180,7 +189,7 @@ func (provider *OpenAIProvider) TextCompletion(ctx context.Context, key schemas.
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -217,7 +226,7 @@ func handleOpenAITextCompletionRequest(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -272,7 +281,7 @@ func (provider *OpenAIProvider) TextCompletionStream(ctx context.Context, postHo
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -343,7 +352,7 @@ func handleOpenAITextCompletionStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -525,7 +534,7 @@ func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, key schemas.
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -564,7 +573,7 @@ func handleOpenAIChatCompletionRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -627,7 +636,7 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx context.Context, postHo
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -698,7 +707,7 @@ func handleOpenAIChatCompletionStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -882,7 +891,7 @@ func (provider *OpenAIProvider) Responses(ctx context.Context, key schemas.Key, 
 	return handleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/responses"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -921,7 +930,7 @@ func handleOpenAIResponsesRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -982,7 +991,7 @@ func (provider *OpenAIProvider) ResponsesStream(ctx context.Context, postHookRun
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/responses"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -1055,7 +1064,7 @@ func handleOpenAIResponsesStreaming(
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, extraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, extraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -1208,7 +1217,7 @@ func (provider *OpenAIProvider) Embedding(ctx context.Context, key schemas.Key, 
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -1249,7 +1258,7 @@ func handleOpenAIEmbeddingRequest(
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, extraHeaders, nil)
+	setExtraHeaders(ctx, req, extraHeaders, nil)
 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
@@ -1324,9 +1333,9 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/audio/speech")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/audio/speech"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -1395,7 +1404,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v1/audio/speech", bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/audio/speech"), bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -1414,7 +1423,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {
@@ -1575,9 +1584,9 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/audio/transcriptions")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/audio/transcriptions"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(writer.FormDataContentType()) // This sets multipart/form-data with boundary
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -1658,7 +1667,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+"/v1/audio/transcriptions", &body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/audio/transcriptions"), &body)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -1677,7 +1686,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set headers
 	for key, value := range headers {

--- a/core/providers/openai.go
+++ b/core/providers/openai.go
@@ -91,7 +91,7 @@ func (provider *OpenAIProvider) ListModels(ctx context.Context, keys []schemas.K
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		providerName,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -194,7 +194,7 @@ func (provider *OpenAIProvider) TextCompletion(ctx context.Context, key schemas.
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -210,20 +210,11 @@ func handleOpenAITextCompletionRequest(
 	sendBackRawResponse bool,
 	logger schemas.Logger,
 ) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	reqBody := openai.ToOpenAITextCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("text completion input is not provided", nil, providerName)
-	}
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
 
 	// Set any extra headers from network config
 	setExtraHeaders(ctx, req, extraHeaders, nil)
@@ -236,7 +227,16 @@ func handleOpenAITextCompletionRequest(
 		req.Header.Set("Authorization", "Bearer "+key.Value)
 	}
 
-	req.SetBody(jsonBody)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return openai.ToOpenAITextCompletionRequest(request), nil },
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	req.SetBody(jsonData)
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
@@ -249,11 +249,14 @@ func handleOpenAITextCompletionRequest(
 		return nil, parseOpenAIError(resp, schemas.TextCompletionRequest, providerName, request.Model)
 	}
 
-	responseBody := resp.Body()
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
 	response := &schemas.BifrostTextCompletionResponse{}
 
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, response, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -278,14 +281,18 @@ func (provider *OpenAIProvider) TextCompletionStream(ctx context.Context, postHo
 	if err := checkOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.TextCompletionStreamRequest); err != nil {
 		return nil, err
 	}
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
 		provider.logger,
@@ -306,16 +313,6 @@ func handleOpenAITextCompletionStreaming(
 	postHookRunner schemas.PostHookRunner,
 	logger schemas.Logger,
 ) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	reqBody := openai.ToOpenAITextCompletionRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("text completion input is not provided", nil, providerName)
-	}
-	reqBody.Stream = schemas.Ptr(true)
-	reqBody.StreamOptions = &schemas.ChatStreamOptions{
-		IncludeUsage: schemas.Ptr(true),
-	}
-
-	// Prepare SGL headers (SGL typically doesn't require authorization, but we include it if provided)
 	headers := map[string]string{
 		"Content-Type":  "application/json",
 		"Accept":        "text/event-stream",
@@ -327,13 +324,26 @@ func handleOpenAITextCompletionStreaming(
 		maps.Copy(headers, authHeader)
 	}
 
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) {
+			reqBody := openai.ToOpenAITextCompletionRequest(request)
+			if reqBody != nil {
+				reqBody.Stream = schemas.Ptr(true)
+				reqBody.StreamOptions = &schemas.ChatStreamOptions{
+					IncludeUsage: schemas.Ptr(true),
+				}
+			}
+			return reqBody, nil
+		},
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -348,7 +358,7 @@ func handleOpenAITextCompletionStreaming(
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set any extra headers from network config
@@ -375,7 +385,7 @@ func handleOpenAITextCompletionStreaming(
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
 	}
 
 	// Check for HTTP errors
@@ -538,7 +548,7 @@ func (provider *OpenAIProvider) ChatCompletion(ctx context.Context, key schemas.
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -555,17 +565,6 @@ func handleOpenAIChatCompletionRequest(
 	providerName schemas.ModelProvider,
 	logger schemas.Logger,
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	// Use centralized converter
-	reqBody := openai.ToOpenAIChatRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, providerName)
-	}
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -583,7 +582,16 @@ func handleOpenAIChatCompletionRequest(
 		req.Header.Set("Authorization", "Bearer "+key.Value)
 	}
 
-	req.SetBody(jsonBody)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return openai.ToOpenAIChatRequest(request), nil },
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	req.SetBody(jsonData)
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
@@ -593,19 +601,17 @@ func handleOpenAIChatCompletionRequest(
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
 		return nil, parseOpenAIError(resp, schemas.ChatCompletionRequest, providerName, request.Model)
 	}
 
-	responseBody := resp.Body()
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
-	// Pre-allocate response structs from pools
-	// response := acquireOpenAIResponse()
-	// defer releaseOpenAIResponse(response)
 	response := &schemas.BifrostChatResponse{}
 
-	// Use enhanced response handler with pre-allocated response
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, response, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -631,16 +637,19 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx context.Context, postHo
 	if err := checkOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
 		return nil, err
 	}
-
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
 		provider.logger,
@@ -661,16 +670,6 @@ func handleOpenAIChatCompletionStreaming(
 	postHookRunner schemas.PostHookRunner,
 	logger schemas.Logger,
 ) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	reqBody := openai.ToOpenAIChatRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("chat completion input is not provided", nil, providerName)
-	}
-	reqBody.Stream = schemas.Ptr(true)
-	reqBody.StreamOptions = &schemas.ChatStreamOptions{
-		IncludeUsage: schemas.Ptr(true),
-	}
-
-	// Prepare SGL headers (SGL typically doesn't require authorization, but we include it if provided)
 	headers := map[string]string{
 		"Content-Type":  "application/json",
 		"Accept":        "text/event-stream",
@@ -682,13 +681,26 @@ func handleOpenAIChatCompletionStreaming(
 		maps.Copy(headers, authHeader)
 	}
 
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) {
+			reqBody := openai.ToOpenAIChatRequest(request)
+			if reqBody != nil {
+				reqBody.Stream = schemas.Ptr(true)
+				reqBody.StreamOptions = &schemas.ChatStreamOptions{
+					IncludeUsage: schemas.Ptr(true),
+				}
+			}
+			return reqBody, nil
+		},
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -703,7 +715,7 @@ func handleOpenAIChatCompletionStreaming(
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set any extra headers from network config
@@ -730,7 +742,7 @@ func handleOpenAIChatCompletionStreaming(
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
 	}
 
 	// Check for HTTP errors
@@ -895,7 +907,7 @@ func (provider *OpenAIProvider) Responses(ctx context.Context, key schemas.Key, 
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -912,17 +924,6 @@ func handleOpenAIResponsesRequest(
 	providerName schemas.ModelProvider,
 	logger schemas.Logger,
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	// Use centralized converter
-	reqBody := openai.ToOpenAIResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
-	}
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -940,7 +941,17 @@ func handleOpenAIResponsesRequest(
 		req.Header.Set("Authorization", "Bearer "+key.Value)
 	}
 
-	req.SetBody(jsonBody)
+	// Use centralized converter
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return openai.ToOpenAIResponsesRequest(request), nil },
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	req.SetBody(jsonData)
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
@@ -950,19 +961,17 @@ func handleOpenAIResponsesRequest(
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
 		return nil, parseOpenAIError(resp, schemas.ResponsesRequest, providerName, request.Model)
 	}
 
-	responseBody := resp.Body()
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
-	// Pre-allocate response structs from pools
-	// response := acquireOpenAIResponse()
-	// defer releaseOpenAIResponse(response)
 	response := &schemas.BifrostResponsesResponse{}
 
-	// Use enhanced response handler with pre-allocated response
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, response, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -986,16 +995,19 @@ func (provider *OpenAIProvider) ResponsesStream(ctx context.Context, postHookRun
 	if err := checkOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
 	}
-
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared streaming logic
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/responses"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
 		nil,
@@ -1018,15 +1030,6 @@ func handleOpenAIResponsesStreaming(
 	postRequestConverter func(*openai.OpenAIResponsesRequest) *openai.OpenAIResponsesRequest,
 	logger schemas.Logger,
 ) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	reqBody := openai.ToOpenAIResponsesRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("responses input is not provided", nil, providerName)
-	}
-	if postRequestConverter != nil {
-		reqBody = postRequestConverter(reqBody)
-	}
-	reqBody.Stream = schemas.Ptr(true)
-
 	// Prepare SGL headers (SGL typically doesn't require authorization, but we include it if provided)
 	headers := map[string]string{
 		"Content-Type":  "application/json",
@@ -1039,13 +1042,26 @@ func handleOpenAIResponsesStreaming(
 		maps.Copy(headers, authHeader)
 	}
 
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) {
+			reqBody := openai.ToOpenAIResponsesRequest(request)
+			if reqBody != nil {
+				if postRequestConverter != nil {
+					reqBody = postRequestConverter(reqBody)
+				}
+				reqBody.Stream = schemas.Ptr(true)
+			}
+			return reqBody, nil
+		},
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create HTTP request for streaming
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(jsonData))
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
@@ -1060,7 +1076,7 @@ func handleOpenAIResponsesStreaming(
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set any extra headers from network config
@@ -1087,7 +1103,7 @@ func handleOpenAIResponsesStreaming(
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
 	}
 
 	// Check for HTTP errors
@@ -1222,7 +1238,7 @@ func (provider *OpenAIProvider) Embedding(ctx context.Context, key schemas.Key, 
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -1240,17 +1256,6 @@ func handleOpenAIEmbeddingRequest(
 	sendBackRawResponse bool,
 	logger schemas.Logger,
 ) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	// Use centralized converter
-	reqBody := openai.ToOpenAIEmbeddingRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("embedding input is not provided", nil, providerName)
-	}
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -1268,7 +1273,17 @@ func handleOpenAIEmbeddingRequest(
 		req.Header.Set("Authorization", "Bearer "+key.Value)
 	}
 
-	req.SetBody(jsonBody)
+	// Use centralized converter
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return openai.ToOpenAIEmbeddingRequest(request), nil },
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	req.SetBody(jsonData)
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, client, req, resp)
@@ -1278,17 +1293,17 @@ func handleOpenAIEmbeddingRequest(
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
 		return nil, parseOpenAIError(resp, schemas.EmbeddingRequest, providerName, request.Model)
 	}
 
-	responseBody := resp.Body()
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
-	// Pre-allocate response structs
 	response := &schemas.BifrostEmbeddingResponse{}
 
-	// Use enhanced response handler with pre-allocated response
-	rawResponse, bifrostErr := handleProviderResponse(responseBody, response, sendBackRawResponse)
+	rawResponse, bifrostErr := handleProviderResponse(body, response, sendBackRawResponse)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -1315,17 +1330,6 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 
 	providerName := provider.GetProviderKey()
 
-	// Use centralized converter
-	reqBody := openai.ToOpenAISpeechRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("speech input is not provided", nil, providerName)
-	}
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -1338,9 +1342,20 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/audio/speech"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 
-	req.SetBody(jsonBody)
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return openai.ToOpenAISpeechRequest(request), nil },
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	req.SetBody(jsonData)
 
 	// Make request
 	latency, bifrostErr := makeRequestWithContext(ctx, provider.client, req, resp)
@@ -1350,18 +1365,20 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
 		return nil, parseOpenAIError(resp, schemas.SpeechRequest, providerName, request.Model)
 	}
 
 	// Get the binary audio data from the response body
-	audioData := resp.Body()
+	body, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
 	// Create final response with the audio data
 	// Note: For speech synthesis, we return the binary audio data in the raw response
 	// The audio data is typically in MP3, WAV, or other audio formats as specified by response_format
 	bifrostResponse := &schemas.BifrostSpeechResponse{
-		Audio: audioData,
+		Audio: body,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType:    schemas.SpeechRequest,
 			Provider:       providerName,
@@ -1383,24 +1400,31 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 
 	providerName := provider.GetProviderKey()
 
-	// Use centralized converter
-	reqBody := openai.ToOpenAISpeechRequest(request)
-	if reqBody == nil {
-		return nil, newBifrostOperationError("speech input is not provided", nil, providerName)
-	}
-	reqBody.StreamFormat = schemas.Ptr("sse")
-
-	jsonBody, err := sonic.Marshal(reqBody)
-	if err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderJSONMarshaling, err, providerName)
-	}
-
 	// Prepare OpenAI headers
 	headers := map[string]string{
 		"Content-Type":  "application/json",
-		"Authorization": "Bearer " + key.Value,
 		"Accept":        "text/event-stream",
 		"Cache-Control": "no-cache",
+	}
+
+	if key.Value != "" {
+		headers["Authorization"] = "Bearer " + key.Value
+	}
+
+	// Use centralized converter
+	jsonData, bifrostErr := checkContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) {
+			reqBody := openai.ToOpenAISpeechRequest(request)
+			if reqBody != nil {
+				reqBody.StreamFormat = schemas.Ptr("sse")
+			}
+			return reqBody, nil
+		},
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
 
 	// Create HTTP request for streaming
@@ -1419,7 +1443,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set any extra headers from network config
@@ -1446,7 +1470,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
 	}
 
 	// Check for HTTP errors
@@ -1529,7 +1553,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 			}
 			lastChunkTime = time.Now()
 
-			if provider.sendBackRawResponse {
+			if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 				response.ExtraFields.RawResponse = jsonData
 			}
 
@@ -1564,6 +1588,7 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 	providerName := provider.GetProviderKey()
 
 	// Use centralized converter
+	// NOTE: Raw body is not supported for transcription requests because it uses multipart/form-data
 	reqBody := openai.ToOpenAITranscriptionRequest(request)
 	if reqBody == nil {
 		return nil, newBifrostOperationError("transcription input is not provided", nil, providerName)
@@ -1572,9 +1597,8 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 	// Create multipart form
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-
-	if bifrostErr := parseTranscriptionFormDataBodyFromRequest(writer, reqBody, providerName); bifrostErr != nil {
-		return nil, bifrostErr
+	if err := parseTranscriptionFormDataBodyFromRequest(writer, reqBody, providerName); err != nil {
+		return nil, err
 	}
 
 	// Create request
@@ -1589,7 +1613,9 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/audio/transcriptions"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(writer.FormDataContentType()) // This sets multipart/form-data with boundary
-	req.Header.Set("Authorization", "Bearer "+key.Value)
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
 
 	req.SetBody(body.Bytes())
 
@@ -1605,7 +1631,10 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 		return nil, parseOpenAIError(resp, schemas.TranscriptionRequest, providerName, request.Model)
 	}
 
-	responseBody := resp.Body()
+	responseBody, err := checkAndDecodeBody(resp)
+	if err != nil {
+		return nil, newBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
 
 	// Parse OpenAI's transcription response directly into BifrostTranscribe
 	response := &schemas.BifrostTranscriptionResponse{}
@@ -1616,8 +1645,10 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 
 	// Parse raw response for RawResponse field
 	var rawResponse interface{}
-	if err := sonic.Unmarshal(responseBody, &rawResponse); err != nil {
-		return nil, newBifrostOperationError(schemas.ErrProviderDecodeRaw, err, providerName)
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		if err := sonic.Unmarshal(responseBody, &rawResponse); err != nil {
+			return nil, newBifrostOperationError(schemas.ErrProviderRawResponseUnmarshal, err, providerName)
+		}
 	}
 
 	response.ExtraFields = schemas.BifrostResponseExtraFields{
@@ -1627,7 +1658,7 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 		Latency:        latency.Milliseconds(),
 	}
 
-	if provider.sendBackRawResponse {
+	if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		response.ExtraFields.RawResponse = rawResponse
 	}
 
@@ -1661,9 +1692,12 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	// Prepare OpenAI headers
 	headers := map[string]string{
 		"Content-Type":  writer.FormDataContentType(),
-		"Authorization": "Bearer " + key.Value,
 		"Accept":        "text/event-stream",
 		"Cache-Control": "no-cache",
+	}
+
+	if key.Value != "" {
+		headers["Authorization"] = "Bearer " + key.Value
 	}
 
 	// Create HTTP request for streaming
@@ -1682,7 +1716,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderCreateRequest, err, providerName)
 	}
 
 	// Set any extra headers from network config
@@ -1709,7 +1743,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 		if errors.Is(err, http.ErrHandlerTimeout) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, newBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, providerName)
 		}
-		return nil, newBifrostOperationError(schemas.ErrProviderRequest, err, providerName)
+		return nil, newBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
 	}
 
 	// Check for HTTP errors
@@ -1790,7 +1824,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 			}
 			lastChunkTime = time.Now()
 
-			if provider.sendBackRawResponse {
+			if shouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 				response.ExtraFields.RawResponse = jsonData
 			}
 

--- a/core/providers/openrouter.go
+++ b/core/providers/openrouter.go
@@ -73,9 +73,9 @@ func (provider *OpenRouterProvider) listModelsByKey(ctx context.Context, key sch
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Set any extra headers from network config
-	setExtraHeaders(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/models")
+	req.SetRequestURI(provider.networkConfig.BaseURL + getPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", "Bearer "+key.Value)
@@ -132,7 +132,7 @@ func (provider *OpenRouterProvider) TextCompletion(ctx context.Context, key sche
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -149,7 +149,7 @@ func (provider *OpenRouterProvider) TextCompletionStream(ctx context.Context, po
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -165,7 +165,7 @@ func (provider *OpenRouterProvider) ChatCompletion(ctx context.Context, key sche
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -184,7 +184,7 @@ func (provider *OpenRouterProvider) ChatCompletionStream(ctx context.Context, po
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,
@@ -200,7 +200,7 @@ func (provider *OpenRouterProvider) Responses(ctx context.Context, key schemas.K
 	return handleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/alpha/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/alpha/responses"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -215,7 +215,7 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx context.Context, postHoo
 	return handleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/alpha/responses",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/alpha/responses"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -72,7 +72,7 @@ func (provider *ParasailProvider) ListModels(ctx context.Context, keys []schemas
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+"/v1/models",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
@@ -98,7 +98,7 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schema
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -117,7 +117,7 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, post
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		map[string]string{"Authorization": "Bearer " + key.Value},
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -76,21 +76,21 @@ func (provider *ParasailProvider) ListModels(ctx context.Context, keys []schemas
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
 
 // TextCompletion is not supported by the Parasail provider.
 func (provider *ParasailProvider) TextCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
 }
 
 // TextCompletionStream performs a streaming text completion request to Parasail's API.
 // It formats the request, sends it to Parasail, and processes the response.
 // Returns a channel of BifrostStream objects or an error if the request fails.
 func (provider *ParasailProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("text completion stream", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
 }
 
 // ChatCompletion performs a chat completion request to the Parasail API.
@@ -102,7 +102,7 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schema
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -113,15 +113,19 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schema
 // Uses Parasail's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
 		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		map[string]string{"Authorization": "Bearer " + key.Value},
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Parasail,
 		postHookRunner,
 		provider.logger,
@@ -155,25 +159,25 @@ func (provider *ParasailProvider) ResponsesStream(ctx context.Context, postHookR
 
 // Embedding is not supported by the Parasail provider.
 func (provider *ParasailProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("embedding", "parasail")
+	return nil, newUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
 // Speech is not supported by the Parasail provider.
 func (provider *ParasailProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "parasail")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the Parasail provider.
 func (provider *ParasailProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "parasail")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the Parasail provider.
 func (provider *ParasailProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the Parasail provider.
 func (provider *ParasailProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "parasail")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -78,7 +78,7 @@ func (provider *SGLProvider) ListModels(ctx context.Context, keys []schemas.Key,
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.SGL,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -93,7 +93,7 @@ func (provider *SGLProvider) TextCompletion(ctx context.Context, key schemas.Key
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
@@ -109,7 +109,7 @@ func (provider *SGLProvider) TextCompletionStream(ctx context.Context, postHookR
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
 		provider.logger,
@@ -125,7 +125,7 @@ func (provider *SGLProvider) ChatCompletion(ctx context.Context, key schemas.Key
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
 	)
@@ -144,7 +144,7 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.SGL,
 		postHookRunner,
 		provider.logger,
@@ -186,27 +186,27 @@ func (provider *SGLProvider) Embedding(ctx context.Context, key schemas.Key, req
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
-		provider.sendBackRawResponse,
+		shouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
 }
 
 // Speech is not supported by the SGL provider.
 func (provider *SGLProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech", "sgl")
+	return nil, newUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
 // SpeechStream is not supported by the SGL provider.
 func (provider *SGLProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("speech stream", "sgl")
+	return nil, newUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
 // Transcription is not supported by the SGL provider.
 func (provider *SGLProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription", "sgl")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
 }
 
 // TranscriptionStream is not supported by the SGL provider.
 func (provider *SGLProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	return nil, newUnsupportedOperationError("transcription stream", "sgl")
+	return nil, newUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -74,7 +74,7 @@ func (provider *SGLProvider) ListModels(ctx context.Context, keys []schemas.Key,
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+"/v1/models",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.SGL,
@@ -88,7 +88,7 @@ func (provider *SGLProvider) TextCompletion(ctx context.Context, key schemas.Key
 	return handleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -105,7 +105,7 @@ func (provider *SGLProvider) TextCompletionStream(ctx context.Context, postHookR
 	return handleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -121,7 +121,7 @@ func (provider *SGLProvider) ChatCompletion(ctx context.Context, key schemas.Key
 	return handleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -140,7 +140,7 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 	return handleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -181,7 +181,7 @@ func (provider *SGLProvider) Embedding(ctx context.Context, key schemas.Key, req
 	return handleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/embeddings",
+		provider.networkConfig.BaseURL+getPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/vertex.go
+++ b/core/providers/vertex.go
@@ -198,7 +198,7 @@ func (provider *VertexProvider) listModelsByKey(ctx context.Context, key schemas
 		}
 
 		// Set any extra headers from network config
-		setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+		setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 		req.Header.Set("Content-Type", "application/json")
 
 		// Make request and measure latency
@@ -401,7 +401,7 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, key schemas.
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.Set("Content-Type", "application/json")
 
@@ -708,7 +708,7 @@ func (provider *VertexProvider) handleVertexEmbedding(ctx context.Context, model
 	}
 
 	// Set any extra headers from network config
-	setExtraHeadersHTTP(req, provider.networkConfig.ExtraHeaders, nil)
+	setExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.Set("Content-Type", "application/json")
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -98,16 +98,17 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeyVirtualKey         BifrostContextKey = "x-bf-vk"                      // string
-	BifrostContextKeyRequestID          BifrostContextKey = "request-id"                   // string
-	BifrostContextKeyFallbackRequestID  BifrostContextKey = "fallback-request-id"          // string
-	BifrostContextKeyDirectKey          BifrostContextKey = "bifrost-direct-key"           // Key struct
-	BifrostContextKeySelectedKey        BifrostContextKey = "bifrost-key-selected"         // string (to store the selected key ID (set by bifrost))
-	BifrostContextKeyStreamEndIndicator BifrostContextKey = "bifrost-stream-end-indicator" // bool
-	BifrostContextKeySkipKeySelection   BifrostContextKey = "bifrost-skip-key-selection"   // bool (will pass an empty key to the provider)
-	BifrostContextKeyExtraHeaders       BifrostContextKey = "bifrost-extra-headers"        // map[string]string
-	BifrostContextKeyURLPath            BifrostContextKey = "bifrost-extra-url-path"       // string
-	BifrostContextKeyRequestBody        BifrostContextKey = "bifrost-request-body"         // []byte
+	BifrostContextKeyVirtualKey          BifrostContextKey = "x-bf-vk"                        // string
+	BifrostContextKeyRequestID           BifrostContextKey = "request-id"                     // string
+	BifrostContextKeyFallbackRequestID   BifrostContextKey = "fallback-request-id"            // string
+	BifrostContextKeyDirectKey           BifrostContextKey = "bifrost-direct-key"             // Key struct
+	BifrostContextKeySelectedKey         BifrostContextKey = "bifrost-key-selected"           // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeyStreamEndIndicator  BifrostContextKey = "bifrost-stream-end-indicator"   // bool
+	BifrostContextKeySkipKeySelection    BifrostContextKey = "bifrost-skip-key-selection"     // bool (will pass an empty key to the provider)
+	BifrostContextKeyExtraHeaders        BifrostContextKey = "bifrost-extra-headers"          // map[string]string
+	BifrostContextKeyURLPath             BifrostContextKey = "bifrost-extra-url-path"         // string
+	BifrostContextKeyUseRawRequestBody   BifrostContextKey = "bifrost-use-raw-request-body"   // bool
+	BifrostContextKeySendBackRawResponse BifrostContextKey = "bifrost-send-back-raw-response" // bool
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,
@@ -211,6 +212,23 @@ func (br *BifrostRequest) SetFallbacks(fallbacks []Fallback) {
 		br.SpeechRequest.Fallbacks = fallbacks
 	case br.TranscriptionRequest != nil:
 		br.TranscriptionRequest.Fallbacks = fallbacks
+	}
+}
+
+func (br *BifrostRequest) SetRawRequestBody(rawRequestBody []byte) {
+	switch {
+	case br.TextCompletionRequest != nil:
+		br.TextCompletionRequest.RawRequestBody = rawRequestBody
+	case br.ChatRequest != nil:
+		br.ChatRequest.RawRequestBody = rawRequestBody
+	case br.ResponsesRequest != nil:
+		br.ResponsesRequest.RawRequestBody = rawRequestBody
+	case br.EmbeddingRequest != nil:
+		br.EmbeddingRequest.RawRequestBody = rawRequestBody
+	case br.SpeechRequest != nil:
+		br.SpeechRequest.RawRequestBody = rawRequestBody
+	case br.TranscriptionRequest != nil:
+		br.TranscriptionRequest.RawRequestBody = rawRequestBody
 	}
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -98,12 +98,16 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeyVirtualKey         BifrostContextKey = "x-bf-vk"
-	BifrostContextKeyRequestID          BifrostContextKey = "request-id"
-	BifrostContextKeyFallbackRequestID  BifrostContextKey = "fallback-request-id"
-	BifrostContextKeyDirectKey          BifrostContextKey = "bifrost-direct-key"
-	BifrostContextKeySelectedKey        BifrostContextKey = "bifrost-key-selected" // To store the selected key ID (set by bifrost)
-	BifrostContextKeyStreamEndIndicator BifrostContextKey = "bifrost-stream-end-indicator"
+	BifrostContextKeyVirtualKey         BifrostContextKey = "x-bf-vk"                      // string
+	BifrostContextKeyRequestID          BifrostContextKey = "request-id"                   // string
+	BifrostContextKeyFallbackRequestID  BifrostContextKey = "fallback-request-id"          // string
+	BifrostContextKeyDirectKey          BifrostContextKey = "bifrost-direct-key"           // Key struct
+	BifrostContextKeySelectedKey        BifrostContextKey = "bifrost-key-selected"         // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeyStreamEndIndicator BifrostContextKey = "bifrost-stream-end-indicator" // bool
+	BifrostContextKeySkipKeySelection   BifrostContextKey = "bifrost-skip-key-selection"   // bool (will pass an empty key to the provider)
+	BifrostContextKeyExtraHeaders       BifrostContextKey = "bifrost-extra-headers"        // map[string]string
+	BifrostContextKeyURLPath            BifrostContextKey = "bifrost-extra-url-path"       // string
+	BifrostContextKeyRequestBody        BifrostContextKey = "bifrost-request-body"         // []byte
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -9,11 +9,16 @@ import (
 
 // BifrostChatRequest is the request struct for chat completion requests
 type BifrostChatRequest struct {
-	Provider  ModelProvider   `json:"provider"`
-	Model     string          `json:"model"`
-	Input     []ChatMessage   `json:"input,omitempty"`
-	Params    *ChatParameters `json:"params,omitempty"`
-	Fallbacks []Fallback      `json:"fallbacks,omitempty"`
+	Provider       ModelProvider   `json:"provider"`
+	Model          string          `json:"model"`
+	Input          []ChatMessage   `json:"input,omitempty"`
+	Params         *ChatParameters `json:"params,omitempty"`
+	Fallbacks      []Fallback      `json:"fallbacks,omitempty"`
+	RawRequestBody []byte          `json:"-"` // set bifrost-use-raw-request-body to true in ctx to use the raw request body. Bifrost will directly send this to the downstream provider.
+}
+
+func (r *BifrostChatRequest) GetRawRequestBody() []byte {
+	return r.RawRequestBody
 }
 
 // BifrostChatResponse represents the complete result from a chat completion request.

--- a/core/schemas/embedding.go
+++ b/core/schemas/embedding.go
@@ -7,11 +7,16 @@ import (
 )
 
 type BifrostEmbeddingRequest struct {
-	Provider  ModelProvider        `json:"provider"`
-	Model     string               `json:"model"`
-	Input     *EmbeddingInput      `json:"input,omitempty"`
-	Params    *EmbeddingParameters `json:"params,omitempty"`
-	Fallbacks []Fallback           `json:"fallbacks,omitempty"`
+	Provider       ModelProvider        `json:"provider"`
+	Model          string               `json:"model"`
+	Input          *EmbeddingInput      `json:"input,omitempty"`
+	Params         *EmbeddingParameters `json:"params,omitempty"`
+	Fallbacks      []Fallback           `json:"fallbacks,omitempty"`
+	RawRequestBody []byte               `json:"-"` // set bifrost-use-raw-request-body to true in ctx to use the raw request body. Bifrost will directly send this to the downstream provider.
+}
+
+func (r *BifrostEmbeddingRequest) GetRawRequestBody() []byte {
+	return r.RawRequestBody
 }
 
 type BifrostEmbeddingResponse struct {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -1,4 +1,4 @@
-	// Package schemas defines the core schemas and types used by the Bifrost system.
+// Package schemas defines the core schemas and types used by the Bifrost system.
 package schemas
 
 import (
@@ -19,14 +19,16 @@ const (
 
 // Pre-defined errors for provider operations
 const (
-	ErrProviderRequestTimedOut   = "request timed out (default is 30 seconds). You can increase it by setting the default_request_timeout_in_seconds in the network_config or in UI - Providers > Provider Name > Network Config."
-	ErrRequestCancelled          = "request cancelled by caller"
-	ErrProviderRequest           = "failed to make HTTP request to provider API"
-	ErrProviderResponseUnmarshal = "failed to unmarshal response from provider API"
-	ErrProviderJSONMarshaling    = "failed to marshal request body to JSON"
-	ErrProviderDecodeStructured  = "failed to decode provider's structured response"
-	ErrProviderDecodeRaw         = "failed to decode provider's raw response"
-	ErrProviderDecompress        = "failed to decompress provider's response"
+	ErrProviderRequestTimedOut      = "request timed out (default is 30 seconds). You can increase it by setting the default_request_timeout_in_seconds in the network_config or in UI - Providers > Provider Name > Network Config."
+	ErrRequestCancelled             = "request cancelled by caller"
+	ErrRequestBodyConversion        = "failed to convert bifrost request to the expected provider request body"
+	ErrProviderRequestMarshal       = "failed to marshal request body to JSON"
+	ErrProviderCreateRequest        = "failed to create HTTP request to provider API"
+	ErrProviderDoRequest            = "failed to execute HTTP request to provider API"
+	ErrProviderResponseDecode       = "failed to decode response body from provider API"
+	ErrProviderResponseUnmarshal    = "failed to unmarshal response from provider API"
+	ErrProviderRawResponseUnmarshal = "failed to unmarshal raw response from provider API"
+	ErrProviderResponseDecompress   = "failed to decompress provider's response"
 )
 
 // NetworkConfig represents the network configuration for provider connections.

--- a/core/schemas/providers/anthropic/types.go
+++ b/core/schemas/providers/anthropic/types.go
@@ -37,6 +37,7 @@ type AnthropicMessageRequest struct {
 	Model         string               `json:"model"`
 	MaxTokens     int                  `json:"max_tokens"`
 	Messages      []AnthropicMessage   `json:"messages"`
+	Metadata      *AnthropicMetaData   `json:"metadata,omitempty"`
 	System        *AnthropicContent    `json:"system,omitempty"`
 	Temperature   *float64             `json:"temperature,omitempty"`
 	TopP          *float64             `json:"top_p,omitempty"`
@@ -47,6 +48,10 @@ type AnthropicMessageRequest struct {
 	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
 	MCPServers    []AnthropicMCPServer `json:"mcp_servers,omitempty"` // This feature requires the beta header: "anthropic-beta": "mcp-client-2025-04-04"
 	Thinking      *AnthropicThinking   `json:"thinking,omitempty"`
+}
+
+type AnthropicMetaData struct {
+	UserID *string `json:"user_id"`
 }
 
 type AnthropicThinking struct {
@@ -135,6 +140,7 @@ type AnthropicContentBlock struct {
 	Type       AnthropicContentBlockType `json:"type"`                  // "text", "image", "tool_use", "tool_result", "thinking"
 	Text       *string                   `json:"text,omitempty"`        // For text content
 	Thinking   *string                   `json:"thinking,omitempty"`    // For thinking content
+	Signature  *string                   `json:"signature,omitempty"`   // For signature content
 	ToolUseID  *string                   `json:"tool_use_id,omitempty"` // For tool_result content
 	ID         *string                   `json:"id,omitempty"`          // For tool_use content
 	Name       *string                   `json:"name,omitempty"`        // For tool_use content

--- a/core/schemas/providers/gemini/speech.go
+++ b/core/schemas/providers/gemini/speech.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest, responseModalities []string) *GeminiGenerationRequest {
+func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest) *GeminiGenerationRequest {
 	if bifrostReq == nil {
 		return nil
 	}
@@ -17,13 +17,7 @@ func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest, responseMod
 	}
 
 	// Convert parameters to generation config
-	if len(responseModalities) > 0 {
-		var modalities []Modality
-		for _, mod := range responseModalities {
-			modalities = append(modalities, Modality(mod))
-		}
-		geminiReq.GenerationConfig.ResponseModalities = modalities
-	}
+	geminiReq.GenerationConfig.ResponseModalities = []Modality{ModalityAudio}
 
 	// Convert speech input to Gemini format
 	if bifrostReq.Input.Input != "" {

--- a/core/schemas/providers/vertex/types.go
+++ b/core/schemas/providers/vertex/types.go
@@ -4,6 +4,10 @@ import "time"
 
 // Vertex AI Embedding API types
 
+const (
+	DefaultVertexAnthropicVersion = "vertex-2023-10-16"
+)
+
 // VertexEmbeddingInstance represents a single embedding instance in the request
 type VertexEmbeddingInstance struct {
 	Content  string  `json:"content"`             // The text to generate embeddings for

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -30,11 +30,16 @@ import (
 // =============================================================================
 
 type BifrostResponsesRequest struct {
-	Provider  ModelProvider        `json:"provider"`
-	Model     string               `json:"model"`
-	Input     []ResponsesMessage   `json:"input,omitempty"`
-	Params    *ResponsesParameters `json:"params,omitempty"`
-	Fallbacks []Fallback           `json:"fallbacks,omitempty"`
+	Provider       ModelProvider        `json:"provider"`
+	Model          string               `json:"model"`
+	Input          []ResponsesMessage   `json:"input,omitempty"`
+	Params         *ResponsesParameters `json:"params,omitempty"`
+	Fallbacks      []Fallback           `json:"fallbacks,omitempty"`
+	RawRequestBody []byte               `json:"-"` // set bifrost-use-raw-request-body to true in ctx to use the raw request body. Bifrost will directly send this to the downstream provider.
+}
+
+func (r *BifrostResponsesRequest) GetRawRequestBody() []byte {
+	return r.RawRequestBody
 }
 
 type BifrostResponsesResponse struct {
@@ -94,7 +99,7 @@ type ResponsesParameters struct {
 	ToolChoice         *ResponsesToolChoice          `json:"tool_choice,omitempty"` // Whether to call a tool
 	Tools              []ResponsesTool               `json:"tools,omitempty"`       // Tools to use
 	Truncation         *string                       `json:"truncation,omitempty"`
-
+	User               *string                       `json:"user,omitempty"`
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`

--- a/core/schemas/speech.go
+++ b/core/schemas/speech.go
@@ -7,11 +7,16 @@ import (
 )
 
 type BifrostSpeechRequest struct {
-	Provider  ModelProvider     `json:"provider"`
-	Model     string            `json:"model"`
-	Input     *SpeechInput      `json:"input,omitempty"`
-	Params    *SpeechParameters `json:"params,omitempty"`
-	Fallbacks []Fallback        `json:"fallbacks,omitempty"`
+	Provider       ModelProvider     `json:"provider"`
+	Model          string            `json:"model"`
+	Input          *SpeechInput      `json:"input,omitempty"`
+	Params         *SpeechParameters `json:"params,omitempty"`
+	Fallbacks      []Fallback        `json:"fallbacks,omitempty"`
+	RawRequestBody []byte            `json:"-"` // set bifrost-use-raw-request-body to true in ctx to use the raw request body. Bifrost will directly send this to the downstream provider.
+}
+
+func (r *BifrostSpeechRequest) GetRawRequestBody() []byte {
+	return r.RawRequestBody
 }
 
 type BifrostSpeechResponse struct {

--- a/core/schemas/textcompletions.go
+++ b/core/schemas/textcompletions.go
@@ -8,11 +8,16 @@ import (
 
 // BifrostTextCompletionRequest is the request struct for text completion requests
 type BifrostTextCompletionRequest struct {
-	Provider  ModelProvider             `json:"provider"`
-	Model     string                    `json:"model"`
-	Input     *TextCompletionInput      `json:"input,omitempty"`
-	Params    *TextCompletionParameters `json:"params,omitempty"`
-	Fallbacks []Fallback                `json:"fallbacks,omitempty"`
+	Provider       ModelProvider             `json:"provider"`
+	Model          string                    `json:"model"`
+	Input          *TextCompletionInput      `json:"input,omitempty"`
+	Params         *TextCompletionParameters `json:"params,omitempty"`
+	Fallbacks      []Fallback                `json:"fallbacks,omitempty"`
+	RawRequestBody []byte                    `json:"-"` // set bifrost-use-raw-request-body to true in ctx to use the raw request body. Bifrost will directly send this to the downstream provider.
+}
+
+func (r *BifrostTextCompletionRequest) GetRawRequestBody() []byte {
+	return r.RawRequestBody
 }
 
 // ToBifrostChatRequest converts a Bifrost text completion request to a Bifrost chat completion request

--- a/core/schemas/transcriptions.go
+++ b/core/schemas/transcriptions.go
@@ -1,11 +1,16 @@
 package schemas
 
 type BifrostTranscriptionRequest struct {
-	Provider  ModelProvider            `json:"provider"`
-	Model     string                   `json:"model"`
-	Input     *TranscriptionInput      `json:"input,omitempty"`
-	Params    *TranscriptionParameters `json:"params,omitempty"`
-	Fallbacks []Fallback               `json:"fallbacks,omitempty"`
+	Provider       ModelProvider            `json:"provider"`
+	Model          string                   `json:"model"`
+	Input          *TranscriptionInput      `json:"input,omitempty"`
+	Params         *TranscriptionParameters `json:"params,omitempty"`
+	Fallbacks      []Fallback               `json:"fallbacks,omitempty"`
+	RawRequestBody []byte                   `json:"-"` // set bifrost-use-raw-request-body to true in ctx to use the raw request body. Bifrost will directly send this to the downstream provider.
+}
+
+func (r *BifrostTranscriptionRequest) GetRawRequestBody() []byte {
+	return r.RawRequestBody
 }
 
 type BifrostTranscriptionResponse struct {

--- a/core/utils.go
+++ b/core/utils.go
@@ -59,6 +59,10 @@ func canProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
 	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock
 }
 
+func isKeySkippingAllowed(providerKey schemas.ModelProvider) bool {
+	return providerKey != schemas.Azure && providerKey != schemas.Bedrock && providerKey != schemas.Vertex
+}
+
 // calculateBackoff implements exponential backoff with jitter for retry attempts.
 func calculateBackoff(attempt int, config *schemas.ProviderConfig) time.Duration {
 	// Calculate an exponential backoff: initial * 2^attempt

--- a/docs/quickstart/gateway/cli-agents.mdx
+++ b/docs/quickstart/gateway/cli-agents.mdx
@@ -29,7 +29,7 @@ Bifrost provides **100% compatible endpoints** for OpenAI, Anthropic, and Gemini
 
 2. **Configure Environment Variables**
    ```bash
-   export ANTHROPIC_API_KEY=dummy-key  # Handled by Bifrost
+   export ANTHROPIC_API_KEY=dummy-key  # Handled by Bifrost (only set when using API key authentication)
    export ANTHROPIC_BASE_URL=http://localhost:8080/anthropic
    ```
 
@@ -39,6 +39,10 @@ Bifrost provides **100% compatible endpoints** for OpenAI, Anthropic, and Gemini
    ```
 
 Now all Claude Code traffic flows through Bifrost, giving you access to any provider/model configured in your Bifrost setup, plus MCP tools and observability.
+
+<Note>
+This setup automatically detects if you're using Anthropic MAX account instead of a regular API key authentication :)
+</Note>
 
 ### Codex CLI
 

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -219,6 +219,9 @@ func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvid
 }
 
 func (mc *ModelCatalog) AddModelDataToPool(modelData *schemas.BifrostListModelsResponse) {
+	if modelData == nil {
+		return
+	}
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 

--- a/transports/bifrost-http/handlers/server.go
+++ b/transports/bifrost-http/handlers/server.go
@@ -579,11 +579,13 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	modelData, listModelsErr := s.Client.ListAllModels(ctx, nil)
 	if listModelsErr != nil {
 		if listModelsErr.Error != nil {
-			return fmt.Errorf("failed to list all models: %s", listModelsErr.Error.Message)
+			logger.Error("failed to list all models: %s", listModelsErr.Error.Message)
+		} else {
+			logger.Error("failed to list all models: %v", listModelsErr)
 		}
-		return fmt.Errorf("failed to list all models: %v", listModelsErr)
+	} else {
+		s.Config.PricingManager.AddModelDataToPool(modelData)
 	}
-	s.Config.PricingManager.AddModelDataToPool(modelData)
 	logger.Info("models added to catalog")
 	s.Config.SetBifrostClient(s.Client)
 	// Initialize routes

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -18,33 +19,42 @@ type AnthropicRouter struct {
 	*GenericRouter
 }
 
-// CreateAnthropicRouteConfigs creates route configurations for Anthropic endpoints.
-func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
-	return []RouteConfig{
-		{
-			Type:   RouteConfigTypeAnthropic,
-			Path:   pathPrefix + "/v1/complete",
-			Method: "POST",
-			GetRequestTypeInstance: func() interface{} {
-				return &anthropic.AnthropicTextRequest{}
-			},
-			RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
-				if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
-					return &schemas.BifrostRequest{
-						TextCompletionRequest: anthropicReq.ToBifrostTextCompletionRequest(),
-					}, nil
-				}
-				return nil, errors.New("invalid request type")
-			},
-			TextResponseConverter: func(resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
-				return anthropic.ToAnthropicTextCompletionResponse(resp), nil
-			},
-			ErrorConverter: func(err *schemas.BifrostError) interface{} {
-				return anthropic.ToAnthropicChatCompletionError(err)
-			},
+// createAnthropicCompleteRouteConfig creates a route configuration for the `/v1/complete` endpoint.
+func createAnthropicCompleteRouteConfig(pathPrefix string) RouteConfig {
+	return RouteConfig{
+		Type:   RouteConfigTypeAnthropic,
+		Path:   pathPrefix + "/v1/complete",
+		Method: "POST",
+		GetRequestTypeInstance: func() interface{} {
+			return &anthropic.AnthropicTextRequest{}
 		},
-		{
-			Path:   pathPrefix + "/v1/messages",
+		RequestConverter: func(req interface{}) (*schemas.BifrostRequest, error) {
+			if anthropicReq, ok := req.(*anthropic.AnthropicTextRequest); ok {
+				return &schemas.BifrostRequest{
+					TextCompletionRequest: anthropicReq.ToBifrostTextCompletionRequest(),
+				}, nil
+			}
+			return nil, errors.New("invalid request type")
+		},
+		TextResponseConverter: func(resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
+			return anthropic.ToAnthropicTextCompletionResponse(resp), nil
+		},
+		ErrorConverter: func(err *schemas.BifrostError) interface{} {
+			return anthropic.ToAnthropicChatCompletionError(err)
+		},
+	}
+}
+
+// createAnthropicMessagesRouteConfig creates a route configuration for the `/v1/messages` endpoint.
+func createAnthropicMessagesRouteConfig(pathPrefix string) []RouteConfig {
+	var routes []RouteConfig
+	for _, path := range []string{
+		"/v1/messages",
+		"/v1/messages/{path:*}",
+	} {
+		routes = append(routes, RouteConfig{
+			Type:   RouteConfigTypeAnthropic,
+			Path:   pathPrefix + path,
 			Method: "POST",
 			GetRequestTypeInstance: func() interface{} {
 				return &anthropic.AnthropicMessageRequest{}
@@ -71,8 +81,17 @@ func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
 					return anthropic.ToAnthropicResponsesStreamError(err)
 				},
 			},
-		},
+			PreCallback: checkAnthropicPassthrough,
+		})
 	}
+	return routes
+}
+
+// CreateAnthropicRouteConfigs creates route configurations for Anthropic endpoints.
+func CreateAnthropicRouteConfigs(pathPrefix string) []RouteConfig {
+	return append([]RouteConfig{
+		createAnthropicCompleteRouteConfig(pathPrefix),
+	}, createAnthropicMessagesRouteConfig(pathPrefix)...)
 }
 
 func CreateAnthropicListModelsRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) []RouteConfig {
@@ -101,6 +120,52 @@ func CreateAnthropicListModelsRouteConfigs(pathPrefix string, handlerStore lib.H
 			PreCallback: extractAnthropicListModelsParams,
 		},
 	}
+}
+
+// checkAnthropicPassthrough pre-callback checks if the request is for a claude model.
+// If it is, it attaches the raw request body for direct use by the provider.
+// It also checks for anthropic oauth headers and sets the bifrost context.
+func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
+	var provider schemas.ModelProvider
+	var model string
+
+	switch r := req.(type) {
+	case *anthropic.AnthropicTextRequest:
+		provider, model = schemas.ParseModelString(r.Model, "")
+		// Check if model parameter explicitly has `anthropic/` prefix
+		if after, ok := strings.CutPrefix(model, "anthropic/"); ok {
+			r.Model = after
+		}
+
+	case *anthropic.AnthropicMessageRequest:
+		provider, model = schemas.ParseModelString(r.Model, "")
+		// Check if model parameter explicitly has `anthropic/` prefix
+		if after, ok := strings.CutPrefix(model, "anthropic/"); ok {
+			r.Model = after
+		}
+	}
+
+	if !strings.Contains(model, "claude") || (provider != schemas.Anthropic && provider != "") {
+		// Not a Claude model or not an Anthropic model, so we can continue
+		return nil
+	}
+
+	// Check if anthropic oauth headers are present
+	if !isAnthropicAPIKeyAuth(ctx) {
+		headers := extractHeadersFromRequest(ctx)
+		url := extractExactPath(ctx)
+		if !strings.HasPrefix(url, "/") {
+			url = "/" + url
+		}
+
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyExtraHeaders, headers)
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyURLPath, url)
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeySkipKeySelection, true)
+	}
+
+	// Set the request body in the context
+	*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRequestBody, rawBody)
+	return nil
 }
 
 // extractAnthropicListModelsParams extracts query parameters for list models request

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -46,9 +46,19 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			return nil, errors.New("invalid request type")
 		},
 		EmbeddingResponseConverter: func(resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini {
+				if resp.ExtraFields.RawResponse != nil {
+					return resp.ExtraFields.RawResponse, nil
+				}
+			}
 			return gemini.ToGeminiEmbeddingResponse(resp), nil
 		},
 		ChatResponseConverter: func(resp *schemas.BifrostChatResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini {
+				if resp.ExtraFields.RawResponse != nil {
+					return resp.ExtraFields.RawResponse, nil
+				}
+			}
 			return gemini.ToGeminiChatResponse(resp), nil
 		},
 		ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -106,7 +116,7 @@ var embeddingPaths = []string{
 }
 
 // extractAndSetModelFromURL extracts model from URL and sets it in the request
-func extractAndSetModelFromURL(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
+func extractAndSetModelFromURL(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}) error {
 	model := ctx.UserValue("model")
 	if model == nil {
 		return fmt.Errorf("model parameter is required")
@@ -155,7 +165,7 @@ func extractAndSetModelFromURL(ctx *fasthttp.RequestCtx, bifrostCtx *context.Con
 }
 
 // extractGeminiListModelsParams extracts query parameters for list models request
-func extractGeminiListModelsParams(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
+func extractGeminiListModelsParams(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}) error {
 	if listModelsReq, ok := req.(*schemas.BifrostListModelsRequest); ok {
 		// Set provider to Gemini
 		listModelsReq.Provider = schemas.Gemini

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -32,8 +32,8 @@ type OpenAIRouter struct {
 	*GenericRouter
 }
 
-func AzureEndpointPreHook(handlerStore lib.HandlerStore) func(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
-	return func(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
+func AzureEndpointPreHook(handlerStore lib.HandlerStore) func(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}) error {
+	return func(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}) error {
 		azureKey := ctx.Request.Header.Peek("authorization")
 		deploymentEndpoint := ctx.Request.Header.Peek("x-bf-azure-endpoint")
 		deploymentID := ctx.UserValue("deployment-id")
@@ -119,6 +119,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid request type")
 			},
 			TextResponseConverter: func(resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -158,6 +163,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid request type")
 			},
 			ChatResponseConverter: func(resp *schemas.BifrostChatResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -198,6 +208,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid request type")
 			},
 			ResponsesResponseConverter: func(resp *schemas.BifrostResponsesResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -237,6 +252,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid embedding request type")
 			},
 			EmbeddingResponseConverter: func(resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -305,6 +325,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 				return nil, errors.New("invalid transcription request type")
 			},
 			TranscriptionResponseConverter: func(resp *schemas.BifrostTranscriptionResponse) (interface{}, error) {
+				if resp.ExtraFields.Provider == schemas.OpenAI {
+					if resp.ExtraFields.RawResponse != nil {
+						return resp.ExtraFields.RawResponse, nil
+					}
+				}
 				return resp, nil
 			},
 			ErrorConverter: func(err *schemas.BifrostError) interface{} {
@@ -367,10 +392,10 @@ func CreateOpenAIListModelsRouteConfigs(pathPrefix string, handlerStore lib.Hand
 func setQueryParamsAndAzureEndpointPreHook(handlerStore lib.HandlerStore) PreRequestCallback {
 	azureHook := AzureEndpointPreHook(handlerStore)
 
-	return func(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}, rawBody []byte) error {
+	return func(ctx *fasthttp.RequestCtx, bifrostCtx *context.Context, req interface{}) error {
 		// First run the Azure endpoint pre-hook if needed
 		if azureHook != nil {
-			if err := azureHook(ctx, bifrostCtx, req, rawBody); err != nil {
+			if err := azureHook(ctx, bifrostCtx, req); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

Add support for passthrough mode to allow direct forwarding of requests to providers without modifying the request body. This enables advanced use cases like Claude Code and other provider-specific features that require exact request formats.

## Changes

- Added context keys to support passthrough mode: `BifrostContextKeySkipKeySelection`, `BifrostContextKeyExtraHeaders`, `BifrostContextKeyURLPath`, and `BifrostContextKeyRequestBody`
- Implemented passthrough detection for Anthropic API requests
- Refactored provider code to check for raw request bodies in context before converting
- Added support for preserving original URL paths and headers
- Improved error handling for unsupported operations with standardized messages
- Fixed handling of response bodies with different content encodings (gzip)
- Added support for skipping key selection when appropriate

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test passthrough mode with Anthropic API:

```sh
# Test with Claude Code request
curl -X POST http://localhost:8080/anthropic/v1/messages \
  -H "Content-Type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "claude-3-opus-20240229",
    "messages": [{"role": "user", "content": "Write a simple Python function to calculate Fibonacci numbers"}],
    "max_tokens": 1000
  }'

# Test with standard API key
curl -X POST http://localhost:8080/anthropic/v1/messages \
  -H "Content-Type: application/json" \
  -H "x-api-key: your-api-key" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "claude-3-opus-20240229",
    "messages": [{"role": "user", "content": "Hello"}],
    "max_tokens": 100
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enables support for Claude Code and other provider-specific features that require exact request formats.

## Security considerations

The implementation preserves security by:
- Filtering out hop-by-hop headers that shouldn't be forwarded
- Maintaining proper authentication mechanisms
- Only allowing passthrough for specific providers and endpoints

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable