### PR TITLE
fix: improve error handling in provider model listing and management

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -361,7 +361,7 @@ func (bifrost *Bifrost) ListAllModels(ctx context.Context, request *schemas.Bifr
 					if !strings.Contains(bifrostErr.Error.Message, "no keys found") &&
 						!strings.Contains(bifrostErr.Error.Message, "not supported") {
 						providerErr = bifrostErr
-						bifrost.logger.Warn(fmt.Sprintf("failed to list models for provider %s: %v", providerKey, bifrostErr.Error.Message))
+						bifrost.logger.Warn(fmt.Sprintf("failed to list models for provider %s: %s", providerKey, GetErrorMessage(bifrostErr)))
 					}
 					break
 				}

--- a/core/utils.go
+++ b/core/utils.go
@@ -228,3 +228,18 @@ func MarshalUnsafe(v any) string {
 	// Encode adds a trailing newline, trim it
 	return strings.TrimSpace(buf.String())
 }
+
+func GetErrorMessage(err *schemas.BifrostError) string {
+	if err == nil {
+		return ""
+	}
+	if err.StatusCode != nil && (*err.StatusCode == 401 || *err.StatusCode == 403) {
+		return "key invalid or unauthorized or forbidden"
+	} else if err.Error != nil && err.Error.Message != "" {
+		return err.Error.Message
+	} else if err.Type != nil {
+		return *err.Type
+	} else {
+		return "unknown error"
+	}
+}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -435,8 +435,14 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if err := h.modelsManager.RefetchModelsForProvider(ctx, provider); err != nil {
-		logger.Warn(fmt.Sprintf("Failed to refetch models for provider %s: %v", provider, err))
+	if len(redactedConfig.Keys) > 0 {
+		if err := h.modelsManager.RefetchModelsForProvider(ctx, provider); err != nil {
+			logger.Warn(fmt.Sprintf("Failed to refetch models for provider %s: %v", provider, err))
+		}
+	} else {
+		if err := h.modelsManager.DeleteModelsForProvider(provider); err != nil {
+			logger.Warn(fmt.Sprintf("Failed to delete models for provider %s: %v", provider, err))
+		}
 	}
 
 	response := h.getProviderResponseFromConfig(provider, *redactedConfig, ProviderStatusActive)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -547,14 +547,14 @@ func (s *BifrostHTTPServer) RefetchModelsForProvider(ctx context.Context, provid
 		return fmt.Errorf("bifrost client not found")
 	}
 
-	s.Config.PricingManager.DeleteModelDataForProvider(provider)
-
 	allModels, err := s.Client.ListModelsRequest(ctx, &schemas.BifrostListModelsRequest{
 		Provider: provider,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to list all models: %v", err)
+		return fmt.Errorf("failed to update provider model catalog: failed to list all models: %s", bifrost.GetErrorMessage(err))
 	}
+
+	s.Config.PricingManager.DeleteModelDataForProvider(provider)
 
 	s.Config.PricingManager.AddModelDataToPool(allModels)
 


### PR DESCRIPTION
## Summary

Improve error handling for provider model management by adding a dedicated error message extraction function and enhancing provider update logic.

## Changes

- Added `GetErrorMessage()` utility function to extract meaningful error messages from BifrostError objects
- Updated error logging in model listing to use the new error message extraction function
- Enhanced provider update logic to handle cases when a provider has no keys:
  - When keys are present: refetch models for the provider
  - When no keys are present: delete models for the provider
- Improved error handling in RefetchModelsForProvider by moving the pricing data deletion after successful model listing

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
# Test error handling with valid and invalid provider keys
go test ./core -run TestGetErrorMessage
go test ./transports/bifrost-http/server -run TestRefetchModelsForProvider

# Verify provider update behavior
# 1. Update a provider with valid keys - should refetch models
# 2. Update a provider removing all keys - should delete models
```

## Breaking changes

- [x] No

## Security considerations

Improves error handling for authentication failures (401/403) by providing a standardized error message that doesn't leak sensitive information.