### PR TITLE
automaticaly update hello-world example plugin deps

### DIFF
--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -38,6 +38,15 @@ else
   CORE_VERSION=${LATEST_CORE_TAG#core/}
 fi
 
+
+# Before starting the test, we need to update hello-word plugin core dependencies
+echo "🔧 Updating hello-word plugin core dependencies..."
+cd examples/plugins/hello-world
+go_get_with_backoff "github.com/maximhq/bifrost/core@$CORE_VERSION"
+go mod tidy
+git add go.mod go.sum
+cd ../../..
+
 echo "🔧 Using core version: $CORE_VERSION"
 
 # Update framework dependencies


### PR DESCRIPTION
## Summary

Update the release framework script to automatically update the hello-world plugin's core dependencies before running tests.

## Changes

- Modified `.github/workflows/scripts/release-framework.sh` to update the hello-world plugin's core dependencies to match the current core version being used
- Added a step that navigates to the hello-world plugin directory, updates the core dependency using go get with backoff, runs go mod tidy, and stages the changes

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release framework script and verify that the hello-world plugin's dependencies are properly updated:

```sh
./.github/workflows/scripts/release-framework.sh
```

Check that the hello-world plugin's go.mod and go.sum files are updated with the correct core version.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Ensures the hello-world plugin example stays in sync with core releases.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable