### PR TITLE
fixes otel plugin

### DIFF
--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -474,11 +474,12 @@ func validateErrorResponse(errorContent ErrorResponse) error {
 	return nil
 }
 
+
+
 // GetName returns the plugin name
 func (p *MockerPlugin) GetName() string {
 	return PluginName
 }
-
 // TransportInterceptor is not used for this plugin
 func (p *MockerPlugin) TransportInterceptor(ctx *context.Context, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
 	return headers, body, nil

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -132,7 +132,7 @@ func (p *OtelPlugin) GetName() string {
 }
 
 // TransportInterceptor is not used for this plugin
-func (p *OtelPlugin) TransportInterceptor(url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+func (p *OtelPlugin) TransportInterceptor(ctx *context.Context, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
 	return headers, body, nil
 }
 

--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.2.17
 	github.com/maximhq/bifrost/framework v1.1.20
-	github.com/maximhq/bifrost/plugins/mocker v1.3.14
+	github.com/maximhq/bifrost/plugins/mocker v1.3.20
 )
 
 require (

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -158,8 +158,8 @@ github.com/maximhq/bifrost/core v1.2.17 h1:0s+YJzhvm+/rk5lMpI132F/bHjC27XCChSlw9
 github.com/maximhq/bifrost/core v1.2.17/go.mod h1:MnEm8BgeDJlb1TLyL9cRWfyPGvPUlztsonun/fldAUQ=
 github.com/maximhq/bifrost/framework v1.1.20 h1:LmLrbzH5eUHefD95QXPrduACJ2L2Y6n23KXeepPx1qs=
 github.com/maximhq/bifrost/framework v1.1.20/go.mod h1:fWaJQoL9RJptpXl0gScpnmIP9CplCl9Mrx/kmXqPk0g=
-github.com/maximhq/bifrost/plugins/mocker v1.3.14 h1:rZwjeRR5yobYaMnLoeCSJ7FjA0lbtRlPSOtLumdGjtQ=
-github.com/maximhq/bifrost/plugins/mocker v1.3.14/go.mod h1:QzN1O3NUokFkMyiRG53RHLjdPobK1Rm6XZhV0WrNIwc=
+github.com/maximhq/bifrost/plugins/mocker v1.3.20 h1:Wgn43k1V6ZX6nRXZ4NfcMbGJqDQtEcSpHGJIh0ArFwM=
+github.com/maximhq/bifrost/plugins/mocker v1.3.20/go.mod h1:AzmO1n+oDm4Hq2vhWkqloGDhwswwF4EmOb+BWseY4SE=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
## Summary

Update the `TransportInterceptor` method signature in the OtelPlugin to match the interface by adding the context parameter.

## Changes

- Updated the `TransportInterceptor` method signature in the OtelPlugin to include the `ctx *context.Context` parameter
- Fixed formatting in the MockerPlugin implementation (added whitespace and removed a line break)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes interface implementation mismatch in the OtelPlugin

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable