### PR TITLE
feat: update model catalog data in provider handlers

### DIFF
--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -281,6 +281,14 @@ func (mc *ModelCatalog) AddModelDataToPool(modelData *schemas.BifrostListModelsR
 	}
 }
 
+// DeleteModelDataForProvider deletes all model data from the pool for a given provider
+func (mc *ModelCatalog) DeleteModelDataForProvider(provider schemas.ModelProvider) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	delete(mc.modelPool, provider)
+}
+
 // RefineModelForProvider refines the model for a given provider.
 // e.g. "gpt-oss-120b" for groq provider -> "openai/gpt-oss-120b"
 func (mc *ModelCatalog) RefineModelForProvider(provider schemas.ModelProvider, model string) string {


### PR DESCRIPTION
## Summary

Implement model catalog management for provider operations, ensuring models are properly refreshed when providers are added, updated, or deleted.

## Changes

- Added `DeleteModelDataForProvider` method to `ModelCatalog` to remove all models for a specific provider
- Created a `ModelsManager` interface to abstract model management operations
- Enhanced provider handlers to automatically refresh models when providers are added or updated
- Added cleanup of provider models when a provider is deleted
- Implemented `RefetchModelsForProvider` and `DeleteModelsForProvider` methods in the HTTP server

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Test adding a provider and verify models are fetched
curl -X POST http://localhost:8000/api/providers -d '{"provider":"openai","api_key":"your-key"}'

# Test updating a provider and verify models are refreshed
curl -X PUT http://localhost:8000/api/providers/openai -d '{"api_key":"new-key"}'

# Test deleting a provider and verify models are removed
curl -X DELETE http://localhost:8000/api/providers/openai
```

## Breaking changes

- [x] No

## Related issues

Improves provider management by ensuring model catalog stays in sync with provider changes.

## Security considerations

No new security implications. Existing authentication and authorization mechanisms apply.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)