### PR TITLE
fix: improve MCP client reconnection and error handling

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1207,7 +1207,7 @@ func (bifrost *Bifrost) RemoveMCPClient(id string) error {
 // This allows for dynamic MCP client tool management at runtime.
 //
 // Parameters:
-//   - id: ID of the client to edit	
+//   - id: ID of the client to edit
 //   - updatedConfig: Updated MCP client configuration
 //
 // Returns:
@@ -1215,10 +1215,10 @@ func (bifrost *Bifrost) RemoveMCPClient(id string) error {
 //
 // Example:
 //
-//  err := bifrost.EditMCPClient("my-mcp-client-id", schemas.MCPClientConfig{
-//      Name:           "my-mcp-client-name",
-//      ToolsToExecute: []string{"tool1", "tool2"},
-//  })
+//	err := bifrost.EditMCPClient("my-mcp-client-id", schemas.MCPClientConfig{
+//	    Name:           "my-mcp-client-name",
+//	    ToolsToExecute: []string{"tool1", "tool2"},
+//	})
 func (bifrost *Bifrost) EditMCPClient(id string, updatedConfig schemas.MCPClientConfig) error {
 	if bifrost.mcpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")


### PR DESCRIPTION
## Improved MCP Client Connection Management

This PR enhances the reliability and robustness of MCP client connections by implementing better connection handling and error recovery.

## Changes

- Fixed reconnection logic to properly handle clients that failed during initialization
- Removed unnecessary connection checks that prevented reconnection of clients
- Improved client connection state management by closing existing connections before reconnecting
- Added ability to reconnect clients that exist in config but failed to initialize
- Enhanced UI with loading state indicators during reconnection attempts
- Fixed code formatting in documentation examples

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create an MCP client with invalid connection details
2. Observe that it fails to connect but remains in the UI
3. Fix the connection details and use the reconnect button
4. Verify the client successfully connects

```sh
# Core/Transports
go test ./core/... ./transports/...

# UI
cd ui
pnpm i
pnpm dev
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves reliability of MCP client connections

## Security considerations

No new security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)