### PR TITLE
fix: stream handling and vertex authentication

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -557,10 +557,6 @@ func HandleAnthropicChatCompletionStreaming(
 				}
 
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil), responseChan)
-
-				if isLastChunk {
-					break
-				}
 			}
 			if bifrostErr != nil {
 				bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
@@ -570,6 +566,10 @@ func HandleAnthropicChatCompletionStreaming(
 				}
 
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger)
+				break
+			}
+
+			if isLastChunk {
 				break
 			}
 

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -517,6 +517,11 @@ func HandleOpenAITextCompletionStreaming(
 
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(&response, nil, nil, nil, nil), responseChan)
 			}
+
+			// For providers that don't send [DONE] marker break on finish_reason
+			if !providerUtils.ProviderSendsDoneMarker(providerName) && finishReason != nil {
+				break
+			}
 		}
 
 		// Handle scanner errors first
@@ -886,6 +891,11 @@ func HandleOpenAIChatCompletionStreaming(
 				}
 
 				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, &response, nil, nil, nil), responseChan)
+			}
+
+			// For providers that don't send [DONE] marker break on finish_reason
+			if !providerUtils.ProviderSendsDoneMarker(providerName) && finishReason != nil {
+				break
 			}
 		}
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -726,6 +726,20 @@ func GetProviderName(defaultProvider schemas.ModelProvider, customConfig *schema
 	return defaultProvider
 }
 
+// ProviderSendsDoneMarker returns true if the provider sends the [DONE] marker in streaming responses.
+// Some OpenAI-compatible providers (like Cerebras) don't send [DONE] and instead end the stream
+// after sending the finish_reason. This function helps determine the correct stream termination logic.
+func ProviderSendsDoneMarker(providerName schemas.ModelProvider) bool {
+	switch providerName {
+	case schemas.Cerebras:
+		// Cerebras doesn't send [DONE] marker, ends stream after finish_reason
+		return false
+	default:
+		// Default to expecting [DONE] marker for safety
+		return true
+	}
+}
+
 // GetResponsesChunkConverterCombinedPostHookRunner gets a combined post hook runner that converts to responses stream, then runs the original post hooks.
 func GetResponsesChunkConverterCombinedPostHookRunner(postHookRunner schemas.PostHookRunner) schemas.PostHookRunner {
 	responsesChunkConverter := func(_ *context.Context, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {


### PR DESCRIPTION
## Summary

Fix streaming response handling for providers that don't send [DONE] markers and correct Vertex API implementation issues.

## Changes

- Fixed Anthropic streaming by moving the `isLastChunk` check outside the event processing loop to prevent premature termination
- Added support for providers that don't send [DONE] markers (like Cerebras) by implementing a check for `finishReason` in OpenAI streaming handlers
- Added `ProviderSendsDoneMarker` utility function to determine if a provider sends [DONE] markers
- Fixed Vertex API implementation:
  - Changed HTTP method from POST to GET for listing models
  - Improved authentication token handling for chat completion streaming

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with different providers:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
go test ./core/providers/openai/...
go test ./core/providers/vertex/...
go test ./core/providers/utils/...
```

Verify streaming works correctly with providers that don't send [DONE] markers (like Cerebras).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes streaming response handling issues with certain providers.

## Security considerations

Improved authentication token handling for Vertex API.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable