### PR TITLE
feat: filter /v1/models endpoint by virtual key provider_configs

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -329,8 +329,9 @@ func (bifrost *Bifrost) ListModelsFromProviders(ctx context.Context, providers [
 
 			// Create request for this provider with limit of 1000
 			providerRequest := &schemas.BifrostListModelsRequest{
-				Provider: providerKey,
-				PageSize: schemas.DefaultPageSize,
+				Provider:    providerKey,
+				PageSize:    schemas.DefaultPageSize,
+				ExtraParams: request.ExtraParams,
 			}
 
 			iterations := 0

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -16,7 +16,7 @@ Virtual Keys are the primary governance entity in Bifrost. Users and application
 <Note>You can also use `Authorization` and `x-api-key` headers to pass direct keys to the provider. Read more about it in [Direct Key Bypass](../keys-management#direct-key-bypass).</Note>
 
 **Key Features:**
-- **Access Control** - Model and provider filtering
+- **Access Control** - Model and provider filtering (applies to `/v1/models` endpoint and inference requests)
 - **Cost Management** - Independent budgets (checked along with team/customer budgets if attached)
 - **Rate Limiting** - Token and request-based throttling (VK-level only)
 - **Key Restrictions** - Limit VK to specific provider API keys (if configured, VK can only use those keys)
@@ -497,6 +497,34 @@ curl -X POST http://localhost:8080/v1/chat/completions \
     "model": "gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
+```
+
+The virtual key can also filter which models are returned by the `/v1/models` endpoint:
+
+```bash
+# List models allowed for a specific virtual key
+curl -X GET http://localhost:8080/v1/models \
+  -H "x-bf-vk: vk-engineering-main"
+```
+
+**How it works:**
+- **With `x-bf-vk` header**: Returns only models specified in the virtual key's `provider_configs`
+- **Without `x-bf-vk` header**: Returns all available models
+- **Empty `provider_configs`**: Returns all models (no filtering)
+- **Empty `allowed_models` for a provider**: Returns all models from that provider
+
+**Example:**
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "allowed_models": ["gpt-4o", "gpt-4o-mini"],
+      "weight": 1.0
+    }
+  ]
+}
+// GET /v1/models with x-bf-vk header returns only openai/gpt-4o and openai/gpt-4o-mini
 ```
 
 By default governance is optional, meaning that if the `x-bf-vk` header is not present, the request will be allowed but without any governance checks/routing. But you can make it mandatory by enforcing the governance header.

--- a/tests/governance/README.md
+++ b/tests/governance/README.md
@@ -48,6 +48,14 @@ This test suite provides extensive coverage of the Bifrost governance system inc
    - Reset functionality
    - Debug and health endpoints
 
+5. **`test_virtual_keys_access.py`** - Virtual Key Model Filtering
+   - `/v1/models` endpoint filtering based on virtual key `provider_configs`
+   - Specific models via `allowed_models` list
+   - Empty `allowed_models` returns all models from that provider
+   - Empty `provider_configs` returns all models
+   - Multiple provider configurations
+   - Invalid and inactive virtual key handling
+
 ### Configuration Files
 
 - **`conftest.py`** - Test fixtures, utilities, and configuration
@@ -162,6 +170,7 @@ The test suite uses pytest markers for categorization:
 - `@pytest.mark.concurrency` - Concurrency tests
 - `@pytest.mark.slow` - Slow running tests (>5s)
 - `@pytest.mark.smoke` - Quick smoke tests
+- `@pytest.mark.access_control` - Access control and filtering tests
 
 ## API Endpoints Tested
 
@@ -195,6 +204,11 @@ The test suite uses pytest markers for categorization:
 
 ### Integration Endpoints
 - `POST /v1/chat/completions` - Chat completion with governance headers
+- `GET /v1/models` - List available models with optional virtual key filtering
+
+#### Model Filtering (`/v1/models`)
+- **With `x-bf-vk` header**: Returns models specified in the virtual key's `provider_configs`
+- **Without `x-bf-vk` header**: Returns all available models
 
 ## Test Data and Schemas
 

--- a/tests/governance/test_virtual_keys_access.py
+++ b/tests/governance/test_virtual_keys_access.py
@@ -1,0 +1,479 @@
+"""
+Tests for /v1/models endpoint filtering based on virtual key provider_configs.
+
+Tests cover:
+- Filtering by specific allowed_models
+- Empty allowed_models (all models from provider)
+- Empty provider_configs (all models)
+- Non-existent providers
+- Multiple providers
+- Invalid and inactive virtual keys
+"""
+
+import pytest
+import requests
+from conftest import BIFROST_BASE_URL, assert_response_success, generate_unique_name
+
+
+class TestModelsFiltering:
+    """Test /v1/models endpoint filtering based on virtual key provider configs"""
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    @pytest.mark.smoke
+    def test_list_models_with_vk_filters_by_provider_config(
+        self, governance_client, cleanup_tracker
+    ):
+        """Test that /v1/models filters models when VK has provider_configs with specific allowed_models"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+        all_models = response.json().get("data", [])
+
+        providers_map = {}
+        for model in all_models:
+            if "/" in model["id"]:
+                provider, model_name = model["id"].split("/", 1)
+                if provider not in providers_map:
+                    providers_map[provider] = []
+                providers_map[provider].append(model_name)
+
+        if not providers_map or not any(
+            len(models) >= 2 for models in providers_map.values()
+        ):
+            pytest.skip("Need at least one provider with 2+ models")
+
+        test_provider = next(
+            p for p, models in providers_map.items() if len(models) >= 2
+        )
+        selected_models = providers_map[test_provider][:2]
+
+        vk_data = {
+            "name": generate_unique_name("Test VK Specific Models"),
+            "provider_configs": [
+                {
+                    "provider": test_provider,
+                    "allowed_models": selected_models,
+                    "weight": 1.0,
+                }
+            ],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        assert vk["provider_configs"] is not None
+        assert len(vk["provider_configs"]) == 1
+        assert vk["provider_configs"][0]["provider"] == test_provider
+        assert set(vk["provider_configs"][0]["allowed_models"]) == set(selected_models)
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+        assert_response_success(response, 200)
+
+        filtered_models = response.json().get("data", [])
+        filtered_ids = [m["id"] for m in filtered_models]
+        expected_ids = [f"{test_provider}/{m}" for m in selected_models]
+
+        assert len(filtered_models) == len(selected_models), (
+            f"Expected {len(selected_models)} models, got {len(filtered_models)}"
+        )
+        assert set(filtered_ids) == set(expected_ids), (
+            f"Model IDs mismatch. Expected: {expected_ids}, Got: {filtered_ids}"
+        )
+
+        provider_models = [
+            m["id"] for m in all_models if m["id"].startswith(f"{test_provider}/")
+        ]
+        excluded = [m for m in provider_models if m not in expected_ids]
+        for excluded_id in excluded:
+            assert excluded_id not in filtered_ids
+
+        for model in filtered_models:
+            assert "id" in model
+            assert "created" in model
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_with_empty_allowed_models_returns_all_provider_models(
+        self, governance_client, cleanup_tracker
+    ):
+        """Test that empty allowed_models returns all models from that provider"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+        all_models = response.json().get("data", [])
+
+        providers = list(
+            set([m["id"].split("/")[0] for m in all_models if "/" in m["id"]])
+        )
+        if not providers:
+            pytest.skip("No providers found")
+
+        test_provider = providers[0]
+        provider_model_ids = [
+            m["id"] for m in all_models if m["id"].startswith(f"{test_provider}/")
+        ]
+
+        vk_data = {
+            "name": generate_unique_name("Test VK All Provider Models"),
+            "provider_configs": [
+                {
+                    "provider": test_provider,
+                    "allowed_models": [],
+                    "weight": 1.0,
+                }
+            ],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        assert vk["provider_configs"] is not None
+        assert len(vk["provider_configs"]) == 1
+        assert vk["provider_configs"][0]["provider"] == test_provider
+        assert vk["provider_configs"][0]["allowed_models"] == []
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+        assert_response_success(response, 200)
+
+        filtered_models = response.json().get("data", [])
+        filtered_ids = [m["id"] for m in filtered_models]
+
+        assert len(filtered_models) == len(provider_model_ids), (
+            f"Expected {len(provider_model_ids)} models, got {len(filtered_models)}"
+        )
+        assert set(filtered_ids) == set(provider_model_ids)
+
+        other_provider_models = [
+            m["id"] for m in all_models if not m["id"].startswith(f"{test_provider}/")
+        ]
+        for other_model_id in other_provider_models:
+            assert other_model_id not in filtered_ids
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_without_provider_configs_returns_all(
+        self, governance_client, cleanup_tracker
+    ):
+        """Test that VK with no provider_configs returns all models"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+        all_models = response.json().get("data", [])
+        all_model_ids = [m["id"] for m in all_models]
+
+        if len(all_models) == 0:
+            pytest.skip("No models available")
+
+        vk_data = {
+            "name": generate_unique_name("Test VK Unrestricted"),
+            "provider_configs": [],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        assert vk["provider_configs"] is not None
+        assert len(vk["provider_configs"]) == 0
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+        assert_response_success(response, 200)
+
+        filtered_models = response.json().get("data", [])
+        filtered_ids = [m["id"] for m in filtered_models]
+
+        assert len(filtered_models) == len(all_models), (
+            f"Expected {len(all_models)} models, got {len(filtered_models)}"
+        )
+        assert set(filtered_ids) == set(all_model_ids)
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_with_nonexistent_provider_returns_empty(
+        self, governance_client, cleanup_tracker
+    ):
+        """Test that VK with non-existent provider returns empty list"""
+        vk_data = {
+            "name": generate_unique_name("Test VK Nonexistent Provider"),
+            "provider_configs": [
+                {
+                    "provider": "nonexistent-provider-xyz-123",
+                    "allowed_models": [],
+                    "weight": 1.0,
+                }
+            ],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        assert vk["provider_configs"] is not None
+        assert len(vk["provider_configs"]) == 1
+        assert vk["provider_configs"][0]["provider"] == "nonexistent-provider-xyz-123"
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+        assert_response_success(response, 200)
+
+        filtered_models = response.json().get("data", [])
+        assert len(filtered_models) == 0
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_with_multiple_providers(
+        self, governance_client, cleanup_tracker
+    ):
+        """Test that VK with multiple providers returns models from all configured providers"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+        all_models = response.json().get("data", [])
+
+        available_providers = list(
+            set([m["id"].split("/")[0] for m in all_models if "/" in m["id"]])
+        )
+
+        if len(available_providers) < 2:
+            pytest.skip(f"Need at least 2 providers, have: {available_providers}")
+
+        provider1 = available_providers[0]
+        provider2 = available_providers[1]
+
+        provider1_models = [
+            m["id"].split("/")[1]
+            for m in all_models
+            if m["id"].startswith(f"{provider1}/")
+        ]
+        provider2_models = [
+            m["id"].split("/")[1]
+            for m in all_models
+            if m["id"].startswith(f"{provider2}/")
+        ]
+
+        if len(provider1_models) == 0 or len(provider2_models) == 0:
+            pytest.skip("Each provider needs at least one model")
+
+        selected_model1 = provider1_models[0]
+        selected_model2 = provider2_models[0]
+
+        vk_data = {
+            "name": generate_unique_name("Test VK Multi Provider"),
+            "provider_configs": [
+                {
+                    "provider": provider1,
+                    "allowed_models": [selected_model1],
+                    "weight": 1.0,
+                },
+                {
+                    "provider": provider2,
+                    "allowed_models": [selected_model2],
+                    "weight": 1.0,
+                },
+            ],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        assert vk["provider_configs"] is not None
+        assert len(vk["provider_configs"]) == 2
+        vk_providers = [pc["provider"] for pc in vk["provider_configs"]]
+        assert provider1 in vk_providers
+        assert provider2 in vk_providers
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+        assert_response_success(response, 200)
+
+        filtered_models = response.json().get("data", [])
+        filtered_ids = [m["id"] for m in filtered_models]
+        expected_ids = [
+            f"{provider1}/{selected_model1}",
+            f"{provider2}/{selected_model2}",
+        ]
+
+        assert len(filtered_models) == 2, (
+            f"Expected 2 models, got {len(filtered_models)}"
+        )
+        assert set(filtered_ids) == set(expected_ids)
+
+        provider1_found = any(
+            m["id"].startswith(f"{provider1}/") for m in filtered_models
+        )
+        provider2_found = any(
+            m["id"].startswith(f"{provider2}/") for m in filtered_models
+        )
+        assert provider1_found
+        assert provider2_found
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_without_vk_header_returns_all(self, governance_client):
+        """Test that requesting models without VK header returns all models"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+
+        all_models = response.json().get("data", [])
+        assert len(all_models) > 0
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_with_invalid_vk_header(self, governance_client):
+        """Test that invalid VK header returns error or all models without filtering"""
+        response_without_vk = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response_without_vk, 200)
+        all_models = response_without_vk.json().get("data", [])
+        all_model_ids = set([m["id"] for m in all_models])
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": "invalid-vk-value-xyz"}
+        )
+
+        assert response.status_code in [200, 401, 403]
+
+        if response.status_code == 200:
+            models = response.json().get("data", [])
+            model_ids = set([m["id"] for m in models])
+            assert isinstance(models, list)
+            assert model_ids == all_model_ids, "Invalid VK should not filter models"
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_with_inactive_vk(self, governance_client, cleanup_tracker):
+        """Test that inactive VK is rejected or returns all models without filtering"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+        all_models = response.json().get("data", [])
+        all_model_ids = set([m["id"] for m in all_models])
+
+        if len(all_models) == 0:
+            pytest.skip("No models available")
+
+        vk_data = {
+            "name": generate_unique_name("Test VK Inactive"),
+            "is_active": False,
+            "provider_configs": [
+                {
+                    "provider": "test-provider",
+                    "allowed_models": ["test-model"],
+                    "weight": 1.0,
+                }
+            ],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        if vk["is_active"] is True:
+            update_response = governance_client.update_virtual_key(
+                vk["id"], {"is_active": False}
+            )
+            if update_response.status_code == 200:
+                vk = update_response.json()["virtual_key"]
+            else:
+                pytest.skip("Cannot deactivate VK")
+
+        assert vk["is_active"] is False
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+
+        assert response.status_code in [200, 401, 403]
+
+        if response.status_code == 200:
+            filtered_models = response.json().get("data", [])
+            filtered_ids = set([m["id"] for m in filtered_models])
+
+            assert filtered_ids == all_model_ids, (
+                f"Inactive VK should not filter models. Expected {len(all_models)} models, "
+                f"got {len(filtered_models)}"
+            )
+
+    @pytest.mark.virtual_keys
+    @pytest.mark.integration
+    def test_list_models_with_mixed_provider_configs(
+        self, governance_client, cleanup_tracker
+    ):
+        """Test VK with one provider having specific models and another with all models"""
+        response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
+        assert_response_success(response, 200)
+        all_models = response.json().get("data", [])
+
+        providers = list(
+            set([m["id"].split("/")[0] for m in all_models if "/" in m["id"]])
+        )
+
+        if len(providers) < 2:
+            pytest.skip(f"Need at least 2 providers, have: {providers}")
+
+        provider1 = providers[0]
+        provider2 = providers[1]
+
+        provider1_models = [
+            m["id"].split("/")[1]
+            for m in all_models
+            if m["id"].startswith(f"{provider1}/")
+        ]
+        provider2_all_models = [
+            m["id"] for m in all_models if m["id"].startswith(f"{provider2}/")
+        ]
+
+        if len(provider1_models) < 2 or len(provider2_all_models) == 0:
+            pytest.skip("Need sufficient models")
+
+        selected_provider1_model = provider1_models[0]
+
+        vk_data = {
+            "name": generate_unique_name("Test VK Mixed Configs"),
+            "provider_configs": [
+                {
+                    "provider": provider1,
+                    "allowed_models": [selected_provider1_model],
+                    "weight": 1.0,
+                },
+                {
+                    "provider": provider2,
+                    "allowed_models": [],
+                    "weight": 1.0,
+                },
+            ],
+        }
+        response = governance_client.create_virtual_key(vk_data)
+        assert_response_success(response, 200)
+        vk = response.json()["virtual_key"]
+        cleanup_tracker.add_virtual_key(vk["id"])
+
+        response = requests.get(
+            f"{BIFROST_BASE_URL}/v1/models", headers={"x-bf-vk": vk["value"]}
+        )
+        assert_response_success(response, 200)
+
+        filtered_models = response.json().get("data", [])
+        filtered_ids = [m["id"] for m in filtered_models]
+
+        expected_count = 1 + len(provider2_all_models)
+        assert len(filtered_models) == expected_count, (
+            f"Expected {expected_count} models, got {len(filtered_models)}"
+        )
+
+        provider1_filtered = [
+            m["id"] for m in filtered_models if m["id"].startswith(f"{provider1}/")
+        ]
+        assert len(provider1_filtered) == 1
+        assert f"{provider1}/{selected_provider1_model}" in provider1_filtered
+
+        provider2_filtered = [
+            m["id"] for m in filtered_models if m["id"].startswith(f"{provider2}/")
+        ]
+        assert set(provider2_filtered) == set(provider2_all_models)

--- a/tests/governance/test_virtual_keys_access.py
+++ b/tests/governance/test_virtual_keys_access.py
@@ -317,7 +317,7 @@ class TestModelsFiltering:
 
     @pytest.mark.virtual_keys
     @pytest.mark.integration
-    def test_list_models_without_vk_header_returns_all(self, governance_client):
+    def test_list_models_without_vk_header_returns_all(self):
         """Test that requesting models without VK header returns all models"""
         response = requests.get(f"{BIFROST_BASE_URL}/v1/models")
         assert_response_success(response, 200)
@@ -327,7 +327,7 @@ class TestModelsFiltering:
 
     @pytest.mark.virtual_keys
     @pytest.mark.integration
-    def test_list_models_with_invalid_vk_header(self, governance_client):
+    def test_list_models_with_invalid_vk_header(self):
         """Test that invalid VK header returns error or all models without filtering"""
         response_without_vk = requests.get(f"{BIFROST_BASE_URL}/v1/models")
         assert_response_success(response_without_vk, 200)
@@ -460,7 +460,6 @@ class TestModelsFiltering:
         assert_response_success(response, 200)
 
         filtered_models = response.json().get("data", [])
-        filtered_ids = [m["id"] for m in filtered_models]
 
         expected_count = 1 + len(provider2_all_models)
         assert len(filtered_models) == expected_count, (

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -442,6 +442,9 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 		resp, bifrostErr = h.client.ListModelsRequest(*bifrostCtx, bifrostListModelsReq)
 	} else {
 		resp, bifrostErr = h.client.ListModelsFromProviders(*bifrostCtx, providersToFetch, bifrostListModelsReq)
+		if bifrostErr == nil && resp != nil {
+			resp = resp.ApplyPagination(bifrostListModelsReq.PageSize, bifrostListModelsReq.PageToken)
+		}
 	}
 
 	if bifrostErr != nil {


### PR DESCRIPTION
## Summary

Implements model filtering for the `/v1/models` endpoint based on virtual key's `provider_configs`. This allows controlling which models are visible to specific virtual keys by specifying allowed models, providing fine-grained access control at the API level.

## Changes

- Added `filterModelsByVirtualKey()` function in `transports/bifrost-http/handlers/inference.go` to filter models based on virtual key's provider_configs
- Integrated filtering in the `listModels` handler for `/v1/models` endpoint (applied only when governance is enabled)
- Modified `NewInferenceHandler()` to accept governance store parameter and added `governanceStore` field to `CompletionHandler` struct
- Updated server initialization (`server/server.go`) to inject governance store into inference handler
- Added comprehensive test suite (`test_virtual_keys_access.py`) with 9 test cases covering all filtering scenarios
- Updated documentation in `tests/governance/README.md` and `docs/features/governance/virtual-keys.mdx` with detailed `/v1/models` filtering behavior

**Design decisions:**
- Filtering happens at the HTTP handler level after models are fetched from bifrost core
- Only applies when `EnableGovernance` config is true
- Returns all models when no VK header is provided (backward compatible)
- Empty `provider_configs` = unrestricted access, empty `allowed_models` = all models from provider
- Fail-safe: returns unfiltered models if governance store is nil or VK not found

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP) - Inference handler, Server initialization
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs
- [x] Tests (Governance)

## How to test

### 1. Start Bifrost server
```sh
make dev
```

### 2. Run the test suite
```sh
cd tests/governance
pytest test_virtual_keys_access.py -v
```

**Expected outcome:** All 9 tests pass
- `test_list_models_with_vk_filters_by_provider_config` - Filters models by VK with specific allowed_models
- `test_list_models_with_empty_allowed_models_returns_all_provider_models` - Empty allowed_models returns all models from that provider
- `test_list_models_without_provider_configs_returns_all` - Empty provider_configs returns all models (unrestricted)
- `test_list_models_with_nonexistent_provider_returns_empty` - Non-existent providers return empty list
- `test_list_models_with_multiple_providers` - Filters models from multiple providers in provider_configs
- `test_list_models_without_vk_header_returns_all` - Without VK header returns all models (backward compatible)
- `test_list_models_with_invalid_vk_header` - Invalid VK header returns all models without filtering
- `test_list_models_with_inactive_vk` - Inactive VK returns all models without filtering
- `test_list_models_with_mixed_provider_configs` - One provider with specific models, another with all models

### 4. Manual testing

**Create a virtual key with allowed models:**
- via UI at http://localhost:3000/workspace/virtual-keys
- Select Provider Configurations and set allowed models for providers

**List models:**
```sh
# List models without VK (returns all models)
curl http://localhost:8080/v1/models

# List models with VK (returns only the allowed models based on provider_configs)
curl http://localhost:8080/v1/models -H "x-bf-vk: <vk-value>"
```

**Expected behavior:**
- Without VK header: All models from all configured providers
- With VK header: Only models matching the virtual key's provider_configs
  - If `provider_configs` is empty → all models
  - If `allowed_models` is empty for a provider → all models from that provider
  - If `allowed_models` has specific models → only those models

## Screenshots/Recordings

N/A - Backend API feature

## Breaking changes

- [ ] Yes
- [x] No

This is a backward-compatible addition. Existing behavior (returning all models without VK header) is preserved.

## Related issues

[Feature]: filter models in /v1/models based on virtual key [#808](https://github.com/maximhq/bifrost/issues/808)

## Security considerations

- Model filtering enforces access control at the API level
- Virtual key validation already handled by existing governance middleware
- No new security vulnerabilities introduced
- Filter logic is fail-safe: returns all models if governance is disabled, governance store is nil, or VK is not found (preserves existing behavior)
- Filtering only applies when `EnableGovernance` is true in config

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate (9 comprehensive test cases)
- [x] I updated documentation where needed (README.md and virtual-keys.mdx)
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable (all tests passing)"
