### PR TITLE
fixes docker arm64 build script

### DIFF
--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -19,7 +19,7 @@ FROM golang:1.24-alpine3.22 AS builder
 WORKDIR /app
 
 # Install dependencies including gcc for CGO and sqlite
-RUN apk add --no-cache upx gcc musl-dev sqlite-dev binutils
+RUN apk add --no-cache upx gcc musl-dev sqlite-dev binutils binutils-gold
 
 # Set environment for CGO-enabled build (required for go-sqlite3)
 ENV CGO_ENABLED=1 GOOS=linux


### PR DESCRIPTION
## Summary

Add `binutils-gold` to the Docker build dependencies to ensure proper linking during the Go build process.

## Changes

- Added `binutils-gold` package to the Alpine Linux dependencies in the Dockerfile
- This package provides the gold linker which is needed for proper linking of CGO-enabled builds

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Build the Docker image to verify the dependency installation works correctly:

```sh
cd transports
docker build -t transports-test .
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes build issues when compiling with CGO enabled on Alpine Linux.

## Security considerations

No security implications as this only affects the build environment.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable