### PR TITLE
fix: Preserve extra_content for Gemini thought signatures (#879)

### DIFF
--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -443,13 +443,25 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) []Content {
 					if toolCall.ID != nil && strings.TrimSpace(*toolCall.ID) != "" {
 						callID = *toolCall.ID
 					}
-					parts = append(parts, &Part{
+
+					part := &Part{
 						FunctionCall: &FunctionCall{
 							ID:   callID,
 							Name: *toolCall.Function.Name,
 							Args: argsMap,
 						},
-					})
+					}
+
+					// Preserve thought signature from extra_content (required for Gemini 3 Pro)
+					if toolCall.ExtraContent != nil {
+						if googleData, ok := toolCall.ExtraContent["google"].(map[string]interface{}); ok {
+							if thoughtSig, ok := googleData["thought_signature"].(string); ok {
+								part.ThoughtSignature = []byte(thoughtSig)
+							}
+						}
+					}
+
+					parts = append(parts, part)
 				}
 			}
 		}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -481,10 +481,11 @@ type ChatAssistantMessageAnnotationCitation struct {
 
 // ChatAssistantMessageToolCall represents a tool call in a message
 type ChatAssistantMessageToolCall struct {
-	Index    uint16                               `json:"index"`
-	Type     *string                              `json:"type,omitempty"`
-	ID       *string                              `json:"id,omitempty"`
-	Function ChatAssistantMessageToolCallFunction `json:"function"`
+	Index        uint16                               `json:"index"`
+	Type         *string                              `json:"type,omitempty"`
+	ID           *string                              `json:"id,omitempty"`
+	Function     ChatAssistantMessageToolCallFunction `json:"function"`
+	ExtraContent map[string]interface{}               `json:"extra_content,omitempty"` // Provider-specific fields (e.g., thought_signature for Gemini)
 }
 
 // ChatAssistantMessageToolCallFunction represents a call to a function.

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -448,12 +448,13 @@ type ResponsesOutputMessageContentRefusal struct {
 }
 
 type ResponsesToolMessage struct {
-	CallID    *string                           `json:"call_id,omitempty"` // Common call ID for tool calls and outputs
-	Name      *string                           `json:"name,omitempty"`    // Common name field for tool calls
-	Arguments *string                           `json:"arguments,omitempty"`
-	Output    *ResponsesToolMessageOutputStruct `json:"output,omitempty"`
-	Action    *ResponsesToolMessageActionStruct `json:"action,omitempty"`
-	Error     *string                           `json:"error,omitempty"`
+	CallID       *string                           `json:"call_id,omitempty"`       // Common call ID for tool calls and outputs
+	Name         *string                           `json:"name,omitempty"`          // Common name field for tool calls
+	Arguments    *string                           `json:"arguments,omitempty"`
+	Output       *ResponsesToolMessageOutputStruct `json:"output,omitempty"`
+	Action       *ResponsesToolMessageActionStruct `json:"action,omitempty"`
+	Error        *string                           `json:"error,omitempty"`
+	ExtraContent map[string]interface{}            `json:"extra_content,omitempty"` // Provider-specific fields (e.g., thought_signature for Gemini)
 
 	// Tool calls and outputs
 	*ResponsesFileSearchToolCall


### PR DESCRIPTION
This commit fixes Bifrost to preserve Gemini's thought signatures in multi-turn function calling conversations.

Changes:
- Added ExtraContent field to ChatAssistantMessageToolCall schema
- Added ExtraContent field to ResponsesToolMessage schema
- Updated Gemini provider to extract and inject thought_signature from/to extra_content
- Modified chat.go, responses.go, and utils.go to handle bidirectional preservation

Background:
Gemini 3 Pro requires thought_signature to be preserved across conversation turns when using function calling. Google's official OpenAI-compatible endpoint returns these in extra_content.google.thought_signature format.

Without this fix, Bifrost would drop the extra_content field during JSON unmarshaling, causing 400 errors on subsequent rounds:
  'Function call is missing a thought_signature in functionCall parts'

Testing:
- Verified against Google's official OpenAI endpoint
- Multi-turn conversations with Gemini 3 Pro now work correctly
- Backward compatible (uses omitempty, only affects Gemini 3 Pro with function calling)

Fixes: #879
