### PR TITLE
feat: add path overrides for each request type in custom provider

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -213,6 +213,29 @@ func GetPathFromContext(ctx context.Context, defaultPath string) string {
 	return defaultPath
 }
 
+// GetRequestPath gets the request path from the context, if it exists, checking for path overrides in the custom provider config.
+func GetRequestPath(ctx context.Context, defaultPath string, customProviderConfig *schemas.CustomProviderConfig, requestType schemas.RequestType) string {
+	// If path set in context, return it
+	if pathInContext, ok := ctx.Value(schemas.BifrostContextKeyURLPath).(string); ok {
+		return pathInContext
+	}
+	// If path override set in custom provider config, return it
+	if customProviderConfig != nil && customProviderConfig.RequestPathOverrides != nil {
+		if raw, ok := customProviderConfig.RequestPathOverrides[requestType]; ok {
+			pathOverride := strings.TrimSpace(raw)
+			if pathOverride == "" {
+				return defaultPath
+			}
+			if !strings.HasPrefix(pathOverride, "/") {
+				pathOverride = "/" + pathOverride
+			}
+			return pathOverride
+		}
+	}
+	// Return default path
+	return defaultPath
+}
+
 type RequestBodyGetter interface {
 	GetRawRequestBody() []byte
 }

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -140,9 +140,10 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 }
 
 type CustomProviderConfig struct {
-	CustomProviderKey string           `json:"-"`                  // Custom provider key, internally set by Bifrost
-	BaseProviderType  ModelProvider    `json:"base_provider_type"` // Base provider type
-	AllowedRequests   *AllowedRequests `json:"allowed_requests,omitempty"`
+	CustomProviderKey    string                 `json:"-"`                                // Custom provider key, internally set by Bifrost
+	BaseProviderType     ModelProvider          `json:"base_provider_type"`               // Base provider type
+	AllowedRequests      *AllowedRequests       `json:"allowed_requests,omitempty"`       // Allowed requests for the custom provider
+	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider
 }
 
 // IsOperationAllowed checks if a specific operation is allowed for this custom provider

--- a/docs/features/custom-providers.mdx
+++ b/docs/features/custom-providers.mdx
@@ -63,13 +63,19 @@ curl --location 'http://localhost:8080/api/providers' \
         "allowed_requests": {
             "list_models": false,
             "text_completion": false,
+            "text_completion_stream": false,
             "chat_completion": true,
             "chat_completion_stream": true,
+            "responses": false,
+            "responses_stream": false,
             "embedding": false,
             "speech": false,
             "speech_stream": false,
             "transcription": false,
             "transcription_stream": false
+        },
+        "request_path_overrides": {
+            "chat_completion": "/v1/chat/completions"
         }
     }
 }'
@@ -95,13 +101,19 @@ curl --location 'http://localhost:8080/api/providers' \
                 "allowed_requests": {
                     "list_models": false,
                     "text_completion": false,
+                    "text_completion_stream": false,
                     "chat_completion": true,
                     "chat_completion_stream": true,
+                    "responses": false,
+                    "responses_stream": false,
                     "embedding": false,
                     "speech": false,
                     "speech_stream": false,
                     "transcription": false,
                     "transcription_stream": false
+                },
+                "request_path_overrides": {
+                    "chat_completion": "/v1/chat/completions"
                 }
             }
         }
@@ -181,13 +193,20 @@ func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schem
                 BaseProviderType: schemas.OpenAI, // Use OpenAI protocol
                 AllowedRequests: &schemas.AllowedRequests{
                     TextCompletion:       false,
+                    TextCompletionStream: false,
                     ChatCompletion:       true,  // Enable chat completion
                     ChatCompletionStream: true,  // Enable streaming
+                    Responses:            false,
+                    ResponsesStream:      false,
                     Embedding:            false,
                     Speech:               false,
                     SpeechStream:         false,
                     Transcription:        false,
                     TranscriptionStream:  false,
+                },
+                RequestPathOverrides: map[schemas.RequestType]string{
+                    schemas.ChatCompletionRequest:       "/v1/chat/completions",
+                    schemas.ChatCompletionStreamRequest: "/v1/chat/completions",
                 },
             },
         }, nil
@@ -213,8 +232,11 @@ Control which operations your custom provider can perform. The behavior is:
 Available operations:
 
 - **`text_completion`**: Legacy text completion requests
+- **`text_completion_stream`**: Streaming text completion requests
 - **`chat_completion`**: Standard chat completion requests
 - **`chat_completion_stream`**: Streaming chat responses
+- **`responses`**: Standard responses requests
+- **`responses_stream`**: Streaming responses requests
 - **`embedding`**: Text embedding generation
 - **`speech`**: Text-to-speech conversion
 - **`speech_stream`**: Streaming text-to-speech
@@ -230,6 +252,57 @@ Custom providers can be built on these supported providers:
 - `bedrock` - AWS Bedrock
 - `cohere` - Cohere
 - `gemini` - Gemini
+
+### Request Path Overrides
+
+The `request_path_overrides` field allows you to override the default API endpoint paths for specific request types. This is useful when:
+
+- Connecting to custom or self-hosted model providers
+- Integrating with proxies that expect specific URL patterns
+- Using provider forks with modified API paths
+
+<Warning>
+**Not Supported:** `request_path_overrides` is not supported for `gemini` and `bedrock` base provider types due to their specialized API implementations.
+</Warning>
+
+The field accepts a mapping of request types to custom paths:
+
+```json
+{
+    "request_path_overrides": {
+        "chat_completion": "/v1/chat/completions",
+        "chat_completion_stream": "/v1/chat/completions",
+        "embedding": "/v1/embeddings",
+        "text_completion": "/v1/completions"
+    }
+}
+```
+
+**Example: OpenAI-Compatible Endpoint with Custom Paths**
+
+```json
+{
+    "custom-llm": {
+        "keys": [{ "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "network_config": {
+            "base_url": "https://your-openai-compatible-endpoint.com"
+        },
+        "custom_provider_config": {
+            "base_provider_type": "openai",
+            "allowed_requests": {
+                "chat_completion": true,
+                "chat_completion_stream": true
+            },
+            "request_path_overrides": {
+                "chat_completion": "/api/v2/chat",
+                "chat_completion_stream": "/api/v2/chat"
+            }
+        }
+    }
+}
+```
+
+In this example, instead of using OpenAI's default `/v1/chat/completions` path, requests will be sent to `https://custom-endpoint.example.com/api/v2/chat`.
 
 ## Use Cases
 

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -1,11 +1,15 @@
 "use client";
 
 import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { BaseProvider } from "@/lib/types/config";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { BaseProvider, RequestType } from "@/lib/types/config";
 import { isRequestTypeDisabled } from "@/lib/utils/validation";
-import { Control } from "react-hook-form";
+import { Control, useFormContext } from "react-hook-form";
+import { Settings2 } from "lucide-react";
+import { useEffect } from "react";
 
 interface AllowedRequestsFieldsProps {
 	control: Control<any>;
@@ -13,9 +17,49 @@ interface AllowedRequestsFieldsProps {
 	providerType?: BaseProvider;
 }
 
-const REQUEST_TYPES = [
+// Provider-specific endpoint paths
+const PROVIDER_ENDPOINTS: Partial<Record<BaseProvider, Partial<Record<RequestType, string>>>> = {
+	openai: {
+		list_models: "/v1/models",
+		text_completion: "/v1/completions",
+		text_completion_stream: "/v1/completions",
+		chat_completion: "/v1/chat/completions",
+		chat_completion_stream: "/v1/chat/completions",
+		responses: "/v1/responses",
+		responses_stream: "/v1/responses",
+		embedding: "/v1/embeddings",
+		speech: "/v1/audio/speech",
+		speech_stream: "/v1/audio/speech",
+		transcription: "/v1/audio/transcriptions",
+		transcription_stream: "/v1/audio/transcriptions",
+	},
+	anthropic: {
+		chat_completion: "/v1/messages",
+		chat_completion_stream: "/v1/messages",
+		responses: "/v1/messages",
+		responses_stream: "/v1/messages",
+	},
+	cohere: {
+		chat_completion: "/v2/chat",
+		chat_completion_stream: "/v2/chat",
+		responses: "/v2/chat",
+		responses_stream: "/v2/chat",
+		embedding: "/v2/embed",
+	},
+};
+
+// Helper function to get the appropriate placeholder
+const getPlaceholder = (providerType: BaseProvider | undefined, requestKey: RequestType): string => {
+	if (providerType && PROVIDER_ENDPOINTS[providerType]?.[requestKey]) {
+		return PROVIDER_ENDPOINTS[providerType][requestKey]!;
+	}
+	return PROVIDER_ENDPOINTS["openai"]?.[requestKey] ?? "";
+};
+
+const REQUEST_TYPES: Array<{ key: RequestType; label: string }> = [
 	{ key: "list_models", label: "List Models" },
 	{ key: "text_completion", label: "Text Completion" },
+	{ key: "text_completion_stream", label: "Text Completion Stream" },
 	{ key: "chat_completion", label: "Chat Completion" },
 	{ key: "chat_completion_stream", label: "Chat Completion Stream" },
 	{ key: "responses", label: "Responses" },
@@ -30,40 +74,81 @@ const REQUEST_TYPES = [
 export function AllowedRequestsFields({ control, namePrefix = "allowed_requests", providerType }: AllowedRequestsFieldsProps) {
 	const leftColumn = REQUEST_TYPES.slice(0, 6);
 	const rightColumn = REQUEST_TYPES.slice(6);
+	const { getValues, setValue } = useFormContext();
 
-	const renderRequestField = (requestType: { key: string; label: string }) => {
+	// Reset disabled fields when providerType changes
+	useEffect(() => {
+		REQUEST_TYPES.forEach(({ key }) => {
+			const fieldName = `${namePrefix}.${key}`;
+			setValue(fieldName, !isRequestTypeDisabled(providerType, key), { shouldDirty: true });
+		});
+	}, [providerType, namePrefix, setValue, getValues]);
+
+	const renderRequestField = (requestType: { key: RequestType; label: string }) => {
 		const isDisabled = isRequestTypeDisabled(providerType, requestType.key);
+		const isPathOverrideDisabled = providerType === "gemini" || providerType === "bedrock";
+		const placeholder = getPlaceholder(providerType, requestType.key);
 
 		return (
 			<FormField
 				key={requestType.key}
 				control={control}
 				name={`${namePrefix}.${requestType.key}`}
-				render={({ field }) => (
+				render={({ field: allowedField }) => (
 					<FormItem
 						className={`flex flex-row items-center justify-between rounded-lg border p-3 ${isDisabled ? "bg-muted/30 opacity-60" : ""}`}
 					>
 						<div className="space-y-0.5">
 							<FormLabel className={isDisabled ? "cursor-not-allowed" : ""}>{requestType.label}</FormLabel>
 						</div>
-						<FormControl>
-							{isDisabled ? (
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<div>
-												<Switch checked={field.value} disabled={true} size="md" />
-											</div>
-										</TooltipTrigger>
-										<TooltipContent>
-											<p>Not supported by {providerType}</p>
-										</TooltipContent>
-									</Tooltip>
-								</TooltipProvider>
-							) : (
-								<Switch checked={field.value} onCheckedChange={field.onChange} size="md" />
+						<div className="flex items-center gap-2">
+							{/* Settings icon for path override - only show when enabled */}
+							{allowedField.value && !isDisabled && !isPathOverrideDisabled && (
+								<FormField
+									control={control}
+									name={`request_path_overrides.${requestType.key}`}
+									render={({ field: pathField }) => (
+										<Popover>
+											<PopoverTrigger asChild>
+												<button
+													type="button"
+													className="text-muted-foreground hover:text-foreground transition-colors"
+													aria-label="Customize endpoint path"
+												>
+													<Settings2 className="h-4 w-4" />
+												</button>
+											</PopoverTrigger>
+											<PopoverContent className="w-80" align="end">
+												<div className="space-y-2">
+													<h4 className="text-sm font-medium">Custom Path</h4>
+													<p className="text-muted-foreground text-xs">Override the default endpoint path</p>
+													<Input placeholder={placeholder} {...pathField} value={pathField.value || ""} className="h-9" />
+												</div>
+											</PopoverContent>
+										</Popover>
+									)}
+								/>
 							)}
-						</FormControl>
+
+							<FormControl>
+								{isDisabled ? (
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<div>
+													<Switch checked={isDisabled ? false : allowedField.value} disabled={true} size="md" />
+												</div>
+											</TooltipTrigger>
+											<TooltipContent>
+												<p>Not supported by {providerType}</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								) : (
+									<Switch checked={allowedField.value} onCheckedChange={allowedField.onChange} size="md" />
+								)}
+							</FormControl>
+						</div>
 					</FormItem>
 				)}
 			/>
@@ -74,7 +159,9 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 		<div className="space-y-4">
 			<div>
 				<div className="text-sm font-medium">Allowed Request Types</div>
-				<p className="text-muted-foreground text-xs">Select which request types this custom provider can handle</p>
+				<p className="text-muted-foreground text-xs">
+					Select which request types this custom provider can handle. Click the settings icon to customize endpoint paths.
+				</p>
 			</div>
 
 			<div className="grid grid-cols-2 gap-4">

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -14,6 +14,7 @@ import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { cleanPathOverrides } from "@/lib/utils/validation";
 
 // Type for form data
 type FormCustomProviderConfig = z.infer<typeof formCustomProviderConfigSchema>;
@@ -34,6 +35,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 			base_provider_type: provider.custom_provider_config?.base_provider_type ?? "openai",
 			allowed_requests: {
 				text_completion: provider.custom_provider_config?.allowed_requests?.text_completion ?? true,
+				text_completion_stream: provider.custom_provider_config?.allowed_requests?.text_completion_stream ?? true,
 				chat_completion: provider.custom_provider_config?.allowed_requests?.chat_completion ?? true,
 				chat_completion_stream: provider.custom_provider_config?.allowed_requests?.chat_completion_stream ?? true,
 				responses: provider.custom_provider_config?.allowed_requests?.responses ?? true,
@@ -45,6 +47,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				transcription_stream: provider.custom_provider_config?.allowed_requests?.transcription_stream ?? true,
 				list_models: provider.custom_provider_config?.allowed_requests?.list_models ?? true,
 			},
+			request_path_overrides: provider.custom_provider_config?.request_path_overrides ?? undefined,
 		},
 	});
 
@@ -63,6 +66,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 			custom_provider_config: {
 				base_provider_type: data.base_provider_type as unknown as BaseProvider,
 				allowed_requests: data.allowed_requests,
+				request_path_overrides: cleanPathOverrides(data.request_path_overrides),
 			},
 		})
 			.unwrap()

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -58,25 +58,12 @@ export const MCP_STATUS_COLORS = {
 	disconnected: "bg-gray-100 text-gray-800",
 } as const;
 
-export const DEFAULT_ALLOWED_REQUESTS = {
-	text_completion: true,
-	chat_completion: true,
-	chat_completion_stream: true,
-	responses: true,
-	responses_stream: true,
-	embedding: true,
-	speech: true,
-	speech_stream: true,
-	transcription: true,
-	transcription_stream: true,
-	list_models: true,
-} as const satisfies Required<AllowedRequests>;
-
 // Mapping of what IS supported by each base provider
 export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 	openai: [
 		"list_models",
         "text_completion",
+        "text_completion_stream",
         "chat_completion",
         "chat_completion_stream",
         "responses",
@@ -89,7 +76,6 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
     ],
 	anthropic: [
 		"list_models",
-		"text_completion",
 		"chat_completion",
 		"chat_completion_stream",
 		"responses",
@@ -97,7 +83,6 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 	],
 	gemini: [
 		"list_models",
-		"text_completion",
 		"chat_completion",
 		"chat_completion_stream",
 		"responses",
@@ -110,7 +95,6 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 	],
 	cohere: [
 		"list_models",
-		"text_completion",
 		"chat_completion",
 		"chat_completion_stream",
 		"responses",

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -113,9 +113,25 @@ export interface ProxyConfig {
 	password?: string;
 }
 
+// Request types matching Go's schemas.RequestType
+export type RequestType = 
+	| "list_models"
+	| "text_completion"
+	| "text_completion_stream"
+	| "chat_completion"
+	| "chat_completion_stream"
+	| "responses"
+	| "responses_stream"
+	| "embedding"
+	| "speech"
+	| "speech_stream"
+	| "transcription"
+	| "transcription_stream";
+
 // AllowedRequests matching Go's schemas.AllowedRequests
 export interface AllowedRequests {
 	text_completion: boolean;
+	text_completion_stream: boolean;
 	chat_completion: boolean;
 	chat_completion_stream: boolean;
 	responses: boolean;
@@ -132,6 +148,7 @@ export interface AllowedRequests {
 export interface CustomProviderConfig {
 	base_provider_type: KnownProvider;
 	allowed_requests?: AllowedRequests;
+	request_path_overrides?: Record<string, string>;
 }
 
 // ProviderConfig matching Go's lib.ProviderConfig

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -274,6 +274,7 @@ export const proxyFormConfigSchema = z
 // Allowed requests schema
 export const allowedRequestsSchema = z.object({
 	text_completion: z.boolean(),
+	text_completion_stream: z.boolean(),
 	chat_completion: z.boolean(),
 	chat_completion_stream: z.boolean(),
 	responses: z.boolean(),
@@ -290,12 +291,14 @@ export const allowedRequestsSchema = z.object({
 export const customProviderConfigSchema = z.object({
 	base_provider_type: knownProviderSchema,
 	allowed_requests: allowedRequestsSchema.optional(),
+	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 });
 
 // Form-specific custom provider config schema
 export const formCustomProviderConfigSchema = z.object({
 	base_provider_type: z.string().min(1, "Base provider type is required"),
 	allowed_requests: allowedRequestsSchema.optional(),
+	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 });
 
 // Full model provider config schema

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -572,3 +572,18 @@ export function isRequestTypeDisabled(providerType: BaseProvider | undefined, re
 	return !supportedRequests.includes(requestType);
 }
 
+
+/**
+ * Cleans the path overrides by removing empty values
+ * @param overrides - The path overrides to clean
+ * @returns The cleaned path overrides
+ */
+export function cleanPathOverrides(overrides?: Record<string, string | undefined>) {
+	if (!overrides) return undefined;
+
+	const entries = Object.entries(overrides)
+		.map(([k, v]) => [k, v?.trim()])
+		.filter(([, v]) => v && v !== "");
+
+	return entries.length ? Object.fromEntries(entries) as Record<string, string> : undefined;
+}


### PR DESCRIPTION
## Summary

Added support for custom request path overrides in provider configurations, allowing more flexibility when integrating with modified API endpoints.

## Changes

- Added a new `RequestPathOverrides` map to the `CustomProviderConfig` struct that maps request types to custom paths
- Implemented a new `GetRequestPath` function that checks for path overrides in the custom provider config
- Updated all provider API endpoint calls to use the new `GetRequestPath` function instead of `GetPathFromContext`
- Maintained backward compatibility with the existing context-based path override mechanism

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with a custom provider configuration that includes path overrides:

```sh
# Core/Transports
go version
go test ./...

# Test with a custom provider config that includes path overrides
curl -X POST http://localhost:8000/providers/custom \
  -H "Content-Type: application/json" \
  -d '{
    "base_provider_type": "openai",
    "request_path_overrides": {
      "chat_completion": "/custom/v1/chat/completions",
      "embedding": "/custom/v1/embeddings"
    }
  }'
```

## Breaking changes

- [x] No

## Related issues

Enhances custom provider flexibility by allowing path customization per request type.

## Security considerations

No additional security implications as this only affects request path construction.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)