### PR TITLE
removes sending back non custom plugins

### DIFF
--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -88,21 +88,6 @@ func (h *PluginsHandler) getPlugins(ctx *fasthttp.RequestCtx) {
 			}
 		}
 		if pluginInfo == nil {
-			finalPlugins = append(finalPlugins, struct {
-				Name     string               `json:"name"`
-				Enabled  bool                 `json:"enabled"`
-				Config   any                  `json:"config"`
-				IsCustom bool                 `json:"isCustom"`
-				Path     *string              `json:"path"`
-				Status   schemas.PluginStatus `json:"status"`
-			}{
-				Name:     pluginStatus.Name,
-				Enabled:  pluginStatus.Status != schemas.PluginStatusDisabled,
-				Config:   map[string]any{},
-				IsCustom: false,
-				Path:     nil,
-				Status:   pluginStatus,
-			})
 			continue
 		}
 		finalPlugins = append(finalPlugins, struct {


### PR DESCRIPTION
## Summary

Removed unnecessary code that was adding disabled plugins to the `finalPlugins` array when plugin information is not available.

## Changes

- Removed a code block in the `getPlugins` method that was appending plugins with no information to the `finalPlugins` array
- This change ensures that only plugins with valid information are included in the response

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the plugins endpoint returns only valid plugins:

```sh
# Core/Transports
go version
go test ./transports/bifrost-http/handlers/...

# Make a request to the plugins endpoint and verify that disabled plugins without info are not included
curl -X GET http://localhost:8080/api/plugins
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves plugin management by removing invalid entries from the API response.

## Security considerations

No security implications as this is just removing data from being returned.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable