### PR TITLE
bumping npx version

### DIFF
--- a/npx/package.json
+++ b/npx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "High-performance AI gateway CLI - connect to 12+ providers through a single API",
   "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
   "homepage": "https://github.com/maximhq/bifrost",


### PR DESCRIPTION
## Summary

Bump Bifrost package version from 1.6.0 to 1.6.1

## Changes

- Updated the version number in `npx/package.json` from 1.6.0 to 1.6.1 for the next release

## Type of change

- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the version number is correctly updated in the package.json file:

```sh
cat npx/package.json | grep version
```

Expected output should show version 1.6.1

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I verified the version number is correctly updated
- [x] I verified builds succeed