### PR TITLE
fix: add parsing for cached creation input tokens for Bedrock

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,1 @@
-- fix: added parsing for cached creation input tokens for Anthropic
+- fix: added parsing for cached creation input tokens for Anthropic and Bedrock

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -723,6 +723,17 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 						CompletionTokens: streamEvent.Usage.OutputTokens,
 						TotalTokens:      streamEvent.Usage.TotalTokens,
 					}
+					// Handle cached tokens if present
+					if streamEvent.Usage.CacheReadInputTokens > 0 {
+						usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+							CachedTokens: streamEvent.Usage.CacheReadInputTokens,
+						}
+					}
+					if streamEvent.Usage.CacheWriteInputTokens > 0 {
+						usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
+							CachedTokens: streamEvent.Usage.CacheWriteInputTokens,
+						}
+					}
 				}
 
 				if streamEvent.StopReason != nil {
@@ -949,6 +960,17 @@ func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRu
 						InputTokens:  streamEvent.Usage.InputTokens,
 						OutputTokens: streamEvent.Usage.OutputTokens,
 						TotalTokens:  streamEvent.Usage.TotalTokens,
+					}
+					// Handle cached tokens if present
+					if streamEvent.Usage.CacheReadInputTokens > 0 {
+						usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
+							CachedTokens: streamEvent.Usage.CacheReadInputTokens,
+						}
+					}
+					if streamEvent.Usage.CacheWriteInputTokens > 0 {
+						usage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{
+							CachedTokens: streamEvent.Usage.CacheWriteInputTokens,
+						}
 					}
 				}
 

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -87,8 +87,8 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(model string) (*s
 
 					toolCalls = append(toolCalls, schemas.ChatAssistantMessageToolCall{
 						Index: uint16(len(toolCalls)),
-						Type: schemas.Ptr("function"),
-						ID:   &toolUseID,
+						Type:  schemas.Ptr("function"),
+						ID:    &toolUseID,
 						Function: schemas.ChatAssistantMessageToolCallFunction{
 							Name:      &toolUseName,
 							Arguments: arguments,
@@ -134,6 +134,17 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(model string) (*s
 			PromptTokens:     response.Usage.InputTokens,
 			CompletionTokens: response.Usage.OutputTokens,
 			TotalTokens:      response.Usage.TotalTokens,
+		}
+		// Handle cached tokens if present
+		if response.Usage.CacheReadInputTokens > 0 {
+			usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+				CachedTokens: response.Usage.CacheReadInputTokens,
+			}
+		}
+		if response.Usage.CacheWriteInputTokens > 0 {
+			usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
+				CachedTokens: response.Usage.CacheWriteInputTokens,
+			}
 		}
 	}
 
@@ -185,7 +196,7 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 		toolUseStart := chunk.Start.ToolUse
 
 		// Create tool call structure for start event
-		var toolCall schemas.ChatAssistantMessageToolCall		
+		var toolCall schemas.ChatAssistantMessageToolCall
 		toolCall.ID = schemas.Ptr(toolUseStart.ToolUseID)
 		toolCall.Type = schemas.Ptr("function")
 		toolCall.Function.Name = schemas.Ptr(toolUseStart.Name)

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -331,6 +331,17 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse() (*schemas.
 			OutputTokens: response.Usage.OutputTokens,
 			TotalTokens:  response.Usage.TotalTokens,
 		}
+		// Handle cached tokens if present
+		if response.Usage.CacheReadInputTokens > 0 {
+			bifrostResp.Usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
+				CachedTokens: response.Usage.CacheReadInputTokens,
+			}
+		}
+		if response.Usage.CacheWriteInputTokens > 0 {
+			bifrostResp.Usage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{
+				CachedTokens: response.Usage.CacheWriteInputTokens,
+			}
+		}
 	}
 
 	// Convert output message to Responses format

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -244,9 +244,11 @@ type BedrockConverseOutput struct {
 
 // BedrockTokenUsage represents token usage information
 type BedrockTokenUsage struct {
-	InputTokens  int `json:"inputTokens"`  // Number of input tokens
-	OutputTokens int `json:"outputTokens"` // Number of output tokens
-	TotalTokens  int `json:"totalTokens"`  // Total number of tokens (input + output)
+	InputTokens           int `json:"inputTokens"`           // Number of input tokens
+	OutputTokens          int `json:"outputTokens"`          // Number of output tokens
+	TotalTokens           int `json:"totalTokens"`           // Total number of tokens (input + output)
+	CacheReadInputTokens  int `json:"cacheReadInputTokens"`  // Number of cached tokens read
+	CacheWriteInputTokens int `json:"cacheWriteInputTokens"` // Number of cached tokens written
 }
 
 // BedrockConverseMetrics represents response metrics

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -566,7 +566,10 @@ type BifrostLLMUsage struct {
 }
 
 type ChatPromptTokensDetails struct {
-	AudioTokens  int `json:"audio_tokens,omitempty"`
+	AudioTokens int `json:"audio_tokens,omitempty"`
+
+	// For Providers which follow OpenAI's spec, CachedTokens means the number of input tokens read from the cache+input tokens used to create the cache entry. (because they do not differentiate between cache creation and cache read tokens)
+	// For Providers which do not follow OpenAI's spec, CachedTokens means only the number of input tokens read from the cache.
 	CachedTokens int `json:"cached_tokens,omitempty"`
 }
 
@@ -578,7 +581,8 @@ type ChatCompletionTokensDetails struct {
 	ReasoningTokens          int  `json:"reasoning_tokens,omitempty"`
 	RejectedPredictionTokens int  `json:"rejected_prediction_tokens,omitempty"`
 
-	CachedTokens int `json:"cached_tokens,omitempty"` // Not in OpenAI's schemas, but sent by a few providers (Anthropic is one of them)
+	// This means the number of input tokens used to create the cache entry. (cache creation tokens)
+	CachedTokens int `json:"cached_tokens,omitempty"` // Not in OpenAI's schemas, but sent by a few providers (Anthropic, Bedrock are some of them)
 }
 
 type BifrostCost struct {

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -257,8 +257,11 @@ type ResponsesResponseUsage struct {
 }
 
 type ResponsesResponseInputTokens struct {
-	AudioTokens  int `json:"audio_tokens"`  // Tokens for audio input
-	CachedTokens int `json:"cached_tokens"` // Tokens retrieved from cache
+	AudioTokens int `json:"audio_tokens"` // Tokens for audio input
+
+	// For Providers which follow OpenAI's spec, CachedTokens means the number of input tokens read from the cache+input tokens used to create the cache entry. (because they do not differentiate between cache creation and cache read tokens)
+	// For Providers which do not follow OpenAI's spec, CachedTokens means only the number of input tokens read from the cache.
+	CachedTokens int `json:"cached_tokens"`
 }
 
 type ResponsesResponseOutputTokens struct {
@@ -269,7 +272,8 @@ type ResponsesResponseOutputTokens struct {
 	CitationTokens           *int `json:"citation_tokens,omitempty"`
 	NumSearchQueries         *int `json:"num_search_queries,omitempty"`
 
-	CachedTokens int `json:"cached_tokens,omitempty"` // Not in OpenAI's schemas, but sent by a few providers (Anthropic is one of them)
+	// This means the number of input tokens used to create the cache entry. (cache creation tokens)
+	CachedTokens int `json:"cached_tokens,omitempty"` // Not in OpenAI's schemas, but sent by a few providers (Anthropic, Bedrock are some of them)
 }
 
 // =============================================================================

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,2 @@
+- fix: added parsing for cached creation input tokens for Anthropic and Bedrock
+- fix: handled cost calculation for cached tokens

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -112,7 +112,7 @@ export default function ClientSettingsView() {
 								Enforce Virtual Keys
 							</label>
 							<p className="text-muted-foreground text-sm">
-								Enforce the use of a virtual key for all requests. If enabled, requests without the <b>x-bf-vk</b> header will be rejected.
+								Enforce the use of a virtual key for all requests. If enabled, requests without the virtual keys will be rejected.
 							</p>
 						</div>
 						<Switch


### PR DESCRIPTION
## Summary

Added support for parsing cached token information from Bedrock responses, extending the existing functionality that was previously only available for Anthropic. This enables proper tracking and cost calculation for cached tokens in both providers.

## Changes

- Added parsing for cached input tokens (`CacheReadInputTokens` and `CacheWriteInputTokens`) in Bedrock responses
- Updated token usage structures to include cached token information
- Implemented handling for cached tokens in both chat completion and responses streams
- Updated UI text for virtual key enforcement to be more generic and accurate
- Added changelog entries for both core and transports

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test with Bedrock provider using cached responses:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Extends the fix for cached token parsing that was previously implemented for Anthropic.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable