### PR TITLE
feat: add selected key and virtual key to logs table

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,5 +1,5 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
-- fix: resolve MCP client deletion when attached to a virtual key
-- fix: vk team/customer association issue when updating a vk
+- chore: Upgrades core to 1.2.19
+- feat: add selected key and virtual key to logs table

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -65,6 +65,7 @@ type ConfigStore interface {
 
 	// Governance config CRUD
 	GetVirtualKeys(ctx context.Context) ([]tables.TableVirtualKey, error)
+	GetRedactedVirtualKeys(ctx context.Context, ids []string) ([]tables.TableVirtualKey, error) // leave ids empty to get all
 	GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error)
 	GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error)
 	CreateVirtualKey(ctx context.Context, virtualKey *tables.TableVirtualKey, tx ...*gorm.DB) error
@@ -129,6 +130,7 @@ type ConfigStore interface {
 
 	// Key management
 	GetKeysByIDs(ctx context.Context, ids []string) ([]tables.TableKey, error)
+	GetAllRedactedKeys(ctx context.Context, ids []string) ([]schemas.Key, error) // leave ids empty to get all
 
 	// Generic transaction manager
 	ExecuteTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -28,6 +28,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddResponsesInputHistoryColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddNumberOfRetriesAndFallbackIndexAndSelectedKeyAndVirtualKeyColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -303,6 +306,77 @@ func migrationAddResponsesInputHistoryColumn(ctx context.Context, db *gorm.DB) e
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding responses_input_history column: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddNumberOfRetriesAndFallbackIndexAndSelectedKeyAndVirtualKeyColumns(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_init_add_number_of_retries_and_fallback_index_and_selected_key_and_virtual_key_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "number_of_retries") {
+				if err := migrator.AddColumn(&Log{}, "number_of_retries"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&Log{}, "fallback_index") {
+				if err := migrator.AddColumn(&Log{}, "fallback_index"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&Log{}, "selected_key_id") {
+				if err := migrator.AddColumn(&Log{}, "selected_key_id"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&Log{}, "selected_key_name") {
+				if err := migrator.AddColumn(&Log{}, "selected_key_name"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&Log{}, "virtual_key_id") {
+				if err := migrator.AddColumn(&Log{}, "virtual_key_id"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&Log{}, "virtual_key_name") {
+				if err := migrator.AddColumn(&Log{}, "virtual_key_name"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if err := migrator.DropColumn(&Log{}, "number_of_retries"); err != nil {
+				return err
+			}
+			if err := migrator.DropColumn(&Log{}, "fallback_index"); err != nil {
+				return err
+			}
+			if err := migrator.DropColumn(&Log{}, "selected_key_id"); err != nil {
+				return err
+			}
+			if err := migrator.DropColumn(&Log{}, "selected_key_name"); err != nil {
+				return err
+			}
+			if err := migrator.DropColumn(&Log{}, "virtual_key_id"); err != nil {
+				return err
+			}
+			if err := migrator.DropColumn(&Log{}, "virtual_key_name"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding number_of_retries and fallback_index columns: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -56,6 +56,12 @@ func (s *RDBLogStore) SearchLogs(ctx context.Context, filters SearchFilters, pag
 	if len(filters.Objects) > 0 {
 		baseQuery = baseQuery.Where("object_type IN ?", filters.Objects)
 	}
+	if len(filters.SelectedKeyIDs) > 0 {
+		baseQuery = baseQuery.Where("selected_key_id IN ?", filters.SelectedKeyIDs)
+	}
+	if len(filters.VirtualKeyIDs) > 0 {
+		baseQuery = baseQuery.Where("virtual_key_id IN ?", filters.VirtualKeyIDs)
+	}
 	if filters.StartTime != nil {
 		baseQuery = baseQuery.Where("timestamp >= ?", *filters.StartTime)
 	}

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,4 +1,5 @@
 <!-- The pattern we follow here is to keep the changelog for the latest version -->
 <!-- Old changelogs are automatically attached to the GitHub releases -->
 
-- chore: version update framework to 1.1.24
+- chore: version update core to 1.2.19 and framework to 1.1.22
+- feat: add selected key and virtual key to logs

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -12,6 +12,12 @@ import (
 	"github.com/maximhq/bifrost/framework/logstore"
 )
 
+// KeyPair represents an ID-Name pair for keys
+type KeyPair struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
 // LogManager defines the main interface that combines all logging functionality
 type LogManager interface {
 	// Search searches for log entries based on filters and pagination
@@ -22,6 +28,12 @@ type LogManager interface {
 
 	// GetAvailableModels returns all unique models from logs
 	GetAvailableModels(ctx context.Context) []string
+
+	// GetAvailableSelectedKeys returns all unique selected key ID-Name pairs from logs
+	GetAvailableSelectedKeys(ctx context.Context) []KeyPair
+
+	// GetAvailableVirtualKeys returns all unique virtual key ID-Name pairs from logs
+	GetAvailableVirtualKeys(ctx context.Context) []KeyPair
 }
 
 // PluginLogManager implements LogManager interface wrapping the plugin
@@ -43,6 +55,16 @@ func (p *PluginLogManager) GetDroppedRequests(ctx context.Context) int64 {
 // GetAvailableModels returns all unique models from logs
 func (p *PluginLogManager) GetAvailableModels(ctx context.Context) []string {
 	return p.plugin.GetAvailableModels(ctx)
+}
+
+// GetAvailableSelectedKeys returns all unique selected key ID-Name pairs from logs
+func (p *PluginLogManager) GetAvailableSelectedKeys(ctx context.Context) []KeyPair {
+	return p.plugin.GetAvailableSelectedKeys(ctx)
+}
+
+// GetAvailableVirtualKeys returns all unique virtual key ID-Name pairs from logs
+func (p *PluginLogManager) GetAvailableVirtualKeys(ctx context.Context) []KeyPair {
+	return p.plugin.GetAvailableVirtualKeys(ctx)
 }
 
 // GetPluginLogManager returns a LogManager interface for this plugin
@@ -139,4 +161,24 @@ func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) ([]s
 		}, []schemas.ResponsesMessage{}
 	}
 	return []schemas.ChatMessage{}, []schemas.ResponsesMessage{}
+}
+
+// getStringFromContext safely extracts a string value from context
+func getStringFromContext(ctx context.Context, key any) string {
+	if value := ctx.Value(key); value != nil {
+		if str, ok := value.(string); ok {
+			return str
+		}
+	}
+	return ""
+}
+
+// getIntFromContext safely extracts an int value from context
+func getIntFromContext(ctx context.Context, key any) int {
+	if value := ctx.Value(key); value != nil {
+		if intVal, ok := value.(int); ok {
+			return intVal
+		}
+	}
+	return 0
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -6,3 +6,4 @@
 - feat: add numberOfRetries, fallbackIndex and selected key name and id to context to telemetry metrics
 - feat: add used virtual key name and id to telemetry metrics
 - feat: send model deployment back in response extra fields
+- feat: add selected key and virtual key to logs filter

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -35,6 +35,8 @@ export default function LogsPage() {
 		models: [],
 		status: [],
 		content_search: "",
+		selected_key_ids: [],
+		virtual_key_ids: [],
 	});
 	const [pagination, setPagination] = useState<Pagination>({
 		limit: 50,
@@ -349,7 +351,7 @@ export default function LogsPage() {
 			) : showEmptyState ? (
 				<EmptyState isSocketConnected={isSocketConnected} error={error} />
 			) : (
-				<div className="space-y-6 max-w-7xl	mx-auto">
+				<div className="mx-auto max-w-7xl space-y-6">
 					<div className="space-y-6">
 						{/* Quick Stats */}
 						<div className="grid grid-cols-1 gap-4 md:grid-cols-5">

--- a/ui/app/workspace/logs/views/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/views/logDetailsSheet.tsx
@@ -101,6 +101,12 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 									</div>
 								}
 							/>
+							{log.selected_key && <LogEntryDetailsView className="w-full" label="Selected Key" value={log.selected_key.name} />}
+							{log.number_of_retries > 0 && (
+								<LogEntryDetailsView className="w-full" label="Number of Retries" value={log.number_of_retries} />
+							)}
+							{log.fallback_index > 0 && <LogEntryDetailsView className="w-full" label="Fallback Index" value={log.fallback_index} />}
+							{log.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={log.virtual_key.name} />}
 
 							{log.params &&
 								Object.keys(log.params).length > 0 &&
@@ -300,23 +306,23 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 					</>
 				)}
 
-			{/* Show input for chat/text completions */}
-			{log.input_history && log.input_history.length > 0 && (
-				<>
-					<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
-					<LogChatMessageView message={log.input_history[log.input_history.length - 1]} />
-				</>
-			)}
+				{/* Show input for chat/text completions */}
+				{log.input_history && log.input_history.length > 0 && (
+					<>
+						<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
+						<LogChatMessageView message={log.input_history[log.input_history.length - 1]} />
+					</>
+				)}
 
-			{/* Show input history for responses API */}
-			{log.responses_input_history && log.responses_input_history.length > 0 && (
-				<>
-					<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
-					<LogResponsesMessageView messages={log.responses_input_history} />
-				</>
-			)}
+				{/* Show input history for responses API */}
+				{log.responses_input_history && log.responses_input_history.length > 0 && (
+					<>
+						<div className="mt-4 w-full text-left text-sm font-medium">Input</div>
+						<LogResponsesMessageView messages={log.responses_input_history} />
+					</>
+				)}
 
-			{log.status !== "processing" && (
+				{log.status !== "processing" && (
 					<>
 						{log.output_message && !log.error_details?.error.message && (
 							<>

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -1,5 +1,6 @@
 import { LogEntry, LogFilters, LogStats, Pagination } from "@/lib/types/logs";
 import { baseApi } from "./baseApi";
+import { DBKey, RedactedDBKey, VirtualKey } from "@/lib/types/governance";
 
 export const logsApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
@@ -36,6 +37,12 @@ export const logsApi = baseApi.injectEndpoints({
 				if (filters.objects && filters.objects.length > 0) {
 					params.objects = filters.objects.join(",");
 				}
+				if (filters.selected_key_ids && filters.selected_key_ids.length > 0) {
+					params.selected_key_ids = filters.selected_key_ids.join(",");
+				}
+				if (filters.virtual_key_ids && filters.virtual_key_ids.length > 0) {
+					params.virtual_key_ids = filters.virtual_key_ids.join(",");
+				}
 				if (filters.start_time) params.start_time = filters.start_time;
 				if (filters.end_time) params.end_time = filters.end_time;
 				if (filters.min_latency) params.min_latency = filters.min_latency;
@@ -59,8 +66,8 @@ export const logsApi = baseApi.injectEndpoints({
 		}),
 
 		// Get available models
-		getAvailableModels: builder.query<{ models: string[] }, void>({
-			query: () => "/logs/models",
+		getAvailableFilterData: builder.query<{ models: string[]; selected_keys: RedactedDBKey[]; virtual_keys: VirtualKey[] }, void>({
+			query: () => "/logs/filterdata",
 			providesTags: ["Logs"],
 		}),
 	}),
@@ -69,8 +76,8 @@ export const logsApi = baseApi.injectEndpoints({
 export const {
 	useGetLogsQuery,
 	useGetDroppedRequestsQuery,
-	useGetAvailableModelsQuery,
+	useGetAvailableFilterDataQuery,
 	useLazyGetLogsQuery,
 	useLazyGetDroppedRequestsQuery,
-	useLazyGetAvailableModelsQuery,
+	useLazyGetAvailableFilterDataQuery,
 } = logsApi;

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -51,6 +51,13 @@ export interface DBKey {
 	provider: ModelProviderName; // Provider name
 }
 
+export interface RedactedDBKey {
+	id: string;
+	name: string;
+	models: string[];
+	weight: number;
+}
+
 export interface VirtualKey {
 	id: string;
 	name: string;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -1,5 +1,7 @@
 // Types for the logs interface based on BifrostResponse schema
 
+import { DBKey, VirtualKey } from "./governance";
+
 // Speech and Transcription types
 export interface VoiceConfig {
 	speaker: string;
@@ -247,6 +249,12 @@ export interface LogEntry {
 	timestamp: string; // ISO string format from Go time.Time
 	provider: string;
 	model: string;
+	number_of_retries: number;
+	fallback_index: number;
+	selected_key_id: string;
+	virtual_key_id?: string;
+	selected_key?: DBKey;
+	virtual_key?: VirtualKey;
 	input_history: ChatMessage[];
 	responses_input_history: ResponsesMessage[];
 	output_message?: ChatMessage;
@@ -273,6 +281,8 @@ export interface LogEntry {
 export interface LogFilters {
 	providers?: string[];
 	models?: string[];
+	selected_key_ids?: string[];
+	virtual_key_ids?: string[];
 	status?: string[];
 	objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
 	start_time?: string; // RFC3339 format


### PR DESCRIPTION
## Summary

Add selected key and virtual key information to logs for better tracking and filtering of API requests.

## Changes

- Added `selected_key_id` and `virtual_key_id` columns to the logs table
- Added `number_of_retries` and `fallback_index` columns to track retry attempts
- Created new methods in ConfigStore to retrieve redacted key information
- Enhanced log filtering to support filtering by selected key and virtual key
- Updated UI to display and filter logs by selected key and virtual key
- Added key information to log details view

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (Next.js)

## How to test

1. Make API requests with different keys and virtual keys
2. Check the logs UI to verify key information is displayed
3. Test filtering logs by selected key and virtual key

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

The implementation uses redacted key information to avoid exposing sensitive data in logs.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)