### PR TITLE
separates server callbacks for handlers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -244,14 +244,14 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 	if ctx == nil {
 		ctx = bifrost.ctx
 	}
-
+	// Preparing request
 	request := &schemas.BifrostListModelsRequest{
 		Provider:    req.Provider,
 		PageSize:    req.PageSize,
 		PageToken:   req.PageToken,
 		ExtraParams: req.ExtraParams,
 	}
-
+	// Getting provider from the memory
 	provider := bifrost.getProviderByKey(req.Provider)
 	if provider == nil {
 		return nil, &schemas.BifrostError{
@@ -1424,24 +1424,21 @@ func (bifrost *Bifrost) getProviderByKey(providerKey schemas.ModelProvider) sche
 	if providers == nil {
 		return nil
 	}
-
+	// Checking if provider is in the memory
 	for _, provider := range *providers {
 		if provider.GetProviderKey() == providerKey {
 			return provider
 		}
 	}
-
 	// Could happen when provider is not initialized yet, check if provider config exists in account and if so, initialize it
 	config, err := bifrost.account.GetConfigForProvider(providerKey)
 	if err != nil || config == nil {
 		return nil
 	}
-
 	// Lock the provider mutex to avoid races
 	providerMutex := bifrost.getProviderMutex(providerKey)
 	providerMutex.Lock()
 	defer providerMutex.Unlock()
-
 	// Double-check after acquiring the lock
 	providers = bifrost.providers.Load()
 	if providers != nil {
@@ -1451,11 +1448,10 @@ func (bifrost *Bifrost) getProviderByKey(providerKey schemas.ModelProvider) sche
 			}
 		}
 	}
-
+	// Preparing provider
 	if err := bifrost.prepareProvider(providerKey, config); err != nil {
 		return nil
 	}
-
 	// Return newly prepared provider without recursion
 	providers = bifrost.providers.Load()
 	if providers != nil {

--- a/core/go.mod
+++ b/core/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.39.5
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.2
 	github.com/aws/aws-sdk-go-v2/config v1.31.13
+	github.com/aws/smithy-go v1.23.1
 	github.com/bytedance/sonic v1.14.1
 	github.com/google/uuid v1.6.0
 	github.com/mark3labs/mcp-go v0.41.1
@@ -29,7 +30,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.29.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.38.7 // indirect
-	github.com/aws/smithy-go v1.23.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -25,7 +25,7 @@ func CorsMiddleware(config *lib.Config) lib.BifrostHTTPMiddleware {
 			// Check if origin is allowed (localhost always allowed + configured origins)
 			if allowed {
 				ctx.Response.Header.Set("Access-Control-Allow-Origin", origin)
-				ctx.Response.Header.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+				ctx.Response.Header.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS")
 				ctx.Response.Header.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 				ctx.Response.Header.Set("Access-Control-Allow-Credentials", "true")
 				ctx.Response.Header.Set("Access-Control-Max-Age", "86400")
@@ -54,7 +54,6 @@ func TransportInterceptorMiddleware(config *lib.Config) lib.BifrostHTTPMiddlewar
 				next(ctx)
 				return
 			}
-
 			// If governance plugin is not loaded, skip interception
 			hasGovernance := false
 			for _, p := range plugins {
@@ -128,7 +127,6 @@ func TransportInterceptorMiddleware(config *lib.Config) lib.BifrostHTTPMiddlewar
 			for key, value := range headers {
 				ctx.Request.Header.Set(key, value)
 			}
-
 			next(ctx)
 		}
 	}
@@ -168,7 +166,7 @@ func AuthMiddleware(store configstore.ConfigStore) lib.BifrostHTTPMiddleware {
 		"/api/session/login",
 		"/api/session/logout",
 		"/health",
-	}	
+	}
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			// We skip authorization for the login route

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -23,7 +23,7 @@ import (
 // ModelsManager defines the interface for managing provider models
 type ModelsManager interface {
 	RefetchModelsForProvider(ctx context.Context, provider schemas.ModelProvider) error
-	DeleteModelsForProvider(provider schemas.ModelProvider) error
+	DeleteModelsForProvider(ctx context.Context, provider schemas.ModelProvider) error
 }
 
 // ProviderHandler manages HTTP requests for provider operations
@@ -453,7 +453,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 			logger.Warn(fmt.Sprintf("Failed to refetch models for provider %s: %v", provider, err))
 		}
 	} else {
-		if err := h.modelsManager.DeleteModelsForProvider(provider); err != nil {
+		if err := h.modelsManager.DeleteModelsForProvider(ctx, provider); err != nil {
 			logger.Warn(fmt.Sprintf("Failed to delete models for provider %s: %v", provider, err))
 		}
 	}
@@ -486,7 +486,7 @@ func (h *ProviderHandler) deleteProvider(ctx *fasthttp.RequestCtx) {
 
 	logger.Info(fmt.Sprintf("Provider %s removed successfully", provider))
 
-	if err := h.modelsManager.DeleteModelsForProvider(provider); err != nil {
+	if err := h.modelsManager.DeleteModelsForProvider(ctx, provider); err != nil {
 		logger.Warn(fmt.Sprintf("Failed to delete models for provider %s: %v", provider, err))
 	}
 

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -142,7 +142,6 @@ export default function SecurityView() {
 				);
 				return;
 			}
-
 			await updateCoreConfig({
 				...bifrostConfig!,
 				client_config: localConfig,

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -125,7 +125,7 @@ const productionSetupHelpCard = {
 			.
 		</>
 	),
-	dismissible: false,
+	dismissible: true,
 };
 
 // Sidebar item interface
@@ -228,9 +228,9 @@ const SidebarItemView = ({
 											isSubItemActive
 												? "bg-sidebar-accent text-primary font-medium"
 												: subItem.hasAccess == false
-													? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground border-transparent cursor-not-allowed"
+													? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
 													: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-										}`}										
+										}`}
 										onClick={() => (subItem.hasAccess === false ? undefined : handleSubItemClick(subItem.url))}
 									>
 										<div className="flex items-center gap-2">
@@ -312,7 +312,7 @@ export default function AppSidebar() {
 	const hasClusterConfigAccess = useRbac(RbacResource.Cluster, RbacOperation.View);
 	const isAdaptiveRoutingAllowed = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
 	const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
-	
+
 	const items = [
 		{
 			title: "Observability",
@@ -371,7 +371,7 @@ export default function AppSidebar() {
 			title: "Governance",
 			url: "/workspace/governance",
 			icon: Landmark,
-			description: "Govern access",		
+			description: "Govern access",
 			hasAccess: true,
 			subItems: [
 				{
@@ -527,9 +527,6 @@ export default function AppSidebar() {
 	// Memoize promo cards array to prevent duplicates and unnecessary re-renders
 	const promoCards = useMemo(() => {
 		const cards = [];
-		if (!IS_ENTERPRISE) {
-			cards.push(productionSetupHelpCard);
-		}
 		if (showNewReleaseBanner && latestRelease) {
 			cards.push({
 				id: "new-release",
@@ -548,6 +545,9 @@ export default function AppSidebar() {
 				),
 				dismissible: true,
 			});
+		}
+		if (!IS_ENTERPRISE) {
+			cards.push(productionSetupHelpCard);
 		}
 		return cards;
 	}, [showNewReleaseBanner, latestRelease, newReleaseImage]);

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -371,7 +371,7 @@ function isValidWildcardOrigin(origin: string): boolean {
  * @returns Object with validation result and invalid origins
  */
 export function validateOrigins(origins: string[]): { isValid: boolean; invalidOrigins: string[] } {
-	const invalidOrigins = origins.filter((origin) => !isValidOrigin(origin));
+	const invalidOrigins = origins?.filter((origin) => !isValidOrigin(origin)) || [];
 
 	return {
 		isValid: invalidOrigins.length === 0,
@@ -565,13 +565,12 @@ export const cleanJson = (text: unknown) => {
  */
 export function isRequestTypeDisabled(providerType: BaseProvider | undefined, requestType: string): boolean {
 	if (!providerType) return false;
-	
+
 	const supportedRequests = PROVIDER_SUPPORTED_REQUESTS[providerType];
 	if (!supportedRequests) return false; // If provider not in base list, allow all
-	
+
 	return !supportedRequests.includes(requestType);
 }
-
 
 /**
  * Cleans the path overrides by removing empty values
@@ -585,5 +584,5 @@ export function cleanPathOverrides(overrides?: Record<string, string | undefined
 		.map(([k, v]) => [k, v?.trim()])
 		.filter(([, v]) => v && v !== "");
 
-	return entries.length ? Object.fromEntries(entries) as Record<string, string> : undefined;
+	return entries.length ? (Object.fromEntries(entries) as Record<string, string>) : undefined;
 }


### PR DESCRIPTION
## Summary

Add context propagation to server interface methods to improve tracing and observability.

## Changes

- Updated interface methods in handlers and server to accept context parameters
- Moved `github.com/aws/smithy-go` from indirect to direct dependency
- Created a new `ServerCallbacks` interface to define server callback methods
- Modified the `RegisterAPIRoutes` method to accept a `ServerCallbacks` parameter
- Updated method implementations to propagate context through the call chain

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

This change modifies several interface methods to accept context parameters, which will require updates to any code implementing these interfaces.

## Security considerations

This change improves observability by propagating context through the application, which can help with tracing and debugging security-related issues.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable