### PR TITLE
feat: add reasoning support for chat completions

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -304,7 +304,7 @@ func (provider *AnthropicProvider) ChatCompletion(ctx context.Context, key schem
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToAnthropicChatRequest(request), nil },
+		func() (any, error) { return ToAnthropicChatRequest(request) },
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -355,10 +355,11 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx context.Context, pos
 		ctx,
 		request,
 		func() (any, error) {
-			reqBody := ToAnthropicChatRequest(request)
-			if reqBody != nil {
-				reqBody.Stream = schemas.Ptr(true)
+			reqBody, err := ToAnthropicChatRequest(request)
+			if err != nil {
+				return nil, err
 			}
+			reqBody.Stream = schemas.Ptr(true)
 			return reqBody, nil
 		},
 		provider.GetProviderKey())
@@ -655,7 +656,7 @@ func (provider *AnthropicProvider) Responses(ctx context.Context, key schemas.Ke
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToAnthropicResponsesRequest(request), nil },
+		func() (any, error) { return ToAnthropicResponsesRequest(request) },
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -704,10 +705,11 @@ func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHook
 		ctx,
 		request,
 		func() (any, error) {
-			reqBody := ToAnthropicResponsesRequest(request)
-			if reqBody != nil {
-				reqBody.Stream = schemas.Ptr(true)
+			reqBody, err := ToAnthropicResponsesRequest(request)
+			if err != nil {
+				return nil, err
 			}
+			reqBody.Stream = schemas.Ptr(true)
 			return reqBody, nil
 		},
 		provider.GetProviderKey())

--- a/core/providers/anthropic/errors.go
+++ b/core/providers/anthropic/errors.go
@@ -6,6 +6,36 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// ToAnthropicChatCompletionError converts a BifrostError to AnthropicMessageError
+func ToAnthropicChatCompletionError(bifrostErr *schemas.BifrostError) *AnthropicMessageError {
+	if bifrostErr == nil {
+		return nil
+	}
+
+	// Provide blank strings for nil pointer fields
+	errorType := ""
+	if bifrostErr.Type != nil {
+		errorType = *bifrostErr.Type
+	}
+
+	// Safely extract message from nested error
+	message := ""
+	if bifrostErr.Error != nil {
+		message = bifrostErr.Error.Message
+	}
+
+	// Handle nested error fields with nil checks
+	errorStruct := AnthropicMessageErrorStruct{
+		Type:    errorType,
+		Message: message,
+	}
+
+	return &AnthropicMessageError{
+		Type:  "error", // always "error" for Anthropic
+		Error: errorStruct,
+	}
+}
+
 func parseAnthropicError(resp *fasthttp.Response) *schemas.BifrostError {
 	var errorResp AnthropicError
 	bifrostErr := providerUtils.HandleProviderAPIError(resp, &errorResp)

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -11,6 +11,7 @@ import (
 // Since Anthropic always needs to have a max_tokens parameter, we set a default value if not provided.
 const (
 	AnthropicDefaultMaxTokens = 4096
+	MinimumReasoningMaxTokens = 1024
 )
 
 // ==================== REQUEST TYPES ====================
@@ -51,7 +52,7 @@ type AnthropicMessageRequest struct {
 	ToolChoice    *AnthropicToolChoice `json:"tool_choice,omitempty"`
 	MCPServers    []AnthropicMCPServer `json:"mcp_servers,omitempty"` // This feature requires the beta header: "anthropic-beta": "mcp-client-2025-04-04"
 	Thinking      *AnthropicThinking   `json:"thinking,omitempty"`
-	OutputFormat  interface{}         `json:"output_format,omitempty"` // This feature requires the beta header: "anthropic-beta": "structured-outputs-2025-11-13" and currently only supported for Claude Sonnet 4.5 and Claude Opus 4.1
+	OutputFormat  interface{}          `json:"output_format,omitempty"` // This feature requires the beta header: "anthropic-beta": "structured-outputs-2025-11-13" and currently only supported for Claude Sonnet 4.5 and Claude Opus 4.1
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
 	Fallbacks []string `json:"fallbacks,omitempty"`

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -350,7 +350,10 @@ func (provider *AzureProvider) ChatCompletion(ctx context.Context, key schemas.K
 		request,
 		func() (any, error) {
 			if schemas.IsAnthropicModel(deployment) {
-				reqBody := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				if err != nil {
+					return nil, err
+				}
 				if reqBody != nil {
 					reqBody.Model = deployment
 				}
@@ -446,7 +449,10 @@ func (provider *AzureProvider) ChatCompletionStream(ctx context.Context, postHoo
 			ctx,
 			request,
 			func() (any, error) {
-				reqBody := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				if err != nil {
+					return nil, err
+				}
 				if reqBody != nil {
 					reqBody.Model = deployment
 					reqBody.Stream = schemas.Ptr(true)
@@ -522,7 +528,10 @@ func (provider *AzureProvider) Responses(ctx context.Context, key schemas.Key, r
 		request,
 		func() (any, error) {
 			if schemas.IsAnthropicModel(deployment) {
-				reqBody := anthropic.ToAnthropicResponsesRequest(request)
+				reqBody, err := anthropic.ToAnthropicResponsesRequest(request)
+				if err != nil {
+					return nil, err
+				}
 				if reqBody != nil {
 					reqBody.Model = deployment
 				}
@@ -619,7 +628,10 @@ func (provider *AzureProvider) ResponsesStream(ctx context.Context, postHookRunn
 			ctx,
 			request,
 			func() (any, error) {
-				reqBody := anthropic.ToAnthropicResponsesRequest(request)
+				reqBody, err := anthropic.ToAnthropicResponsesRequest(request)
+				if err != nil {
+					return nil, err
+				}
 				if reqBody != nil {
 					reqBody.Model = deployment
 					reqBody.Stream = schemas.Ptr(true)

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -105,6 +105,9 @@ type BedrockContentBlock struct {
 	// Guard content (for guardrails)
 	GuardContent *BedrockGuardContent `json:"guardContent,omitempty"`
 
+	// Reasoning content
+	ReasoningContent *BedrockReasoningContent `json:"reasoningContent,omitempty"`
+
 	// For Tool Call Result content
 	JSON interface{} `json:"json,omitempty"`
 }
@@ -149,6 +152,15 @@ type BedrockToolResult struct {
 // BedrockGuardContent represents guard content for guardrails
 type BedrockGuardContent struct {
 	Text *BedrockGuardContentText `json:"text,omitempty"`
+}
+
+type BedrockReasoningContent struct {
+	ReasoningText *BedrockReasoningContentText `json:"reasoningText,omitempty"`
+}
+
+type BedrockReasoningContentText struct {
+	Text      string  `json:"text"`
+	Signature *string `json:"signature,omitempty"`
 }
 
 // BedrockGuardContentText represents text content for guardrails
@@ -429,8 +441,9 @@ type BedrockToolUseStart struct {
 
 // BedrockContentBlockDelta represents the incremental content
 type BedrockContentBlockDelta struct {
-	Text    *string              `json:"text,omitempty"`    // Text content delta
-	ToolUse *BedrockToolUseDelta `json:"toolUse,omitempty"` // Tool use delta
+	Text             *string                      `json:"text,omitempty"`             // Text content delta
+	ReasoningContent *BedrockReasoningContentText `json:"reasoningContent,omitempty"` // Reasoning content delta
+	ToolUse          *BedrockToolUseDelta         `json:"toolUse,omitempty"`          // Tool use delta
 }
 
 // BedrockToolUseDelta represents incremental tool use content

--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -1,15 +1,16 @@
 package cohere
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
 // ToCohereChatCompletionRequest converts a Bifrost request to Cohere v2 format
-func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *CohereChatRequest {
+func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*CohereChatRequest, error) {
 	if bifrostReq == nil || bifrostReq.Input == nil {
-		return nil
+		return nil, fmt.Errorf("bifrost request is nil")
 	}
 
 	messages := bifrostReq.Input
@@ -99,6 +100,23 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Cohe
 		cohereReq.FrequencyPenalty = bifrostReq.Params.FrequencyPenalty
 		cohereReq.PresencePenalty = bifrostReq.Params.PresencePenalty
 
+		if bifrostReq.Params.Reasoning != nil {
+			if bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort == "none" {
+				cohereReq.Thinking = &CohereThinking{
+					Type: ThinkingTypeDisabled,
+				}
+			} else {
+				if bifrostReq.Params.Reasoning.MaxTokens == nil {
+					return nil, fmt.Errorf("reasoning.max_tokens is required for reasoning")
+				} else {
+					cohereReq.Thinking = &CohereThinking{
+						Type:        ThinkingTypeEnabled,
+						TokenBudget: bifrostReq.Params.Reasoning.MaxTokens,
+					}
+				}
+			}
+		}
+
 		// Convert response format
 		if bifrostReq.Params.ResponseFormat != nil {
 			cohereReq.ResponseFormat = convertResponseFormatToCohere(bifrostReq.Params.ResponseFormat)
@@ -179,7 +197,7 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Cohe
 		}
 	}
 
-	return cohereReq
+	return cohereReq, nil
 }
 
 // ToBifrostChatRequest converts a Cohere v2 chat request to Bifrost format
@@ -193,10 +211,16 @@ func (req *CohereChatRequest) ToBifrostChatRequest() *schemas.BifrostChatRequest
 	bifrostReq := &schemas.BifrostChatRequest{
 		Provider: provider,
 		Model:    model,
-		Input:    convertCohereMessagesToBifrost(req.Messages),
 		Params:   &schemas.ChatParameters{},
 	}
-
+	// Convert messages
+	if req.Messages != nil {
+		bifrostMessages := make([]schemas.ChatMessage, len(req.Messages))
+		for i, message := range req.Messages {
+			bifrostMessages[i] = *message.ToBifrostChatMessage()
+		}
+		bifrostReq.Input = bifrostMessages
+	}
 	// Convert parameters
 	if req.MaxTokens != nil {
 		bifrostReq.Params.MaxCompletionTokens = req.MaxTokens
@@ -215,6 +239,22 @@ func (req *CohereChatRequest) ToBifrostChatRequest() *schemas.BifrostChatRequest
 	}
 	if req.PresencePenalty != nil {
 		bifrostReq.Params.PresencePenalty = req.PresencePenalty
+	}
+
+	// Convert reasoning
+	if req.Thinking != nil {
+		if req.Thinking.Type == ThinkingTypeDisabled {
+			bifrostReq.Params.Reasoning = &schemas.ChatReasoning{
+				Effort: schemas.Ptr("none"),
+			}
+		} else {
+			bifrostReq.Params.Reasoning = &schemas.ChatReasoning{
+				Effort: schemas.Ptr("auto"),
+			}
+			if req.Thinking.TokenBudget != nil {
+				bifrostReq.Params.Reasoning.MaxTokens = req.Thinking.TokenBudget
+			}
+		}
 	}
 	if req.ResponseFormat != nil {
 		bifrostReq.Params.ResponseFormat = convertCohereResponseFormatToBifrost(req.ResponseFormat)
@@ -293,12 +333,8 @@ func (response *CohereChatResponse) ToBifrostChatResponse(model string) *schemas
 		Object: "chat.completion",
 		Choices: []schemas.BifrostResponseChoice{
 			{
-				Index: 0,
-				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
-					Message: &schemas.ChatMessage{
-						Role: schemas.ChatMessageRoleAssistant,
-					},
-				},
+				Index:                       0,
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{},
 			},
 		},
 		Created: int(time.Now().Unix()),
@@ -308,95 +344,10 @@ func (response *CohereChatResponse) ToBifrostChatResponse(model string) *schemas
 		},
 	}
 
-	var content *string
-	var contentBlocks []schemas.ChatContentBlock
-	var toolCalls []schemas.ChatAssistantMessageToolCall
-
-	// Convert message content
+	// Convert messages
 	if response.Message != nil {
-		if response.Message.Content != nil {
-			if response.Message.Content.IsString() ||
-				(response.Message.Content.IsBlocks() &&
-					len(response.Message.Content.GetBlocks()) == 1 &&
-					response.Message.Content.GetBlocks()[0].Type == CohereContentBlockTypeText) {
-				if response.Message.Content.IsString() {
-					content = response.Message.Content.GetString()
-				} else {
-					content = response.Message.Content.GetBlocks()[0].Text
-				}
-			} else if response.Message.Content.IsBlocks() {
-				for _, block := range response.Message.Content.GetBlocks() {
-					if block.Type == CohereContentBlockTypeText && block.Text != nil {
-						contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
-							Type: schemas.ChatContentBlockTypeText,
-							Text: block.Text,
-						})
-					} else if block.Type == CohereContentBlockTypeImage && block.ImageURL != nil {
-						contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
-							Type: schemas.ChatContentBlockTypeImage,
-							ImageURLStruct: &schemas.ChatInputImage{
-								URL: block.ImageURL.URL,
-							},
-						})
-					}
-				}
-			}
-		}
-
-		// Create the message content
-		messageContent := &schemas.ChatMessageContent{
-			ContentStr:    content,
-			ContentBlocks: contentBlocks,
-		}
-
-		// Convert tool calls
-		if response.Message.ToolCalls != nil {
-			for _, toolCall := range response.Message.ToolCalls {
-				// Check if Function is nil to avoid nil pointer dereference
-				if toolCall.Function == nil {
-					// Skip this tool call if Function is nil
-					continue
-				}
-
-				// Safely extract function name and arguments
-				var functionName *string
-				var functionArguments string
-
-				if toolCall.Function.Name != nil {
-					functionName = toolCall.Function.Name
-				} else {
-					// Use empty string if Name is nil
-					functionName = schemas.Ptr("")
-				}
-
-				// Arguments is a string, not a pointer, so it's safe to access directly
-				functionArguments = toolCall.Function.Arguments
-
-				bifrostToolCall := schemas.ChatAssistantMessageToolCall{
-					Index: uint16(len(toolCalls)),
-					ID:    toolCall.ID,
-					Function: schemas.ChatAssistantMessageToolCallFunction{
-						Name:      functionName,
-						Arguments: functionArguments,
-					},
-				}
-				toolCalls = append(toolCalls, bifrostToolCall)
-			}
-		}
-
-		// Create assistant message if we have tool calls
-		var assistantMessage *schemas.ChatAssistantMessage
-		if len(toolCalls) > 0 {
-			assistantMessage = &schemas.ChatAssistantMessage{
-				ToolCalls: toolCalls,
-			}
-		}
-
-		bifrostResponse.Choices[0].ChatNonStreamResponseChoice.Message = &schemas.ChatMessage{
-			Role:                 schemas.ChatMessageRoleAssistant,
-			Content:              messageContent,
-			ChatAssistantMessage: assistantMessage,
-		}
+		bifrostMessage := response.Message.ToBifrostChatMessage()
+		bifrostResponse.Choices[0].ChatNonStreamResponseChoice.Message = bifrostMessage
 	}
 
 	// Convert finish reason
@@ -456,24 +407,48 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 		if chunk.Delta != nil &&
 			chunk.Delta.Message != nil &&
 			chunk.Delta.Message.Content != nil &&
-			chunk.Delta.Message.Content.CohereStreamContentObject != nil &&
-			chunk.Delta.Message.Content.CohereStreamContentObject.Text != nil {
-			// Try to cast content to CohereStreamContent
-			streamResponse := &schemas.BifrostChatResponse{
-				Object: "chat.completion.chunk",
-				Choices: []schemas.BifrostResponseChoice{
-					{
-						Index: 0,
-						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
-							Delta: &schemas.ChatStreamResponseChoiceDelta{
-								Content: chunk.Delta.Message.Content.CohereStreamContentObject.Text,
+			chunk.Delta.Message.Content.CohereStreamContentObject != nil {
+			if chunk.Delta.Message.Content.CohereStreamContentObject.Text != nil {
+				// Try to cast content to CohereStreamContent
+				streamResponse := &schemas.BifrostChatResponse{
+					Object: "chat.completion.chunk",
+					Choices: []schemas.BifrostResponseChoice{
+						{
+							Index: 0,
+							ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+								Delta: &schemas.ChatStreamResponseChoiceDelta{
+									Content: chunk.Delta.Message.Content.CohereStreamContentObject.Text,
+								},
 							},
 						},
 					},
-				},
-			}
+				}
 
-			return streamResponse, nil, false
+				return streamResponse, nil, false
+			} else if chunk.Delta.Message.Content.CohereStreamContentObject.Thinking != nil {
+				streamResponse := &schemas.BifrostChatResponse{
+					Object: "chat.completion.chunk",
+					Choices: []schemas.BifrostResponseChoice{
+						{
+							Index: 0,
+							ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+								Delta: &schemas.ChatStreamResponseChoiceDelta{
+									Reasoning: chunk.Delta.Message.Content.CohereStreamContentObject.Thinking,
+									ReasoningDetails: []schemas.ChatReasoningDetails{
+										{
+											Index: 0,
+											Type:  schemas.BifrostReasoningDetailsTypeText,
+											Text:  chunk.Delta.Message.Content.CohereStreamContentObject.Thinking,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				return streamResponse, nil, false
+			}
 		}
 
 	case StreamEventToolPlanDelta:
@@ -485,7 +460,7 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 						Index: 0,
 						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 							Delta: &schemas.ChatStreamResponseChoiceDelta{
-								Thought: chunk.Delta.Message.ToolPlan,
+								Reasoning: chunk.Delta.Message.ToolPlan,
 							},
 						},
 					},
@@ -583,84 +558,123 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 	return nil, nil, false
 }
 
-// convertCohereMessagesToBifrost converts Cohere messages to Bifrost format
-func convertCohereMessagesToBifrost(messages []CohereMessage) []schemas.ChatMessage {
-	if messages == nil {
+func (cm *CohereMessage) ToBifrostChatMessage() *schemas.ChatMessage {
+	if cm == nil {
 		return nil
 	}
 
-	bifrostMessages := make([]schemas.ChatMessage, len(messages))
-	for i, msg := range messages {
-		bifrostMsg := schemas.ChatMessage{
-			Role: schemas.ChatMessageRole(msg.Role),
-		}
+	var content *string
+	var contentBlocks []schemas.ChatContentBlock
+	var toolCalls []schemas.ChatAssistantMessageToolCall
+	var reasoningDetails []schemas.ChatReasoningDetails
+	var reasoningText string
 
-		// Convert content
-		if msg.Content != nil {
-			if msg.Content.IsString() {
-				bifrostMsg.Content = &schemas.ChatMessageContent{
-					ContentStr: msg.Content.GetString(),
-				}
-			} else if msg.Content.IsBlocks() {
-				var contentBlocks []schemas.ChatContentBlock
-				for _, block := range msg.Content.GetBlocks() {
-					switch block.Type {
-					case CohereContentBlockTypeText:
-						contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
-							Type: schemas.ChatContentBlockTypeText,
-							Text: block.Text,
-						})
-					case CohereContentBlockTypeImage:
-						if block.ImageURL != nil {
-							contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
-								Type: schemas.ChatContentBlockTypeImage,
-								ImageURLStruct: &schemas.ChatInputImage{
-									URL: block.ImageURL.URL,
-								},
-							})
-						}
+	// Convert message content
+	if cm.Content != nil {
+		if cm.Content.IsString() ||
+			(cm.Content.IsBlocks() &&
+				len(cm.Content.GetBlocks()) == 1 &&
+				cm.Content.GetBlocks()[0].Type == CohereContentBlockTypeText) {
+			if cm.Content.IsString() {
+				content = cm.Content.GetString()
+			} else {
+				content = cm.Content.GetBlocks()[0].Text
+			}
+		} else if cm.Content.IsBlocks() {
+			for _, block := range cm.Content.GetBlocks() {
+				if block.Type == CohereContentBlockTypeText && block.Text != nil {
+					contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
+						Type: schemas.ChatContentBlockTypeText,
+						Text: block.Text,
+					})
+				} else if block.Type == CohereContentBlockTypeImage && block.ImageURL != nil {
+					contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
+						Type: schemas.ChatContentBlockTypeImage,
+						ImageURLStruct: &schemas.ChatInputImage{
+							URL: block.ImageURL.URL,
+						},
+					})
+				} else if block.Type == CohereContentBlockTypeThinking && block.Thinking != nil {
+					reasoningDetails = append(reasoningDetails, schemas.ChatReasoningDetails{
+						Index: len(reasoningDetails),
+						Type:  schemas.BifrostReasoningDetailsTypeText,
+						Text:  block.Thinking,
+					})
+					if len(reasoningText) > 0 {
+						reasoningText += "\n"
 					}
-				}
-				if len(contentBlocks) > 0 {
-					bifrostMsg.Content = &schemas.ChatMessageContent{
-						ContentBlocks: contentBlocks,
-					}
+					reasoningText += *block.Thinking
 				}
 			}
 		}
-
-		// Convert tool calls (for assistant messages)
-		if msg.ToolCalls != nil {
-			var toolCalls []schemas.ChatAssistantMessageToolCall
-			for j, tc := range msg.ToolCalls {
-				toolCall := schemas.ChatAssistantMessageToolCall{
-					Index: uint16(j),
-					ID:    tc.ID,
-				}
-				if tc.Function != nil {
-					toolCall.Function = schemas.ChatAssistantMessageToolCallFunction{
-						Name:      tc.Function.Name,
-						Arguments: tc.Function.Arguments,
-					}
-				}
-				toolCalls = append(toolCalls, toolCall)
-			}
-			if len(toolCalls) > 0 {
-				bifrostMsg.ChatAssistantMessage = &schemas.ChatAssistantMessage{
-					ToolCalls: toolCalls,
-				}
-			}
-		}
-
-		// Convert tool call ID (for tool messages)
-		if msg.ToolCallID != nil {
-			bifrostMsg.ChatToolMessage = &schemas.ChatToolMessage{
-				ToolCallID: msg.ToolCallID,
-			}
-		}
-
-		bifrostMessages[i] = bifrostMsg
 	}
 
-	return bifrostMessages
+	if len(contentBlocks) == 1 && contentBlocks[0].Type == schemas.ChatContentBlockTypeText {
+		content = contentBlocks[0].Text
+		contentBlocks = nil
+	}
+
+	// Create the message content
+	messageContent := &schemas.ChatMessageContent{
+		ContentStr:    content,
+		ContentBlocks: contentBlocks,
+	}
+
+	// Convert tool calls
+	if cm.ToolCalls != nil {
+		for _, toolCall := range cm.ToolCalls {
+			// Check if Function is nil to avoid nil pointer dereference
+			if toolCall.Function == nil {
+				// Skip this tool call if Function is nil
+				continue
+			}
+
+			// Safely extract function name and arguments
+			var functionName *string
+			var functionArguments string
+
+			if toolCall.Function.Name != nil {
+				functionName = toolCall.Function.Name
+			} else {
+				// Use empty string if Name is nil
+				functionName = schemas.Ptr("")
+			}
+
+			// Arguments is a string, not a pointer, so it's safe to access directly
+			functionArguments = toolCall.Function.Arguments
+
+			bifrostToolCall := schemas.ChatAssistantMessageToolCall{
+				Index: uint16(len(toolCalls)),
+				ID:    toolCall.ID,
+				Function: schemas.ChatAssistantMessageToolCallFunction{
+					Name:      functionName,
+					Arguments: functionArguments,
+				},
+			}
+			toolCalls = append(toolCalls, bifrostToolCall)
+		}
+	}
+
+	// Create assistant message if we have tool calls
+	var assistantMessage *schemas.ChatAssistantMessage
+	if len(toolCalls) > 0 {
+		assistantMessage = &schemas.ChatAssistantMessage{
+			ToolCalls: toolCalls,
+		}
+	}
+
+	if len(reasoningDetails) > 0 {
+		if assistantMessage == nil {
+			assistantMessage = &schemas.ChatAssistantMessage{}
+		}
+		assistantMessage.ReasoningDetails = reasoningDetails
+		assistantMessage.Reasoning = schemas.Ptr(reasoningText)
+	}
+
+	bifrostMessage := &schemas.ChatMessage{
+		Role:                 schemas.ChatMessageRole(cm.Role),
+		Content:              messageContent,
+		ChatAssistantMessage: assistantMessage,
+	}
+	return bifrostMessage
 }

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -279,7 +279,7 @@ func (provider *CohereProvider) ChatCompletion(ctx context.Context, key schemas.
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToCohereChatCompletionRequest(request), nil },
+		func() (any, error) { return ToCohereChatCompletionRequest(request) },
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -329,10 +329,11 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 		ctx,
 		request,
 		func() (any, error) {
-			reqBody := ToCohereChatCompletionRequest(request)
-			if reqBody != nil {
-				reqBody.Stream = schemas.Ptr(true)
+			reqBody, err := ToCohereChatCompletionRequest(request)
+			if err != nil {
+				return nil, err
 			}
+			reqBody.Stream = schemas.Ptr(true)
 			return reqBody, nil
 		},
 		provider.GetProviderKey())

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -533,8 +533,9 @@ type CohereStreamMessage struct {
 
 // CohereStreamContent represents content in streaming events
 type CohereStreamContent struct {
-	Type CohereContentBlockType `json:"type,omitempty"` // For content-start
-	Text *string                `json:"text,omitempty"` // For content deltas
+	Type     CohereContentBlockType `json:"type,omitempty"`     // For content-start
+	Text     *string                `json:"text,omitempty"`     // For content deltas
+	Thinking *string                `json:"thinking,omitempty"` // For thinking deltas
 }
 
 // ==================== ERROR TYPES ====================

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -11,7 +11,7 @@ func (request *OpenAIChatRequest) ToBifrostChatRequest() *schemas.BifrostChatReq
 	return &schemas.BifrostChatRequest{
 		Provider:  provider,
 		Model:     model,
-		Input:     request.Messages,
+		Input:     ConvertOpenAIMessagesToBifrostMessages(request.Messages),
 		Params:    &request.ChatParameters,
 		Fallbacks: schemas.ParseFallbacks(request.Fallbacks),
 	}
@@ -25,7 +25,7 @@ func ToOpenAIChatRequest(bifrostReq *schemas.BifrostChatRequest) *OpenAIChatRequ
 
 	openaiReq := &OpenAIChatRequest{
 		Model:    bifrostReq.Model,
-		Messages: bifrostReq.Input,
+		Messages: ConvertBifrostMessagesToOpenAIMessages(bifrostReq.Input),
 	}
 
 	if bifrostReq.Params != nil {
@@ -60,8 +60,8 @@ func ToOpenAIChatRequest(bifrostReq *schemas.BifrostChatRequest) *OpenAIChatRequ
 
 // Filter OpenAI Specific Parameters
 func (request *OpenAIChatRequest) filterOpenAISpecificParameters() {
-	if request.ChatParameters.ReasoningEffort != nil && *request.ChatParameters.ReasoningEffort == "minimal" {
-		request.ChatParameters.ReasoningEffort = schemas.Ptr("low")
+	if request.ChatParameters.Reasoning != nil && request.ChatParameters.Reasoning.Effort != nil && *request.ChatParameters.Reasoning.Effort == "minimal" {
+		request.ChatParameters.Reasoning.Effort = schemas.Ptr("low")
 	}
 	if request.ChatParameters.PromptCacheKey != nil {
 		request.ChatParameters.PromptCacheKey = nil

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -512,6 +512,12 @@ func HandleOpenAITextCompletionStreaming(
 				if calculatedTotal > usage.TotalTokens {
 					usage.TotalTokens = calculatedTotal
 				}
+				if response.Usage.CompletionTokensDetails != nil {
+					usage.CompletionTokensDetails = response.Usage.CompletionTokensDetails
+				}
+				if response.Usage.PromptTokensDetails != nil {
+					usage.PromptTokensDetails = response.Usage.PromptTokensDetails
+				}
 				response.Usage = nil
 			}
 
@@ -971,6 +977,12 @@ func HandleOpenAIChatCompletionStreaming(
 					calculatedTotal := usage.PromptTokens + usage.CompletionTokens
 					if calculatedTotal > usage.TotalTokens {
 						usage.TotalTokens = calculatedTotal
+					}
+					if response.Usage.PromptTokensDetails != nil {
+						usage.PromptTokensDetails = response.Usage.PromptTokensDetails
+					}
+					if response.Usage.CompletionTokensDetails != nil {
+						usage.CompletionTokensDetails = response.Usage.CompletionTokensDetails
 					}
 					response.Usage = nil
 				}

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -1,0 +1,45 @@
+package openai
+
+import "github.com/maximhq/bifrost/core/schemas"
+
+func ConvertOpenAIMessagesToBifrostMessages(messages []OpenAIMessage) []schemas.ChatMessage {
+	bifrostMessages := make([]schemas.ChatMessage, len(messages))
+	for i, message := range messages {
+		bifrostMessages[i] = schemas.ChatMessage{
+			Name:            message.Name,
+			Role:            message.Role,
+			Content:         message.Content,
+			ChatToolMessage: message.ChatToolMessage,
+		}
+		if message.OpenAIChatAssistantMessage != nil {
+			bifrostMessages[i].ChatAssistantMessage = &schemas.ChatAssistantMessage{
+				Refusal:     message.OpenAIChatAssistantMessage.Refusal,
+				Reasoning:   message.OpenAIChatAssistantMessage.Reasoning,
+				Annotations: message.OpenAIChatAssistantMessage.Annotations,
+				ToolCalls:   message.OpenAIChatAssistantMessage.ToolCalls,
+			}
+		}
+	}
+	return bifrostMessages
+}
+
+func ConvertBifrostMessagesToOpenAIMessages(messages []schemas.ChatMessage) []OpenAIMessage {
+	openaiMessages := make([]OpenAIMessage, len(messages))
+	for i, message := range messages {
+		openaiMessages[i] = OpenAIMessage{
+			Name:            message.Name,
+			Role:            message.Role,
+			Content:         message.Content,
+			ChatToolMessage: message.ChatToolMessage,
+		}
+		if message.ChatAssistantMessage != nil {
+			openaiMessages[i].OpenAIChatAssistantMessage = &OpenAIChatAssistantMessage{
+				Refusal:     message.ChatAssistantMessage.Refusal,
+				Reasoning:   message.ChatAssistantMessage.Reasoning,
+				Annotations: message.ChatAssistantMessage.Annotations,
+				ToolCalls:   message.ChatAssistantMessage.ToolCalls,
+			}
+		}
+	}
+	return openaiMessages
+}

--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -27,11 +27,11 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 		perplexityReq.ResponseFormat = bifrostReq.Params.ResponseFormat
 
 		// Handle reasoning effort mapping
-		if bifrostReq.Params.ReasoningEffort != nil {
-			if *bifrostReq.Params.ReasoningEffort == "minimal" {
+		if bifrostReq.Params.Reasoning != nil && bifrostReq.Params.Reasoning.Effort != nil {
+			if *bifrostReq.Params.Reasoning.Effort == "minimal" {
 				perplexityReq.ReasoningEffort = schemas.Ptr("low")
 			} else {
-				perplexityReq.ReasoningEffort = bifrostReq.Params.ReasoningEffort
+				perplexityReq.ReasoningEffort = bifrostReq.Params.Reasoning.Effort
 			}
 		}
 

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -280,7 +280,10 @@ func (provider *VertexProvider) ChatCompletion(ctx context.Context, key schemas.
 
 			if schemas.IsAnthropicModel(deployment) {
 				// Use centralized Anthropic converter
-				reqBody := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				if err != nil {
+					return nil, err
+				}
 				if reqBody == nil {
 					return nil, fmt.Errorf("chat completion input is not provided")
 				}
@@ -512,13 +515,14 @@ func (provider *VertexProvider) ChatCompletionStream(ctx context.Context, postHo
 			ctx,
 			request,
 			func() (any, error) {
-				reqBody := anthropic.ToAnthropicChatRequest(request)
-				if reqBody == nil {
-					return nil, fmt.Errorf("chat completion input is not provided")
+				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				if err != nil {
+					return nil, err
 				}
-
-				reqBody.Model = deployment
-				reqBody.Stream = schemas.Ptr(true)
+				if reqBody != nil {
+					reqBody.Model = deployment
+					reqBody.Stream = schemas.Ptr(true)
+				}
 
 				// Convert struct to map for Vertex API
 				reqBytes, err := sonic.Marshal(reqBody)
@@ -682,13 +686,13 @@ func (provider *VertexProvider) Responses(ctx context.Context, key schemas.Key, 
 				var requestBody map[string]interface{}
 
 				// Use centralized Anthropic converter
-				reqBody := anthropic.ToAnthropicResponsesRequest(request)
-				if reqBody == nil {
-					return nil, fmt.Errorf("responses input is not provided")
+				reqBody, err := anthropic.ToAnthropicResponsesRequest(request)
+				if err != nil {
+					return nil, err
 				}
-
-				reqBody.Model = deployment
-
+				if reqBody != nil {
+					reqBody.Model = deployment
+				}
 				// Convert struct to map for Vertex API
 				reqBytes, err := sonic.Marshal(reqBody)
 				if err != nil {
@@ -840,14 +844,14 @@ func (provider *VertexProvider) ResponsesStream(ctx context.Context, postHookRun
 			ctx,
 			request,
 			func() (any, error) {
-				reqBody := anthropic.ToAnthropicResponsesRequest(request)
-				if reqBody == nil {
-					return nil, fmt.Errorf("responses input is not provided")
+				reqBody, err := anthropic.ToAnthropicResponsesRequest(request)
+				if err != nil {
+					return nil, err
 				}
-
-				reqBody.Model = deployment
-				reqBody.Stream = schemas.Ptr(true)
-
+				if reqBody != nil {
+					reqBody.Model = deployment
+					reqBody.Stream = schemas.Ptr(true)
+				}
 				// Convert struct to map for Vertex API
 				reqBytes, err := sonic.Marshal(reqBody)
 				if err != nil {

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -162,7 +162,7 @@ type ChatParameters struct {
 	ParallelToolCalls   *bool               `json:"parallel_tool_calls,omitempty"`
 	PresencePenalty     *float64            `json:"presence_penalty,omitempty"`  // Penalizes repeated tokens
 	PromptCacheKey      *string             `json:"prompt_cache_key,omitempty"`  // Prompt cache key
-	ReasoningEffort     *string             `json:"reasoning_effort,omitempty"`  // "minimal" | "low" | "medium" | "high"
+	Reasoning           *ChatReasoning      `json:"reasoning,omitempty"`         // Reasoning parameters
 	ResponseFormat      *interface{}        `json:"response_format,omitempty"`   // Format for the response
 	SafetyIdentifier    *string             `json:"safety_identifier,omitempty"` // Safety identifier
 	Seed                *int                `json:"seed,omitempty"`
@@ -181,6 +181,48 @@ type ChatParameters struct {
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for ChatParameters.
+func (cp *ChatParameters) UnmarshalJSON(data []byte) error {
+	// Alias to avoid recursion
+	type Alias ChatParameters
+
+	// Aux struct adds reasoning_effort for decoding
+	var aux struct {
+		*Alias
+		ReasoningEffort *string `json:"reasoning_effort"` // only for input
+	}
+
+	aux.Alias = (*Alias)(cp)
+
+	// Single unmarshal
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Now aux.Reasoning (from Alias) and aux.ReasoningEffort are filled
+
+	// If both are non-nil, they were both set in JSON
+	if aux.Alias != nil && aux.Alias.Reasoning != nil && aux.ReasoningEffort != nil {
+		return fmt.Errorf("both reasoning_effort and reasoning fields cannot be present at the same time")
+	}
+
+	// If reasoning_effort is set, convert it into Reasoning
+	if aux.ReasoningEffort != nil {
+		cp.Reasoning = &ChatReasoning{
+			Effort: aux.ReasoningEffort,
+		}
+	}
+
+	// ExtraParams etc. are already handled by the alias
+	return nil
+}
+
+// Not in OpenAI's spec, but needed to support extra parameters for reasoning.
+type ChatReasoning struct {
+	Effort    *string `json:"effort,omitempty"`     // "none" |  "minimal" | "low" | "medium" | "high" (any value other than "none" will enable reasoning)
+	MaxTokens *int    `json:"max_tokens,omitempty"` // Maximum number of tokens to generate for the reasoning output (required for anthropic)
 }
 
 // ChatStreamOptions represents the stream options for a chat completion.
@@ -435,6 +477,49 @@ type ChatMessage struct {
 	*ChatAssistantMessage
 }
 
+// UnmarshalJSON implements custom JSON unmarshalling for ChatMessage.
+// This is needed because ChatAssistantMessage has a custom UnmarshalJSON method,
+// which interferes with sonic's handling of other fields in ChatMessage.
+func (cm *ChatMessage) UnmarshalJSON(data []byte) error {
+	// Unmarshal the base fields directly
+	type baseFields struct {
+		Name    *string             `json:"name,omitempty"`
+		Role    ChatMessageRole     `json:"role,omitempty"`
+		Content *ChatMessageContent `json:"content,omitempty"`
+	}
+	var base baseFields
+	if err := sonic.Unmarshal(data, &base); err != nil {
+		return err
+	}
+	cm.Name = base.Name
+	cm.Role = base.Role
+	cm.Content = base.Content
+
+	// Unmarshal ChatToolMessage fields
+	type toolMsgAlias ChatToolMessage
+	var toolMsg toolMsgAlias
+	if err := sonic.Unmarshal(data, &toolMsg); err != nil {
+		return err
+	}
+	if toolMsg.ToolCallID != nil {
+		cm.ChatToolMessage = (*ChatToolMessage)(&toolMsg)
+	}
+
+	// Unmarshal ChatAssistantMessage (which has its own custom unmarshaller)
+	var assistantMsg ChatAssistantMessage
+	if err := sonic.Unmarshal(data, &assistantMsg); err != nil {
+		return err
+	}
+	// Only set if any field is populated
+	if assistantMsg.Refusal != nil || assistantMsg.Reasoning != nil ||
+		len(assistantMsg.ReasoningDetails) > 0 || len(assistantMsg.Annotations) > 0 ||
+		len(assistantMsg.ToolCalls) > 0 {
+		cm.ChatAssistantMessage = &assistantMsg
+	}
+
+	return nil
+}
+
 // ChatMessageContent represents a content in a message.
 type ChatMessageContent struct {
 	ContentStr    *string
@@ -539,9 +624,46 @@ type ChatToolMessage struct {
 
 // ChatAssistantMessage represents a message in a chat conversation.
 type ChatAssistantMessage struct {
-	Refusal     *string                          `json:"refusal,omitempty"`
-	Annotations []ChatAssistantMessageAnnotation `json:"annotations,omitempty"`
-	ToolCalls   []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`
+	Refusal          *string                          `json:"refusal,omitempty"`
+	Reasoning        *string                          `json:"reasoning,omitempty"`
+	ReasoningDetails []ChatReasoningDetails           `json:"reasoning_details,omitempty"`
+	Annotations      []ChatAssistantMessageAnnotation `json:"annotations,omitempty"`
+	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`
+}
+
+// UnmarshalJSON implements custom unmarshalling for ChatAssistantMessage.
+// If Reasoning is non-nil and ReasoningDetails is nil/empty, it adds a single
+// ChatReasoningDetails entry of type "reasoning.text" with the text set to Reasoning.
+func (cm *ChatAssistantMessage) UnmarshalJSON(data []byte) error {
+	if cm == nil {
+		return nil
+	}
+
+	// Alias to avoid infinite recursion
+	type Alias ChatAssistantMessage
+
+	var aux Alias
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Copy decoded data back into the original type
+	*cm = ChatAssistantMessage(aux)
+
+	// If Reasoning is present and there are no reasoning_details,
+	// synthesize a text reasoning_details entry.
+	if cm.Reasoning != nil && len(cm.ReasoningDetails) == 0 {
+		text := *cm.Reasoning
+		cm.ReasoningDetails = []ChatReasoningDetails{
+			{
+				Index: 0,
+				Type:  BifrostReasoningDetailsTypeText,
+				Text:  &text,
+			},
+		}
+	}
+
+	return nil
 }
 
 // ChatAssistantMessageAnnotation represents an annotation in a response.
@@ -589,6 +711,24 @@ type BifrostResponseChoice struct {
 	*ChatStreamResponseChoice
 }
 
+type BifrostReasoningDetailsType string
+
+const (
+	BifrostReasoningDetailsTypeSummary   BifrostReasoningDetailsType = "reasoning.summary"
+	BifrostReasoningDetailsTypeEncrypted BifrostReasoningDetailsType = "reasoning.encrypted"
+	BifrostReasoningDetailsTypeText      BifrostReasoningDetailsType = "reasoning.text"
+)
+
+// Not in OpenAI's spec, but needed to support inter provider reasoning capabilities.
+type ChatReasoningDetails struct {
+	Index     int                         `json:"index"`
+	Type      BifrostReasoningDetailsType `json:"type"`
+	Summary   *string                     `json:"summary,omitempty"`
+	Text      *string                     `json:"text,omitempty"`
+	Signature *string                     `json:"signature,omitempty"`
+	Data      *string                     `json:"data,omitempty"` // for encrypted data
+}
+
 // BifrostLogProbs represents the log probabilities for different aspects of a response.
 type BifrostLogProbs struct {
 	Content []ContentLogProb `json:"content,omitempty"`
@@ -614,11 +754,43 @@ type ChatStreamResponseChoice struct {
 
 // ChatStreamResponseChoiceDelta represents a delta in the stream response
 type ChatStreamResponseChoiceDelta struct {
-	Role      *string                        `json:"role,omitempty"`       // Only in the first chunk
-	Content   *string                        `json:"content,omitempty"`    // May be empty string or null
-	Thought   *string                        `json:"thought,omitempty"`    // May be empty string or null
-	Refusal   *string                        `json:"refusal,omitempty"`    // Refusal content if any
-	ToolCalls []ChatAssistantMessageToolCall `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
+	Role             *string                        `json:"role,omitempty"`      // Only in the first chunk
+	Content          *string                        `json:"content,omitempty"`   // May be empty string or null
+	Refusal          *string                        `json:"refusal,omitempty"`   // Refusal content if any
+	Reasoning        *string                        `json:"reasoning,omitempty"` // May be empty string or null
+	ReasoningDetails []ChatReasoningDetails         `json:"reasoning_details,omitempty"`
+	ToolCalls        []ChatAssistantMessageToolCall `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
+}
+
+// UnmarshalJSON implements custom unmarshalling for ChatStreamResponseChoiceDelta.
+// If Reasoning is non-nil and ReasoningDetails is nil/empty, it adds a single
+// ChatReasoningDetails entry of type "reasoning.text" with the text set to Reasoning.
+func (d *ChatStreamResponseChoiceDelta) UnmarshalJSON(data []byte) error {
+	// Alias to avoid infinite recursion
+	type Alias ChatStreamResponseChoiceDelta
+
+	var aux Alias
+	if err := sonic.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// Copy decoded data back into the original type
+	*d = ChatStreamResponseChoiceDelta(aux)
+
+	// If Reasoning is present and there are no reasoning_details,
+	// synthesize a text reasoning_details entry.
+	if d.Reasoning != nil && len(d.ReasoningDetails) == 0 {
+		text := *d.Reasoning
+		d.ReasoningDetails = []ChatReasoningDetails{
+			{
+				Index: 0,
+				Type:  BifrostReasoningDetailsTypeText,
+				Text:  &text,
+			},
+		}
+	}
+
+	return nil
 }
 
 // LogProb represents the log probability of a token.
@@ -660,6 +832,7 @@ type ChatCompletionTokensDetails struct {
 	CitationTokens           *int `json:"citation_tokens,omitempty"`
 	NumSearchQueries         *int `json:"num_search_queries,omitempty"`
 	ReasoningTokens          int  `json:"reasoning_tokens,omitempty"`
+	ImageTokens              *int `json:"image_tokens,omitempty"`
 	RejectedPredictionTokens int  `json:"rejected_prediction_tokens,omitempty"`
 
 	// This means the number of input tokens used to create the cache entry. (cache creation tokens)

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -770,9 +770,10 @@ func (bcr *BifrostChatRequest) ToResponsesRequest() *BifrostResponsesRequest {
 		}
 
 		// Handle Reasoning from reasoning_effort
-		if bcr.Params.ReasoningEffort != nil {
+		if bcr.Params.Reasoning != nil && (bcr.Params.Reasoning.Effort != nil || bcr.Params.Reasoning.MaxTokens != nil) {
 			brr.Params.Reasoning = &ResponsesParametersReasoning{
-				Effort: bcr.Params.ReasoningEffort,
+				Effort:    bcr.Params.Reasoning.Effort,
+				MaxTokens: bcr.Params.Reasoning.MaxTokens,
 			}
 		}
 
@@ -848,9 +849,12 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 			bcr.Params.ToolChoice = chatToolChoice
 		}
 
-		// Handle ReasoningEffort from Reasoning
-		if brr.Params.Reasoning != nil && brr.Params.Reasoning.Effort != nil {
-			bcr.Params.ReasoningEffort = brr.Params.Reasoning.Effort
+		// Handle Reasoning from Reasoning
+		if brr.Params.Reasoning != nil {
+			bcr.Params.Reasoning = &ChatReasoning{
+				Effort:    brr.Params.Reasoning.Effort,
+				MaxTokens: brr.Params.Reasoning.MaxTokens,
+			}
 		}
 
 		// Handle Verbosity from Text config
@@ -1354,13 +1358,13 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 		}
 	}
 
-	if delta.Thought != nil && *delta.Thought != "" {
+	if delta.Reasoning != nil && *delta.Reasoning != "" {
 		// Reasoning/thought content delta (for models that support reasoning)
 		response := &BifrostResponsesStreamResponse{
 			Type:           ResponsesStreamResponseTypeReasoningSummaryTextDelta,
 			SequenceNumber: state.SequenceNumber,
 			OutputIndex:    Ptr(0),
-			Delta:          delta.Thought,
+			Delta:          delta.Reasoning,
 			ExtraFields:    cr.ExtraFields,
 		}
 		responses = append(responses, response)

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -231,9 +231,10 @@ type ResponsesPrompt struct {
 }
 
 type ResponsesParametersReasoning struct {
-	Effort          *string `json:"effort,omitempty"`           // "minimal" | "low" | "medium" | "high"
+	Effort          *string `json:"effort,omitempty"`           // "none" | "minimal" | "low" | "medium" | "high" (any value other than "none" will enable reasoning)
 	GenerateSummary *string `json:"generate_summary,omitempty"` // Deprecated: use summary instead
 	Summary         *string `json:"summary,omitempty"`          // "auto" | "concise" | "detailed"
+	MaxTokens       *int    `json:"max_tokens,omitempty"`       // Maximum number of tokens to generate for the reasoning output (required for anthropic)
 }
 
 type ResponsesResponseConversationStruct struct {
@@ -320,6 +321,7 @@ type ResponsesMessage struct {
 	*ResponsesToolMessage // For Tool calls and outputs
 
 	// Reasoning
+	// gpt-oss models include only reasoning_text content blocks in a message, while other openai models include summaries+encrypted_content
 	*ResponsesReasoning
 }
 

--- a/plugins/jsonparser/utils.go
+++ b/plugins/jsonparser/utils.go
@@ -308,7 +308,7 @@ func (p *JsonParserPlugin) deepCopyChatStreamResponseChoiceDelta(original *schem
 
 	result := &schemas.ChatStreamResponseChoiceDelta{
 		Role:      original.Role,
-		Thought:   original.Thought,   // Shallow copy
+		Reasoning: original.Reasoning, // Shallow copy
 		Refusal:   original.Refusal,   // Shallow copy
 		ToolCalls: original.ToolCalls, // Shallow copy - we don't modify tool calls
 	}

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -470,10 +470,23 @@ func (plugin *Plugin) PostHook(ctx *schemas.BifrostContext, result *schemas.Bifr
 		generationID, ok := (*ctx).Value(GenerationIDKey).(string)
 		if ok {
 			if bifrostErr != nil {
+				// Safely extract message from nested error
+				message := ""
+				code := ""
+				errorType := ""
+				if bifrostErr.Error != nil {
+					message = bifrostErr.Error.Message
+					if bifrostErr.Error.Code != nil {
+						code = *bifrostErr.Error.Code
+					}
+					if bifrostErr.Error.Type != nil {
+						errorType = *bifrostErr.Error.Type
+					}
+				}
 				genErr := logging.GenerationError{
-					Message: bifrostErr.Error.Message,
-					Code:    bifrostErr.Error.Code,
-					Type:    bifrostErr.Error.Type,
+					Message: message,
+					Code:    &code,
+					Type:    &errorType,
 				}
 				logger.SetGenerationError(generationID, &genErr)
 

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -666,8 +666,8 @@ func (plugin *Plugin) extractChatParametersToMetadata(params *schemas.ChatParame
 	if params.PromptCacheKey != nil {
 		metadata["prompt_cache_key"] = *params.PromptCacheKey
 	}
-	if params.ReasoningEffort != nil {
-		metadata["reasoning_effort"] = *params.ReasoningEffort
+	if params.Reasoning != nil && params.Reasoning.Effort != nil {
+		metadata["reasoning_effort"] = *params.Reasoning.Effort
 	}
 	if params.ResponseFormat != nil {
 		metadata["response_format"] = params.ResponseFormat
@@ -748,6 +748,9 @@ func (plugin *Plugin) extractResponsesParametersToMetadata(params *schemas.Respo
 	if params.Reasoning != nil {
 		if params.Reasoning.Effort != nil {
 			metadata["reasoning_effort"] = *params.Reasoning.Effort
+		}
+		if params.Reasoning.MaxTokens != nil {
+			metadata["reasoning_max_tokens"] = *params.Reasoning.MaxTokens
 		}
 		if params.Reasoning.Summary != nil {
 			metadata["reasoning_summary"] = *params.Reasoning.Summary

--- a/ui/app/workspace/logs/views/logChatMessageView.tsx
+++ b/ui/app/workspace/logs/views/logChatMessageView.tsx
@@ -70,23 +70,25 @@ export default function LogChatMessageView({ message }: LogChatMessageViewProps)
 				{message.tool_call_id && <span className="text-muted-foreground ml-2 text-xs">Tool Call ID: {message.tool_call_id}</span>}
 			</div>
 
-			{/* Handle thought content */}
-			{message.thought && (
+			{/* Handle reasoning content */}
+			{message.reasoning && (
 				<div className="border-b last:border-b-0">
-					<div className="bg-muted/50 text-muted-foreground px-6 py-2 text-xs font-medium">Thought Process</div>
-					{isJson(message.thought) ? (
+					<div className="bg-muted/50 text-muted-foreground px-6 py-2 text-xs font-medium">Reasoning</div>
+					{isJson(message.reasoning) ? (
 						<CodeEditor
 							className="z-0 w-full"
 							shouldAdjustInitialHeight={true}
 							maxHeight={200}
 							wrap={true}
-							code={JSON.stringify(cleanJson(message.thought), null, 2)}
+							code={JSON.stringify(cleanJson(message.reasoning), null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
 						/>
 					) : (
-						<div className="text-muted-foreground px-6 py-2 font-mono text-xs whitespace-pre-wrap italic">{message.thought}</div>
+						<div className="text-muted-foreground px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap italic">
+							{message.reasoning}
+						</div>
 					)}
 				</div>
 			)}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -119,7 +119,17 @@ export interface ChatMessage {
 	refusal?: string;
 	annotations?: Annotation[];
 	tool_calls?: ToolCall[]; // For backward compatibility, tool calls are now in the content
-	thought?: string;
+	reasoning?: string;
+	reasoning_details?: ReasoningDetails[];
+}
+
+export interface ReasoningDetails {
+	index: number;
+	type: "reasoning.summary" | "reasoning.encrypted" | "reasoning.text";
+	summary?: string;
+	text?: string;
+	signature?: string;
+	data?: string;
 }
 
 export interface BifrostEmbedding {


### PR DESCRIPTION
## Summary

Added support for reasoning capabilities across providers, with a focus on Anthropic's thinking feature. This PR introduces a unified reasoning interface in the Bifrost schema and implements provider-specific mappings.

## Changes

- Added `reasoning` field to `ChatParameters` to replace the deprecated `reasoning_effort` field
- Implemented support for Anthropic's thinking feature with budget tokens
- Added caching support for reasoning tokens
- Refactored Anthropic provider to handle errors properly in request conversion functions
- Updated UI to display reasoning content in logs
- Added support for reasoning details with signatures for verification

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test reasoning capabilities with Anthropic models:

```sh
# Core/Transports
go version
go test ./...

# Test with Anthropic API
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-3-opus-20240229",
    "messages": [{"role": "user", "content": "Explain quantum computing"}],
    "reasoning": {
      "effort": "high",
      "max_tokens": 1000
    }
  }'

# UI
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

The `reasoning_effort` field is now deprecated in favor of the new `reasoning` object. Existing code using `reasoning_effort` will continue to work but should be updated to use the new structure.

## Related issues

N/A

## Security considerations

Reasoning content is properly sanitized and displayed in the UI.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable