### PR TITLE
transports/lib: ensure x-bf-vk is written under both the typed key and string key in request context

### DIFF
--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -143,7 +143,11 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool) (*c
 		}
 		// Handle virtual key header (x-bf-vk)
 		if keyStr == string(schemas.BifrostContextKeyVirtualKey) {
-			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey(keyStr), string(value))
+			vk := string(value)
+			// Store under both the typed constant key and the string-cast key to
+			// ensure consistent retrieval across call sites that use either form.
+			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKeyVirtualKey, vk)
+			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey(keyStr), vk)
 			return true
 		}
 		// Handle cache key header (x-bf-cache-key)


### PR DESCRIPTION
## Summary

The governance plugin reads VK via `schemas.BifrostContextKeyVirtualKey`. `ConvertToBifrostContext` now explicitly writes VK under that same typed key (and the existing string-cast key). 

Under enforced governance, some paths read VK from governance.ContextKey("x-bf-vk") while others read from schemas.BifrostContextKeyVirtualKeyHeader. If only one is set, VK‑scoped routing/auth can fail.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)
- [x] Plugins

## Breaking changes

- [x] No

If yes, describe impact and migration instructions.

## Security considerations

I don't see any.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


