### PR TITLE
feat: support multiple authentication headers for virtual keys

### DIFF
--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -6,7 +6,14 @@ icon: "key"
 
 ## Overview
 
-Virtual Keys are the primary governance entity in Bifrost. Users and applications authenticate using the `x-bf-vk` header (*not the `Authorization` header*), which maps to specific access permissions, budgets, and rate limits.
+Virtual Keys are the primary governance entity in Bifrost. Users and applications authenticate using the given headers to access virtual keys and get specific access permissions, budgets, and rate limits.
+
+**Allowed Headers:**
+- `x-bf-vk` - Virtual key header, eg. `sk-bf-*`
+- `Authorization` - Authorization header, eg. `Bearer sk-bf-*` (OpenAI style)
+- `x-api-key` - API key header, eg. `sk-bf-*` (Anthropic style)
+
+<Note>You can also use `Authorization` and `x-api-key` headers to pass direct keys to the provider. Read more about it in [Direct Key Bypass](../keys-management#direct-key-bypass).</Note>
 
 **Key Features:**
 - **Access Control** - Model and provider filtering

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -244,6 +244,8 @@ Send API keys in `Authorization` (Bearer) or `x-api-key` headers. Requires `allo
 
 </Tabs>
 
+<Note>If a Bifrost virtual key (`sk-bf-*`) is attached in the auth header, direct key bypass will be skipped.</Note>
+
 **When to Use Direct Keys:**
 - Per-user API key scenarios
 - External key management systems

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -24,6 +24,8 @@ const (
 	governanceRejectedContextKey    schemas.BifrostContextKey = "bf-governance-rejected"
 	governanceIsCacheReadContextKey schemas.BifrostContextKey = "bf-governance-is-cache-read"
 	governanceIsBatchContextKey     schemas.BifrostContextKey = "bf-governance-is-batch"
+
+	VirtualKeyPrefix = "sk-bf-"
 )
 
 // Config is the configuration for the governance plugin

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -239,7 +239,7 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		vk = configstoreTables.TableVirtualKey{
 			ID:          uuid.NewString(),
 			Name:        req.Name,
-			Value:       uuid.NewString(),
+			Value:       governance.VirtualKeyPrefix + uuid.NewString(),
 			Description: req.Description,
 			TeamID:      req.TeamID,
 			CustomerID:  req.CustomerID,


### PR DESCRIPTION
## Summary

Added support for multiple authentication header formats for virtual keys, allowing users to authenticate using OpenAI and Anthropic-style headers in addition to the existing `x-bf-vk` header.

## Changes

- Added support for `Authorization` header with `Bearer sk-bf-*` format (OpenAI style)
- Added support for `x-api-key` header with `sk-bf-*` format (Anthropic style)
- Created a constant `VirtualKeyPrefix` (`sk-bf-`) to standardize virtual key identification
- Updated virtual key creation to automatically prefix new keys with `sk-bf-`
- Modified direct key bypass logic to skip when a Bifrost virtual key is detected
- Updated documentation to reflect the new authentication options

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] Docs

## How to test

Test authentication with different header formats:

```sh
# Test with x-bf-vk header
curl -H "x-bf-vk: sk-bf-your-key" https://your-bifrost-instance/v1/chat/completions

# Test with Authorization header (OpenAI style)
curl -H "Authorization: Bearer sk-bf-your-key" https://your-bifrost-instance/v1/chat/completions

# Test with x-api-key header (Anthropic style)
curl -H "x-api-key: sk-bf-your-key" https://your-bifrost-instance/v1/chat/completions

# Verify direct key bypass still works with non-Bifrost keys
curl -H "Authorization: Bearer sk-org-your-openai-key" https://your-bifrost-instance/v1/chat/completions
```

## Breaking changes

- [x] No

## Related issues

Enhances authentication flexibility for better compatibility with existing client libraries.

## Security considerations

This change maintains the security model while adding flexibility in how virtual keys are provided.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)