### PR TITLE
fix: use net.Listen with Server.Serve to properly support IPv6 addresses

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1161,9 +1161,13 @@ func (s *BifrostHTTPServer) Start() error {
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 	// Start server in a goroutine
 	serverAddr := net.JoinHostPort(s.Host, s.Port)
+	ln, err := net.Listen("tcp", serverAddr)
+	if err != nil {
+		return fmt.Errorf("failed to create listener on %s: %v", serverAddr, err)
+	}
 	go func() {
 		logger.Info("successfully started bifrost, serving UI on http://%s:%s", s.Host, s.Port)
-		if err := s.Server.ListenAndServe(serverAddr); err != nil {
+		if err := s.Server.Serve(ln); err != nil {
 			errChan <- err
 		}
 	}()


### PR DESCRIPTION
## Summary

This PR makes it possible to make Bifrost listen to IPv6 addresses, eg. `::`. [ListenAndServe](https://pkg.go.dev/github.com/valyala/fasthttp#Server.ListenAndServe) that is currently being used seems to make Bifrost listen to IPv4 address always, no matter what host value is provided to Bifrost. For example, even when host is set to `::`, Bifrost still actually listens to IPv4 address `0.0.0.0`.

Without being able to listen to IPv6, Bifrost can't be used eg. in IPv6-only EKS environments.

## Changes

- Use [Serve](https://pkg.go.dev/github.com/valyala/fasthttp#Server.Serve) with a custom listener (both TCP stacks) instead of `ListenAndServe`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Start Bifrost (dev mode or production docker image) with `HOST=::` and eg. verify from inside the container that Bifrost is listening to either IPv4 or IPv6 address.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

Should not be a breaking change, as far as I could verify. I verified the IPv6 functionality by building Bifrost's Docker image with this change and deploying it to an IPv6-only EKS environment.


## Related issues

## Security considerations

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


