### PR TITLE
refactor: remove unused header fields and simplify governance tracking

### DIFF
--- a/.github/workflows/configs/withobservability/config.json
+++ b/.github/workflows/configs/withobservability/config.json
@@ -19,6 +19,7 @@
         "enabled": true,
         "name": "otel",
         "config": {
+          "service_name": "bifrost",
           "collector_url": "http://localhost:4318/v1/traces",
           "trace_type": "otel",
           "protocol": "http"

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -545,8 +545,6 @@ Include additional headers for enhanced tracking and audit trails:
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "x-bf-vk: vk-engineering-main" \
-  -H "x-bf-team: team-eng-001" \
-  -H "x-bf-customer: customer-acme-corp" \
   -H "x-bf-user-id: user-alice" \
   -d '{
     "model": "gpt-4o-mini", 
@@ -556,9 +554,6 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 **Header Definitions:**
 - `x-bf-vk` - **Required** virtual key for access control
-- `x-bf-team` - Optional team identifier for audit trails
-- `x-bf-customer` - Optional customer identifier for audit trails  
-- `x-bf-user-id` - Optional user identifier for detailed tracking
 
 ### Error Responses
 

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -30,6 +30,7 @@ The plugin supports multiple trace formats to match your observability platform:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
+| `service_name` | `string` | ❌ No | Service name to be used for tracing, defaults to `bifrost` |
 | `collector_url` | `string` | ✅ Yes | OTLP collector endpoint URL |
 | `trace_type` | `string` | ✅ Yes | One of: `genai_extension`, `vercel`, `open_inference` |
 | `protocol` | `string` | ✅ Yes | Transport protocol: `http` or `grpc` |
@@ -78,6 +79,7 @@ func main() {
     
     // Initialize OTel plugin
     otelPlugin, err := otel.Init(ctx, &otel.Config{
+        ServiceName:  "bifrost",
         CollectorURL: "http://localhost:4318",
         TraceType:    otel.TraceTypeGenAIExtension,
         Protocol:     otel.ProtocolHTTP,
@@ -115,6 +117,7 @@ For Gateway mode, configure via `config.json`:
       "enabled": true,
       "name": "otel",
       "config": {
+        "service_name": "bifrost",
         "collector_url": "http://localhost:4318",
         "trace_type": "genai_extension",
         "protocol": "http",
@@ -381,6 +384,7 @@ Access Grafana at `http://localhost:3000` (default credentials: admin/admin)
       "enabled": true,
       "name": "otel",
       "config": {
+        "service_name": "bifrost",
         "collector_url": "https://otlp-gateway-prod-us-central-0.grafana.net/otlp",
         "trace_type": "genai_extension",
         "protocol": "http",
@@ -408,6 +412,7 @@ export GRAFANA_CLOUD_API_KEY="Basic <your-base64-encoded-token>"
       "enabled": true,
       "name": "otel",
       "config": {
+        "service_name": "bifrost",
         "collector_url": "https://trace.agent.datadoghq.com",
         "trace_type": "genai_extension",
         "protocol": "http",
@@ -435,6 +440,7 @@ export DATADOG_API_KEY="your-datadog-api-key"
       "enabled": true,
       "name": "otel",
       "config": {
+        "service_name": "bifrost",
         "collector_url": "https://otlp.nr-data.net:4318",
         "trace_type": "genai_extension",
         "protocol": "http",
@@ -462,6 +468,7 @@ export NEW_RELIC_LICENSE_KEY="your-license-key"
       "enabled": true,
       "name": "otel",
       "config": {
+        "service_name": "bifrost",
         "collector_url": "https://api.honeycomb.io",
         "trace_type": "genai_extension",
         "protocol": "http",
@@ -492,6 +499,7 @@ Use the included Docker Compose stack or point to your own collector:
       "enabled": true,
       "name": "otel",
       "config": {
+        "service_name": "bifrost",
         "collector_url": "http://your-collector:4318",
         "trace_type": "genai_extension",
         "protocol": "http"

--- a/docs/integrations/anthropic-sdk.mdx
+++ b/docs/integrations/anthropic-sdk.mdx
@@ -183,9 +183,6 @@ client = anthropic.Anthropic(
     api_key="dummy-key",
     default_headers={
         "x-bf-vk": "vk_12345",  # Virtual key for governance
-        "x-bf-user-id": "user_789",  # User identification
-        "x-bf-team-id": "team_456",  # Team identification
-        "x-bf-trace-id": "trace_abc123",  # Request tracing
     }
 )
 
@@ -207,9 +204,6 @@ const anthropic = new Anthropic({
   apiKey: "dummy-key",
   defaultHeaders: {
     "x-bf-vk": "vk_12345", // Virtual key for governance
-    "x-bf-user-id": "user_789", // User identification
-    "x-bf-team-id": "team_456", // Team identification
-    "x-bf-trace-id": "trace_abc123", // Request tracing
   },
 });
 

--- a/docs/integrations/genai-sdk.mdx
+++ b/docs/integrations/genai-sdk.mdx
@@ -162,9 +162,6 @@ client = genai.Client(
         base_url="http://localhost:8080/genai",
         headers={
             "x-bf-vk": "vk_12345",  # Virtual key for governance
-            "x-bf-user-id": "user_789",  # User identification
-            "x-bf-team-id": "team_456",  # Team identification
-            "x-bf-trace-id": "trace_abc123",  # Request tracing
         }
     )
 )
@@ -186,9 +183,6 @@ const genAI = new GoogleGenerativeAI("dummy-key", {
   baseUrl: "http://localhost:8080/genai",
   customHeaders: {
     "x-bf-vk": "vk_12345", // Virtual key for governance
-    "x-bf-user-id": "user_789", // User identification
-    "x-bf-team-id": "team_456", // Team identification
-    "x-bf-trace-id": "trace_abc123", // Request tracing
   },
 });
 

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -153,9 +153,6 @@ llm = ChatOpenAI(
     openai_api_base="http://localhost:8080/langchain",
     default_headers={
         "x-bf-vk": "your-virtual-key",          # Virtual key for governance
-        "x-bf-user-id": "user123",              # User tracking
-        "x-bf-team-id": "team-ai",              # Team tracking  
-        "x-bf-trace-id": "trace-456"            # Custom trace ID
     }
 )
 
@@ -176,9 +173,6 @@ const llm = new ChatOpenAI({
     baseURL: "http://localhost:8080/langchain",
     defaultHeaders: {
       "x-bf-vk": "your-virtual-key",          // Virtual key for governance
-      "x-bf-user-id": "user123",              // User tracking
-      "x-bf-team-id": "team-ai",              // Team tracking  
-      "x-bf-trace-id": "trace-456"            // Custom trace ID
     }
   }
 });

--- a/docs/integrations/litellm-sdk.mdx
+++ b/docs/integrations/litellm-sdk.mdx
@@ -100,9 +100,6 @@ response = completion(
     base_url="http://localhost:8080/litellm",
     extra_headers={
         "x-bf-vk": "your-virtual-key",          # Virtual key for governance
-        "x-bf-user-id": "user123",              # User tracking
-        "x-bf-team-id": "team-ai",              # Team tracking  
-        "x-bf-trace-id": "trace-456"            # Custom trace ID
     }
 )
 

--- a/docs/integrations/openai-sdk.mdx
+++ b/docs/integrations/openai-sdk.mdx
@@ -171,9 +171,6 @@ client = openai.OpenAI(
     api_key="dummy-key",
     default_headers={
         "x-bf-vk": "vk_12345",  # Virtual key for governance
-        "x-bf-user-id": "user_789",  # User identification
-        "x-bf-team-id": "team_456",  # Team identification
-        "x-bf-trace-id": "trace_abc123",  # Request tracing
     }
 )
 
@@ -194,9 +191,6 @@ const openai = new OpenAI({
   apiKey: "dummy-key",
   defaultHeaders: {
     "x-bf-vk": "vk_12345", // Virtual key for governance
-    "x-bf-user-id": "user_789", // User identification
-    "x-bf-team-id": "team_456", // Team identification
-    "x-bf-trace-id": "trace_abc123", // Request tracing
   },
 });
 

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -979,7 +979,9 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 	var virtualKeys []tables.TableVirtualKey
 
 	// Preload all relationships for complete information
-	if err := s.db.WithContext(ctx).Preload("Team").
+	if err := s.db.WithContext(ctx).
+		Preload("Team").
+		Preload("Team.Customer").
 		Preload("Customer").
 		Preload("Budget").
 		Preload("RateLimit").
@@ -1000,7 +1002,9 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 // GetVirtualKey retrieves a virtual key from the database.
 func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error) {
 	var virtualKey tables.TableVirtualKey
-	if err := s.db.WithContext(ctx).Preload("Team").
+	if err := s.db.WithContext(ctx).
+		Preload("Team").
+		Preload("Team.Customer").
 		Preload("Customer").
 		Preload("Budget").
 		Preload("RateLimit").
@@ -1009,9 +1013,9 @@ func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.
 		Preload("ProviderConfigs.RateLimit").
 		Preload("MCPConfigs").
 		Preload("MCPConfigs.MCPClient").
-	Preload("Keys", func(db *gorm.DB) *gorm.DB {
-		return db.Select("id, name, key_id, models_json, provider")
-	}).First(&virtualKey, "id = ?", id).Error; err != nil {
+		Preload("Keys", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id, name, key_id, models_json, provider")
+		}).First(&virtualKey, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -1023,7 +1027,9 @@ func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.
 // GetVirtualKeyByValue retrieves a virtual key by its value
 func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error) {
 	var virtualKey tables.TableVirtualKey
-	if err := s.db.WithContext(ctx).Preload("Team").
+	if err := s.db.WithContext(ctx).
+		Preload("Team").
+		Preload("Team.Customer").
 		Preload("Customer").
 		Preload("Budget").
 		Preload("RateLimit").
@@ -1032,9 +1038,9 @@ func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string)
 		Preload("ProviderConfigs.RateLimit").
 		Preload("MCPConfigs").
 		Preload("MCPConfigs.MCPClient").
-	Preload("Keys", func(db *gorm.DB) *gorm.DB {
-		return db.Select("id, name, key_id, models_json, provider")
-	}).First(&virtualKey, "value = ?", value).Error; err != nil {
+		Preload("Keys", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id, name, key_id, models_json, provider")
+		}).First(&virtualKey, "value = ?", value).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -32,7 +32,6 @@ type EvaluationRequest struct {
 	VirtualKey string                `json:"virtual_key"` // Virtual key value
 	Provider   schemas.ModelProvider `json:"provider"`
 	Model      string                `json:"model"`
-	Headers    map[string]string     `json:"headers"`
 	RequestID  string                `json:"request_id"`
 }
 
@@ -90,6 +89,18 @@ func (r *BudgetResolver) EvaluateRequest(ctx *context.Context, evaluationRequest
 	// Set virtual key id and name in context
 	*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-virtual-key-id"), vk.ID)
 	*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-virtual-key-name"), vk.Name)
+	if vk.Team != nil {
+		*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-team-id"), vk.Team.ID)
+		*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-team-name"), vk.Team.Name)
+		if vk.Team.Customer != nil {
+			*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-customer-id"), vk.Team.Customer.ID)
+			*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-customer-name"), vk.Team.Customer.Name)
+		}
+	}
+	if vk.Customer != nil {
+		*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-customer-id"), vk.Customer.ID)
+		*ctx = context.WithValue(*ctx, schemas.BifrostContextKey("bf-governance-customer-name"), vk.Customer.Name)
+	}
 
 	if !vk.IsActive {
 		return &EvaluationResult{

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -21,8 +21,6 @@ type UsageUpdate struct {
 	TokensUsed int64                 `json:"tokens_used"`
 	Cost       float64               `json:"cost"` // Cost in dollars
 	RequestID  string                `json:"request_id"`
-	TeamID     *string               `json:"team_id,omitempty"`     // For audit trail
-	CustomerID *string               `json:"customer_id,omitempty"` // For audit trail
 
 	// Streaming optimization fields
 	IsStreaming  bool `json:"is_streaming"`   // Whether this is a streaming response

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -3,27 +3,7 @@ package governance
 
 import (
 	"context"
-
-	"github.com/maximhq/bifrost/core/schemas"
 )
-
-// extractHeadersFromContext extracts governance headers from context (standalone version)
-func extractHeadersFromContext(ctx context.Context) map[string]string {
-	headers := make(map[string]string)
-
-	// Extract governance headers using schemas.BifrostContextKey
-	if teamID := getStringFromContext(ctx, schemas.BifrostContextKey("x-bf-team")); teamID != "" {
-		headers["x-bf-team"] = teamID
-	}
-	if userID := getStringFromContext(ctx, schemas.BifrostContextKey("x-bf-user")); userID != "" {
-		headers["x-bf-user"] = userID
-	}
-	if customerID := getStringFromContext(ctx, schemas.BifrostContextKey("x-bf-customer")); customerID != "" {
-		headers["x-bf-customer"] = customerID
-	}
-
-	return headers
-}
 
 // getStringFromContext safely extracts a string value from context
 func getStringFromContext(ctx context.Context, key any) string {

--- a/plugins/otel/changelog.md
+++ b/plugins/otel/changelog.md
@@ -1,0 +1,2 @@
+fix: properly set bifrost version in metrics
+feat: added team_id, team_name, customer_id and customer_name labels to otel metrics

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -368,7 +368,7 @@ func getResponsesRequestParams(req *schemas.BifrostResponsesRequest) []*KeyValue
 }
 
 // createResourceSpan creates a new resource span for a Bifrost request
-func createResourceSpan(traceID, spanID string, timestamp time.Time, req *schemas.BifrostRequest) *ResourceSpan {
+func createResourceSpan(traceID, spanID string, timestamp time.Time, req *schemas.BifrostRequest, bifrostVersion string) *ResourceSpan {
 	provider, model, _ := req.GetRequestFields()
 
 	// preparing parameters
@@ -402,7 +402,7 @@ func createResourceSpan(traceID, spanID string, timestamp time.Time, req *schema
 		Resource: &resourcepb.Resource{
 			Attributes: []*commonpb.KeyValue{
 				kvStr("service.name", "bifrost"),
-				kvStr("service.version", "1.0.0"),
+				kvStr("service.version", bifrostVersion),
 			},
 		},
 		ScopeSpans: []*ScopeSpan{
@@ -439,6 +439,10 @@ func completeResourceSpan(
 	selectedKeyName string,
 	numberOfRetries int,
 	fallbackIndex int,
+	teamID string,
+	teamName string,
+	customerID string,
+	customerName string,
 ) *ResourceSpan {
 	params := []*KeyValue{}
 
@@ -679,6 +683,14 @@ func completeResourceSpan(
 	if selectedKeyID != "" {
 		params = append(params, kvStr("gen_ai.selected_key_id", selectedKeyID))
 		params = append(params, kvStr("gen_ai.selected_key_name", selectedKeyName))
+	}
+	if teamID != "" {
+		params = append(params, kvStr("gen_ai.team_id", teamID))
+		params = append(params, kvStr("gen_ai.team_name", teamName))
+	}
+	if customerID != "" {
+		params = append(params, kvStr("gen_ai.customer_id", customerID))
+		params = append(params, kvStr("gen_ai.customer_name", customerName))
 	}
 	params = append(params, kvInt("gen_ai.number_of_retries", int64(numberOfRetries)))
 	params = append(params, kvInt("gen_ai.fallback_index", int64(fallbackIndex)))

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -52,6 +52,7 @@ const ProtocolHTTP Protocol = "http"
 const ProtocolGRPC Protocol = "grpc"
 
 type Config struct {
+	ServiceName  string            `json:"service_name"`
 	CollectorURL string            `json:"collector_url"`
 	Headers      map[string]string `json:"headers"`
 	TraceType    TraceType         `json:"trace_type"`
@@ -63,10 +64,13 @@ type OtelPlugin struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
-	url       string
-	headers   map[string]string
-	traceType TraceType
-	protocol  Protocol
+	serviceName string
+	url         string
+	headers     map[string]string
+	traceType   TraceType
+	protocol    Protocol
+
+	bifrostVersion string
 
 	ongoingSpans *TTLSyncMap
 
@@ -79,7 +83,7 @@ type OtelPlugin struct {
 }
 
 // Init function for the OTEL plugin
-func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingManager *modelcatalog.ModelCatalog) (*OtelPlugin, error) {
+func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingManager *modelcatalog.ModelCatalog, bifrostVersion string) (*OtelPlugin, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
 	}
@@ -100,7 +104,11 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			}
 		}
 	}
+	if config.ServiceName == "" {
+		config.ServiceName = "bifrost"
+	}
 	p := &OtelPlugin{
+		serviceName:    config.ServiceName,
 		url:            config.CollectorURL,
 		traceType:      config.TraceType,
 		headers:        config.Headers,
@@ -109,6 +117,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		pricingManager: pricingManager,
 		accumulator:    streaming.NewAccumulator(pricingManager, logger),
 		emitWg:         sync.WaitGroup{},
+		bifrostVersion: bifrostVersion,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
@@ -196,7 +205,7 @@ func (p *OtelPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) 
 	if bifrost.IsStreamRequestType(req.RequestType) {
 		p.accumulator.CreateStreamAccumulator(traceID, createdTimestamp)
 	}
-	p.ongoingSpans.Set(traceID, createResourceSpan(traceID, spanID, time.Now(), req))
+	p.ongoingSpans.Set(traceID, createResourceSpan(traceID, spanID, time.Now(), req, p.bifrostVersion))
 	return req, nil, nil
 }
 
@@ -221,6 +230,11 @@ func (p *OtelPlugin) PostHook(ctx *context.Context, resp *schemas.BifrostRespons
 
 	numberOfRetries := bifrost.GetIntFromContext(*ctx, schemas.BifrostContextKeyNumberOfRetries)
 	fallbackIndex := bifrost.GetIntFromContext(*ctx, schemas.BifrostContextKeyFallbackIndex)
+
+	teamID := bifrost.GetStringFromContext(*ctx, schemas.BifrostContextKey("bf-governance-team-id"))
+	teamName := bifrost.GetStringFromContext(*ctx, schemas.BifrostContextKey("bf-governance-team-name"))
+	customerID := bifrost.GetStringFromContext(*ctx, schemas.BifrostContextKey("bf-governance-customer-id"))
+	customerName := bifrost.GetStringFromContext(*ctx, schemas.BifrostContextKey("bf-governance-customer-name"))
 
 	// Track every PostHook emission, stream and non-stream.
 	p.emitWg.Add(1)
@@ -253,6 +267,10 @@ func (p *OtelPlugin) PostHook(ctx *context.Context, resp *schemas.BifrostRespons
 						selectedKeyName,
 						numberOfRetries,
 						fallbackIndex,
+						teamID,
+						teamName,
+						customerID,
+						customerName,
 					)}); err != nil {
 						logger.Error("failed to emit response span for request %s: %v", traceID, err)
 					}
@@ -272,6 +290,10 @@ func (p *OtelPlugin) PostHook(ctx *context.Context, resp *schemas.BifrostRespons
 				selectedKeyName,
 				numberOfRetries,
 				fallbackIndex,
+				teamID,
+				teamName,
+				customerID,
+				customerName,
 			)
 			if err := p.client.Emit(p.ctx, []*ResourceSpan{rs}); err != nil {
 				logger.Error("failed to emit response span for request %s: %v", traceID, err)

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -205,7 +205,7 @@ func (p *OtelPlugin) PreHook(ctx *context.Context, req *schemas.BifrostRequest) 
 	if bifrost.IsStreamRequestType(req.RequestType) {
 		p.accumulator.CreateStreamAccumulator(traceID, createdTimestamp)
 	}
-	p.ongoingSpans.Set(traceID, createResourceSpan(traceID, spanID, time.Now(), req, p.bifrostVersion))
+	p.ongoingSpans.Set(traceID, p.createResourceSpan(traceID, spanID, time.Now(), req))
 	return req, nil, nil
 }
 

--- a/plugins/telemetry/changelog.md
+++ b/plugins/telemetry/changelog.md
@@ -1,0 +1,2 @@
+feat: added filter for custom labels that are already default labels
+feat: added team_id, team_name, customer_id and customer_name labels to telemetry metrics

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -87,3 +87,27 @@ func getIntFromContext(ctx context.Context, key any) int {
 	}
 	return 0
 }
+
+// containsLabel checks if a string slice contains a specific label, ignoring differences
+// between underscores and hyphens. It checks for:
+// - Direct match
+// - Match after removing underscores
+// - Match after replacing hyphens with underscores
+// - Match after replacing underscores with hyphens
+func containsLabel(slice []string, label string) bool {
+	for _, s := range slice {
+		// Direct match
+		if s == label {
+			return true
+		}
+		// Match after replacing hyphens with underscores
+		if strings.ReplaceAll(s, "-", "_") == strings.ReplaceAll(label, "-", "_") {
+			return true
+		}
+		// Match after replacing underscores with hyphens
+		if strings.ReplaceAll(s, "_", "-") == strings.ReplaceAll(label, "_", "-") {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/configs/withobservability/config.json
+++ b/tests/configs/withobservability/config.json
@@ -27,6 +27,7 @@
         "enabled": true,
         "name": "otel",
         "config": {
+          "service_name": "bifrost",
           "collector_url": "http://localhost:4318/v1/traces",
           "trace_type": "otel",
           "protocol": "http"

--- a/transports/bifrost-http/handlers/init.go
+++ b/transports/bifrost-http/handlers/init.go
@@ -14,3 +14,7 @@ func SetLogger(l schemas.Logger) {
 func SetVersion(v string) {
 	version = v
 }
+
+func GetVersion() string {
+	return version
+}

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -41,9 +41,6 @@ import (
 //
 // 4. Governance Headers:
 //   - x-bf-vk: Virtual key for governance (required for governance to work)
-//   - x-bf-team: Team identifier for team-based governance rules
-//   - x-bf-user: User identifier for user-based governance rules
-//   - x-bf-customer: Customer identifier for customer-based governance rules
 //
 // 5. API Key Headers:
 //   - Authorization: Bearer token format only (e.g., "Bearer sk-...") - OpenAI style
@@ -136,11 +133,6 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool) (*c
 				bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey("mcp-"+labelName), parsedValues)
 				return true
 			}
-		}
-		// Handle governance headers (x-bf-team, x-bf-user, x-bf-customer)
-		if keyStr == "x-bf-team" || keyStr == "x-bf-user" || keyStr == "x-bf-customer" {
-			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKey(keyStr), string(value))
-			return true
 		}
 		// Handle virtual key header (x-bf-vk, authorization, x-api-key headers)
 		if keyStr == string(schemas.BifrostContextKeyVirtualKey) {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -297,7 +297,7 @@ func LoadPlugin[T schemas.Plugin](ctx context.Context, name string, path *string
 		if err != nil {
 			return zero, fmt.Errorf("failed to marshal otel plugin config: %v", err)
 		}
-		plugin, err := otel.Init(ctx, otelConfig, logger, bifrostConfig.PricingManager)
+		plugin, err := otel.Init(ctx, otelConfig, logger, bifrostConfig.PricingManager, handlers.GetVersion())
 		if err != nil {
 			return zero, err
 		}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -837,6 +837,11 @@
                   "type": "object",
                   "description": "Configuration for the OpenTelemetry plugin",
                   "properties": {
+                    "service_name": {
+                      "type": "string",
+                      "description": "Service name to be used for tracing",
+                      "default": "bifrost"
+                    },
                     "collector_url": {
                       "type": "string",
                       "description": "URL of the OpenTelemetry collector",

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -15,6 +15,7 @@ import { useForm, type Resolver } from "react-hook-form";
 interface OtelFormFragmentProps {
 	currentConfig?: {
 		enabled?: boolean;
+		service_name?: string;
 		collector_url?: string;
 		headers?: Record<string, string>;
 		trace_type?: "otel" | "genai_extension" | "vercel" | "arize_otel";
@@ -33,6 +34,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 		defaultValues: {
 			enabled: initialConfig?.enabled ?? false,
 			otel_config: {
+				service_name: initialConfig?.service_name ?? "bifrost",
 				collector_url: initialConfig?.collector_url ?? "",
 				headers: initialConfig?.headers ?? {},
 				trace_type: initialConfig?.trace_type ?? "otel",
@@ -59,6 +61,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 		form.reset({
 			enabled: initialConfig?.enabled || false,
 			otel_config: {
+				service_name: initialConfig?.service_name ?? "bifrost",
 				collector_url: initialConfig?.collector_url || "",
 				headers: initialConfig?.headers || {},
 				trace_type: initialConfig?.trace_type || "otel",
@@ -81,6 +84,19 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 				{/* OTEL Configuration */}
 				<div className="space-y-4">
 					<div className="flex flex-col gap-4">
+						<FormField
+							control={form.control}
+							name="otel_config.service_name"
+							render={({ field }) => (
+								<FormItem className="w-full">
+									<FormLabel>Service Name</FormLabel>
+									<FormControl>
+										<Input placeholder="bifrost" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 						<FormField
 							control={form.control}
 							name="otel_config.collector_url"
@@ -116,7 +132,6 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 								</FormItem>
 							)}
 						/>
-
 						<div className="flex flex-row gap-4">
 							<FormField
 								control={form.control}

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -90,6 +90,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 							render={({ field }) => (
 								<FormItem className="w-full">
 									<FormLabel>Service Name</FormLabel>
+									<FormDescription>If kept empty, the service name will be set to "bifrost"</FormDescription>
 									<FormControl>
 										<Input placeholder="bifrost" {...field} />
 									</FormControl>

--- a/ui/app/workspace/user-groups/views/customerDialog.tsx
+++ b/ui/app/workspace/user-groups/views/customerDialog.tsx
@@ -180,48 +180,11 @@ export default function CustomerDialog({ customer, onSave, onCancel }: CustomerD
 							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
 							options={resetDurationOptions}
 						/>
-
-						{isEditing && customer?.budget && (
-							<div>
-								<div className="border-accent mb-2 flex w-full flex-row items-center gap-2 border-b pb-2 font-medium">
-									<div className="flex w-[300px] flex-row items-center gap-2">
-										<DollarSign className="h-4 w-4" />
-										Current Budget
-									</div>
-									<div className="ml-auto h-2 w-full rounded-full bg-gray-200">
-										<div
-											className="h-2 rounded-full bg-blue-600"
-											style={{
-												width: `${Math.min((customer.budget.current_usage / customer.budget.max_limit) * 100, 100)}%`,
-											}}
-										></div>
-									</div>
-								</div>
-								<div className="space-y-2 text-sm">
-									<div className="flex justify-between">
-										<span>Current Usage:</span>
-										<span className="font-mono">{formatCurrency(customer.budget.current_usage)}</span>
-									</div>
-									<div className="flex justify-between">
-										<span>Budget Limit:</span>
-										<span className="font-mono">{formatCurrency(customer.budget.max_limit)}</span>
-									</div>
-									<div className="flex justify-between">
-										<span>Reset Period:</span>
-										<span className="font-mono">{customer.budget.reset_duration}</span>
-									</div>
-								</div>
-								<div className="text-muted-foreground bg-accent border-accent mt-3 rounded-md border p-2 text-sm">
-									Budget management for existing customers should be done through the budget edit dialog.
-								</div>
-							</div>
-						)}
-
 						{isEditing && customer?.budget && (
 							<div className="space-y-2">
 								<div className="flex items-center gap-2">
 									<span className="text-sm">Current Usage:</span>
-									<div className="flex items-center gap-2 mt-0.5">
+									<div className="mt-0.5 flex items-center gap-2">
 										<span className="font-mono text-sm">
 											{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
 										</span>
@@ -235,7 +198,7 @@ export default function CustomerDialog({ customer, onSave, onCancel }: CustomerD
 								</div>
 								<div className="flex items-center gap-2">
 									<span className="text-sm">Last Reset:</span>
-									<div className="flex items-center gap-2 mt-0.5">
+									<div className="mt-0.5 flex items-center gap-2">
 										<span className="font-mono text-sm">
 											{formatDistanceToNow(new Date(customer.budget.last_reset), { addSuffix: true })}
 										</span>

--- a/ui/app/workspace/user-groups/views/customerTable.tsx
+++ b/ui/app/workspace/user-groups/views/customerTable.tsx
@@ -18,7 +18,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { getErrorMessage, useDeleteCustomerMutation } from "@/lib/store";
 import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { formatCurrency, parseResetPeriod } from "@/lib/utils/governance";
-import { Edit, Key, Plus, Trash2, Users } from "lucide-react";
+import { Edit, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import CustomerDialog from "./customerDialog";
@@ -120,7 +120,6 @@ export default function CustomersTable({ customers, teams, virtualKeys, onRefres
 											<TableCell>
 												{teams?.length > 0 ? (
 													<div className="flex items-center gap-2">
-														<Users className="h-4 w-4" />
 														<TooltipProvider>
 															<Tooltip>
 																<TooltipTrigger>
@@ -160,7 +159,6 @@ export default function CustomersTable({ customers, teams, virtualKeys, onRefres
 											<TableCell>
 												{vks?.length > 0 ? (
 													<div className="flex items-center gap-2">
-														<Key className="h-4 w-4" />
 														<TooltipProvider>
 															<Tooltip>
 																<TooltipTrigger>

--- a/ui/app/workspace/user-groups/views/teamsTable.tsx
+++ b/ui/app/workspace/user-groups/views/teamsTable.tsx
@@ -19,7 +19,7 @@ import { getErrorMessage, useDeleteTeamMutation } from "@/lib/store";
 import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency, parseResetPeriod } from "@/lib/utils/governance";
-import { Edit, Key, Plus, Trash2 } from "lucide-react";
+import { Edit, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import TeamDialog from "./teamDialog";
@@ -146,8 +146,6 @@ export default function TeamsTable({ teams, customers, virtualKeys, onRefresh }:
 												<TableCell>
 													{vks.length > 0 ? (
 														<div className="flex items-center gap-2">
-															<Key className="h-4 w-4" />
-
 															<Tooltip>
 																<TooltipTrigger>
 																	<Badge variant="outline" className="text-xs">

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -481,6 +481,7 @@ export const performanceFormSchema = z.object({
 // OTEL Configuration Schema
 export const otelConfigSchema = z
 	.object({
+		service_name: z.string().optional(),
 		collector_url: z.string().min(1, "Collector address is required"),
 		trace_type: z
 			.enum(["otel", "genai_extension", "vercel", "arize_otel"], {


### PR DESCRIPTION
## Summary

This PR simplifies the header structure for governance by removing unnecessary tracking headers and moving team/customer information to context values. It reduces the number of headers clients need to send while maintaining governance functionality.

## Changes

- Removed optional tracking headers (`x-bf-team`, `x-bf-customer`, `x-bf-team-id`, etc.) from documentation and code examples
- Moved team and customer information from headers to context values in the governance plugin
- Added team and customer context values to telemetry and OTEL metrics for better tracking
- Updated documentation to reflect the simplified header requirements
- Fixed version reporting in OTEL metrics
- Added filtering for custom labels in telemetry to prevent duplicates

## Type of change

- [x] Feature
- [x] Refactor
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

Test that governance still works with only the required `x-bf-vk` header:

```sh
# Test with minimal headers
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-bf-vk: vk-engineering-main" \
  -H "x-bf-user-id: user-alice" \
  -d '{
    "model": "gpt-4o-mini", 
    "messages": [{"role": "user", "content": "Hello, world!"}]
  }'

# Verify metrics include team and customer information
curl http://localhost:8080/metrics | grep team_id
curl http://localhost:8080/metrics | grep customer_id
```

## Breaking changes

- [x] No

## Related issues

Simplifies the header requirements for clients while maintaining governance functionality.

## Security considerations

This change improves the design by reducing the number of headers clients need to send, while maintaining the same level of governance and tracking capabilities through context values.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)