### PR TITLE
feat: add context tracking for fallbacks and retries in prometheus, and send back model deployments

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -49,6 +49,7 @@ func createBifrostError(message string, statusCode *int, errorType *string, isBi
 // Test executeRequestWithRetries - success scenarios
 func TestExecuteRequestWithRetries_SuccessScenarios(t *testing.T) {
 	config := createTestConfig(3, 100*time.Millisecond, 1*time.Second)
+	ctx := context.Background()
 
 	// Test immediate success
 	t.Run("ImmediateSuccess", func(t *testing.T) {
@@ -59,6 +60,7 @@ func TestExecuteRequestWithRetries_SuccessScenarios(t *testing.T) {
 		}
 
 		result, err := executeRequestWithRetries(
+			&ctx,
 			config,
 			handler,
 			schemas.ChatCompletionRequest,
@@ -91,6 +93,7 @@ func TestExecuteRequestWithRetries_SuccessScenarios(t *testing.T) {
 		}
 
 		result, err := executeRequestWithRetries(
+			&ctx,
 			config,
 			handler,
 			schemas.ChatCompletionRequest,
@@ -113,7 +116,7 @@ func TestExecuteRequestWithRetries_SuccessScenarios(t *testing.T) {
 // Test executeRequestWithRetries - retry limits
 func TestExecuteRequestWithRetries_RetryLimits(t *testing.T) {
 	config := createTestConfig(2, 100*time.Millisecond, 1*time.Second)
-
+	ctx := context.Background()
 	t.Run("ExceedsMaxRetries", func(t *testing.T) {
 		callCount := 0
 		handler := func() (string, *schemas.BifrostError) {
@@ -123,6 +126,7 @@ func TestExecuteRequestWithRetries_RetryLimits(t *testing.T) {
 		}
 
 		result, err := executeRequestWithRetries(
+			&ctx,
 			config,
 			handler,
 			schemas.ChatCompletionRequest,
@@ -152,7 +156,7 @@ func TestExecuteRequestWithRetries_RetryLimits(t *testing.T) {
 // Test executeRequestWithRetries - non-retryable errors
 func TestExecuteRequestWithRetries_NonRetryableErrors(t *testing.T) {
 	config := createTestConfig(3, 100*time.Millisecond, 1*time.Second)
-
+	ctx := context.Background()
 	testCases := []struct {
 		name  string
 		error *schemas.BifrostError
@@ -184,6 +188,7 @@ func TestExecuteRequestWithRetries_NonRetryableErrors(t *testing.T) {
 			}
 
 			result, err := executeRequestWithRetries(
+				&ctx,
 				config,
 				handler,
 				schemas.ChatCompletionRequest,
@@ -207,7 +212,7 @@ func TestExecuteRequestWithRetries_NonRetryableErrors(t *testing.T) {
 // Test executeRequestWithRetries - retryable conditions
 func TestExecuteRequestWithRetries_RetryableConditions(t *testing.T) {
 	config := createTestConfig(1, 100*time.Millisecond, 1*time.Second)
-
+	ctx := context.Background()
 	testCases := []struct {
 		name  string
 		error *schemas.BifrostError
@@ -255,6 +260,7 @@ func TestExecuteRequestWithRetries_RetryableConditions(t *testing.T) {
 			}
 
 			result, err := executeRequestWithRetries(
+				&ctx,
 				config,
 				handler,
 				schemas.ChatCompletionRequest,
@@ -464,6 +470,7 @@ func TestIsRateLimitError_EdgeCases(t *testing.T) {
 // Test retry logging and attempt counting
 func TestExecuteRequestWithRetries_LoggingAndCounting(t *testing.T) {
 	config := createTestConfig(2, 50*time.Millisecond, 1*time.Second)
+	ctx := context.Background()
 
 	// Capture calls and timing for verification
 	var attemptCounts []int
@@ -482,6 +489,7 @@ func TestExecuteRequestWithRetries_LoggingAndCounting(t *testing.T) {
 	}
 
 	result, err := executeRequestWithRetries(
+		&ctx,
 		config,
 		handler,
 		schemas.ChatCompletionRequest,

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,6 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
+- feat: add numberOfRetries, fallbackIndex and selected key name to context
+[BREAKING] changed BifrostContextKeySelectedKey to BifrostContextKeySelectedKeyID
+- feat: send model deployment back in response extra fields

--- a/core/providers/cerebras.go
+++ b/core/providers/cerebras.go
@@ -108,6 +108,7 @@ func (provider *CerebrasProvider) TextCompletionStream(ctx context.Context, post
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }
@@ -147,6 +148,7 @@ func (provider *CerebrasProvider) ChatCompletionStream(ctx context.Context, post
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Cerebras,
 		postHookRunner,
+		nil,
 		nil,
 		provider.logger,
 	)

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -33,9 +33,7 @@ func (request *GeminiGenerationRequest) ToBifrostChatRequest() *schemas.BifrostC
 	if request.SystemInstruction != nil {
 		allGenAiMessages = append(allGenAiMessages, *request.SystemInstruction)
 	}
-	for _, content := range request.Contents {
-		allGenAiMessages = append(allGenAiMessages, content)
-	}
+	allGenAiMessages = append(allGenAiMessages, request.Contents...)
 
 	for _, content := range allGenAiMessages {
 		if len(content.Parts) == 0 {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -318,6 +318,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx context.Context, postHo
 		provider.GetProviderKey(),
 		postHookRunner,
 		nil,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/groq.go
+++ b/core/providers/groq.go
@@ -188,6 +188,7 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 		schemas.Groq,
 		postHookRunner,
 		nil,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -178,6 +178,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postH
 		schemas.Mistral,
 		postHookRunner,
 		nil,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/ollama.go
+++ b/core/providers/ollama.go
@@ -111,6 +111,7 @@ func (provider *OllamaProvider) TextCompletionStream(ctx context.Context, postHo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }
@@ -146,6 +147,7 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Ollama,
 		postHookRunner,
+		nil,
 		nil,
 		provider.logger,
 	)

--- a/core/providers/openrouter.go
+++ b/core/providers/openrouter.go
@@ -160,6 +160,7 @@ func (provider *OpenRouterProvider) TextCompletionStream(ctx context.Context, po
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }
@@ -200,6 +201,7 @@ func (provider *OpenRouterProvider) ChatCompletionStream(ctx context.Context, po
 		schemas.OpenRouter,
 		postHookRunner,
 		nil,
+		nil,
 		provider.logger,
 	)
 }
@@ -235,6 +237,7 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx context.Context, postHoo
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		nil,
 		provider.logger,
 	)

--- a/core/providers/parasail.go
+++ b/core/providers/parasail.go
@@ -120,6 +120,7 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, post
 		schemas.Parasail,
 		postHookRunner,
 		nil,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -187,6 +187,7 @@ func (provider *PerplexityProvider) ChatCompletionStream(ctx context.Context, po
 		schemas.Perplexity,
 		postHookRunner,
 		customRequestConverter,
+		nil,
 		provider.logger,
 	)
 }

--- a/core/providers/sgl.go
+++ b/core/providers/sgl.go
@@ -108,6 +108,7 @@ func (provider *SGLProvider) TextCompletionStream(ctx context.Context, postHookR
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
+		nil,
 		provider.logger,
 	)
 }
@@ -143,6 +144,7 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.SGL,
 		postHookRunner,
+		nil,
 		nil,
 		provider.logger,
 	)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -640,6 +640,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 			providerName,
 			postHookRunner,
 			nil,
+			nil,
 			provider.logger,
 		)
 	}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -104,7 +104,10 @@ const (
 	BifrostContextKeyRequestID           BifrostContextKey = "request-id"                     // string
 	BifrostContextKeyFallbackRequestID   BifrostContextKey = "fallback-request-id"            // string
 	BifrostContextKeyDirectKey           BifrostContextKey = "bifrost-direct-key"             // Key struct
-	BifrostContextKeySelectedKey         BifrostContextKey = "bifrost-key-selected"           // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeySelectedKeyID       BifrostContextKey = "bifrost-selected-key-id"        // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeySelectedKeyName     BifrostContextKey = "bifrost-selected-key-name"      // string (to store the selected key name (set by bifrost))
+	BifrostContextKeyNumberOfRetries     BifrostContextKey = "bifrost-number-of-retries"      // int (to store the number of retries (set by bifrost))
+	BifrostContextKeyFallbackIndex       BifrostContextKey = "bifrost-fallback-index"         // int (to store the fallback index (set by bifrost)) 0 for primary, 1 for first fallback, etc.
 	BifrostContextKeyStreamEndIndicator  BifrostContextKey = "bifrost-stream-end-indicator"   // bool (set by bifrost)
 	BifrostContextKeySkipKeySelection    BifrostContextKey = "bifrost-skip-key-selection"     // bool (will pass an empty key to the provider)
 	BifrostContextKeyExtraHeaders        BifrostContextKey = "bifrost-extra-headers"          // map[string]string
@@ -276,13 +279,14 @@ func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 
 // BifrostResponseExtraFields contains additional fields in a response.
 type BifrostResponseExtraFields struct {
-	RequestType    RequestType        `json:"request_type"`
-	Provider       ModelProvider      `json:"provider,omitempty"`
-	ModelRequested string             `json:"model_requested,omitempty"`
-	Latency        int64              `json:"latency"`     // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
-	ChunkIndex     int                `json:"chunk_index"` // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
-	RawResponse    interface{}        `json:"raw_response,omitempty"`
-	CacheDebug     *BifrostCacheDebug `json:"cache_debug,omitempty"`
+	RequestType     RequestType        `json:"request_type"`
+	Provider        ModelProvider      `json:"provider,omitempty"`
+	ModelRequested  string             `json:"model_requested,omitempty"`
+	ModelDeployment string             `json:"model_deployment,omitempty"` // only present for providers which use model deployments (e.g. Azure, Bedrock)
+	Latency         int64              `json:"latency"`                    // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
+	ChunkIndex      int                `json:"chunk_index"`                // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
+	RawResponse     interface{}        `json:"raw_response,omitempty"`
+	CacheDebug      *BifrostCacheDebug `json:"cache_debug,omitempty"`
 }
 
 // BifrostCacheDebug represents debug information about the cache.

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -28,12 +28,18 @@ The telemetry plugin operates asynchronously to ensure metrics collection doesn'
 
 These metrics track all incoming HTTP requests to Bifrost:
 
-| Metric | Type | Description | Labels |
-|--------|------|-------------|---------|
-| `http_requests_total` | Counter | Total number of HTTP requests | `path`, `method`, `status`, custom labels |
-| `http_request_duration_seconds` | Histogram | Duration of HTTP requests | `path`, `method`, `status`, custom labels |
-| `http_request_size_bytes` | Histogram | Size of incoming HTTP requests | `path`, `method`, `status`, custom labels |
-| `http_response_size_bytes` | Histogram | Size of outgoing HTTP responses | `path`, `method`, `status`, custom labels |
+| Metric | Type | Description |
+|--------|------|-------------|
+| `http_requests_total` | Counter | Total number of HTTP requests |
+| `http_request_duration_seconds` | Histogram | Duration of HTTP requests |
+| `http_request_size_bytes` | Histogram | Size of incoming HTTP requests |
+| `http_response_size_bytes` | Histogram | Size of outgoing HTTP responses |
+
+Labels:
+- `path`: HTTP endpoint path
+- `method`: HTTP verb (e.g., `GET`, `POST`, `PUT`, `DELETE`)
+- `status`: HTTP status code
+- custom labels: Custom labels configured in the Bifrost configuration
 
 ### Upstream Provider Metrics
 
@@ -41,14 +47,26 @@ These metrics track requests forwarded to AI providers:
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|---------|
-| `bifrost_upstream_requests_total` | Counter | Total requests forwarded to upstream providers | `provider`, `model`, `method`, custom labels |
-| `bifrost_upstream_latency_seconds` | Histogram | Latency of upstream provider requests | `provider`, `model`, `method`, custom labels |
-| `bifrost_success_requests_total` | Counter | Total successful requests to upstream providers | `provider`, `model`, `method`, custom labels |
-| `bifrost_error_requests_total` | Counter | Total failed requests to upstream providers | `provider`, `model`, `method`, custom labels |
-| `bifrost_input_tokens_total` | Counter | Total input tokens sent to upstream providers | `provider`, `model`, `method`, custom labels |
-| `bifrost_output_tokens_total` | Counter | Total output tokens received from upstream providers | `provider`, `model`, `method`, custom labels |
-| `bifrost_cache_hits_total` | Counter | Total cache hits by type (direct/semantic) | `provider`, `model`, `method`, `cache_type`, custom labels |
-| `bifrost_cost_total` | Counter | Total cost in USD for upstream provider requests | `provider`, `model`, `method`, custom labels |
+| `bifrost_upstream_requests_total` | Counter | Total requests forwarded to upstream providers | Base Labels, custom labels |
+| `bifrost_success_requests_total` | Counter | Total successful requests to upstream providers | Base Labels, custom labels |
+| `bifrost_error_requests_total` | Counter | Total failed requests to upstream providers | Base Labels, `reason`, custom labels |
+| `bifrost_upstream_latency_seconds` | Histogram | Latency of upstream provider requests | Base Labels, `is_success`, custom labels |
+| `bifrost_input_tokens_total` | Counter | Total input tokens sent to upstream providers | Base Labels, custom labels |
+| `bifrost_output_tokens_total` | Counter | Total output tokens received from upstream providers | Base Labels, custom labels |
+| `bifrost_cache_hits_total` | Counter | Total cache hits by type (direct/semantic) | Base Labels, `cache_type`, custom labels |
+| `bifrost_cost_total` | Counter | Total cost in USD for upstream provider requests | Base Labels, custom labels |
+
+Base Labels:
+- `provider`: AI provider name (e.g., `openai`, `anthropic`, `azure`)
+- `model`: Model name (e.g., `gpt-4o-mini`, `claude-3-sonnet`)
+- `method`: Request type (`chat`, `text`, `embedding`, `speech`, `transcription`)
+- `virtual_key_id`: Virtual key ID
+- `virtual_key_name`: Virtual key name
+- `selected_key_id`: Selected key ID
+- `selected_key_name`: Selected key name
+- `number_of_retries`: Number of retries
+- `fallback_index`: Fallback index (0 for first attempt, 1 for second attempt, etc.)
+- custom labels: Custom labels configured in the Bifrost configuration
 
 ### Streaming Metrics
 
@@ -56,17 +74,8 @@ These metrics capture latency characteristics specific to streaming responses:
 
 | Metric | Type | Description | Labels |
 |--------|------|-------------|---------|
-| `bifrost_stream_first_token_latency_seconds` | Histogram | Time from request start to first streamed token | `provider`, `model`, `method`, custom labels |
-| `bifrost_stream_inter_token_latency_seconds` | Histogram | Latency between subsequent streamed tokens | `provider`, `model`, `method`, custom labels |
-
-**Label Definitions:**
-- `provider`: AI provider name (e.g., `openai`, `anthropic`, `azure`)
-- `model`: Model name (e.g., `gpt-4o-mini`, `claude-3-sonnet`)
-- `method`: Request type (`chat`, `text`, `embedding`, `speech`, `transcription`)
-- `cache_type`: Cache hit type (`direct`, `semantic`) - only for cache hits metric
-- `reason`: Error reason string - only for `bifrost_error_requests_total`
-- `path`: HTTP endpoint path
-- `status`: HTTP status code
+| `bifrost_stream_first_token_latency_seconds` | Histogram | Time from request start to first streamed token | Base Labels |
+| `bifrost_stream_inter_token_latency_seconds` | Histogram | Latency between subsequent streamed tokens | Base Labels |
 
 ---
 

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -316,9 +316,9 @@ func (p *GovernancePlugin) addMCPIncludeTools(headers map[string]string, virtual
 func (p *GovernancePlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
 	// Extract governance headers and virtual key using utility functions
 	headers := extractHeadersFromContext(*ctx)
-	virtualKey := getStringFromContext(*ctx, schemas.BifrostContextKeyVirtualKey)
+	virtualKeyValue := getStringFromContext(*ctx, schemas.BifrostContextKeyVirtualKey)
 	requestID := getStringFromContext(*ctx, schemas.BifrostContextKeyRequestID)
-	if virtualKey == "" {
+	if virtualKeyValue == "" {
 		if p.isVkMandatory != nil && *p.isVkMandatory {
 			return req, &schemas.PluginShortCircuit{
 				Error: &schemas.BifrostError{
@@ -338,7 +338,7 @@ func (p *GovernancePlugin) PreHook(ctx *context.Context, req *schemas.BifrostReq
 
 	// Create request context for evaluation
 	evaluationRequest := &EvaluationRequest{
-		VirtualKey: virtualKey,
+		VirtualKey: virtualKeyValue,
 		Provider:   provider,
 		Model:      model,
 		Headers:    headers,

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -29,7 +29,7 @@ const (
 
 // EvaluationRequest contains the context for evaluating a request
 type EvaluationRequest struct {
-	VirtualKey string                `json:"virtual_key"`
+	VirtualKey string                `json:"virtual_key"` // Virtual key value
 	Provider   schemas.ModelProvider `json:"provider"`
 	Model      string                `json:"model"`
 	Headers    map[string]string     `json:"headers"`
@@ -86,6 +86,10 @@ func (r *BudgetResolver) EvaluateRequest(ctx *context.Context, evaluationRequest
 			Reason:   "Virtual key not found",
 		}
 	}
+
+	// Set virtual key id and name in context
+	*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-virtual-key-id"), vk.ID)
+	*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-virtual-key-name"), vk.Name)
 
 	if !vk.IsActive {
 		return &EvaluationResult{

--- a/plugins/telemetry/changelog.md
+++ b/plugins/telemetry/changelog.md
@@ -1,4 +1,6 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
-- chore: version update framework to 1.1.24
+- chore: version update core to 1.2.19 and framework to 1.1.22
+- feat: add numberOfRetries, fallbackIndex and selected key name and id to context to telemetry metrics
+- feat: add used virtual key name and id to telemetry metrics

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -4,6 +4,7 @@
 package telemetry
 
 import (
+	"context"
 	"log"
 	"math"
 	"strings"
@@ -65,4 +66,24 @@ func safeObserve(histogram *prometheus.HistogramVec, value float64, labels ...st
 			metric.Observe(value)
 		}
 	}
+}
+
+// getStringFromContext safely extracts a string value from context
+func getStringFromContext(ctx context.Context, key any) string {
+	if value := ctx.Value(key); value != nil {
+		if str, ok := value.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+// getIntFromContext safely extracts an int value from context
+func getIntFromContext(ctx context.Context, key any) int {
+	if value := ctx.Value(key); value != nil {
+		if intValue, ok := value.(int); ok {
+			return intValue
+		}
+	}
+	return 0
 }

--- a/tests/core-providers/scenarios/reasoning.go
+++ b/tests/core-providers/scenarios/reasoning.go
@@ -82,8 +82,7 @@ func RunReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 
 		// Enhanced validation for reasoning scenarios
 		expectations := GetExpectationsForScenario("Reasoning", testConfig, map[string]interface{}{
-			"requires_reasoning":   true,
-			"mathematical_problem": true,
+			"requires_reasoning": true,
 		})
 		expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 		expectations.MinContentLength = 50   // Reasoning requires substantial content

--- a/tests/core-providers/scenarios/speech_synthesis_stream.go
+++ b/tests/core-providers/scenarios/speech_synthesis_stream.go
@@ -355,7 +355,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 
 			// Test streaming with all available voices
 			openaiVoices := []string{"alloy", "echo", "fable", "onyx", "nova", "shimmer"}
-			geminiVoices := []string{"achernar", "achird", "despina", "erinome"}
+			geminiVoices := []string{"achernar", "achird", "erinome"}
 			testText := "Testing streaming speech synthesis with different voice options."
 
 			if testConfig.Provider == schemas.OpenAI {

--- a/tests/core-providers/scenarios/utils.go
+++ b/tests/core-providers/scenarios/utils.go
@@ -44,7 +44,7 @@ func GetProviderVoice(provider schemas.ModelProvider, voiceType string) string {
 		case "secondary":
 			return "aoede"
 		case "tertiary":
-			return "despina"
+			return "erinome"
 		default:
 			return "achernar"
 		}

--- a/tests/core-providers/scenarios/validation_presets.go
+++ b/tests/core-providers/scenarios/validation_presets.go
@@ -298,7 +298,7 @@ func GetExpectationsForScenario(scenarioName string, testConfig config.Comprehen
 	case "Reasoning":
 		expectations := ReasoningExpectations()
 		if requiresReasoning, ok := customParams["requires_reasoning"].(bool); ok && requiresReasoning {
-			expectations.ShouldContainAnyOf = []string{"step", "first", "then", "calculate", "therefore", "because", "solve"}
+			expectations.ShouldContainAnyOf = append(expectations.ShouldContainAnyOf, []string{"step", "first", "then", "calculate", "therefore", "because", "solve"}...)
 		}
 		return expectations
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,4 +1,8 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
-- change: health endpoint is whitelisted from auth middleware
+- chore: version update framework to 1.1.24
+- chore: allowed changing name when updating a virtual key
+- feat: add numberOfRetries, fallbackIndex and selected key name and id to context to telemetry metrics
+- feat: add used virtual key name and id to telemetry metrics
+- feat: send model deployment back in response extra fields


### PR DESCRIPTION
## Summary

Add context tracking for fallbacks, retries, and model deployments to improve observability and debugging capabilities.

## Changes

- Added fallback index tracking in context to identify which provider is being used (0 for primary, 1+ for fallbacks)
- Added retry count tracking in context to monitor how many retries were needed for a request
- Added model deployment information to response extra fields for Azure and Bedrock providers
- Renamed `BifrostContextKeySelectedKey` to `BifrostContextKeySelectedKeyID` and added `BifrostContextKeySelectedKeyName` for better key tracking
- Enhanced telemetry plugin to capture and report these new metrics
- Added governance plugin context values for virtual key ID and name

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Check that the new context values are properly passed through the request lifecycle by examining logs or using the telemetry plugin.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves observability for debugging and monitoring.

## Security considerations

No security implications as this only adds internal tracking information.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable