### PR TITLE
feat: enabled a key without deleting

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2668,6 +2668,10 @@ func (bifrost *Bifrost) getAllSupportedKeys(ctx *context.Context, providerKey sc
 	// Filter keys for ListModels - only check if key has a value
 	var supportedKeys []schemas.Key
 	for _, k := range keys {
+		// Skip disabled keys (default enabled when nil)
+		if k.Enabled != nil && !*k.Enabled {
+			continue
+		}
 		if strings.TrimSpace(k.Value) != "" || canProviderKeyValueBeEmpty(baseProviderType) {
 			supportedKeys = append(supportedKeys, k)
 		}
@@ -2709,12 +2713,22 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *context.Context, requ
 	if requestType == schemas.ListModelsRequest {
 		// Skip deployment check but still check if the key has a value
 		for _, k := range keys {
+			// Skip disabled keys
+			if k.Enabled != nil && !*k.Enabled {
+				continue
+			}
+
 			if strings.TrimSpace(k.Value) != "" || canProviderKeyValueBeEmpty(baseProviderType) {
 				supportedKeys = append(supportedKeys, k)
 			}
 		}
 	} else {
 		for _, key := range keys {
+			// Skip disabled keys
+			if key.Enabled != nil && !*key.Enabled {
+				continue
+			}
+
 			modelSupported := (slices.Contains(key.Models, model) && (strings.TrimSpace(key.Value) != "" || canProviderKeyValueBeEmpty(baseProviderType))) || len(key.Models) == 0
 
 			// Additional deployment checks for Azure, Bedrock and Vertex

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,2 @@
+fix: vertex and bedrock usage aggregation improvements for streaming
+fix: choice index fixed to 0 for anthropic and bedrock streaming

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -14,6 +14,7 @@ type Key struct {
 	AzureKeyConfig   *AzureKeyConfig   `json:"azure_key_config,omitempty"`   // Azure-specific key configuration
 	VertexKeyConfig  *VertexKeyConfig  `json:"vertex_key_config,omitempty"`  // Vertex-specific key configuration
 	BedrockKeyConfig *BedrockKeyConfig `json:"bedrock_key_config,omitempty"` // AWS Bedrock-specific key configuration
+	Enabled          *bool             `json:"enabled,omitempty"`            // Whether the key is active (default:true)
 }
 
 // AzureKeyConfig represents the Azure-specific configuration.

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -80,6 +80,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddLogRetentionDaysColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddEnabledColumnToKeyTable(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddBatchAndCachePricingColumns(ctx, db); err != nil {
 		return err
 	}
@@ -1079,6 +1082,49 @@ func migrationAddLogRetentionDaysColumn(ctx context.Context, db *gorm.DB) error 
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while running db migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddEnabledColumnToKeyTable adds the enabled column to the config_keys table
+func migrationAddEnabledColumnToKeyTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_enabled_column_to_key_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// Check if column already exists
+			if !mg.HasColumn(&tables.TableKey{}, "enabled") {
+				// Add the column
+				if err := mg.AddColumn(&tables.TableKey{}, "enabled"); err != nil {
+					return fmt.Errorf("failed to add enabled column: %w", err)
+				}
+
+			}
+			// Set default = true for existing rows
+			if err := tx.Exec("UPDATE config_keys SET enabled = TRUE WHERE enabled IS NULL").Error; err != nil {
+				return fmt.Errorf("failed to backfill enabled column: %w", err)
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			if mg.HasColumn(&tables.TableKey{}, "enabled") {
+				if err := mg.DropColumn(&tables.TableKey{}, "enabled"); err != nil {
+					return fmt.Errorf("failed to drop enabled column: %w", err)
+				}
+			}
+
+			return nil
+		},
+	}})
+
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running enabled column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -243,6 +243,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				Value:            key.Value,
 				Models:           key.Models,
 				Weight:           key.Weight,
+				Enabled:          key.Enabled,
 				AzureKeyConfig:   key.AzureKeyConfig,
 				VertexKeyConfig:  key.VertexKeyConfig,
 				BedrockKeyConfig: key.BedrockKeyConfig,
@@ -285,6 +286,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				// Update existing key with new data
 				dbKey.ID = existingKey.ID                 // Keep the same database ID
 				dbKey.ProviderID = existingKey.ProviderID // Preserve the existing ProviderID
+				dbKey.Enabled = existingKey.Enabled       // Preserve the existing Enabled status
 				if err := txDB.WithContext(ctx).Save(&dbKey).Error; err != nil {
 					return s.parseGormError(err)
 				}
@@ -367,6 +369,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			Value:            key.Value,
 			Models:           key.Models,
 			Weight:           key.Weight,
+			Enabled:          key.Enabled,
 			AzureKeyConfig:   key.AzureKeyConfig,
 			VertexKeyConfig:  key.VertexKeyConfig,
 			BedrockKeyConfig: key.BedrockKeyConfig,
@@ -400,6 +403,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 		if existingKey, exists := existingKeysMap[key.ID]; exists {
 			// Update existing key - preserve the database ID
 			dbKey.ID = existingKey.ID
+			dbKey.Enabled = existingKey.Enabled
 			if err := txDB.WithContext(ctx).Save(&dbKey).Error; err != nil {
 				return s.parseGormError(err)
 			}

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -19,6 +19,7 @@ type TableKey struct {
 	Value      string    `gorm:"type:text;not null" json:"value"`
 	ModelsJSON string    `gorm:"type:text" json:"-"` // JSON serialized []string
 	Weight     float64   `gorm:"default:1.0" json:"weight"`
+	Enabled    *bool     `gorm:"default:true" json:"enabled,omitempty"`
 	CreatedAt  time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt  time.Time `gorm:"index;not null" json:"updated_at"`
 
@@ -65,6 +66,11 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.ModelsJSON = string(data)
 	} else {
 		k.ModelsJSON = "[]"
+	}
+
+	if k.Enabled == nil {
+		enabled := true // DB default
+		k.Enabled = &enabled
 	}
 
 	if k.AzureKeyConfig != nil {
@@ -169,6 +175,11 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		if err := json.Unmarshal([]byte(k.ModelsJSON), &k.Models); err != nil {
 			return err
 		}
+	}
+
+	if k.Enabled == nil {
+		enabled := true // DB default
+		k.Enabled = &enabled
 	}
 
 	// Reconstruct Azure config if fields are present

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1427,6 +1427,10 @@ func (c *Config) GetProviderConfigRedacted(provider schemas.ModelProvider) (*con
 			Models: key.Models, // Copy slice reference - read-only so safe
 			Weight: key.Weight,
 		}
+		if key.Enabled != nil {
+			enabled := *key.Enabled
+			redactedConfig.Keys[i].Enabled = &enabled
+		}
 
 		// Redact API key value
 		path := fmt.Sprintf("providers.%s.keys[%s]", provider, key.ID)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+feat: add support for enabling/disabling provider keys without deletion

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { CardHeader, CardTitle } from "@/components/ui/card";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Switch } from "@/components/ui/switch";
 import { getErrorMessage, useUpdateProviderMutation } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
@@ -104,18 +105,20 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 						<TableRow>
 							<TableHead>API Key</TableHead>
 							<TableHead>Weight</TableHead>
+							<TableHead>Enabled</TableHead>
 							<TableHead className="text-right"></TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
 						{provider.keys.length === 0 && (
 							<TableRow>
-								<TableCell colSpan={3} className="py-6 text-center">
+								<TableCell colSpan={4} className="py-6 text-center">
 									No keys found.
 								</TableCell>
 							</TableRow>
 						)}
 						{provider.keys.map((key, index) => {
+							const isKeyEnabled = key.enabled ?? true;
 							return (
 								<TableRow key={index} className="text-sm transition-colors hover:bg-white" onClick={() => {}}>
 									<TableCell>
@@ -127,6 +130,27 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 										<div className="flex items-center space-x-2">
 											<span className="font-mono text-sm">{key.weight}</span>
 										</div>
+									</TableCell>
+									<TableCell>
+										<Switch
+											checked={isKeyEnabled}
+											disabled={!hasUpdateProviderAccess}
+											onCheckedChange={(checked) => {
+												updateProvider({
+													...provider,
+													keys: provider.keys.map((k, i) =>
+														i === index ? { ...k, enabled: checked } : k
+													),
+												})
+													.unwrap()
+													.then(() => {
+														toast.success(`Key ${checked ? "enabled" : "disabled"} successfully`);
+													})
+													.catch((err) => {
+														toast.error("Failed to update key", { description: getErrorMessage(err) });
+													});
+											}}
+										/>
 									</TableCell>
 									<TableCell className="text-right">
 										<div className="flex items-center justify-end space-x-2">
@@ -141,6 +165,7 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 														onClick={() => {
 															setShowAddNewKeyDialog({ show: true, keyIndex: index });
 														}}
+														disabled={!hasUpdateProviderAccess || !isKeyEnabled}
 													>
 														<PencilIcon className="mr-1 h-4 w-4" />
 														Edit

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -76,6 +76,7 @@ export interface ModelProviderKey {
 	value?: string;
 	models?: string[];
 	weight: number;
+	enabled?: boolean;
 	azure_key_config?: AzureKeyConfig;
 	vertex_key_config?: VertexKeyConfig;
 	bedrock_key_config?: BedrockKeyConfig;
@@ -88,6 +89,7 @@ export const DefaultModelProviderKey: ModelProviderKey = {
 	value: "",
 	models: [],
 	weight: 1.0,
+	enabled: true,
 };
 
 // NetworkConfig matching Go's schemas.NetworkConfig


### PR DESCRIPTION
## Summary

Implemented a feature that user can disable or enable a key without deleting the key on the website.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

If adding new configs or environment variables, document them here.

Added `Enabled` in `core/schemas/account.go`
```
type Key struct {
	ID               string            `json:"id"`                           // The unique identifier for the key (used by bifrost to identify the key)
	Name             string            `json:"name"`                         // The name of the key (used by users to identify the key, not used by bifrost)
	Value            string            `json:"value"`                        // The actual API key value
	Models           []string          `json:"models"`                       // List of models this key can access
	Weight           float64           `json:"weight"`                       // Weight for load balancing between multiple keys
	AzureKeyConfig   *AzureKeyConfig   `json:"azure_key_config,omitempty"`   // Azure-specific key configuration
	VertexKeyConfig  *VertexKeyConfig  `json:"vertex_key_config,omitempty"`  // Vertex-specific key configuration
	BedrockKeyConfig *BedrockKeyConfig `json:"bedrock_key_config,omitempty"` // AWS Bedrock-specific key configuration
	Enabled          *bool             `json:"enabled,omitempty"`            // Whether the key is active (default: true)
}
```

### Before

### After
<img width="1312" height="1188" alt="Image" src="https://github.com/user-attachments/assets/2ae785d8-db8a-47e2-a03a-213241989d53" />

<img width="1312" height="1188" alt="Image" src="https://github.com/user-attachments/assets/34cece82-4ff2-4d12-961c-ab4af509a872" />

<img width="1312" height="1188" alt="Image" src="https://github.com/user-attachments/assets/07e133b7-f9d3-414e-abca-577676e8d01c" />

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #831

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


