### PR TITLE
fixes integration test

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -667,13 +667,15 @@ func (s *BifrostHTTPServer) RegisterRoutes(ctx context.Context, middlewares ...l
 	sessionHandler := handlers.NewSessionHandler(s.Config.ConfigStore)
 	// Determine which middlewares to use for integration/inference routes
 	integrationMiddlewares := middlewaresWithTelemetry
-	authConfig := s.Config.GovernanceConfig.AuthConfig
+	var authConfig *configstore.AuthConfig
 	if s.Config.ConfigStore != nil {
 		authConfig, err = s.Config.ConfigStore.GetAuthConfig(ctx)
 		if err != nil {
 			logger.Error("failed to get auth config: %v", err)
 			return fmt.Errorf("failed to get auth config: %v", err)
 		}
+	} else if s.Config.GovernanceConfig != nil && s.Config.GovernanceConfig.AuthConfig != nil {
+		authConfig = s.Config.GovernanceConfig.AuthConfig
 	}
 	if ctx.Value("isEnterprise") == nil {
 		if authConfig != nil && authConfig.IsEnabled {

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fasthttp/websocket v1.5.12
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.2.20
-	github.com/maximhq/bifrost/framework v1.1.24
+	github.com/maximhq/bifrost/framework v1.1.25
 	github.com/maximhq/bifrost/plugins/governance v1.3.25
 	github.com/maximhq/bifrost/plugins/logging v1.3.24
 	github.com/maximhq/bifrost/plugins/maxim v1.4.24

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -166,8 +166,8 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/maximhq/bifrost/core v1.2.20 h1:cSJ5jCkq34ObfQH9VKIz4PhCfDoqDU2lH/6RVNq+juM=
 github.com/maximhq/bifrost/core v1.2.20/go.mod h1:tCsM7mGAUgs+jY9yfotSsE0HFr7J7SjzEItKhVDvLPo=
-github.com/maximhq/bifrost/framework v1.1.24 h1:9Vn0zASSZx28JlzPG0TRnUzO8l1+MhKTu/LaZPwYOk0=
-github.com/maximhq/bifrost/framework v1.1.24/go.mod h1:YtFNKPDTxjIdM/UcqNDlp7rOPVzFW+DztI6WYwMYb/A=
+github.com/maximhq/bifrost/framework v1.1.25 h1:VQSQ4VZFvp4kmgwshLG8Lu2VuMPP7X5PGPQ9j6l8sYI=
+github.com/maximhq/bifrost/framework v1.1.25/go.mod h1:YtFNKPDTxjIdM/UcqNDlp7rOPVzFW+DztI6WYwMYb/A=
 github.com/maximhq/bifrost/plugins/governance v1.3.25 h1:aQ/HwUD6hiRenlhTq7lJzm9UHb5ui54yJQcNWobbRBo=
 github.com/maximhq/bifrost/plugins/governance v1.3.25/go.mod h1:oqsHbvcza55ztxr308zdSCgK3CO5QfGrvACasfKfBiw=
 github.com/maximhq/bifrost/plugins/logging v1.3.24 h1:jYf2TcIELXBiViAUlf5XbyfmbOAsIhUKIQNJoNYh4Wk=


### PR DESCRIPTION
## Summary

Fix authentication configuration handling in the BifrostHTTPServer by properly initializing the authConfig variable and adding a fallback to GovernanceConfig when ConfigStore is not available.

## Changes

- Fixed a potential nil pointer dereference in the BifrostHTTPServer's RegisterRoutes method by properly initializing the authConfig variable
- Added a fallback to use GovernanceConfig.AuthConfig when ConfigStore is not available
- Updated the framework dependency from v1.1.24 to v1.1.25

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the BifrostHTTPServer can properly initialize with or without a ConfigStore:

```sh
# Core/Transports
go version
go test ./transports/bifrost-http/server/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This fix ensures proper authentication configuration handling, which is critical for security. The change prevents potential authentication bypass that could occur if the authConfig was improperly initialized.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable