### PR TITLE
removes complexity section from multinode setup

### DIFF
--- a/docs/deployment-guides/how-to/multinode.mdx
+++ b/docs/deployment-guides/how-to/multinode.mdx
@@ -15,7 +15,6 @@ Running multiple Bifrost nodes provides high availability, load distribution, an
 | **Configuration Source** | Shared `config.json` file | Database with P2P sync |
 | **Sync Mechanism** | File sharing (ConfigMap, volumes) | Gossip protocol (real-time) |
 | **Config Updates** | Modify file + restart nodes | UI/API with automatic propagation |
-| **Complexity** | Complex | Simple |
 
 ---
 


### PR DESCRIPTION
## Summary

Removed the "Complexity" row from the comparison table in the multinode deployment documentation.

## Changes

- Removed the row that compared complexity between shared configuration and database with P2P sync approaches
- This change provides a more neutral comparison between the two deployment options without making subjective claims about their complexity

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. View the rendered multinode.mdx file to confirm the complexity row is removed from the comparison table
2. Verify the table formatting remains intact

```sh
# If using a documentation preview tool
cd docs
npm run dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable