### PR TITLE
fixes build failure

### DIFF
--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -36,6 +36,7 @@ export const isKeyRequiredByProvider: Record<ProviderName, boolean> = {
 	ollama: false,
 	openai: true,
 	vertex: true,
+	perplexity: true,
 };
 
 export const DefaultNetworkConfig = {


### PR DESCRIPTION
## Summary

Added Perplexity AI to the list of providers that require an API key.

## Changes

- Added `perplexity: true` to the `isKeyRequiredByProvider` configuration object to indicate that Perplexity AI requires an API key to function

## Type of change

- [x] Feature
- [x] Providers/Integrations

## Affected areas

- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

Verify that the Perplexity AI provider correctly prompts for an API key:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Then navigate to the provider settings and confirm that Perplexity AI shows as requiring an API key.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

This change properly enforces API key requirements for the Perplexity AI provider.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)