### PR TITLE
feat: replace JSON textarea with HeadersTable component for HTTP headers

### DIFF
--- a/ui/app/workspace/mcp-clients/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-clients/views/mcpClientSheet.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { HeadersTable } from "@/components/ui/headersTable";
 import { MCPClient } from "@/lib/types/mcp";
 import { CodeEditor } from "@/app/workspace/logs/views/codeEditor";
 import { MCP_STATUS_COLORS } from "@/lib/constants/config";
@@ -15,7 +16,6 @@ import { mcpClientUpdateSchema, type MCPClientUpdateSchema } from "@/lib/types/s
 import { useUpdateMCPClientMutation, getErrorMessage } from "@/lib/store";
 import { useToast } from "@/hooks/use-toast";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 
 interface MCPClientSheetProps {
 	mcpClient: MCPClient;
@@ -129,7 +129,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 						<div className="space-y-6">
 							{/* Name and Header Section */}
 							<div className="space-y-4">
-							<h3 className="font-semibold">Basic Information</h3>
+								<h3 className="font-semibold">Basic Information</h3>
 								<FormField
 									control={form.control}
 									name="name"
@@ -150,39 +150,16 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 									name="headers"
 									render={({ field }) => (
 										<FormItem className="flex flex-col gap-3">
-											<FormLabel>Headers (JSON)</FormLabel>
-											<div>
-												<FormControl>
-													<Textarea
-														placeholder='{"Authorization": "Bearer token", "Content-Type": "application/json"}'
-														value={typeof field.value === "string" ? field.value : JSON.stringify(field.value || {}, null, 2)}
-														onChange={(e) => {
-															// Store as string during editing to allow intermediate invalid states
-															field.onChange(e.target.value);
-														}}
-														onBlur={(e) => {
-															// Try to parse as JSON on blur, but keep as string if invalid
-															const value = e.target.value.trim();
-															if (value) {
-																try {
-																	const parsed = JSON.parse(value);
-																	if (typeof parsed === "object" && parsed !== null) {
-																		field.onChange(parsed);
-																	}
-																} catch {
-																	// Keep as string for validation on submit
-																}
-															} else {
-																field.onChange(undefined);
-															}
-															field.onBlur();
-														}}
-														rows={3}
-														className="max-w-full font-mono text-sm wrap-anywhere"
-													/>
-												</FormControl>
-												<FormMessage />
-											</div>
+											<FormControl>
+												<HeadersTable
+													value={field.value || {}}
+													onChange={field.onChange}
+													keyPlaceholder="Header name"
+													valuePlaceholder="Header value"
+													label="Headers"
+												/>
+											</FormControl>
+											<FormMessage />
 										</FormItem>
 									)}
 								/>
@@ -192,28 +169,28 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 								<h3 className="font-semibold">Configuration</h3>
 								<div className="rounded-sm border">
 									<div className="bg-muted/50 text-muted-foreground border-b px-6 py-2 text-xs font-medium">Client ConnectionConfig</div>
-								<CodeEditor
-									className="z-0 w-full"
-									shouldAdjustInitialHeight={true}
-									maxHeight={300}
-									wrap={true}
-									code={JSON.stringify(
-										(() => {
-											const { id, name, tools_to_execute, headers, ...rest } = mcpClient.config;
-											return rest;
-										})(),
-										null,
-										2
-									)}
-									lang="json"
-									readonly={true}
-									options={{
-										scrollBeyondLastLine: false,
-										collapsibleBlocks: true,
-										lineNumbers: "off",
-										alwaysConsumeMouseWheel: false,
-									}}
-								/>
+									<CodeEditor
+										className="z-0 w-full"
+										shouldAdjustInitialHeight={true}
+										maxHeight={300}
+										wrap={true}
+										code={JSON.stringify(
+											(() => {
+												const { id, name, tools_to_execute, headers, ...rest } = mcpClient.config;
+												return rest;
+											})(),
+											null,
+											2,
+										)}
+										lang="json"
+										readonly={true}
+										options={{
+											scrollBeyondLastLine: false,
+											collapsibleBlocks: true,
+											lineNumbers: "off",
+											alwaysConsumeMouseWheel: false,
+										}}
+									/>
 								</div>
 							</div>
 							{/* Tools Section */}

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -2,13 +2,13 @@
 
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { otelFormSchema, type OtelFormSchema } from "@/lib/types/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Trash } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 
@@ -87,7 +87,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 							render={({ field }) => (
 								<FormItem className="w-full">
 									<FormLabel>OTLP Collector URL</FormLabel>
-									<div className="text-xs text-muted-foreground">
+									<div className="text-muted-foreground text-xs">
 										<code>{form.watch("otel_config.protocol") === "http" ? "http(s)://<host>:<port>/v1/traces" : "<host>:<port>"}</code>
 									</div>
 									<FormControl>
@@ -107,117 +107,14 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 						<FormField
 							control={form.control}
 							name="otel_config.headers"
-							render={({ field }) => {
-								// Convert headers object to array format for table display
-								// Filter out any empty string keys from stored headers
-								const headerEntries = Object.entries(field.value || {}).filter(([key]) => key !== "");
-								// Always show at least one empty row at the bottom
-								const rows = [...headerEntries, ["", ""]];
-
-								const handleKeyChange = (oldKey: string, newKey: string, currentValue: string, rowIndex: number) => {
-									const newHeaders = { ...field.value };
-
-									// Remove old key if it exists and is not empty
-									if (oldKey !== "" && oldKey in newHeaders) {
-										delete newHeaders[oldKey];
-									}
-
-									// Only add new entry if key is not empty
-									if (newKey !== "") {
-										newHeaders[newKey] = currentValue;
-									}
-
-									// Clean up any empty string keys
-									delete newHeaders[""];
-
-									field.onChange(newHeaders);
-								};
-
-								const handleValueChange = (currentKey: string, newValue: string, rowIndex: number) => {
-									const newHeaders = { ...field.value };
-
-									// Only update if key is not empty
-									if (currentKey !== "") {
-										newHeaders[currentKey] = newValue;
-									}
-
-									// Clean up any empty string keys
-									delete newHeaders[""];
-
-									field.onChange(newHeaders);
-								};
-
-								const handleDelete = (key: string) => {
-									const newHeaders = { ...field.value };
-									delete newHeaders[key];
-									field.onChange(newHeaders);
-								};
-
-								const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, rowIndex: number, column: "key" | "value") => {
-									if (e.key === "Tab" && !e.shiftKey) {
-										if (column === "key") {
-											e.preventDefault();
-											const valueInput = document.querySelector(`input[data-row="${rowIndex}"][data-column="value"]`) as HTMLInputElement;
-											valueInput?.focus();
-										}
-									}
-								};
-
-								return (
-									<FormItem className="w-full">
-										<FormLabel>Headers</FormLabel>
-										<FormControl>
-											<div className="rounded-md border">
-												<table className="w-full">
-													<thead>
-														<tr className="bg-muted/50 border-b">
-															<th className="px-4 py-2 text-left text-sm font-medium">Name</th>
-															<th className="px-4 py-2 text-left text-sm font-medium">Value</th>
-															<th className="w-12 px-4 py-2"></th>
-														</tr>
-													</thead>
-													<tbody>
-														{rows.map(([key, value], index) => (
-															<tr key={index} className="border-b last:border-0">
-																<td className="p-2">
-																	<Input
-																		placeholder="Header name"
-																		value={key}
-																		data-row={index}
-																		data-column="key"
-																		onChange={(e) => handleKeyChange(key, e.target.value, value as string, index)}
-																		onKeyDown={(e) => handleKeyDown(e, index, "key")}
-																		className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
-																	/>
-																</td>
-																<td className="p-2">
-																	<Input
-																		placeholder="Header value"
-																		value={value as string}
-																		data-row={index}
-																		data-column="value"
-																		onChange={(e) => handleValueChange(key, e.target.value, index)}
-																		onKeyDown={(e) => handleKeyDown(e, index, "value")}
-																		className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
-																	/>
-																</td>
-																<td className="p-2">
-																	{(key !== "" || value !== "") && (
-																		<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key)} className="h-8 w-8">
-																			<Trash className="h-4 w-4" />
-																		</Button>
-																	)}
-																</td>
-															</tr>
-														))}
-													</tbody>
-												</table>
-											</div>
-										</FormControl>
-										<FormMessage />
-									</FormItem>
-								);
-							}}
+							render={({ field }) => (
+								<FormItem className="w-full">
+									<FormControl>
+										<HeadersTable value={field.value || {}} onChange={field.onChange} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
 						/>
 
 						<div className="flex flex-row gap-4">

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -2,8 +2,8 @@
 
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { DefaultNetworkConfig } from "@/lib/constants/config";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
@@ -177,34 +177,13 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 							name="network_config.extra_headers"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Extra Headers (Optional)</FormLabel>
 									<FormControl>
-										<Textarea
-											placeholder='{"Authorization": "Bearer token", "X-Custom-Header": "value"}'
-											value={typeof field.value === "string" ? field.value : JSON.stringify(field.value || {}, null, 2)}
-											onChange={(e) => {
-												// Store as string during editing to allow intermediate invalid states
-												field.onChange(e.target.value);
-											}}
-											onBlur={(e) => {
-												// Try to parse as JSON on blur, but keep as string if invalid
-												const value = e.target.value.trim();
-												if (value) {
-													try {
-														const parsed = JSON.parse(value);
-														if (typeof parsed === "object" && parsed !== null) {
-															field.onChange(parsed);
-														}
-													} catch {
-														// Keep as string for validation on submit
-													}
-												} else {
-													field.onChange(undefined);
-												}
-												field.onBlur();
-											}}
-											rows={3}
-											className="max-w-full font-mono text-sm wrap-anywhere"
+										<HeadersTable
+											value={field.value || {}}
+											onChange={field.onChange}
+											keyPlaceholder="Header name"
+											valuePlaceholder="Header value"
+											label="Extra Headers"
 										/>
 									</FormControl>
 									<FormMessage />

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Trash } from "lucide-react";
+
+interface HeadersTableProps {
+	value: Record<string, string>;
+	onChange: (value: Record<string, string>) => void;
+	keyPlaceholder?: string;
+	valuePlaceholder?: string;
+	label?: string;
+}
+
+export function HeadersTable({
+	value,
+	onChange,
+	keyPlaceholder = "Header name",
+	valuePlaceholder = "Header value",
+	label = "Headers",
+}: HeadersTableProps) {
+	// Convert headers object to array format for table display
+	// Filter out any empty string keys from stored headers
+	const headerEntries = Object.entries(value || {}).filter(([key]) => key !== "");
+	// Always show at least one empty row at the bottom
+	const rows = [...headerEntries, ["", ""]];
+
+	const handleKeyChange = (oldKey: string, newKey: string, currentValue: string, rowIndex: number) => {
+		const newHeaders = { ...value };
+
+		// Remove old key if it exists and is not empty
+		if (oldKey !== "" && oldKey in newHeaders) {
+			delete newHeaders[oldKey];
+		}
+
+		// Only add new entry if key is not empty
+		if (newKey !== "") {
+			newHeaders[newKey] = currentValue;
+		}
+
+		// Clean up any empty string keys
+		delete newHeaders[""];
+
+		onChange(newHeaders);
+	};
+
+	const handleValueChange = (currentKey: string, newValue: string, rowIndex: number) => {
+		const newHeaders = { ...value };
+
+		// Only update if key is not empty
+		if (currentKey !== "") {
+			newHeaders[currentKey] = newValue;
+		}
+
+		// Clean up any empty string keys
+		delete newHeaders[""];
+
+		onChange(newHeaders);
+	};
+
+	const handleDelete = (key: string) => {
+		const newHeaders = { ...value };
+		delete newHeaders[key];
+		onChange(newHeaders);
+	};
+
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, rowIndex: number, column: "key" | "value") => {
+		if (e.key === "Tab" && !e.shiftKey) {
+			if (column === "key") {
+				e.preventDefault();
+				const valueInput = document.querySelector(`input[data-row="${rowIndex}"][data-column="value"]`) as HTMLInputElement;
+				valueInput?.focus();
+			}
+		}
+	};
+
+	return (
+		<div className="w-full">
+			{label && (
+				<label className="mb-2 block text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+					{label}
+				</label>
+			)}
+			<div className="rounded-md border">
+				<Table>
+					<TableHeader>
+						<TableRow>
+							<TableHead className="px-4 py-2">Name</TableHead>
+							<TableHead className="px-4 py-2">Value</TableHead>
+							<TableHead className="w-12 px-4 py-2">
+								<span className="sr-only">Actions</span>
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{rows.map(([key, value], index) => {
+							// Use key for existing entries, index for the empty row
+							const rowKey = key !== "" ? key : `empty-${index}`;
+							return (
+								<TableRow key={rowKey} className="border-b last:border-0">
+									<TableCell className="p-2">
+										<Input
+											placeholder={keyPlaceholder}
+											value={key}
+											data-row={index}
+											data-column="key"
+											onChange={(e) => handleKeyChange(key, e.target.value, value as string, index)}
+											onKeyDown={(e) => handleKeyDown(e, index, "key")}
+											className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+										/>
+									</TableCell>
+									<TableCell className="p-2">
+										<Input
+											placeholder={valuePlaceholder}
+											value={value as string}
+											data-row={index}
+											data-column="value"
+											onChange={(e) => handleValueChange(key, e.target.value, index)}
+											onKeyDown={(e) => handleKeyDown(e, index, "value")}
+											className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+										/>
+									</TableCell>
+									<TableCell className="p-2">
+										{(key !== "" || value !== "") && (
+											<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key)} className="h-8 w-8">
+												<Trash className="h-4 w-4" />
+											</Button>
+										)}
+									</TableCell>
+								</TableRow>
+							);
+						})}
+					</TableBody>
+				</Table>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Implemented a reusable HeadersTable component to standardize and improve the UI for managing HTTP headers across the application.

## Changes

- Created a new `HeadersTable` component that provides a consistent interface for editing HTTP headers
- Replaced JSON textarea inputs with the new HeadersTable component in:
  - MCP Client form
  - MCP Client sheet
  - OTEL configuration form
  - Network provider configuration
- Simplified header validation logic by handling it directly in the component
- Improved UX by providing a more intuitive table interface for adding, editing, and removing headers

## Type of change

- [x] Feature
- [x] Refactor
- [x] UI (Next.js)

## Affected areas

- [x] UI (Next.js)

## How to test

1. Navigate to various areas that use HTTP headers:
   - Create/edit MCP clients
   - Configure OTEL settings
   - Edit network provider settings

2. Verify that the headers table works correctly:
   - Add new headers
   - Edit existing headers
   - Delete headers
   - Validate that empty headers are not saved

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

The component properly handles header values which may contain sensitive information.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable