### PR TITLE
enhancement: replaced name usage with id in mcp and made name and headers editable

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1141,7 +1141,6 @@ func (bifrost *Bifrost) GetMCPClients() ([]schemas.MCPClient, error) {
 		}
 
 		clientsInConfig = append(clientsInConfig, schemas.MCPClient{
-			Name:   client.Name,
 			Config: client.ExecutionConfig,
 			Tools:  tools,
 			State:  state,
@@ -1185,62 +1184,62 @@ func (bifrost *Bifrost) AddMCPClient(config schemas.MCPClientConfig) error {
 // This allows for dynamic MCP client management at runtime.
 //
 // Parameters:
-//   - name: Name of the client to remove
+//   - id: ID of the client to remove
 //
 // Returns:
 //   - error: Any removal error
 //
 // Example:
 //
-//	err := bifrost.RemoveMCPClient("my-mcp-client")
+//	err := bifrost.RemoveMCPClient("my-mcp-client-id")
 //	if err != nil {
 //	    log.Fatalf("Failed to remove MCP client: %v", err)
 //	}
-func (bifrost *Bifrost) RemoveMCPClient(name string) error {
+func (bifrost *Bifrost) RemoveMCPClient(id string) error {
 	if bifrost.mcpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.RemoveClient(name)
+	return bifrost.mcpManager.RemoveClient(id)
 }
 
 // EditMCPClientTools edits the tools of an MCP client.
 // This allows for dynamic MCP client tool management at runtime.
 //
 // Parameters:
-//   - name: Name of the client to edit
-//   - toolsToExecute: Tools to execute for this client (['*'] = all tools; [] = no tools)
+//   - id: ID of the client to edit	
+//   - updatedConfig: Updated MCP client configuration
 //
 // Returns:
 //   - error: Any edit error
 //
 // Example:
 //
-//	err := bifrost.EditMCPClientTools("my-mcp-client", []string{"tool1", "tool2"})
-//	if err != nil {
-//	    log.Fatalf("Failed to edit MCP client tools: %v", err)
-//	}
-func (bifrost *Bifrost) EditMCPClientTools(name string, toolsToExecute []string) error {
+//  err := bifrost.EditMCPClient("my-mcp-client-id", schemas.MCPClientConfig{
+//      Name:           "my-mcp-client-name",
+//      ToolsToExecute: []string{"tool1", "tool2"},
+//  })
+func (bifrost *Bifrost) EditMCPClient(id string, updatedConfig schemas.MCPClientConfig) error {
 	if bifrost.mcpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.EditClientTools(name, toolsToExecute)
+	return bifrost.mcpManager.EditClient(id, updatedConfig)
 }
 
 // ReconnectMCPClient attempts to reconnect an MCP client if it is disconnected.
 //
 // Parameters:
-//   - name: Name of the client to reconnect
+//   - id: ID of the client to reconnect
 //
 // Returns:
 //   - error: Any reconnection error
-func (bifrost *Bifrost) ReconnectMCPClient(name string) error {
+func (bifrost *Bifrost) ReconnectMCPClient(id string) error {
 	if bifrost.mcpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.ReconnectClient(name)
+	return bifrost.mcpManager.ReconnectClient(id)
 }
 
 // PROVIDER MANAGEMENT

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -14,6 +14,7 @@ type MCPConfig struct {
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
+	ID               string            `json:"id"`                          // Client ID
 	Name             string            `json:"name"`                        // Client name
 	ConnectionType   MCPConnectionType `json:"connection_type"`             // How to connect (HTTP, STDIO, SSE, or InProcess)
 	ConnectionString *string           `json:"connection_string,omitempty"` // HTTP or SSE URL (required for HTTP or SSE connections)
@@ -57,7 +58,6 @@ const (
 // and connection information, after it has been initialized.
 // It is returned by GetMCPClients() method.
 type MCPClient struct {
-	Name   string             `json:"name"`   // Unique name for this client
 	Config MCPClientConfig    `json:"config"` // Tool filtering settings
 	Tools  []ChatToolFunction `json:"tools"`  // Available tools
 	State  MCPConnectionState `json:"state"`  // Connection state

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -10,7 +10,8 @@ import (
 
 // TableMCPClient represents an MCP client configuration in the database
 type TableMCPClient struct {
-	ID                 uint      `gorm:"primaryKey;autoIncrement" json:"id"`
+	ID                 uint      `gorm:"primaryKey;autoIncrement" json:"id"` // ID is used as the internal primary key and is also accessed by public methods, so it must be present.
+	ClientID           string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
 	Name               string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"name"`
 	ConnectionType     string    `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
 	ConnectionString   *string   `gorm:"type:text" json:"connection_string,omitempty"`

--- a/ui/app/workspace/mcp-clients/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-clients/views/mcpClientsTable.tsx
@@ -55,8 +55,8 @@ export default function MCPClientsTable({ mcpClients }: MCPClientsTableProps) {
 
 	const handleReconnect = async (client: MCPClient) => {
 		try {
-			await reconnectMCPClient(client.name).unwrap();
-			toast({ title: "Reconnected", description: `Client ${client.name} reconnected successfully.` });
+			await reconnectMCPClient(client.config.id).unwrap();
+			toast({ title: "Reconnected", description: `Client ${client.config.name} reconnected successfully.` });
 			loadClients();
 		} catch (error) {
 			toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
@@ -65,8 +65,8 @@ export default function MCPClientsTable({ mcpClients }: MCPClientsTableProps) {
 
 	const handleDelete = async (client: MCPClient) => {
 		try {
-			await deleteMCPClient(client.name).unwrap();
-			toast({ title: "Deleted", description: `Client ${client.name} removed successfully.` });
+			await deleteMCPClient(client.config.id).unwrap();
+			toast({ title: "Deleted", description: `Client ${client.config.name} removed successfully.` });
 			loadClients();
 		} catch (error) {
 			toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
@@ -149,8 +149,8 @@ export default function MCPClientsTable({ mcpClients }: MCPClientsTableProps) {
 							</TableRow>
 						)}
 						{clients.map((c: MCPClient) => (
-							<TableRow key={c.name} className="hover:bg-muted/50 cursor-pointer transition-colors" onClick={() => handleRowClick(c)}>
-								<TableCell className="font-medium">{c.name}</TableCell>
+							<TableRow key={c.config.id} className="hover:bg-muted/50 cursor-pointer transition-colors" onClick={() => handleRowClick(c)}>
+								<TableCell className="font-medium">{c.config.name}</TableCell>
 								<TableCell>{getConnectionTypeDisplay(c.config.connection_type)}</TableCell>
 								<TableCell className="max-w-72 overflow-hidden text-ellipsis whitespace-nowrap">{getConnectionDisplay(c)}</TableCell>
 								<TableCell>

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -118,7 +118,7 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 													<Settings2 className="h-4 w-4" />
 												</button>
 											</PopoverTrigger>
-											<PopoverContent className="w-80" align="end">
+											<PopoverContent className="w-80" align="end" onOpenAutoFocus={(e) => e.preventDefault()}>
 												<div className="space-y-2">
 													<h4 className="text-sm font-medium">Custom Path</h4>
 													<p className="text-muted-foreground text-xs">Override the default endpoint path</p>

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -20,9 +20,9 @@ export const mcpApi = baseApi.injectEndpoints({
 		}),
 
 		// Update existing MCP client
-		updateMCPClient: builder.mutation<null, { name: string; data: UpdateMCPClientRequest }>({
-			query: ({ name, data }) => ({
-				url: `/mcp/client/${name}`,
+		updateMCPClient: builder.mutation<null, { id: string; data: UpdateMCPClientRequest }>({
+			query: ({ id, data }) => ({
+				url: `/mcp/client/${id}`,
 				method: "PUT",
 				body: data,
 			}),
@@ -31,8 +31,8 @@ export const mcpApi = baseApi.injectEndpoints({
 
 		// Delete MCP client
 		deleteMCPClient: builder.mutation<null, string>({
-			query: (name) => ({
-				url: `/mcp/client/${name}`,
+			query: (id) => ({
+				url: `/mcp/client/${id}`,
 				method: "DELETE",
 			}),
 			invalidatesTags: ["MCPClients"],
@@ -40,8 +40,8 @@ export const mcpApi = baseApi.injectEndpoints({
 
 		// Reconnect MCP client
 		reconnectMCPClient: builder.mutation<null, string>({
-			query: (name) => ({
-				url: `/mcp/client/${name}/reconnect`,
+			query: (id) => ({
+				url: `/mcp/client/${id}/reconnect`,
 				method: "POST",
 			}),
 			invalidatesTags: ["MCPClients"],

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -11,6 +11,7 @@ export interface MCPStdioConfig {
 }
 
 export interface MCPClientConfig {
+	id: string;
 	name: string;
 	connection_type: MCPConnectionType;
 	connection_string?: string;
@@ -36,5 +37,7 @@ export interface CreateMCPClientRequest {
 }
 
 export interface UpdateMCPClientRequest {
+	name?: string;
+	headers?: Record<string, string>;
 	tools_to_execute?: string[];
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -515,6 +515,8 @@ export const maximFormSchema = z.object({
 
 // MCP Client update schema
 export const mcpClientUpdateSchema = z.object({
+	name: z.string().min(1, "Name is required"),
+	headers: z.record(z.string(), z.string()).optional(),
 	tools_to_execute: z
 		.array(z.string())
 		.optional()


### PR DESCRIPTION
## Summary

Refactor MCP client management to use unique IDs instead of names for client identification, improving reliability and flexibility in client operations.

## Changes

- Changed MCP client identification from name-based to ID-based (using UUID)
- Added client ID field to MCPClientConfig struct and database schema
- Updated all MCP client management functions to use ID instead of name
- Renamed `EditMCPClientTools` to `EditMCPClient` with expanded functionality
- Enhanced UI to support editing client name and headers
- Updated API endpoints to use client ID in URL paths
- Removed redundant `Name` field from MCPClient struct

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create a new MCP client through the UI
2. Verify the client appears in the list with a unique ID
3. Edit the client name and headers
4. Verify changes persist after refresh
5. Reconnect and delete the client using the UI controls

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

This change modifies the MCP client API endpoints and function signatures. Any code directly calling MCP client management functions will need to be updated to use client IDs instead of names.

Migration instructions:
- Update any direct calls to `RemoveMCPClient`, `EditMCPClientTools` (now `EditMCPClient`), and `ReconnectMCPClient` to use client ID instead of name
- Update any API calls to use the client ID in URL paths

## Security considerations

This change improves security by using unique IDs for client identification, making it harder to guess or conflict with other client identifiers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable