### PR TITLE
feat: filter list models response by allowed models and deployments

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
 fix: vertex and bedrock usage aggregation improvements for streaming
 fix: choice index fixed to 0 for anthropic and bedrock streaming
 feat: model field added to responses api response
+feat: check allowed models and deployments of key for list models

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -216,7 +216,7 @@ func (provider *AnthropicProvider) listModelsByKey(ctx context.Context, key sche
 	}
 
 	// Create final response
-	response := anthropicResponse.ToBifrostListModelsResponse(provider.GetProviderKey())
+	response := anthropicResponse.ToBifrostListModelsResponse(provider.GetProviderKey(), key.Models)
 	response.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw response if enabled

--- a/core/providers/anthropic/models.go
+++ b/core/providers/anthropic/models.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func (response *AnthropicListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
+func (response *AnthropicListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -25,8 +25,22 @@ func (response *AnthropicListModelsResponse) ToBifrostListModelsResponse(provide
 	}
 
 	for _, model := range response.Data {
+		modelID := model.ID
+		if len(allowedModels) > 0 {
+			allowed := false
+			for _, allowedModel := range allowedModels {
+				if schemas.SameBaseModel(model.ID, allowedModel) {
+					modelID = allowedModel
+					allowed = true
+					break
+				}
+			}
+			if !allowed {
+				continue
+			}
+		}
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
-			ID:      string(providerKey) + "/" + model.ID,
+			ID:      string(providerKey) + "/" + modelID,
 			Name:    schemas.Ptr(model.DisplayName),
 			Created: schemas.Ptr(model.CreatedAt.Unix()),
 		})

--- a/core/providers/azure/models.go
+++ b/core/providers/azure/models.go
@@ -1,8 +1,64 @@
 package azure
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
 
-func (response *AzureListModelsResponse) ToBifrostListModelsResponse() *schemas.BifrostListModelsResponse {
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// findMatchingAllowedModel finds a matching item in a slice, considering both
+// exact match and base model matches (ignoring version suffixes).
+// Returns the matched item from the slice if found, empty string otherwise.
+// If matched via base model, returns the item from slice (not the value parameter).
+func findMatchingAllowedModel(slice []string, value string) string {
+	// First check exact match
+	if slices.Contains(slice, value) {
+		return value
+	}
+
+	// Additional layer: check base model matches (ignoring version suffixes)
+	// This handles cases where model versions differ but base model is the same
+	// Return the item from slice (not value) to use the actual name from allowedModels
+	for _, item := range slice {
+		if schemas.SameBaseModel(item, value) {
+			return item
+		}
+	}
+	return ""
+}
+
+// findDeploymentMatch finds a matching deployment value in the deployments map,
+// considering both exact match and base model matches (ignoring version suffixes).
+// Returns the deployment value and alias if found, empty strings otherwise.
+func findDeploymentMatch(deployments map[string]string, modelID string) (deploymentValue, alias string) {
+	// Check exact match first (by alias/key)
+	if deployment, ok := deployments[modelID]; ok {
+		return deployment, modelID
+	}
+
+	// Check exact match by deployment value
+	for aliasKey, depValue := range deployments {
+		if depValue == modelID {
+			return depValue, aliasKey
+		}
+	}
+
+	// Additional layer: check base model matches (ignoring version suffixes)
+	// This handles cases where model versions differ but base model is the same
+	for aliasKey, deploymentValue := range deployments {
+		// Check if modelID's base matches deploymentValue's base
+		if schemas.SameBaseModel(deploymentValue, modelID) {
+			return deploymentValue, aliasKey
+		}
+		// Also check if modelID's base matches alias's base (for cases where alias is used as deployment)
+		if schemas.SameBaseModel(aliasKey, modelID) {
+			return deploymentValue, aliasKey
+		}
+	}
+	return "", ""
+}
+
+func (response *AzureListModelsResponse) ToBifrostListModelsResponse(allowedModels []string, deployments map[string]string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -12,11 +68,63 @@ func (response *AzureListModelsResponse) ToBifrostListModelsResponse() *schemas.
 	}
 
 	for _, model := range response.Data {
-		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
-			ID:      string(schemas.Azure) + "/" + model.ID,
+		modelID := model.ID
+		matchedAllowedModel := ""
+		deploymentValue := ""
+		deploymentAlias := ""
+
+		// Filter if model is not present in both lists (when both are non-empty)
+		// Empty lists mean "allow all" for that dimension
+		// Check considering base model matches (ignoring version suffixes)
+		shouldFilter := false
+		if len(allowedModels) > 0 && len(deployments) > 0 {
+			// Both lists are present: model must be in allowedModels AND deployments
+			// AND the deployment alias must also be in allowedModels
+			matchedAllowedModel = findMatchingAllowedModel(allowedModels, model.ID)
+			deploymentValue, deploymentAlias = findDeploymentMatch(deployments, model.ID)
+			inDeployments := deploymentAlias != ""
+
+			// Check if deployment alias is also in allowedModels (direct string match)
+			deploymentAliasInAllowedModels := false
+			if deploymentAlias != "" {
+				deploymentAliasInAllowedModels = slices.Contains(allowedModels, deploymentAlias)
+			}
+
+			// Filter if: model not in deployments OR deployment alias not in allowedModels
+			shouldFilter = !inDeployments || !deploymentAliasInAllowedModels
+		} else if len(allowedModels) > 0 {
+			// Only allowedModels is present: filter if model is not in allowedModels
+			matchedAllowedModel = findMatchingAllowedModel(allowedModels, model.ID)
+			shouldFilter = matchedAllowedModel == ""
+		} else if len(deployments) > 0 {
+			// Only deployments is present: filter if model is not in deployments
+			deploymentValue, deploymentAlias = findDeploymentMatch(deployments, model.ID)
+			shouldFilter = deploymentValue == ""
+		}
+		// If both are empty, shouldFilter remains false (allow all)
+
+		if shouldFilter {
+			continue
+		}
+
+		// Use the matched name from allowedModels or deployments (like Anthropic)
+		// Priority: deployment value > matched allowedModel > original model.ID
+		if deploymentValue != "" {
+			modelID = deploymentValue
+		} else if matchedAllowedModel != "" {
+			modelID = matchedAllowedModel
+		}
+
+		modelEntry := schemas.Model{
+			ID:      string(schemas.Azure) + "/" + modelID,
 			Created: schemas.Ptr(model.CreatedAt),
-			Name:    schemas.Ptr(model.Model),
-		})
+		}
+		// Set deployment info if matched via deployments
+		if deploymentValue != "" && deploymentAlias != "" {
+			modelEntry.ID = string(schemas.Azure) + "/" + deploymentAlias
+			modelEntry.Deployment = schemas.Ptr(deploymentValue)
+		}
+		bifrostResponse.Data = append(bifrostResponse.Data, modelEntry)
 	}
 	return bifrostResponse
 }

--- a/core/providers/azure/types.go
+++ b/core/providers/azure/types.go
@@ -21,7 +21,6 @@ type AzureModelDeprecation struct {
 type AzureModel struct {
 	ID              string                 `json:"id"`
 	Status          string                 `json:"status"`
-	Model           string                 `json:"model,omitempty"`
 	FineTune        string                 `json:"fine_tune,omitempty"`
 	Capabilities    AzureModelCapabilities `json:"capabilities,omitempty"`
 	LifecycleStatus string                 `json:"lifecycle_status"`

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -453,20 +452,9 @@ func (provider *BedrockProvider) listModelsByKey(ctx context.Context, key schema
 	}
 
 	// Convert to Bifrost response
-	response := bedrockResponse.ToBifrostListModelsResponse(providerName)
+	response := bedrockResponse.ToBifrostListModelsResponse(providerName, key.Models, config.Deployments)
 	if response == nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert Bedrock model list response", nil, providerName)
-	}
-
-	// Add deployment aliases to the response
-	for i, model := range response.Data {
-		for keyDeploymentAlias, keyDeploymentName := range key.BedrockKeyConfig.Deployments {
-			if strings.TrimPrefix(model.ID, string(providerName)+"/") == keyDeploymentName {
-				response.Data[i].ID = string(providerName) + "/" + keyDeploymentAlias
-				response.Data[i].Deployment = schemas.Ptr(keyDeploymentName)
-				break
-			}
-		}
 	}
 
 	response.ExtraFields.Latency = time.Since(startTime).Milliseconds()

--- a/core/providers/bedrock/models.go
+++ b/core/providers/bedrock/models.go
@@ -1,8 +1,119 @@
 package bedrock
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
+	"strings"
 
-func (response *BedrockListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const globalPrefix = "global."
+
+// findMatchingAllowedModel finds a matching item in a slice, considering both
+// exact match and match with/without the "global." prefix,
+// and also checks base model matches (ignoring version suffixes).
+// Returns the matched item from the slice if found, empty string otherwise.
+// If matched via base model, returns the item from slice (not the value parameter).
+func findMatchingAllowedModel(slice []string, value string) string {
+	// First check exact matches with global prefix variations
+	if slices.Contains(slice, value) {
+		return value
+	}
+	// Check with global prefix added/removed
+	if strings.HasPrefix(value, globalPrefix) {
+		withoutPrefix := strings.TrimPrefix(value, globalPrefix)
+		if slices.Contains(slice, withoutPrefix) {
+			return withoutPrefix
+		}
+	} else {
+		// Check with global prefix added
+		withPrefix := globalPrefix + value
+		if slices.Contains(slice, withPrefix) {
+			return withPrefix
+		}
+	}
+
+	// Additional layer: check base model matches (ignoring version suffixes)
+	// This handles cases where model versions differ but base model is the same
+	// Normalize value by removing global prefix for base model comparison
+	valueNormalized := value
+	if strings.HasPrefix(value, globalPrefix) {
+		valueNormalized = strings.TrimPrefix(value, globalPrefix)
+	}
+
+	for _, item := range slice {
+		// Normalize item by removing global prefix for base model comparison
+		itemNormalized := item
+		if strings.HasPrefix(item, globalPrefix) {
+			itemNormalized = strings.TrimPrefix(item, globalPrefix)
+		}
+
+		// Check base model match with normalized values (prefix removed from both)
+		// Return the item from slice (not value) to use the actual name from allowedModels
+		if schemas.SameBaseModel(itemNormalized, valueNormalized) {
+			return item
+		}
+	}
+	return ""
+}
+
+// findDeploymentMatch finds a matching deployment value in the deployments map,
+// considering both exact match and match with/without "global." prefix,
+// and also checks base model matches (ignoring version suffixes).
+// The modelID from the API response should match a deployment value (not the alias/key).
+// Returns the deployment value and alias if found, empty strings otherwise.
+func findDeploymentMatch(deployments map[string]string, modelID string) (deploymentValue, alias string) {
+	// Check if any deployment value matches the modelID (with or without prefix)
+	for aliasKey, deploymentValue := range deployments {
+		// Exact match
+		if deploymentValue == modelID {
+			return deploymentValue, aliasKey
+		}
+		// Check if modelID matches deployment value with global prefix variations
+		if strings.HasPrefix(deploymentValue, globalPrefix) {
+			// deploymentValue has prefix, check if modelID matches without prefix
+			if strings.TrimPrefix(deploymentValue, globalPrefix) == modelID {
+				return deploymentValue, aliasKey
+			}
+		} else {
+			// deploymentValue doesn't have prefix, check if modelID matches with prefix
+			if globalPrefix+deploymentValue == modelID {
+				return deploymentValue, aliasKey
+			}
+		}
+		// Check reverse: modelID has prefix, deployment value doesn't
+		if strings.HasPrefix(modelID, globalPrefix) {
+			if strings.TrimPrefix(modelID, globalPrefix) == deploymentValue {
+				return deploymentValue, aliasKey
+			}
+		} else {
+			// modelID doesn't have prefix, deployment value does
+			if globalPrefix+modelID == deploymentValue {
+				return deploymentValue, aliasKey
+			}
+		}
+
+		// Additional layer: check base model matches (ignoring version suffixes)
+		// This handles cases where model versions differ but base model is the same
+		// Normalize both values by removing global prefix for base model comparison
+		deploymentNormalized := deploymentValue
+		if strings.HasPrefix(deploymentValue, globalPrefix) {
+			deploymentNormalized = strings.TrimPrefix(deploymentValue, globalPrefix)
+		}
+		modelIDNormalized := modelID
+		if strings.HasPrefix(modelID, globalPrefix) {
+			modelIDNormalized = strings.TrimPrefix(modelID, globalPrefix)
+		}
+
+		// Check base model match with normalized values (prefix removed from both)
+		if schemas.SameBaseModel(deploymentNormalized, modelIDNormalized) {
+			return deploymentValue, aliasKey
+		}
+	}
+	return "", ""
+}
+
+func (response *BedrockListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string, deployments map[string]string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -11,16 +122,75 @@ func (response *BedrockListModelsResponse) ToBifrostListModelsResponse(providerK
 		Data: make([]schemas.Model, 0, len(response.ModelSummaries)),
 	}
 
+	deploymentValues := make([]string, 0, len(deployments))
+	for _, deployment := range deployments {
+		deploymentValues = append(deploymentValues, deployment)
+	}
+
 	for _, model := range response.ModelSummaries {
-		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
-			ID:      string(providerKey) + "/" + model.ModelID,
+		modelID := model.ModelID
+		matchedAllowedModel := ""
+		deploymentValue := ""
+		deploymentAlias := ""
+
+		// Filter if model is not present in both lists (when both are non-empty)
+		// Empty lists mean "allow all" for that dimension
+		// Check considering global prefix variations
+		shouldFilter := false
+		if len(allowedModels) > 0 && len(deploymentValues) > 0 {
+			// Both lists are present: model must be in allowedModels AND deployments
+			// AND the deployment alias must also be in allowedModels
+			matchedAllowedModel = findMatchingAllowedModel(allowedModels, model.ModelID)
+			deploymentValue, deploymentAlias = findDeploymentMatch(deployments, model.ModelID)
+			inDeployments := deploymentAlias != ""
+
+			// Check if deployment alias is also in allowedModels (direct string match)
+			deploymentAliasInAllowedModels := false
+			if deploymentAlias != "" {
+				deploymentAliasInAllowedModels = slices.Contains(allowedModels, deploymentAlias)
+			}
+
+			// Filter if: model not in deployments OR deployment alias not in allowedModels
+			shouldFilter = !inDeployments || !deploymentAliasInAllowedModels
+		} else if len(allowedModels) > 0 {
+			// Only allowedModels is present: filter if model is not in allowedModels
+			matchedAllowedModel = findMatchingAllowedModel(allowedModels, model.ModelID)
+			shouldFilter = matchedAllowedModel == ""
+		} else if len(deploymentValues) > 0 {
+			// Only deployments is present: filter if model is not in deployments
+			deploymentValue, deploymentAlias = findDeploymentMatch(deployments, model.ModelID)
+			shouldFilter = deploymentValue == ""
+		}
+		// If both are empty, shouldFilter remains false (allow all)
+
+		if shouldFilter {
+			continue
+		}
+
+		// Use the matched name from allowedModels or deployments (like Anthropic)
+		// Priority: deployment value > matched allowedModel > original model.ModelID
+		if deploymentValue != "" {
+			modelID = deploymentValue
+		} else if matchedAllowedModel != "" {
+			modelID = matchedAllowedModel
+		}
+
+		modelEntry := schemas.Model{
+			ID:      string(providerKey) + "/" + modelID,
 			Name:    schemas.Ptr(model.ModelName),
 			OwnedBy: schemas.Ptr(model.ProviderName),
 			Architecture: &schemas.Architecture{
 				InputModalities:  model.InputModalities,
 				OutputModalities: model.OutputModalities,
 			},
-		})
+		}
+		// Set deployment info if matched via deployments
+		if deploymentValue != "" && deploymentAlias != "" {
+			modelEntry.ID = string(providerKey) + "/" + deploymentAlias
+			// Use the actual deployment value (which might have global prefix)
+			modelEntry.Deployment = schemas.Ptr(deploymentValue)
+		}
+		bifrostResponse.Data = append(bifrostResponse.Data, modelEntry)
 	}
 
 	return bifrostResponse

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -240,7 +240,7 @@ func (provider *CohereProvider) listModelsByKey(ctx context.Context, key schemas
 	}
 
 	// Convert Cohere v2 response to Bifrost response
-	response := cohereResponse.ToBifrostListModelsResponse(providerName)
+	response := cohereResponse.ToBifrostListModelsResponse(providerName, key.Models)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/cohere/models.go
+++ b/core/providers/cohere/models.go
@@ -1,17 +1,24 @@
 package cohere
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
 
-func (response *CohereListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func (response *CohereListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
 
 	bifrostResponse := &schemas.BifrostListModelsResponse{
-		Data:          make([]schemas.Model, 0, len(response.Models)),
+		Data: make([]schemas.Model, 0, len(response.Models)),
 	}
 
 	for _, model := range response.Models {
+		if len(allowedModels) > 0 && !slices.Contains(allowedModels, model.Name) {
+			continue
+		}
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
 			ID:               string(providerKey) + "/" + model.Name,
 			Name:             schemas.Ptr(model.Name),

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -103,7 +103,7 @@ func (provider *ElevenlabsProvider) listModelsByKey(ctx context.Context, key sch
 		return nil, bifrostErr
 	}
 
-	response := elevenlabsResponse.ToBifrostListModelsResponse(providerName)
+	response := elevenlabsResponse.ToBifrostListModelsResponse(providerName, key.Models)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/elevenlabs/models.go
+++ b/core/providers/elevenlabs/models.go
@@ -1,8 +1,12 @@
 package elevenlabs
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
 
-func (response *ElevenlabsListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func (response *ElevenlabsListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -12,6 +16,9 @@ func (response *ElevenlabsListModelsResponse) ToBifrostListModelsResponse(provid
 	}
 
 	for _, model := range *response {
+		if len(allowedModels) > 0 && !slices.Contains(allowedModels, model.ModelID) {
+			continue
+		}
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
 			ID:   string(providerKey) + "/" + model.ModelID,
 			Name: schemas.Ptr(model.Name),

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -165,7 +165,7 @@ func (provider *GeminiProvider) listModelsByKey(ctx context.Context, key schemas
 		return nil, bifrostErr
 	}
 
-	response := geminiResponse.ToBifrostListModelsResponse(providerName)
+	response := geminiResponse.ToBifrostListModelsResponse(providerName, key.Models)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -106,7 +106,7 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 	}
 
 	// Create final response
-	response := mistralResponse.ToBifrostListModelsResponse()
+	response := mistralResponse.ToBifrostListModelsResponse(key.Models)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/mistral/models.go
+++ b/core/providers/mistral/models.go
@@ -1,8 +1,12 @@
 package mistral
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
 
-func (response *MistralListModelsResponse) ToBifrostListModelsResponse() *schemas.BifrostListModelsResponse {
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func (response *MistralListModelsResponse) ToBifrostListModelsResponse(allowedModels []string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -12,6 +16,9 @@ func (response *MistralListModelsResponse) ToBifrostListModelsResponse() *schema
 	}
 
 	for _, model := range response.Data {
+		if len(allowedModels) > 0 && !slices.Contains(allowedModels, model.ID) {
+			continue
+		}
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
 			ID:            string(schemas.Mistral) + "/" + model.ID,
 			Name:          schemas.Ptr(model.Name),

--- a/core/providers/openai/models.go
+++ b/core/providers/openai/models.go
@@ -1,8 +1,12 @@
 package openai
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"slices"
 
-func (response *OpenAIListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider) *schemas.BifrostListModelsResponse {
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func (response *OpenAIListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -12,6 +16,9 @@ func (response *OpenAIListModelsResponse) ToBifrostListModelsResponse(providerKe
 	}
 
 	for _, model := range response.Data {
+		if len(allowedModels) > 0 && !slices.Contains(allowedModels, model.ID) {
+			continue
+		}
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
 			ID:            string(providerKey) + "/" + model.ID,
 			Created:       model.Created,

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -158,7 +158,7 @@ func listModelsByKey(
 		return nil, bifrostErr
 	}
 
-	response := openaiResponse.ToBifrostListModelsResponse(providerName)
+	response := openaiResponse.ToBifrostListModelsResponse(providerName, key.Models)
 
 	response.ExtraFields.Provider = providerName
 	response.ExtraFields.RequestType = schemas.ListModelsRequest

--- a/core/providers/vertex/models.go
+++ b/core/providers/vertex/models.go
@@ -1,12 +1,29 @@
 package vertex
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func (response *VertexListModelsResponse) ToBifrostListModelsResponse() *schemas.BifrostListModelsResponse {
+// findDeploymentMatch finds a matching deployment value in the deployments map.
+// Returns the deployment value and alias if found, empty strings otherwise.
+func findDeploymentMatch(deployments map[string]string, customModelID string) (deploymentValue, alias string) {
+	// Check exact match by deployment value
+	for aliasKey, depValue := range deployments {
+		if depValue == customModelID {
+			return depValue, aliasKey
+		}
+	}
+	// Check exact match by alias/key
+	if deployment, ok := deployments[customModelID]; ok {
+		return deployment, customModelID
+	}
+	return "", ""
+}
+
+func (response *VertexListModelsResponse) ToBifrostListModelsResponse(allowedModels []string, deployments map[string]string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -14,7 +31,6 @@ func (response *VertexListModelsResponse) ToBifrostListModelsResponse() *schemas
 	bifrostResponse := &schemas.BifrostListModelsResponse{
 		Data: make([]schemas.Model, 0, len(response.Models)),
 	}
-
 	for _, model := range response.Models {
 		if len(model.DeployedModels) == 0 {
 			continue
@@ -29,12 +45,53 @@ func (response *VertexListModelsResponse) ToBifrostListModelsResponse() *schemas
 			if customModelID == "" {
 				continue
 			}
-			bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
-				ID:          string(schemas.Vertex) + "/" + customModelID,
+
+			// Filter if model is not present in both lists (when both are non-empty)
+			// Empty lists mean "allow all" for that dimension
+			var deploymentValue, deploymentAlias string
+			shouldFilter := false
+			if len(allowedModels) > 0 && len(deployments) > 0 {
+				// Both lists are present: model must be in allowedModels AND deployments
+				// AND the deployment alias must also be in allowedModels
+				deploymentValue, deploymentAlias = findDeploymentMatch(deployments, customModelID)
+				inDeployments := deploymentAlias != ""
+
+				// Check if deployment alias is also in allowedModels (direct string match)
+				deploymentAliasInAllowedModels := false
+				if deploymentAlias != "" {
+					deploymentAliasInAllowedModels = slices.Contains(allowedModels, deploymentAlias)
+				}
+
+				// Filter if: model not in deployments OR deployment alias not in allowedModels
+				shouldFilter = !inDeployments || !deploymentAliasInAllowedModels
+			} else if len(allowedModels) > 0 {
+				// Only allowedModels is present: filter if model is not in allowedModels
+				shouldFilter = !slices.Contains(allowedModels, customModelID)
+			} else if len(deployments) > 0 {
+				// Only deployments is present: filter if model is not in deployments
+				deploymentValue, deploymentAlias = findDeploymentMatch(deployments, customModelID)
+				shouldFilter = deploymentValue == ""
+			}
+			// If both are empty, shouldFilter remains false (allow all)
+
+			if shouldFilter {
+				continue
+			}
+
+			modelID := customModelID
+
+			modelEntry := schemas.Model{
+				ID:          string(schemas.Vertex) + "/" + modelID,
 				Name:        schemas.Ptr(model.DisplayName),
 				Description: schemas.Ptr(model.Description),
 				Created:     schemas.Ptr(model.VersionCreateTime.Unix()),
-			})
+			}
+			// Set deployment info if matched via deployments
+			if deploymentValue != "" && deploymentAlias != "" {
+				modelEntry.ID = string(schemas.Vertex) + "/" + deploymentAlias
+				modelEntry.Deployment = schemas.Ptr(deploymentValue)
+			}
+			bifrostResponse.Data = append(bifrostResponse.Data, modelEntry)
 		}
 	}
 	bifrostResponse.NextPageToken = response.NextPageToken

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -219,7 +219,7 @@ func (provider *VertexProvider) listModelsByKey(ctx context.Context, key schemas
 	aggregatedResponse := &VertexListModelsResponse{
 		Models: allModels,
 	}
-	response := aggregatedResponse.ToBifrostListModelsResponse()
+	response := aggregatedResponse.ToBifrostListModelsResponse(key.Models, key.VertexKeyConfig.Deployments)
 
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 		response.ExtraFields.RawResponse = rawResponses
@@ -240,24 +240,6 @@ func (provider *VertexProvider) ListModels(ctx context.Context, keys []schemas.K
 	)
 	if bifrostErr != nil {
 		return nil, bifrostErr
-	}
-
-	providerName := provider.GetProviderKey()
-
-	// Add deployment aliases to the response
-	for i, model := range finalResponse.Data {
-		for _, key := range keys {
-			if key.VertexKeyConfig == nil {
-				continue
-			}
-			for keyDeploymentAlias, keyDeploymentName := range key.VertexKeyConfig.Deployments {
-				if strings.TrimPrefix(model.ID, string(providerName)+"/") == keyDeploymentName {
-					finalResponse.Data[i].ID = string(providerName) + "/" + keyDeploymentAlias
-					finalResponse.Data[i].Deployment = schemas.Ptr(keyDeploymentName)
-					break
-				}
-			}
-		}
 	}
 
 	return finalResponse, nil

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1048,3 +1048,89 @@ func IsAnthropicModel(model string) bool {
 func IsMistralModel(model string) bool {
 	return strings.Contains(model, "mistral") || strings.Contains(model, "codestral")
 }
+
+// Precompiled regexes for different kinds of version suffixes.
+var (
+	// Anthropic-style date: 20250514
+	anthropicDateRe = regexp.MustCompile(`^\d{8}$`)
+
+	// OpenAI-style date: 2024-09-12
+	openAIDateRe = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+	// Generic tagged versions:
+	//   v1, v1.2, v1.2.3, rc1, alpha, beta, preview, canary, experimental, etc.
+	//
+	// NOTE: we intentionally require 'v' for numeric semver-ish versions so that
+	// things like "-4" or "-4.5" are NOT treated as version tags.
+	taggedVersionRe = regexp.MustCompile(
+		`^(?:v\d+(?:\.\d+){0,2}|rc\d+|alpha|beta|preview|canary|experimental)$`,
+	)
+)
+
+// SplitModelAndVersion splits a model id into (base, versionSuffix).
+// If no known version suffix is found, versionSuffix will be empty and
+// base will be the original id.
+//
+// Examples:
+//
+//	"claude-sonnet-4"                 -> ("claude-sonnet-4", "")
+//	"claude-sonnet-4-20250514"        -> ("claude-sonnet-4", "20250514")
+//	"gpt-4.1-2024-09-12"              -> ("gpt-4.1", "2024-09-12")
+//	"gpt-4.1-mini-2024-09-12"         -> ("gpt-4.1-mini", "2024-09-12")
+//	"some-model-v2"                   -> ("some-model", "v2")
+//	"text-embedding-3-large-beta"     -> ("text-embedding-3-large", "beta")
+//	"claude-sonnet-4.5"               -> ("claude-sonnet-4.5", "")
+func SplitModelAndVersion(id string) (base, version string) {
+	if id == "" {
+		return "", ""
+	}
+
+	parts := strings.Split(id, "-")
+	n := len(parts)
+	if n == 0 {
+		return "", ""
+	}
+
+	// 1. Try OpenAI-style date: last 3 parts, e.g. "2024-09-12".
+	if n >= 3 {
+		last3 := strings.Join(parts[n-3:], "-")
+		if openAIDateRe.MatchString(last3) {
+			base := strings.Join(parts[:n-3], "-")
+			return base, last3
+		}
+	}
+
+	// 2. Try Anthropic-style date (20250514) or tagged versions (v1, beta, etc.) in last part.
+	if n >= 2 {
+		last := parts[n-1]
+		if anthropicDateRe.MatchString(last) || taggedVersionRe.MatchString(last) {
+			base := strings.Join(parts[:n-1], "-")
+			return base, last
+		}
+	}
+
+	// 3. No recognized version suffix.
+	return id, ""
+}
+
+// BaseModelName returns the model id with any recognized version suffix stripped.
+//
+// This is your "model name without version".
+func BaseModelName(id string) string {
+	base, _ := SplitModelAndVersion(id)
+	return base
+}
+
+// SameBaseModel reports whether two model ids refer to the same base model,
+// ignoring any recognized version suffixes.
+//
+// This works even if both sides are versioned, or both unversioned.
+func SameBaseModel(a, b string) bool {
+	// Fast path: exact match.
+	if a == b {
+		return true
+	}
+
+	// Compare normalized base names.
+	return BaseModelName(a) == BaseModelName(b)
+}

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -24,6 +24,8 @@ func normalizeProvider(p string) string {
 		return string(schemas.Vertex)
 	} else if strings.Contains(p, "bedrock") {
 		return string(schemas.Bedrock)
+	} else if strings.Contains(p, "cohere") {
+		return string(schemas.Cohere)
 	} else {
 		return p
 	}

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -344,6 +344,10 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 		for i, modelEntry := range resp.Data {
 			provider, modelName := schemas.ParseModelString(modelEntry.ID, "")
 			pricingEntry := h.config.PricingManager.GetPricingEntryForModel(modelName, provider)
+			if pricingEntry == nil && modelEntry.Deployment != nil {
+				// Retry with deployment
+				pricingEntry = h.config.PricingManager.GetPricingEntryForModel(*modelEntry.Deployment, provider)
+			}
 			if pricingEntry != nil && modelEntry.Pricing == nil {
 				pricing := &schemas.Pricing{
 					Prompt:     bifrost.Ptr(fmt.Sprintf("%f", pricingEntry.InputCostPerToken)),

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
 fix: vertex and bedrock usage aggregation improvements for streaming
 fix: choice index fixed to 0 for anthropic and bedrock streaming
 feat: model field added to responses api response
+feat: check allowed models and deployments of key for list models


### PR DESCRIPTION
## Summary

Filter models in the list models API response based on the allowed models and deployments configured for the API key.

## Changes

- Added filtering logic to all provider implementations to check if models are allowed for the key
- Implemented base model matching to support version-agnostic model filtering
- Added utility functions to normalize and compare model names across different versioning schemes
- Updated list models endpoints to respect both allowed models and deployment configurations
- Fixed pricing lookup for models with deployment aliases

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Configure an API key with specific allowed models:

```sh
# Create a key with only specific models allowed
curl -X POST http://localhost:8000/keys \
  -H "Content-Type: application/json" \
  -d '{"name": "Test Key", "models": ["openai/gpt-4", "anthropic/claude-3-sonnet"]}'
```

2. Test the list models endpoint with this key:

```sh
curl http://localhost:8000/models \
  -H "Authorization: Bearer YOUR_KEY"
```

3. Verify that only the allowed models appear in the response

4. Test with deployment configurations:

```sh
# Create a key with deployment aliases
curl -X POST http://localhost:8000/keys \
  -H "Content-Type: application/json" \
  -d '{"name": "Azure Key", "provider": "azure", "azure_key_config": {"deployments": {"gpt4": "gpt-4"}}}'
```

5. Verify that only the configured deployments appear in the models list

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Implements model filtering for list models API to match the behavior of completion endpoints.

## Security considerations

Improves security by ensuring users can only see and access models they are explicitly allowed to use.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable