### PR TITLE
fixes azure account config

### DIFF
--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -186,11 +186,11 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *context.Context
 				},
 			},
 			{
-				Value:  os.Getenv("AZURE_REASONING_API_KEY"),
+				Value:  os.Getenv("AZURE_API_KEY"),
 				Models: []string{},
 				Weight: 1.0,
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint: os.Getenv("AZURE_REASONING_ENDPOINT"),
+					Endpoint: os.Getenv("AZURE_API_KEY"),
 					Deployments: map[string]string{
 						"o1": "o1",
 					},


### PR DESCRIPTION
## Summary

Updated Azure environment variable names in the test utility to use consistent naming conventions.

## Changes

- Changed `AZURE_REASONING_API_KEY` to `AZURE_API_KEY` in the environment variable reference
- Changed `AZURE_REASONING_ENDPOINT` to `AZURE_API_KEY` for the endpoint configuration

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Ensure the Azure API key environment variables are set correctly:

```sh
# Set the environment variables
export AZURE_API_KEY="your-api-key"
export AZURE_API_KEY="your-endpoint"

# Run the tests
go test ./core/internal/testutil/...
```

## Breaking changes

- [x] Yes
- [ ] No

If you were previously using `AZURE_REASONING_API_KEY` and `AZURE_REASONING_ENDPOINT` environment variables, you'll need to update to use `AZURE_API_KEY` instead.

## Security considerations

This change involves environment variables used for API authentication, but doesn't change how credentials are handled or stored.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable