### PR TITLE
feat: restrict request types in custom provider as per bifrost

### DIFF
--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -94,6 +94,8 @@ type AllowedRequests struct {
 	TextCompletionStream bool `json:"text_completion_stream"`
 	ChatCompletion       bool `json:"chat_completion"`
 	ChatCompletionStream bool `json:"chat_completion_stream"`
+	Responses            bool `json:"responses"`
+	ResponsesStream      bool `json:"responses_stream"`
 	Embedding            bool `json:"embedding"`
 	Speech               bool `json:"speech"`
 	SpeechStream         bool `json:"speech_stream"`
@@ -118,6 +120,10 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 		return ar.ChatCompletion
 	case ChatCompletionStreamRequest:
 		return ar.ChatCompletionStream
+	case ResponsesRequest:
+		return ar.Responses
+	case ResponsesStreamRequest:
+		return ar.ResponsesStream
 	case EmbeddingRequest:
 		return ar.Embedding
 	case SpeechRequest:

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -37,8 +37,8 @@ type ConfigStore interface {
 	GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, error)
 	GetMCPClientByName(ctx context.Context, name string) (*tables.TableMCPClient, error)
 	CreateMCPClientConfig(ctx context.Context, clientConfig schemas.MCPClientConfig, envKeys map[string][]EnvKeyInfo) error
-	UpdateMCPClientConfig(ctx context.Context, name string, clientConfig schemas.MCPClientConfig, envKeys map[string][]EnvKeyInfo) error
-	DeleteMCPClientConfig(ctx context.Context, name string) error
+	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig schemas.MCPClientConfig, envKeys map[string][]EnvKeyInfo) error
+	DeleteMCPClientConfig(ctx context.Context, id string) error
 
 	// Vector store config CRUD
 	UpdateVectorStoreConfig(ctx context.Context, config *vectorstore.Config) error

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { AllowedRequestsFields } from "./allowedRequestsFields";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
-import { KnownProvider, ModelProvider } from "@/lib/types/config";
+import { BaseProvider, ModelProvider } from "@/lib/types/config";
 import { formCustomProviderConfigSchema } from "@/lib/types/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
@@ -36,6 +36,8 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				text_completion: provider.custom_provider_config?.allowed_requests?.text_completion ?? true,
 				chat_completion: provider.custom_provider_config?.allowed_requests?.chat_completion ?? true,
 				chat_completion_stream: provider.custom_provider_config?.allowed_requests?.chat_completion_stream ?? true,
+				responses: provider.custom_provider_config?.allowed_requests?.responses ?? true,
+				responses_stream: provider.custom_provider_config?.allowed_requests?.responses_stream ?? true,
 				embedding: provider.custom_provider_config?.allowed_requests?.embedding ?? true,
 				speech: provider.custom_provider_config?.allowed_requests?.speech ?? true,
 				speech_stream: provider.custom_provider_config?.allowed_requests?.speech_stream ?? true,
@@ -59,7 +61,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 		updateProvider({
 			...provider,
 			custom_provider_config: {
-				base_provider_type: data.base_provider_type as unknown as KnownProvider,
+				base_provider_type: data.base_provider_type as unknown as BaseProvider,
 				allowed_requests: data.allowed_requests,
 			},
 		})
@@ -106,7 +108,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				</div>
 
 				{/* Allowed Requests Configuration */}
-				<AllowedRequestsFields control={form.control} />
+				<AllowedRequestsFields control={form.control} providerType={form.watch("base_provider_type") as BaseProvider} />
 
 				{/* Form Actions */}
 				<div className="flex justify-end space-x-2 py-2">

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -1,4 +1,4 @@
-import { AllowedRequests, ConcurrencyAndBufferSize, NetworkConfig } from "@/lib/types/config";
+import { AllowedRequests, BaseProvider, ConcurrencyAndBufferSize, NetworkConfig } from "@/lib/types/config";
 import { ProviderName } from "./logs";
 
 // Model placeholders based on provider type
@@ -62,6 +62,8 @@ export const DEFAULT_ALLOWED_REQUESTS = {
 	text_completion: true,
 	chat_completion: true,
 	chat_completion_stream: true,
+	responses: true,
+	responses_stream: true,
 	embedding: true,
 	speech: true,
 	speech_stream: true,
@@ -69,5 +71,62 @@ export const DEFAULT_ALLOWED_REQUESTS = {
 	transcription_stream: true,
 	list_models: true,
 } as const satisfies Required<AllowedRequests>;
+
+// Mapping of what IS supported by each base provider
+export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
+	openai: [
+		"list_models",
+        "text_completion",
+        "chat_completion",
+        "chat_completion_stream",
+        "responses",
+        "responses_stream",
+        "embedding",
+        "speech",
+        "speech_stream",
+        "transcription",
+        "transcription_stream",
+    ],
+	anthropic: [
+		"list_models",
+		"text_completion",
+		"chat_completion",
+		"chat_completion_stream",
+		"responses",
+		"responses_stream",
+	],
+	gemini: [
+		"list_models",
+		"text_completion",
+		"chat_completion",
+		"chat_completion_stream",
+		"responses",
+		"responses_stream",
+		"embedding",
+		"transcription",
+		"transcription_stream",
+        "speech",
+        "speech_stream",
+	],
+	cohere: [
+		"list_models",
+		"text_completion",
+		"chat_completion",
+		"chat_completion_stream",
+		"responses",
+		"responses_stream",
+		"embedding",
+	],
+	bedrock: [
+		"list_models",
+		"text_completion",
+		"chat_completion",
+		"chat_completion_stream",
+		"responses",
+		"responses_stream",
+		"embedding",
+	],
+};
+
 
 export const IS_ENTERPRISE = process.env.NEXT_PUBLIC_IS_ENTERPRISE === "true";

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -56,6 +56,8 @@ const AllowedRequestsSchema = z.object({
 	text_completion: z.boolean(),
 	chat_completion: z.boolean(),
 	chat_completion_stream: z.boolean(),
+	responses: z.boolean(),
+	responses_stream: z.boolean(),
 	embedding: z.boolean(),
 	speech: z.boolean(),
 	speech_stream: z.boolean(),

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -5,6 +5,9 @@ import { KnownProvidersNames } from "@/lib/constants/logs";
 // Known provider names - all supported standard providers
 export type KnownProvider = (typeof KnownProvidersNames)[number];
 
+// Base provider names - all supported base providers
+export type BaseProvider = "openai" | "anthropic" | "cohere" | "gemini" | "bedrock";
+
 // Branded type for custom provider names to prevent collision with known providers
 export type CustomProviderName = string & { readonly __brand: "CustomProviderName" };
 
@@ -115,6 +118,8 @@ export interface AllowedRequests {
 	text_completion: boolean;
 	chat_completion: boolean;
 	chat_completion_stream: boolean;
+	responses: boolean;
+	responses_stream: boolean;
 	embedding: boolean;
 	speech: boolean;
 	speech_stream: boolean;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -276,6 +276,8 @@ export const allowedRequestsSchema = z.object({
 	text_completion: z.boolean(),
 	chat_completion: z.boolean(),
 	chat_completion_stream: z.boolean(),
+	responses: z.boolean(),
+	responses_stream: z.boolean(),
 	embedding: z.boolean(),
 	speech: z.boolean(),
 	speech_stream: z.boolean(),

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -1,3 +1,6 @@
+import { PROVIDER_SUPPORTED_REQUESTS } from "../constants/config";
+import { BaseProvider, KnownProvider } from "../types/config";
+
 export interface ValidationRule {
 	isValid: boolean;
 	message: string;
@@ -553,3 +556,19 @@ export const cleanJson = (text: unknown) => {
 		return text;
 	}
 };
+
+/**
+ * Checks if a request type is disabled for a provider
+ * @param providerType - The provider type
+ * @param requestType - The request type
+ * @returns true if the request type is disabled
+ */
+export function isRequestTypeDisabled(providerType: BaseProvider | undefined, requestType: string): boolean {
+	if (!providerType) return false;
+	
+	const supportedRequests = PROVIDER_SUPPORTED_REQUESTS[providerType];
+	if (!supportedRequests) return false; // If provider not in base list, allow all
+	
+	return !supportedRequests.includes(requestType);
+}
+


### PR DESCRIPTION
## Add support for Responses API in custom providers

This PR adds support for the Responses API in custom providers, allowing users to enable or disable this capability when configuring custom providers. It also improves the UI by disabling request types that aren't supported by specific base providers.

## Changes

- Added `responses` and `responses_stream` fields to the allowed requests schema
- Created a mapping of supported request types for each base provider
- Added validation to disable unsupported request types based on the selected provider
- Added tooltips to explain why certain request types are disabled
- Improved the form layout with better scrolling behavior and loading state
- Moved the `allowedRequestsSchema` to a shared location for reuse

## Type of change

- [x] Feature
- [x] UI (Next.js)

## Affected areas

- [x] UI (Next.js)
- [x] Providers/Integrations

## How to test

1. Navigate to the Providers section in the workspace
2. Click "Add Custom Provider"
3. Select different base formats (OpenAI, Anthropic, etc.) and observe how the available request types change
4. Verify that the Responses API options are available and properly disabled based on provider support
5. Complete the form and verify the provider is created with the correct settings

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is a UI enhancement for existing functionality.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (UI)
- [x] I verified the changes work as expected in the application