### PR TITLE
fixes docker compose command

### DIFF
--- a/.github/workflows/scripts/get_curls.sh
+++ b/.github/workflows/scripts/get_curls.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 # Bifrost HTTP Transport - GET API Endpoints
 # This script tests all GET endpoints and reports their status
@@ -61,3 +61,19 @@ test_endpoint "/v1/models"
 
 echo ""
 echo -e "${YELLOW}Note: WebSocket endpoint (/ws) requires a WebSocket client${NC}"
+echo ""
+echo "========================================"
+echo "Test Summary:"
+echo "  Total tests: $TOTAL_TESTS"
+echo "  Passed: $((TOTAL_TESTS - FAILED_TESTS))"
+echo "  Failed: $FAILED_TESTS"
+echo "========================================"
+
+# Exit with error if any tests failed
+if [ "$FAILED_TESTS" -gt 0 ]; then
+  echo -e "${RED}✗ Some tests failed${NC}"
+  exit 1
+else
+  echo -e "${GREEN}✓ All tests passed${NC}"
+  exit 0
+fi

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -190,7 +190,7 @@ TEST_BINARY="../tmp/bifrost-http"
 CONFIGS_DIR="../.github/workflows/configs"
 # Running docker compose
 echo "🐳 Starting Docker services (PostgreSQL, Weaviate, Redis)..."
-docker-compose -f "$CONFIGS_DIR/docker-compose.yml" up -d
+docker compose -f "$CONFIGS_DIR/docker-compose.yml" up -d
 
 # Wait for services to be healthy
 echo "⏳ Waiting for Docker services to be ready..."


### PR DESCRIPTION
## Summary

Enhance the GET API endpoints testing script with better error reporting and update the Docker Compose command in the release script.

## Changes

- Added test summary statistics to the `get_curls.sh` script showing total tests, passed, and failed counts
- Modified the script to exit with error code 1 if any tests fail, enabling CI pipelines to detect failures
- Updated Docker command from `docker-compose` to `docker compose` (hyphen removed) in the release script to use the newer command format
- Removed the `-e` flag from the bash options in `get_curls.sh` to allow the script to continue running even if some endpoints fail

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the GET endpoints test script to verify it now provides a summary and proper exit code:

```sh
./.github/workflows/scripts/get_curls.sh
```

Verify the release script works with the updated Docker Compose command:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves CI reliability by making the test script properly report failures.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable