### PR TITLE
feat: add model field to responses API response

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 fix: vertex and bedrock usage aggregation improvements for streaming
 fix: choice index fixed to 0 for anthropic and bedrock streaming
+feat: model field added to responses api response

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -946,6 +946,8 @@ func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key,
 		return nil, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName)
 	}
 
+	bifrostResponse.Model = deployment
+
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Provider = providerName
 	bifrostResponse.ExtraFields.ModelRequested = request.Model
@@ -1002,7 +1004,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRu
 
 		// Create stream state for stateful conversions
 		streamState := acquireBedrockResponsesStreamState()
-		streamState.Model = &request.Model
+		streamState.Model = &deployment
 		defer releaseBedrockResponsesStreamState(streamState)
 
 		// Process AWS Event Stream format using proper decoder

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1161,7 +1161,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 				CreatedAt: state.CreatedAt,
 			}
 			if state.Model != nil {
-				// Note: Model field doesn't exist in BifrostResponsesResponse schema
+				response.Model = *state.Model
 			}
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeCreated,
@@ -1176,6 +1176,9 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 			response := &schemas.BifrostResponsesResponse{
 				ID:        state.MessageID,
 				CreatedAt: state.CreatedAt, // Use same timestamp
+			}
+			if state.Model != nil {
+				response.Model = *state.Model
 			}
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeInProgress,
@@ -1495,6 +1498,10 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 		ID:        state.MessageID,
 		CreatedAt: state.CreatedAt,
 		Usage:     usage,
+	}
+
+	if state.Model != nil {
+		response.Model = *state.Model
 	}
 
 	responses = append(responses, &schemas.BifrostResponsesStreamResponse{

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -533,6 +533,8 @@ func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, 
 
 	bifrostResponse := response.ToBifrostResponsesResponse()
 
+	bifrostResponse.Model = request.Model
+
 	// Set ExtraFields
 	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
 	bifrostResponse.ExtraFields.ModelRequested = request.Model

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -1122,6 +1122,9 @@ func (chunk *CohereStreamEvent) ToBifrostResponsesStream(sequenceNumber int, sta
 		if state.MessageID != nil {
 			response.ID = state.MessageID
 		}
+		if state.Model != nil {
+			response.Model = *state.Model
+		}
 
 		if chunk.Delta != nil {
 			if chunk.Delta.Usage != nil {

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -878,6 +878,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesResponse() *BifrostResponsesRes
 	// Create new BifrostResponsesResponse from Chat fields
 	responsesResp := &BifrostResponsesResponse{
 		CreatedAt:     cr.Created,
+		Model:         cr.Model,
 		Citations:     cr.Citations,
 		SearchResults: cr.SearchResults,
 		Videos:        cr.Videos,
@@ -921,6 +922,7 @@ func (responsesResp *BifrostResponsesResponse) ToBifrostChatResponse() *BifrostC
 	chatResp := &BifrostChatResponse{
 		Created:       responsesResp.CreatedAt,
 		Object:        "chat.completion",
+		Model:         responsesResp.Model,
 		Citations:     responsesResp.Citations,
 		SearchResults: responsesResp.SearchResults,
 		Videos:        responsesResp.Videos,
@@ -1481,6 +1483,10 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			ID:        state.MessageID,
 			CreatedAt: state.CreatedAt,
 			Usage:     usage,
+		}
+
+		if state.Model != nil {
+			response.Model = *state.Model
 		}
 
 		responses = append(responses, &BifrostResponsesStreamResponse{

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -55,6 +55,7 @@ type BifrostResponsesResponse struct {
 	MaxOutputTokens    *int                                `json:"max_output_tokens,omitempty"`
 	MaxToolCalls       *int                                `json:"max_tool_calls,omitempty"`
 	Metadata           *map[string]any                     `json:"metadata,omitempty"`
+	Model              string                              `json:"model"`
 	Output             []ResponsesMessage                  `json:"output,omitempty"`
 	ParallelToolCalls  *bool                               `json:"parallel_tool_calls,omitempty"`
 	PreviousResponseID *string                             `json:"previous_response_id,omitempty"`

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,3 @@
 fix: vertex and bedrock usage aggregation improvements for streaming
 fix: choice index fixed to 0 for anthropic and bedrock streaming
+feat: model field added to responses api response


### PR DESCRIPTION
## Summary

Added the `model` field to the Responses API response structure, ensuring it's properly populated across all providers (Anthropic, Bedrock, Cohere) and in streaming responses.

## Changes

- Added `Model` field to `BifrostResponsesResponse` struct in the schemas
- Updated Anthropic provider to populate the model field in responses and streaming events
- Updated Bedrock provider to include model information in responses and streaming events
- Updated Cohere provider to set the model field in responses
- Ensured model field is properly transferred when converting between chat and responses formats
- Fixed model field propagation in streaming response handlers

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Responses API with different providers and verify the model field is present in the response:

```sh
# Core/Transports
go version
go test ./...

# Test with curl
curl -X POST "http://localhost:8000/api/v1/responses" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -d '{
    "model": "anthropic/claude-3-opus-20240229",
    "messages": [{"role": "user", "content": "Hello, world!"}]
  }'

# Verify model field is in the response
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enhances the Responses API by adding model information to responses, which was previously missing.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)