### PR TITLE
fix: improve Cohere stream handling and finish reason conversion

### DIFF
--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -436,11 +436,11 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 
 	case StreamEventMessageEnd:
 		if chunk.Delta != nil {
-			var finishReason *string
+			var finishReason string
 			usage := &schemas.BifrostLLMUsage{}
 			// Set finish reason
 			if chunk.Delta.FinishReason != nil {
-				finishReason = schemas.Ptr(string(*chunk.Delta.FinishReason))
+				finishReason = ConvertCohereFinishReasonToBifrost(*chunk.Delta.FinishReason)
 			}
 
 			// Set usage information
@@ -461,7 +461,7 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 				Choices: []schemas.BifrostResponseChoice{
 					{
 						Index:        0,
-						FinishReason: finishReason,
+						FinishReason: &finishReason,
 						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 							Delta: &schemas.ChatStreamResponseChoiceDelta{},
 						},


### PR DESCRIPTION
## Summary

Improved Cohere provider's streaming response handling and finish reason conversion to ensure proper formatting and consistent behavior.

## Changes

- Replaced `jsonData` variable with more descriptive `eventData` in the streaming handler
- Added proper latency tracking for the final chunk in streaming responses
- Implemented special handling for the last chunk in the stream using `HandleStreamEndWithSuccess`
- Added conversion of Cohere finish reasons to Bifrost format with `ConvertCohereFinishReasonToBifrost`
- Changed `finishReason` from pointer to string type for more consistent handling

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Cohere streaming responses to verify proper handling of finish reasons and latency tracking:

```sh
# Core/Transports
go version
go test ./core/providers/cohere/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves streaming response handling for Cohere provider

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable