### PR TITLE
fixed dark mode selection for mutliselect

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -538,6 +538,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 																			"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
 																			optionProps.isFocused && "bg-accent dark:!bg-card",
 																			"hover:bg-accent",
+																			optionProps.isSelected && "bg-accent dark:!bg-card",
 																		)}
 																	>
 																		<RenderProviderIcon


### PR DESCRIPTION
## Summary

Add selected state styling to dropdown options in the VirtualKeySheet component to improve visual feedback for users.

## Changes

- Added the `optionProps.isSelected && "bg-accent dark:!bg-card"` class condition to highlight selected options in the dropdown
- This ensures that both focused and selected states have consistent styling

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the Virtual Keys section
2. Open the dropdown in the VirtualKeySheet component
3. Select an option and verify it remains highlighted with the accent background color
4. Verify the selected state styling is consistent in both light and dark modes

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable