### PR TITLE
feat: handle cached tokens in Anthropic streaming responses

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -558,6 +558,24 @@ func HandleAnthropicChatCompletionStreaming(
 				if calculatedTotal > usage.TotalTokens {
 					usage.TotalTokens = calculatedTotal
 				}
+				// Handle cached tokens if present
+				if usageToProcess.CacheReadInputTokens > 0 {
+					if usage.PromptTokensDetails == nil {
+						usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
+					}
+					if usageToProcess.CacheReadInputTokens > usage.PromptTokensDetails.CachedTokens {
+						usage.PromptTokensDetails.CachedTokens = usageToProcess.CacheReadInputTokens
+					}
+				}
+				// Handle cached tokens if present
+				if usageToProcess.CacheCreationInputTokens > 0 {
+					if usage.CompletionTokensDetails == nil {
+						usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{}
+					}
+					if usageToProcess.CacheCreationInputTokens > usage.CompletionTokensDetails.CachedTokens {
+						usage.CompletionTokensDetails.CachedTokens = usageToProcess.CacheCreationInputTokens
+					}
+				}
 			}
 
 			if event.Delta != nil && event.Delta.StopReason != nil {
@@ -888,6 +906,24 @@ func HandleAnthropicResponsesStream(
 				calculatedTotal := usage.InputTokens + usage.OutputTokens
 				if calculatedTotal > usage.TotalTokens {
 					usage.TotalTokens = calculatedTotal
+				}
+				// Handle cached tokens if present
+				if usageToProcess.CacheReadInputTokens > 0 {
+					if usage.InputTokensDetails == nil {
+						usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
+					}
+					if usageToProcess.CacheReadInputTokens > usage.InputTokensDetails.CachedTokens {
+						usage.InputTokensDetails.CachedTokens = usageToProcess.CacheReadInputTokens
+					}
+				}
+				// Handle cached tokens if present
+				if usageToProcess.CacheCreationInputTokens > 0 {
+					if usage.OutputTokensDetails == nil {
+						usage.OutputTokensDetails = &schemas.ResponsesResponseOutputTokens{}
+					}
+					if usageToProcess.CacheCreationInputTokens > usage.OutputTokensDetails.CachedTokens {
+						usage.OutputTokensDetails.CachedTokens = usageToProcess.CacheCreationInputTokens
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

Added support for tracking cached tokens in Anthropic streaming responses for both chat completions and responses endpoints.

## Changes

- Added handling for cached tokens in `HandleAnthropicChatCompletionStreaming` function
- Added handling for cached tokens in `HandleAnthropicResponsesStream` function
- Implemented proper initialization of token details structures when cached tokens are present
- Ensured cached token counts are properly updated when processing usage information

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Test the Anthropic provider with caching enabled and verify that cached token counts are properly reported in the response:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

## Breaking changes

- [x] No

## Related issues

Improves token usage tracking for cached responses with Anthropic provider.

## Security considerations

No security implications as this only affects token usage reporting.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)