### PR TITLE
fix: azure responses api openai fixes and tests refactor

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -19,7 +19,7 @@ jobs:
   check-skip:
     runs-on: ubuntu-latest
     permissions:
-          contents: read
+      contents: read
     outputs:
       should-skip: ${{ steps.check.outputs.should-skip }}
     steps:
@@ -101,8 +101,6 @@ jobs:
           BEDROCK_API_KEY: ${{ secrets.BEDROCK_API_KEY }}
           AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-          AZURE_EMB_API_KEY: ${{ secrets.AZURE_EMB_API_KEY }}
-          AZURE_EMB_ENDPOINT: ${{ secrets.AZURE_EMB_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -100,8 +100,6 @@ jobs:
           BEDROCK_API_KEY: ${{ secrets.BEDROCK_API_KEY }}
           AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-          AZURE_EMB_API_KEY: ${{ secrets.AZURE_EMB_API_KEY }}
-          AZURE_EMB_ENDPOINT: ${{ secrets.AZURE_EMB_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
@@ -174,8 +172,6 @@ jobs:
           BEDROCK_API_KEY: ${{ secrets.BEDROCK_API_KEY }}
           AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-          AZURE_EMB_API_KEY: ${{ secrets.AZURE_EMB_API_KEY }}
-          AZURE_EMB_ENDPOINT: ${{ secrets.AZURE_EMB_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
@@ -252,8 +248,6 @@ jobs:
           BEDROCK_API_KEY: ${{ secrets.BEDROCK_API_KEY }}
           AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-          AZURE_EMB_API_KEY: ${{ secrets.AZURE_EMB_API_KEY }}
-          AZURE_EMB_ENDPOINT: ${{ secrets.AZURE_EMB_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
@@ -342,8 +336,6 @@ jobs:
           BEDROCK_API_KEY: ${{ secrets.BEDROCK_API_KEY }}
           AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
           AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-          AZURE_EMB_API_KEY: ${{ secrets.AZURE_EMB_API_KEY }}
-          AZURE_EMB_ENDPOINT: ${{ secrets.AZURE_EMB_ENDPOINT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
@@ -363,7 +355,15 @@ jobs:
 
   # Docker build amd64
   docker-build-amd64:
-    needs: [check-skip, detect-changes, core-release, framework-release, plugins-release, bifrost-http-release]
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        core-release,
+        framework-release,
+        plugins-release,
+        bifrost-http-release,
+      ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
@@ -420,7 +420,15 @@ jobs:
 
   # Docker build arm64
   docker-build-arm64:
-    needs: [check-skip, detect-changes, core-release, framework-release, plugins-release, bifrost-http-release]
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        core-release,
+        framework-release,
+        plugins-release,
+        bifrost-http-release,
+      ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -500,7 +508,15 @@ jobs:
 
   # Push Mintlify changelog
   push-mintlify-changelog:
-    needs: [check-skip, detect-changes, core-release, framework-release, plugins-release, bifrost-http-release]
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        core-release,
+        framework-release,
+        plugins-release,
+        bifrost-http-release,
+      ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:

--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -169,31 +169,11 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *context.Context
 				AzureKeyConfig: &schemas.AzureKeyConfig{
 					Endpoint: os.Getenv("AZURE_ENDPOINT"),
 					Deployments: map[string]string{
-						"gpt-4o":        "gpt-4o",
-						"gpt-4o-backup": "gpt-4o-3",
-					},
-				},
-			},
-			{
-				Value:  os.Getenv("AZURE_EMB_API_KEY"),
-				Models: []string{},
-				Weight: 1.0,
-				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint: os.Getenv("AZURE_EMB_ENDPOINT"),
-					Deployments: map[string]string{
+						"gpt-4o":                 "gpt-4o",
+						"gpt-4o-backup":          "gpt-4o-3",
+						"claude-opus-4-5":        "claude-opus-4-5",
+						"o1":                     "o1",
 						"text-embedding-ada-002": "text-embedding-ada-002",
-					},
-				},
-			},
-			{
-				Value:  os.Getenv("AZURE_API_KEY"),
-				Models: []string{},
-				Weight: 1.0,
-				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint: os.Getenv("AZURE_ENDPOINT"),
-					Deployments: map[string]string{
-						"claude-opus-4-5": "claude-opus-4-5",
-						"o1":              "o1",
 					},
 				},
 			},

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -98,7 +98,11 @@ func (provider *AzureProvider) completeRequest(
 		if apiVersion == nil {
 			apiVersion = schemas.Ptr(AzureAPIVersionDefault)
 		}
-		url = fmt.Sprintf("%s/%s?api-version=%s", key.AzureKeyConfig.Endpoint, path, *apiVersion)
+		if path == "openai/v1/responses" {
+			url = fmt.Sprintf("%s/%s?api-version=preview", key.AzureKeyConfig.Endpoint, path)
+		} else {
+			url = fmt.Sprintf("%s/%s?api-version=%s", key.AzureKeyConfig.Endpoint, path, *apiVersion)
+		}
 	}
 
 	req.SetRequestURI(url)
@@ -553,7 +557,7 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 	if schemas.IsAnthropicModel(deployment) {
 		path = "anthropic/v1/messages"
 	} else {
-		path = fmt.Sprintf("openai/deployments/%s/responses", deployment)
+		path = "openai/v1/responses"
 	}
 
 	responseBody, deployment, latency, err := provider.completeRequest(
@@ -661,11 +665,7 @@ func (provider *AzureProvider) ResponsesStream(ctx context.Context, postHookRunn
 		} else {
 			authHeader["api-key"] = key.Value
 		}
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.Ptr(AzureAPIVersionDefault)
-		}
-		url = fmt.Sprintf("%s/openai/deployments/%s/responses?api-version=%s", key.AzureKeyConfig.Endpoint, deployment, *apiVersion)
+		url = fmt.Sprintf("%s/openai/v1/responses?api-version=preview", key.AzureKeyConfig.Endpoint)
 
 		postRequestConverter := func(req *openai.OpenAIResponsesRequest) *openai.OpenAIResponsesRequest {
 			req.Model = deployment

--- a/core/providers/azure/azure_test.go
+++ b/core/providers/azure/azure_test.go
@@ -52,13 +52,6 @@ func TestAzure(t *testing.T) {
 		},
 	}
 
-	// Disable embedding if embeddings key is not provided
-	if os.Getenv("AZURE_EMB_API_KEY") == "" {
-		t.Logf("AZURE_EMB_API_KEY not set; disabling Azure embedding tests")
-		testConfig.EmbeddingModel = ""
-		testConfig.Scenarios.Embedding = false
-	}
-
 	t.Run("AzureTests", func(t *testing.T) {
 		testutil.RunAllComprehensiveTests(t, client, ctx, testConfig)
 	})


### PR DESCRIPTION
## Summary

Refactored Azure provider to use the unified responses API endpoint and simplified Azure key configuration in GitHub workflows.

## Changes

- Updated Azure provider to use the new unified `/openai/v1/responses` endpoint with `api-version=preview` instead of deployment-specific paths
- Consolidated Azure key configurations by removing separate embedding-specific keys (`AZURE_EMB_API_KEY` and `AZURE_EMB_ENDPOINT`)
- Added Claude and O1 model deployments to the main Azure key configuration
- Fixed indentation in GitHub workflow files
- Improved formatting of job dependency lists in workflow files
- Simplified Azure test configuration by removing unnecessary fallbacks

## Type of change

- [x] Refactor
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Core/Transports
go test ./core/providers/azure/...
```

## Breaking changes

- [x] No

## Security considerations

This PR simplifies API key management by consolidating Azure keys, which reduces the number of secrets needed in CI/CD environments.

GitHub: 