### PR TITLE
fix: set fixed index 0 for stream responses and remove nil check for usage

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 fix: vertex and bedrock usage aggregation improvements for streaming
+fix: choice index fixed to 0 for anthropic and bedrock streaming

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -931,9 +931,7 @@ func HandleAnthropicResponsesStream(
 						if response.Response == nil {
 							response.Response = &schemas.BifrostResponsesResponse{}
 						}
-						if usage != nil {
-							response.Response.Usage = usage
-						}
+						response.Response.Usage = usage
 						response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
 						ctx = context.WithValue(ctx, schemas.BifrostContextKeyStreamEndIndicator, true)
 						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil), responseChan)

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -725,7 +725,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bif
 				Object: "chat.completion.chunk",
 				Choices: []schemas.BifrostResponseChoice{
 					{
-						Index: *chunk.Index,
+						Index: 0,
 						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 							Delta: &schemas.ChatStreamResponseChoiceDelta{
 								ToolCalls: []schemas.ChatAssistantMessageToolCall{
@@ -760,7 +760,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bif
 						Object: "chat.completion.chunk",
 						Choices: []schemas.BifrostResponseChoice{
 							{
-								Index: *chunk.Index,
+								Index: 0,
 								ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 									Delta: &schemas.ChatStreamResponseChoiceDelta{
 										Content: chunk.Delta.Text,
@@ -781,7 +781,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bif
 						Object: "chat.completion.chunk",
 						Choices: []schemas.BifrostResponseChoice{
 							{
-								Index: *chunk.Index,
+								Index: 0,
 								ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 									Delta: &schemas.ChatStreamResponseChoiceDelta{
 										ToolCalls: []schemas.ChatAssistantMessageToolCall{
@@ -809,7 +809,7 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bif
 						Object: "chat.completion.chunk",
 						Choices: []schemas.BifrostResponseChoice{
 							{
-								Index: *chunk.Index,
+								Index: 0,
 								ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 									Delta: &schemas.ChatStreamResponseChoiceDelta{
 										Thought: chunk.Delta.Thinking,

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -187,12 +187,6 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 		return streamResponse, nil, false
 
 	case chunk.Start != nil && chunk.Start.ToolUse != nil:
-		// Handle tool use start event
-		contentBlockIndex := 0
-		if chunk.ContentBlockIndex != nil {
-			contentBlockIndex = *chunk.ContentBlockIndex
-		}
-
 		toolUseStart := chunk.Start.ToolUse
 
 		// Create tool call structure for start event
@@ -206,7 +200,7 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 			Object: "chat.completion.chunk",
 			Choices: []schemas.BifrostResponseChoice{
 				{
-					Index: contentBlockIndex,
+					Index: 0,
 					ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 						Delta: &schemas.ChatStreamResponseChoiceDelta{
 							ToolCalls: []schemas.ChatAssistantMessageToolCall{toolCall},
@@ -218,10 +212,7 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 
 		return streamResponse, nil, false
 
-	case chunk.ContentBlockIndex != nil && chunk.Delta != nil:
-		// Handle contentBlockDelta event
-		contentBlockIndex := *chunk.ContentBlockIndex
-
+	case chunk.Delta != nil:
 		switch {
 		case chunk.Delta.Text != nil:
 			// Handle text delta
@@ -231,7 +222,7 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 					Object: "chat.completion.chunk",
 					Choices: []schemas.BifrostResponseChoice{
 						{
-							Index: contentBlockIndex,
+							Index: 0,
 							ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 								Delta: &schemas.ChatStreamResponseChoiceDelta{
 									Content: &text,
@@ -260,7 +251,7 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 				Object: "chat.completion.chunk",
 				Choices: []schemas.BifrostResponseChoice{
 					{
-						Index: contentBlockIndex,
+						Index: 0,
 						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 							Delta: &schemas.ChatStreamResponseChoiceDelta{
 								ToolCalls: []schemas.ChatAssistantMessageToolCall{toolCall},

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,2 @@
+fix: vertex and bedrock usage aggregation improvements for streaming
+fix: choice index fixed to 0 for anthropic and bedrock streaming


### PR DESCRIPTION
## Summary

Fixed inconsistencies in stream response handling for Anthropic and Bedrock providers by standardizing index values and removing unnecessary conditional checks.

## Changes

- Removed conditional check for `usage` in Anthropic response handling, ensuring usage is always assigned
- Changed dynamic index values to fixed `0` index in stream responses for both Anthropic and Bedrock providers
- Removed unnecessary content block index handling in Bedrock provider

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses from Anthropic and Bedrock providers to ensure proper index values and usage information:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes inconsistencies in stream response handling across providers.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable