### PR TITLE
and env resolution for config based auth_config

### DIFF
--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -814,6 +814,17 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 		} else if governanceConfig != nil && governanceConfig.AuthConfig == nil {
 			// Adding this config
 			governanceConfig.AuthConfig = configData.AuthConfig
+			// Resolving username and password if the value contains env.VAR_NAME
+			if configData.AuthConfig.AdminUserName != "" {
+				if configData.AuthConfig.AdminUserName, _, err = config.processEnvValue(configData.AuthConfig.AdminUserName); err != nil {
+					logger.Warn("failed to resolve username: %v", err)
+				}
+			}
+			if configData.AuthConfig.AdminPassword != "" {
+				if configData.AuthConfig.AdminPassword, _, err = config.processEnvValue(configData.AuthConfig.AdminPassword); err != nil {
+					logger.Warn("failed to resolve password: %v", err)
+				}
+			}
 		}
 	}
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -135,43 +135,6 @@
       },
       "additionalProperties": true
     },
-    "auth_config": {
-      "type": "object",
-      "description": "Authentication configuration for governance",
-      "properties": {
-        "api_key": {
-          "type": "string",
-          "description": "API key for authentication"
-        },
-        "jwks_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "JWKS URL for JWT validation"
-        },
-        "jwt_secret": {
-          "type": "string",
-          "description": "JWT secret for token validation"
-        }
-      },
-      "additionalProperties": false,
-      "anyOf": [
-        {
-          "required": [
-            "api_key"
-          ]
-        },
-        {
-          "required": [
-            "jwks_url"
-          ]
-        },
-        {
-          "required": [
-            "jwt_secret"
-          ]
-        }
-      ]
-    },
     "governance": {
       "type": "object",
       "description": "Governance configuration for budgets, rate limits, customers, teams, and virtual keys",
@@ -360,6 +323,9 @@
             ],
             "additionalProperties": false
           }
+        },
+        "auth_config": {
+          "$ref": "#/$defs/auth_config"
         }
       },
       "additionalProperties": false
@@ -901,6 +867,28 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "auth_config": {
+      "type": "object",
+      "properties": {
+        "admin_username": {
+          "type": "string",
+          "description": "Admin username"
+        },
+        "admin_password": {
+          "type": "string",
+          "description": "Admin password"
+        },
+        "is_enabled": {
+          "type": "boolean",
+          "description": "Whether authentication is enabled"
+        },
+        "disable_auth_on_inference": {
+          "type": "boolean",
+          "description": "Whether authentication is disabled on inference"
+        }
+      },
+      "additionalProperties": false
+    },
     "pricing_config": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
## Summary

Added environment variable resolution for admin username and password in the authentication configuration, and restructured the auth configuration schema.

## Changes

- Added logic to resolve environment variables in admin username and password fields
- Moved the `auth_config` schema definition from the root level to the `$defs` section
- Updated the schema to include new auth configuration properties: `admin_username`, `admin_password`, `is_enabled`, and `disable_auth_on_inference`
- Added a reference to the auth_config definition in the governance section

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

1. Set environment variables for admin credentials:
```sh
export ADMIN_USERNAME=myuser
export ADMIN_PASSWORD=mypassword
```

2. Configure auth settings using environment variable references:
```json
{
  "governance": {
    "auth_config": {
      "admin_username": "env.ADMIN_USERNAME",
      "admin_password": "env.ADMIN_PASSWORD",
      "is_enabled": true
    }
  }
}
```

3. Verify that the environment variables are properly resolved when loading the configuration.

## Breaking changes

- [x] No

## Security considerations

This change improves security by allowing admin credentials to be stored in environment variables rather than directly in configuration files.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)