### PR TITLE
feat: add keyless custom provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ node_modules
 temp*/
 tmp/
 tmp-*
+private
 
 # Go workspaces (local only)
 go.work

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -298,7 +298,7 @@ func (bifrost *Bifrost) ListAllModels(ctx context.Context, request *schemas.Bifr
 		request = &schemas.BifrostListModelsRequest{}
 	}
 
-	providerKeys, err := bifrost.account.GetConfiguredProviders()
+	providerKeys, err := bifrost.GetConfiguredProviders()
 	if err != nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
@@ -1520,7 +1520,7 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 		return false
 	}
 
-	bifrost.logger.Warn(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
+	bifrost.logger.Debug(fmt.Sprintf("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message))
 	return true
 }
 
@@ -2038,7 +2038,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		}
 
 		key := schemas.Key{}
-		if providerRequiresKey(baseProvider) {
+		if providerRequiresKey(baseProvider, config.CustomProviderConfig) {
 			// Use the custom provider name for actual key selection, but pass base provider type for key validation
 			key, err = bifrost.selectKeyFromProviderForModel(&req.Context, req.RequestType, provider.GetProviderKey(), model, baseProvider)
 			if err != nil {
@@ -2055,7 +2055,6 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			req.Context = context.WithValue(req.Context, schemas.BifrostContextKeySelectedKeyID, key.ID)
 			req.Context = context.WithValue(req.Context, schemas.BifrostContextKeySelectedKeyName, key.Name)
 		}
-
 		// Create plugin pipeline for streaming requests outside retry loop to prevent leaks
 		var postHookRunner schemas.PostHookRunner
 		var pipeline *PluginPipeline

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,6 @@
+<!-- The pattern we follow here is to keep the changelog for the latest version -->
+<!-- Old changelogs are automatically attached to the GitHub releases -->
+
+- feat: add headers to MCP client config
+- refactor: better mcp client management
+- [BREAKING] MCP client Public API now takes mcp client ids instead of names

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -134,7 +134,7 @@ func (provider *AnthropicProvider) completeRequest(ctx context.Context, jsonData
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	// Can be empty in case of passthrough
+	// Can be empty in case of passthrough or keyless custom provider
 	if key != "" {
 		req.Header.Set("x-api-key", key)
 	}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -214,8 +214,8 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx context.Context, jsonD
 	providerUtils.SetExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
+	req.Header.Set("Accept", "application/vnd.amazon.eventstream")
 	if key.Value != "" {
-		req.Header.Set("Accept", "application/vnd.amazon.eventstream")
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value))
 	} else {
 		req.Header.Set("Accept", "application/vnd.amazon.eventstream")

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -141,9 +141,10 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 
 type CustomProviderConfig struct {
 	CustomProviderKey    string                 `json:"-"`                                // Custom provider key, internally set by Bifrost
+	IsKeyLess            bool                   `json:"is_key_less"`                      // Whether the custom provider requires a key (not allowed for Bedrock)
 	BaseProviderType     ModelProvider          `json:"base_provider_type"`               // Base provider type
 	AllowedRequests      *AllowedRequests       `json:"allowed_requests,omitempty"`       // Allowed requests for the custom provider
-	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider
+	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider (not allowed for Bedrock)
 }
 
 // IsOperationAllowed checks if a specific operation is allowed for this custom provider

--- a/core/utils.go
+++ b/core/utils.go
@@ -51,7 +51,11 @@ func Ptr[T any](v T) *T {
 
 // providerRequiresKey returns true if the given provider requires an API key for authentication.
 // Some providers like Ollama and SGL are keyless and don't require API keys.
-func providerRequiresKey(providerKey schemas.ModelProvider) bool {
+func providerRequiresKey(providerKey schemas.ModelProvider, customConfig *schemas.CustomProviderConfig) bool {
+	// Keyless custom providers are not allowed for Bedrock.
+	if customConfig != nil && customConfig.IsKeyLess && customConfig.BaseProviderType != schemas.Bedrock {
+		return false
+	}
 	return providerKey != schemas.Ollama && providerKey != schemas.SGL
 }
 

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -9,7 +9,7 @@ import { BaseProvider, RequestType } from "@/lib/types/config";
 import { isRequestTypeDisabled } from "@/lib/utils/validation";
 import { Control, useFormContext } from "react-hook-form";
 import { Settings2 } from "lucide-react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 interface AllowedRequestsFieldsProps {
 	control: Control<any>;
@@ -84,9 +84,10 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 		});
 	}, [providerType, namePrefix, setValue, getValues]);
 
+	const isPathOverrideDisabled = useMemo(() => providerType === "gemini" || providerType === "bedrock", [providerType]);
+
 	const renderRequestField = (requestType: { key: RequestType; label: string }) => {
 		const isDisabled = isRequestTypeDisabled(providerType, requestType.key);
-		const isPathOverrideDisabled = providerType === "gemini" || providerType === "bedrock";
 		const placeholder = getPlaceholder(providerType, requestType.key);
 
 		return (
@@ -160,7 +161,8 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 			<div>
 				<div className="text-sm font-medium">Allowed Request Types</div>
 				<p className="text-muted-foreground text-xs">
-					Select which request types this custom provider can handle. Click the settings icon to customize endpoint paths.
+					Select which request types this custom provider can handle.{" "}
+					{!isPathOverrideDisabled ? "Click the settings icon to customize endpoint paths." : ""}
 				</p>
 			</div>
 

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -10,11 +10,12 @@ import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { BaseProvider, ModelProvider } from "@/lib/types/config";
 import { formCustomProviderConfigSchema } from "@/lib/types/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { cleanPathOverrides } from "@/lib/utils/validation";
+import { Switch } from "@/components/ui/switch";
 
 // Type for form data
 type FormCustomProviderConfig = z.infer<typeof formCustomProviderConfigSchema>;
@@ -33,6 +34,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 		mode: "onChange",
 		defaultValues: {
 			base_provider_type: provider.custom_provider_config?.base_provider_type ?? "openai",
+			is_key_less: provider.custom_provider_config?.is_key_less ?? false,
 			allowed_requests: {
 				text_completion: provider.custom_provider_config?.allowed_requests?.text_completion ?? true,
 				text_completion_stream: provider.custom_provider_config?.allowed_requests?.text_completion_stream ?? true,
@@ -65,6 +67,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 			...provider,
 			custom_provider_config: {
 				base_provider_type: data.base_provider_type as unknown as BaseProvider,
+				is_key_less: data.is_key_less ?? false,
 				allowed_requests: data.allowed_requests,
 				request_path_overrides: cleanPathOverrides(data.request_path_overrides),
 			},
@@ -80,10 +83,15 @@ export function ApiStructureFormFragment({ provider }: Props) {
 			});
 	};
 
+	const isKeyLessDisabled = useMemo(
+		() => provider.custom_provider_config?.base_provider_type === "bedrock",
+		[provider.custom_provider_config?.base_provider_type],
+	);
+
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
-				<div className="space-y-4">
+				<div className="flex flex-col gap-4">
 					<FormField
 						control={form.control}
 						name="base_provider_type"
@@ -109,6 +117,25 @@ export function ApiStructureFormFragment({ provider }: Props) {
 							</FormItem>
 						)}
 					/>
+					{!isKeyLessDisabled && (
+						<FormField
+							control={form.control}
+							name="is_key_less"
+							render={({ field }) => (
+								<FormItem>
+									<div className="flex items-center justify-between space-x-2 rounded-lg border p-3">
+										<div className="space-y-0.5">
+											<label htmlFor="drop-excess-requests" className="text-sm font-medium">
+												Is Keyless?
+											</label>
+											<p className="text-muted-foreground text-sm">Whether the custom provider requires a key (not allowed for Bedrock)</p>
+										</div>
+										<Switch id="drop-excess-requests" size="md" checked={field.value} onCheckedChange={field.onChange} />
+									</div>
+								</FormItem>
+							)}
+						/>
+					)}
 				</div>
 
 				{/* Allowed Requests Configuration */}

--- a/ui/app/workspace/providers/views/modelProviderConfig.tsx
+++ b/ui/app/workspace/providers/views/modelProviderConfig.tsx
@@ -49,7 +49,12 @@ export default function ModelProviderConfig({ provider }: Props) {
 		return availableTabs(provider);
 	}, [provider.name, provider.custom_provider_config]);
 
-	const showApiKeys = keysRequired(provider.name);
+	const showApiKeys = useMemo(() => {
+		if (provider.custom_provider_config) {
+			return !(provider.custom_provider_config?.is_key_less ?? false);
+		}
+		return keysRequired(provider.name);
+	}, [provider.name, provider.custom_provider_config?.is_key_less]);
 
 	useEffect(() => {
 		setSelectedTab(tabs[0]?.id);

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -89,6 +89,7 @@ export const DefaultModelProviderKey: ModelProviderKey = {
 // NetworkConfig matching Go's schemas.NetworkConfig
 export interface NetworkConfig {
 	base_url?: string;
+	is_key_less?: boolean;
 	extra_headers?: Record<string, string>;
 	default_request_timeout_in_seconds: number;
 	max_retries: number;
@@ -114,7 +115,7 @@ export interface ProxyConfig {
 }
 
 // Request types matching Go's schemas.RequestType
-export type RequestType = 
+export type RequestType =
 	| "list_models"
 	| "text_completion"
 	| "text_completion_stream"
@@ -147,6 +148,7 @@ export interface AllowedRequests {
 // CustomProviderConfig matching Go's schemas.CustomProviderConfig
 export interface CustomProviderConfig {
 	base_provider_type: KnownProvider;
+	is_key_less?: boolean;
 	allowed_requests?: AllowedRequests;
 	request_path_overrides?: Record<string, string>;
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -22,30 +22,30 @@ export const azureKeyConfigSchema = z
 	.refine(
 		(data) => {
 			// If deployments is not provided, it's valid
-			if (!data.deployments) return true
+			if (!data.deployments) return true;
 			// If it's already an object, it's valid
-			if (typeof data.deployments === 'object') return true
+			if (typeof data.deployments === "object") return true;
 			// If it's a string, check if it's valid JSON or an env variable
-			if (typeof data.deployments === 'string') {
-				const trimmed = data.deployments.trim()
+			if (typeof data.deployments === "string") {
+				const trimmed = data.deployments.trim();
 				// Allow empty string
-				if (trimmed === '') return true
+				if (trimmed === "") return true;
 				// Allow env variables
-				if (trimmed.startsWith('env.')) return true
+				if (trimmed.startsWith("env.")) return true;
 				// Validate JSON format
 				try {
-					const parsed = JSON.parse(trimmed)
-					return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+					const parsed = JSON.parse(trimmed);
+					return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
 				} catch {
-					return false
+					return false;
 				}
 			}
-			return false
+			return false;
 		},
 		{
-			message: 'Deployments must be a valid JSON object or an environment variable reference',
-			path: ['deployments'],
-		}
+			message: "Deployments must be a valid JSON object or an environment variable reference",
+			path: ["deployments"],
+		},
 	);
 
 // Vertex key config schema
@@ -68,30 +68,30 @@ export const bedrockKeyConfigSchema = z
 	.refine(
 		(data) => {
 			// If deployments is not provided, it's valid
-			if (!data.deployments) return true
+			if (!data.deployments) return true;
 			// If it's already an object, it's valid
-			if (typeof data.deployments === 'object') return true
+			if (typeof data.deployments === "object") return true;
 			// If it's a string, check if it's valid JSON or an env variable
-			if (typeof data.deployments === 'string') {
-				const trimmed = data.deployments.trim()
+			if (typeof data.deployments === "string") {
+				const trimmed = data.deployments.trim();
 				// Allow empty string
-				if (trimmed === '') return true
+				if (trimmed === "") return true;
 				// Allow env variables
-				if (trimmed.startsWith('env.')) return true
+				if (trimmed.startsWith("env.")) return true;
 				// Validate JSON format
 				try {
-					const parsed = JSON.parse(trimmed)
-					return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+					const parsed = JSON.parse(trimmed);
+					return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
 				} catch {
-					return false
+					return false;
 				}
 			}
-			return false
+			return false;
 		},
 		{
-			message: 'Deployments must be a valid JSON object or an environment variable reference',
-			path: ['deployments'],
-		}
+			message: "Deployments must be a valid JSON object or an environment variable reference",
+			path: ["deployments"],
+		},
 	);
 
 // Model provider key schema
@@ -288,19 +288,46 @@ export const allowedRequestsSchema = z.object({
 });
 
 // Custom provider config schema
-export const customProviderConfigSchema = z.object({
-	base_provider_type: knownProviderSchema,
-	allowed_requests: allowedRequestsSchema.optional(),
-	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
-});
+export const customProviderConfigSchema = z
+	.object({
+		base_provider_type: knownProviderSchema,
+		is_key_less: z.boolean().optional(),
+		allowed_requests: allowedRequestsSchema.optional(),
+		request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
+	})
+	.refine(
+		(data) => {
+			if (data.base_provider_type === "bedrock") {
+				return !data.is_key_less;
+			}
+			return true;
+		},
+		{
+			message: "Is keyless is not allowed for Bedrock",
+			path: ["is_key_less"],
+		},
+	);
 
 // Form-specific custom provider config schema
-export const formCustomProviderConfigSchema = z.object({
-	base_provider_type: z.string().min(1, "Base provider type is required"),
-	allowed_requests: allowedRequestsSchema.optional(),
-	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
-});
-
+export const formCustomProviderConfigSchema = z
+	.object({
+		base_provider_type: z.string().min(1, "Base provider type is required"),
+		is_key_less: z.boolean().optional(),
+		allowed_requests: allowedRequestsSchema.optional(),
+		request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
+	})
+	.refine(
+		(data) => {
+			if (data.base_provider_type === "bedrock") {
+				return !data.is_key_less;
+			}
+			return true;
+		},
+		{
+			message: "Is keyless is not allowed for Bedrock",
+			path: ["is_key_less"],
+		},
+	);
 // Full model provider config schema
 export const modelProviderConfigSchema = z.object({
 	keys: z.array(modelProviderKeySchema).min(1, "At least one key is required"),


### PR DESCRIPTION
## Summary

Added support for keyless custom providers, allowing users to create custom providers that don't require API keys for authentication. This feature enhances flexibility for self-hosted or internal services that don't use API key authentication.

## Changes

- Added `is_key_less` flag to custom provider configuration
- Modified provider authentication logic to respect the keyless flag
- Changed fallback provider failure logging from WARN to DEBUG level
- Updated UI to include a toggle for keyless providers in the provider configuration forms
- Added validation to prevent keyless configuration for Bedrock providers
- Fixed header handling in Bedrock provider for streaming requests
- Updated model fetching logic to skip for keyless providers when appropriate

## Type of change

- [x] Feature
- [x] Refactor
- [x] UI (Next.js)

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

1. Create a new custom provider with the "Is Keyless" option enabled
2. Configure the base URL to point to a service that doesn't require API keys
3. Verify that requests work without providing API keys
4. Try creating a keyless Bedrock provider and verify it's not allowed

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

MCP client Public API now takes MCP client IDs instead of names, as noted in the changelog.

## Security considerations

This feature allows for keyless authentication to custom providers. Users should ensure that their keyless providers are properly secured through other means (network isolation, internal firewalls, etc.) if they contain sensitive information.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)