### PR TITLE
fixes dark mode for async multiselect

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -492,12 +492,13 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 												value: key.key_id,
 												description: key.models.join(", "),
 												provider: key.provider,
-											}))
-										
+											}));
+
 										return (
 											<FormItem>
 												<FormControl>
 													<AsyncMultiSelect
+														hideSelectedOptions
 														isNonAsync
 														closeMenuOnSelect={false}
 														defaultOptions={availableKeys.map((key) => ({
@@ -511,7 +512,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 																return (
 																	<div
 																		{...multiValueProps.innerProps}
-																		className="bg-accent flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
+																		className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
 																	>
 																		<RenderProviderIcon
 																			provider={multiValueProps.data.provider as ProviderIconType}
@@ -535,7 +536,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 																		{...optionProps.innerProps}
 																		className={cn(
 																			"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
-																			optionProps.isFocused && "bg-accent",
+																			optionProps.isFocused && "bg-accent dark:!bg-card",
 																			"hover:bg-accent",
 																		)}
 																	>
@@ -555,13 +556,13 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 														value={selectedKeyValues}
 														onChange={(keys) => field.onChange(keys.map((key) => key.value as string))}
 														placeholder="Select keys..."
-														className="hover:bg-accent w-full bg-white dark:bg-zinc-800"
+														className="hover:bg-accent w-full"
 														menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
 													/>
 												</FormControl>
 												<FormMessage />
 											</FormItem>
-										)
+										);
 									}}
 								/>
 							</div>

--- a/ui/components/ui/asyncMultiselect.tsx
+++ b/ui/components/ui/asyncMultiselect.tsx
@@ -423,19 +423,19 @@ export function AsyncMultiSelect<T>(props: AsyncMultiSelectProps<T>) {
 					container: () => cn("min-h-8 border-none", props.className),
 					control: ({ isFocused }) =>
 						cn(
-							"border-border! multiselect-control flex flex-wrap items-start justify-between rounded-md border bg-white",
+							"border-border! multiselect-control flex flex-wrap items-start justify-between rounded-md border bg-white dark:!bg-accent",
 							props.triggerClassName,
 						),
 					placeholder: () => "text-sm text-content-disabled truncate p-0 text-ellipsis",
 					group: () => cn(props.groupClassName),
 					input: () => "text-sm m-0 border-none p-0",
-					menu: () => cn("p-0", props.menuClassName),
+					menu: () => cn("p-0 bg-white dark:!bg-accent", props.menuClassName),
 					menuList: () => cn("p-2", props.menuListClassName),
 					valueContainer: () => cn("flex h-full w-full", props.valueContainerClassName),
 					option: ({ isFocused }) =>
 						cn("multiselect-option flex w-full justify-between rounded-sm p-2 text-sm", isFocused && "bg-background-highlight-primary/60"),
 					singleValue: () => "text-sm text-content-primary",
-					multiValue: () => "bg-background-highlight-primary text-content-disabled flex gap-1 rounded-sm pl-2 pr-[7px] text-sm font-medium",
+					multiValue: () =>"bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm",
 					multiValueLabel: () => "text-content-tertiary",
 					multiValueRemove: () => "text-content-tertiary h-inherit flex items-center opacity-60 hover:cursor-pointer hover:opacity-100",
 					loadingMessage: () => "text-sm",


### PR DESCRIPTION
## Summary

Improved the visual styling of the Virtual Key Sheet component for better dark mode compatibility and enhanced the user experience of the AsyncMultiSelect component.

## Changes

- Added `hideSelectedOptions` prop to AsyncMultiSelect in VirtualKeySheet to prevent selected options from appearing in the dropdown
- Fixed dark mode styling issues by adding appropriate dark mode classes to various elements
- Added proper background colors for dark mode in the AsyncMultiSelect component
- Improved styling consistency for selected items in the multiselect dropdown
- Fixed minor syntax issues (added missing semicolons)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Open the Virtual Key Sheet in both light and dark mode
2. Verify that the multiselect dropdown properly hides selected options
3. Check that the styling is consistent in both light and dark mode
4. Test the selection and deselection of options to ensure proper visual feedback

```sh
# UI
cd ui
pnpm i || npm i
pnpm dev || npm run dev
```

## Screenshots/Recordings

[Add before/after screenshots showing the dark mode improvements]

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

[Link to any related issues]

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable