### PR TITLE
fix: skip google/ prefix for Vertex AI fine-tuned models

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+fix: skip adding google/ prefix for custom fine-tuned models in vertex provider

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -14,8 +14,8 @@ func (request *GeminiGenerationRequest) ToBifrostChatRequest() *schemas.BifrostC
 	provider, model := schemas.ParseModelString(request.Model, schemas.Gemini)
 
 	if provider == schemas.Vertex && !request.IsEmbedding {
-		// Add google/ prefix for Bifrost if not already present
-		if !strings.HasPrefix(model, "google/") {
+		// Add google/ prefix if not already present and model is not a custom fine-tuned model
+		if !schemas.IsAllDigitsASCII(model) && !strings.HasPrefix(model, "google/") {
 			model = "google/" + model
 		}
 	}
@@ -75,8 +75,8 @@ func (request *GeminiGenerationRequest) ToBifrostChatRequest() *schemas.BifrostC
 					}
 					toolCall := schemas.ChatAssistantMessageToolCall{
 						Index: uint16(len(toolCalls)),
-						ID:   schemas.Ptr(callID),
-						Type: schemas.Ptr(string(schemas.ChatToolChoiceTypeFunction)),
+						ID:    schemas.Ptr(callID),
+						Type:  schemas.Ptr(string(schemas.ChatToolChoiceTypeFunction)),
 						Function: schemas.ChatAssistantMessageToolCallFunction{
 							Name:      &name,
 							Arguments: string(jsonArgs),

--- a/core/providers/gemini/embedding.go
+++ b/core/providers/gemini/embedding.go
@@ -108,8 +108,8 @@ func (request *GeminiGenerationRequest) ToBifrostEmbeddingRequest() *schemas.Bif
 	provider, model := schemas.ParseModelString(request.Model, schemas.Gemini)
 
 	if provider == schemas.Vertex && request.IsEmbedding {
-		// Add google/ prefix for Bifrost if not already present
-		if !strings.HasPrefix(model, "google/") {
+		// Add google/ prefix if not already present and model is not a custom fine-tuned model
+		if !schemas.IsAllDigitsASCII(model) && !strings.HasPrefix(model, "google/") {
 			model = "google/" + model
 		}
 	}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,3 @@
+fix: properly set bifrost version in metrics
+feat: added team_id, team_name, customer_id and customer_name labels to otel metrics
+fix: skip adding google/ prefix for custom fine-tuned models in vertex provider (for genai integration)


### PR DESCRIPTION
## Summary

Fix Vertex AI model name handling for custom fine-tuned models by preventing the `google/` prefix from being added to numeric model IDs.

## Changes

- Modified the logic in both chat and embedding request handlers to check if the model name consists entirely of digits before adding the `google/` prefix
- Added a condition to skip adding the `google/` prefix for custom fine-tuned models (which use numeric IDs) when using Vertex AI

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Configure Vertex AI provider
2. Try using a custom fine-tuned model with a numeric ID
3. Verify the model ID is passed correctly without the `google/` prefix

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where custom fine-tuned models on Vertex AI couldn't be used properly because their numeric IDs were incorrectly prefixed with "google/".

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable