### PR TITLE
fixes go version

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.24.3"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.24.3"
       - name: Configure Git
         run: |
           git config user.name "GitHub Actions Bot"
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.24.3"
 
       - name: Configure Git
         run: |
@@ -215,7 +215,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.24.3"
 
       - name: Configure Git
         run: |
@@ -295,7 +295,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.1"
+          go-version: "1.24.3"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.24.3'
 
       - name: Install Snyk CLI
         uses: snyk/actions/setup@master
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.24.3'
 
       - name: Build
         run: make build

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.24.3'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/plugins/governance/go.mod
+++ b/plugins/governance/go.mod
@@ -1,8 +1,6 @@
 module github.com/maximhq/bifrost/plugins/governance
 
-go 1.24.1
-
-toolchain go1.24.3
+go 1.24.3
 
 require gorm.io/gorm v1.31.1
 

--- a/tests/core-chatbot/go.mod
+++ b/tests/core-chatbot/go.mod
@@ -1,8 +1,6 @@
 module github.com/maximhq/bifrost/tests/core-chatbot
 
-go 1.24.1
-
-toolchain go1.24.3
+go 1.24.3
 
 require (
 	github.com/maximhq/bifrost/core v1.2.22

--- a/tests/core-providers/go.mod
+++ b/tests/core-providers/go.mod
@@ -1,8 +1,6 @@
 module github.com/maximhq/bifrost/tests/core-providers
 
-go 1.24.0
-
-toolchain go1.24.3
+go 1.24.3
 
 replace github.com/maximhq/bifrost/core => ../../core
 

--- a/tests/scripts/1millogs/go.mod
+++ b/tests/scripts/1millogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/tests/scripts/1millogs
 
-go 1.24.0
+go 1.24.3
 
 require (
 	github.com/maximhq/bifrost/core v1.2.25


### PR DESCRIPTION
## Summary

Upgrade Go version from 1.24.1 to 1.24.3 across all GitHub workflows and module files.

## Changes

- Updated Go version from 1.24.1 to 1.24.3 in all GitHub workflow files
- Simplified go.mod files by removing the separate toolchain directive and standardizing on Go 1.24.3

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the project builds and tests pass with Go 1.24.3:

```sh
# Core/Transports
go version  # Should show 1.24.3
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This update includes security patches from the Go 1.24.3 release.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable