### PR TITLE
fix: remove reasoning keyword validation requirements

### DIFF
--- a/tests/core-providers/scenarios/validation_presets.go
+++ b/tests/core-providers/scenarios/validation_presets.go
@@ -37,7 +37,7 @@ func ToolCallExpectations(toolName string, requiredArgs []string) ResponseExpect
 		{
 			FunctionName:     toolName,
 			RequiredArgs:     requiredArgs,
-			ValidateArgsJSON: true,			
+			ValidateArgsJSON: true,
 		},
 	}
 	// Tool calls might not have text content
@@ -205,11 +205,6 @@ func ReasoningExpectations() ResponseExpectations {
 		ShouldHaveUsageStats: true,
 		ShouldHaveTimestamps: true,
 		ShouldHaveModel:      true,
-		// Reasoning-specific validations
-		ShouldContainAnyOf: []string{
-			"step", "first", "then", "next", "calculate", "therefore", "because",
-			"reasoning", "think", "analysis", "conclusion", "solution", "solve",
-		},
 		ProviderSpecific: map[string]interface{}{
 			"response_type":        "reasoning",
 			"expects_step_by_step": true,
@@ -297,9 +292,6 @@ func GetExpectationsForScenario(scenarioName string, testConfig config.Comprehen
 
 	case "Reasoning":
 		expectations := ReasoningExpectations()
-		if requiresReasoning, ok := customParams["requires_reasoning"].(bool); ok && requiresReasoning {
-			expectations.ShouldContainAnyOf = append(expectations.ShouldContainAnyOf, []string{"step", "first", "then", "calculate", "therefore", "because", "solve"}...)
-		}
 		return expectations
 
 	case "ProviderSpecific":


### PR DESCRIPTION
## Summary

Removed unnecessary text content validation in reasoning expectations to improve test flexibility.

## Changes

- Removed the `ShouldContainAnyOf` validation from the `ReasoningExpectations()` function that was checking for specific reasoning-related keywords
- Removed the code that appended additional reasoning keywords when the `requires_reasoning` parameter was set to true
- These changes allow for more flexible reasoning responses without requiring specific keywords

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the reasoning tests to verify they still pass without the keyword validation:

```sh
# Core/Transports
go test ./tests/core-providers/... -run TestReasoning
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves test reliability by removing overly restrictive validation requirements.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable