### PR TITLE
fix: handle keyless providers in initial list models requests

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - feat: added unified streaming lifecycle events across all providers to fully align with OpenAI’s streaming response types.
 - chore: shift from `alpha/responses` to `v1/responses` in openrouter provider for responses API
+- fix: custom keyless providers initial list models request fixes

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -235,6 +235,9 @@ func (provider *AnthropicProvider) ListModels(ctx context.Context, keys []schema
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ListModelsRequest); err != nil {
 		return nil, err
 	}
+	if provider.customProviderConfig != nil && provider.customProviderConfig.IsKeyLess {
+		return provider.listModelsByKey(ctx, schemas.Key{}, request)
+	}
 	return providerUtils.HandleMultipleListModelsRequests(
 		ctx,
 		keys,

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -257,6 +257,9 @@ func (provider *CohereProvider) ListModels(ctx context.Context, keys []schemas.K
 	if err := providerUtils.CheckOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ListModelsRequest); err != nil {
 		return nil, err
 	}
+	if provider.customProviderConfig != nil && provider.customProviderConfig.IsKeyLess {
+		return provider.listModelsByKey(ctx, schemas.Key{}, request)
+	}
 	return providerUtils.HandleMultipleListModelsRequests(
 		ctx,
 		keys,

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -179,6 +179,9 @@ func (provider *GeminiProvider) ListModels(ctx context.Context, keys []schemas.K
 	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.ListModelsRequest); err != nil {
 		return nil, err
 	}
+	if provider.customProviderConfig != nil && provider.customProviderConfig.IsKeyLess {
+		return provider.listModelsByKey(ctx, schemas.Key{}, request)
+	}
 	return providerUtils.HandleMultipleListModelsRequests(
 		ctx,
 		keys,

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -83,6 +83,18 @@ func (provider *OpenAIProvider) ListModels(ctx context.Context, keys []schemas.K
 
 	providerName := provider.GetProviderKey()
 
+	if provider.customProviderConfig != nil && provider.customProviderConfig.IsKeyLess {
+		return listModelsByKeyOpenAI(
+			ctx,
+			provider.client,
+			provider.buildRequestURL(ctx, "/v1/models", schemas.ListModelsRequest),
+			schemas.Key{},
+			provider.networkConfig.ExtraHeaders,
+			providerName,
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		)
+	}
+
 	return HandleOpenAIListModelsRequest(ctx,
 		provider.client,
 		request,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,3 +2,4 @@
 - feat: added unified streaming lifecycle events across all providers to fully align with OpenAI’s streaming response types.
 - chore: shift from `alpha/responses` to `v1/responses` in openrouter provider for responses API
 - feat: send back pricing data for models in list models response
+- fix: custom keyless providers initial list models request fixes


### PR DESCRIPTION
## Summary

Fixed issues with custom keyless providers during initial list models requests, ensuring proper initialization and handling of providers that don't require API keys.

## Changes

- Added a check to skip key retrieval for providers that don't require keys
- Implemented auto-initialization of providers when they're not yet initialized but have a valid config
- Added support for keyless model listing in Anthropic, Cohere, Gemini, and OpenAI providers
- Updated provider implementations to handle keyless configurations properly

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test listing models with custom keyless providers:

```sh
# Core/Transports
go version
go test ./...

# Test with a custom keyless provider configuration
curl -X GET "http://localhost:8000/v1/models" -H "Authorization: Bearer your_token"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with custom keyless providers failing to initialize or list models properly.

## Security considerations

This change maintains the security model by properly handling keyless provider configurations without exposing sensitive information.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable