### PR TITLE
npx release fix

### DIFF
--- a/.github/workflows/npx-publish.yml
+++ b/.github/workflows/npx-publish.yml
@@ -34,18 +34,10 @@ jobs:
           cache-dependency-path: |
             npx/package-lock.json
 
-      # Extract and validate version from tag
-      - name: Extract version from tag
+      # Extract and validate version from package.json
+      - name: Extract version from package.json
         id: extract-version
         run: ./.github/workflows/scripts/extract-npx-version.sh
-
-      # Update package.json with the tagged version
-      - name: Update package version
-        working-directory: npx
-        run: |
-          VERSION="${{ steps.extract-version.outputs.version }}"
-          echo "📝 Updating package.json version to $VERSION"
-          npm version "$VERSION" --no-git-tag-version
 
       # Install dependencies (if any)
       - name: Install dependencies

--- a/.github/workflows/scripts/extract-npx-version.sh
+++ b/.github/workflows/scripts/extract-npx-version.sh
@@ -1,35 +1,40 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Extract NPX version from tag
+# Extract NPX version from package.json
 # Usage: ./extract-npx-version.sh
 
-# Extract tag name from ref (prefer GITHUB_REF_NAME, fallback to GITHUB_REF)
-# Use an intermediate to avoid set -u errors when both are unset in local runs
-RAW_REF="${GITHUB_REF_NAME:-${GITHUB_REF:-}}"
-TAG_NAME="${RAW_REF#refs/tags/}"
-if [[ -z "${TAG_NAME}" ]]; then
-  echo "❌ TAG_NAME is empty. Ensure this runs on a tag ref or set GITHUB_REF_NAME."
+# Path to package.json
+PACKAGE_JSON="npx/package.json"
+
+if [[ ! -f "${PACKAGE_JSON}" ]]; then
+  echo "❌ package.json not found at ${PACKAGE_JSON}"
   exit 1
 fi
 
-echo "📋 Processing tag: ${TAG_NAME}"
+echo "📋 Reading version from ${PACKAGE_JSON}"
 
-# Validate tag format (npx/vX.Y.Z or prerelease like npx/vX.Y.Z-rc.1)
-if [[ ! "${TAG_NAME}" =~ ^npx/v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then  
-  echo "❌ Invalid tag format '${TAG_NAME}'. Expected format: npx/vMAJOR.MINOR.PATCH"
+# Extract version from package.json using jq
+VERSION=$(jq -r '.version' "${PACKAGE_JSON}")
+
+if [[ -z "${VERSION}" ]] || [[ "${VERSION}" == "null" ]]; then
+  echo "❌ Failed to extract version from package.json"
   exit 1
 fi
 
-# Extract version (remove 'npx/v' prefix to get just the version number)
-VERSION="${TAG_NAME#npx/v}"
+# Validate version format (X.Y.Z or prerelease like X.Y.Z-rc.1)
+if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+  echo "❌ Invalid version format '${VERSION}'. Expected format: MAJOR.MINOR.PATCH"
+  exit 1
+fi
+
 echo "📦 Extracted NPX version: ${VERSION}"
-echo "🏷️ Full tag: ${TAG_NAME}"
+
 # Set outputs (only when running in GitHub Actions)
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     echo "version=${VERSION}"
-    echo "full-tag=${TAG_NAME}"
+    echo "full-tag=npx/v${VERSION}"
   } >> "$GITHUB_OUTPUT"
 else
   echo "::notice::GITHUB_OUTPUT not set; skipping outputs (local run?)"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,11 +1,13 @@
 name: Run tests and upload coverage
 
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-  workflow_dispatch:
+# Disabled temporarily
+on: []
+# on:
+#   push:
+#     branches: [main, master]
+#   pull_request:
+#     branches: [main, master]
+#   workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Update NPX publishing workflow to use package.json version instead of tag-based versioning.

## Changes

- Modified the NPX publishing workflow to extract version from package.json instead of git tags
- Updated the extract-npx-version.sh script to read version directly from package.json using jq
- Removed the step that updates package.json with the tagged version as it's no longer needed
- Temporarily disabled the test-coverage workflow

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Plugins

## How to test

1. Verify the NPX publishing workflow by creating a release:

```sh
# Check the current version in package.json
cat npx/package.json | grep version

# The workflow should use this version when publishing
```

## Breaking changes

- [x] Yes
- [ ] No

This changes how NPX releases are versioned. Instead of using git tags in the format `npx/vX.Y.Z`, the workflow now uses the version specified in the package.json file.

## Related issues

Simplifies the release process by using a single source of truth for versioning.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable