### PR TITLE
bumping chart version

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: v4.0.0
+          version: v3.16.0
 
       - name: Run chart-testing (lint)
         run: |

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,15 +2,15 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 1.3.5
-appVersion: "1.3.5"
+version: 1.3.36
+appVersion: "1.3.36"
 keywords:
   - ai
   - gateway
   - llm
   - openai
   - anthropic
-home: https://www.getbifrost.ai
+home: https://www.getmaxim.ai/bifrost
 sources:
   - https://github.com/maximhq/bifrost
 maintainers:


### PR DESCRIPTION
## Summary

Update Helm chart configuration for Bifrost with new version numbers and website URL.

## Changes

- Updated Helm version in GitHub workflow from v4.0.0 to v3.16.0
- Bumped Bifrost chart and app version from 1.3.5 to 1.3.36
- Updated home URL from getbifrost.ai to getmaxim.ai/bifrost

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Docs

## How to test

Verify the Helm chart can be installed with the updated version:

```sh
# Add the Helm repository
helm repo add bifrost https://maximhq.github.io/bifrost/

# Update repositories
helm repo update

# Install the chart
helm install bifrost bifrost/bifrost --version 1.3.36
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable