### PR TITLE
feat: Send back raw requests in BifrostError for better debugging

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1585,6 +1585,10 @@ func (bifrost *Bifrost) handleRequest(ctx context.Context, req *schemas.BifrostR
 
 	provider, model, fallbacks := req.GetRequestFields()
 
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
 	if err := validateRequest(req); err != nil {
 		err.ExtraFields = schemas.BifrostErrorExtraFields{
 			RequestType:    req.RequestType,
@@ -1593,11 +1597,6 @@ func (bifrost *Bifrost) handleRequest(ctx context.Context, req *schemas.BifrostR
 			RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 		}
 		return nil, err
-	}
-
-	// Handle nil context early to prevent blocking
-	if ctx == nil {
-		ctx = bifrost.ctx
 	}
 
 	bifrost.logger.Debug(fmt.Sprintf("Primary provider %s with model %s and %d fallbacks", provider, model, len(fallbacks)))
@@ -1683,6 +1682,10 @@ func (bifrost *Bifrost) handleStreamRequest(ctx context.Context, req *schemas.Bi
 
 	provider, model, fallbacks := req.GetRequestFields()
 
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
 	if err := validateRequest(req); err != nil {
 		err.ExtraFields = schemas.BifrostErrorExtraFields{
 			RequestType:    req.RequestType,
@@ -1691,11 +1694,6 @@ func (bifrost *Bifrost) handleStreamRequest(ctx context.Context, req *schemas.Bi
 			RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 		}
 		return nil, err
-	}
-
-	// Handle nil context early to prevent blocking
-	if ctx == nil {
-		ctx = bifrost.ctx
 	}
 
 	// Try the primary provider first

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -554,6 +554,7 @@ func HandleAnthropicChatCompletionStreaming(
 					RequestType:    schemas.ChatCompletionStreamRequest,
 					Provider:       providerType,
 					ModelRequested: modelName,
+					RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 				}
 				ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger)
@@ -800,6 +801,7 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 					RequestType:    schemas.ResponsesStreamRequest,
 					Provider:       provider.GetProviderKey(),
 					ModelRequested: request.Model,
+					RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 				}
 				ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -104,7 +104,9 @@ func (provider *AzureProvider) completeRequest(ctx context.Context, jsonData []b
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, deployment, latency, openai.ParseOpenAIError(resp, requestType, provider.GetProviderKey(), model)
+		bifrostErr := openai.ParseOpenAIError(resp, requestType, provider.GetProviderKey(), model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, deployment, latency, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
@@ -168,7 +170,9 @@ func (provider *AzureProvider) listModelsByKey(ctx context.Context, key schemas.
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, openai.ParseOpenAIError(resp, schemas.ListModelsRequest, provider.GetProviderKey(), "")
+		bifrostErr := openai.ParseOpenAIError(resp, schemas.ListModelsRequest, provider.GetProviderKey(), "")
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
@@ -477,7 +481,9 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, openai.ParseOpenAIError(resp, schemas.ResponsesRequest, provider.GetProviderKey(), request.Model)
+		bifrostErr := openai.ParseOpenAIError(resp, schemas.ResponsesRequest, provider.GetProviderKey(), request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	response := &schemas.BifrostResponsesResponse{}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -735,6 +735,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 						RequestType:    schemas.ChatCompletionStreamRequest,
 						Provider:       providerName,
 						ModelRequested: request.Model,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
@@ -958,6 +959,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRu
 						RequestType:    schemas.ResponsesStreamRequest,
 						Provider:       providerName,
 						ModelRequested: request.Model,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -458,6 +458,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 						RequestType:    schemas.ChatCompletionStreamRequest,
 						Provider:       providerName,
 						ModelRequested: request.Model,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
@@ -683,6 +684,7 @@ func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRun
 					RequestType:    schemas.ResponsesStreamRequest,
 					Provider:       providerName,
 					ModelRequested: request.Model,
+					RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 				}
 				ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -94,7 +94,9 @@ func (provider *ElevenlabsProvider) listModelsByKey(ctx context.Context, key sch
 		return nil, bifrostErr
 	}
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, parseElevenlabsError(providerName, resp)
+		bifrostErr := parseElevenlabsError(providerName, resp)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	var elevenlabsResponse ElevenlabsListModelsResponse
@@ -226,7 +228,9 @@ func (provider *ElevenlabsProvider) Speech(ctx context.Context, key schemas.Key,
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, parseElevenlabsError(providerName, resp)
+		bifrostErr := parseElevenlabsError(providerName, resp)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	// Get the response body
@@ -346,7 +350,9 @@ func (provider *ElevenlabsProvider) SpeechStream(ctx context.Context, postHookRu
 	// Check for HTTP errors
 	if resp.StatusCode() != fasthttp.StatusOK {
 		defer providerUtils.ReleaseStreamingResponse(resp)
-		return nil, parseElevenlabsError(providerName, resp)
+		bifrostErr := parseElevenlabsError(providerName, resp)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	// Create response channel
@@ -483,7 +489,9 @@ func (provider *ElevenlabsProvider) Transcription(ctx context.Context, key schem
 	}
 	if resp.StatusCode() != fasthttp.StatusOK {
 		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, parseElevenlabsError(providerName, resp)
+		bifrostErr := parseElevenlabsError(providerName, resp)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	responseBody, err := providerUtils.CheckAndDecodeBody(resp)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -539,6 +539,7 @@ func (provider *GeminiProvider) SpeechStream(ctx context.Context, postHookRunner
 							RequestType:    schemas.SpeechStreamRequest,
 							Provider:       providerName,
 							ModelRequested: request.Model,
+							RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 						},
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
@@ -792,6 +793,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx context.Context, postHoo
 						RequestType:    schemas.TranscriptionStreamRequest,
 						Provider:       providerName,
 						ModelRequested: request.Model,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					},
 				}
 				ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -92,6 +92,7 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		bifrostErr := openai.ParseOpenAIError(resp, schemas.ListModelsRequest, providerName, "")
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
 		return nil, bifrostErr
 	}
 

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -144,6 +144,7 @@ func listModelsByKey(
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		bifrostErr := ParseOpenAIError(resp, schemas.ListModelsRequest, providerName, "")
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
 		return nil, bifrostErr
 	}
 
@@ -264,7 +265,9 @@ func HandleOpenAITextCompletionRequest(
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, ParseOpenAIError(resp, schemas.TextCompletionRequest, providerName, request.Model)
+		bifrostErr := ParseOpenAIError(resp, schemas.TextCompletionRequest, providerName, request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
@@ -471,6 +474,7 @@ func HandleOpenAITextCompletionStreaming(
 						Provider:       providerName,
 						ModelRequested: request.Model,
 						RequestType:    schemas.TextCompletionStreamRequest,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &bifrostErr, responseChan, logger)
@@ -645,7 +649,9 @@ func HandleOpenAIChatCompletionRequest(
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, ParseOpenAIError(resp, schemas.ChatCompletionRequest, providerName, request.Model)
+		bifrostErr := ParseOpenAIError(resp, schemas.ChatCompletionRequest, providerName, request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
@@ -879,6 +885,7 @@ func HandleOpenAIChatCompletionStreaming(
 						Provider:       providerName,
 						ModelRequested: request.Model,
 						RequestType:    schemas.ChatCompletionStreamRequest,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &bifrostErr, responseChan, logger)
@@ -905,6 +912,7 @@ func HandleOpenAIChatCompletionStreaming(
 								RequestType:    schemas.ResponsesStreamRequest,
 								Provider:       providerName,
 								ModelRequested: request.Model,
+								RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 							},
 						}
 
@@ -1108,7 +1116,9 @@ func HandleOpenAIResponsesRequest(
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, ParseOpenAIError(resp, schemas.ResponsesRequest, providerName, request.Model)
+		bifrostErr := ParseOpenAIError(resp, schemas.ResponsesRequest, providerName, request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
@@ -1333,6 +1343,7 @@ func HandleOpenAIResponsesStreaming(
 						RequestType:    schemas.ResponsesStreamRequest,
 						Provider:       providerName,
 						ModelRequested: request.Model,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					},
 				}
 
@@ -1456,7 +1467,9 @@ func HandleOpenAIEmbeddingRequest(
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, ParseOpenAIError(resp, schemas.EmbeddingRequest, providerName, request.Model)
+		bifrostErr := ParseOpenAIError(resp, schemas.EmbeddingRequest, providerName, request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
@@ -1529,8 +1542,9 @@ func (provider *OpenAIProvider) Speech(ctx context.Context, key schemas.Key, req
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, ParseOpenAIError(resp, schemas.SpeechRequest, providerName, request.Model)
+		bifrostErr := ParseOpenAIError(resp, schemas.SpeechRequest, providerName, request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	// Get the binary audio data from the response body
@@ -1706,6 +1720,7 @@ func (provider *OpenAIProvider) SpeechStream(ctx context.Context, postHookRunner
 						Provider:       providerName,
 						ModelRequested: request.Model,
 						RequestType:    schemas.SpeechStreamRequest,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &bifrostErr, responseChan, provider.logger)
@@ -1804,8 +1819,9 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
-		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
-		return nil, ParseOpenAIError(resp, schemas.TranscriptionRequest, providerName, request.Model)
+		bifrostErr := ParseOpenAIError(resp, schemas.TranscriptionRequest, providerName, request.Model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
@@ -1979,6 +1995,7 @@ func (provider *OpenAIProvider) TranscriptionStream(ctx context.Context, postHoo
 						Provider:       providerName,
 						ModelRequested: request.Model,
 						RequestType:    schemas.TranscriptionStreamRequest,
+						RawRequest:     schemas.GetRawRequestFromContext(&ctx),
 					}
 					ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &bifrostErr, responseChan, provider.logger)

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -90,7 +90,9 @@ func (provider *PerplexityProvider) completeRequest(ctx context.Context, jsonDat
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK {
 		provider.logger.Debug(fmt.Sprintf("error from %s provider: %s", provider.GetProviderKey(), string(resp.Body())))
-		return nil, latency, openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), model)
+		bifrostErr := openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), model)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, latency, bifrostErr
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -190,9 +190,13 @@ func (provider *VertexProvider) listModelsByKey(ctx context.Context, key schemas
 
 			var errorResp VertexError
 			if err := sonic.Unmarshal(resp.Body(), &errorResp); err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, schemas.Vertex)
+				bifrostErr := providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, schemas.Vertex)
+				bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+				return nil, bifrostErr
 			}
-			return nil, providerUtils.NewProviderAPIError(errorResp.Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+			bifrostErr := providerUtils.NewProviderAPIError(errorResp.Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+			bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+			return nil, bifrostErr
 		}
 
 		// Parse Vertex's response
@@ -459,25 +463,39 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, key schemas.
 					// Try VertexValidationError format (validation errors from Mistral endpoint)
 					var validationErr VertexValidationError
 					if err := sonic.Unmarshal(resp.Body(), &validationErr); err != nil {
-						return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, schemas.Vertex)
+						bifrostErr := providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, schemas.Vertex)
+						bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+						return nil, bifrostErr
 					}
 					if len(validationErr.Detail) > 0 {
-						return nil, providerUtils.NewProviderAPIError(validationErr.Detail[0].Msg, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+						bifrostErr := providerUtils.NewProviderAPIError(validationErr.Detail[0].Msg, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+						bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+						return nil, bifrostErr
 					}
-					return nil, providerUtils.NewProviderAPIError("Unknown error", nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+					bifrostErr := providerUtils.NewProviderAPIError("Unknown error", nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+					bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+					return nil, bifrostErr
 				}
 
-				return nil, providerUtils.NewProviderAPIError(vertexErr.Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+				bifrostErr := providerUtils.NewProviderAPIError(vertexErr.Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+				bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+				return nil, bifrostErr
 			}
 
 			if len(vertexErr) > 0 {
-				return nil, providerUtils.NewProviderAPIError(vertexErr[0].Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+				bifrostErr := providerUtils.NewProviderAPIError(vertexErr[0].Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+				bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+				return nil, bifrostErr
 			}
 
-			return nil, providerUtils.NewProviderAPIError("Unknown error", nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+			bifrostErr := providerUtils.NewProviderAPIError("Unknown error", nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+			bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+			return nil, bifrostErr
 		} else {
 			// OpenAI error format succeeded with valid Error field
-			return nil, providerUtils.NewProviderAPIError(openAIErr.Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+			bifrostErr := providerUtils.NewProviderAPIError(openAIErr.Error.Message, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+			bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+			return nil, bifrostErr
 		}
 	}
 
@@ -818,7 +836,9 @@ func (provider *VertexProvider) Embedding(ctx context.Context, key schemas.Key, 
 		// Try to parse Vertex's error format
 		var vertexError map[string]interface{}
 		if err := sonic.Unmarshal(resp.Body(), &vertexError); err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, schemas.Vertex)
+			bifrostErr := providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, schemas.Vertex)
+			bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+			return nil, bifrostErr
 		}
 
 		// Extract error message from Vertex's error format
@@ -833,7 +853,9 @@ func (provider *VertexProvider) Embedding(ctx context.Context, key schemas.Key, 
 			}
 		}
 
-		return nil, providerUtils.NewProviderAPIError(errorMessage, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+		bifrostErr := providerUtils.NewProviderAPIError(errorMessage, nil, resp.StatusCode(), schemas.Vertex, nil, nil)
+		bifrostErr.ExtraFields.RawRequest = schemas.GetRawRequestFromContext(&ctx)
+		return nil, bifrostErr
 	}
 
 	// Parse Vertex's native embedding response using typed response

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -116,6 +116,7 @@ const (
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                           // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"                     // bool
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool
+	BifrostContextKeyRawRequestBody                      BifrostContextKey = "bifrost-raw-request-body"                         // []byte (raw request body for error debugging)
 	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost)
 )
 
@@ -421,4 +422,21 @@ type BifrostErrorExtraFields struct {
 	Provider       ModelProvider `json:"provider"`
 	ModelRequested string        `json:"model_requested"`
 	RequestType    RequestType   `json:"request_type"`
+	RawRequest     interface{}   `json:"raw_request,omitempty"` // Raw request body for debugging
+}
+
+// GetRawRequestFromContext extracts and parses the raw request body from the context.
+// Returns the parsed request as interface{} or nil if not available or parsing fails.
+func GetRawRequestFromContext(ctx *context.Context) interface{} {
+	if ctx == nil {
+		return nil
+	}
+
+	if rawBody, ok := (*ctx).Value(BifrostContextKeyRawRequestBody).([]byte); ok && len(rawBody) > 0 {
+		var rawRequest interface{}
+		if err := sonic.Unmarshal(rawBody, &rawRequest); err == nil {
+			return rawRequest
+		}
+	}
+	return nil
 }

--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -30,6 +30,11 @@ Bifrost traces comprehensive information for every request, without any changes 
 - **Performance Metrics**: Latency and token usage
 - **Status Information**: Success or error details
 
+### **Error Debugging**
+- **Raw Request Body**: Full JSON request sent to the provider (included in error details)
+- **Error Details**: Complete error messages and codes from providers
+- **Provider Context**: Which provider and model were attempted
+
 ### **Multimodal & Tool Support**
 - **Audio Processing**: Speech synthesis and transcription inputs/outputs
 - **Vision Analysis**: Image URLs and vision model responses

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -366,8 +366,9 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 // textCompletion handles POST /v1/completions - Process text completion requests
 func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
+	rawBody := ctx.PostBody()
 	var req TextRequest
-	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+	if err := sonic.Unmarshal(rawBody, &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
@@ -391,7 +392,7 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 	if req.TextCompletionParameters == nil {
 		req.TextCompletionParameters = &schemas.TextCompletionParameters{}
 	}
-	extraParams, err := extractExtraParams(ctx.PostBody(), textParamsKnownFields)
+	extraParams, err := extractExtraParams(rawBody, textParamsKnownFields)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Failed to extract extra params: %v", err))
 	} else {
@@ -415,6 +416,12 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
 		return
 	}
+
+	// Set raw request body in context for error debugging
+	if len(rawBody) > 0 {
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRawRequestBody, rawBody)
+	}
+
 	if req.Stream != nil && *req.Stream {
 		h.handleStreamingTextCompletion(ctx, bifrostTextReq, bifrostCtx, cancel)
 		return
@@ -437,8 +444,9 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 
 // chatCompletion handles POST /v1/chat/completions - Process chat completion requests
 func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
+	rawBody := ctx.PostBody()
 	var req ChatRequest
-	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+	if err := sonic.Unmarshal(rawBody, &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
@@ -467,7 +475,7 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 		req.ChatParameters = &schemas.ChatParameters{}
 	}
 
-	extraParams, err := extractExtraParams(ctx.PostBody(), chatParamsKnownFields)
+	extraParams, err := extractExtraParams(rawBody, chatParamsKnownFields)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Failed to extract extra params: %v", err))
 	} else {
@@ -490,6 +498,11 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Set raw request body in context for error debugging
+	if len(rawBody) > 0 {
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRawRequestBody, rawBody)
+	}
+
 	if req.Stream != nil && *req.Stream {
 		h.handleStreamingChatCompletion(ctx, bifrostChatReq, bifrostCtx, cancel)
 		return
@@ -509,8 +522,9 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 
 // responses handles POST /v1/responses - Process responses requests
 func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
+	rawBody := ctx.PostBody()
 	var req ResponsesRequest
-	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+	if err := sonic.Unmarshal(rawBody, &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
@@ -539,7 +553,7 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 		req.ResponsesParameters = &schemas.ResponsesParameters{}
 	}
 
-	extraParams, err := extractExtraParams(ctx.PostBody(), responsesParamsKnownFields)
+	extraParams, err := extractExtraParams(rawBody, responsesParamsKnownFields)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Failed to extract extra params: %v", err))
 	} else {
@@ -572,6 +586,11 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Set raw request body in context for error debugging
+	if len(rawBody) > 0 {
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRawRequestBody, rawBody)
+	}
+
 	if req.Stream != nil && *req.Stream {
 		h.handleStreamingResponses(ctx, bifrostResponsesReq, bifrostCtx, cancel)
 		return
@@ -591,8 +610,9 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 
 // embeddings handles POST /v1/embeddings - Process embeddings requests
 func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
+	rawBody := ctx.PostBody()
 	var req EmbeddingRequest
-	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+	if err := sonic.Unmarshal(rawBody, &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
@@ -621,7 +641,7 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 		req.EmbeddingParameters = &schemas.EmbeddingParameters{}
 	}
 
-	extraParams, err := extractExtraParams(ctx.PostBody(), embeddingParamsKnownFields)
+	extraParams, err := extractExtraParams(rawBody, embeddingParamsKnownFields)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Failed to extract extra params: %v", err))
 	} else {
@@ -645,6 +665,11 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Set raw request body in context for error debugging
+	if len(rawBody) > 0 {
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRawRequestBody, rawBody)
+	}
+
 	resp, bifrostErr := h.client.EmbeddingRequest(*bifrostCtx, bifrostEmbeddingReq)
 	if bifrostErr != nil {
 		SendBifrostError(ctx, bifrostErr)
@@ -657,8 +682,9 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 
 // speech handles POST /v1/audio/speech - Process speech completion requests
 func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
+	rawBody := ctx.PostBody()
 	var req SpeechRequest
-	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
+	if err := sonic.Unmarshal(rawBody, &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
@@ -697,7 +723,7 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 		req.SpeechParameters = &schemas.SpeechParameters{}
 	}
 
-	extraParams, err := extractExtraParams(ctx.PostBody(), speechParamsKnownFields)
+	extraParams, err := extractExtraParams(rawBody, speechParamsKnownFields)
 	if err != nil {
 		logger.Warn(fmt.Sprintf("Failed to extract extra params: %v", err))
 	} else {
@@ -718,6 +744,11 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
 		return
+	}
+
+	// Set raw request body in context for error debugging
+	if len(rawBody) > 0 {
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyRawRequestBody, rawBody)
 	}
 
 	if req.StreamFormat != nil && *req.StreamFormat == "sse" {

--- a/ui/app/workspace/logs/views/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/views/logDetailsSheet.tsx
@@ -393,6 +393,30 @@ export function LogDetailSheet({ log, open, onOpenChange }: LogDetailSheetProps)
 								</div>
 							</>
 						)}
+						{log.error_details?.extra_fields?.raw_request && (
+							<>
+								<div className="mt-4 w-full text-left text-sm font-medium">
+									Raw Request to <span className="font-medium capitalize">{log.provider}</span>
+								</div>
+								<div className="w-full rounded-sm border">
+									<CodeEditor
+										className="z-0 w-full"
+										shouldAdjustInitialHeight={true}
+										maxHeight={450}
+										wrap={true}
+										code={JSON.stringify(log.error_details.extra_fields.raw_request, null, 2)}
+										lang="json"
+										readonly={true}
+										options={{
+											scrollBeyondLastLine: false,
+											collapsibleBlocks: true,
+											lineNumbers: "off",
+											alwaysConsumeMouseWheel: false,
+										}}
+									/>
+								</div>
+							</>
+						)}
 					</>
 				)}
 			</SheetContent>

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -219,12 +219,20 @@ export interface ErrorField {
 	event_id?: string;
 }
 
+export interface BifrostErrorExtraFields {
+  provider?: string;
+  model_requested?: string;
+  request_type?: string;
+  raw_request?: unknown;
+}
+
 export interface BifrostError {
 	event_id?: string;
 	type?: string;
 	is_bifrost_error: boolean;
 	status_code?: number;
 	error: ErrorField;
+  extra_fields?: BifrostErrorExtraFields;
 }
 
 // Citation and Annotation types


### PR DESCRIPTION
## Summary

This PR enhances error debugging capabilities by capturing and including the raw request body in `BifrostError` responses. When requests fail, developers can now see the exact JSON payload that was sent to the AI provider, making it significantly easier to diagnose and fix issues related to malformed requests or parameter mismatches.

## Changes

- **Core Changes**: Added `RawRequest` field to `BifrostErrorExtraFields` struct to store parsed request body
- **Context Handling**: Introduced `BifrostContextKeyRawRequestBody` constant and `GetRawRequestFromContext()` helper function
- **Provider Updates**: Updated all provider error paths (OpenAI, Anthropic, Azure, Bedrock, Cohere, Gemini, Mistral, Perplexity, Vertex, ElevenLabs) to include raw request in error responses
- **HTTP Transport**: Modified inference handlers to capture raw request body before parsing and store it in context
- **Integration Router**: Enhanced generic router to preserve raw request body across all integration endpoints and include it in error responses
- **UI Enhancement**: Added "Raw Request" section in log details sheet to display the exact request sent to providers
- **Documentation**: Updated observability documentation to highlight the new error debugging capabilities

### Design Decisions
- Stored raw request as `interface{}` after JSON parsing to provide structured data in error responses
- Only included raw request in error scenarios to minimize memory overhead during successful operations
- Added helper functions to safely extract and parse raw request from context, with proper nil checks

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

### 1. Start the Bifrost server

```sh
# Start Bifrost with default configuration
make dev
```

The server will start on `http://localhost:8080` (API) and the UI will be available at `http://localhost:3000`.

### 2. Test error scenarios with raw request debugging

Send a request with intentional errors (e.g., typo in JSON field name like "rolee" instead of "role"):

```sh
# Test with typo in role field - should trigger an error
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"azure/gpt-4.1","messages":[{"rolee":"user","content":"hi"}]}'

# Test with wrong model name - should trigger an error
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"azure/gpt-unknown","messages":[{"role":"user","content":"hi"}]}'
```

### 3. Verify in UI

Open the Bifrost UI to check the error logs:

```
http://localhost:3000/workspace/logs
```

**Steps:**
1. Navigate to **Workspace > Logs** in the UI
2. Find the failed request in the logs table (should have an error status)
3. Click on the log entry to open the details sheet
4. Scroll down to see the **"Raw Request to \<provider\>"** section
5. Verify the exact JSON request that was sent is displayed with syntax highlighting

## Screenshots/Recordings

### UI Changes - Log Details Sheet

**Before:**
Error details showed error message and code but not the original request that caused the error.
<img width="1287" height="701" alt="Screenshot from 2025-11-19 15-43-29" src="https://github.com/user-attachments/assets/42ac4fac-e800-4c64-9c96-b8012df87a07" />

**After:**
Error details now include a "Raw Request to \<provider\>" section showing the exact JSON request body that was sent:
<img width="1278" height="701" alt="Screenshot from 2025-11-19 15-43-42" src="https://github.com/user-attachments/assets/11c33a7b-1fe3-4c39-bb83-d5b62a051650" />

## Breaking changes

- [ ] Yes
- [x] No

No breaking changes. This is a purely additive feature that enhances existing error responses with additional debug information.

## Related issues

[Feature]: Send back raw requests in BifrostError for better debugging [#673](https://github.com/maximhq/bifrost/issues/673)

## Security considerations

- API keys passed in request headers are NOT included (headers are separate from body)

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable