### PR TITLE
fix: handle bifrost cost object type

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -584,6 +584,27 @@ type BifrostCost struct {
 	TotalCost        float64 `json:"total_cost,omitempty"`
 }
 
+// UnmarshalJSON implements custom JSON unmarshalling for BifrostCost.
+func (bc *BifrostCost) UnmarshalJSON(data []byte) error {
+	// First, try to unmarshal as a direct float
+	var costFloat float64
+	if err := sonic.Unmarshal(data, &costFloat); err == nil {
+		bc.TotalCost = costFloat
+		return nil
+	}
+
+	// Try to unmarshal as a full BifrostCost struct
+	// Use a type alias to avoid infinite recursion
+	type Alias BifrostCost
+	var costStruct Alias
+	if err := sonic.Unmarshal(data, &costStruct); err == nil {
+		*bc = BifrostCost(costStruct)
+		return nil
+	}
+
+	return fmt.Errorf("cost field is neither a float nor an object")
+}
+
 type SearchResult struct {
 	Title       string  `json:"title"`
 	URL         string  `json:"url"`


### PR DESCRIPTION
## Summary

Added custom JSON unmarshalling for the BifrostCost struct to handle both float and object representations of cost data.

## Changes

- Implemented `UnmarshalJSON` method for the `BifrostCost` struct that can handle two formats:
  - Direct float values (which are assigned to TotalCost)
  - Full object representation with all BifrostCost fields
- Added error handling that returns a descriptive error message when the cost field is neither a float nor an object

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Test with JSON payloads containing both formats:
1. A simple float value for cost
2. A full object with BifrostCost fields

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses inconsistent cost field formats in API responses.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable