### PR TITLE
fixes schema

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -568,7 +568,7 @@
                   "max_open_conns": {
                     "type": "integer",
                     "description": "Maximum number of open connections to the database (default: 50)",
-                    "minimum": 0,
+                    "minimum": 2,
                     "default": 50
                   }
                 },


### PR DESCRIPTION
## Summary

Update the minimum value for `max_open_conns` in the database configuration schema from 0 to 2.

## Changes

- Changed the minimum allowed value for `max_open_conns` from 0 to 2 in the database configuration schema
- The default value remains unchanged at 50

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that database configurations with `max_open_conns` set to 0 or 1 are rejected:

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

This is a breaking change for configurations that previously specified `max_open_conns` with values of 0 or 1. These configurations will now be rejected as invalid. Users will need to update their configurations to use a value of at least 2.

## Security considerations

Setting a minimum of 2 connections helps prevent potential connection starvation issues that could occur with fewer connections.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable