### PR TITLE
chore: update bifrost/core dependency in example plugin to v1.2.18

### DIFF
--- a/examples/plugins/hello-world/go.mod
+++ b/examples/plugins/hello-world/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 toolchain go1.24.3
 
-require github.com/maximhq/bifrost/core v1.2.17
+require github.com/maximhq/bifrost/core v1.2.18
 
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/examples/plugins/hello-world/go.sum
+++ b/examples/plugins/hello-world/go.sum
@@ -12,8 +12,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/maximhq/bifrost/core v1.2.17 h1:0s+YJzhvm+/rk5lMpI132F/bHjC27XCChSlw9bSKZqY=
-github.com/maximhq/bifrost/core v1.2.17/go.mod h1:MnEm8BgeDJlb1TLyL9cRWfyPGvPUlztsonun/fldAUQ=
+github.com/maximhq/bifrost/core v1.2.18 h1:han3TRp4122ef2L37N2Vr5j+mvySdLrRi0cpVaCtXvM=
+github.com/maximhq/bifrost/core v1.2.18/go.mod h1:tCsM7mGAUgs+jY9yfotSsE0HFr7J7SjzEItKhVDvLPo=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
## Summary

Update the Bifrost core dependency in the hello-world plugin from v1.2.17 to v1.2.18.

## Changes

- Upgraded `github.com/maximhq/bifrost/core` from v1.2.17 to v1.2.18 in the hello-world plugin
- Updated corresponding checksums in go.sum

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Plugins

## How to test

Verify the hello-world plugin builds and functions correctly with the updated dependency:

```sh
cd examples/plugins/hello-world
go mod tidy
go build
```

## Breaking changes

- [x] No

## Security considerations

This is a routine dependency update with no direct security implications.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable