### PR TITLE
fix: add context cancellation to prevent resource leaks in streaming requests

### DIFF
--- a/transports/bifrost-http/handlers/cache.go
+++ b/transports/bifrost-http/handlers/cache.go
@@ -9,11 +9,10 @@ import (
 )
 
 type CacheHandler struct {
-	logger schemas.Logger
 	plugin *semanticcache.Plugin
 }
 
-func NewCacheHandler(plugin schemas.Plugin, logger schemas.Logger) *CacheHandler {
+func NewCacheHandler(plugin schemas.Plugin) *CacheHandler {
 	semanticCachePlugin, ok := plugin.(*semanticcache.Plugin)
 	if !ok {
 		logger.Fatal("Cache handler requires a semantic cache plugin")
@@ -21,7 +20,6 @@ func NewCacheHandler(plugin schemas.Plugin, logger schemas.Logger) *CacheHandler
 
 	return &CacheHandler{
 		plugin: semanticCachePlugin,
-		logger: logger,
 	}
 }
 
@@ -33,31 +31,31 @@ func (h *CacheHandler) RegisterRoutes(r *router.Router, middlewares ...lib.Bifro
 func (h *CacheHandler) clearCache(ctx *fasthttp.RequestCtx) {
 	requestID, ok := ctx.UserValue("requestId").(string)
 	if !ok {
-		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request ID", h.logger)
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request ID")
 		return
 	}
 	if err := h.plugin.ClearCacheForRequestID(requestID); err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache", h.logger)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache")
 		return
 	}
 
 	SendJSON(ctx, map[string]any{
 		"message": "Cache cleared successfully",
-	}, h.logger)
+	})
 }
 
 func (h *CacheHandler) clearCacheByKey(ctx *fasthttp.RequestCtx) {
 	cacheKey, ok := ctx.UserValue("cacheKey").(string)
 	if !ok {
-		SendError(ctx, fasthttp.StatusBadRequest, "Invalid cache key", h.logger)
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid cache key")
 		return
 	}
 	if err := h.plugin.ClearCacheForKey(cacheKey); err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache", h.logger)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache")
 		return
 	}
 
 	SendJSON(ctx, map[string]any{
 		"message": "Cache cleared successfully",
-	}, h.logger)
+	})
 }

--- a/transports/bifrost-http/handlers/health.go
+++ b/transports/bifrost-http/handlers/health.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/fasthttp/router"
-	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -14,14 +13,12 @@ import (
 // HealthHandler manages HTTP requests for health checks.
 type HealthHandler struct {
 	config *lib.Config
-	logger schemas.Logger
 }
 
 // NewHealthHandler creates a new health handler instance.
-func NewHealthHandler(config *lib.Config, logger schemas.Logger) *HealthHandler {
+func NewHealthHandler(config *lib.Config) *HealthHandler {
 	return &HealthHandler{
 		config: config,
-		logger: logger,
 	}
 }
 
@@ -80,8 +77,8 @@ func (h *HealthHandler) getHealth(ctx *fasthttp.RequestCtx) {
 	wg.Wait()
 
 	if len(errors) > 0 {
-		SendError(ctx, fasthttp.StatusServiceUnavailable, errors[0], h.logger)
+		SendError(ctx, fasthttp.StatusServiceUnavailable, errors[0])
 		return
 	}
-	SendJSON(ctx, map[string]any{"status": "ok"}, h.logger)
+	SendJSON(ctx, map[string]any{"status": "ok"})
 }

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -5,7 +5,6 @@ package handlers
 import (
 	"github.com/fasthttp/router"
 	bifrost "github.com/maximhq/bifrost/core"
-	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
@@ -16,7 +15,7 @@ type IntegrationHandler struct {
 }
 
 // NewIntegrationHandler creates a new integration handler instance
-func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *IntegrationHandler {
+func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStore) *IntegrationHandler {
 	// Initialize all available integration routers
 	extensions := []integrations.ExtensionRouter{
 		integrations.NewOpenAIRouter(client, handlerStore, logger),

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/fasthttp/router"
-	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/plugins/logging"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -19,14 +18,12 @@ import (
 // LoggingHandler manages HTTP requests for logging operations
 type LoggingHandler struct {
 	logManager logging.LogManager
-	logger     schemas.Logger
 }
 
 // NewLoggingHandler creates a new logging handler instance
-func NewLoggingHandler(logManager logging.LogManager, logger schemas.Logger) *LoggingHandler {
+func NewLoggingHandler(logManager logging.LogManager) *LoggingHandler {
 	return &LoggingHandler{
 		logManager: logManager,
-		logger:     logger,
 	}
 }
 
@@ -106,11 +103,11 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 	if limit := string(ctx.QueryArgs().Peek("limit")); limit != "" {
 		if i, err := strconv.Atoi(limit); err == nil {
 			if i <= 0 {
-				SendError(ctx, fasthttp.StatusBadRequest, "limit must be greater than 0", h.logger)
+				SendError(ctx, fasthttp.StatusBadRequest, "limit must be greater than 0")
 				return
 			}
 			if i > 1000 {
-				SendError(ctx, fasthttp.StatusBadRequest, "limit cannot exceed 1000", h.logger)
+				SendError(ctx, fasthttp.StatusBadRequest, "limit cannot exceed 1000")
 				return
 			}
 			pagination.Limit = i
@@ -121,7 +118,7 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 	if offset := string(ctx.QueryArgs().Peek("offset")); offset != "" {
 		if i, err := strconv.Atoi(offset); err == nil {
 			if i < 0 {
-				SendError(ctx, fasthttp.StatusBadRequest, "offset cannot be negative", h.logger)
+				SendError(ctx, fasthttp.StatusBadRequest, "offset cannot be negative")
 				return
 			}
 			pagination.Offset = i
@@ -145,23 +142,23 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 
 	result, err := h.logManager.Search(ctx, filters, pagination)
 	if err != nil {
-		h.logger.Error("failed to search logs: %v", err)
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Search failed: %v", err), h.logger)
+		logger.Error("failed to search logs: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Search failed: %v", err))
 		return
 	}
-	SendJSON(ctx, result, h.logger)
+	SendJSON(ctx, result)
 }
 
 // getDroppedRequests handles GET /api/logs/dropped - Get the number of dropped requests
 func (h *LoggingHandler) getDroppedRequests(ctx *fasthttp.RequestCtx) {
 	droppedRequests := h.logManager.GetDroppedRequests(ctx)
-	SendJSON(ctx, map[string]int64{"dropped_requests": droppedRequests}, h.logger)
+	SendJSON(ctx, map[string]int64{"dropped_requests": droppedRequests})
 }
 
 // getAvailableModels handles GET /api/logs/models - Get all unique models from logs
 func (h *LoggingHandler) getAvailableModels(ctx *fasthttp.RequestCtx) {
 	models := h.logManager.GetAvailableModels(ctx)
-	SendJSON(ctx, map[string]interface{}{"models": models}, h.logger)
+	SendJSON(ctx, map[string]interface{}{"models": models})
 }
 
 // Helper functions

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -103,7 +103,7 @@ func TransportInterceptorMiddleware(config *lib.Config) lib.BifrostHTTPMiddlewar
 			// Marshal the body back to JSON
 			updatedBody, err := json.Marshal(requestBody)
 			if err != nil {
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("TransportInterceptor: Failed to marshal request body: %v", err), logger)
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("TransportInterceptor: Failed to marshal request body: %v", err))
 				return
 			}
 			ctx.Request.SetBody(updatedBody)

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/fasthttp/router"
-	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -22,17 +21,15 @@ type PluginsLoader interface {
 
 // PluginsHandler is the handler for the plugins API
 type PluginsHandler struct {
-	logger        schemas.Logger
 	configStore   configstore.ConfigStore
 	pluginsLoader PluginsLoader
 }
 
 // NewPluginsHandler creates a new PluginsHandler
-func NewPluginsHandler(pluginsLoader PluginsLoader, configStore configstore.ConfigStore, logger schemas.Logger) *PluginsHandler {
+func NewPluginsHandler(pluginsLoader PluginsLoader, configStore configstore.ConfigStore) *PluginsHandler {
 	return &PluginsHandler{
 		pluginsLoader: pluginsLoader,
 		configStore:   configStore,
-		logger:        logger,
 	}
 }
 
@@ -62,15 +59,15 @@ func (h *PluginsHandler) RegisterRoutes(r *router.Router, middlewares ...lib.Bif
 func (h *PluginsHandler) getPlugins(ctx *fasthttp.RequestCtx) {
 	plugins, err := h.configStore.GetPlugins(ctx)
 	if err != nil {
-		h.logger.Error("failed to get plugins: %v", err)
-		SendError(ctx, 500, "Failed to retrieve plugins", h.logger)
+		logger.Error("failed to get plugins: %v", err)
+		SendError(ctx, 500, "Failed to retrieve plugins")
 		return
 	}
 
 	SendJSON(ctx, map[string]any{
 		"plugins": plugins,
 		"count":   len(plugins),
-	}, h.logger)
+	})
 }
 
 // getPlugin gets a plugin by name
@@ -78,56 +75,56 @@ func (h *PluginsHandler) getPlugin(ctx *fasthttp.RequestCtx) {
 	// Safely validate the "name" parameter
 	nameValue := ctx.UserValue("name")
 	if nameValue == nil {
-		h.logger.Warn("missing required 'name' parameter in request")
-		SendError(ctx, 400, "Missing required 'name' parameter", h.logger)
+		logger.Warn("missing required 'name' parameter in request")
+		SendError(ctx, 400, "Missing required 'name' parameter")
 		return
 	}
 
 	name, ok := nameValue.(string)
 	if !ok {
-		h.logger.Warn("invalid 'name' parameter type, expected string but got %T", nameValue)
-		SendError(ctx, 400, "Invalid 'name' parameter type, expected string", h.logger)
+		logger.Warn("invalid 'name' parameter type, expected string but got %T", nameValue)
+		SendError(ctx, 400, "Invalid 'name' parameter type, expected string")
 		return
 	}
 
 	if name == "" {
-		h.logger.Warn("empty 'name' parameter provided")
-		SendError(ctx, 400, "Empty 'name' parameter not allowed", h.logger)
+		logger.Warn("empty 'name' parameter provided")
+		SendError(ctx, 400, "Empty 'name' parameter not allowed")
 		return
 	}
 
 	plugin, err := h.configStore.GetPlugin(ctx, name)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found", h.logger)
+			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found")
 			return
 		}
-		h.logger.Error("failed to get plugin: %v", err)
-		SendError(ctx, 500, "Failed to retrieve plugin", h.logger)
+		logger.Error("failed to get plugin: %v", err)
+		SendError(ctx, 500, "Failed to retrieve plugin")
 		return
 	}
-	SendJSON(ctx, plugin, h.logger)
+	SendJSON(ctx, plugin)
 }
 
 // createPlugin creates a new plugin
 func (h *PluginsHandler) createPlugin(ctx *fasthttp.RequestCtx) {
 	var request CreatePluginRequest
 	if err := json.Unmarshal(ctx.PostBody(), &request); err != nil {
-		h.logger.Error("failed to unmarshal create plugin request: %v", err)
-		SendError(ctx, 400, "Invalid request body", h.logger)
+		logger.Error("failed to unmarshal create plugin request: %v", err)
+		SendError(ctx, 400, "Invalid request body")
 		return
 	}
 
 	// Validate required fields
 	if request.Name == "" {
-		SendError(ctx, fasthttp.StatusBadRequest, "Plugin name is required", h.logger)
+		SendError(ctx, fasthttp.StatusBadRequest, "Plugin name is required")
 		return
 	}
 
 	// Check if plugin already exists
 	existingPlugin, err := h.configStore.GetPlugin(ctx, request.Name)
 	if err == nil && existingPlugin != nil {
-		SendError(ctx, fasthttp.StatusConflict, "Plugin already exists", h.logger)
+		SendError(ctx, fasthttp.StatusConflict, "Plugin already exists")
 		return
 	}
 	if err := h.configStore.CreatePlugin(ctx, &configstoreTables.TablePlugin{
@@ -135,26 +132,26 @@ func (h *PluginsHandler) createPlugin(ctx *fasthttp.RequestCtx) {
 		Enabled: request.Enabled,
 		Config:  request.Config,
 	}); err != nil {
-		h.logger.Error("failed to create plugin: %v", err)
-		SendError(ctx, 500, "Failed to create plugin", h.logger)
+		logger.Error("failed to create plugin: %v", err)
+		SendError(ctx, 500, "Failed to create plugin")
 		return
 	}
 
 	plugin, err := h.configStore.GetPlugin(ctx, request.Name)
 	if err != nil {
-		h.logger.Error("failed to get plugin: %v", err)
-		SendError(ctx, 500, "Failed to retrieve plugin", h.logger)
+		logger.Error("failed to get plugin: %v", err)
+		SendError(ctx, 500, "Failed to retrieve plugin")
 		return
 	}
 
 	// We reload the plugin if its enabled
 	if request.Enabled {
 		if err := h.pluginsLoader.ReloadPlugin(ctx, request.Name, request.Config); err != nil {
-			h.logger.Error("failed to load plugin: %v", err)
+			logger.Error("failed to load plugin: %v", err)
 			SendJSON(ctx, map[string]any{
 				"message": fmt.Sprintf("Plugin created successfully; but failed to load plugin with new config: %v", err),
 				"plugin":  plugin,
-			}, h.logger)
+			})
 			return
 		}
 	}
@@ -163,7 +160,7 @@ func (h *PluginsHandler) createPlugin(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]any{
 		"message": "Plugin created successfully",
 		"plugin":  plugin,
-	}, h.logger)
+	})
 }
 
 // updatePlugin updates an existing plugin
@@ -171,21 +168,21 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	// Safely validate the "name" parameter
 	nameValue := ctx.UserValue("name")
 	if nameValue == nil {
-		h.logger.Warn("missing required 'name' parameter in update plugin request")
-		SendError(ctx, 400, "Missing required 'name' parameter", h.logger)
+		logger.Warn("missing required 'name' parameter in update plugin request")
+		SendError(ctx, 400, "Missing required 'name' parameter")
 		return
 	}
 
 	name, ok := nameValue.(string)
 	if !ok {
-		h.logger.Warn("invalid 'name' parameter type in update plugin request, expected string but got %T", nameValue)
-		SendError(ctx, 400, "Invalid 'name' parameter type, expected string", h.logger)
+		logger.Warn("invalid 'name' parameter type in update plugin request, expected string but got %T", nameValue)
+		SendError(ctx, 400, "Invalid 'name' parameter type, expected string")
 		return
 	}
 
 	if name == "" {
-		h.logger.Warn("empty 'name' parameter provided in update plugin request")
-		SendError(ctx, 400, "Empty 'name' parameter not allowed", h.logger)
+		logger.Warn("empty 'name' parameter provided in update plugin request")
+		SendError(ctx, 400, "Empty 'name' parameter not allowed")
 		return
 	}
 
@@ -198,21 +195,21 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 				Enabled: false,
 				Config:  map[string]any{},
 			}); err != nil {
-				h.logger.Error("failed to create plugin: %v", err)
-				SendError(ctx, 500, "Failed to create plugin", h.logger)
+				logger.Error("failed to create plugin: %v", err)
+				SendError(ctx, 500, "Failed to create plugin")
 				return
 			}
 		} else {
-			h.logger.Error("failed to get plugin: %v", err)
-			SendError(ctx, 404, "Plugin not found", h.logger)
+			logger.Error("failed to get plugin: %v", err)
+			SendError(ctx, 404, "Plugin not found")
 			return
 		}
 	}
 
 	var request UpdatePluginRequest
 	if err := json.Unmarshal(ctx.PostBody(), &request); err != nil {
-		h.logger.Error("failed to unmarshal update plugin request: %v", err)
-		SendError(ctx, 400, "Invalid request body", h.logger)
+		logger.Error("failed to unmarshal update plugin request: %v", err)
+		SendError(ctx, 400, "Invalid request body")
 		return
 	}
 
@@ -221,38 +218,38 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		Enabled: request.Enabled,
 		Config:  request.Config,
 	}); err != nil {
-		h.logger.Error("failed to update plugin: %v", err)
-		SendError(ctx, 500, "Failed to update plugin", h.logger)
+		logger.Error("failed to update plugin: %v", err)
+		SendError(ctx, 500, "Failed to update plugin")
 		return
 	}
 
 	plugin, err := h.configStore.GetPlugin(ctx, name)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found", h.logger)
+			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found")
 			return
 		}
-		h.logger.Error("failed to get plugin: %v", err)
-		SendError(ctx, 500, "Failed to retrieve plugin", h.logger)
+		logger.Error("failed to get plugin: %v", err)
+		SendError(ctx, 500, "Failed to retrieve plugin")
 		return
 	}
 	// We reload the plugin if its enabled, otherwise we stop it
 	if request.Enabled {
 		if err := h.pluginsLoader.ReloadPlugin(ctx, name, request.Config); err != nil {
-			h.logger.Error("failed to load plugin: %v", err)
+			logger.Error("failed to load plugin: %v", err)
 			SendJSON(ctx, map[string]any{
 				"message": fmt.Sprintf("Plugin updated successfully; but failed to load plugin with new config: %v", err),
 				"plugin":  plugin,
-			}, h.logger)
+			})
 			return
 		}
 	} else {
 		if err := h.pluginsLoader.RemovePlugin(ctx, name); err != nil {
-			h.logger.Error("failed to stop plugin: %v", err)
+			logger.Error("failed to stop plugin: %v", err)
 			SendJSON(ctx, map[string]any{
 				"message": fmt.Sprintf("Plugin updated successfully; but failed to stop plugin: %v", err),
 				"plugin":  plugin,
-			}, h.logger)
+			})
 			return
 		}
 	}
@@ -260,7 +257,7 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Plugin updated successfully",
 		"plugin":  plugin,
-	}, h.logger)
+	})
 }
 
 // deletePlugin deletes an existing plugin
@@ -268,44 +265,44 @@ func (h *PluginsHandler) deletePlugin(ctx *fasthttp.RequestCtx) {
 	// Safely validate the "name" parameter
 	nameValue := ctx.UserValue("name")
 	if nameValue == nil {
-		h.logger.Warn("missing required 'name' parameter in delete plugin request")
-		SendError(ctx, 400, "Missing required 'name' parameter", h.logger)
+		logger.Warn("missing required 'name' parameter in delete plugin request")
+		SendError(ctx, 400, "Missing required 'name' parameter")
 		return
 	}
 
 	name, ok := nameValue.(string)
 	if !ok {
-		h.logger.Warn("invalid 'name' parameter type in delete plugin request, expected string but got %T", nameValue)
-		SendError(ctx, 400, "Invalid 'name' parameter type, expected string", h.logger)
+		logger.Warn("invalid 'name' parameter type in delete plugin request, expected string but got %T", nameValue)
+		SendError(ctx, 400, "Invalid 'name' parameter type, expected string")
 		return
 	}
 
 	if name == "" {
-		h.logger.Warn("empty 'name' parameter provided in delete plugin request")
-		SendError(ctx, 400, "Empty 'name' parameter not allowed", h.logger)
+		logger.Warn("empty 'name' parameter provided in delete plugin request")
+		SendError(ctx, 400, "Empty 'name' parameter not allowed")
 		return
 	}
 
 	if err := h.configStore.DeletePlugin(ctx, name); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found", h.logger)
+			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found")
 			return
 		}
-		h.logger.Error("failed to delete plugin: %v", err)
-		SendError(ctx, 500, "Failed to delete plugin", h.logger)
+		logger.Error("failed to delete plugin: %v", err)
+		SendError(ctx, 500, "Failed to delete plugin")
 		return
 	}
 
 	if err := h.pluginsLoader.RemovePlugin(ctx, name); err != nil {
-		h.logger.Error("failed to stop plugin: %v", err)
+		logger.Error("failed to stop plugin: %v", err)
 		SendJSON(ctx, map[string]any{
 			"message": fmt.Sprintf("Plugin deleted successfully; but failed to stop plugin: %v", err),
 			"plugin":  name,
-		}, h.logger)
+		})
 		return
 	}
 
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Plugin deleted successfully",
-	}, h.logger)
+	})
 }

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -13,26 +13,26 @@ import (
 )
 
 // SendJSON sends a JSON response with 200 OK status
-func SendJSON(ctx *fasthttp.RequestCtx, data interface{}, logger schemas.Logger) {
+func SendJSON(ctx *fasthttp.RequestCtx, data interface{}) {
 	ctx.SetContentType("application/json")
 	if err := json.NewEncoder(ctx).Encode(data); err != nil {
 		logger.Warn(fmt.Sprintf("Failed to encode JSON response: %v", err))
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to encode response: %v", err), logger)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to encode response: %v", err))
 	}
 }
 
 // SendJSONWithStatus sends a JSON response with a custom status code
-func SendJSONWithStatus(ctx *fasthttp.RequestCtx, data interface{}, statusCode int, logger schemas.Logger) {
+func SendJSONWithStatus(ctx *fasthttp.RequestCtx, data interface{}, statusCode int) {
 	ctx.SetContentType("application/json")
 	ctx.SetStatusCode(statusCode)
 	if err := json.NewEncoder(ctx).Encode(data); err != nil {
 		logger.Warn(fmt.Sprintf("Failed to encode JSON response: %v", err))
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to encode response: %v", err), logger)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to encode response: %v", err))
 	}
 }
 
 // SendError sends a BifrostError response
-func SendError(ctx *fasthttp.RequestCtx, statusCode int, message string, logger schemas.Logger) {
+func SendError(ctx *fasthttp.RequestCtx, statusCode int, message string) {
 	bifrostErr := &schemas.BifrostError{
 		IsBifrostError: false,
 		StatusCode:     &statusCode,
@@ -40,11 +40,11 @@ func SendError(ctx *fasthttp.RequestCtx, statusCode int, message string, logger 
 			Message: message,
 		},
 	}
-	SendBifrostError(ctx, bifrostErr, logger)
+	SendBifrostError(ctx, bifrostErr)
 }
 
 // SendBifrostError sends a BifrostError response
-func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError, logger schemas.Logger) {
+func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError) {
 	if bifrostErr.StatusCode != nil {
 		ctx.SetStatusCode(*bifrostErr.StatusCode)
 	} else if !bifrostErr.IsBifrostError {
@@ -62,7 +62,7 @@ func SendBifrostError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError
 }
 
 // SendSSEError sends an error in Server-Sent Events format
-func SendSSEError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError, logger schemas.Logger) {
+func SendSSEError(ctx *fasthttp.RequestCtx, bifrostErr *schemas.BifrostError) {
 	errorJSON, err := json.Marshal(map[string]interface{}{
 		"error": bifrostErr,
 	})


### PR DESCRIPTION
## Summary

Implement proper context cancellation for HTTP requests to prevent resource leaks and wasted provider quota when clients disconnect, especially during streaming operations.

## Changes

- Added cancellable context support in `ConvertToBifrostContext()` which now returns both a context and a cancel function
- Ensured all HTTP handlers properly defer the cancel function to clean up resources
- Modified streaming handlers to immediately cancel upstream provider requests when clients disconnect
- Added detailed comments explaining the context cancellation pattern and its importance
- Fixed potential resource leaks in streaming handlers by properly handling write errors

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that streaming requests are properly cancelled when clients disconnect:

```sh
# Start Bifrost server
go run cmd/bifrost/main.go

# In another terminal, start a streaming request and then cancel it (Ctrl+C)
curl -N http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Write a very long story"}], "stream": true}'

# Verify in server logs that the upstream request was cancelled
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses resource leaks and wasted provider quota when clients disconnect during streaming requests.

## Security considerations

Improves resource management by ensuring provider requests are cancelled when no longer needed, preventing potential resource exhaustion.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable