### PR TITLE
refactor: improve changelog handling with version-aware file content extraction

### DIFF
--- a/.github/workflows/scripts/changelog-utils.sh
+++ b/.github/workflows/scripts/changelog-utils.sh
@@ -1,13 +1,19 @@
-# Function to extract changelog content from a file
-# Usage: get_changelog_content <file_path>
-get_changelog_content() {
-    CHANGELOG_BODY=$(cat $1)
-    # Skip comments from changelog
-    CHANGELOG_BODY=$(echo "$CHANGELOG_BODY" | grep -v '^<!--' | grep -v '^-->')
-    # If changelog is empty, return error
-    if [ -z "$CHANGELOG_BODY" ]; then
-        echo "❌ Changelog is empty"
-        exit 1
+#!/usr/bin/env bash
+
+# Function to extract content from a file
+# Usage: get_file_content <file_path>
+# Returns the file content with comments removed, or empty string if file doesn't exist
+get_file_content() {
+    if [ -f "$1" ]; then
+        content=$(cat "$1")
+        # Skip comments from content
+        content=$(echo "$content" | grep -v '^<!--' | grep -v '^-->')
+        # For version files, also trim newlines and whitespace
+        if [[ "$1" == *"/version" ]]; then
+            content=$(echo "$content" | tr -d '\n' | xargs)
+        fi
+        echo "$content"
+    else
+        echo ""
     fi
-    echo "$CHANGELOG_BODY"
 }

--- a/.github/workflows/scripts/push-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-mintlify-changelog.sh
@@ -36,10 +36,19 @@ append_section () {
   label=$1
   path=$2
   if [ -f "$path" ]; then
-    content=$(get_changelog_content "$path")
-    if [ -n "$content" ]; then
-      CHANGELOG_BODY+=$'\n'"<Update label=\"$label\" description=\"$VERSION\">"$'\n'"$content"$'\n\n'"</Update>"
+    # Get changelog content
+    content=$(get_file_content "$path")
+    # If changelog is empty, skip
+    if [ -z "$content" ]; then
+      echo "❌ Changelog is empty"
+      return
     fi
+    # Remove /changelog.md from the path and add /version
+    version_file_path="${path%/changelog.md}/version"
+    # Get version content
+    version_body=$(get_file_content "$version_file_path")
+    # Build the changelog section
+    CHANGELOG_BODY+=$'\n'"<Update label=\"$label\" description=\"$version_body\">"$'\n'"$content"$'\n\n'"</Update>"
     # Clear the changelog file after processing
     printf '' > "$path"
     # Track this file for git commit


### PR DESCRIPTION
## Summary

Enhance changelog generation by adding version information to update labels in the Mintlify documentation.

## Changes

- Renamed `get_changelog_content` to `get_file_content` to better reflect its more general purpose
- Added support for reading version files and trimming whitespace/newlines from version content
- Modified the `append_section` function to include version information from a separate version file in the "description" field of Update tags
- Added error handling for empty changelog content
- Improved file existence checking to prevent errors when files don't exist

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Docs
- [x] Chore/CI

## How to test

Run the changelog generation workflow manually:

```sh
# Test the script with a sample changelog and version file
mkdir -p test/changelog
echo "- New feature added" > test/changelog/changelog.md
echo "1.2.3" > test/changelog/version
.github/workflows/scripts/push-mintlify-changelog.sh
```

## Related issues

Improves documentation automation by including version information in changelog entries.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable
- [x] I updated documentation where needed