### PR TITLE
fixes failing bifrost-test

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -728,13 +728,14 @@ func TestUpdateProvider(t *testing.T) {
 			t.Fatalf("Failed to initialize Bifrost: %v", err)
 		}
 
-		// Add provider to account after bifrost initialization
-		account.AddProvider(schemas.Anthropic, 3, 500)
-
+		
 		// Verify provider doesn't exist initially
 		if bifrost.getProviderByKey(schemas.Anthropic) != nil {
 			t.Fatal("Provider should not exist initially")
 		}
+
+		// Add provider to account after bifrost initialization
+		account.AddProvider(schemas.Anthropic, 3, 500)
 
 		// Update should succeed and initialize the provider
 		err = bifrost.UpdateProvider(schemas.Anthropic)


### PR DESCRIPTION
## Summary

Fix test order in `TestUpdateProvider` to ensure proper sequence of operations when testing provider updates in Bifrost.

## Changes

- Reordered test operations in `TestUpdateProvider` to verify the provider doesn't exist before adding it to the account
- Moved the `account.AddProvider` call after the initial verification check to create a more logical test flow

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the core tests to verify the fix:

```sh
# Core/Transports
go version
go test ./core/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a test-only change.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable