### PR TITLE
updates API spec to include name

### DIFF
--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -4326,9 +4326,15 @@
       "Key": {
         "type": "object",
         "required": [
+          "name",
           "value"
         ],
         "properties": {
+          "name": {
+            "type": "string",
+            "description": "Unique name for the API key",
+            "example": "openai-key-1"
+          },
           "value": {
             "type": "string",
             "description": "API key value or environment variable reference",

--- a/docs/features/custom-providers.mdx
+++ b/docs/features/custom-providers.mdx
@@ -53,7 +53,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai-custom",
     "keys": [
         {
-            "name" "openai-custom-key-1",
+            "name": "openai-custom-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -92,7 +92,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai-custom": {
             "keys": [
                 {
-                    "name" "openai-custom-key-1",
+                    "name": "openai-custom-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -285,7 +285,7 @@ The field accepts a mapping of request types to custom paths:
 ```json
 {
     "custom-llm": {
-        "keys": [{ "name" "custom-llm-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "custom-llm-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "network_config": {
             "base_url": "https://your-openai-compatible-endpoint.com"
         },
@@ -315,7 +315,7 @@ Create different configurations for production, staging, and development environ
 ```json
 {
     "openai-production": {
-        "keys": [{ "name" "openai-prod-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-prod-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -328,7 +328,7 @@ Create different configurations for production, staging, and development environ
         }
     },
     "openai-staging": {
-        "keys": [{ "name" "openai-stage-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-stage-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -341,7 +341,7 @@ Create different configurations for production, staging, and development environ
         }
     },
     "openai-dev": {
-        "keys": [{ "name" "openai-dev-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-dev-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -363,7 +363,7 @@ Restrict capabilities based on user roles or team permissions. You can then crea
 ```json
 {
     "openai-developers": {
-        "keys": [{ "name" "openai-developers-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-developers-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -375,7 +375,7 @@ Restrict capabilities based on user roles or team permissions. You can then crea
         }
     },
     "openai-analysts": {
-        "keys": [{ "name" "openai-analysts-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-analysts-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -385,7 +385,7 @@ Restrict capabilities based on user roles or team permissions. You can then crea
         }
     },
     "openai-support": {
-        "keys": [{ "name" "openai-support-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-support-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -404,7 +404,7 @@ Test new features with limited user groups:
 ```json
 {
     "openai-beta-streaming": {
-        "keys": [{ "name" "openai-streaming-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-streaming-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -415,7 +415,7 @@ Test new features with limited user groups:
         }
     },
     "openai-stable": {
-        "keys": [{ "name" "openai-stable-key-1" "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-stable-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -36,13 +36,13 @@ curl -X POST http://localhost:8080/api/providers \
     "provider": "openai",
     "keys": [
       {
-        "name" "openai-key-1",
+        "name": "openai-key-1",
         "value": "env.OPENAI_API_KEY_1",
         "models": ["gpt-4o", "gpt-4o-mini"],
         "weight": 0.7
       },
       {
-        "name" "openai-key-2",
+        "name": "openai-key-2",
         "value": "env.OPENAI_API_KEY_2", 
         "models": [],
         "weight": 0.3
@@ -176,13 +176,13 @@ Keys can be restricted to specific models for access control and cost management
 {
   "keys": [
     {
-      "name" "openai-pre-key-1",
+      "name": "openai-pre-key-1",
       "value": "premium-key",
       "models": ["gpt-4o", "o1-preview"],  // Only premium models
       "weight": 1.0
     },
     {
-      "name" "openai-std-key-1",
+      "name": "openai-std-key-1",
       "value": "standard-key", 
       "models": ["gpt-4o-mini", "gpt-3.5-turbo"], // Only standard models
       "weight": 1.0

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -32,7 +32,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -47,7 +47,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "anthropic",
     "keys": [
         {
-            "name" "anthropic-key-1",
+            "name": "anthropic-key-1",
             "value": "env.ANTHROPIC_API_KEY",
             "models": [],
             "weight": 1.0
@@ -62,7 +62,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "vllm-local",
     "keys": [
         {
-            "name" "vllm-key-1",
+            "name": "vllm-key-1",
             "value": "dummy",
             "models": [],
             "weight": 1.0
@@ -209,13 +209,13 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY_1",
             "models": [],
             "weight": 0.7
         },
         {
-            "name" "openai-key-2",
+            "name": "openai-key-2",
             "value": "env.OPENAI_API_KEY_2", 
             "models": [],
             "weight": 0.3
@@ -234,13 +234,13 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY_1",
                     "models": [],
                     "weight": 0.7
                 },
                 {
-                    "name" "openai-key-2",
+                    "name": "openai-key-2",
                     "value": "env.OPENAI_API_KEY_2",
                     "models": [],
                     "weight": 0.3
@@ -281,13 +281,13 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": ["gpt-4o", "gpt-4o-mini"],
             "weight": 1.0
         },
         {
-            "name" "openai-key-2",
+            "name": "openai-key-2",
             "value": "env.OPENAI_API_KEY_PREMIUM",
             "models": ["o1-preview", "o1-mini"],
             "weight": 1.0
@@ -306,13 +306,13 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": ["gpt-4o", "gpt-4o-mini"],
                     "weight": 1.0
                 },
                 {
-                    "name" "openai-key-2",
+                    "name": "openai-key-2",
                     "value": "env.OPENAI_API_KEY_PREMIUM",
                     "models": ["o1-preview", "o1-mini"],
                     "weight": 1.0
@@ -353,7 +353,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -379,7 +379,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -428,7 +428,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -452,7 +452,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -499,7 +499,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -518,7 +518,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "anthropic", 
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.ANTHROPIC_API_KEY",
             "models": [],
             "weight": 1.0
@@ -541,7 +541,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -555,7 +555,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "anthropic": {
             "keys": [
                 {
-                    "name" "anthropic-key-1",
+                    "name": "anthropic-key-1",
                     "value": "env.ANTHROPIC_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -602,7 +602,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -621,7 +621,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "anthropic",
     "keys": [
         {
-            "name" "anthropic-key-1",
+            "name": "anthropic-key-1",
             "value": "env.ANTHROPIC_API_KEY",
             "models": [],
             "weight": 1.0
@@ -646,7 +646,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -660,7 +660,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "anthropic": {
             "keys": [
                 {
-                    "name" "anthropic-key-1",
+                    "name": "anthropic-key-1",
                     "value": "env.ANTHROPIC_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -706,7 +706,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "openai",
     "keys": [
         {
-            "name" "openai-key-1",
+            "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
             "models": [],
             "weight": 1.0
@@ -726,7 +726,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "openai": {
             "keys": [
                 {
-                    "name" "openai-key-1",
+                    "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
                     "models": [],
                     "weight": 1.0
@@ -789,7 +789,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "azure",
     "keys": [
         {
-            "name" "azure-key-1",
+            "name": "azure-key-1",
             "value": "env.AZURE_API_KEY",
             "models": ["gpt-4o", "gpt-4o-mini"],
             "weight": 1.0,
@@ -816,7 +816,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "azure": {
             "keys": [
                 {
-                    "name" "azure-key-1",
+                    "name": "azure-key-1",
                     "value": "env.AZURE_API_KEY",
                     "models": ["gpt-4o", "gpt-4o-mini"],
                     "weight": 1.0,
@@ -869,7 +869,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "bedrock",
     "keys": [
         {
-            "name" "bedrock-key-1",
+            "name": "bedrock-key-1",
             "models": ["anthropic.claude-3-sonnet-20240229-v1:0", "anthropic.claude-v2:1"],
             "weight": 1.0,
             "bedrock_key_config": {
@@ -897,7 +897,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "bedrock": {
             "keys": [
                 {
-                    "name" "bedrock-key-1",
+                    "name": "bedrock-key-1",
                     "models": ["anthropic.claude-3-sonnet-20240229-v1:0", "anthropic.claude-v2:1"],
                     "weight": 1.0,
                     "bedrock_key_config": {
@@ -954,7 +954,7 @@ curl --location 'http://localhost:8080/api/providers' \
     "provider": "vertex",
     "keys": [
         {
-            "name" "vertex-key-1",
+            "name": "vertex-key-1",
             "value": "env.VERTEX_API_KEY",
             "models": ["gemini-pro", "gemini-pro-vision"],
             "weight": 1.0,
@@ -981,7 +981,7 @@ curl --location 'http://localhost:8080/api/providers' \
         "vertex": {
             "keys": [
                 {
-                    "name" "vertex-key-1",
+                    "name": "vertex-key-1",
                     "value": "env.VERTEX_API_KEY",
                     "models": ["gemini-pro", "gemini-pro-vision"],
                     "weight": 1.0,

--- a/docs/quickstart/gateway/setting-up.mdx
+++ b/docs/quickstart/gateway/setting-up.mdx
@@ -149,7 +149,7 @@ Create `config.json` in your app directory:
     "openai": {
       "keys": [
         {
-          "name" "openai-key-1",
+          "name": "openai-key-1",
           "value": "env.OPENAI_API_KEY",
           "models": ["gpt-4o-mini", "gpt-4o"],
           "weight": 1.0


### PR DESCRIPTION
## Add required `name` field to API key schema and fix documentation examples

This PR adds the `name` field as a required property in the API key schema and fixes numerous documentation examples where the `name` field was missing a colon in the JSON syntax.

## Changes

- Added `name` as a required field in the OpenAPI schema for API keys
- Added description and example for the `name` field in the schema
- Fixed JSON syntax in documentation examples where `"name" "key-name"` was incorrectly formatted (missing colon)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the OpenAPI schema correctly shows `name` as a required field:

```sh
# Check the updated OpenAPI schema
cat docs/apis/openapi.json | grep -A 10 "\"Key\": {"
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. This is a documentation and schema update only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable