### PR TITLE
adds new flags for dynamic builds of bifrost

### DIFF
--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Helm"
 description: "Deploy Bifrost on Kubernetes using Helm charts with flexible configuration options"
-icon: "helm"
+icon: "helicopter-symbol"
 ---
 
 Deploy Bifrost on Kubernetes using the official Helm chart. This is the recommended way to deploy Bifrost on Kubernetes with production-ready defaults and flexible configuration.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
             "icon": "puzzle-piece",
             "pages": [
               "plugins/getting-started",
+              "plugins/building-dynamic-binary",
               "plugins/writing-plugin"              
             ]
           },

--- a/docs/models-catalog/list.mdx
+++ b/docs/models-catalog/list.mdx
@@ -135,6 +135,99 @@ export const ModelsCatalog = () => {
     fetchModels()
   }, [])
 
+  useEffect(() => {
+    const styleId = 'custom-scrollbar-styles'
+    if (document.getElementById(styleId)) return
+
+    const style = document.createElement('style')
+    style.id = styleId
+    style.textContent = `
+      /* Firefox overlay scrollbar - always visible */
+      .custom-scrollbar {
+        overflow: auto !important;
+        scrollbar-gutter: auto !important;
+        scrollbar-width: thin !important;
+        scrollbar-color: rgba(228, 228, 231, 0.6) rgba(241, 245, 249, 0.5) !important;
+      }
+
+      .custom-scrollbar:hover {
+        scrollbar-color: rgba(228, 228, 231, 1) rgba(241, 245, 249, 0.7) !important;
+      }
+
+      .dark .custom-scrollbar {
+        scrollbar-color: rgba(113, 113, 122, 0.6) rgba(39, 39, 42, 0.5) !important;
+      }
+
+      .dark .custom-scrollbar:hover {
+        scrollbar-color: rgba(113, 113, 122, 1) rgba(39, 39, 42, 0.7) !important;
+      }
+
+      /* WebKit overlay scrollbar - always visible */
+      .custom-scrollbar::-webkit-scrollbar {
+        width: 8px !important;
+        height: 8px !important;
+        background: transparent !important;
+      }
+
+      .custom-scrollbar::-webkit-scrollbar-track {
+        background-color: rgba(241, 245, 249, 0.5) !important;
+        margin: 0 !important;
+        border: none !important;
+        border-radius: 8px !important;
+      }
+
+      .dark .custom-scrollbar::-webkit-scrollbar-track {
+        background-color: rgba(39, 39, 42, 0.5) !important;
+      }
+
+      .custom-scrollbar::-webkit-scrollbar-thumb {
+        background-color: rgba(228, 228, 231, 0.6) !important;
+        border-radius: 8px !important;
+        border: 2px solid transparent !important;
+        background-clip: padding-box !important;
+        transition: background-color 0.2s !important;
+      }
+
+      .custom-scrollbar:hover::-webkit-scrollbar-thumb {
+        background-color: rgba(228, 228, 231, 1) !important;
+      }
+
+      .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+        background-color: rgba(82, 82, 91, 1) !important;
+      }
+
+      .dark .custom-scrollbar::-webkit-scrollbar-thumb {
+        background-color: rgba(113, 113, 122, 0.6) !important;
+      }
+
+      .dark .custom-scrollbar:hover::-webkit-scrollbar-thumb {
+        background-color: rgba(113, 113, 122, 1) !important;
+      }
+
+      .dark .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+        background-color: rgba(161, 161, 170, 1) !important;
+      }
+
+      /* Make scrollbar overlay by extending table into scrollbar area */
+      .custom-scrollbar {
+        overflow-x: hidden !important;
+      }
+
+      .custom-scrollbar > table {
+        width: calc(100% + 8px) !important;
+        margin-right: -8px !important;
+      }
+    `
+    document.head.appendChild(style)
+
+    return () => {
+      const existingStyle = document.getElementById(styleId)
+      if (existingStyle) {
+        existingStyle.remove()
+      }
+    }
+  }, [])
+
   const providers = useMemo(() => {
     const uniqueProviders = new Set()
     models.forEach(model => {
@@ -239,17 +332,17 @@ export const ModelsCatalog = () => {
         </div>
       </div>
 
-      <div className="overflow-auto border border-zinc-950/20 dark:border-white/20 rounded-lg bg-white dark:bg-zinc-950" style={{ maxHeight: '600px' }}>
-        <table className="w-full border-collapse text-sm">
-          <thead className="sticky top-0 z-10 bg-zinc-50 dark:bg-zinc-900">
+      <div className="overflow-y-auto custom-scrollbar border border-zinc-950/20 dark:border-white/20 rounded-lg" style={{ maxHeight: '600px', padding: 0, margin: 0, overflowX: 'hidden' }}>
+        <table className="w-full text-sm bg-white dark:bg-zinc-950" style={{ borderCollapse: 'collapse', tableLayout: 'fixed', margin: 0, padding: 0 }}>
+          <thead className="sticky bg-zinc-50 dark:bg-zinc-900" style={{ top: 0, zIndex: 10 }}>
             <tr>
-              <th className="px-4 py-3 text-left font-semibold text-zinc-950 dark:text-white whitespace-nowrap border-b-2 border-zinc-950/20 dark:border-white/20" style={{ width: '200px' }}>
+              <th className="px-6 py-3 text-left font-semibold text-zinc-950 dark:text-white whitespace-nowrap border-b-2 border-zinc-950/20 dark:border-white/20" style={{ width: '200px' }}>
                 Provider
               </th>
-              <th className="px-4 py-3 text-left font-semibold text-zinc-950 dark:text-white whitespace-nowrap border-b-2 border-zinc-950/20 dark:border-white/20">
+              <th className="px-6 py-3 text-left font-semibold text-zinc-950 dark:text-white whitespace-nowrap border-b-2 border-zinc-950/20 dark:border-white/20">
                 Model
               </th>
-              <th className="px-4 py-3 text-center font-semibold text-zinc-950 dark:text-white whitespace-nowrap border-b-2 border-zinc-950/20 dark:border-white/20" style={{ width: '150px' }}>
+              <th className="px-6 py-3 text-center font-semibold text-zinc-950 dark:text-white whitespace-nowrap border-b-2 border-zinc-950/20 dark:border-white/20" style={{ width: '150px' }}>
                 Details
               </th>
             </tr>
@@ -257,7 +350,7 @@ export const ModelsCatalog = () => {
           <tbody>
             {filteredModels.length === 0 && searchTerm ? (
               <tr>
-                <td colSpan={3} className="px-4 py-10 text-center text-zinc-950/70 dark:text-white/70">
+                <td colSpan={3} className="px-6 py-10 text-center text-zinc-950/70 dark:text-white/70">
                   No models found matching "{searchTerm}"
                 </td>
               </tr>
@@ -267,13 +360,13 @@ export const ModelsCatalog = () => {
                   key={`${model.provider}-${model.model}`}
                   className="transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-900"
                 >
-                  <td className="px-4 py-3 text-zinc-950/80 dark:text-white/80 border-b border-zinc-950/10 dark:border-white/10 capitalize">
+                  <td className="px-6 py-3 text-zinc-950/80 dark:text-white/80 border-b border-zinc-950/10 dark:border-white/10 capitalize">
                     {model.provider || '—'}
                   </td>
-                  <td className="px-4 py-3 text-zinc-950/80 dark:text-white/80 border-b border-zinc-950/10 dark:border-white/10 font-mono">
+                  <td className="px-6 py-3 text-zinc-950/80 dark:text-white/80 border-b border-zinc-950/10 dark:border-white/10 font-mono">
                     {model.model || '—'}
                   </td>
-                  <td className="px-4 py-3 border-b border-zinc-950/10 dark:border-white/10 text-center">
+                  <td className="px-6 py-3 border-b border-zinc-950/10 dark:border-white/10 text-center">
                     <button
                       onClick={() => handleRowClick(model)}
                       className="text-[#0C3B43] dark:text-[#07C983] hover:underline font-medium text-sm"
@@ -292,6 +385,7 @@ export const ModelsCatalog = () => {
     </div>
   )
 }
+
 
 <ModelsCatalog />
 

--- a/docs/plugins/building-dynamic-binary.mdx
+++ b/docs/plugins/building-dynamic-binary.mdx
@@ -1,0 +1,706 @@
+---
+title: "Building Dynamically Linked Bifrost Binary"
+description: "Learn how to build a dynamically linked Bifrost binary required for custom plugin support"
+icon: "hammer"
+---
+
+## Why Dynamic Linking?
+
+Go's plugin system requires **dynamic linking** to load `.so` files at runtime. By default, Bifrost builds are **statically linked** for maximum portability across Linux distributions - they bundle all dependencies including the C standard library (libc). However, statically linked binaries **cannot load Go plugins**.
+
+To use custom plugins with Bifrost, you must build a dynamically linked binary that links against the system's libc at runtime.
+
+<Warning>
+Dynamic plugins only work on **Linux** and **macOS** (Darwin). Windows is not supported by Go's plugin system.
+</Warning>
+
+## Static vs Dynamic Builds
+
+### Static Builds (Default)
+
+Bifrost's default build configuration creates statically linked binaries:
+
+```bash
+go build \
+  -ldflags="-w -s -extldflags '-static' -X main.Version=v1.3.30" \
+  -tags "sqlite_static" \
+  -o bifrost-http
+```
+
+**Characteristics:**
+- ✅ Portable across all Linux distributions (musl, glibc, etc.)
+- ✅ No external dependencies required at runtime
+- ✅ Smaller deployment surface area
+- ❌ **Cannot load Go plugins**
+
+**Use static builds when:** You don't need custom plugins and want maximum portability.
+
+### Dynamic Builds (For Plugins)
+
+To enable plugin support, build without static linking flags:
+
+```bash
+go build \
+  -ldflags="-w -s -X main.Version=v1.3.30" \
+  -o bifrost-http
+```
+
+**Characteristics:**
+- ✅ **Can load Go plugins** (`.so` files)
+- ✅ Slightly faster compilation
+- ⚠️ Must match the target system's libc (musl vs glibc)
+- ⚠️ Less portable across different Linux distributions
+
+**Use dynamic builds when:** You need custom plugin support.
+
+## Building with Makefile
+
+The easiest way to build a dynamic binary is using the `DYNAMIC=1` flag with the Makefile:
+
+### Local Build
+
+```bash
+# Build dynamically linked binary for your current platform
+make build DYNAMIC=1
+
+# With version tag
+make build DYNAMIC=1 VERSION=1.3.30
+```
+
+This creates `tmp/bifrost-http` as a dynamically linked binary.
+
+### Cross-Compilation
+
+```bash
+# Build for Linux AMD64 (uses Docker if cross-compiling)
+make build DYNAMIC=1 GOOS=linux GOARCH=amd64
+
+# Build for Linux ARM64
+make build DYNAMIC=1 GOOS=linux GOARCH=arm64
+```
+
+### How It Works
+
+The `DYNAMIC=1` flag automatically:
+- ✅ Removes `-extldflags "-static"` from ldflags
+- ✅ Removes `-tags "sqlite_static"` build tag
+- ✅ Keeps `CGO_ENABLED=1` (required for SQLite and plugins)
+- ✅ Uses Docker for cross-compilation when needed
+
+## Building with Docker
+
+For containerized deployments, you'll need to modify the Dockerfile. Here are two complete examples based on your target environment's libc.
+
+### Option A: Alpine Linux (musl libc)
+
+Use this for Alpine-based deployments or when you want minimal image size.
+
+<Accordion title="Complete Dockerfile for Alpine (musl libc)">
+
+```dockerfile
+# --- UI Build Stage: Build the Next.js frontend ---
+FROM node:24-alpine3.22 AS ui-builder
+WORKDIR /app
+
+# Copy UI package files and install dependencies
+COPY ui/package*.json ./
+RUN npm ci
+
+# Copy UI source code
+COPY ui/ ./
+
+# Build UI (skip the copy-build step)
+RUN npx next build
+RUN node scripts/fix-paths.js
+
+# --- Go Build Stage: Compile the Go binary ---
+FROM golang:1.24.3-alpine3.22 AS builder
+WORKDIR /app
+
+# Install dependencies including gcc for CGO and sqlite
+RUN apk add --no-cache gcc musl-dev sqlite-dev
+
+# Set environment for CGO-enabled build (required for go-sqlite3 and plugins)
+ENV CGO_ENABLED=1 GOOS=linux
+
+COPY transports/go.mod transports/go.sum ./
+RUN go mod download
+
+# Copy source code and dependencies
+COPY transports/ ./
+
+COPY --from=ui-builder /app/out ./bifrost-http/ui
+
+# Build the binary with CGO enabled for DYNAMIC LINKING
+ENV GOWORK=off
+ARG VERSION=unknown
+RUN go build \
+    -ldflags="-w -s -X main.Version=v${VERSION}" \
+    -a -trimpath \
+    -o /app/main \
+    ./bifrost-http
+
+# Verify build succeeded
+RUN test -f /app/main || (echo "Build failed" && exit 1)
+
+# --- Runtime Stage: Minimal runtime image ---
+FROM alpine:3.22
+WORKDIR /app
+
+# Install runtime dependencies for CGO-enabled dynamic binary
+# musl: C standard library (required for CGO binaries)
+# libgcc: GCC runtime library
+# ca-certificates: For HTTPS connections
+RUN apk add --no-cache musl libgcc ca-certificates
+
+# Create data directory and set up user
+COPY --from=builder /app/main .
+COPY --from=builder /app/docker-entrypoint.sh .
+
+# Getting arguments
+ARG ARG_APP_PORT=8080
+ARG ARG_APP_HOST=0.0.0.0
+ARG ARG_LOG_LEVEL=info
+ARG ARG_LOG_STYLE=json
+ARG ARG_APP_DIR=/app/data
+
+# Environment variables with defaults (can be overridden at runtime)
+ENV APP_PORT=$ARG_APP_PORT \
+    APP_HOST=$ARG_APP_HOST \
+    LOG_LEVEL=$ARG_LOG_LEVEL \
+    LOG_STYLE=$ARG_LOG_STYLE \
+    APP_DIR=$ARG_APP_DIR
+
+RUN mkdir -p $APP_DIR/logs && \
+    adduser -D -s /bin/sh appuser && \
+    chown -R appuser:appuser /app && \
+    chmod +x /app/docker-entrypoint.sh
+USER appuser
+
+# Declare volume for data persistence
+VOLUME ["/app/data"]
+EXPOSE $APP_PORT
+
+# Health check for container status monitoring
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${APP_PORT}/metrics || exit 1
+
+# Use entrypoint script that handles volume permissions and argument processing
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/main"]
+```
+
+</Accordion>
+
+**Key changes from static build:**
+- Line 40-44: Removed `-extldflags '-static'` and `-tags "sqlite_static"`
+- Removed UPX compression step (optional, but simpler)
+- Runtime uses musl libc from Alpine base image
+
+**Build and run:**
+
+```bash
+# Build the image
+docker build -f transports/Dockerfile -t bifrost:dynamic-alpine .
+
+# Run the container
+docker run -p 8080:8080 -v ./plugins:/app/data/plugins bifrost:dynamic-alpine
+```
+
+### Option B: Debian (glibc)
+
+Use this for Debian/Ubuntu-based deployments or when deploying to glibc-based systems.
+
+<Accordion title="Complete Dockerfile for Debian (glibc)">
+
+```dockerfile
+# --- UI Build Stage: Build the Next.js frontend ---
+FROM node:24-bookworm AS ui-builder
+WORKDIR /app
+
+# Copy UI package files and install dependencies
+COPY ui/package*.json ./
+RUN npm ci
+
+# Copy UI source code
+COPY ui/ ./
+
+# Build UI
+RUN npx next build
+RUN node scripts/fix-paths.js
+
+# --- Go Build Stage: Compile the Go binary ---
+FROM golang:1.24.3-bookworm AS builder
+WORKDIR /app
+
+# Install dependencies including gcc for CGO and sqlite
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libc6-dev \
+    libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment for CGO-enabled build (required for go-sqlite3 and plugins)
+ENV CGO_ENABLED=1 GOOS=linux
+
+COPY transports/go.mod transports/go.sum ./
+RUN go mod download
+
+# Copy source code and dependencies
+COPY transports/ ./
+
+COPY --from=ui-builder /app/out ./bifrost-http/ui
+
+# Build the binary with CGO enabled for DYNAMIC LINKING
+ENV GOWORK=off
+ARG VERSION=unknown
+RUN go build \
+    -ldflags="-w -s -X main.Version=v${VERSION}" \
+    -a -trimpath \
+    -o /app/main \
+    ./bifrost-http
+
+# Verify build succeeded
+RUN test -f /app/main || (echo "Build failed" && exit 1)
+
+# --- Runtime Stage: Minimal runtime image ---
+FROM debian:bookworm-slim
+WORKDIR /app
+
+# Install runtime dependencies for CGO-enabled dynamic binary
+# libc6: GNU C Library (required for glibc-linked binaries)
+# ca-certificates: For HTTPS connections
+RUN apt-get update && apt-get install -y \
+    libc6 \
+    ca-certificates \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create data directory and set up user
+COPY --from=builder /app/main .
+COPY --from=builder /app/docker-entrypoint.sh .
+
+# Getting arguments
+ARG ARG_APP_PORT=8080
+ARG ARG_APP_HOST=0.0.0.0
+ARG ARG_LOG_LEVEL=info
+ARG ARG_LOG_STYLE=json
+ARG ARG_APP_DIR=/app/data
+
+# Environment variables with defaults (can be overridden at runtime)
+ENV APP_PORT=$ARG_APP_PORT \
+    APP_HOST=$ARG_APP_HOST \
+    LOG_LEVEL=$ARG_LOG_LEVEL \
+    LOG_STYLE=$ARG_LOG_STYLE \
+    APP_DIR=$ARG_APP_DIR
+
+RUN mkdir -p $APP_DIR/logs && \
+    useradd -m -s /bin/sh appuser && \
+    chown -R appuser:appuser /app && \
+    chmod +x /app/docker-entrypoint.sh
+USER appuser
+
+# Declare volume for data persistence
+VOLUME ["/app/data"]
+EXPOSE $APP_PORT
+
+# Health check for container status monitoring
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${APP_PORT}/metrics || exit 1
+
+# Use entrypoint script that handles volume permissions and argument processing
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/main"]
+```
+
+</Accordion>
+
+**Key differences from Alpine version:**
+- Uses `bookworm` (Debian 12) base images instead of Alpine
+- Installs `apt` packages instead of `apk`
+- Runtime uses glibc (libc6) instead of musl
+- Uses `useradd` instead of `adduser` for user creation
+
+**Build and run:**
+
+```bash
+# Build the image
+docker build -f transports/Dockerfile.debian -t bifrost:dynamic-debian .
+
+# Run the container
+docker run -p 8080:8080 -v ./plugins:/app/data/plugins bifrost:dynamic-debian
+```
+
+## libc Compatibility
+
+Understanding libc (C standard library) compatibility is **critical** when building dynamic binaries and plugins.
+
+### musl vs glibc
+
+Linux distributions use one of two main C standard libraries:
+
+| libc Type | Used By | Characteristics |
+|-----------|---------|-----------------|
+| **musl** | Alpine Linux | Lightweight, minimal, security-focused |
+| **glibc** | Debian, Ubuntu, RHEL, CentOS, Fedora, Amazon Linux | Standard GNU C Library, feature-rich |
+
+### The Golden Rule
+
+<Warning>
+- **A binary built with musl will NOT run on glibc systems.**
+- **A binary built with glibc will NOT run on musl systems.**
+- **Plugins and Bifrost MUST use the same libc.**
+</Warning>
+
+### Why This Matters
+
+When you build a dynamic binary:
+
+```bash
+# Built on Alpine (musl)
+$ ldd bifrost-http
+        linux-vdso.so.1
+        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1
+
+# Built on Debian (glibc)
+$ ldd bifrost-http
+        linux-vdso.so.1
+        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
+```
+
+The binary is linked to a **specific** libc implementation. If you try to run it on a system with a different libc, you'll get errors like:
+
+```
+error while loading shared libraries: libc.musl-x86_64.so.1: cannot open shared object file
+```
+
+### Choosing Your Build Environment
+
+**Decision Matrix:**
+
+| Target Deployment | Build With | Dockerfile Base |
+|-------------------|------------|-----------------|
+| Alpine containers | musl | `golang:1.24.3-alpine3.22` |
+| Debian/Ubuntu containers | glibc | `golang:1.24.3-bookworm` |
+| Ubuntu/Debian servers | glibc | `golang:1.24.3-bookworm` |
+| RHEL/CentOS servers | glibc | Native build or glibc container |
+| Kubernetes (Alpine) | musl | `golang:1.24.3-alpine3.22` |
+| Kubernetes (Debian) | glibc | `golang:1.24.3-bookworm` |
+
+**Simple rule:** Build with the same base OS family as your deployment target.
+
+### Building Plugins
+
+Plugins **must** be built with the **exact same environment** as your Bifrost binary:
+
+```bash
+# If Bifrost was built with Alpine/musl
+docker run --rm \
+  -v "$PWD:/work" \
+  -w /work \
+  golang:1.24.3-alpine3.22 \
+  sh -c "apk add --no-cache gcc musl-dev && \
+         go build -buildmode=plugin -o myplugin.so main.go"
+
+# If Bifrost was built with Debian/glibc  
+docker run --rm \
+  -v "$PWD:/work" \
+  -w /work \
+  golang:1.24.3-bookworm \
+  sh -c "apt-get update && apt-get install -y gcc && \
+         go build -buildmode=plugin -o myplugin.so main.go"
+```
+
+See the [hello-world plugin Makefile](https://github.com/maximhq/bifrost/blob/main/examples/plugins/hello-world/Makefile) for a complete example.
+
+## Verification
+
+### Verify Dynamic Linking
+
+After building, check that your binary is dynamically linked:
+
+```bash
+# Check binary dependencies
+ldd tmp/bifrost-http
+
+# Expected output (musl):
+linux-vdso.so.1
+libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1
+
+# Expected output (glibc):
+linux-vdso.so.1
+libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6
+libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0
+```
+
+If you see `statically linked`, the binary **will not load plugins**.
+
+### Verify Plugin Compatibility
+
+Test that your plugin loads successfully:
+
+```bash
+# Start Bifrost with your plugin configured
+./tmp/bifrost-http -config config.json
+
+# Check logs for plugin initialization
+# Should see: "Plugin loaded successfully: your-plugin-name"
+```
+
+## Go Version and Package Compatibility
+
+### Go Version Requirement
+
+Bifrost is built with **Go 1.24.3**. Your plugin **must** be compiled with the exact same Go version to ensure compatibility.
+
+```bash
+# Check your Go version
+go version
+# Should output: go version go1.24.3 ...
+
+# If you need to install Go 1.24.3
+# Visit: https://go.dev/dl/
+```
+
+### Key Package Versions
+
+Bifrost uses the following key packages across its three main modules that may affect plugin development:
+
+#### Transport Layer (`transports/go.mod`)
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `github.com/bytedance/sonic` | v1.14.1 | High-performance JSON serialization |
+| `github.com/valyala/fasthttp` | v1.67.0 | Fast HTTP server/client |
+| `github.com/fasthttp/router` | v1.5.4 | HTTP router for fasthttp |
+| `github.com/fasthttp/websocket` | v1.5.12 | WebSocket support |
+| `github.com/prometheus/client_golang` | v1.23.0 | Prometheus metrics |
+| `gorm.io/gorm` | v1.31.1 | Database ORM |
+
+#### Core Layer (`core/go.mod`)
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `github.com/bytedance/sonic` | v1.14.1 | High-performance JSON serialization |
+| `github.com/valyala/fasthttp` | v1.67.0 | Fast HTTP client for providers |
+| `github.com/google/uuid` | v1.6.0 | UUID generation |
+| `github.com/rs/zerolog` | v1.34.0 | Zero-allocation JSON logger |
+| `github.com/mark3labs/mcp-go` | v0.41.1 | Model Context Protocol support |
+| `golang.org/x/oauth2` | v0.32.0 | OAuth2 client |
+
+#### Framework Layer (`framework/go.mod`)
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `github.com/redis/go-redis/v9` | v9.14.0 | Redis client for caching |
+| `github.com/weaviate/weaviate-go-client/v5` | v5.5.0 | Weaviate vector store client |
+| `github.com/mattn/go-sqlite3` | v1.14.32 | SQLite3 driver (requires CGO) |
+| `gorm.io/gorm` | v1.31.1 | Database ORM |
+| `gorm.io/driver/sqlite` | v1.6.0 | GORM SQLite driver |
+| `gorm.io/driver/postgres` | v1.6.0 | GORM PostgreSQL driver |
+| `golang.org/x/crypto` | v0.43.0 | Cryptographic functions |
+
+<Note>
+If your plugin imports any of these packages, use compatible versions to avoid runtime issues. Check `transports/go.mod`, `core/go.mod`, and `framework/go.mod` for complete dependency lists.
+</Note>
+
+### Checking Bifrost's Dependencies
+
+To see all dependencies used by Bifrost across its three main modules:
+
+```bash
+# View transport layer dependencies
+cat transports/go.mod
+
+# View core dependencies
+cat core/go.mod
+
+# View framework dependencies
+cat framework/go.mod
+
+# Or list all dependencies for a specific module
+cd transports && go list -m all
+cd ../core && go list -m all
+cd ../framework && go list -m all
+```
+
+### Plugin go.mod Example
+
+When creating a plugin, your `go.mod` should match Bifrost's Go version:
+
+```go
+module github.com/example/my-plugin
+
+go 1.24.3
+
+require (
+    github.com/maximhq/bifrost/core v1.2.26
+    // Optional: Add framework for advanced features
+    // github.com/maximhq/bifrost/framework v1.1.33
+    
+    // Add other dependencies as needed, matching versions from Bifrost's go.mod files
+    // github.com/bytedance/sonic v1.14.1
+    // github.com/rs/zerolog v1.34.0
+)
+```
+
+<Tip>
+Import only the Bifrost modules you need. Most plugins only require `core`. Use `framework` if you need access to config stores, vector stores, or other framework features.
+</Tip>
+
+## Troubleshooting
+
+### Common Errors
+
+#### 1. Cannot load plugin - Go version mismatch
+
+```
+cannot load plugin: plugin was built with a different version of package runtime/internal/sys
+```
+
+**Cause:** Plugin and Bifrost were built with different Go versions.
+
+**Solution:** Use the exact same Go version (Go 1.24.3) for both:
+
+```bash
+# Check Go version used for Bifrost
+./tmp/bifrost-http -version
+
+# Verify your Go version matches
+go version  # Should output: go version go1.24.3
+
+# See full compatibility requirements
+```
+
+Refer to [Go Version and Package Compatibility](#go-version-and-package-compatibility) for details.
+
+#### 2. Shared library not found
+
+```
+error while loading shared libraries: libc.musl-x86_64.so.1: cannot open shared object file
+```
+
+**Cause:** Binary built with musl trying to run on glibc system (or vice versa).
+
+**Solution:** Rebuild with the correct libc for your target system.
+
+#### 3. Plugin architecture mismatch
+
+```
+plugin was built with a different version of package internal/cpu
+```
+
+**Cause:** Plugin and Bifrost built for different architectures (amd64 vs arm64).
+
+**Solution:** Ensure `GOARCH` matches for both builds:
+
+```bash
+# Check architecture
+uname -m  # x86_64 = amd64, aarch64 = arm64
+
+# Build with explicit architecture
+GOARCH=amd64 go build ...
+```
+
+#### 4. Plugin file not found
+
+```
+plugin.Open("myplugin.so"): realpath failed: no such file or directory
+```
+
+**Cause:** Plugin file path is incorrect in config.
+
+**Solution:** Use absolute paths or verify relative paths:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "/app/data/plugins/myplugin.so",
+      "config": {}
+    }
+  ]
+}
+```
+
+## Best Practices
+
+### 1. Document Your Build Environment
+
+Create a `BUILD.md` file documenting:
+- Go version used
+- Base image (Alpine vs Debian)
+- Build commands
+- Target deployment platform
+
+### 2. Use Consistent Tooling
+
+Match Bifrost's exact Go version and key dependencies (see [Go Version and Package Compatibility](#go-version-and-package-compatibility)):
+
+```bash
+# Pin Go version in Dockerfile
+FROM golang:1.24.3-alpine3.22 AS builder
+
+# Pin Go version in Makefile/CI
+GO_VERSION=1.24.3
+```
+
+### 3. Test Plugin Loading Locally
+
+Before deploying, test plugin loading:
+
+```bash
+# Build both Bifrost and plugin
+make build DYNAMIC=1
+cd examples/plugins/hello-world && make build
+
+# Test loading
+./tmp/bifrost-http -config examples/plugins/hello-world/config.json
+```
+
+### 4. Version Your Plugins
+
+Tag plugin builds with version and build info:
+
+```bash
+go build -buildmode=plugin \
+  -ldflags="-X main.Version=v1.0.0 -X main.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  -o myplugin-v1.0.0.so
+```
+
+### 5. Multi-Stage Dockerfiles for Plugins
+
+Build plugins in the same Dockerfile as Bifrost:
+
+```dockerfile
+# Build plugin
+FROM golang:1.24.3-alpine3.22 AS plugin-builder
+WORKDIR /plugin
+COPY plugins/myplugin/ .
+RUN apk add --no-cache gcc musl-dev && \
+    go build -buildmode=plugin -o myplugin.so main.go
+
+# Build Bifrost
+FROM golang:1.24.3-alpine3.22 AS bifrost-builder
+# ... (bifrost build steps)
+
+# Runtime
+FROM alpine:3.22
+COPY --from=bifrost-builder /app/main .
+COPY --from=plugin-builder /plugin/myplugin.so /app/plugins/
+```
+
+This ensures plugins and Bifrost use identical build environments.
+
+## Next Steps
+
+Now that you have a dynamically linked Bifrost binary:
+
+1. **[Write your first plugin](./writing-plugin)** - Learn the plugin API and create custom functionality
+2. **[Deploy with plugins](./deployment)** - Best practices for production deployments
+3. **[Example plugins](https://github.com/maximhq/bifrost/tree/main/examples/plugins)** - Study working examples
+
+<Note>
+For questions or issues with dynamic builds and plugins, visit our [GitHub Discussions](https://github.com/maximhq/bifrost/discussions) or [Discord community](https://discord.gg/bifrost).
+</Note>
+

--- a/docs/plugins/getting-started.mdx
+++ b/docs/plugins/getting-started.mdx
@@ -5,7 +5,7 @@ icon: "book"
 ---
 
 <Note>
-Dynamic plugins are only enabled on Docker builds of the OSS version. If you are using npx, you won't be able to dynamically load the .so files. 
+Dynamic plugins require dynamic builds of Bifrost which are not enabled by default to keep Bifrost setup easier. If you want to build and try custom plugins on OSS read [building dynamically linked Bifrost binary](./building-dynamic-binary)
 </Note>
 
 

--- a/examples/plugins/hello-world/Makefile
+++ b/examples/plugins/hello-world/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean install help test
+.PHONY: all build clean install help test deps
 
 # Note: Go plugins only support Linux and macOS (Darwin)
 # - Native builds: Use native Go compiler
@@ -46,21 +46,30 @@ ifeq ($(UNAME_M),aarch64)
 	HOST_ARCH = arm64
 endif
 
-# Determine if we need Docker for cross-compilation
-USE_DOCKER = no
-ifneq ($(HOST_OS),linux)
-	USE_DOCKER = yes
-endif
+# Build configuration (can be overridden via command line)
+# Example: make build GOOS=linux GOARCH=amd64
+GOOS ?=
+GOARCH ?=
 
 # Output file
 OUTPUT = $(OUTPUT_DIR)/$(PLUGIN_NAME)$(PLUGIN_EXT)
 
 help: ## Show this help message
-	@echo '$(COLOR_BOLD)Usage:$(COLOR_RESET) make [target]'
+	@echo '$(COLOR_BOLD)Usage:$(COLOR_RESET) make [target] [GOOS=...] [GOARCH=...]'
+	@echo ''
+	@echo '$(COLOR_BOLD)Examples:$(COLOR_RESET)'
+	@echo '  make build                           # Build for current platform'
+	@echo '  make build GOOS=linux GOARCH=amd64   # Build for Linux AMD64'
+	@echo '  make build GOOS=darwin GOARCH=arm64  # Build for macOS ARM64'
 	@echo ''
 	@echo '$(COLOR_BOLD)Host System:$(COLOR_RESET)'
 	@echo '  OS:           $(HOST_OS)'
 	@echo '  Architecture: $(HOST_ARCH)'
+	@echo ''
+	@echo '$(COLOR_BOLD)Build Notes:$(COLOR_RESET)'
+	@echo '  - Native builds: Uses local Go compiler with CGO enabled'
+	@echo '  - Cross-compilation: Uses Docker (Linux targets only)'
+	@echo '  - macOS cross-compilation: Only works on macOS hosts'
 	@echo ''
 	@echo '$(COLOR_BOLD)Available targets:$(COLOR_RESET)'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(COLOR_INFO)%-20s$(COLOR_RESET) %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -70,119 +79,51 @@ _clean_build_dir:
 	@rm -rf $(OUTPUT_DIR)
 	@echo "$(COLOR_SUCCESS)✓ Build directory cleaned$(COLOR_RESET)"
 
-build: _clean_build_dir ## Build the plugin for current platform
-	@echo "$(COLOR_INFO)Building plugin for $(PLATFORM)/$(ARCH)...$(COLOR_RESET)"
+build: _clean_build_dir ## Build the plugin (supports: make build GOOS=linux GOARCH=amd64)
 	@mkdir -p $(OUTPUT_DIR)
-	go build --buildmode=plugin -o $(OUTPUT) main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT)$(COLOR_RESET)"
+	@TARGET_OS="$(GOOS)"; \
+	TARGET_ARCH="$(GOARCH)"; \
+	ACTUAL_OS=$$(uname -s | tr '[:upper:]' '[:lower:]'); \
+	ACTUAL_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/;s/arm64/arm64/'); \
+	if [ -z "$$TARGET_OS" ]; then \
+		TARGET_OS=$$ACTUAL_OS; \
+	fi; \
+	if [ -z "$$TARGET_ARCH" ]; then \
+		TARGET_ARCH=$$ACTUAL_ARCH; \
+	fi; \
+	HOST_OS=$$ACTUAL_OS; \
+	HOST_ARCH=$$ACTUAL_ARCH; \
+	echo "$(COLOR_INFO)Host: $$HOST_OS/$$HOST_ARCH | Target: $$TARGET_OS/$$TARGET_ARCH$(COLOR_RESET)"; \
+	if [ "$$TARGET_OS" = "$$HOST_OS" ] && [ "$$TARGET_ARCH" = "$$HOST_ARCH" ]; then \
+		echo "$(COLOR_INFO)Building plugin for $$TARGET_OS/$$TARGET_ARCH (native build)...$(COLOR_RESET)"; \
+		CGO_ENABLED=1 GOOS=$$TARGET_OS GOARCH=$$TARGET_ARCH \
+			go build -buildmode=plugin -ldflags="-w -s" -trimpath -o $(OUTPUT) main.go; \
+		echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT)$(COLOR_RESET)"; \
+	else \
+		echo "$(COLOR_WARNING)Cross-compilation detected: $$HOST_OS/$$HOST_ARCH -> $$TARGET_OS/$$TARGET_ARCH$(COLOR_RESET)"; \
+		echo "$(COLOR_INFO)Using Docker for cross-compilation...$(COLOR_RESET)"; \
+		$(MAKE) _build-with-docker TARGET_OS=$$TARGET_OS TARGET_ARCH=$$TARGET_ARCH; \
+	fi
 
-build-linux-amd64: _clean_build_dir ## Build the plugin for Linux AMD64
-ifeq ($(HOST_OS),linux)
-ifeq ($(HOST_ARCH),amd64)
-	@echo "$(COLOR_INFO)Building plugin for linux/amd64 (native)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so$(COLOR_RESET)"
-else
-	@echo "$(COLOR_INFO)Building plugin for linux/amd64 using Docker...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	docker run --rm --platform linux/amd64 -v "$(PWD):/work" -w /work \
-		-e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 \
-		golang:1.24.3-alpine \
-		go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so$(COLOR_RESET)"
-endif
-else
-	@echo "$(COLOR_INFO)Building plugin for linux/amd64 using Docker...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	docker run --rm --platform linux/amd64 -v "$(PWD):/work" -w /work \
-		-e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 \
-		golang:1.24.3-alpine \
-		go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so$(COLOR_RESET)"
-endif
-
-build-linux-arm64: _clean_build_dir ## Build the plugin for Linux ARM64
-ifeq ($(HOST_OS),linux)
-ifeq ($(HOST_ARCH),arm64)
-	@echo "$(COLOR_INFO)Building plugin for linux/arm64 (native)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	go build -buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-arm64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-arm64.so$(COLOR_RESET)"
-else
-	@echo "$(COLOR_INFO)Building plugin for linux/arm64 using Docker...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	docker run --rm --platform linux/arm64 -v "$(PWD):/work" -w /work \
-		-e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
-		golang:1.24.3-alpine \
-		go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-arm64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-arm64.so$(COLOR_RESET)"
-endif
-else
-	@echo "$(COLOR_INFO)Building plugin for linux/arm64 using Docker...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	docker run --rm --platform linux/arm64 -v "$(PWD):/work" -w /work \
-		-e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
-		golang:1.24.3-alpine \
-		go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-arm64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-arm64.so$(COLOR_RESET)"
-endif
-
-build-darwin-amd64: _clean_build_dir ## Build the plugin for macOS AMD64
-ifeq ($(HOST_OS),darwin)
-ifeq ($(HOST_ARCH),amd64)
-	@echo "$(COLOR_INFO)Building plugin for darwin/amd64 (native)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-amd64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-amd64.so$(COLOR_RESET)"
-else
-	@echo "$(COLOR_INFO)Building plugin for darwin/amd64 (cross-compile)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	GOOS=darwin GOARCH=amd64 go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-amd64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-amd64.so$(COLOR_RESET)"
-endif
-else
-	@echo "$(COLOR_WARNING)⚠ Cannot build macOS plugins on non-macOS systems$(COLOR_RESET)"
-	@exit 1
-endif
-
-build-darwin-arm64: _clean_build_dir ## Build the plugin for macOS ARM64
-ifeq ($(HOST_OS),darwin)
-ifeq ($(HOST_ARCH),arm64)
-	@echo "$(COLOR_INFO)Building plugin for darwin/arm64 (native)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-arm64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-arm64.so$(COLOR_RESET)"
-else
-	@echo "$(COLOR_INFO)Building plugin for darwin/arm64 (cross-compile)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	GOOS=darwin GOARCH=arm64 go build --buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-arm64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-darwin-arm64.so$(COLOR_RESET)"
-endif
-else
-	@echo "$(COLOR_WARNING)⚠ Cannot build macOS plugins on non-macOS systems$(COLOR_RESET)"
-	@exit 1
-endif
-
-build-all: _clean_build_dir ## Build for all supported platforms (based on host OS)
-ifeq ($(HOST_OS),darwin)
-	@$(MAKE) build-linux-amd64 build-linux-arm64 build-darwin-amd64 build-darwin-arm64
-else ifeq ($(HOST_OS),linux)
-	@$(MAKE) build-linux-amd64 build-linux-arm64
-	@echo "$(COLOR_WARNING)⚠ Skipping macOS builds (requires macOS host)$(COLOR_RESET)"
-else
-	@echo "$(COLOR_ERROR)✗ Unsupported host OS: $(HOST_OS)$(COLOR_RESET)"
-	@exit 1
-endif
-
-# Alternative: Cross-compile with CGO (EXPERIMENTAL - may not work reliably)
-# Requires: brew install FiloSottile/musl-cross/musl-cross (for macOS)
-build-linux-amd64-cgo: _clean_build_dir ## [EXPERIMENTAL] Build for Linux AMD64 using cross-compilation with CGO
-	@echo "$(COLOR_WARNING)⚠ Building plugin for linux/amd64 with CGO (experimental)...$(COLOR_RESET)"
-	@mkdir -p $(OUTPUT_DIR)
-	GOOS=linux GOARCH=amd64 CC=x86_64-linux-musl-gcc \
-		go build -buildmode=plugin -o $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so main.go
-	@echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT_DIR)/$(PLUGIN_NAME)-linux-amd64.so$(COLOR_RESET)"
+_build-with-docker: # Internal target for Docker-based cross-compilation
+	@if [ "$(TARGET_OS)" = "linux" ]; then \
+		echo "$(COLOR_INFO)Building for $(TARGET_OS)/$(TARGET_ARCH) in Docker container...$(COLOR_RESET)"; \
+		docker run --rm \
+			--platform linux/$(TARGET_ARCH) \
+			-v "$(PWD):/work" \
+			-w /work \
+			-e CGO_ENABLED=1 \
+			-e GOOS=$(TARGET_OS) \
+			-e GOARCH=$(TARGET_ARCH) \
+			golang:1.24.3-alpine3.22 \
+			sh -c "apk add --no-cache gcc musl-dev && \
+				go build -buildmode=plugin -ldflags='-w -s' -trimpath -o $(OUTPUT) main.go"; \
+		echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT) ($(TARGET_OS)/$(TARGET_ARCH))$(COLOR_RESET)"; \
+	else \
+		echo "$(COLOR_ERROR)✗ Docker cross-compilation only supports Linux targets$(COLOR_RESET)"; \
+		echo "$(COLOR_WARNING)For $(TARGET_OS), please build on a native $(TARGET_OS) machine$(COLOR_RESET)"; \
+		exit 1; \
+	fi
 
 clean: _clean_build_dir ## Remove build artifacts
 	@echo "$(COLOR_INFO)Cleaning build artifacts...$(COLOR_RESET)"


### PR DESCRIPTION
## Add support for dynamic linking builds

This PR adds support for dynamically linked builds of bifrost-http alongside the existing statically linked builds. This enables better support for dynamic plugin loading.

## Changes

- Added a `DYNAMIC` flag to the Makefile that can be used to create dynamically linked builds
- Updated the build process to conditionally use dynamic linking when the flag is set
- Modified Docker-based cross-compilation to support dynamic linking
- Simplified the plugin example Makefile with a more streamlined build process that handles both native and cross-compilation builds

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test static build (default):
```sh
make build
```

Test dynamic build:
```sh
make build DYNAMIC=1
```

Test plugin build:
```sh
cd examples/plugins/hello-world
make build
```

Cross-compile plugin for Linux:
```sh
cd examples/plugins/hello-world
make build GOOS=linux GOARCH=amd64
```

## Breaking changes

- [x] No

## Security considerations

Dynamic linking may have different security implications than static linking, particularly regarding library dependencies and potential for library-based exploits.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable