### PR TITLE
feat: add path context support and improve API key handling across providers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -281,6 +281,10 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 		return provider.ListModels(ctx, keys, request)
 	}, schemas.ListModelsRequest, req.Provider, "")
 	if bifrostErr != nil {
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ListModelsRequest,
+			Provider:    req.Provider,
+		}
 		return nil, bifrostErr
 	}
 	return response, nil

--- a/core/providers/gemini/errors.go
+++ b/core/providers/gemini/errors.go
@@ -9,7 +9,7 @@ func ToGeminiError(bifrostErr *schemas.BifrostError) *GeminiChatRequestError {
 	}
 	code := 500
 	status := ""
-	if bifrostErr.Error != nil && bifrostErr.Error.Type != nil {		
+	if bifrostErr.Error != nil && bifrostErr.Error.Type != nil {
 		status = *bifrostErr.Error.Type
 	}
 	message := ""

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -284,7 +284,7 @@ func (provider *OpenAIProvider) TextCompletionStream(ctx context.Context, postHo
 	return HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
@@ -316,7 +316,6 @@ func HandleOpenAITextCompletionStreaming(
 	}
 
 	if authHeader != nil {
-		// Copy auth header to headers
 		maps.Copy(headers, authHeader)
 	}
 
@@ -334,6 +333,7 @@ func HandleOpenAITextCompletionStreaming(
 			return reqBody, nil
 		},
 		providerName)
+		
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -357,11 +357,11 @@ func HandleOpenAITextCompletionStreaming(
 	}
 
 	req.SetBody(jsonBody)
-
+	
 	// Make the request
 	err := client.Do(req, resp)
 	if err != nil {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
@@ -377,9 +377,10 @@ func HandleOpenAITextCompletionStreaming(
 		}
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
 	}
+
 	// Check for HTTP errors
 	if resp.StatusCode() != fasthttp.StatusOK {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		return nil, parseStreamOpenAIError(resp, schemas.TextCompletionStreamRequest, providerName, request.Model)
 	}
 
@@ -389,7 +390,7 @@ func HandleOpenAITextCompletionStreaming(
 	// Start streaming in a goroutine
 	go func() {
 		defer close(responseChan)
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 
 		scanner := bufio.NewScanner(resp.BodyStream())
 		buf := make([]byte, 0, 1024*1024)
@@ -648,7 +649,7 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx context.Context, postHo
 	return HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
@@ -720,12 +721,13 @@ func HandleOpenAIChatCompletionStreaming(
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}
+
 	req.SetBody(jsonBody)
 
 	// Make the request
 	err := client.Do(req, resp)
 	if err != nil {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
@@ -744,7 +746,7 @@ func HandleOpenAIChatCompletionStreaming(
 
 	// Check for HTTP errors
 	if resp.StatusCode() != fasthttp.StatusOK {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		return nil, parseStreamOpenAIError(resp, schemas.ChatCompletionStreamRequest, providerName, request.Model)
 	}
 
@@ -754,7 +756,7 @@ func HandleOpenAIChatCompletionStreaming(
 	// Start streaming in a goroutine
 	go func() {
 		defer close(responseChan)
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 
 		scanner := bufio.NewScanner(resp.BodyStream())
 		buf := make([]byte, 0, 1024*1024)
@@ -1014,7 +1016,7 @@ func (provider *OpenAIProvider) ResponsesStream(ctx context.Context, postHookRun
 	return HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/responses",
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
@@ -1094,7 +1096,7 @@ func HandleOpenAIResponsesStreaming(
 	// Make the request
 	err := client.Do(req, resp)
 	if err != nil {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
@@ -1113,7 +1115,7 @@ func HandleOpenAIResponsesStreaming(
 
 	// Check for HTTP errors
 	if resp.StatusCode() != fasthttp.StatusOK {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		return nil, parseStreamOpenAIError(resp, schemas.ResponsesStreamRequest, providerName, request.Model)
 	}
 
@@ -1123,7 +1125,7 @@ func HandleOpenAIResponsesStreaming(
 	// Start streaming in a goroutine
 	go func() {
 		defer close(responseChan)
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 
 		scanner := bufio.NewScanner(resp.BodyStream())
 		buf := make([]byte, 0, 1024*1024)
@@ -1440,10 +1442,13 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 		"Accept":        "text/event-stream",
 		"Cache-Control": "no-cache",
 	}
-	url := fmt.Sprintf("%s/v1/audio/speech", provider.networkConfig.BaseURL)
+
+	if key.Value != "" {
+		headers["Authorization"] = "Bearer " + key.Value
+	}
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(url)
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"))
 	req.Header.SetContentType("application/json")
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -1459,7 +1464,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 	// Make the request
 	err = provider.client.Do(req, resp)
 	if err != nil {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
@@ -1478,7 +1483,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 
 	// Check for HTTP errors
 	if resp.StatusCode() != fasthttp.StatusOK {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		return nil, parseStreamOpenAIError(resp, schemas.SpeechStreamRequest, providerName, request.Model)
 	}
 
@@ -1488,7 +1493,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 	// Start streaming in a goroutine
 	go func() {
 		defer close(responseChan)
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 
 		scanner := bufio.NewScanner(resp.BodyStream())
 		chunkIndex := -1
@@ -1716,13 +1721,11 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	resp.StreamBody = true
 	defer fasthttp.ReleaseRequest(req)
 
-	url := fmt.Sprintf("%s/v1/audio/transcriptions", provider.networkConfig.BaseURL)
-
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(url)
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
 	req.Header.SetContentType("application/json")
 
 	// Set any extra headers from network config
@@ -1738,7 +1741,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	// Make the request
 	err := provider.client.Do(req, resp)
 	if err != nil {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		if errors.Is(err, context.Canceled) {
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
@@ -1757,7 +1760,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 
 	// Check for HTTP errors
 	if resp.StatusCode() != fasthttp.StatusOK {
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 		return nil, parseStreamOpenAIError(resp, schemas.TranscriptionStreamRequest, providerName, request.Model)
 	}
 
@@ -1767,7 +1770,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 	// Start streaming in a goroutine
 	go func() {
 		defer close(responseChan)
-		defer fasthttp.ReleaseResponse(resp)
+		defer providerUtils.ReleaseStreamingResponse(resp)
 
 		scanner := bufio.NewScanner(resp.BodyStream())
 		chunkIndex := -1

--- a/core/providers/openai/text.go
+++ b/core/providers/openai/text.go
@@ -9,18 +9,14 @@ func ToOpenAITextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionRequ
 	if bifrostReq == nil {
 		return nil
 	}
-
 	params := bifrostReq.Params
-
 	openaiReq := &OpenAITextCompletionRequest{
 		Model:  bifrostReq.Model,
 		Prompt: bifrostReq.Input,
 	}
-
 	if params != nil {
 		openaiReq.TextCompletionParameters = *params
 	}
-
 	return openaiReq
 }
 

--- a/core/providers/openrouter.go
+++ b/core/providers/openrouter.go
@@ -192,7 +192,7 @@ func (provider *OpenRouterProvider) ChatCompletionStream(ctx context.Context, po
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
@@ -227,7 +227,7 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx context.Context, postHoo
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/alpha/responses",
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/alpha/responses"),
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -124,21 +124,11 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 				"admin_password": password,
 				"is_enabled":     authConfig.IsEnabled,
 			}
-			// Computing token
-			token, err := encrypt.Hash(authConfig.AdminPassword)
-			if err != nil {
-				logger.Warn(fmt.Sprintf("failed to hash password: %v", err))
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to hash password: %v", err))
-				return
-			}
-
-			mapConfig["auth_token"] = string(token)
 		}
 	}
 	mapConfig["is_db_connected"] = h.store.ConfigStore != nil
 	mapConfig["is_cache_connected"] = h.store.VectorStore != nil
 	mapConfig["is_logs_connected"] = h.store.LogsStore != nil
-
 	SendJSON(ctx, mapConfig)
 }
 

--- a/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
@@ -2,19 +2,35 @@
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { useGetCoreConfigQuery } from "@/lib/store";
-import { Copy, Eye, EyeOff, InfoIcon } from "lucide-react";
+import { Copy, InfoIcon, KeyRound } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import ContactUsView from "../views/contactUsView";
 
 export default function APIKeysView() {
 	const { data: bifrostConfig, isLoading } = useGetCoreConfigQuery({ fromDB: true });
 	const [isTokenVisible, setIsTokenVisible] = useState(false);
-	const authToken = useMemo(() => {
-		return bifrostConfig?.auth_token;
+	const isAuthConfigure = useMemo(() => {
+		return bifrostConfig?.auth_config?.is_enabled;
 	}, [bifrostConfig]);
+
+	const curlExample = `# Base64 encode your username:password
+# Example: echo -n "username:password" | base64
+curl --location 'http://localhost:8080/v1/chat/completions'
+--header 'Content-Type: application/json' 
+--header 'Accept: application/json' 
+--header 'Authorization: Basic <base64_encoded_username:password>' 
+--data '{ 
+  "model": "openai/gpt-4", 
+  "messages": [ 
+    { 
+      "role": "user", 
+      "content": "explain big bang?" 
+    } 
+  ] 
+}'`;
 
 	const maskToken = (token: string, revealed: boolean) => {
 		if (revealed) return token;
@@ -29,7 +45,7 @@ export default function APIKeysView() {
 	if (isLoading) {
 		return <div>Loading...</div>;
 	}
-	if (!authToken) {
+	if (!isAuthConfigure) {
 		return (
 			<Alert variant="default">
 				<InfoIcon className="text-muted h-4 w-4" />
@@ -54,61 +70,37 @@ export default function APIKeysView() {
 				<InfoIcon className="text-muted h-4 w-4" />
 				<AlertDescription>
 					<p className="text-md text-gray-600">
-						Use this token as <code className="bg-muted rounded px-1 py-0.5 text-sm">Basic auth</code> in the header when making API calls
-						to Bifrost.
+						Use Basic auth with your admin credentials when making API calls to Bifrost. Encode your credentials in the standard{" "}
+						<code className="bg-muted rounded px-1 py-0.5 text-sm">username:password</code> format with base64 encoding.
 					</p>
 					<br />
-					<div className="flex items-center gap-2">
-						<p className="text-md text-gray-600">
-							<strong>Example:</strong>
-						</p>
+					<p className="text-md text-gray-600">
+						<strong>Example:</strong>
+					</p>
+
+					<div className="relative mt-2 w-full min-w-0 overflow-x-auto">
 						<Button
 							variant="ghost"
 							size="sm"
-							onClick={() => setIsTokenVisible(!isTokenVisible)}
-							className="h-6 w-6 p-0"
+							onClick={() => copyToClipboard(curlExample)}
+							className="absolute right-2 top-2 h-8 z-10"
 						>
-							{isTokenVisible ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+							<Copy className="h-4 w-4" />
 						</Button>
-					</div>
-					<div className="mt-2 min-w-0 w-full overflow-x-auto">
-						<pre className="bg-muted rounded p-3 font-mono text-sm whitespace-pre min-w-max">
-							{`curl -X GET "http://localhost:8080/api/v1/config" \\
-  -H "Authorization: Basic ${maskToken(authToken, isTokenVisible)}"`}
+						<pre className="bg-muted min-w-max rounded p-3 pr-12 font-mono text-sm whitespace-pre">
+							{curlExample}
 						</pre>
 					</div>
 				</AlertDescription>
 			</Alert>
-			<div className="space-y-2">
-				<Label htmlFor="auth-token">Auth Token</Label>
-				<div className="dark:bg-input/30  flex w-full items-center rounded-sm border px-1">
-					<input
-						id="auth-token"
-						type="text"
-						value={maskToken(authToken, isTokenVisible)}
-						readOnly
-						className="file:text-foreground placeholder:text-muted-foreground/70 selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 px-3 py-1 text-base shadow-none transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm font-mono"
-					/>
-					<div className="ml-auto flex items-center gap-1">
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() => setIsTokenVisible(!isTokenVisible)}
-							className="h-8 w-8"
-						>
-							{isTokenVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-						</Button>
-						<Button
-							variant="ghost"
-							size="icon"
-							onClick={() => copyToClipboard(authToken)}
-							className="h-8 w-8"
-						>
-							<Copy className="h-4 w-4" />
-						</Button>
-					</div>
-				</div>
-			</div>
+
+			<ContactUsView
+				className=" mt-4 rounded-md border px-3 py-8"
+				icon={<KeyRound size={48} />}
+				title="Scope Based API Keys"
+				description="Need granular access control with scope-based API keys? Enterprise customers can create multiple API keys with specific permissions for different services, teams, or environments."
+				readmeLink="https://docs.getbifrost.io/enterprise/api-keys"
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

Enhanced error handling and improved API request path management across multiple providers to support dynamic path configuration and more robust authentication.

## Changes

- Added extra fields to Bifrost errors in `ListModelsRequest` for better error context
- Implemented `GetPathFromContext` utility to dynamically set API request paths
- Added conditional API key handling to prevent sending empty authentication headers
- Fixed Gemini error handling to use `StatusCode()` method instead of direct property access
- Updated request URI construction in Anthropic, Cohere, Gemini, and OpenAI providers

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test API requests with various providers to ensure paths are correctly constructed:

```sh
# Core/Transports
go version
go test ./...
```

Test error handling by triggering errors in the ListModelsRequest flow and verify the extra fields are populated correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Improved authentication handling by only setting auth headers when API keys have non-empty values, preventing potential issues with malformed requests.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable