### PR TITLE
feat: add Perplexity API provider support

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to test (leave empty for current branch)'
+        description: "PR number to test (leave empty for current branch)"
         required: false
         type: string
 
@@ -19,34 +19,34 @@ jobs:
   run-tests:
     name: Run Tests (Awaiting Approval)
     runs-on: ubuntu-latest
-    
+
     # Environment with protection rules - requires admin approval
     # Note: You need to configure this environment in repo settings
     environment:
       name: pr-testing
       url: ${{ github.event.pull_request.html_url || github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-    
+
     permissions:
       contents: read
       pull-requests: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
-      
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.1'
-      
+          go-version: "1.24.1"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
-      
+          python-version: "3.11"
+
       - name: Add comment to PR
         if: github.event.pull_request.number
         env:
@@ -61,10 +61,10 @@ jobs:
           - 🔗 Integration Tests
 
           [View workflow run →](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-      
+
       - name: Make test script executable
         run: chmod +x .github/workflows/scripts/run-tests.sh
-      
+
       - name: Run tests
         env:
           # API Keys for provider tests
@@ -86,6 +86,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           SGL_API_KEY: ${{ secrets.SGL_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
@@ -94,7 +95,7 @@ jobs:
         run: |
           echo "Running tests for PR #${{ github.event.pull_request.number || 'manual run' }}"
           ./.github/workflows/scripts/run-tests.sh
-      
+
       - name: Report test results
         if: always() && github.event.pull_request.number
         env:
@@ -113,5 +114,3 @@ jobs:
 
             [View detailed results →](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           fi
-
-

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -109,6 +109,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           SGL_API_KEY: ${{ secrets.SGL_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
@@ -180,6 +181,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           SGL_API_KEY: ${{ secrets.SGL_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
@@ -255,6 +257,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           SGL_API_KEY: ${{ secrets.SGL_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
@@ -263,7 +266,14 @@ jobs:
         run: ./.github/workflows/scripts/release-all-plugins.sh '${{ needs.detect-changes.outputs.changed-plugins }}'
 
   bifrost-http-release:
-    needs: [check-skip, detect-changes, core-release, framework-release, plugins-release]
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        core-release,
+        framework-release,
+        plugins-release,
+      ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
@@ -335,6 +345,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           SGL_API_KEY: ${{ secrets.SGL_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
@@ -391,7 +402,7 @@ jobs:
         with:
           context: .
           build-args: |
-              VERSION=${{ needs.detect-changes.outputs.transport-version }}
+            VERSION=${{ needs.detect-changes.outputs.transport-version }}
           file: ./transports/Dockerfile
           push: true
           tags: ${{ steps.tags.outputs.tags }}
@@ -401,83 +412,83 @@ jobs:
 
   # Docker build arm64
   docker-build-arm64:
-      needs: [check-skip, detect-changes, bifrost-http-release]
-      if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
-      runs-on: ubuntu-24.04-arm
-      permissions:
-        contents: write
-      env:
-        REGISTRY: docker.io
-        ACCOUNT: maximhq
-        IMAGE_NAME: bifrost
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
-            fetch-tags: true
+    needs: [check-skip, detect-changes, bifrost-http-release]
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    env:
+      REGISTRY: docker.io
+      ACCOUNT: maximhq
+      IMAGE_NAME: bifrost
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-        - name: Verify bifrost-http release
-          id: verify
-          continue-on-error: true
-          env:
-            GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          run: |
-            ./.github/workflows/scripts/verify-bifrost-http-release.sh "${{ needs.detect-changes.outputs.transport-version }}" "${{ needs.detect-changes.outputs.bifrost-http-needs-release }}"
-            echo "verified=true" >> $GITHUB_OUTPUT        
+      - name: Verify bifrost-http release
+        id: verify
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          ./.github/workflows/scripts/verify-bifrost-http-release.sh "${{ needs.detect-changes.outputs.transport-version }}" "${{ needs.detect-changes.outputs.bifrost-http-needs-release }}"
+          echo "verified=true" >> $GITHUB_OUTPUT
 
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-        - name: Log in to Docker Hub
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-        - name: Determine Docker tags
-          id: tags
-          run: |
-            git pull origin ${{ github.ref_name }}
-            VERSION="${{ needs.detect-changes.outputs.transport-version }}"
-            BASE_TAG="${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}-arm64"
-            echo "tags=${BASE_TAG}" >> $GITHUB_OUTPUT
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          git pull origin ${{ github.ref_name }}
+          VERSION="${{ needs.detect-changes.outputs.transport-version }}"
+          BASE_TAG="${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}-arm64"
+          echo "tags=${BASE_TAG}" >> $GITHUB_OUTPUT
 
-        - name: Build and push ARM64 Docker image
-          uses: docker/build-push-action@v5
-          with:
-            context: .
-            file: ./transports/Dockerfile
-            push: true
-            build-args: |
-              VERSION=${{ needs.detect-changes.outputs.transport-version }}
-            tags: ${{ steps.tags.outputs.tags }}
-            platforms: linux/arm64
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
+      - name: Build and push ARM64 Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./transports/Dockerfile
+          push: true
+          build-args: |
+            VERSION=${{ needs.detect-changes.outputs.transport-version }}
+          tags: ${{ steps.tags.outputs.tags }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   # Docker manifest
   docker-manifest:
-      needs: [check-skip, detect-changes, docker-build-amd64, docker-build-arm64]
-      if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.docker-build-amd64.result == 'success' && needs.docker-build-arm64.result == 'success'"
-      runs-on: ubuntu-latest
-      env:
-        REGISTRY: docker.io
-        ACCOUNT: maximhq
-        IMAGE_NAME: bifrost
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4
+    needs: [check-skip, detect-changes, docker-build-amd64, docker-build-arm64]
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.docker-build-amd64.result == 'success' && needs.docker-build-arm64.result == 'success'"
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: docker.io
+      ACCOUNT: maximhq
+      IMAGE_NAME: bifrost
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-        - name: Log in to Docker Hub
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.DOCKER_USERNAME }}
-            password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-        - name: Create and push multi-arch manifest
-          run: |
-            ./.github/workflows/scripts/create-docker-manifest.sh "${{ needs.detect-changes.outputs.transport-version }}"
+      - name: Create and push multi-arch manifest
+        run: |
+          ./.github/workflows/scripts/create-docker-manifest.sh "${{ needs.detect-changes.outputs.transport-version }}"
 
   # Push Mintlify changelog
   push-mintlify-changelog:
@@ -485,7 +496,7 @@ jobs:
     if: "always() && needs.check-skip.outputs.should-skip != 'true' &&  (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
-        contents: write
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -500,7 +511,16 @@ jobs:
 
   # Notification
   notify:
-    needs: [check-skip, detect-changes, core-release, framework-release, plugins-release, bifrost-http-release, docker-manifest]
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        core-release,
+        framework-release,
+        plugins-release,
+        bifrost-http-release,
+        docker-manifest,
+      ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true'"
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## The fastest way to build AI applications that never go down
 
-Bifrost is a high-performance AI gateway that unifies access to 12+ providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex, and more) through a single OpenAI-compatible API. Deploy in seconds with zero configuration and get automatic failover, load balancing, semantic caching, and enterprise-grade features.
+Bifrost is a high-performance AI gateway that unifies access to 15+ providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex, and more) through a single OpenAI-compatible API. Deploy in seconds with zero configuration and get automatic failover, load balancing, semantic caching, and enterprise-grade features.
 
 ## Quick Start
 

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -23,6 +23,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/providers/mistral"
 	"github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/providers/perplexity"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/providers/vertex"
 	schemas "github.com/maximhq/bifrost/core/schemas"
@@ -1289,6 +1290,8 @@ func (bifrost *Bifrost) createBaseProvider(providerKey schemas.ModelProvider, co
 		return providers.NewSGLProvider(config, bifrost.logger)
 	case schemas.Parasail:
 		return providers.NewParasailProvider(config, bifrost.logger)
+	case schemas.Perplexity:
+		return perplexity.NewPerplexityProvider(config, bifrost.logger)
 	case schemas.Cerebras:
 		return providers.NewCerebrasProvider(config, bifrost.logger)
 	case schemas.Gemini:

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,3 +2,4 @@
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
 - refactor: minor until changes
+- feat: added Perplexity provider support

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -383,6 +383,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHoo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/cerebras.go
+++ b/core/providers/cerebras.go
@@ -147,6 +147,7 @@ func (provider *CerebrasProvider) ChatCompletionStream(ctx context.Context, post
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Cerebras,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -306,14 +306,14 @@ func (response *CohereChatResponse) ToBifrostChatResponse(model string) *schemas
 
 		if response.Usage.Tokens != nil {
 			if response.Usage.Tokens.InputTokens != nil {
-				usage.PromptTokens = int(*response.Usage.Tokens.InputTokens)
+				usage.PromptTokens = *response.Usage.Tokens.InputTokens
 			}
 			if response.Usage.Tokens.OutputTokens != nil {
-				usage.CompletionTokens = int(*response.Usage.Tokens.OutputTokens)
+				usage.CompletionTokens = *response.Usage.Tokens.OutputTokens
 			}
 			if response.Usage.CachedTokens != nil {
 				usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
-					CachedTokens: int(*response.Usage.CachedTokens),
+					CachedTokens: *response.Usage.CachedTokens,
 				}
 			}
 			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
@@ -447,10 +447,10 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 			if chunk.Delta.Usage != nil {
 				if chunk.Delta.Usage.Tokens != nil {
 					if chunk.Delta.Usage.Tokens.InputTokens != nil {
-						usage.PromptTokens = int(*chunk.Delta.Usage.Tokens.InputTokens)
+						usage.PromptTokens = *chunk.Delta.Usage.Tokens.InputTokens
 					}
 					if chunk.Delta.Usage.Tokens.OutputTokens != nil {
-						usage.CompletionTokens = int(*chunk.Delta.Usage.Tokens.OutputTokens)
+						usage.CompletionTokens = *chunk.Delta.Usage.Tokens.OutputTokens
 					}
 					usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 				}

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -108,17 +108,17 @@ func (response *CohereChatResponse) ToBifrostResponsesResponse() *schemas.Bifros
 
 		if response.Usage.Tokens != nil {
 			if response.Usage.Tokens.InputTokens != nil {
-				usage.InputTokens = int(*response.Usage.Tokens.InputTokens)
+				usage.InputTokens = *response.Usage.Tokens.InputTokens
 			}
 			if response.Usage.Tokens.OutputTokens != nil {
-				usage.OutputTokens = int(*response.Usage.Tokens.OutputTokens)
+				usage.OutputTokens = *response.Usage.Tokens.OutputTokens
 			}
 			usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 		}
 
 		if response.Usage.CachedTokens != nil {
 			usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
-				CachedTokens: int(*response.Usage.CachedTokens),
+				CachedTokens: *response.Usage.CachedTokens,
 			}
 		}
 
@@ -649,17 +649,17 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int) (*s
 
 				if chunk.Delta.Usage.Tokens != nil {
 					if chunk.Delta.Usage.Tokens.InputTokens != nil {
-						usage.InputTokens = int(*chunk.Delta.Usage.Tokens.InputTokens)
+						usage.InputTokens = *chunk.Delta.Usage.Tokens.InputTokens
 					}
 					if chunk.Delta.Usage.Tokens.OutputTokens != nil {
-						usage.OutputTokens = int(*chunk.Delta.Usage.Tokens.OutputTokens)
+						usage.OutputTokens = *chunk.Delta.Usage.Tokens.OutputTokens
 					}
 					usage.TotalTokens = usage.InputTokens + usage.OutputTokens
 				}
 
 				if chunk.Delta.Usage.CachedTokens != nil {
 					usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
-						CachedTokens: int(*chunk.Delta.Usage.CachedTokens),
+						CachedTokens: *chunk.Delta.Usage.CachedTokens,
 					}
 				}
 				response.Response.Usage = usage

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -300,21 +300,21 @@ const (
 type CohereUsage struct {
 	BilledUnits  *CohereBilledUnits `json:"billed_units,omitempty"`  // Billed usage information
 	Tokens       *CohereTokenUsage  `json:"tokens,omitempty"`        // Token usage details
-	CachedTokens *float64           `json:"cached_tokens,omitempty"` // Cached tokens
+	CachedTokens *int               `json:"cached_tokens,omitempty"` // Cached tokens
 }
 
 // CohereBilledUnits represents billed usage information
 type CohereBilledUnits struct {
-	InputTokens     *float64 `json:"input_tokens,omitempty"`    // Number of billed input tokens
-	OutputTokens    *float64 `json:"output_tokens,omitempty"`   // Number of billed output tokens
-	SearchUnits     *float64 `json:"search_units,omitempty"`    // Number of billed search units
-	Classifications *float64 `json:"classifications,omitempty"` // Number of billed classification units
+	InputTokens     *int `json:"input_tokens,omitempty"`    // Number of billed input tokens
+	OutputTokens    *int `json:"output_tokens,omitempty"`   // Number of billed output tokens
+	SearchUnits     *int `json:"search_units,omitempty"`    // Number of billed search units
+	Classifications *int `json:"classifications,omitempty"` // Number of billed classification units
 }
 
 // CohereTokenUsage represents detailed token usage
 type CohereTokenUsage struct {
-	InputTokens  *float64 `json:"input_tokens"`  // Number of input tokens used
-	OutputTokens *float64 `json:"output_tokens"` // Number of output tokens produced
+	InputTokens  *int `json:"input_tokens"`  // Number of input tokens used
+	OutputTokens *int `json:"output_tokens"` // Number of output tokens produced
 }
 
 // CohereLogProb represents log probability information

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -317,6 +317,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -187,6 +187,7 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Groq,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -177,6 +177,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postH
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Mistral,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -146,6 +146,7 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Ollama,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -661,6 +661,7 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx context.Context, postHo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }
@@ -677,6 +678,7 @@ func HandleOpenAIChatCompletionStreaming(
 	sendBackRawResponse bool,
 	providerName schemas.ModelProvider,
 	postHookRunner schemas.PostHookRunner,
+	customRequestConverter func(*schemas.BifrostChatRequest) (any, error),
 	logger schemas.Logger,
 ) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	headers := map[string]string{
@@ -694,6 +696,9 @@ func HandleOpenAIChatCompletionStreaming(
 		ctx,
 		request,
 		func() (any, error) {
+			if customRequestConverter != nil {
+				return customRequestConverter(request)
+			}
 			reqBody := ToOpenAIChatRequest(request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)

--- a/core/providers/openrouter.go
+++ b/core/providers/openrouter.go
@@ -199,6 +199,7 @@ func (provider *OpenRouterProvider) ChatCompletionStream(ctx context.Context, po
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.OpenRouter,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -119,6 +119,7 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, post
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Parasail,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -1,0 +1,237 @@
+package perplexity
+
+import (
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToPerplexityChatCompletionRequest converts a Bifrost request to Perplexity chat completion request
+func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *PerplexityChatRequest {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil
+	}
+
+	messages := bifrostReq.Input
+	perplexityReq := &PerplexityChatRequest{
+		Model:    bifrostReq.Model,
+		Messages: messages,
+	}
+
+	// Map parameters if they exist
+	if bifrostReq.Params != nil {
+		// Core parameters
+		perplexityReq.MaxTokens = bifrostReq.Params.MaxCompletionTokens
+		perplexityReq.Temperature = bifrostReq.Params.Temperature
+		perplexityReq.TopP = bifrostReq.Params.TopP
+		perplexityReq.PresencePenalty = bifrostReq.Params.PresencePenalty
+		perplexityReq.FrequencyPenalty = bifrostReq.Params.FrequencyPenalty
+		perplexityReq.ResponseFormat = bifrostReq.Params.ResponseFormat
+
+		// Handle reasoning effort mapping
+		if bifrostReq.Params.ReasoningEffort != nil {
+			if *bifrostReq.Params.ReasoningEffort == "minimal" {
+				perplexityReq.ReasoningEffort = schemas.Ptr("low")
+			} else {
+				perplexityReq.ReasoningEffort = bifrostReq.Params.ReasoningEffort
+			}
+		}
+
+		// Handle extra parameters for Perplexity-specific fields
+		if bifrostReq.Params.ExtraParams != nil {
+			// Search-related parameters
+			if searchMode, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_mode"]); ok {
+				perplexityReq.SearchMode = searchMode
+			}
+
+			if languagePreference, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["language_preference"]); ok {
+				perplexityReq.LanguagePreference = languagePreference
+			}
+
+			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filters"]); ok {
+				perplexityReq.SearchDomainFilters = searchDomainFilters
+			}
+
+			if returnImages, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_images"]); ok {
+				perplexityReq.ReturnImages = returnImages
+			}
+
+			if returnRelatedQuestions, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_related_questions"]); ok {
+				perplexityReq.ReturnRelatedQuestions = returnRelatedQuestions
+			}
+
+			if searchRecencyFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_recency_filter"]); ok {
+				perplexityReq.SearchRecencyFilter = searchRecencyFilter
+			}
+
+			if searchAfterDateFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_after_date_filter"]); ok {
+				perplexityReq.SearchAfterDateFilter = searchAfterDateFilter
+			}
+
+			if searchBeforeDateFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_before_date_filter"]); ok {
+				perplexityReq.SearchBeforeDateFilter = searchBeforeDateFilter
+			}
+
+			if lastUpdatedAfterFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["last_updated_after_filter"]); ok {
+				perplexityReq.LastUpdatedAfterFilter = lastUpdatedAfterFilter
+			}
+
+			if lastUpdatedBeforeFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["last_updated_before_filter"]); ok {
+				perplexityReq.LastUpdatedBeforeFilter = lastUpdatedBeforeFilter
+			}
+
+			if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
+				perplexityReq.TopK = topK
+			}
+
+			if stream, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["stream"]); ok {
+				perplexityReq.Stream = stream
+			}
+
+			if disableSearch, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["disable_search"]); ok {
+				perplexityReq.DisableSearch = disableSearch
+			}
+
+			if enableSearchClassifier, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["enable_search_classifier"]); ok {
+				perplexityReq.EnableSearchClassifier = enableSearchClassifier
+			}
+
+			// Handle web_search_options
+			if webSearchOptionsParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "web_search_options"); ok {
+				if webSearchOptionsSlice, ok := webSearchOptionsParam.([]interface{}); ok {
+					var webSearchOptions []WebSearchOption
+					for _, optionInterface := range webSearchOptionsSlice {
+						if optionMap, ok := optionInterface.(map[string]interface{}); ok {
+							option := WebSearchOption{}
+
+							if searchContextSize, ok := schemas.SafeExtractStringPointer(optionMap["search_context_size"]); ok {
+								option.SearchContextSize = searchContextSize
+							}
+
+							if imageSearchRelevanceEnhanced, ok := schemas.SafeExtractBoolPointer(optionMap["image_search_relevance_enhanced"]); ok {
+								option.ImageSearchRelevanceEnhanced = imageSearchRelevanceEnhanced
+							}
+
+							// Handle user_location
+							if userLocationParam, ok := schemas.SafeExtractFromMap(optionMap, "user_location"); ok {
+								if userLocationMap, ok := userLocationParam.(map[string]interface{}); ok {
+									userLocation := &WebSearchOptionUserLocation{}
+
+									if latitude, ok := schemas.SafeExtractFloat64Pointer(userLocationMap["latitude"]); ok {
+										userLocation.Latitude = latitude
+									}
+									if longitude, ok := schemas.SafeExtractFloat64Pointer(userLocationMap["longitude"]); ok {
+										userLocation.Longitude = longitude
+									}
+									if city, ok := schemas.SafeExtractStringPointer(userLocationMap["city"]); ok {
+										userLocation.City = city
+									}
+									if country, ok := schemas.SafeExtractStringPointer(userLocationMap["country"]); ok {
+										userLocation.Country = country
+									}
+									if region, ok := schemas.SafeExtractStringPointer(userLocationMap["region"]); ok {
+										userLocation.Region = region
+									}
+
+									option.UserLocation = userLocation
+								}
+							}
+
+							webSearchOptions = append(webSearchOptions, option)
+						}
+					}
+					perplexityReq.WebSearchOptions = webSearchOptions
+				}
+			}
+
+			// Handle media_response
+			if mediaResponseParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "media_response"); ok {
+				if mediaResponseMap, ok := mediaResponseParam.(map[string]interface{}); ok {
+					mediaResponse := &MediaResponse{}
+
+					if overridesParam, ok := schemas.SafeExtractFromMap(mediaResponseMap, "overrides"); ok {
+						if overridesMap, ok := overridesParam.(map[string]interface{}); ok {
+							overrides := MediaResponseOverrides{}
+
+							if returnVideos, ok := schemas.SafeExtractBoolPointer(overridesMap["return_videos"]); ok {
+								overrides.ReturnVideos = returnVideos
+							}
+							if returnImages, ok := schemas.SafeExtractBoolPointer(overridesMap["return_images"]); ok {
+								overrides.ReturnImages = returnImages
+							}
+
+							mediaResponse.Overrides = overrides
+						}
+					}
+
+					perplexityReq.MediaResponse = mediaResponse
+				}
+			}
+		}
+	}
+
+	return perplexityReq
+}
+
+// ToBifrostChatResponse converts a Perplexity chat completion response to Bifrost format
+func (response *PerplexityChatResponse) ToBifrostChatResponse(model string) *schemas.BifrostChatResponse {
+	if response == nil {
+		return nil
+	}
+
+	bifrostResponse := &schemas.BifrostChatResponse{
+		ID:      response.ID,
+		Model:   model,
+		Object:  response.Object,
+		Created: response.Created,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.ChatCompletionRequest,
+			Provider:    schemas.Perplexity,
+		},
+		SearchResults: response.SearchResults,
+		Videos:        response.Videos,
+	}
+
+	// Map all response fields
+	if len(response.Choices) > 0 {
+		bifrostResponse.Choices = response.Choices
+	}
+
+	// Convert usage information with all available fields
+	if response.Usage != nil {
+		usage := &schemas.BifrostLLMUsage{
+			PromptTokens:     response.Usage.PromptTokens,
+			CompletionTokens: response.Usage.CompletionTokens,
+			TotalTokens:      response.Usage.TotalTokens,
+		}
+
+		// Map Perplexity-specific usage details to CompletionTokensDetails
+		completionDetails := &schemas.ChatCompletionTokensDetails{}
+		hasCompletionDetails := false
+
+		if response.Usage.CitationTokens != nil {
+			completionDetails.CitationTokens = response.Usage.CitationTokens
+			hasCompletionDetails = true
+		}
+
+		if response.Usage.NumSearchQueries != nil {
+			completionDetails.NumSearchQueries = response.Usage.NumSearchQueries
+			hasCompletionDetails = true
+		}
+
+		if response.Usage.ReasoningTokens != nil {
+			completionDetails.ReasoningTokens = *response.Usage.ReasoningTokens
+			hasCompletionDetails = true
+		}
+
+		if hasCompletionDetails {
+			usage.CompletionTokensDetails = completionDetails
+		}
+
+		if response.Usage.Cost != nil {
+			usage.Cost = response.Usage.Cost
+		}
+
+		bifrostResponse.Usage = usage
+	}
+
+	return bifrostResponse
+}

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -1,0 +1,242 @@
+// Package providers implements various LLM providers and their utility functions.
+// This file contains the Perplexity provider implementation.
+package perplexity
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/core/providers/openai"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// PerplexityProvider implements the Provider interface for Perplexity's API.
+type PerplexityProvider struct {
+	logger              schemas.Logger        // Logger for provider operations
+	client              *fasthttp.Client      // HTTP client for API requests
+	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
+}
+
+// NewPerplexityProvider creates a new Perplexity provider instance.
+// It initializes the HTTP client with the provided configuration and sets up response pools.
+// The client is configured with timeouts, concurrency limits, and optional proxy settings.
+func NewPerplexityProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*PerplexityProvider, error) {
+	config.CheckAndSetDefaults()
+
+	client := &fasthttp.Client{
+		ReadTimeout:         time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
+		WriteTimeout:        time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
+		MaxConnsPerHost:     5000,
+		MaxIdleConnDuration: 60 * time.Second,
+		MaxConnWaitTimeout:  10 * time.Second,
+	}
+
+	// Configure proxy if provided
+	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
+
+	// Set default BaseURL if not provided
+	if config.NetworkConfig.BaseURL == "" {
+		config.NetworkConfig.BaseURL = "https://api.perplexity.ai"
+	}
+	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+
+	return &PerplexityProvider{
+		logger:              logger,
+		client:              client,
+		networkConfig:       config.NetworkConfig,
+		sendBackRawResponse: config.SendBackRawResponse,
+	}, nil
+}
+
+// GetProviderKey returns the provider identifier for Perplexity.
+func (provider *PerplexityProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.Perplexity
+}
+
+// completeRequest sends a request to Perplexity's API and handles the response.
+// It constructs the API URL, sets up authentication, and processes the response.
+// Returns the response body or an error if the request fails.
+func (provider *PerplexityProvider) completeRequest(ctx context.Context, jsonData []byte, url string, key string, model string) ([]byte, time.Duration, *schemas.BifrostError) {
+	// Create the request with the JSON body
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set any extra headers from network config
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(url)
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	if key != "" {
+		req.Header.Set("Authorization", "Bearer "+key)
+	}
+
+	req.SetBody(jsonData)
+
+	// Send the request
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, latency, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", provider.GetProviderKey(), string(resp.Body())))
+		return nil, latency, openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), model)
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, latency, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, provider.GetProviderKey())
+	}
+
+	// Read the response body and copy it before releasing the response
+	// to avoid use-after-free since resp.Body() references fasthttp's internal buffer
+	bodyCopy := append([]byte(nil), body...)
+
+	return bodyCopy, latency, nil
+}
+
+// ListModels performs a list models request to Perplexity's API.
+func (provider *PerplexityProvider) ListModels(ctx context.Context, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ListModelsRequest, provider.GetProviderKey())
+}
+
+// TextCompletion is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) TextCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionRequest, provider.GetProviderKey())
+}
+
+// TextCompletionStream performs a streaming text completion request to Perplexity's API.
+// It formats the request, sends it to Perplexity, and processes the response.
+// Returns a channel of BifrostStream objects or an error if the request fails.
+func (provider *PerplexityProvider) TextCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TextCompletionStreamRequest, provider.GetProviderKey())
+}
+
+// ChatCompletion performs a chat completion request to the Perplexity API.
+func (provider *PerplexityProvider) ChatCompletion(ctx context.Context, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	// Convert to Perplexity chat completion request
+	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return ToPerplexityChatCompletionRequest(request), nil },
+		provider.GetProviderKey())
+	if err != nil {
+		return nil, err
+	}
+
+	responseBody, latency, err := provider.completeRequest(ctx, jsonBody, provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"), key.Value, request.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	var response PerplexityChatResponse
+	rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &response, providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	bifrostResponse := response.ToBifrostChatResponse(request.Model)
+
+	// Set ExtraFields
+	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	// Set raw response if enabled
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
+// ChatCompletionStream performs a streaming chat completion request to the Perplexity API.
+// It supports real-time streaming of responses using Server-Sent Events (SSE).
+// Uses Perplexity's OpenAI-compatible streaming format.
+// Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
+func (provider *PerplexityProvider) ChatCompletionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	var authHeader map[string]string
+	if key.Value != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value}
+	}
+	customRequestConverter := func(request *schemas.BifrostChatRequest) (any, error) {
+		reqBody := ToPerplexityChatCompletionRequest(request)
+		reqBody.Stream = schemas.Ptr(true)
+		return reqBody, nil
+	}
+	// Use shared OpenAI-compatible streaming logic
+	return openai.HandleOpenAIChatCompletionStreaming(
+		ctx,
+		provider.client,
+		provider.networkConfig.BaseURL+"/chat/completions",
+		request,
+		authHeader,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		schemas.Perplexity,
+		postHookRunner,
+		customRequestConverter,
+		provider.logger,
+	)
+}
+
+// Responses performs a responses request to the Perplexity API.
+func (provider *PerplexityProvider) Responses(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
+	if err != nil {
+		return nil, err
+	}
+
+	response := chatResponse.ToBifrostResponsesResponse()
+	response.ExtraFields.RequestType = schemas.ResponsesRequest
+	response.ExtraFields.Provider = provider.GetProviderKey()
+	response.ExtraFields.ModelRequested = request.Model
+
+	return response, nil
+}
+
+// ResponsesStream performs a streaming responses request to the Perplexity API.
+func (provider *PerplexityProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return provider.ChatCompletionStream(
+		ctx,
+		providerUtils.GetResponsesChunkConverterCombinedPostHookRunner(postHookRunner),
+		key,
+		request.ToChatRequest(),
+	)
+}
+
+// Embedding is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) Embedding(ctx context.Context, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
+}
+
+// Speech is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) Speech(ctx context.Context, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+}
+
+// SpeechStream is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) SpeechStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
+}
+
+// Transcription is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) Transcription(ctx context.Context, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+}
+
+// TranscriptionStream is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) TranscriptionStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
+}

--- a/core/providers/perplexity/responses.go
+++ b/core/providers/perplexity/responses.go
@@ -1,0 +1,194 @@
+package perplexity
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToPerplexityResponsesRequest converts a BifrostResponsesRequest to PerplexityChatRequest
+func ToPerplexityResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *PerplexityChatRequest {
+	if bifrostReq == nil {
+		return nil
+	}
+
+	perplexityReq := &PerplexityChatRequest{
+		Model: bifrostReq.Model,
+	}
+
+	// Map basic parameters
+	if bifrostReq.Params != nil {
+		// Core parameters
+		perplexityReq.MaxTokens = bifrostReq.Params.MaxOutputTokens
+		perplexityReq.Temperature = bifrostReq.Params.Temperature
+		perplexityReq.TopP = bifrostReq.Params.TopP
+
+		// Handle reasoning effort mapping
+		if bifrostReq.Params.Reasoning != nil && bifrostReq.Params.Reasoning.Effort != nil {
+			if *bifrostReq.Params.Reasoning.Effort == "minimal" {
+				perplexityReq.ReasoningEffort = schemas.Ptr("low")
+			} else {
+				perplexityReq.ReasoningEffort = schemas.Ptr(*bifrostReq.Params.Reasoning.Effort)
+			}
+		}
+
+		// Handle extra parameters for Perplexity-specific fields
+		if bifrostReq.Params.ExtraParams != nil {
+			// Search-related parameters
+			if searchMode, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_mode"]); ok {
+				perplexityReq.SearchMode = searchMode
+			}
+
+			if languagePreference, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["language_preference"]); ok {
+				perplexityReq.LanguagePreference = languagePreference
+			}
+
+			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filters"]); ok {
+				perplexityReq.SearchDomainFilters = searchDomainFilters
+			}
+
+			if returnImages, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_images"]); ok {
+				perplexityReq.ReturnImages = returnImages
+			}
+
+			if returnRelatedQuestions, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_related_questions"]); ok {
+				perplexityReq.ReturnRelatedQuestions = returnRelatedQuestions
+			}
+
+			if searchRecencyFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_recency_filter"]); ok {
+				perplexityReq.SearchRecencyFilter = searchRecencyFilter
+			}
+
+			if searchAfterDateFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_after_date_filter"]); ok {
+				perplexityReq.SearchAfterDateFilter = searchAfterDateFilter
+			}
+
+			if searchBeforeDateFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_before_date_filter"]); ok {
+				perplexityReq.SearchBeforeDateFilter = searchBeforeDateFilter
+			}
+
+			if lastUpdatedAfterFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["last_updated_after_filter"]); ok {
+				perplexityReq.LastUpdatedAfterFilter = lastUpdatedAfterFilter
+			}
+
+			if lastUpdatedBeforeFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["last_updated_before_filter"]); ok {
+				perplexityReq.LastUpdatedBeforeFilter = lastUpdatedBeforeFilter
+			}
+
+			if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
+				perplexityReq.TopK = topK
+			}
+
+			if stream, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["stream"]); ok {
+				perplexityReq.Stream = stream
+			}
+
+			if disableSearch, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["disable_search"]); ok {
+				perplexityReq.DisableSearch = disableSearch
+			}
+
+			if enableSearchClassifier, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["enable_search_classifier"]); ok {
+				perplexityReq.EnableSearchClassifier = enableSearchClassifier
+			}
+
+			if presencePenalty, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["presence_penalty"]); ok {
+				perplexityReq.PresencePenalty = presencePenalty
+			}
+
+			if frequencyPenalty, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["frequency_penalty"]); ok {
+				perplexityReq.FrequencyPenalty = frequencyPenalty
+			}
+
+			if responseFormat, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "response_format"); ok {
+				perplexityReq.ResponseFormat = &responseFormat
+			}
+
+			// Handle web_search_options
+			if webSearchOptionsParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "web_search_options"); ok {
+				if webSearchOptionsSlice, ok := webSearchOptionsParam.([]interface{}); ok {
+					var webSearchOptions []WebSearchOption
+					for _, optionInterface := range webSearchOptionsSlice {
+						if optionMap, ok := optionInterface.(map[string]interface{}); ok {
+							option := WebSearchOption{}
+
+							if searchContextSize, ok := schemas.SafeExtractStringPointer(optionMap["search_context_size"]); ok {
+								option.SearchContextSize = searchContextSize
+							}
+
+							if imageSearchRelevanceEnhanced, ok := schemas.SafeExtractBoolPointer(optionMap["image_search_relevance_enhanced"]); ok {
+								option.ImageSearchRelevanceEnhanced = imageSearchRelevanceEnhanced
+							}
+
+							// Handle user_location
+							if userLocationParam, ok := schemas.SafeExtractFromMap(optionMap, "user_location"); ok {
+								if userLocationMap, ok := userLocationParam.(map[string]interface{}); ok {
+									userLocation := &WebSearchOptionUserLocation{}
+
+									if latitude, ok := schemas.SafeExtractFloat64Pointer(userLocationMap["latitude"]); ok {
+										userLocation.Latitude = latitude
+									}
+									if longitude, ok := schemas.SafeExtractFloat64Pointer(userLocationMap["longitude"]); ok {
+										userLocation.Longitude = longitude
+									}
+									if city, ok := schemas.SafeExtractStringPointer(userLocationMap["city"]); ok {
+										userLocation.City = city
+									}
+									if country, ok := schemas.SafeExtractStringPointer(userLocationMap["country"]); ok {
+										userLocation.Country = country
+									}
+									if region, ok := schemas.SafeExtractStringPointer(userLocationMap["region"]); ok {
+										userLocation.Region = region
+									}
+
+									option.UserLocation = userLocation
+								}
+							}
+
+							webSearchOptions = append(webSearchOptions, option)
+						}
+					}
+					perplexityReq.WebSearchOptions = webSearchOptions
+				}
+			}
+
+			// Handle media_response
+			if mediaResponseParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "media_response"); ok {
+				if mediaResponseMap, ok := mediaResponseParam.(map[string]interface{}); ok {
+					mediaResponse := &MediaResponse{}
+
+					if overridesParam, ok := schemas.SafeExtractFromMap(mediaResponseMap, "overrides"); ok {
+						if overridesMap, ok := overridesParam.(map[string]interface{}); ok {
+							overrides := MediaResponseOverrides{}
+
+							if returnVideos, ok := schemas.SafeExtractBoolPointer(overridesMap["return_videos"]); ok {
+								overrides.ReturnVideos = returnVideos
+							}
+							if returnImages, ok := schemas.SafeExtractBoolPointer(overridesMap["return_images"]); ok {
+								overrides.ReturnImages = returnImages
+							}
+
+							mediaResponse.Overrides = overrides
+						}
+					}
+
+					perplexityReq.MediaResponse = mediaResponse
+				}
+			}
+		}
+	}
+
+	// Process ResponsesInput (which contains the Responses messages)
+	if bifrostReq.Input != nil {
+		perplexityReq.Messages = schemas.ToChatMessages(bifrostReq.Input)
+	}
+
+	return perplexityReq
+}
+
+// ToBifrostResponsesResponse converts PerplexityChatResponse to BifrostResponsesResponse
+func (response *PerplexityChatResponse) ToBifrostResponsesResponse() *schemas.BifrostResponsesResponse {
+	if response == nil {
+		return nil
+	}
+
+	chatCompletionResponse := response.ToBifrostChatResponse(response.Model)
+	return chatCompletionResponse.ToBifrostResponsesResponse()
+}

--- a/core/providers/perplexity/types.go
+++ b/core/providers/perplexity/types.go
@@ -1,0 +1,78 @@
+package perplexity
+
+import "github.com/maximhq/bifrost/core/schemas"
+
+// PerplexityChatRequest represents a Perplexity chat completion request
+type PerplexityChatRequest struct {
+	Model                   string                `json:"model"`                                // Required: Model to use for chat completion
+	Messages                []schemas.ChatMessage `json:"messages"`                             // Required: Array of message objects
+	SearchMode              *string               `json:"search_mode"`                          // Required: Search mode
+	ReasoningEffort         *string               `json:"reasoning_effort"`                     // Required: Reasoning effort (low, medium, high)
+	MaxTokens               *int                  `json:"max_tokens,omitempty"`                 // Optional: Maximum tokens to generate
+	Temperature             *float64              `json:"temperature,omitempty"`                // Optional: Sampling temperature
+	TopP                    *float64              `json:"top_p,omitempty"`                      // Optional: Top-p sampling
+	LanguagePreference      *string               `json:"language_preference,omitempty"`        // Optional: Language preference
+	SearchDomainFilters     []string              `json:"search_domain_filters,omitempty"`      // Optional: Search domain filters
+	ReturnImages            *bool                 `json:"return_images,omitempty"`              // Optional: Return images
+	ReturnRelatedQuestions  *bool                 `json:"return_related_questions,omitempty"`   // Optional: Return related questions
+	SearchRecencyFilter     *string               `json:"search_recency_filter,omitempty"`      // Optional: Search recency filter
+	SearchAfterDateFilter   *string               `json:"search_after_date_filter,omitempty"`   // Optional: Search after date filter
+	SearchBeforeDateFilter  *string               `json:"search_before_date_filter,omitempty"`  // Optional: Search before date filter
+	LastUpdatedAfterFilter  *string               `json:"last_updated_after_filter,omitempty"`  // Optional: Last updated after filter
+	LastUpdatedBeforeFilter *string               `json:"last_updated_before_filter,omitempty"` // Optional: Last updated before filter
+	TopK                    *int                  `json:"top_k,omitempty"`                      // Optional: Top-k sampling
+	Stream                  *bool                 `json:"stream,omitempty"`                     // Optional: Enable streaming
+	PresencePenalty         *float64              `json:"presence_penalty,omitempty"`           // Optional: Presence penalty
+	FrequencyPenalty        *float64              `json:"frequency_penalty,omitempty"`          // Optional: Frequency penalty
+	ResponseFormat          *interface{}          `json:"response_format,omitempty"`            // Format for the response
+	DisableSearch           *bool                 `json:"disable_search,omitempty"`             // Optional: Disable search
+	EnableSearchClassifier  *bool                 `json:"enable_search_classifier,omitempty"`   // Optional: Enable search classifier
+	WebSearchOptions        []WebSearchOption     `json:"web_search_options,omitempty"`         // Optional: Web search options
+	MediaResponse           *MediaResponse        `json:"media_response,omitempty"`             // Optional: Media response
+}
+
+type WebSearchOption struct {
+	SearchContextSize            *string                      `json:"search_context_size,omitempty"`             // "low" | "medium" | "high"
+	UserLocation                 *WebSearchOptionUserLocation `json:"user_location,omitempty"`                   // The approximate location of the user
+	ImageSearchRelevanceEnhanced *bool                        `json:"image_search_relevance_enhanced,omitempty"` // Optional: Image search relevance enhanced
+}
+
+type WebSearchOptionUserLocation struct {
+	Latitude  *float64 `json:"latitude,omitempty"`
+	Longitude *float64 `json:"longitude,omitempty"`
+	City      *string  `json:"city,omitempty"`    // Free text input for the city
+	Country   *string  `json:"country,omitempty"` // Two-letter ISO country code
+	Region    *string  `json:"region,omitempty"`  // Free text input for the region
+}
+
+type MediaResponse struct {
+	Overrides MediaResponseOverrides `json:"overrides,omitempty"` // Optional: Overrides for the media response
+}
+
+type MediaResponseOverrides struct {
+	ReturnVideos *bool `json:"return_videos,omitempty"` // Optional: Return videos
+	ReturnImages *bool `json:"return_images,omitempty"` // Optional: Return images
+}
+
+type PerplexityChatResponse struct {
+	ID            string                          `json:"id"`
+	Choices       []schemas.BifrostResponseChoice `json:"choices"`
+	Created       int                             `json:"created"` // The Unix timestamp (in seconds).
+	Model         string                          `json:"model"`
+	Object        string                          `json:"object"` // "chat.completion" or "chat.completion.chunk"
+	Citations     []string                        `json:"citations,omitempty"`
+	SearchResults []schemas.SearchResult          `json:"search_results,omitempty"`
+	Videos        []schemas.VideoResult           `json:"videos,omitempty"`
+	Usage         *Usage                          `json:"usage,omitempty"`
+}
+
+type Usage struct {
+	PromptTokens      int                  `json:"prompt_tokens"`
+	CompletionTokens  int                  `json:"completion_tokens"`
+	TotalTokens       int                  `json:"total_tokens"`
+	SearchContextSize *string              `json:"search_context_size,omitempty"`
+	CitationTokens    *int                 `json:"citation_tokens,omitempty"`
+	NumSearchQueries  *int                 `json:"num_search_queries,omitempty"`
+	ReasoningTokens   *int                 `json:"reasoning_tokens,omitempty"`
+	Cost              *schemas.BifrostCost `json:"cost,omitempty"`
+}

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -143,6 +143,7 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.SGL,
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -731,12 +731,21 @@ func GetProviderName(defaultProvider schemas.ModelProvider, customConfig *schema
 // after sending the finish_reason. This function helps determine the correct stream termination logic.
 func ProviderSendsDoneMarker(providerName schemas.ModelProvider) bool {
 	switch providerName {
-	case schemas.Cerebras:
-		// Cerebras doesn't send [DONE] marker, ends stream after finish_reason
+	case schemas.Cerebras, schemas.Perplexity:
+		// Cerebras and Perplexity don't send [DONE] marker, ends stream after finish_reason
 		return false
 	default:
 		// Default to expecting [DONE] marker for safety
 		return true
+	}
+}
+
+func ProviderIsResponsesAPINative(providerName schemas.ModelProvider) bool {
+	switch providerName {
+	case schemas.OpenAI, schemas.OpenRouter, schemas.Azure:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -607,6 +607,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 			providerName,
 			postHookRunner,
+			nil,
 			provider.logger,
 		)
 	}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -43,6 +43,7 @@ const (
 	Groq       ModelProvider = "groq"
 	SGL        ModelProvider = "sgl"
 	Parasail   ModelProvider = "parasail"
+	Perplexity ModelProvider = "perplexity"
 	Cerebras   ModelProvider = "cerebras"
 	Gemini     ModelProvider = "gemini"
 	OpenRouter ModelProvider = "openrouter"
@@ -70,6 +71,7 @@ var StandardProviders = []ModelProvider{
 	Ollama,
 	OpenAI,
 	Parasail,
+	Perplexity,
 	SGL,
 	Vertex,
 	OpenRouter,

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -32,6 +32,11 @@ type BifrostChatResponse struct {
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`
 	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
+
+	// Perplexity-specific fields
+	SearchResults []SearchResult `json:"search_results,omitempty"`
+	Videos        []VideoResult  `json:"videos,omitempty"`
+	Citations     []string       `json:"citations,omitempty"`
 }
 
 // ToTextCompletionResponse converts a BifrostChatResponse to a BifrostTextCompletionResponse
@@ -555,6 +560,7 @@ type BifrostLLMUsage struct {
 	CompletionTokens        int                          `json:"completion_tokens,omitempty"`
 	CompletionTokensDetails *ChatCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
 	TotalTokens             int                          `json:"total_tokens"`
+	Cost                    *BifrostCost                 `json:"cost,omitempty"` //Only for the providers which support cost calculation
 }
 
 type ChatPromptTokensDetails struct {
@@ -563,8 +569,34 @@ type ChatPromptTokensDetails struct {
 }
 
 type ChatCompletionTokensDetails struct {
-	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
-	AudioTokens              int `json:"audio_tokens,omitempty"`
-	ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
-	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
+	AcceptedPredictionTokens int  `json:"accepted_prediction_tokens,omitempty"`
+	AudioTokens              int  `json:"audio_tokens,omitempty"`
+	CitationTokens           *int `json:"citation_tokens,omitempty"`
+	NumSearchQueries         *int `json:"num_search_queries,omitempty"`
+	ReasoningTokens          int  `json:"reasoning_tokens,omitempty"`
+	RejectedPredictionTokens int  `json:"rejected_prediction_tokens,omitempty"`
+}
+
+type BifrostCost struct {
+	InputTokensCost  float64 `json:"input_tokens_cost,omitempty"`
+	OutputTokensCost float64 `json:"output_tokens_cost,omitempty"`
+	RequestCost      float64 `json:"request_cost,omitempty"`
+	TotalCost        float64 `json:"total_cost,omitempty"`
+}
+
+type SearchResult struct {
+	Title       string  `json:"title"`
+	URL         string  `json:"url"`
+	Date        *string `json:"date,omitempty"`
+	LastUpdated *string `json:"last_updated,omitempty"`
+	Snippet     *string `json:"snippet,omitempty"`
+	Source      *string `json:"source,omitempty"`
+}
+
+type VideoResult struct {
+	URL             string   `json:"url"`
+	ThumbnailURL    *string  `json:"thumbnail_url,omitempty"`
+	ThumbnailWidth  *int     `json:"thumbnail_width,omitempty"`
+	ThumbnailHeight *int     `json:"thumbnail_height,omitempty"`
+	Duration        *float64 `json:"duration,omitempty"`
 }

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -74,6 +74,11 @@ type BifrostResponsesResponse struct {
 	Truncation         *string                             `json:"truncation,omitempty"`
 	Usage              *ResponsesResponseUsage             `json:"usage,omitempty"`
 	ExtraFields        BifrostResponseExtraFields          `json:"extra_fields"`
+
+	// Perplexity-specific fields
+	SearchResults []SearchResult `json:"search_results,omitempty"`
+	Videos        []VideoResult  `json:"videos,omitempty"`
+	Citations     []string       `json:"citations,omitempty"`
 }
 
 type ResponsesParameters struct {
@@ -248,6 +253,7 @@ type ResponsesResponseUsage struct {
 	OutputTokens        int                            `json:"output_tokens"`         // Number of output tokens
 	OutputTokensDetails *ResponsesResponseOutputTokens `json:"output_tokens_details"` // Detailed breakdown of output tokens	TotalTokens int `json:"total_tokens"` // Total number of tokens used
 	TotalTokens         int                            `json:"total_tokens"`          // Total number of tokens used
+	Cost                *BifrostCost                   `json:"cost,omitempty"`        // Only for the providers which support cost calculation
 }
 
 type ResponsesResponseInputTokens struct {
@@ -256,10 +262,12 @@ type ResponsesResponseInputTokens struct {
 }
 
 type ResponsesResponseOutputTokens struct {
-	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
-	AudioTokens              int `json:"audio_tokens,omitempty"`
-	ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
-	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
+	AcceptedPredictionTokens int  `json:"accepted_prediction_tokens,omitempty"`
+	AudioTokens              int  `json:"audio_tokens,omitempty"`
+	ReasoningTokens          int  `json:"reasoning_tokens,omitempty"`
+	RejectedPredictionTokens int  `json:"rejected_prediction_tokens,omitempty"`
+	CitationTokens           *int `json:"citation_tokens,omitempty"`
+	NumSearchQueries         *int `json:"num_search_queries,omitempty"`
 }
 
 // =============================================================================
@@ -1431,5 +1439,10 @@ type BifrostResponsesStreamResponse struct {
 	Message *string `json:"message,omitempty"`
 	Param   *string `json:"param,omitempty"`
 
-	ExtraFields BifrostResponseExtraFields `json:"extra_fields,omitempty"`
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+
+	// Perplexity-specific fields
+	SearchResults []SearchResult `json:"search_results,omitempty"`
+	Videos        []VideoResult  `json:"videos,omitempty"`
+	Citations     []string       `json:"citations,omitempty"`
 }

--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -3251,6 +3251,7 @@
           "openrouter",
           "sgl",
           "parasail",
+          "perplexity",
           "cerebras"
         ],
         "description": "AI model provider",

--- a/docs/features/unified-interface.mdx
+++ b/docs/features/unified-interface.mdx
@@ -98,7 +98,8 @@ The following table summarizes which operations are supported by each provider v
 | Ollama (`ollama/<model>`) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | No | No |
 | OpenAI (`openai/<model>`) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 | OpenRouter (`openrouter/<model>`) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | No | No | No |
-| Parasail (`parasail/<model>`) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | No | No | No |
+| Parasail (`parasail/<model>`) | Yes | No | No | Yes | Yes | Yes | Yes | No | No | No | No | No |
+| Perplexity (`perplexity/<model>`) | Yes | No | No | Yes | Yes | Yes | Yes | No | No | No | No | No |
 | SGL (`sgl/<model>`) | Yes | Yes | Yes | Yes | Yes | Yes | Yes | Yes | No | No | No | No |
 | Vertex AI (`vertex/<model>`) | Yes | No | No | Yes | Yes | Yes | Yes | Yes | No | No | No | No |
 

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -142,6 +142,10 @@ func (pm *ModelCatalog) CalculateCostFromUsage(provider string, model string, us
 		return 0.0
 	}
 
+	if usage.Cost != nil && usage.Cost.TotalCost > 0 {
+		return usage.Cost.TotalCost
+	}
+
 	pm.logger.Debug("looking up pricing for model %s and provider %s of request type %s", model, provider, normalizeRequestType(requestType))
 	// Get pricing for the model
 	pricing, exists := pm.getPricing(model, provider, requestType)

--- a/tests/core-providers/README.md
+++ b/tests/core-providers/README.md
@@ -15,6 +15,7 @@ This directory contains comprehensive tests for all Bifrost AI providers, ensuri
 - **Groq** - OSS models
 - **SGLang** - OSS models
 - **Parasail** - OSS models
+- **Perplexity** - Sonar models
 - **Cerebras** - Llama, Qwen and GPT-OSS models
 - **Gemini** - Gemini models
 - **OpenRouter** - Models supported by OpenRouter

--- a/tests/core-providers/config/account.go
+++ b/tests/core-providers/config/account.go
@@ -86,6 +86,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 		schemas.Groq,
 		schemas.SGL,
 		schemas.Parasail,
+		schemas.Perplexity,
 		schemas.Cerebras,
 		schemas.Gemini,
 		schemas.OpenRouter,
@@ -227,6 +228,14 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *context.Context
 				Weight: 1.0,
 			},
 		}, nil
+	case schemas.Perplexity:
+		return []schemas.Key{
+			{
+				Value:  os.Getenv("PERPLEXITY_API_KEY"),
+				Models: []string{},
+				Weight: 1.0,
+			},
+		}, nil
 	case schemas.Cerebras:
 		return []schemas.Key{
 			{
@@ -279,7 +288,7 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 				DefaultRequestTimeoutInSeconds: 120,
 				MaxRetries:                     4, // Higher retries for Groq (can be flaky)
 				RetryBackoffInitial:            1 * time.Second,
-				RetryBackoffMax:                10 * time.Second,				
+				RetryBackoffMax:                10 * time.Second,
 			},
 			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
 				Concurrency: Concurrency,
@@ -423,6 +432,19 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 			NetworkConfig: schemas.NetworkConfig{
 				DefaultRequestTimeoutInSeconds: 120,
 				MaxRetries:                     5, // Parasail can be variable
+				RetryBackoffInitial:            1 * time.Second,
+				RetryBackoffMax:                12 * time.Second,
+			},
+			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+				Concurrency: Concurrency,
+				BufferSize:  10,
+			},
+		}, nil
+	case schemas.Perplexity:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 120,
+				MaxRetries:                     5, // Perplexity can be variable
 				RetryBackoffInitial:            1 * time.Second,
 				RetryBackoffMax:                12 * time.Second,
 			},

--- a/tests/core-providers/perplexity_test.go
+++ b/tests/core-providers/perplexity_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/maximhq/bifrost/tests/core-providers/config"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestPerplexity(t *testing.T) {
+	t.Parallel()
+	if os.Getenv("PERPLEXITY_API_KEY") == "" {
+		t.Skip("Skipping Perplexity tests because PERPLEXITY_API_KEY is not set")
+	}
+
+	client, ctx, cancel, err := config.SetupTest()
+	if err != nil {
+		t.Fatalf("Error initializing test setup: %v", err)
+	}
+	defer cancel()
+
+	testConfig := config.ComprehensiveTestConfig{
+		Provider:       schemas.Perplexity,
+		ChatModel:      "sonar-pro",
+		TextModel:      "", // Perplexity doesn't support text completion
+		EmbeddingModel: "", // Perplexity doesn't support embedding
+		Scenarios: config.TestScenarios{
+			TextCompletion:        false, // Not supported
+			SimpleChat:            true,
+			CompletionStream:      true,
+			MultiTurnConversation: true,
+			ToolCalls:             false,
+			MultipleToolCalls:     false,
+			End2EndToolCalling:    false,
+			AutomaticFunctionCall: false,
+			ImageURL:              false, // Not supported yet
+			ImageBase64:           false, // Not supported yet
+			MultipleImages:        false, // Not supported yet
+			CompleteEnd2End:       false,
+			Embedding:             false, // Not supported yet
+			ListModels:            false,
+		},
+	}
+
+	t.Run("PerplexityTests", func(t *testing.T) {
+		runAllComprehensiveTests(t, client, ctx, testConfig)
+	})
+	client.Shutdown()
+}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,4 +2,4 @@
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
 - chore: version update core to 1.2.18 and framework to 1.1.21
-- enhancement: provider lookup enhancements in modelcatelog
+- feat: added Perplexity provider support

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -126,6 +126,9 @@
         "parasail": {
           "$ref": "#/$defs/provider"
         },
+        "perplexity": {
+          "$ref": "#/$defs/provider"
+        },
         "cerebras": {
           "$ref": "#/$defs/provider"
         }
@@ -531,6 +534,7 @@
                         "vertex",
                         "cerebras",
                         "parasail",
+                        "perplexity",
                         "sgl"
                       ]
                     },

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -15,6 +15,7 @@ export const ModelPlaceholders = {
 	openrouter: "e.g. openai/gpt-4, anthropic/claude-3-haiku",
 	sgl: "e.g. sgl-2, sgl-vision",
 	parasail: "e.g. parasail-2, parasail-vision",
+	perplexity: "e.g. sonar-pro, sonar-deep-research",
 	ollama: "e.g. llama3.1, llama2",
 	openai: "e.g. gpt-4, gpt-4o, gpt-4o-mini, gpt-3.5-turbo",
 	vertex: "e.g. gemini-1.5-pro, text-bison, chat-bison",

--- a/ui/lib/constants/icons.tsx
+++ b/ui/lib/constants/icons.tsx
@@ -366,6 +366,26 @@ export const ProviderIcons = {
 		);
 	},
 
+	perplexity: ({ size = "md", className = "" }: IconProps) => {
+		const resolvedSize = resolveSize(size);
+		return (
+			<svg
+				width={resolvedSize}
+				height={resolvedSize}
+				viewBox="0 0 24 24"
+				xmlns="http://www.w3.org/2000/svg"
+				className={className}
+			>
+				<title>Perplexity</title>
+				<path
+					d="M19.785 0v7.272H22.5V17.62h-2.935V24l-7.037-6.194v6.145h-1.091v-6.152L4.392 24v-6.465H1.5V7.188h2.884V0l7.053 6.494V.19h1.09v6.49L19.786 0zm-7.257 9.044v7.319l5.946 5.234V14.44l-5.946-5.397zm-1.099-.08l-5.946 5.398v7.235l5.946-5.234V8.965zm8.136 7.58h1.844V8.349H13.46l6.105 5.54v2.655zm-8.982-8.28H2.59v8.195h1.8v-2.576l6.192-5.62zM5.475 2.476v4.71h5.115l-5.115-4.71zm13.219 0l-5.115 4.71h5.115v-4.71z"
+					fill="#22B8CD"
+					fill-rule="nonzero"
+				></path>
+			</svg>
+		);
+	},
+
 	sgl: ({ size = "md", className = "" }: IconProps) => {
 		const resolvedSize = resolveSize(size);
 

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -12,6 +12,7 @@ export const KnownProvidersNames = [
 	"openai",
 	"openrouter",
 	"parasail",
+	"perplexity",
 	"sgl",
 	"vertex",
 ] as const;
@@ -48,6 +49,7 @@ export const ProviderLabels: Record<ProviderName, string> = {
 	ollama: "Ollama",
 	groq: "Groq",
 	parasail: "Parasail",
+	perplexity: "Perplexity",
 	sgl: "SGLang",
 	cerebras: "Cerebras",
 	gemini: "Gemini",


### PR DESCRIPTION
## Summary

Added Perplexity AI as a new provider in Bifrost, enabling access to Perplexity's Sonar models through the unified API.

## Changes

- Added Perplexity provider implementation with support for chat completions and responses
- Integrated Perplexity-specific features including search results, citations, and videos in response objects
- Added API key configuration in CI workflows for testing
- Updated documentation and UI to include Perplexity as a supported provider
- Updated README to reflect the increased provider count (now 15+)

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

1. Configure a Perplexity API key in your environment:

```sh
export PERPLEXITY_API_KEY=your_api_key_here
```

2. Run the core provider tests:

```sh
cd tests/core-providers
go test -v -run TestPerplexity
```

3. Test with the HTTP transport:

```sh
# Start Bifrost with the Perplexity provider enabled
./bifrost-http

# Make a request to the Perplexity provider
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "perplexity/sonar-pro",
    "messages": [{"role": "user", "content": "What is Bifrost?"}]
  }'
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

The implementation requires a Perplexity API key to be configured, which is handled securely through environment variables.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable