### PR TITLE
fix: support ResponsesOutputMessageContentTypeText in Bedrock content blocks

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -430,7 +430,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(content s
 			bedrockBlock := BedrockContentBlock{}
 
 			switch block.Type {
-			case schemas.ResponsesInputMessageContentBlockTypeText:
+			case schemas.ResponsesInputMessageContentBlockTypeText, schemas.ResponsesOutputMessageContentTypeText:
 				bedrockBlock.Text = block.Text
 			case schemas.ResponsesInputMessageContentBlockTypeImage:
 				if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {


### PR DESCRIPTION
## Summary

Added support for handling text content blocks from output messages in Bedrock provider responses.

## Changes

- Updated the `convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks` function to handle the `schemas.ResponsesOutputMessageContentTypeText` case in addition to the existing `schemas.ResponsesInputMessageContentBlockTypeText` case
- This ensures text content from output messages is properly converted to Bedrock content blocks

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test that text content from output messages is properly handled in Bedrock responses:

```sh
# Core/Transports
go version
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects content type handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable