### PR TITLE
refactor: move MCP manager to dedicated package with agent mode support

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -523,7 +523,7 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 
 	// Check if we should enter agent mode
 	if bifrost.mcpManager != nil {
-		return bifrost.mcpManager.CheckAndExecuteAgentMode(&ctx, req, response.ChatResponse, bifrost)
+		return bifrost.mcpManager.CheckAndExecuteAgent(ctx, req, response.ChatResponse, bifrost)
 	}
 
 	//TODO: Release the response
@@ -1148,10 +1148,7 @@ func (bifrost *Bifrost) GetMCPClients() ([]schemas.MCPClient, error) {
 		return nil, fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	clients, err := bifrost.mcpManager.GetClients()
-	if err != nil {
-		return nil, err
-	}
+	clients := bifrost.mcpManager.GetClients()
 
 	clientsInConfig := make([]schemas.MCPClient, 0, len(clients))
 	for _, client := range clients {
@@ -1775,7 +1772,7 @@ func (bifrost *Bifrost) tryRequest(ctx context.Context, req *schemas.BifrostRequ
 		req.RequestType != schemas.SpeechRequest &&
 		req.RequestType != schemas.TranscriptionRequest &&
 		bifrost.mcpManager != nil {
-		req = bifrost.mcpManager.AddMCPToolsToBifrostRequest(ctx, req)
+		req = bifrost.mcpManager.AddToolsToRequest(ctx, req)
 	}
 
 	pipeline := bifrost.getPluginPipeline()
@@ -1861,7 +1858,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx context.Context, req *schemas.Bifro
 
 	// Add MCP tools to request if MCP is configured and requested
 	if req.RequestType != schemas.SpeechStreamRequest && req.RequestType != schemas.TranscriptionStreamRequest && bifrost.mcpManager != nil {
-		req = bifrost.mcpManager.AddMCPToolsToBifrostRequest(ctx, req)
+		req = bifrost.mcpManager.AddToolsToRequest(ctx, req)
 	}
 
 	pipeline := bifrost.getPluginPipeline()

--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// ExecuteAgentMode handles the agent mode execution loop
-func CheckAndExecuteAgentMode(
+// ExecuteAgent handles the agent mode execution loop
+func ExecuteAgent(
 	ctx *context.Context,
 	maxAgentDepth int,
 	originalReq *schemas.BifrostChatRequest,
@@ -17,29 +18,8 @@ func CheckAndExecuteAgentMode(
 	llmCaller schemas.BifrostLLMCaller,
 	fetchNewRequestIDFunc func(ctx context.Context) string,
 	executeToolFunc func(ctx context.Context, toolCall schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, error),
+	clientForToolFetcherFunc func(toolName string) *schemas.MCPClientState, // Function to get the client for a tool
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	if llmCaller == nil {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: false,
-			Error: &schemas.ErrorField{
-				Message: "llmCaller is required to execute agent mode",
-			},
-		}
-	}
-	if executeToolFunc == nil {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: false,
-			Error: &schemas.ErrorField{
-				Message: "executeToolFunc is required to execute agent mode",
-			},
-		}
-	}
-	// Check if initial response has tool calls
-	if !hasToolCalls(initialResponse) {
-		logger.Debug("No tool calls detected, returning initial response")
-		return initialResponse, nil
-	}
-
 	logger.Debug("Entering agent mode - detected tool calls in response")
 
 	// Create conversation history starting with original messages
@@ -50,6 +30,10 @@ func CheckAndExecuteAgentMode(
 
 	currentResponse := initialResponse
 	depth := 0
+
+	// Track all executed tool results and tool calls across all iterations
+	allExecutedToolResults := make([]*schemas.ChatMessage, 0)
+	allExecutedToolCalls := make([]schemas.ChatAssistantMessageToolCall, 0)
 
 	originalRequestID, ok := (*ctx).Value(schemas.BifrostContextKeyRequestID).(string)
 	if ok {
@@ -64,52 +48,97 @@ func CheckAndExecuteAgentMode(
 
 		logger.Debug(fmt.Sprintf("Agent mode depth %d: executing %d tool calls", depth, len(toolCalls)))
 
-		// Add assistant message with tool calls to conversation
-		assistantMessage := &schemas.ChatMessage{
-			Role: schemas.ChatMessageRoleAssistant,
-			ChatAssistantMessage: &schemas.ChatAssistantMessage{
-				ToolCalls: toolCalls,
-			},
-		}
+		// Separate tools into auto-executable and non-auto-executable groups
+		var autoExecutableTools []schemas.ChatAssistantMessageToolCall
+		var nonAutoExecutableTools []schemas.ChatAssistantMessageToolCall
 
-		// Add content if present
-		if len(currentResponse.Choices) > 0 &&
-			currentResponse.Choices[0].ChatNonStreamResponseChoice != nil &&
-			currentResponse.Choices[0].ChatNonStreamResponseChoice.Message != nil &&
-			currentResponse.Choices[0].ChatNonStreamResponseChoice.Message.Content != nil {
-			assistantMessage.Content = currentResponse.Choices[0].ChatNonStreamResponseChoice.Message.Content
-		}
-
-		conversationHistory = append(conversationHistory, *assistantMessage)
-
-		// Execute all tool calls parallelly
-		wg := sync.WaitGroup{}
-		wg.Add(len(toolCalls))
-		channelToolResults := make(chan *schemas.ChatMessage, len(toolCalls))
 		for _, toolCall := range toolCalls {
-			go func(toolCall schemas.ChatAssistantMessageToolCall) {
-				defer wg.Done()
-				toolResult, toolErr := executeToolFunc(*ctx, toolCall)
-				if toolErr != nil {
-					logger.Warn(fmt.Sprintf("Tool execution failed: %v", toolErr))
-					channelToolResults <- createToolResultMessage(toolCall, "", toolErr)
-				} else {
-					channelToolResults <- toolResult
-				}
-			}(toolCall)
-		}
-		wg.Wait()
-		close(channelToolResults)
+			if toolCall.Function.Name == nil {
+				// Skip tools without names
+				nonAutoExecutableTools = append(nonAutoExecutableTools, toolCall)
+				continue
+			}
 
-		// Collect tool results
-		toolResults := make([]*schemas.ChatMessage, 0, len(toolCalls))
-		for toolResult := range channelToolResults {
-			toolResults = append(toolResults, toolResult)
+			toolName := *toolCall.Function.Name
+			client := clientForToolFetcherFunc(toolName)
+			if client == nil {
+				// If client not found, treat as non-auto-executable
+				logger.Warn(fmt.Sprintf("Client not found for tool %s, treating as non-auto-executable", toolName))
+				nonAutoExecutableTools = append(nonAutoExecutableTools, toolCall)
+				continue
+			}
+
+			// Check if tool can be auto-executed
+			if canAutoExecuteTool(toolName, client.ExecutionConfig) {
+				autoExecutableTools = append(autoExecutableTools, toolCall)
+				logger.Debug(fmt.Sprintf("Tool %s can be auto-executed", toolName))
+			} else {
+				nonAutoExecutableTools = append(nonAutoExecutableTools, toolCall)
+				logger.Debug(fmt.Sprintf("Tool %s cannot be auto-executed", toolName))
+			}
 		}
 
-		// Add tool results to conversation history
-		for _, toolResult := range toolResults {
-			conversationHistory = append(conversationHistory, *toolResult)
+		// Execute auto-executable tools first
+		var executedToolResults []*schemas.ChatMessage
+		if len(autoExecutableTools) > 0 {
+			// Add assistant message with auto-executable tool calls to conversation
+			assistantMessage := &schemas.ChatMessage{
+				Role: schemas.ChatMessageRoleAssistant,
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					ToolCalls: autoExecutableTools,
+				},
+			}
+
+			// Add content if present
+			if len(currentResponse.Choices) > 0 &&
+				currentResponse.Choices[0].ChatNonStreamResponseChoice != nil &&
+				currentResponse.Choices[0].ChatNonStreamResponseChoice.Message != nil &&
+				currentResponse.Choices[0].ChatNonStreamResponseChoice.Message.Content != nil {
+				assistantMessage.Content = currentResponse.Choices[0].ChatNonStreamResponseChoice.Message.Content
+			}
+
+			conversationHistory = append(conversationHistory, *assistantMessage)
+
+			// Execute all auto-executable tool calls parallelly
+			wg := sync.WaitGroup{}
+			wg.Add(len(autoExecutableTools))
+			channelToolResults := make(chan *schemas.ChatMessage, len(autoExecutableTools))
+			for _, toolCall := range autoExecutableTools {
+				go func(toolCall schemas.ChatAssistantMessageToolCall) {
+					defer wg.Done()
+					toolResult, toolErr := executeToolFunc(*ctx, toolCall)
+					if toolErr != nil {
+						logger.Warn(fmt.Sprintf("Tool execution failed: %v", toolErr))
+						channelToolResults <- createToolResultMessage(toolCall, "", toolErr)
+					} else {
+						channelToolResults <- toolResult
+					}
+				}(toolCall)
+			}
+			wg.Wait()
+			close(channelToolResults)
+
+			// Collect tool results
+			executedToolResults = make([]*schemas.ChatMessage, 0, len(autoExecutableTools))
+			for toolResult := range channelToolResults {
+				executedToolResults = append(executedToolResults, toolResult)
+			}
+
+			// Track executed tool results and calls across all iterations
+			allExecutedToolResults = append(allExecutedToolResults, executedToolResults...)
+			allExecutedToolCalls = append(allExecutedToolCalls, autoExecutableTools...)
+
+			// Add tool results to conversation history
+			for _, toolResult := range executedToolResults {
+				conversationHistory = append(conversationHistory, *toolResult)
+			}
+		}
+
+		// If there are non-auto-executable tools, return them immediately without continuing the loop
+		if len(nonAutoExecutableTools) > 0 {
+			logger.Debug(fmt.Sprintf("Found %d non-auto-executable tools, returning them immediately without continuing the loop", len(nonAutoExecutableTools)))
+			// Create response with all executed tool results from all iterations, and non-auto-executable tool calls
+			return createResponseWithExecutedToolsAndNonAutoExecutableCalls(currentResponse, allExecutedToolResults, allExecutedToolCalls, nonAutoExecutableTools), nil
 		}
 
 		// Create new request with updated conversation history
@@ -219,4 +248,113 @@ func createToolResultMessage(toolCall schemas.ChatAssistantMessageToolCall, resu
 			ToolCallID: toolCall.ID,
 		},
 	}
+}
+
+// createResponseWithExecutedToolsAndNonAutoExecutableCalls creates a response that includes:
+// 1. A single choice with text content showing executed tool results
+// 2. Non-auto-executable tool calls
+func createResponseWithExecutedToolsAndNonAutoExecutableCalls(
+	originalResponse *schemas.BifrostChatResponse,
+	executedToolResults []*schemas.ChatMessage,
+	executedToolCalls []schemas.ChatAssistantMessageToolCall,
+	nonAutoExecutableToolCalls []schemas.ChatAssistantMessageToolCall,
+) *schemas.BifrostChatResponse {
+	// Start with a copy of the original response metadata
+	response := &schemas.BifrostChatResponse{
+		ID:      originalResponse.ID,
+		Object:  originalResponse.Object,
+		Created: originalResponse.Created,
+		Model:   originalResponse.Model,
+		Choices: make([]schemas.BifrostResponseChoice, 0),
+	}
+
+	// Build a map from tool call ID to tool name for easy lookup
+	toolCallIDToName := make(map[string]string)
+	for _, toolCall := range executedToolCalls {
+		if toolCall.ID != nil && toolCall.Function.Name != nil {
+			toolCallIDToName[*toolCall.ID] = *toolCall.Function.Name
+		}
+	}
+
+	// Build content text showing executed tool results
+	var contentText string
+	if len(executedToolResults) > 0 {
+		// Format tool results as JSON-like structure
+		toolResultsMap := make(map[string]interface{})
+		for _, toolResult := range executedToolResults {
+			// Get tool name from tool call ID mapping
+			var toolName string
+			if toolResult.ChatToolMessage != nil && toolResult.ChatToolMessage.ToolCallID != nil {
+				toolCallID := *toolResult.ChatToolMessage.ToolCallID
+				if name, ok := toolCallIDToName[toolCallID]; ok {
+					toolName = name
+				} else {
+					toolName = toolCallID // Fallback to tool call ID if name not found
+				}
+			} else {
+				toolName = "unknown_tool"
+			}
+
+			// Extract output from tool result
+			var output interface{}
+			if toolResult.Content != nil {
+				if toolResult.Content.ContentStr != nil {
+					output = *toolResult.Content.ContentStr
+				} else if toolResult.Content.ContentBlocks != nil {
+					// Convert content blocks to a readable format
+					blocks := make([]map[string]interface{}, 0)
+					for _, block := range toolResult.Content.ContentBlocks {
+						blockMap := make(map[string]interface{})
+						blockMap["type"] = string(block.Type)
+						if block.Text != nil {
+							blockMap["text"] = *block.Text
+						}
+						blocks = append(blocks, blockMap)
+					}
+					output = blocks
+				}
+			}
+			toolResultsMap[toolName] = output
+		}
+
+		// Convert to JSON string for display
+		jsonBytes, err := sonic.Marshal(toolResultsMap)
+		if err != nil {
+			// Fallback to simple string representation
+			contentText = fmt.Sprintf("The Output from allowed tools calls is - %v\n\nNow I shall call these tools next...", toolResultsMap)
+		} else {
+			contentText = fmt.Sprintf("The Output from allowed tools calls is - %s\n\nNow I shall call these tools next...", string(jsonBytes))
+		}
+	} else {
+		contentText = "Now I shall call these tools next..."
+	}
+
+	// Create content with the formatted text
+	content := &schemas.ChatMessageContent{
+		ContentStr: &contentText,
+	}
+
+	// Determine finish reason
+	var finishReason *string
+	if len(nonAutoExecutableToolCalls) > 0 {
+		reason := "tool_calls"
+		finishReason = &reason
+	}
+
+	// Create a single choice with the formatted content and non-auto-executable tool calls
+	response.Choices = append(response.Choices, schemas.BifrostResponseChoice{
+		Index:        0,
+		FinishReason: finishReason,
+		ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+			Message: &schemas.ChatMessage{
+				Role:    schemas.ChatMessageRoleAssistant,
+				Content: content,
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					ToolCalls: nonAutoExecutableToolCalls,
+				},
+			},
+		},
+	})
+
+	return response
 }

--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -1,0 +1,222 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ExecuteAgentMode handles the agent mode execution loop
+func CheckAndExecuteAgentMode(
+	ctx *context.Context,
+	maxAgentDepth int,
+	originalReq *schemas.BifrostChatRequest,
+	initialResponse *schemas.BifrostChatResponse,
+	llmCaller schemas.BifrostLLMCaller,
+	fetchNewRequestIDFunc func(ctx context.Context) string,
+	executeToolFunc func(ctx context.Context, toolCall schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, error),
+) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	if llmCaller == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "llmCaller is required to execute agent mode",
+			},
+		}
+	}
+	if executeToolFunc == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "executeToolFunc is required to execute agent mode",
+			},
+		}
+	}
+	// Check if initial response has tool calls
+	if !hasToolCalls(initialResponse) {
+		logger.Debug("No tool calls detected, returning initial response")
+		return initialResponse, nil
+	}
+
+	logger.Debug("Entering agent mode - detected tool calls in response")
+
+	// Create conversation history starting with original messages
+	conversationHistory := make([]schemas.ChatMessage, 0)
+	if originalReq.Input != nil {
+		conversationHistory = append(conversationHistory, originalReq.Input...)
+	}
+
+	currentResponse := initialResponse
+	depth := 0
+
+	originalRequestID, ok := (*ctx).Value(schemas.BifrostContextKeyRequestID).(string)
+	if ok {
+		*ctx = context.WithValue(*ctx, schemas.BifrostMCPAgentOriginalRequestID, originalRequestID)
+	}
+	for depth < maxAgentDepth {
+		toolCalls := extractToolCalls(currentResponse)
+		if len(toolCalls) == 0 {
+			logger.Debug("No more tool calls found, exiting agent mode")
+			break
+		}
+
+		logger.Debug(fmt.Sprintf("Agent mode depth %d: executing %d tool calls", depth, len(toolCalls)))
+
+		// Add assistant message with tool calls to conversation
+		assistantMessage := &schemas.ChatMessage{
+			Role: schemas.ChatMessageRoleAssistant,
+			ChatAssistantMessage: &schemas.ChatAssistantMessage{
+				ToolCalls: toolCalls,
+			},
+		}
+
+		// Add content if present
+		if len(currentResponse.Choices) > 0 &&
+			currentResponse.Choices[0].ChatNonStreamResponseChoice != nil &&
+			currentResponse.Choices[0].ChatNonStreamResponseChoice.Message != nil &&
+			currentResponse.Choices[0].ChatNonStreamResponseChoice.Message.Content != nil {
+			assistantMessage.Content = currentResponse.Choices[0].ChatNonStreamResponseChoice.Message.Content
+		}
+
+		conversationHistory = append(conversationHistory, *assistantMessage)
+
+		// Execute all tool calls parallelly
+		wg := sync.WaitGroup{}
+		wg.Add(len(toolCalls))
+		channelToolResults := make(chan *schemas.ChatMessage, len(toolCalls))
+		for _, toolCall := range toolCalls {
+			go func(toolCall schemas.ChatAssistantMessageToolCall) {
+				defer wg.Done()
+				toolResult, toolErr := executeToolFunc(*ctx, toolCall)
+				if toolErr != nil {
+					logger.Warn(fmt.Sprintf("Tool execution failed: %v", toolErr))
+					channelToolResults <- createToolResultMessage(toolCall, "", toolErr)
+				} else {
+					channelToolResults <- toolResult
+				}
+			}(toolCall)
+		}
+		wg.Wait()
+		close(channelToolResults)
+
+		// Collect tool results
+		toolResults := make([]*schemas.ChatMessage, 0, len(toolCalls))
+		for toolResult := range channelToolResults {
+			toolResults = append(toolResults, toolResult)
+		}
+
+		// Add tool results to conversation history
+		for _, toolResult := range toolResults {
+			conversationHistory = append(conversationHistory, *toolResult)
+		}
+
+		// Create new request with updated conversation history
+		newReq := &schemas.BifrostChatRequest{
+			Provider:  originalReq.Provider,
+			Model:     originalReq.Model,
+			Fallbacks: originalReq.Fallbacks,
+			Params:    originalReq.Params, // Preserve all original parameters including tools
+			Input:     conversationHistory,
+		}
+
+		if fetchNewRequestIDFunc != nil {
+			newID := fetchNewRequestIDFunc(*ctx)
+			if newID != "" {
+				*ctx = context.WithValue(*ctx, schemas.BifrostContextKeyRequestID, newID)
+			}
+		}
+
+		// Make new LLM request
+		response, err := llmCaller.ChatCompletionRequest(*ctx, newReq)
+		if err != nil {
+			logger.Error("Agent mode: LLM request failed: %v", err)
+			return nil, err
+		}
+
+		currentResponse = response
+		depth++
+	}
+
+	// Check if we hit max depth
+	if depth >= maxAgentDepth {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: fmt.Sprintf("Agent mode exceeded maximum depth of %d", maxAgentDepth),
+			},
+		}
+	}
+
+	logger.Debug(fmt.Sprintf("Agent mode completed after %d iterations", depth))
+	return currentResponse, nil
+}
+
+// hasToolCalls checks if a chat response contains tool calls that need to be executed
+func hasToolCalls(response *schemas.BifrostChatResponse) bool {
+	if response == nil || len(response.Choices) == 0 {
+		return false
+	}
+
+	choice := response.Choices[0]
+
+	// Check finish reason
+	if choice.FinishReason != nil && *choice.FinishReason == "tool_calls" {
+		return true
+	}
+
+	// Check if message has tool calls
+	if choice.ChatNonStreamResponseChoice != nil &&
+		choice.ChatNonStreamResponseChoice.Message != nil &&
+		choice.ChatNonStreamResponseChoice.Message.ChatAssistantMessage != nil &&
+		len(choice.ChatNonStreamResponseChoice.Message.ChatAssistantMessage.ToolCalls) > 0 {
+		return true
+	}
+
+	return false
+}
+
+// extractToolCalls extracts tool calls from a chat response
+func extractToolCalls(response *schemas.BifrostChatResponse) []schemas.ChatAssistantMessageToolCall {
+	if !hasToolCalls(response) {
+		return nil
+	}
+
+	var toolCalls []schemas.ChatAssistantMessageToolCall
+	for _, choice := range response.Choices {
+		if choice.ChatNonStreamResponseChoice != nil &&
+			choice.ChatNonStreamResponseChoice.Message != nil &&
+			choice.ChatNonStreamResponseChoice.Message.ChatAssistantMessage != nil {
+			toolCalls = append(toolCalls, choice.ChatNonStreamResponseChoice.Message.ChatAssistantMessage.ToolCalls...)
+		}
+	}
+
+	return toolCalls
+}
+
+// createToolResultMessage creates a tool result message from tool execution
+func createToolResultMessage(toolCall schemas.ChatAssistantMessageToolCall, result string, err error) *schemas.ChatMessage {
+	var content string
+	if err != nil {
+		content = fmt.Sprintf("Error executing tool %s: %s",
+			func() string {
+				if toolCall.Function.Name != nil {
+					return *toolCall.Function.Name
+				}
+				return "unknown"
+			}(), err.Error())
+	} else {
+		content = result
+	}
+
+	return &schemas.ChatMessage{
+		Role: schemas.ChatMessageRoleTool,
+		Content: &schemas.ChatMessageContent{
+			ContentStr: &content,
+		},
+		ChatToolMessage: &schemas.ChatToolMessage{
+			ToolCallID: toolCall.ID,
+		},
+	}
+}

--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -1,0 +1,279 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// MockLLMCaller implements schemas.BifrostLLMCaller for testing
+type MockLLMCaller struct {
+	responses []*schemas.BifrostChatResponse
+	callCount int
+}
+
+func (m *MockLLMCaller) ChatCompletionRequest(ctx context.Context, req *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	if m.callCount >= len(m.responses) {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "no more mock responses available",
+			},
+		}
+	}
+
+	response := m.responses[m.callCount]
+	m.callCount++
+	return response, nil
+}
+
+// MockLogger implements schemas.Logger for testing
+type MockLogger struct{}
+
+func (m *MockLogger) Debug(msg string, args ...any)                     {}
+func (m *MockLogger) Info(msg string, args ...any)                      {}
+func (m *MockLogger) Warn(msg string, args ...any)                      {}
+func (m *MockLogger) Error(msg string, args ...any)                     {}
+func (m *MockLogger) Fatal(msg string, args ...any)                     {}
+func (m *MockLogger) SetLevel(level schemas.LogLevel)                   {}
+func (m *MockLogger) SetOutputType(outputType schemas.LoggerOutputType) {}
+
+func TestHasToolCalls(t *testing.T) {
+	// Test nil response
+	if hasToolCalls(nil) {
+		t.Error("Should return false for nil response")
+	}
+
+	// Test empty choices
+	emptyResponse := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{},
+	}
+	if hasToolCalls(emptyResponse) {
+		t.Error("Should return false for response with empty choices")
+	}
+
+	// Test response with tool_calls finish reason
+	toolCallsResponse := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				FinishReason: schemas.Ptr("tool_calls"),
+			},
+		},
+	}
+	if !hasToolCalls(toolCallsResponse) {
+		t.Error("Should return true for response with tool_calls finish reason")
+	}
+
+	// Test response with actual tool calls
+	responseWithToolCalls := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						ChatAssistantMessage: &schemas.ChatAssistantMessage{
+							ToolCalls: []schemas.ChatAssistantMessageToolCall{
+								{
+									Function: schemas.ChatAssistantMessageToolCallFunction{
+										Name: schemas.Ptr("test_tool"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	if !hasToolCalls(responseWithToolCalls) {
+		t.Error("Should return true for response with tool calls in message")
+	}
+}
+
+func TestExtractToolCalls(t *testing.T) {
+	// Test response without tool calls
+	responseNoTools := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				FinishReason: schemas.Ptr("stop"),
+			},
+		},
+	}
+
+	toolCalls := extractToolCalls(responseNoTools)
+	if len(toolCalls) != 0 {
+		t.Error("Should return empty slice for response without tool calls")
+	}
+
+	// Test response with tool calls
+	expectedToolCalls := []schemas.ChatAssistantMessageToolCall{
+		{
+			ID: schemas.Ptr("call_123"),
+			Function: schemas.ChatAssistantMessageToolCallFunction{
+				Name:      schemas.Ptr("test_tool"),
+				Arguments: `{"param": "value"}`,
+			},
+		},
+	}
+
+	responseWithTools := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						ChatAssistantMessage: &schemas.ChatAssistantMessage{
+							ToolCalls: expectedToolCalls,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actualToolCalls := extractToolCalls(responseWithTools)
+	if len(actualToolCalls) != 1 {
+		t.Errorf("Expected 1 tool call, got %d", len(actualToolCalls))
+	}
+
+	if actualToolCalls[0].Function.Name == nil || *actualToolCalls[0].Function.Name != "test_tool" {
+		t.Error("Tool call name mismatch")
+	}
+}
+
+func TestCheckAndExecuteAgentMode(t *testing.T) {
+	// Set up logger for the test
+	SetLogger(&MockLogger{})
+
+	// Test with response that has no tool calls - should return immediately
+	responseNoTools := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				FinishReason: schemas.Ptr("stop"),
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						Role: schemas.ChatMessageRoleAssistant,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hello, how can I help you?"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	llmCaller := &MockLLMCaller{}
+	originalReq := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: schemas.Ptr("Hello"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	result, err := CheckAndExecuteAgentMode(&ctx, 10, originalReq, responseNoTools, llmCaller, nil, nil)
+	if err != nil {
+		t.Errorf("Expected no error for response without tool calls, got: %v", err)
+	}
+	if result != responseNoTools {
+		t.Error("Expected same response to be returned for response without tool calls")
+	}
+}
+
+func TestCheckAndExecuteAgentMode_MaxDepth(t *testing.T) {
+	// Set up logger for the test
+	SetLogger(&MockLogger{})
+
+	maxDepth := 2
+
+	// Create a response with tool calls that will trigger agent mode
+	createToolCallResponse := func(toolID string) *schemas.BifrostChatResponse {
+		return &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					FinishReason: schemas.Ptr("tool_calls"),
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role: schemas.ChatMessageRoleAssistant,
+							ChatAssistantMessage: &schemas.ChatAssistantMessage{
+								ToolCalls: []schemas.ChatAssistantMessageToolCall{
+									{
+										ID: schemas.Ptr(toolID),
+										Function: schemas.ChatAssistantMessageToolCallFunction{
+											Name:      schemas.Ptr("test_tool"),
+											Arguments: `{}`,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// Create mock LLM caller that always returns responses with tool calls
+	// This will cause the agent mode to loop until max depth is reached
+	initialResponse := createToolCallResponse("call_1")
+	response1 := createToolCallResponse("call_2")
+	response2 := createToolCallResponse("call_3") // This will be called but max depth will be exceeded
+
+	llmCaller := &MockLLMCaller{
+		responses: []*schemas.BifrostChatResponse{
+			response1, // First iteration after initial
+			response2, // Second iteration (will hit max depth)
+		},
+	}
+
+	originalReq := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: schemas.Ptr("Test message"),
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	// Execute agent mode - should hit max depth and return error
+	result, err := CheckAndExecuteAgentMode(&ctx, maxDepth, originalReq, initialResponse, llmCaller, nil, nil)
+
+	// Should return error when max depth is exceeded
+	if err == nil {
+		t.Error("Expected error when max depth is exceeded, got nil")
+	}
+
+	if result != nil {
+		t.Error("Expected nil result when max depth is exceeded")
+	}
+
+	// Verify error message contains max depth information
+	if err != nil && (err.Error == nil || err.Error.Message == "") {
+		t.Error("Expected error message when max depth is exceeded")
+	}
+
+	expectedErrorMsg := fmt.Sprintf("Agent mode exceeded maximum depth of %d", maxDepth)
+	if err.Error.Message != expectedErrorMsg {
+		t.Errorf("Expected error message '%s', got '%s'", expectedErrorMsg, err.Error.Message)
+	}
+
+	// Verify that the LLM was called the expected number of times
+	// Initial response triggers agent mode, then we make maxDepth calls before hitting the limit
+	expectedCalls := maxDepth
+	if llmCaller.callCount != expectedCalls {
+		t.Errorf("Expected %d LLM calls before hitting max depth, got %d", expectedCalls, llmCaller.callCount)
+	}
+}

--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -178,7 +178,7 @@ func TestCheckAndExecuteAgentMode(t *testing.T) {
 
 	ctx := context.Background()
 
-	result, err := CheckAndExecuteAgentMode(&ctx, 10, originalReq, responseNoTools, llmCaller, nil, nil)
+	result, err := ExecuteAgent(&ctx, 10, originalReq, responseNoTools, llmCaller, nil, nil, nil)
 	if err != nil {
 		t.Errorf("Expected no error for response without tool calls, got: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestCheckAndExecuteAgentMode_MaxDepth(t *testing.T) {
 	ctx := context.Background()
 
 	// Execute agent mode - should hit max depth and return error
-	result, err := CheckAndExecuteAgentMode(&ctx, maxDepth, originalReq, initialResponse, llmCaller, nil, nil)
+	result, err := ExecuteAgent(&ctx, maxDepth, originalReq, initialResponse, llmCaller, nil, nil, nil)
 
 	// Should return error when max depth is exceeded
 	if err == nil {

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -1,0 +1,624 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// GetClients returns all MCP clients managed by the manager.
+//
+// Returns:
+//   - []*schemas.MCPClientState: List of all MCP clients
+func (m *MCPManager) GetClients() []schemas.MCPClientState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	clients := make([]schemas.MCPClientState, 0, len(m.clientMap))
+	for _, client := range m.clientMap {
+		clients = append(clients, *client)
+	}
+
+	return clients
+}
+
+// ReconnectClient attempts to reconnect an MCP client if it is disconnected.
+func (m *MCPManager) ReconnectClient(id string) error {
+	m.mu.Lock()
+
+	client, ok := m.clientMap[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s not found", id)
+	}
+
+	m.mu.Unlock()
+
+	// connectToMCPClient handles locking internally
+	err := m.connectToMCPClient(client.ExecutionConfig)
+	if err != nil {
+		return fmt.Errorf("failed to connect to MCP client %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// AddClient adds a new MCP client to the manager.
+// It validates the client configuration and establishes a connection.
+//
+// Parameters:
+//   - config: MCP client configuration
+//
+// Returns:
+func (m *MCPManager) AddClient(config schemas.MCPClientConfig) error {
+	if err := validateMCPClientConfig(&config); err != nil {
+		return fmt.Errorf("invalid MCP client configuration: %w", err)
+	}
+
+	// Make a copy of the config to use after unlocking
+	configCopy := config
+
+	m.mu.Lock()
+
+	if _, ok := m.clientMap[config.ID]; ok {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s already exists", config.Name)
+	}
+
+	// Create placeholder entry
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		ExecutionConfig: config,
+		ToolMap:         make(map[string]schemas.ChatTool),
+	}
+
+	// Temporarily unlock for the connection attempt
+	// This is to avoid deadlocks when the connection attempt is made
+	m.mu.Unlock()
+
+	// Connect using the copied config
+	if err := m.connectToMCPClient(configCopy); err != nil {
+		// Re-lock to clean up the failed entry
+		m.mu.Lock()
+		delete(m.clientMap, config.ID)
+		m.mu.Unlock()
+		return fmt.Errorf("failed to connect to MCP client %s: %w", config.Name, err)
+	}
+
+	return nil
+}
+
+// RemoveClient removes an MCP client from the manager.
+// It handles cleanup for all transport types (HTTP, STDIO, SSE).
+//
+// Parameters:
+//   - id: ID of the client to remove
+func (m *MCPManager) RemoveClient(id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.removeClientUnsafe(id)
+}
+
+func (m *MCPManager) removeClientUnsafe(id string) error {
+	client, ok := m.clientMap[id]
+	if !ok {
+		return fmt.Errorf("client %s not found", id)
+	}
+
+	logger.Info(fmt.Sprintf("%s Disconnecting MCP client: %s", MCPLogPrefix, client.ExecutionConfig.Name))
+
+	// Cancel SSE context if present (required for proper SSE cleanup)
+	if client.CancelFunc != nil {
+		client.CancelFunc()
+		client.CancelFunc = nil
+	}
+
+	// Close the client transport connection
+	// This handles cleanup for all transport types (HTTP, STDIO, SSE)
+	if client.Conn != nil {
+		if err := client.Conn.Close(); err != nil {
+			logger.Error("%s Failed to close MCP client %s: %v", MCPLogPrefix, client.ExecutionConfig.Name, err)
+		}
+		client.Conn = nil
+	}
+
+	// Clear client tool map
+	client.ToolMap = make(map[string]schemas.ChatTool)
+
+	delete(m.clientMap, id)
+	return nil
+}
+
+func (m *MCPManager) EditClient(id string, updatedConfig schemas.MCPClientConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	client, ok := m.clientMap[id]
+	if !ok {
+		return fmt.Errorf("client %s not found", id)
+	}
+
+	// Update the client's execution config with new tool filters
+	config := client.ExecutionConfig
+	config.Name = updatedConfig.Name
+	config.Headers = updatedConfig.Headers
+	config.ToolsToExecute = updatedConfig.ToolsToExecute
+	config.ToolsToAutoExecute = updatedConfig.ToolsToAutoExecute
+
+	// Store the updated config
+	client.ExecutionConfig = config
+
+	if client.Conn == nil {
+		return nil // Client is not connected, so no tools to update
+	}
+
+	// Clear current tool map
+	client.ToolMap = make(map[string]schemas.ChatTool)
+
+	// Temporarily unlock for the network call
+	m.mu.Unlock()
+
+	// Retrieve tools with updated configuration
+	tools, err := retrieveExternalTools(m.ctx, client.Conn)
+
+	// Re-lock to update the tool map
+	m.mu.Lock()
+
+	// Verify client still exists
+	if _, ok := m.clientMap[id]; !ok {
+		return fmt.Errorf("client %s was removed during tool update", id)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to retrieve external tools: %w", err)
+	}
+
+	// Store discovered tools
+	maps.Copy(client.ToolMap, tools)
+
+	return nil
+}
+
+// registerTool registers a typed tool handler with the local MCP server.
+// This is a convenience function that handles the conversion between typed Go
+// handlers and the MCP protocol.
+//
+// Type Parameters:
+//   - T: The expected argument type for the tool (must be JSON-deserializable)
+//
+// Parameters:
+//   - name: Unique tool name
+//   - description: Human-readable tool description
+//   - handler: Typed function that handles tool execution
+//   - toolSchema: Bifrost tool schema for function calling
+//
+// Returns:
+//   - error: Any registration error
+//
+// Example:
+//
+//	type EchoArgs struct {
+//	    Message string `json:"message"`
+//	}
+//
+//	err := bifrost.RegisterMCPTool("echo", "Echo a message",
+//	    func(args EchoArgs) (string, error) {
+//	        return args.Message, nil
+//	    }, toolSchema)
+func (m *MCPManager) RegisterTool(name, description string, toolFunction MCPToolFunction[any], toolSchema schemas.ChatTool) error {
+	// Ensure local server is set up
+	if err := m.setupLocalHost(); err != nil {
+		return fmt.Errorf("failed to setup local host: %w", err)
+	}
+
+	// Verify internal client exists
+	if _, ok := m.clientMap[BifrostMCPClientKey]; !ok {
+		return fmt.Errorf("bifrost client not found")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if tool name already exists to prevent silent overwrites
+	if _, exists := m.clientMap[BifrostMCPClientKey].ToolMap[name]; exists {
+		return fmt.Errorf("tool '%s' is already registered", name)
+	}
+
+	logger.Info(fmt.Sprintf("%s Registering typed tool: %s", MCPLogPrefix, name))
+
+	// Create MCP handler wrapper that converts between typed and MCP interfaces
+	mcpHandler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		// Extract arguments from the request using the request's methods
+		args := request.GetArguments()
+		result, err := toolFunction(args)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Error: %s", err.Error())), nil
+		}
+		return mcp.NewToolResultText(result), nil
+	}
+
+	// Register the tool with the local MCP server using AddTool
+	if m.server != nil {
+		tool := mcp.NewTool(name, mcp.WithDescription(description))
+		m.server.AddTool(tool, mcpHandler)
+	}
+
+	// Store tool definition for Bifrost integration
+	m.clientMap[BifrostMCPClientKey].ToolMap[name] = toolSchema
+
+	return nil
+}
+
+// ============================================================================
+// CONNECTION HELPER METHODS
+// ============================================================================
+
+// connectToMCPClient establishes a connection to an external MCP server and
+// registers its available tools with the manager.
+func (m *MCPManager) connectToMCPClient(config schemas.MCPClientConfig) error {
+	// First lock: Initialize or validate client entry
+	m.mu.Lock()
+
+	// Initialize or validate client entry
+	if existingClient, exists := m.clientMap[config.ID]; exists {
+		// Client entry exists from config, check for existing connection, if it does then close
+		if existingClient.CancelFunc != nil {
+			existingClient.CancelFunc()
+			existingClient.CancelFunc = nil
+		}
+		if existingClient.Conn != nil {
+			existingClient.Conn.Close()
+		}
+		// Update connection type for this connection attempt
+		existingClient.ConnectionInfo.Type = config.ConnectionType
+	}
+	// Create new client entry with configuration
+	m.clientMap[config.ID] = &schemas.MCPClientState{
+		ExecutionConfig: config,
+		ToolMap:         make(map[string]schemas.ChatTool),
+		ConnectionInfo: schemas.MCPClientConnectionInfo{
+			Type: config.ConnectionType,
+		},
+	}
+	m.mu.Unlock()
+
+	// Heavy operations performed outside lock
+	var externalClient *client.Client
+	var connectionInfo schemas.MCPClientConnectionInfo
+	var err error
+
+	// Create appropriate transport based on connection type
+	switch config.ConnectionType {
+	case schemas.MCPConnectionTypeHTTP:
+		externalClient, connectionInfo, err = m.createHTTPConnection(config)
+	case schemas.MCPConnectionTypeSTDIO:
+		externalClient, connectionInfo, err = m.createSTDIOConnection(config)
+	case schemas.MCPConnectionTypeSSE:
+		externalClient, connectionInfo, err = m.createSSEConnection(config)
+	case schemas.MCPConnectionTypeInProcess:
+		externalClient, connectionInfo, err = m.createInProcessConnection(config)
+	default:
+		return fmt.Errorf("unknown connection type: %s", config.ConnectionType)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to create connection: %w", err)
+	}
+
+	// Initialize the external client with timeout
+	// For SSE connections, we need a long-lived context, for others we can use timeout
+	var ctx context.Context
+	var cancel context.CancelFunc
+
+	if config.ConnectionType == schemas.MCPConnectionTypeSSE {
+		// SSE connections need a long-lived context for the persistent stream
+		ctx, cancel = context.WithCancel(m.ctx)
+		// Don't defer cancel here - SSE needs the context to remain active
+	} else {
+		// Other connection types can use timeout context
+		ctx, cancel = context.WithTimeout(m.ctx, MCPClientConnectionEstablishTimeout)
+		defer cancel()
+	}
+
+	// Start the transport first (required for STDIO and SSE clients)
+	if err := externalClient.Start(ctx); err != nil {
+		if config.ConnectionType == schemas.MCPConnectionTypeSSE {
+			cancel() // Cancel SSE context only on error
+		}
+		return fmt.Errorf("failed to start MCP client transport %s: %v", config.Name, err)
+	}
+
+	// Create proper initialize request for external client
+	extInitRequest := mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			Capabilities:    mcp.ClientCapabilities{},
+			ClientInfo: mcp.Implementation{
+				Name:    fmt.Sprintf("Bifrost-%s", config.Name),
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	_, err = externalClient.Initialize(ctx, extInitRequest)
+	if err != nil {
+		if config.ConnectionType == schemas.MCPConnectionTypeSSE {
+			cancel() // Cancel SSE context only on error
+		}
+		return fmt.Errorf("failed to initialize MCP client %s: %v", config.Name, err)
+	}
+
+	// Retrieve tools from the external server (this also requires network I/O)
+	tools, err := retrieveExternalTools(ctx, externalClient)
+	if err != nil {
+		logger.Warn(fmt.Sprintf("%s Failed to retrieve tools from %s: %v", MCPLogPrefix, config.Name, err))
+		// Continue with connection even if tool retrieval fails
+		tools = make(map[string]schemas.ChatTool)
+	}
+
+	// Second lock: Update client with final connection details and tools
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Verify client still exists (could have been cleaned up during heavy operations)
+	if client, exists := m.clientMap[config.ID]; exists {
+		// Store the external client connection and details
+		client.Conn = externalClient
+		client.ConnectionInfo = connectionInfo
+
+		// Store cancel function for SSE connections to enable proper cleanup
+		if config.ConnectionType == schemas.MCPConnectionTypeSSE {
+			client.CancelFunc = cancel
+		}
+
+		// Store discovered tools
+		for toolName, tool := range tools {
+			client.ToolMap[toolName] = tool
+		}
+
+		logger.Info(fmt.Sprintf("%s Connected to MCP client: %s", MCPLogPrefix, config.Name))
+	} else {
+		return fmt.Errorf("client %s was removed during connection setup", config.Name)
+	}
+
+	return nil
+}
+
+// createHTTPConnection creates an HTTP-based MCP client connection without holding locks.
+func (m *MCPManager) createHTTPConnection(config schemas.MCPClientConfig) (*client.Client, schemas.MCPClientConnectionInfo, error) {
+	if config.ConnectionString == nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("HTTP connection string is required")
+	}
+
+	// Prepare connection info
+	connectionInfo := schemas.MCPClientConnectionInfo{
+		Type:          config.ConnectionType,
+		ConnectionURL: config.ConnectionString,
+	}
+
+	// Create StreamableHTTP transport
+	httpTransport, err := transport.NewStreamableHTTP(*config.ConnectionString, transport.WithHTTPHeaders(config.Headers))
+	if err != nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("failed to create HTTP transport: %w", err)
+	}
+
+	client := client.NewClient(httpTransport)
+
+	return client, connectionInfo, nil
+}
+
+// createSTDIOConnection creates a STDIO-based MCP client connection without holding locks.
+func (m *MCPManager) createSTDIOConnection(config schemas.MCPClientConfig) (*client.Client, schemas.MCPClientConnectionInfo, error) {
+	if config.StdioConfig == nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("stdio config is required")
+	}
+
+	// Prepare STDIO command info for display
+	cmdString := fmt.Sprintf("%s %s", config.StdioConfig.Command, strings.Join(config.StdioConfig.Args, " "))
+
+	// Check if environment variables are set
+	for _, env := range config.StdioConfig.Envs {
+		if os.Getenv(env) == "" {
+			return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("environment variable %s is not set for MCP client %s", env, config.Name)
+		}
+	}
+
+	// Create STDIO transport
+	stdioTransport := transport.NewStdio(
+		config.StdioConfig.Command,
+		config.StdioConfig.Envs,
+		config.StdioConfig.Args...,
+	)
+
+	// Prepare connection info
+	connectionInfo := schemas.MCPClientConnectionInfo{
+		Type:               config.ConnectionType,
+		StdioCommandString: &cmdString,
+	}
+
+	client := client.NewClient(stdioTransport)
+
+	// Return nil for cmd since mark3labs/mcp-go manages the process internally
+	return client, connectionInfo, nil
+}
+
+// createSSEConnection creates a SSE-based MCP client connection without holding locks.
+func (m *MCPManager) createSSEConnection(config schemas.MCPClientConfig) (*client.Client, schemas.MCPClientConnectionInfo, error) {
+	if config.ConnectionString == nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("SSE connection string is required")
+	}
+
+	// Prepare connection info
+	connectionInfo := schemas.MCPClientConnectionInfo{
+		Type:          config.ConnectionType,
+		ConnectionURL: config.ConnectionString, // Reuse HTTPConnectionURL field for SSE URL display
+	}
+
+	// Create SSE transport
+	sseTransport, err := transport.NewSSE(*config.ConnectionString, transport.WithHeaders(config.Headers))
+	if err != nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("failed to create SSE transport: %w", err)
+	}
+
+	client := client.NewClient(sseTransport)
+
+	return client, connectionInfo, nil
+}
+
+// createInProcessConnection creates an in-process MCP client connection without holding locks.
+// This allows direct connection to an MCP server running in the same process, providing
+// the lowest latency and highest performance for tool execution.
+func (m *MCPManager) createInProcessConnection(config schemas.MCPClientConfig) (*client.Client, schemas.MCPClientConnectionInfo, error) {
+	if config.InProcessServer == nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("InProcess connection requires a server instance")
+	}
+
+	// Create in-process client directly connected to the provided server
+	inProcessClient, err := client.NewInProcessClient(config.InProcessServer)
+	if err != nil {
+		return nil, schemas.MCPClientConnectionInfo{}, fmt.Errorf("failed to create in-process client: %w", err)
+	}
+
+	// Prepare connection info
+	connectionInfo := schemas.MCPClientConnectionInfo{
+		Type: config.ConnectionType,
+	}
+
+	return inProcessClient, connectionInfo, nil
+}
+
+// ============================================================================
+// LOCAL MCP SERVER AND CLIENT MANAGEMENT
+// ============================================================================
+
+// setupLocalHost initializes the local MCP server and client if not already running.
+// This creates a STDIO-based server for local tool hosting and a corresponding client.
+// This is called automatically when tools are registered or when the server is needed.
+//
+// Returns:
+//   - error: Any setup error
+func (m *MCPManager) setupLocalHost() error {
+	// Check if server is already running
+	if m.server != nil && m.serverRunning {
+		return nil
+	}
+
+	// Create and configure local MCP server (STDIO-based)
+	server, err := m.createLocalMCPServer()
+	if err != nil {
+		return fmt.Errorf("failed to create local MCP server: %w", err)
+	}
+	m.server = server
+
+	// Create and configure local MCP client (STDIO-based)
+	client, err := m.createLocalMCPClient()
+	if err != nil {
+		return fmt.Errorf("failed to create local MCP client: %w", err)
+	}
+	m.clientMap[BifrostMCPClientKey] = client
+
+	// Start the server and initialize client connection
+	return m.startLocalMCPServer()
+}
+
+// createLocalMCPServer creates a new local MCP server instance with STDIO transport.
+// This server will host tools registered via RegisterTool function.
+//
+// Returns:
+//   - *server.MCPServer: Configured MCP server instance
+//   - error: Any creation error
+func (m *MCPManager) createLocalMCPServer() (*server.MCPServer, error) {
+	// Create MCP server
+	mcpServer := server.NewMCPServer(
+		"Bifrost-MCP-Server",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	return mcpServer, nil
+}
+
+// createLocalMCPClient creates a placeholder client entry for the local MCP server.
+// The actual in-process client connection will be established in startLocalMCPServer.
+//
+// Returns:
+//   - *schemas.MCPClientState: Placeholder client for local server
+//   - error: Any creation error
+func (m *MCPManager) createLocalMCPClient() (*schemas.MCPClientState, error) {
+	// Don't create the actual client connection here - it will be created
+	// after the server is ready using NewInProcessClient
+	return &schemas.MCPClientState{
+		ExecutionConfig: schemas.MCPClientConfig{
+			Name: BifrostMCPClientName,
+		},
+		ToolMap: make(map[string]schemas.ChatTool),
+		ConnectionInfo: schemas.MCPClientConnectionInfo{
+			Type: schemas.MCPConnectionTypeInProcess, // Accurate: in-process (in-memory) transport
+		},
+	}, nil
+}
+
+// startLocalMCPServer creates an in-process connection between the local server and client.
+//
+// Returns:
+//   - error: Any startup error
+func (m *MCPManager) startLocalMCPServer() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Check if server is already running
+	if m.server != nil && m.serverRunning {
+		return nil
+	}
+
+	if m.server == nil {
+		return fmt.Errorf("server not initialized")
+	}
+
+	// Create in-process client directly connected to the server
+	inProcessClient, err := client.NewInProcessClient(m.server)
+	if err != nil {
+		return fmt.Errorf("failed to create in-process MCP client: %w", err)
+	}
+
+	// Update the client connection
+	clientEntry, ok := m.clientMap[BifrostMCPClientKey]
+	if !ok {
+		return fmt.Errorf("bifrost client not found")
+	}
+	clientEntry.Conn = inProcessClient
+
+	// Initialize the in-process client
+	ctx, cancel := context.WithTimeout(m.ctx, MCPClientConnectionEstablishTimeout)
+	defer cancel()
+
+	// Create proper initialize request with correct structure
+	initRequest := mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			Capabilities:    mcp.ClientCapabilities{},
+			ClientInfo: mcp.Implementation{
+				Name:    BifrostMCPClientName,
+				Version: BifrostMCPVersion,
+			},
+		},
+	}
+
+	_, err = inProcessClient.Initialize(ctx, initRequest)
+	if err != nil {
+		return fmt.Errorf("failed to initialize MCP client: %w", err)
+	}
+
+	// Mark server as running
+	m.serverRunning = true
+
+	return nil
+}

--- a/core/mcp/default_toolmanager.go
+++ b/core/mcp/default_toolmanager.go
@@ -1,0 +1,229 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+type DefaultToolsHandler struct {
+	toolExecutionTimeout  time.Duration
+	maxAgentDepth         int
+	fetchNewRequestIDFunc func(ctx context.Context) string
+	clientForToolFetcher  func(toolName string) *schemas.MCPClientState
+	toolsGetterFunc       func(ctx context.Context) []schemas.ChatTool
+}
+
+type DefaultHandlerConfig struct {
+	toolExecutionTimeout time.Duration
+	maxAgentDepth        int
+}
+
+func NewDefaultToolsHandler(config *DefaultHandlerConfig) (*DefaultToolsHandler, error) {
+	if config == nil {
+		config = &DefaultHandlerConfig{
+			toolExecutionTimeout: 30 * time.Second,
+			maxAgentDepth:        10,
+		}
+	}
+	if config.maxAgentDepth <= 0 {
+		config.maxAgentDepth = 10
+	}
+	if config.toolExecutionTimeout <= 0 {
+		config.toolExecutionTimeout = 30 * time.Second
+	}
+	return &DefaultToolsHandler{
+		toolExecutionTimeout: config.toolExecutionTimeout,
+		maxAgentDepth:        config.maxAgentDepth,
+	}, nil
+}
+
+// SetupCompleted checks if the handler is fully setup and ready to use.
+func (m *DefaultToolsHandler) SetupCompleted() bool {
+	return m.toolsFetcherFunc != nil && m.clientForToolFetcher != nil && m.fetchNewRequestIDFunc != nil
+}
+
+// SetToolsFetcherFunc sets the function to get the available tools.
+// TO BE CALLED JUST AFTER THE HANDLER IS CREATED AND BEFORE THE FIRST USE.
+func (m *DefaultToolsHandler) SetToolsFetcherFunc(toolsGetterFunc func(ctx context.Context) []schemas.ChatTool) {
+	m.toolsGetterFunc = toolsGetterFunc
+}
+
+// SetClientForToolFetcherFunc sets the function to get the client for a tool.
+// TO BE CALLED JUST AFTER THE HANDLER IS CREATED AND BEFORE THE FIRST USE.
+func (m *DefaultToolsHandler) SetClientForToolFetcherFunc(clientForToolFetcherFunc func(toolName string) *schemas.MCPClientState) {
+	m.clientForToolFetcher = clientForToolFetcherFunc
+}
+
+// SetFetchNewRequestIDFunc sets the function to get a new request ID.
+// TO BE CALLED JUST AFTER THE HANDLER IS CREATED AND BEFORE THE FIRST USE.
+func (m *DefaultToolsHandler) SetFetchNewRequestIDFunc(fetchNewRequestIDFunc func(ctx context.Context) string) {
+	m.fetchNewRequestIDFunc = fetchNewRequestIDFunc
+}
+
+// ParseAndAddToolsToRequest parses the available tools and adds them to the Bifrost request.
+//
+// Parameters:
+//   - ctx: Execution context
+//   - req: Bifrost request
+//
+// Returns:
+//   - *schemas.BifrostRequest: Bifrost request with MCP tools added
+func (m *DefaultToolsHandler) ParseAndAddToolsToRequest(ctx context.Context, req *schemas.BifrostRequest) *schemas.BifrostRequest {
+	availableTools := m.toolsGetterFunc(ctx)
+	if len(availableTools) > 0 {
+		logger.Debug(fmt.Sprintf("%s Adding %d MCP tools to request", MCPLogPrefix, len(availableTools)))
+		switch req.RequestType {
+		case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+			// Only allocate new Params if it's nil to preserve caller-supplied settings
+			if req.ChatRequest.Params == nil {
+				req.ChatRequest.Params = &schemas.ChatParameters{}
+			}
+
+			tools := req.ChatRequest.Params.Tools
+
+			// Create a map of existing tool names for O(1) lookup
+			existingToolsMap := make(map[string]bool)
+			for _, tool := range tools {
+				if tool.Function != nil && tool.Function.Name != "" {
+					existingToolsMap[tool.Function.Name] = true
+				}
+			}
+
+			// Add MCP tools that are not already present
+			for _, mcpTool := range availableTools {
+				// Skip tools with nil Function or empty Name
+				if mcpTool.Function == nil || mcpTool.Function.Name == "" {
+					continue
+				}
+
+				if !existingToolsMap[mcpTool.Function.Name] {
+					tools = append(tools, mcpTool)
+					// Update the map to prevent duplicates within MCP tools as well
+					existingToolsMap[mcpTool.Function.Name] = true
+				}
+			}
+			req.ChatRequest.Params.Tools = tools
+		case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
+			// Only allocate new Params if it's nil to preserve caller-supplied settings
+			if req.ResponsesRequest.Params == nil {
+				req.ResponsesRequest.Params = &schemas.ResponsesParameters{}
+			}
+
+			tools := req.ResponsesRequest.Params.Tools
+
+			// Create a map of existing tool names for O(1) lookup
+			existingToolsMap := make(map[string]bool)
+			for _, tool := range tools {
+				if tool.Name != nil {
+					existingToolsMap[*tool.Name] = true
+				}
+			}
+
+			// Add MCP tools that are not already present
+			for _, mcpTool := range availableTools {
+				// Skip tools with nil Function or empty Name
+				if mcpTool.Function == nil || mcpTool.Function.Name == "" {
+					continue
+				}
+
+				if !existingToolsMap[mcpTool.Function.Name] {
+					responsesTool := mcpTool.ToResponsesTool()
+					// Skip if the converted tool has nil Name
+					if responsesTool.Name == nil {
+						continue
+					}
+
+					tools = append(tools, *responsesTool)
+					// Update the map to prevent duplicates within MCP tools as well
+					existingToolsMap[*responsesTool.Name] = true
+				}
+			}
+			req.ResponsesRequest.Params.Tools = tools
+		}
+	}
+	return req
+}
+
+// ============================================================================
+// TOOL REGISTRATION AND DISCOVERY
+// ============================================================================
+
+// executeTool executes a tool call and returns the result as a tool message.
+//
+// Parameters:
+//   - ctx: Execution context
+//   - toolCall: The tool call to execute (from assistant message)
+//
+// Returns:
+//   - schemas.ChatMessage: Tool message with execution result
+//   - error: Any execution error
+func (m *DefaultToolsHandler) ExecuteTool(ctx context.Context, toolCall schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, error) {
+	if toolCall.Function.Name == nil {
+		return nil, fmt.Errorf("tool call missing function name")
+	}
+	toolName := *toolCall.Function.Name
+
+	client := m.clientForToolFetcher(toolName)
+	if client == nil {
+		return nil, fmt.Errorf("client not found for tool %s", toolName)
+	}
+
+	// Parse tool arguments
+	var arguments map[string]interface{}
+	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &arguments); err != nil {
+		return nil, fmt.Errorf("failed to parse tool arguments for '%s': %v", toolName, err)
+	}
+
+	// Call the tool via MCP client -> MCP server
+	callRequest := mcp.CallToolRequest{
+		Request: mcp.Request{
+			Method: string(mcp.MethodToolsCall),
+		},
+		Params: mcp.CallToolParams{
+			Name:      toolName,
+			Arguments: arguments,
+		},
+	}
+
+	logger.Debug(fmt.Sprintf("%s Starting tool execution: %s via client: %s", MCPLogPrefix, toolName, client.ExecutionConfig.Name))
+
+	// Create timeout context for tool execution
+	toolCtx, cancel := context.WithTimeout(ctx, m.toolExecutionTimeout)
+	defer cancel()
+
+	toolResponse, callErr := client.Conn.CallTool(toolCtx, callRequest)
+	if callErr != nil {
+		// Check if it was a timeout error
+		if toolCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("MCP tool call timed out after %v: %s", m.toolExecutionTimeout, toolName)
+		}
+		logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
+		return nil, fmt.Errorf("MCP tool call failed: %v", callErr)
+	}
+
+	logger.Debug(fmt.Sprintf("%s Tool execution completed: %s", MCPLogPrefix, toolName))
+
+	// Extract text from MCP response
+	responseText := extractTextFromMCPResponse(toolResponse, toolName)
+
+	// Create tool response message
+	return createToolResponseMessage(toolCall, responseText), nil
+}
+
+func (m *DefaultToolsHandler) ExecuteAgent(ctx context.Context, req *schemas.BifrostChatRequest, resp *schemas.BifrostChatResponse, llmCaller schemas.BifrostLLMCaller) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	return ExecuteAgent(
+		&ctx,
+		m.maxAgentDepth,
+		req,
+		resp,
+		llmCaller,
+		m.fetchNewRequestIDFunc,
+		m.ExecuteTool,
+		m.clientForToolFetcher,
+	)
+}

--- a/core/mcp/init.go
+++ b/core/mcp/init.go
@@ -1,0 +1,9 @@
+package mcp
+
+import "github.com/maximhq/bifrost/core/schemas"
+
+var logger schemas.Logger
+
+func SetLogger(l schemas.Logger) {
+	logger = l
+}

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -2,19 +2,12 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"maps"
-	"os"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 
-	"github.com/mark3labs/mcp-go/client"
-	"github.com/mark3labs/mcp-go/client/transport"
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -47,12 +40,13 @@ const (
 // both local tool hosting and external MCP server connections.
 type MCPManager struct {
 	ctx                  context.Context
-	server               *server.MCPServer     // Local MCP server instance for hosting tools (STDIO-based)
-	clientMap            map[string]*MCPClient // Map of MCP client names to their configurations
-	mu                   sync.RWMutex          // Read-write mutex for thread-safe operations
-	serverRunning        bool                  // Track whether local MCP server is running
-	maxAgentDepth        int                   // Maximum depth of agent mode tool calls
-	toolExecutionTimeout time.Duration         // Timeout for individual tool execution
+	toolsHandler         schemas.MCPToolHandler             // Handler for MCP tools
+	server               *server.MCPServer                  // Local MCP server instance for hosting tools (STDIO-based)
+	clientMap            map[string]*schemas.MCPClientState // Map of MCP client names to their configurations
+	mu                   sync.RWMutex                       // Read-write mutex for thread-safe operations
+	serverRunning        bool                               // Track whether local MCP server is running
+	maxAgentDepth        int                                // Maximum depth of agent mode tool calls
+	toolExecutionTimeout time.Duration                      // Timeout for individual tool execution
 
 	// Function to fetch a new request ID for each tool call result message in agent mode,
 	// this is used to ensure that the tool call result messages are unique and can be tracked in plugins or by the user.
@@ -61,26 +55,9 @@ type MCPManager struct {
 	fetchNewRequestIDFunc func(ctx context.Context) string
 }
 
-// MCPClient represents a connected MCP client with its configuration and tools.
-type MCPClient struct {
-	// Name            string                      // Unique name for this client
-	Conn            *client.Client              // Active MCP client connection
-	ExecutionConfig schemas.MCPClientConfig     // Tool filtering settings
-	ToolMap         map[string]schemas.ChatTool // Available tools mapped by name
-	ConnectionInfo  MCPClientConnectionInfo     `json:"connection_info"` // Connection metadata for management
-	cancelFunc      context.CancelFunc          `json:"-"`               // Cancel function for SSE connections (not serialized)
-}
-
-// MCPClientConnectionInfo stores metadata about how a client is connected.
-type MCPClientConnectionInfo struct {
-	Type               schemas.MCPConnectionType `json:"type"`                           // Connection type (HTTP, STDIO, SSE, or InProcess)
-	ConnectionURL      *string                   `json:"connection_url,omitempty"`       // HTTP/SSE endpoint URL (for HTTP/SSE connections)
-	StdioCommandString *string                   `json:"stdio_command_string,omitempty"` // Command string for display (for STDIO connections)
-}
-
-// MCPToolHandler is a generic function type for handling tool calls with typed arguments.
+// MCPToolFunction is a generic function type for handling tool calls with typed arguments.
 // T represents the expected argument structure for the tool.
-type MCPToolHandler[T any] func(args T) (string, error)
+type MCPToolFunction[T any] func(args T) (string, error)
 
 // ============================================================================
 // CONSTRUCTOR AND INITIALIZATION
@@ -96,27 +73,35 @@ type MCPToolHandler[T any] func(args T) (string, error)
 //   - *MCPManager: Initialized manager instance
 //   - error: Any initialization error
 func NewMCPManager(ctx context.Context, config schemas.MCPConfig, logger schemas.Logger) (*MCPManager, error) {
+	SetLogger(logger)
 	// Set default values
 	maxAgentDepth := config.MaxAgentDepth
 	if maxAgentDepth <= 0 {
 		maxAgentDepth = 10 // Default max depth
 	}
-
 	toolExecutionTimeout := time.Duration(config.ToolExecutionTimeout) * time.Second
 	if toolExecutionTimeout <= 0 {
 		toolExecutionTimeout = 30 * time.Second // Default timeout
 	}
-
 	// Creating new instance
 	manager := &MCPManager{
 		ctx:                   ctx,
-		clientMap:             make(map[string]*MCPClient),
+		clientMap:             make(map[string]*schemas.MCPClientState),
 		maxAgentDepth:         maxAgentDepth,
 		toolExecutionTimeout:  toolExecutionTimeout,
 		fetchNewRequestIDFunc: config.FetchNewRequestIDFunc,
 	}
-	SetLogger(logger)
-
+	toolsHandler, err := NewDefaultToolsHandler(&DefaultHandlerConfig{
+		toolExecutionTimeout: toolExecutionTimeout,
+		maxAgentDepth:        maxAgentDepth,
+	})
+	if err != nil {
+		return nil, err
+	}
+	toolsHandler.SetToolsFetcherFunc(manager.getAvailableTools)
+	toolsHandler.SetClientForToolFetcherFunc(manager.findMCPClientForTool)
+	toolsHandler.SetFetchNewRequestIDFunc(config.FetchNewRequestIDFunc)
+	manager.toolsHandler = toolsHandler
 	// Process client configs: create client map entries and establish connections
 	for _, clientConfig := range config.ClientConfigs {
 		if err := manager.AddClient(clientConfig); err != nil {
@@ -127,534 +112,66 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, logger schemas
 	return manager, nil
 }
 
-// GetClients returns all MCP clients managed by the manager.
-//
-// Returns:
-//   - []*MCPClient: List of all MCP clients
-//   - error: Any retrieval error
-func (m *MCPManager) GetClients() ([]MCPClient, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	clients := make([]MCPClient, 0, len(m.clientMap))
-	for _, client := range m.clientMap {
-		clients = append(clients, *client)
+func (m *MCPManager) AddToolsToRequest(ctx context.Context, req *schemas.BifrostRequest) *schemas.BifrostRequest {
+	if !m.toolsHandler.SetupCompleted() {
+		logger.Error("%s Tools handler is not fully setup", MCPLogPrefix)
+		return req
 	}
-
-	return clients, nil
+	return m.toolsHandler.ParseAndAddToolsToRequest(ctx, req)
 }
 
-// ReconnectClient attempts to reconnect an MCP client if it is disconnected.
-func (m *MCPManager) ReconnectClient(id string) error {
-	m.mu.Lock()
-
-	client, ok := m.clientMap[id]
-	if !ok {
-		m.mu.Unlock()
-		return fmt.Errorf("client %s not found", id)
-	}
-
-	m.mu.Unlock()
-
-	// connectToMCPClient handles locking internally
-	err := m.connectToMCPClient(client.ExecutionConfig)
-	if err != nil {
-		return fmt.Errorf("failed to connect to MCP client %s: %w", id, err)
-	}
-
-	return nil
-}
-
-// AddClient adds a new MCP client to the manager.
-// It validates the client configuration and establishes a connection.
-//
-// Parameters:
-//   - config: MCP client configuration
-//
-// Returns:
-func (m *MCPManager) AddClient(config schemas.MCPClientConfig) error {
-	if err := validateMCPClientConfig(&config); err != nil {
-		return fmt.Errorf("invalid MCP client configuration: %w", err)
-	}
-
-	// Make a copy of the config to use after unlocking
-	configCopy := config
-
-	m.mu.Lock()
-
-	if _, ok := m.clientMap[config.ID]; ok {
-		m.mu.Unlock()
-		return fmt.Errorf("client %s already exists", config.Name)
-	}
-
-	// Create placeholder entry
-	m.clientMap[config.ID] = &MCPClient{
-		ExecutionConfig: config,
-		ToolMap:         make(map[string]schemas.ChatTool),
-	}
-
-	// Temporarily unlock for the connection attempt
-	// This is to avoid deadlocks when the connection attempt is made
-	m.mu.Unlock()
-
-	// Connect using the copied config
-	if err := m.connectToMCPClient(configCopy); err != nil {
-		// Re-lock to clean up the failed entry
-		m.mu.Lock()
-		delete(m.clientMap, config.ID)
-		m.mu.Unlock()
-		return fmt.Errorf("failed to connect to MCP client %s: %w", config.Name, err)
-	}
-
-	return nil
-}
-
-// RemoveClient removes an MCP client from the manager.
-// It handles cleanup for all transport types (HTTP, STDIO, SSE).
-//
-// Parameters:
-//   - id: ID of the client to remove
-func (m *MCPManager) RemoveClient(id string) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.removeClientUnsafe(id)
-}
-
-func (m *MCPManager) removeClientUnsafe(id string) error {
-	client, ok := m.clientMap[id]
-	if !ok {
-		return fmt.Errorf("client %s not found", id)
-	}
-
-	logger.Info(fmt.Sprintf("%s Disconnecting MCP client: %s", MCPLogPrefix, client.ExecutionConfig.Name))
-
-	// Cancel SSE context if present (required for proper SSE cleanup)
-	if client.cancelFunc != nil {
-		client.cancelFunc()
-		client.cancelFunc = nil
-	}
-
-	// Close the client transport connection
-	// This handles cleanup for all transport types (HTTP, STDIO, SSE)
-	if client.Conn != nil {
-		if err := client.Conn.Close(); err != nil {
-			logger.Error("%s Failed to close MCP client %s: %v", MCPLogPrefix, client.ExecutionConfig.Name, err)
-		}
-		client.Conn = nil
-	}
-
-	// Clear client tool map
-	client.ToolMap = make(map[string]schemas.ChatTool)
-
-	delete(m.clientMap, id)
-	return nil
-}
-
-func (m *MCPManager) EditClient(id string, updatedConfig schemas.MCPClientConfig) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	client, ok := m.clientMap[id]
-	if !ok {
-		return fmt.Errorf("client %s not found", id)
-	}
-
-	// Update the client's execution config with new tool filters
-	config := client.ExecutionConfig
-	config.Name = updatedConfig.Name
-	config.Headers = updatedConfig.Headers
-	config.ToolsToExecute = updatedConfig.ToolsToExecute
-
-	// Store the updated config
-	client.ExecutionConfig = config
-
-	if client.Conn == nil {
-		return nil // Client is not connected, so no tools to update
-	}
-
-	// Clear current tool map
-	client.ToolMap = make(map[string]schemas.ChatTool)
-
-	// Temporarily unlock for the network call
-	m.mu.Unlock()
-
-	// Retrieve tools with updated configuration
-	tools, err := retrieveExternalTools(m.ctx, client.Conn)
-
-	// Re-lock to update the tool map
-	m.mu.Lock()
-
-	// Verify client still exists
-	if _, ok := m.clientMap[id]; !ok {
-		return fmt.Errorf("client %s was removed during tool update", id)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to retrieve external tools: %w", err)
-	}
-
-	// Store discovered tools
-	maps.Copy(client.ToolMap, tools)
-
-	return nil
-}
-
-// ============================================================================
-// TOOL REGISTRATION AND DISCOVERY
-// ============================================================================
-
-// registerTool registers a typed tool handler with the local MCP server.
-// This is a convenience function that handles the conversion between typed Go
-// handlers and the MCP protocol.
-//
-// Type Parameters:
-//   - T: The expected argument type for the tool (must be JSON-deserializable)
-//
-// Parameters:
-//   - name: Unique tool name
-//   - description: Human-readable tool description
-//   - handler: Typed function that handles tool execution
-//   - toolSchema: Bifrost tool schema for function calling
-//
-// Returns:
-//   - error: Any registration error
-//
-// Example:
-//
-//	type EchoArgs struct {
-//	    Message string `json:"message"`
-//	}
-//
-//	err := bifrost.RegisterMCPTool("echo", "Echo a message",
-//	    func(args EchoArgs) (string, error) {
-//	        return args.Message, nil
-//	    }, toolSchema)
-func (m *MCPManager) RegisterTool(name, description string, handler MCPToolHandler[any], toolSchema schemas.ChatTool) error {
-	// Ensure local server is set up
-	if err := m.setupLocalHost(); err != nil {
-		return fmt.Errorf("failed to setup local host: %w", err)
-	}
-
-	// Verify internal client exists
-	if _, ok := m.clientMap[BifrostMCPClientKey]; !ok {
-		return fmt.Errorf("bifrost client not found")
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Check if tool name already exists to prevent silent overwrites
-	if _, exists := m.clientMap[BifrostMCPClientKey].ToolMap[name]; exists {
-		return fmt.Errorf("tool '%s' is already registered", name)
-	}
-
-	logger.Info(fmt.Sprintf("%s Registering typed tool: %s", MCPLogPrefix, name))
-
-	// Create MCP handler wrapper that converts between typed and MCP interfaces
-	mcpHandler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		// Extract arguments from the request using the request's methods
-		args := request.GetArguments()
-		result, err := handler(args)
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Error: %s", err.Error())), nil
-		}
-		return mcp.NewToolResultText(result), nil
-	}
-
-	// Register the tool with the local MCP server using AddTool
-	if m.server != nil {
-		tool := mcp.NewTool(name, mcp.WithDescription(description))
-		m.server.AddTool(tool, mcpHandler)
-	}
-
-	// Store tool definition for Bifrost integration
-	m.clientMap[BifrostMCPClientKey].ToolMap[name] = toolSchema
-
-	return nil
-}
-
-// executeTool executes a tool call and returns the result as a tool message.
-//
-// Parameters:
-//   - ctx: Execution context
-//   - toolCall: The tool call to execute (from assistant message)
-//
-// Returns:
-//   - schemas.ChatMessage: Tool message with execution result
-//   - error: Any execution error
 func (m *MCPManager) ExecuteTool(ctx context.Context, toolCall schemas.ChatAssistantMessageToolCall) (*schemas.ChatMessage, error) {
-	if toolCall.Function.Name == nil {
+	if !m.toolsHandler.SetupCompleted() {
+		logger.Error("%s Tools handler is not fully setup", MCPLogPrefix)
+		return nil, fmt.Errorf("tools handler is not fully setup")
+	}
+	// Check if the user has permission to execute the tool call
+	availableTools := m.getAvailableTools(ctx)
+	toolName := toolCall.Function.Name
+	if toolName == nil {
 		return nil, fmt.Errorf("tool call missing function name")
 	}
-	toolName := *toolCall.Function.Name
 
-	// Parse tool arguments
-	var arguments map[string]interface{}
-	if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &arguments); err != nil {
-		return nil, fmt.Errorf("failed to parse tool arguments for '%s': %v", toolName, err)
-	}
-
-	// Find which client has this tool
-	client := m.findMCPClientForTool(toolName)
-	if client == nil {
-		return nil, fmt.Errorf("tool '%s' not found in any connected MCP client", toolName)
-	}
-
-	if client.Conn == nil {
-		return nil, fmt.Errorf("client '%s' has no active connection", client.ExecutionConfig.Name)
-	}
-
-	// Call the tool via MCP client -> MCP server
-	callRequest := mcp.CallToolRequest{
-		Request: mcp.Request{
-			Method: string(mcp.MethodToolsCall),
-		},
-		Params: mcp.CallToolParams{
-			Name:      toolName,
-			Arguments: arguments,
-		},
-	}
-
-	logger.Debug(fmt.Sprintf("%s Starting tool execution: %s via client: %s", MCPLogPrefix, toolName, client.ExecutionConfig.Name))
-
-	// Create timeout context for tool execution
-	toolCtx, cancel := context.WithTimeout(ctx, m.toolExecutionTimeout)
-	defer cancel()
-
-	toolResponse, callErr := client.Conn.CallTool(toolCtx, callRequest)
-	if callErr != nil {
-		// Check if it was a timeout error
-		if toolCtx.Err() == context.DeadlineExceeded {
-			return nil, fmt.Errorf("MCP tool call timed out after %v: %s", m.toolExecutionTimeout, toolName)
+	// Check if the tool is available
+	toolFound := false
+	for _, mcpTool := range availableTools {
+		if mcpTool.Function != nil && mcpTool.Function.Name == *toolName {
+			toolFound = true
+			break
 		}
-		logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
-		return nil, fmt.Errorf("MCP tool call failed: %v", callErr)
 	}
 
-	logger.Debug(fmt.Sprintf("%s Tool execution completed: %s", MCPLogPrefix, toolName))
+	if !toolFound {
+		return nil, fmt.Errorf("tool '%s' is not available or not permitted", *toolName)
+	}
 
-	// Extract text from MCP response
-	responseText := extractTextFromMCPResponse(toolResponse, toolName)
-
-	// Create tool response message
-	return createToolResponseMessage(toolCall, responseText), nil
+	return m.toolsHandler.ExecuteTool(ctx, toolCall)
 }
 
-// ============================================================================
-// LOCAL MCP SERVER AND CLIENT MANAGEMENT
-// ============================================================================
-
-// setupLocalHost initializes the local MCP server and client if not already running.
-// This creates a STDIO-based server for local tool hosting and a corresponding client.
-// This is called automatically when tools are registered or when the server is needed.
-//
-// Returns:
-//   - error: Any setup error
-func (m *MCPManager) setupLocalHost() error {
-	// Check if server is already running
-	if m.server != nil && m.serverRunning {
-		return nil
-	}
-
-	// Create and configure local MCP server (STDIO-based)
-	server, err := m.createLocalMCPServer()
-	if err != nil {
-		return fmt.Errorf("failed to create local MCP server: %w", err)
-	}
-	m.server = server
-
-	// Create and configure local MCP client (STDIO-based)
-	client, err := m.createLocalMCPClient()
-	if err != nil {
-		return fmt.Errorf("failed to create local MCP client: %w", err)
-	}
-	m.clientMap[BifrostMCPClientKey] = client
-
-	// Start the server and initialize client connection
-	return m.startLocalMCPServer()
-}
-
-// createLocalMCPServer creates a new local MCP server instance with STDIO transport.
-// This server will host tools registered via RegisterTool function.
-//
-// Returns:
-//   - *server.MCPServer: Configured MCP server instance
-//   - error: Any creation error
-func (m *MCPManager) createLocalMCPServer() (*server.MCPServer, error) {
-	// Create MCP server
-	mcpServer := server.NewMCPServer(
-		"Bifrost-MCP-Server",
-		"1.0.0",
-		server.WithToolCapabilities(true),
-	)
-
-	return mcpServer, nil
-}
-
-// createLocalMCPClient creates a placeholder client entry for the local MCP server.
-// The actual in-process client connection will be established in startLocalMCPServer.
-//
-// Returns:
-//   - *MCPClient: Placeholder client for local server
-//   - error: Any creation error
-func (m *MCPManager) createLocalMCPClient() (*MCPClient, error) {
-	// Don't create the actual client connection here - it will be created
-	// after the server is ready using NewInProcessClient
-	return &MCPClient{
-		ExecutionConfig: schemas.MCPClientConfig{
-			Name: BifrostMCPClientName,
-		},
-		ToolMap: make(map[string]schemas.ChatTool),
-		ConnectionInfo: MCPClientConnectionInfo{
-			Type: schemas.MCPConnectionTypeInProcess, // Accurate: in-process (in-memory) transport
-		},
-	}, nil
-}
-
-// startLocalMCPServer creates an in-process connection between the local server and client.
-//
-// Returns:
-//   - error: Any startup error
-func (m *MCPManager) startLocalMCPServer() error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Check if server is already running
-	if m.server != nil && m.serverRunning {
-		return nil
-	}
-
-	if m.server == nil {
-		return fmt.Errorf("server not initialized")
-	}
-
-	// Create in-process client directly connected to the server
-	inProcessClient, err := client.NewInProcessClient(m.server)
-	if err != nil {
-		return fmt.Errorf("failed to create in-process MCP client: %w", err)
-	}
-
-	// Update the client connection
-	clientEntry, ok := m.clientMap[BifrostMCPClientKey]
-	if !ok {
-		return fmt.Errorf("bifrost client not found")
-	}
-	clientEntry.Conn = inProcessClient
-
-	// Initialize the in-process client
-	ctx, cancel := context.WithTimeout(m.ctx, MCPClientConnectionEstablishTimeout)
-	defer cancel()
-
-	// Create proper initialize request with correct structure
-	initRequest := mcp.InitializeRequest{
-		Params: mcp.InitializeParams{
-			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
-			Capabilities:    mcp.ClientCapabilities{},
-			ClientInfo: mcp.Implementation{
-				Name:    BifrostMCPClientName,
-				Version: BifrostMCPVersion,
+func (m *MCPManager) CheckAndExecuteAgent(ctx context.Context, req *schemas.BifrostChatRequest, response *schemas.BifrostChatResponse, llmCaller schemas.BifrostLLMCaller) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	if !m.toolsHandler.SetupCompleted() {
+		logger.Error("%s Tools handler is not fully setup", MCPLogPrefix)
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "tools handler is not fully setup",
 			},
-		},
-	}
-
-	_, err = inProcessClient.Initialize(ctx, initRequest)
-	if err != nil {
-		return fmt.Errorf("failed to initialize MCP client: %w", err)
-	}
-
-	// Mark server as running
-	m.serverRunning = true
-
-	return nil
-}
-
-// ============================================================================
-// EXTERNAL MCP CONNECTION MANAGEMENT
-// ============================================================================
-
-// AddMCPToolsToBifrostRequest adds MCP tools to a Bifrost request.
-//
-// Parameters:
-//   - ctx: Execution context
-//   - req: Bifrost request
-//
-// Returns:
-//   - *schemas.BifrostRequest: Bifrost request with MCP tools added
-func (m *MCPManager) AddMCPToolsToBifrostRequest(ctx context.Context, req *schemas.BifrostRequest) *schemas.BifrostRequest {
-	mcpTools := m.getAvailableTools(ctx)
-	if len(mcpTools) > 0 {
-		logger.Debug(fmt.Sprintf("%s Adding %d MCP tools to request", MCPLogPrefix, len(mcpTools)))
-		switch req.RequestType {
-		case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
-			// Only allocate new Params if it's nil to preserve caller-supplied settings
-			if req.ChatRequest.Params == nil {
-				req.ChatRequest.Params = &schemas.ChatParameters{}
-			}
-
-			tools := req.ChatRequest.Params.Tools
-
-			// Create a map of existing tool names for O(1) lookup
-			existingToolsMap := make(map[string]bool)
-			for _, tool := range tools {
-				if tool.Function != nil && tool.Function.Name != "" {
-					existingToolsMap[tool.Function.Name] = true
-				}
-			}
-
-			// Add MCP tools that are not already present
-			for _, mcpTool := range mcpTools {
-				// Skip tools with nil Function or empty Name
-				if mcpTool.Function == nil || mcpTool.Function.Name == "" {
-					continue
-				}
-
-				if !existingToolsMap[mcpTool.Function.Name] {
-					tools = append(tools, mcpTool)
-					// Update the map to prevent duplicates within MCP tools as well
-					existingToolsMap[mcpTool.Function.Name] = true
-				}
-			}
-			req.ChatRequest.Params.Tools = tools
-		case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
-			// Only allocate new Params if it's nil to preserve caller-supplied settings
-			if req.ResponsesRequest.Params == nil {
-				req.ResponsesRequest.Params = &schemas.ResponsesParameters{}
-			}
-
-			tools := req.ResponsesRequest.Params.Tools
-
-			// Create a map of existing tool names for O(1) lookup
-			existingToolsMap := make(map[string]bool)
-			for _, tool := range tools {
-				if tool.Name != nil {
-					existingToolsMap[*tool.Name] = true
-				}
-			}
-
-			// Add MCP tools that are not already present
-			for _, mcpTool := range mcpTools {
-				// Skip tools with nil Function or empty Name
-				if mcpTool.Function == nil || mcpTool.Function.Name == "" {
-					continue
-				}
-
-				if !existingToolsMap[mcpTool.Function.Name] {
-					responsesTool := mcpTool.ToResponsesTool()
-					// Skip if the converted tool has nil Name
-					if responsesTool.Name == nil {
-						continue
-					}
-
-					tools = append(tools, *responsesTool)
-					// Update the map to prevent duplicates within MCP tools as well
-					existingToolsMap[*responsesTool.Name] = true
-				}
-			}
-			req.ResponsesRequest.Params.Tools = tools
 		}
 	}
-	return req
+	if llmCaller == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "llmCaller is required to execute agent mode",
+			},
+		}
+	}
+	// Check if initial response has tool calls
+	if !hasToolCalls(response) {
+		logger.Debug("No tool calls detected, returning response")
+		return response, nil
+	}
+	return m.toolsHandler.ExecuteAgent(ctx, req, response, llmCaller)
 }
 
 // Cleanup performs cleanup of all MCP resources including clients and local server.
@@ -676,7 +193,7 @@ func (m *MCPManager) Cleanup() error {
 	}
 
 	// Clear the client map
-	m.clientMap = make(map[string]*MCPClient)
+	m.clientMap = make(map[string]*schemas.MCPClientState)
 
 	// Clear local server reference
 	// Note: mark3labs/mcp-go STDIO server cleanup is handled automatically
@@ -688,248 +205,4 @@ func (m *MCPManager) Cleanup() error {
 
 	logger.Info(MCPLogPrefix + " MCP cleanup completed")
 	return nil
-}
-
-// ============================================================================
-// CONNECTION HELPER METHODS
-// ============================================================================
-
-// connectToMCPClient establishes a connection to an external MCP server and
-// registers its available tools with the manager.
-func (m *MCPManager) connectToMCPClient(config schemas.MCPClientConfig) error {
-	// First lock: Initialize or validate client entry
-	m.mu.Lock()
-
-	// Initialize or validate client entry
-	if existingClient, exists := m.clientMap[config.ID]; exists {
-		// Client entry exists from config, check for existing connection, if it does then close
-		if existingClient.cancelFunc != nil {
-			existingClient.cancelFunc()
-			existingClient.cancelFunc = nil
-		}
-		if existingClient.Conn != nil {
-			existingClient.Conn.Close()
-		}
-		// Update connection type for this connection attempt
-		existingClient.ConnectionInfo.Type = config.ConnectionType
-	}
-	// Create new client entry with configuration
-	m.clientMap[config.ID] = &MCPClient{
-		ExecutionConfig: config,
-		ToolMap:         make(map[string]schemas.ChatTool),
-		ConnectionInfo: MCPClientConnectionInfo{
-			Type: config.ConnectionType,
-		},
-	}
-	m.mu.Unlock()
-
-	// Heavy operations performed outside lock
-	var externalClient *client.Client
-	var connectionInfo MCPClientConnectionInfo
-	var err error
-
-	// Create appropriate transport based on connection type
-	switch config.ConnectionType {
-	case schemas.MCPConnectionTypeHTTP:
-		externalClient, connectionInfo, err = m.createHTTPConnection(config)
-	case schemas.MCPConnectionTypeSTDIO:
-		externalClient, connectionInfo, err = m.createSTDIOConnection(config)
-	case schemas.MCPConnectionTypeSSE:
-		externalClient, connectionInfo, err = m.createSSEConnection(config)
-	case schemas.MCPConnectionTypeInProcess:
-		externalClient, connectionInfo, err = m.createInProcessConnection(config)
-	default:
-		return fmt.Errorf("unknown connection type: %s", config.ConnectionType)
-	}
-
-	if err != nil {
-		return fmt.Errorf("failed to create connection: %w", err)
-	}
-
-	// Initialize the external client with timeout
-	// For SSE connections, we need a long-lived context, for others we can use timeout
-	var ctx context.Context
-	var cancel context.CancelFunc
-
-	if config.ConnectionType == schemas.MCPConnectionTypeSSE {
-		// SSE connections need a long-lived context for the persistent stream
-		ctx, cancel = context.WithCancel(m.ctx)
-		// Don't defer cancel here - SSE needs the context to remain active
-	} else {
-		// Other connection types can use timeout context
-		ctx, cancel = context.WithTimeout(m.ctx, MCPClientConnectionEstablishTimeout)
-		defer cancel()
-	}
-
-	// Start the transport first (required for STDIO and SSE clients)
-	if err := externalClient.Start(ctx); err != nil {
-		if config.ConnectionType == schemas.MCPConnectionTypeSSE {
-			cancel() // Cancel SSE context only on error
-		}
-		return fmt.Errorf("failed to start MCP client transport %s: %v", config.Name, err)
-	}
-
-	// Create proper initialize request for external client
-	extInitRequest := mcp.InitializeRequest{
-		Params: mcp.InitializeParams{
-			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
-			Capabilities:    mcp.ClientCapabilities{},
-			ClientInfo: mcp.Implementation{
-				Name:    fmt.Sprintf("Bifrost-%s", config.Name),
-				Version: "1.0.0",
-			},
-		},
-	}
-
-	_, err = externalClient.Initialize(ctx, extInitRequest)
-	if err != nil {
-		if config.ConnectionType == schemas.MCPConnectionTypeSSE {
-			cancel() // Cancel SSE context only on error
-		}
-		return fmt.Errorf("failed to initialize MCP client %s: %v", config.Name, err)
-	}
-
-	// Retrieve tools from the external server (this also requires network I/O)
-	tools, err := retrieveExternalTools(ctx, externalClient)
-	if err != nil {
-		logger.Warn(fmt.Sprintf("%s Failed to retrieve tools from %s: %v", MCPLogPrefix, config.Name, err))
-		// Continue with connection even if tool retrieval fails
-		tools = make(map[string]schemas.ChatTool)
-	}
-
-	// Second lock: Update client with final connection details and tools
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Verify client still exists (could have been cleaned up during heavy operations)
-	if client, exists := m.clientMap[config.ID]; exists {
-		// Store the external client connection and details
-		client.Conn = externalClient
-		client.ConnectionInfo = connectionInfo
-
-		// Store cancel function for SSE connections to enable proper cleanup
-		if config.ConnectionType == schemas.MCPConnectionTypeSSE {
-			client.cancelFunc = cancel
-		}
-
-		// Store discovered tools
-		for toolName, tool := range tools {
-			client.ToolMap[toolName] = tool
-		}
-
-		logger.Info(fmt.Sprintf("%s Connected to MCP client: %s", MCPLogPrefix, config.Name))
-	} else {
-		return fmt.Errorf("client %s was removed during connection setup", config.Name)
-	}
-
-	return nil
-}
-
-// createHTTPConnection creates an HTTP-based MCP client connection without holding locks.
-func (m *MCPManager) createHTTPConnection(config schemas.MCPClientConfig) (*client.Client, MCPClientConnectionInfo, error) {
-	if config.ConnectionString == nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("HTTP connection string is required")
-	}
-
-	// Prepare connection info
-	connectionInfo := MCPClientConnectionInfo{
-		Type:          config.ConnectionType,
-		ConnectionURL: config.ConnectionString,
-	}
-
-	// Create StreamableHTTP transport
-	httpTransport, err := transport.NewStreamableHTTP(*config.ConnectionString, transport.WithHTTPHeaders(config.Headers))
-	if err != nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("failed to create HTTP transport: %w", err)
-	}
-
-	client := client.NewClient(httpTransport)
-
-	return client, connectionInfo, nil
-}
-
-// createSTDIOConnection creates a STDIO-based MCP client connection without holding locks.
-func (m *MCPManager) createSTDIOConnection(config schemas.MCPClientConfig) (*client.Client, MCPClientConnectionInfo, error) {
-	if config.StdioConfig == nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("stdio config is required")
-	}
-
-	// Prepare STDIO command info for display
-	cmdString := fmt.Sprintf("%s %s", config.StdioConfig.Command, strings.Join(config.StdioConfig.Args, " "))
-
-	// Check if environment variables are set
-	for _, env := range config.StdioConfig.Envs {
-		if os.Getenv(env) == "" {
-			return nil, MCPClientConnectionInfo{}, fmt.Errorf("environment variable %s is not set for MCP client %s", env, config.Name)
-		}
-	}
-
-	// Create STDIO transport
-	stdioTransport := transport.NewStdio(
-		config.StdioConfig.Command,
-		config.StdioConfig.Envs,
-		config.StdioConfig.Args...,
-	)
-
-	// Prepare connection info
-	connectionInfo := MCPClientConnectionInfo{
-		Type:               config.ConnectionType,
-		StdioCommandString: &cmdString,
-	}
-
-	client := client.NewClient(stdioTransport)
-
-	// Return nil for cmd since mark3labs/mcp-go manages the process internally
-	return client, connectionInfo, nil
-}
-
-// createSSEConnection creates a SSE-based MCP client connection without holding locks.
-func (m *MCPManager) createSSEConnection(config schemas.MCPClientConfig) (*client.Client, MCPClientConnectionInfo, error) {
-	if config.ConnectionString == nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("SSE connection string is required")
-	}
-
-	// Prepare connection info
-	connectionInfo := MCPClientConnectionInfo{
-		Type:          config.ConnectionType,
-		ConnectionURL: config.ConnectionString, // Reuse HTTPConnectionURL field for SSE URL display
-	}
-
-	// Create SSE transport
-	sseTransport, err := transport.NewSSE(*config.ConnectionString, transport.WithHeaders(config.Headers))
-	if err != nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("failed to create SSE transport: %w", err)
-	}
-
-	client := client.NewClient(sseTransport)
-
-	return client, connectionInfo, nil
-}
-
-// createInProcessConnection creates an in-process MCP client connection without holding locks.
-// This allows direct connection to an MCP server running in the same process, providing
-// the lowest latency and highest performance for tool execution.
-func (m *MCPManager) createInProcessConnection(config schemas.MCPClientConfig) (*client.Client, MCPClientConnectionInfo, error) {
-	if config.InProcessServer == nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("InProcess connection requires a server instance")
-	}
-
-	// Type assert to ensure we have a proper MCP server
-	mcpServer, ok := config.InProcessServer.(*server.MCPServer)
-	if !ok {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("InProcessServer must be a *server.MCPServer instance")
-	}
-
-	// Create in-process client directly connected to the provided server
-	inProcessClient, err := client.NewInProcessClient(mcpServer)
-	if err != nil {
-		return nil, MCPClientConnectionInfo{}, fmt.Errorf("failed to create in-process client: %w", err)
-	}
-
-	// Prepare connection info
-	connectionInfo := MCPClientConnectionInfo{
-		Type: config.ConnectionType,
-	}
-
-	return inProcessClient, connectionInfo, nil
 }

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -1,0 +1,284 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// findMCPClientForTool safely finds a client that has the specified tool.
+func (m *MCPManager) findMCPClientForTool(toolName string) *MCPClient {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, client := range m.clientMap {
+		if _, exists := client.ToolMap[toolName]; exists {
+			return client
+		}
+	}
+	return nil
+}
+
+// getAvailableTools returns all tools from connected MCP clients.
+// Applies client filtering if specified in the context.
+func (m *MCPManager) getAvailableTools(ctx context.Context) []schemas.ChatTool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var includeClients []string
+
+	// Extract client filtering from request context
+	if existingIncludeClients, ok := ctx.Value(MCPContextKeyIncludeClients).([]string); ok && existingIncludeClients != nil {
+		includeClients = existingIncludeClients
+	}
+
+	tools := make([]schemas.ChatTool, 0)
+	for id, client := range m.clientMap {
+		// Apply client filtering logic
+		if !shouldIncludeClient(id, includeClients) {
+			logger.Debug(fmt.Sprintf("%s Skipping MCP client %s: not in include clients list", MCPLogPrefix, id))
+			continue
+		}
+
+		logger.Debug(fmt.Sprintf("Checking tools for MCP client %s with tools to execute: %v", id, client.ExecutionConfig.ToolsToExecute))
+
+		// Add all tools from this client
+		for toolName, tool := range client.ToolMap {
+			// Check if tool should be skipped based on client configuration
+			if shouldSkipToolForConfig(toolName, client.ExecutionConfig) {
+				logger.Debug(fmt.Sprintf("%s Skipping MCP tool %s: not in tools to execute list", MCPLogPrefix, toolName))
+				continue
+			}
+
+			// Check if tool should be skipped based on request context
+			if shouldSkipToolForRequest(id, toolName, ctx) {
+				logger.Debug(fmt.Sprintf("%s Skipping MCP tool %s: not in include tools list", MCPLogPrefix, toolName))
+				continue
+			}
+
+			tools = append(tools, tool)
+		}
+	}
+	return tools
+}
+
+// retrieveExternalTools retrieves and filters tools from an external MCP server without holding locks.
+func retrieveExternalTools(ctx context.Context, client *client.Client) (map[string]schemas.ChatTool, error) {
+	// Get available tools from external server
+	listRequest := mcp.ListToolsRequest{
+		PaginatedRequest: mcp.PaginatedRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsList),
+			},
+		},
+	}
+
+	toolsResponse, err := client.ListTools(ctx, listRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tools: %v", err)
+	}
+
+	if toolsResponse == nil {
+		return make(map[string]schemas.ChatTool), nil // No tools available
+	}
+
+	tools := make(map[string]schemas.ChatTool)
+
+	// toolsResponse is already a ListToolsResult
+	for _, mcpTool := range toolsResponse.Tools {
+		// Convert MCP tool schema to Bifrost format
+		bifrostTool := convertMCPToolToBifrostSchema(&mcpTool)
+		tools[mcpTool.Name] = bifrostTool
+	}
+
+	return tools, nil
+}
+
+// shouldIncludeClient determines if a client should be included based on filtering rules.
+func shouldIncludeClient(clientID string, includeClients []string) bool {
+	// If includeClients is specified (not nil), apply whitelist filtering
+	if includeClients != nil {
+		// Handle empty array [] - means no clients are included
+		if len(includeClients) == 0 {
+			return false // No clients allowed
+		}
+
+		// Handle wildcard "*" - if present, all clients are included
+		if slices.Contains(includeClients, "*") {
+			return true // All clients allowed
+		}
+
+		// Check if specific client is in the list
+		return slices.Contains(includeClients, clientID)
+	}
+
+	// Default: include all clients when no filtering specified (nil case)
+	return true
+}
+
+// shouldSkipToolForConfig checks if a tool should be skipped based on client configuration (without accessing clientMap).
+func shouldSkipToolForConfig(toolName string, config schemas.MCPClientConfig) bool {
+	// If ToolsToExecute is specified (not nil), apply filtering
+	if config.ToolsToExecute != nil {
+		// Handle empty array [] - means no tools are allowed
+		if len(config.ToolsToExecute) == 0 {
+			return true // No tools allowed
+		}
+
+		// Handle wildcard "*" - if present, all tools are allowed
+		if slices.Contains(config.ToolsToExecute, "*") {
+			return false // All tools allowed
+		}
+
+		// Check if specific tool is in the allowed list
+		return !slices.Contains(config.ToolsToExecute, toolName) // Tool not in allowed list
+	}
+
+	return true // Tool is skipped (nil is treated as [] - no tools)
+}
+
+// shouldSkipToolForRequest checks if a tool should be skipped based on the request context.
+func shouldSkipToolForRequest(clientID, toolName string, ctx context.Context) bool {
+	includeTools := ctx.Value(MCPContextKeyIncludeTools)
+
+	if includeTools != nil {
+		// Try []string first (preferred type)
+		if includeToolsList, ok := includeTools.([]string); ok {
+			// Handle empty array [] - means no tools are included
+			if len(includeToolsList) == 0 {
+				return true // No tools allowed
+			}
+
+			// Handle wildcard "clientName/*" - if present, all tools are included for this client
+			if slices.Contains(includeToolsList, fmt.Sprintf("%s/*", clientID)) {
+				return false // All tools allowed
+			}
+
+			// Check if specific tool is in the list (format: clientName/toolName)
+			fullToolName := fmt.Sprintf("%s/%s", clientID, toolName)
+			if slices.Contains(includeToolsList, fullToolName) {
+				return false // Tool is explicitly allowed
+			}
+
+			// If includeTools is specified but this tool is not in it, skip it
+			return true
+		}
+	}
+
+	return false // Tool is allowed (default when no filtering specified)
+}
+
+// convertMCPToolToBifrostSchema converts an MCP tool definition to Bifrost format.
+func convertMCPToolToBifrostSchema(mcpTool *mcp.Tool) schemas.ChatTool {
+	return schemas.ChatTool{
+		Type: schemas.ChatToolTypeFunction,
+		Function: &schemas.ChatToolFunction{
+			Name:        mcpTool.Name,
+			Description: schemas.Ptr(mcpTool.Description),
+			Parameters: &schemas.ToolFunctionParameters{
+				Type:       mcpTool.InputSchema.Type,
+				Properties: schemas.Ptr(mcpTool.InputSchema.Properties),
+				Required:   mcpTool.InputSchema.Required,
+			},
+		},
+	}
+}
+
+// extractTextFromMCPResponse extracts text content from an MCP tool response.
+func extractTextFromMCPResponse(toolResponse *mcp.CallToolResult, toolName string) string {
+	if toolResponse == nil {
+		return fmt.Sprintf("MCP tool '%s' executed successfully", toolName)
+	}
+
+	var result strings.Builder
+	for _, contentBlock := range toolResponse.Content {
+		// Handle typed content
+		switch content := contentBlock.(type) {
+		case mcp.TextContent:
+			result.WriteString(content.Text)
+		case mcp.ImageContent:
+			result.WriteString(fmt.Sprintf("[Image Response: %s, MIME: %s]\n", content.Data, content.MIMEType))
+		case mcp.AudioContent:
+			result.WriteString(fmt.Sprintf("[Audio Response: %s, MIME: %s]\n", content.Data, content.MIMEType))
+		case mcp.EmbeddedResource:
+			result.WriteString(fmt.Sprintf("[Embedded Resource Response: %s]\n", content.Type))
+		default:
+			// Fallback: try to extract from map structure
+			if jsonBytes, err := json.Marshal(contentBlock); err == nil {
+				var contentMap map[string]interface{}
+				if json.Unmarshal(jsonBytes, &contentMap) == nil {
+					if text, ok := contentMap["text"].(string); ok {
+						result.WriteString(fmt.Sprintf("[Text Response: %s]\n", text))
+						continue
+					}
+				}
+				// Final fallback: serialize as JSON
+				result.WriteString(string(jsonBytes))
+			}
+		}
+	}
+
+	if result.Len() > 0 {
+		return strings.TrimSpace(result.String())
+	}
+	return fmt.Sprintf("MCP tool '%s' executed successfully", toolName)
+}
+
+// createToolResponseMessage creates a tool response message with the execution result.
+func createToolResponseMessage(toolCall schemas.ChatAssistantMessageToolCall, responseText string) *schemas.ChatMessage {
+	return &schemas.ChatMessage{
+		Role: schemas.ChatMessageRoleTool,
+		Content: &schemas.ChatMessageContent{
+			ContentStr: &responseText,
+		},
+		ChatToolMessage: &schemas.ChatToolMessage{
+			ToolCallID: toolCall.ID,
+		},
+	}
+}
+
+// validateMCPClientConfig validates an MCP client configuration.
+func validateMCPClientConfig(config *schemas.MCPClientConfig) error {
+	if strings.TrimSpace(config.ID) == "" {
+		return fmt.Errorf("id is required for MCP client config")
+	}
+
+	if strings.TrimSpace(config.Name) == "" {
+		return fmt.Errorf("name is required for MCP client config")
+	}
+
+	if config.ConnectionType == "" {
+		return fmt.Errorf("connection type is required for MCP client config")
+	}
+
+	switch config.ConnectionType {
+	case schemas.MCPConnectionTypeHTTP:
+		if config.ConnectionString == nil {
+			return fmt.Errorf("ConnectionString is required for HTTP connection type in client '%s'", config.Name)
+		}
+	case schemas.MCPConnectionTypeSSE:
+		if config.ConnectionString == nil {
+			return fmt.Errorf("ConnectionString is required for SSE connection type in client '%s'", config.Name)
+		}
+	case schemas.MCPConnectionTypeSTDIO:
+		if config.StdioConfig == nil {
+			return fmt.Errorf("StdioConfig is required for STDIO connection type in client '%s'", config.Name)
+		}
+	case schemas.MCPConnectionTypeInProcess:
+		// InProcess requires a server instance to be provided programmatically
+		// This cannot be validated from JSON config - the server must be set when using the Go package
+		if config.InProcessServer == nil {
+			return fmt.Errorf("InProcessServer is required for InProcess connection type in client '%s' (Go package only)", config.Name)
+		}
+	default:
+		return fmt.Errorf("unknown connection type '%s' in client '%s'", config.ConnectionType, config.Name)
+	}
+
+	return nil
+}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1820,6 +1820,8 @@ func (provider *OpenAIProvider) Transcription(ctx context.Context, key schemas.K
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, providerName)
 	}
 
+	//TODO: add HandleProviderResponse here
+
 	// Parse raw response for RawResponse field
 	var rawResponse interface{}
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -117,6 +117,7 @@ const (
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"                     // bool
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool
 	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost)
+	BifrostMCPAgentOriginalRequestID                     BifrostContextKey = "bifrost-mcp-agent-original-request-id"            // string (to store the original request ID for MCP agent mode)
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -1,15 +1,53 @@
 // Package schemas defines the core schemas and types used by the Bifrost system.
 package schemas
 
+import "context"
+
 // MCPServerInstance represents an MCP server instance for InProcess connections.
 // This should be a *github.com/mark3labs/mcp-go/server.MCPServer instance.
 // We use interface{} to avoid creating a dependency on the mcp-go package in schemas.
 type MCPServerInstance interface{}
 
+// MCPManager defines the interface for MCP (Model Context Protocol) management operations.
+// It provides methods for client management, tool registration and execution, and agent mode functionality.
+type MCPManager interface {
+	// Client Management
+	GetClients() ([]MCPClient, error)
+	AddClient(config MCPClientConfig) error
+	RemoveClient(id string) error
+	EditClient(id string, updatedConfig MCPClientConfig) error
+	ReconnectClient(id string) error
+
+	// Tool Management
+	RegisterTool(name, description string, handler func(args any) (string, error), toolSchema ChatTool) error
+	ExecuteTool(ctx context.Context, toolCall ChatAssistantMessageToolCall) (*ChatMessage, error)
+	AddMCPToolsToBifrostRequest(ctx context.Context, req *BifrostRequest) *BifrostRequest
+
+	// Agent Mode
+	CheckAndExecuteAgentMode(ctx *context.Context, originalReq *BifrostChatRequest, initialResponse *BifrostChatResponse, llmCaller BifrostLLMCaller) (*BifrostChatResponse, *BifrostError)
+
+	// Lifecycle Management
+	Cleanup() error
+}
+
+// BifrostLLMCaller defines the interface for making LLM calls from the agent mode.
+// This interface allows the MCP manager to make chat completion requests during agent execution.
+type BifrostLLMCaller interface {
+	ChatCompletionRequest(ctx context.Context, req *BifrostChatRequest) (*BifrostChatResponse, *BifrostError)
+}
+
 // MCPConfig represents the configuration for MCP integration in Bifrost.
 // It enables tool auto-discovery and execution from local and external MCP servers.
 type MCPConfig struct {
-	ClientConfigs []MCPClientConfig `json:"client_configs,omitempty"` // Per-client execution configurations
+	ClientConfigs        []MCPClientConfig `json:"client_configs,omitempty"`         // Per-client execution configurations
+	MaxAgentDepth        int               `json:"max_agent_depth,omitempty"`        // Maximum depth for agent mode tool execution (default: 10)
+	ToolExecutionTimeout int               `json:"tool_execution_timeout,omitempty"` // Timeout for individual tool execution in seconds (default: 30)
+
+	// Function to fetch a new request ID for each tool call result message in agent mode,
+	// this is used to ensure that the tool call result messages are unique and can be tracked in plugins or by the user.
+	// This id is attached to ctx.Value(schemas.BifrostContextKeyRequestID) in the agent mode.
+	// If not provider, same request ID is used for all tool call result messages without any overrides.
+	FetchNewRequestIDFunc func(ctx context.Context) string `json:"-"`
 }
 
 // MCPClientConfig defines tool filtering for an MCP client.
@@ -27,6 +65,13 @@ type MCPClientConfig struct {
 	// - []    => no tools are included (deny-by-default)
 	// - nil/omitted => treated as [] (no tools)
 	// - ["tool1", "tool2"] => include only the specified tools
+	ToolsToAutoExecute []string `json:"tools_to_auto_execute,omitempty"` // Auto-execute list.
+	// ToolsToAutoExecute semantics:
+	// - ["*"] => all tools are auto-executed
+	// - []    => no tools are auto-executed (deny-by-default)
+	// - nil/omitted => treated as [] (no tools)
+	// - ["tool1", "tool2"] => auto-execute only the specified tools
+	// Note: If a tool is in ToolsToAutoExecute but not in ToolsToExecute, it will be skipped.
 }
 
 // MCPConnectionType defines the communication protocol for MCP connections

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -76,6 +76,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationMissingProviderColumnInKeyTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddToolsToAutoExecuteJSONColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddLogRetentionDaysColumn(ctx, db); err != nil {
 		return err
 	}
@@ -1036,6 +1039,40 @@ func migrationMissingProviderColumnInKeyTable(ctx context.Context, db *gorm.DB) 
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while running add and fill provider column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddToolsToAutoExecuteJSONColumn adds the tools_to_auto_execute_json column to the mcp_client table
+func migrationAddToolsToAutoExecuteJSONColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_tools_to_auto_execute_json_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableMCPClient{}, "tools_to_auto_execute_json") {
+				if err := migrator.AddColumn(&tables.TableMCPClient{}, "tools_to_auto_execute_json"); err != nil {
+					return err
+				}
+				// Initialize existing rows with empty array
+				if err := tx.Exec("UPDATE config_mcp_clients SET tools_to_auto_execute_json = '[]' WHERE tools_to_auto_execute_json IS NULL OR tools_to_auto_execute_json = ''").Error; err != nil {
+					return fmt.Errorf("failed to initialize tools_to_auto_execute_json: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if err := migrator.DropColumn(&tables.TableMCPClient{}, "tools_to_auto_execute_json"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while running db migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -156,7 +156,6 @@ func (s *RDBConfigStore) UpdateFrameworkConfig(ctx context.Context, config *tabl
 		}
 		return tx.Create(config).Error
 	})
-
 }
 
 // GetFrameworkConfig retrieves the framework configuration from the database.
@@ -666,13 +665,14 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 		}
 
 		clientConfigs[i] = schemas.MCPClientConfig{
-			ID:               dbClient.ClientID,
-			Name:             dbClient.Name,
-			ConnectionType:   schemas.MCPConnectionType(dbClient.ConnectionType),
-			ConnectionString: processedConnectionString,
-			StdioConfig:      dbClient.StdioConfig,
-			ToolsToExecute:   dbClient.ToolsToExecute,
-			Headers:          processedHeaders,
+			ID:                 dbClient.ClientID,
+			Name:               dbClient.Name,
+			ConnectionType:     schemas.MCPConnectionType(dbClient.ConnectionType),
+			ConnectionString:   processedConnectionString,
+			StdioConfig:        dbClient.StdioConfig,
+			ToolsToExecute:     dbClient.ToolsToExecute,
+			ToolsToAutoExecute: dbClient.ToolsToAutoExecute,
+			Headers:            processedHeaders,
 		}
 	}
 	return &schemas.MCPConfig{
@@ -706,13 +706,14 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 
 		// Create new client
 		dbClient := tables.TableMCPClient{
-			ClientID:         clientConfigCopy.ID,
-			Name:             clientConfigCopy.Name,
-			ConnectionType:   string(clientConfigCopy.ConnectionType),
-			ConnectionString: clientConfigCopy.ConnectionString,
-			StdioConfig:      clientConfigCopy.StdioConfig,
-			ToolsToExecute:   clientConfigCopy.ToolsToExecute,
-			Headers:          clientConfigCopy.Headers,
+			ClientID:           clientConfigCopy.ID,
+			Name:               clientConfigCopy.Name,
+			ConnectionType:     string(clientConfigCopy.ConnectionType),
+			ConnectionString:   clientConfigCopy.ConnectionString,
+			StdioConfig:        clientConfigCopy.StdioConfig,
+			ToolsToExecute:     clientConfigCopy.ToolsToExecute,
+			ToolsToAutoExecute: clientConfigCopy.ToolsToAutoExecute,
+			Headers:            clientConfigCopy.Headers,
 		}
 
 		if err := tx.WithContext(ctx).Create(&dbClient).Error; err != nil {
@@ -749,6 +750,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		existingClient.ConnectionString = clientConfigCopy.ConnectionString
 		existingClient.StdioConfig = clientConfigCopy.StdioConfig
 		existingClient.ToolsToExecute = clientConfigCopy.ToolsToExecute
+		existingClient.ToolsToAutoExecute = clientConfigCopy.ToolsToAutoExecute
 		existingClient.Headers = clientConfigCopy.Headers
 
 		if err := tx.WithContext(ctx).Updates(&existingClient).Error; err != nil {

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -10,21 +10,23 @@ import (
 
 // TableMCPClient represents an MCP client configuration in the database
 type TableMCPClient struct {
-	ID                 uint      `gorm:"primaryKey;autoIncrement" json:"id"` // ID is used as the internal primary key and is also accessed by public methods, so it must be present.
-	ClientID           string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
-	Name               string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"name"`
-	ConnectionType     string    `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
-	ConnectionString   *string   `gorm:"type:text" json:"connection_string,omitempty"`
-	StdioConfigJSON    *string   `gorm:"type:text" json:"-"` // JSON serialized schemas.MCPStdioConfig
-	ToolsToExecuteJSON string    `gorm:"type:text" json:"-"` // JSON serialized []string
-	HeadersJSON        string    `gorm:"type:text" json:"-"` // JSON serialized map[string]string
-	CreatedAt          time.Time `gorm:"index;not null" json:"created_at"`
-	UpdatedAt          time.Time `gorm:"index;not null" json:"updated_at"`
+	ID                     uint      `gorm:"primaryKey;autoIncrement" json:"id"` // ID is used as the internal primary key and is also accessed by public methods, so it must be present.
+	ClientID               string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
+	Name                   string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"name"`
+	ConnectionType         string    `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
+	ConnectionString       *string   `gorm:"type:text" json:"connection_string,omitempty"`
+	StdioConfigJSON        *string   `gorm:"type:text" json:"-"` // JSON serialized schemas.MCPStdioConfig
+	ToolsToExecuteJSON     string    `gorm:"type:text" json:"-"` // JSON serialized []string
+	ToolsToAutoExecuteJSON string    `gorm:"type:text" json:"-"` // JSON serialized []string
+	HeadersJSON            string    `gorm:"type:text" json:"-"` // JSON serialized map[string]string
+	CreatedAt              time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt              time.Time `gorm:"index;not null" json:"updated_at"`
 
 	// Virtual fields for runtime use (not stored in DB)
-	StdioConfig    *schemas.MCPStdioConfig `gorm:"-" json:"stdio_config,omitempty"`
-	ToolsToExecute []string                `gorm:"-" json:"tools_to_execute"`
-	Headers        map[string]string       `gorm:"-" json:"headers"`
+	StdioConfig        *schemas.MCPStdioConfig `gorm:"-" json:"stdio_config,omitempty"`
+	ToolsToExecute     []string                `gorm:"-" json:"tools_to_execute"`
+	ToolsToAutoExecute []string                `gorm:"-" json:"tools_to_auto_execute"`
+	Headers            map[string]string       `gorm:"-" json:"headers"`
 }
 
 // TableName sets the table name for each model
@@ -52,6 +54,16 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.ToolsToExecuteJSON = "[]"
 	}
 
+	if c.ToolsToAutoExecute != nil {
+		data, err := json.Marshal(c.ToolsToAutoExecute)
+		if err != nil {
+			return err
+		}
+		c.ToolsToAutoExecuteJSON = string(data)
+	} else {
+		c.ToolsToAutoExecuteJSON = "[]"
+	}
+
 	if c.Headers != nil {
 		data, err := json.Marshal(c.Headers)
 		if err != nil {
@@ -77,6 +89,12 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 
 	if c.ToolsToExecuteJSON != "" {
 		if err := json.Unmarshal([]byte(c.ToolsToExecuteJSON), &c.ToolsToExecute); err != nil {
+			return err
+		}
+	}
+
+	if c.ToolsToAutoExecuteJSON != "" {
+		if err := json.Unmarshal([]byte(c.ToolsToAutoExecuteJSON), &c.ToolsToAutoExecute); err != nil {
 			return err
 		}
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2145,6 +2145,7 @@ func (c *Config) EditMCPClient(ctx context.Context, id string, updatedConfig sch
 	c.MCPConfig.ClientConfigs[configIndex].Name = processedConfig.Name
 	c.MCPConfig.ClientConfigs[configIndex].Headers = processedConfig.Headers
 	c.MCPConfig.ClientConfigs[configIndex].ToolsToExecute = processedConfig.ToolsToExecute
+	c.MCPConfig.ClientConfigs[configIndex].ToolsToAutoExecute = processedConfig.ToolsToAutoExecute
 
 	// Check if client is registered in Bifrost (can be not registered if client initialization failed)
 	if clients, err := c.client.GetMCPClients(); err == nil && len(clients) > 0 {
@@ -2179,12 +2180,13 @@ func (c *Config) EditMCPClient(ctx context.Context, id string, updatedConfig sch
 func (c *Config) RedactMCPClientConfig(config schemas.MCPClientConfig) schemas.MCPClientConfig {
 	// Create a copy with basic fields
 	configCopy := schemas.MCPClientConfig{
-		ID:               config.ID,
-		Name:             config.Name,
-		ConnectionType:   config.ConnectionType,
-		ConnectionString: config.ConnectionString,
-		StdioConfig:      config.StdioConfig,
-		ToolsToExecute:   append([]string{}, config.ToolsToExecute...),
+		ID:                 config.ID,
+		Name:               config.Name,
+		ConnectionType:     config.ConnectionType,
+		ConnectionString:   config.ConnectionString,
+		StdioConfig:        config.StdioConfig,
+		ToolsToExecute:     append([]string{}, config.ToolsToExecute...),
+		ToolsToAutoExecute: append([]string{}, config.ToolsToAutoExecute...),
 	}
 
 	// Handle connection string if present

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
+	"github.com/google/uuid"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
@@ -1042,6 +1043,12 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load plugins %v", err)
 	}
+	mcpConfig := s.Config.MCPConfig
+	if mcpConfig != nil {
+		mcpConfig.FetchNewRequestIDFunc = func(ctx context.Context) string {
+			return uuid.New().String()
+		}
+	}
 	// Initialize bifrost client
 	// Create account backed by the high-performance store (all processing is done in LoadFromDatabase)
 	// The account interface now benefits from ultra-fast config access times via in-memory storage
@@ -1051,7 +1058,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		InitialPoolSize:    s.Config.ClientConfig.InitialPoolSize,
 		DropExcessRequests: s.Config.ClientConfig.DropExcessRequests,
 		Plugins:            s.Plugins,
-		MCPConfig:          s.Config.MCPConfig,
+		MCPConfig:          mcpConfig,
 		Logger:             logger,
 	})
 	if err != nil {

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -173,7 +173,7 @@ export default function SecurityView() {
 					<h2 className="text-2xl font-semibold tracking-tight">Security Settings</h2>
 					<p className="text-muted-foreground text-sm">Configure security and access control settings.</p>
 				</div>
-				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess	}>
+				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>
 			</div>

--- a/ui/app/workspace/logs/views/logChatMessageView.tsx
+++ b/ui/app/workspace/logs/views/logChatMessageView.tsx
@@ -86,7 +86,9 @@ export default function LogChatMessageView({ message }: LogChatMessageViewProps)
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
 						/>
 					) : (
-						<div className="text-muted-foreground px-6 py-2 font-mono text-xs whitespace-pre-wrap italic">{message.thought}</div>
+						<div className="text-muted-foreground px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap italic">
+							{message.thought}
+						</div>
 					)}
 				</div>
 			)}
@@ -107,7 +109,7 @@ export default function LogChatMessageView({ message }: LogChatMessageViewProps)
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
 						/>
 					) : (
-						<div className="px-6 py-2 font-mono text-xs text-red-800">{message.refusal}</div>
+						<div className="px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap text-red-800">{message.refusal}</div>
 					)}
 				</div>
 			)}
@@ -129,7 +131,7 @@ export default function LogChatMessageView({ message }: LogChatMessageViewProps)
 									options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
 								/>
 							) : (
-								<div className="px-6 py-2 font-mono text-xs whitespace-pre-wrap">{message.content}</div>
+								<div className="px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap">{message.content}</div>
 							)}
 						</>
 					) : (

--- a/ui/app/workspace/mcp-clients/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-clients/views/mcpClientSheet.tsx
@@ -36,6 +36,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			name: mcpClient.config.name,
 			headers: mcpClient.config.headers,
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
+			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 		},
 	});
 
@@ -45,6 +46,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			name: mcpClient.config.name,
 			headers: mcpClient.config.headers,
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
+			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 		});
 	}, [form, mcpClient]);
 
@@ -56,6 +58,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					name: data.name,
 					headers: data.headers,
 					tools_to_execute: data.tools_to_execute,
+					tools_to_auto_execute: data.tools_to_auto_execute,
 				},
 			}).unwrap();
 
@@ -106,6 +109,70 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 		}
 
 		form.setValue("tools_to_execute", newTools, { shouldDirty: true });
+
+		// If tool is being removed from tools_to_execute, also remove it from tools_to_auto_execute
+		if (!checked) {
+			const currentAutoExecute = form.getValues("tools_to_auto_execute") || [];
+			if (currentAutoExecute.includes(toolName) || currentAutoExecute.includes("*")) {
+				const newAutoExecute = currentAutoExecute.filter((tool) => tool !== toolName);
+				// If we had "*" and removed a tool, we need to recalculate
+				if (currentAutoExecute.includes("*")) {
+					// If all tools mode, keep "*" only if tool is still in tools_to_execute
+					if (newTools.includes("*")) {
+						form.setValue("tools_to_auto_execute", ["*"], { shouldDirty: true });
+					} else {
+						// Switch to explicit list
+						const remainingTools = newTools.filter((tool) => currentAutoExecute.includes(tool) || currentAutoExecute.includes("*"));
+						form.setValue("tools_to_auto_execute", remainingTools, { shouldDirty: true });
+					}
+				} else {
+					form.setValue("tools_to_auto_execute", newAutoExecute, { shouldDirty: true });
+				}
+			}
+		}
+	};
+
+	const handleAutoExecuteToggle = (toolName: string, checked: boolean) => {
+		const currentAutoExecute = form.getValues("tools_to_auto_execute") || [];
+		const currentTools = form.getValues("tools_to_execute") || [];
+		const allToolNames = mcpClient.tools?.map((tool) => tool.name) || [];
+
+		// Check if we're in "all tools" mode (wildcard)
+		const isAllToolsMode = currentTools.includes("*");
+		const isAllAutoExecuteMode = currentAutoExecute.includes("*");
+
+		let newAutoExecute: string[];
+
+		if (isAllAutoExecuteMode) {
+			if (checked) {
+				// Already all selected, keep wildcard
+				newAutoExecute = ["*"];
+			} else {
+				// Unchecking a tool when all are selected - switch to explicit list without this tool
+				if (isAllToolsMode) {
+					newAutoExecute = allToolNames.filter((name) => name !== toolName);
+				} else {
+					newAutoExecute = currentTools.filter((name) => name !== toolName);
+				}
+			}
+		} else {
+			// We're in explicit tool selection mode
+			if (checked) {
+				// Add tool to selection
+				newAutoExecute = currentAutoExecute.includes(toolName) ? currentAutoExecute : [...currentAutoExecute, toolName];
+
+				// If we now have all allowed tools selected, switch to wildcard mode
+				const allowedTools = isAllToolsMode ? allToolNames : currentTools;
+				if (newAutoExecute.length === allowedTools.length && allowedTools.every((tool) => newAutoExecute.includes(tool))) {
+					newAutoExecute = ["*"];
+				}
+			} else {
+				// Remove tool from selection
+				newAutoExecute = currentAutoExecute.filter((tool) => tool !== toolName);
+			}
+		}
+
+		form.setValue("tools_to_auto_execute", newAutoExecute, { shouldDirty: true });
 	};
 
 	return (
@@ -242,34 +309,65 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 									<div className="space-y-4">
 										{mcpClient.tools.map((tool, index) => {
 											const currentTools = form.watch("tools_to_execute") || [];
+											const currentAutoExecute = form.watch("tools_to_auto_execute") || [];
 
 											// If tools_to_execute contains "*", all tools are enabled
 											const isToolEnabled = currentTools?.includes("*") || currentTools?.includes(tool.name);
+											// If tools_to_auto_execute contains "*", all enabled tools are auto-executed
+											const isAutoExecuteEnabled =
+												(currentAutoExecute?.includes("*") && isToolEnabled) ||
+												(currentAutoExecute?.includes(tool.name) && isToolEnabled);
+											// Disable auto-execute toggle if tool is not in tools_to_execute
+											const isAutoExecuteDisabled = !isToolEnabled;
 
 											return (
 												<div key={index} className="rounded-sm border">
 													{/* Tool Header */}
 													<div className="bg-muted/50 text-muted-foreground border-b px-6 py-3">
 														<div className="flex items-center justify-between gap-4">
-															<div>
+															<div className="flex-1">
 																<span className="text-sm font-medium">{tool.name}</span>
 																{tool.description && <p className="text-muted-foreground mt-1 text-xs">{tool.description}</p>}
 															</div>
-															<FormField
-																control={form.control}
-																name="tools_to_execute"
-																render={({ field }) => (
-																	<FormItem>
-																		<FormControl>
-																			<Switch
-																				size="md"
-																				checked={isToolEnabled}
-																				onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
-																			/>
-																		</FormControl>
-																	</FormItem>
-																)}
-															/>
+															<div className="flex items-center gap-4">
+																<div className="flex flex-col items-end gap-1">
+																	<span className="text-muted-foreground text-xs">Execute</span>
+																	<FormField
+																		control={form.control}
+																		name="tools_to_execute"
+																		render={({ field }) => (
+																			<FormItem>
+																				<FormControl>
+																					<Switch
+																						size="md"
+																						checked={isToolEnabled}
+																						onCheckedChange={(checked) => handleToolToggle(tool.name, checked)}
+																					/>
+																				</FormControl>
+																			</FormItem>
+																		)}
+																	/>
+																</div>
+																<div className="flex flex-col items-end gap-1">
+																	<span className="text-muted-foreground text-xs">Auto-execute</span>
+																	<FormField
+																		control={form.control}
+																		name="tools_to_auto_execute"
+																		render={({ field }) => (
+																			<FormItem>
+																				<FormControl>
+																					<Switch
+																						size="md"
+																						checked={isAutoExecuteEnabled}
+																						disabled={isAutoExecuteDisabled}
+																						onCheckedChange={(checked) => handleAutoExecuteToggle(tool.name, checked)}
+																					/>
+																				</FormControl>
+																			</FormItem>
+																		)}
+																	/>
+																</div>
+															</div>
 														</div>
 													</div>
 

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -17,6 +17,7 @@ export interface MCPClientConfig {
 	connection_string?: string;
 	stdio_config?: MCPStdioConfig;
 	tools_to_execute?: string[];
+	tools_to_auto_execute?: string[];
 	headers?: Record<string, string>;
 }
 
@@ -32,6 +33,7 @@ export interface CreateMCPClientRequest {
 	connection_string?: string;
 	stdio_config?: MCPStdioConfig;
 	tools_to_execute?: string[];
+	tools_to_auto_execute?: string[];
 	headers?: Record<string, string>;
 }
 
@@ -39,4 +41,5 @@ export interface UpdateMCPClientRequest {
 	name?: string;
 	headers?: Record<string, string>;
 	tools_to_execute?: string[];
+	tools_to_auto_execute?: string[];
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -594,6 +594,24 @@ export const mcpClientUpdateSchema = z.object({
 			},
 			{ message: "Duplicate tool names are not allowed" },
 		),
+	tools_to_auto_execute: z
+		.array(z.string())
+		.optional()
+		.refine(
+			(tools) => {
+				if (!tools || tools.length === 0) return true;
+				const hasWildcard = tools.includes("*");
+				return !hasWildcard || tools.length === 1;
+			},
+			{ message: "Wildcard '*' cannot be combined with other tool names" },
+		)
+		.refine(
+			(tools) => {
+				if (!tools) return true;
+				return tools.length === new Set(tools).size;
+			},
+			{ message: "Duplicate tool names are not allowed" },
+		),
 });
 
 // Export type inference helpers

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -371,7 +371,11 @@ function isValidWildcardOrigin(origin: string): boolean {
  * @returns Object with validation result and invalid origins
  */
 export function validateOrigins(origins: string[]): { isValid: boolean; invalidOrigins: string[] } {
-	const invalidOrigins = origins?.filter((origin) => !isValidOrigin(origin)) || [];
+	if (!origins || origins.length === 0) {
+		return { isValid: true, invalidOrigins: [] };
+	}
+
+	const invalidOrigins = origins.filter((origin) => !isValidOrigin(origin));
 
 	return {
 		isValid: invalidOrigins.length === 0,


### PR DESCRIPTION
## Summary

Refactors the MCP (Model Control Protocol) integration into a separate package and adds agent mode functionality, allowing Bifrost to automatically execute tool calls and chain them together for more complex workflows.

## Changes

- Moved MCP code from core/bifrost.go to a dedicated core/mcp package for better organization
- Added agent mode functionality that can automatically execute tool calls and chain them together
- Introduced tools auto-execution configuration to control which tools can be executed automatically
- Added UI support for configuring auto-executable tools
- Added database migration for the new tools_to_auto_execute field
- Improved error handling and context management for tool execution

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Configure an MCP client with auto-executable tools:

```sh
# Start Bifrost
go run cmd/bifrost/main.go

# Configure an MCP client via UI or API
# Mark some tools as auto-executable in the UI
```

2. Make a chat completion request that uses tools:

```sh
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4",
    "messages": [
      {"role": "user", "content": "Use a tool to help me with this task"}
    ]
  }'
```

3. Observe that auto-executable tools are executed automatically without requiring user intervention.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Implements agent mode functionality for MCP tools.

## Security considerations

- Tool execution is controlled by configuration, allowing administrators to specify which tools can be auto-executed
- Agent mode has a configurable maximum depth to prevent infinite loops

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable