### PR TITLE
fixes miltify publish flow

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -256,6 +256,20 @@
         "icon": "bolt",
         "pages": [
           "changelogs/v1.3.36",
+          "changelogs/v1.3.35",
+          "changelogs/v1.3.34",
+          "changelogs/v1.3.33",
+          "changelogs/v1.3.32",
+          "changelogs/v1.3.31",
+          "changelogs/v1.3.30",
+          "changelogs/v1.3.29",
+          "changelogs/v1.3.28",
+          "changelogs/v1.3.27",
+          "changelogs/v1.3.26",
+          "changelogs/v1.3.25",
+          "changelogs/v1.3.24",
+          "changelogs/v1.3.23",
+          "changelogs/v1.3.22",
           {
             "group": "October 2025",
             "pages": [
@@ -289,25 +303,6 @@
               "changelogs/v1.3.0",
               "changelogs/v1.2.22",
               "changelogs/v1.2.21"
-            ]
-          },
-          {
-            "group": "November 2025",
-            "pages": [
-              "changelogs/v1.3.35",
-              "changelogs/v1.3.34",
-              "changelogs/v1.3.33",
-              "changelogs/v1.3.32",
-              "changelogs/v1.3.31",
-              "changelogs/v1.3.30",
-              "changelogs/v1.3.29",
-              "changelogs/v1.3.28",
-              "changelogs/v1.3.27",
-              "changelogs/v1.3.26",
-              "changelogs/v1.3.25",
-              "changelogs/v1.3.24",
-              "changelogs/v1.3.23",
-              "changelogs/v1.3.22"
             ]
           }
         ]


### PR DESCRIPTION
## Summary

Improve changelog organization in Mintlify documentation by simplifying how entries are grouped by month.

## Changes

- Simplified the changelog grouping logic to only create a new month group when the release month changes
- Previously, the script would always group top-level entries by month, now it only does so when necessary
- Fixed an issue where entries from the same month were incorrectly being placed in different groups
- Updated the docs.json file to move v1.3.22-v1.3.35 entries from "November 2025" group to the top level, keeping them with v1.3.36

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Run the changelog script after a new release:
```sh
.github/workflows/scripts/push-mintlify-changelog.sh
```
2. Verify that changelog entries from the same month stay together at the top level
3. Verify that only when a new month's release happens, the previous month's entries get grouped

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with changelog organization in the documentation site.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified the CI pipeline passes locally if applicable