### PR TITLE
removes authConfig check while updating config

### DIFF
--- a/ui/lib/store/apis/configApi.ts
+++ b/ui/lib/store/apis/configApi.ts
@@ -1,3 +1,4 @@
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { BifrostConfig, LatestReleaseResponse } from "@/lib/types/config";
 import axios from "axios";
 import { baseApi } from "./baseApi";
@@ -20,58 +21,58 @@ export const configApi = baseApi.injectEndpoints({
 			}),
 		}),
 
-	// Get latest release from public site
-	getLatestRelease: builder.query<LatestReleaseResponse, void>({
-		queryFn: async (_arg, { signal }) => {
-			try {
-				const response = await axios.get('https://getbifrost.ai/latest-release', {
-					timeout: 3000, // 3 second timeout
-					signal,
-					headers: {
-						Accept: 'application/json',
-					},
-					maxRedirects: 5,
-					validateStatus: (status) => status >= 200 && status < 300,
-				})
-				const data = response.data as any
-				const normalized: LatestReleaseResponse = {
-					name: data.name ?? data.tag ?? data.version ?? '',
-					changelogUrl: data.changelogUrl ?? data.changelog_url ?? '',
-				}
-				return { data: normalized }
-			} catch (error) {
-				if (axios.isAxiosError(error)) {
-					if (error.code === 'ECONNABORTED' || error.code === 'ETIMEDOUT') {
-						console.warn('Latest release fetch timed out after 3s')
-						return {
-							error: {
-								status: 'TIMEOUT_ERROR',
-								error: 'Request timeout',
-								data: { error: { message: 'Request timeout' } },
-							},
+		// Get latest release from public site
+		getLatestRelease: builder.query<LatestReleaseResponse, void>({
+			queryFn: async (_arg, { signal }) => {
+				try {
+					const response = await axios.get("https://getbifrost.ai/latest-release", {
+						timeout: 3000, // 3 second timeout
+						signal,
+						headers: {
+							Accept: "application/json",
+						},
+						maxRedirects: 5,
+						validateStatus: (status) => status >= 200 && status < 300,
+					});
+					const data = response.data as any;
+					const normalized: LatestReleaseResponse = {
+						name: data.name ?? data.tag ?? data.version ?? "",
+						changelogUrl: data.changelogUrl ?? data.changelog_url ?? "",
+					};
+					return { data: normalized };
+				} catch (error) {
+					if (axios.isAxiosError(error)) {
+						if (error.code === "ECONNABORTED" || error.code === "ETIMEDOUT") {
+							console.warn("Latest release fetch timed out after 3s");
+							return {
+								error: {
+									status: "TIMEOUT_ERROR",
+									error: "Request timeout",
+									data: { error: { message: "Request timeout" } },
+								},
+							};
 						}
+						console.error("Latest release fetch error:", error.message);
+					} else {
+						console.error("Latest release fetch error:", error);
 					}
-					console.error('Latest release fetch error:', error.message)
-				} else {
-					console.error('Latest release fetch error:', error)
+					return {
+						error: {
+							status: "FETCH_ERROR",
+							error: String(error),
+							data: { error: { message: "Network error" } },
+						},
+					};
 				}
-				return {
-					error: {
-						status: 'FETCH_ERROR',
-						error: String(error),
-						data: { error: { message: 'Network error' } },
-					},
-				}
-			}
-		},
-		keepUnusedDataFor: 300, // Cache for 5 minutes (seconds)
-	}),
+			},
+			keepUnusedDataFor: 300, // Cache for 5 minutes (seconds)
+		}),
 		// Update core configuration
 		updateCoreConfig: builder.mutation<null, BifrostConfig>({
 			query: (data) => ({
 				url: "/config",
 				method: "PUT",
-				body: data,
+				body: IS_ENTERPRISE ? { ...data, auth_config: undefined } : data,
 			}),
 			invalidatesTags: ["Config"],
 		}),


### PR DESCRIPTION
## Summary

Fix error handling in the ConfigHandler to properly handle the case when auth config is not found.

## Changes

- Modified the error handling in `updateConfig` method to check specifically for `configstore.ErrNotFound` errors
- When auth config is not found, the handler now continues execution instead of returning early
- Removed a condition that checked if `authConfig != nil` before updating auth config, allowing updates when no previous config exists

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Try to update auth config when no previous config exists:

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# Test with API call
curl -X PUT http://localhost:8080/api/config -H "Content-Type: application/json" -d '{"authConfig": {"adminUserName": "admin"}}'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where updating auth config would fail when no previous config exists.

## Security considerations

This change improves the robustness of auth configuration updates.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable