### PR TITLE
fixes codecov config to use correct coveage for core

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          for dir in core framework transports; do
+          for dir in core framework transports tests/core-providers tests/core-chatbot; do
             if [ -f "$dir/go.mod" ]; then
               echo "Installing dependencies for $dir..."
               (cd "$dir" && go mod download)
@@ -34,10 +34,11 @@ jobs:
       - name: Run tests
         run: |
           # Run tests for each module and combine coverage
-          for dir in core framework transports; do
+          for dir in core framework transports tests/core-providers tests/core-chatbot; do
             if [ -f "$dir/go.mod" ]; then
               echo "Running tests for $dir..."
-              (cd "$dir" && go test -coverprofile=../coverage-$(basename $dir).txt ./... || true)
+              dirname=$(echo $dir | sed 's/\//-/g')
+              (cd "$dir" && go test -coverprofile=../coverage-$dirname.txt -coverpkg=github.com/maximhq/bifrost/core/...,github.com/maximhq/bifrost/framework/...,github.com/maximhq/bifrost/transports/... ./... || true)
             fi
           done
           


### PR DESCRIPTION
## Summary

Enhance test coverage workflow to include additional modules in the testing process.

## Changes

- Added `tests/core-providers` and `tests/core-chatbot` to the list of directories for dependency installation and test execution
- Modified the test command to properly handle directory names with slashes by converting them to hyphens for coverage filenames
- Added `-coverpkg` flag to ensure coverage is collected for all relevant packages across the codebase

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Run the GitHub Actions workflow to verify that test coverage now includes the additional modules:

```sh
# Locally you can test with
go test -coverprofile=coverage.txt -coverpkg=github.com/maximhq/bifrost/core/...,github.com/maximhq/bifrost/framework/...,github.com/maximhq/bifrost/transports/... ./...
```

## Breaking changes

- [x] No

## Related issues

Improves test coverage reporting for the project.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable