### PR TITLE
feat: send back raw request in extra fields

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,4 @@
+feat: send back raw request in extra fields
+feat: added support for reasoning in chat completions
+feat: enhanced reasoning support in responses api
+enhancement: improved internal inter provider conversions for integrations

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -17,6 +17,7 @@ type CerebrasProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -47,6 +48,7 @@ func NewCerebrasProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
@@ -66,6 +68,7 @@ func (provider *CerebrasProvider) ListModels(ctx context.Context, keys []schemas
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -83,6 +86,7 @@ func (provider *CerebrasProvider) TextCompletion(ctx context.Context, key schema
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -104,6 +108,7 @@ func (provider *CerebrasProvider) TextCompletionStream(ctx context.Context, post
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
@@ -121,6 +126,7 @@ func (provider *CerebrasProvider) ChatCompletion(ctx context.Context, key schema
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
@@ -144,6 +150,7 @@ func (provider *CerebrasProvider) ChatCompletionStream(ctx context.Context, post
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Cerebras,
 		postHookRunner,

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -17,6 +17,7 @@ type GroqProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -52,6 +53,7 @@ func NewGroqProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*Gr
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
@@ -71,6 +73,7 @@ func (provider *GroqProvider) ListModels(ctx context.Context, keys []schemas.Key
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Groq,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -160,6 +163,7 @@ func (provider *GroqProvider) ChatCompletion(ctx context.Context, key schemas.Ke
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
@@ -183,6 +187,7 @@ func (provider *GroqProvider) ChatCompletionStream(ctx context.Context, postHook
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Groq,
 		postHookRunner,

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -18,6 +18,7 @@ type MistralProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -53,6 +54,7 @@ func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}
 }
@@ -100,7 +102,7 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 
 	// Parse Mistral's response
 	var mistralResponse MistralListModelsResponse
-	rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &mistralResponse, providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &mistralResponse, nil, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -109,6 +111,11 @@ func (provider *MistralProvider) listModelsByKey(ctx context.Context, key schema
 	response := mistralResponse.ToBifrostListModelsResponse(key.Models)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
+
+	// Set raw request if enabled
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		response.ExtraFields.RawRequest = rawRequest
+	}
 
 	// Set raw response if enabled
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
@@ -151,6 +158,7 @@ func (provider *MistralProvider) ChatCompletion(ctx context.Context, key schemas
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
@@ -174,6 +182,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx context.Context, postH
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Mistral,
 		postHookRunner,
@@ -222,6 +231,7 @@ func (provider *MistralProvider) Embedding(ctx context.Context, key schemas.Key,
 		key,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Mistral,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -19,6 +19,7 @@ type OllamaProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -55,6 +56,7 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
@@ -77,6 +79,7 @@ func (provider *OllamaProvider) ListModels(ctx context.Context, keys []schemas.K
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -92,6 +95,7 @@ func (provider *OllamaProvider) TextCompletion(ctx context.Context, key schemas.
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -108,6 +112,7 @@ func (provider *OllamaProvider) TextCompletionStream(ctx context.Context, postHo
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
@@ -125,6 +130,7 @@ func (provider *OllamaProvider) ChatCompletion(ctx context.Context, key schemas.
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
@@ -144,6 +150,7 @@ func (provider *OllamaProvider) ChatCompletionStream(ctx context.Context, postHo
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Ollama,
 		postHookRunner,
@@ -190,6 +197,7 @@ func (provider *OllamaProvider) Embedding(ctx context.Context, key schemas.Key, 
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -18,6 +18,7 @@ type ParasailProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -48,6 +49,7 @@ func NewParasailProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
@@ -67,6 +69,7 @@ func (provider *ParasailProvider) ListModels(ctx context.Context, keys []schemas
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -93,6 +96,7 @@ func (provider *ParasailProvider) ChatCompletion(ctx context.Context, key schema
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
@@ -116,6 +120,7 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx context.Context, post
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Parasail,
 		postHookRunner,

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -20,6 +20,7 @@ type PerplexityProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -50,6 +51,7 @@ func NewPerplexityProvider(config *schemas.ProviderConfig, logger schemas.Logger
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
@@ -140,7 +142,7 @@ func (provider *PerplexityProvider) ChatCompletion(ctx context.Context, key sche
 	}
 
 	var response PerplexityChatResponse
-	rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &response, providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -152,6 +154,11 @@ func (provider *PerplexityProvider) ChatCompletion(ctx context.Context, key sche
 	bifrostResponse.ExtraFields.ModelRequested = request.Model
 	bifrostResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
 	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	// Set raw request if enabled
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		bifrostResponse.ExtraFields.RawRequest = rawRequest
+	}
 
 	// Set raw response if enabled
 	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
@@ -183,6 +190,7 @@ func (provider *PerplexityProvider) ChatCompletionStream(ctx context.Context, po
 		request,
 		authHeader,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.Perplexity,
 		postHookRunner,

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -19,6 +19,7 @@ type SGLProvider struct {
 	logger              schemas.Logger        // Logger for provider operations
 	client              *fasthttp.Client      // HTTP client for API requests
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
 }
 
@@ -55,6 +56,7 @@ func NewSGLProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*SGL
 		logger:              logger,
 		client:              client,
 		networkConfig:       config.NetworkConfig,
+		sendBackRawRequest:  config.SendBackRawRequest,
 		sendBackRawResponse: config.SendBackRawResponse,
 	}, nil
 }
@@ -74,6 +76,7 @@ func (provider *SGLProvider) ListModels(ctx context.Context, keys []schemas.Key,
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.SGL,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -89,6 +92,7 @@ func (provider *SGLProvider) TextCompletion(ctx context.Context, key schemas.Key
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)
@@ -105,6 +109,7 @@ func (provider *SGLProvider) TextCompletionStream(ctx context.Context, postHookR
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		postHookRunner,
@@ -122,6 +127,7 @@ func (provider *SGLProvider) ChatCompletion(ctx context.Context, key schemas.Key
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
 		provider.logger,
@@ -141,6 +147,7 @@ func (provider *SGLProvider) ChatCompletionStream(ctx context.Context, postHookR
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		schemas.SGL,
 		postHookRunner,
@@ -187,6 +194,7 @@ func (provider *SGLProvider) Embedding(ctx context.Context, key schemas.Key, req
 		key,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
 	)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -102,19 +102,20 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                                          // string
-	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                                       // string
-	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"                              // string
-	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"                               // Key struct
-	BifrostContextKeySelectedKeyID                       BifrostContextKey = "bifrost-selected-key-id"                          // string (to store the selected key ID (set by bifrost))
-	BifrostContextKeySelectedKeyName                     BifrostContextKey = "bifrost-selected-key-name"                        // string (to store the selected key name (set by bifrost))
-	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"                        // int (to store the number of retries (set by bifrost))
-	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"                           // int (to store the fallback index (set by bifrost)) 0 for primary, 1 for first fallback, etc.
-	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"                     // bool (set by bifrost)
-	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"                       // bool (will pass an empty key to the provider)
-	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"                            // map[string]string
-	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                           // string
-	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"                     // bool
+	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                      // string
+	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                   // string
+	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"          // string
+	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"           // Key struct
+	BifrostContextKeySelectedKeyID                       BifrostContextKey = "bifrost-selected-key-id"      // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeySelectedKeyName                     BifrostContextKey = "bifrost-selected-key-name"    // string (to store the selected key name (set by bifrost))
+	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"    // int (to store the number of retries (set by bifrost))
+	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"       // int (to store the fallback index (set by bifrost)) 0 for primary, 1 for first fallback, etc.
+	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator" // bool (set by bifrost)
+	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"   // bool (will pass an empty key to the provider)
+	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"        // map[string]string
+	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"       // string
+	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
+	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool
 	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost)
 	BifrostContextKeyStructuredOutputToolName            BifrostContextKey = "bifrost-structured-output-tool-name"              // string (to store the name of the structured output tool (set by bifrost))
@@ -289,6 +290,7 @@ type BifrostResponseExtraFields struct {
 	ModelDeployment string             `json:"model_deployment,omitempty"` // only present for providers which use model deployments (e.g. Azure, Bedrock)
 	Latency         int64              `json:"latency"`                    // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
 	ChunkIndex      int                `json:"chunk_index"`                // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
+	RawRequest      interface{}        `json:"raw_request,omitempty"`
 	RawResponse     interface{}        `json:"raw_response,omitempty"`
 	CacheDebug      *BifrostCacheDebug `json:"cache_debug,omitempty"`
 }

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -28,6 +28,7 @@ const (
 	ErrProviderDoRequest            = "failed to execute HTTP request to provider API"
 	ErrProviderResponseDecode       = "failed to decode response body from provider API"
 	ErrProviderResponseUnmarshal    = "failed to unmarshal response from provider API"
+	ErrProviderRawRequestUnmarshal  = "failed to unmarshal raw request from provider API"
 	ErrProviderRawResponseUnmarshal = "failed to unmarshal raw response from provider API"
 	ErrProviderResponseDecompress   = "failed to decompress provider's response"
 )
@@ -237,6 +238,7 @@ type ProviderConfig struct {
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
 	Logger               Logger                `json:"-"`
 	ProxyConfig          *ProxyConfig          `json:"proxy_config,omitempty"` // Proxy configuration
+	SendBackRawRequest   bool                  `json:"send_back_raw_request"`  // Send raw request back in the bifrost response (default: false)
 	SendBackRawResponse  bool                  `json:"send_back_raw_response"` // Send raw response back in the bifrost response (default: false)
 	CustomProviderConfig *CustomProviderConfig `json:"custom_provider_config,omitempty"`
 }

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,3 @@
 feat: support raw response accumulation in stream accumulator
+feat: support raw request configuration and logging
+feat: added support for reasoning accumulation in stream accumulator

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -150,6 +150,7 @@ type ProviderConfig struct {
 	NetworkConfig            *schemas.NetworkConfig            `json:"network_config,omitempty"`              // Network-related settings
 	ConcurrencyAndBufferSize *schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size,omitempty"` // Concurrency settings
 	ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config,omitempty"`                // Proxy configuration
+	SendBackRawRequest       bool                              `json:"send_back_raw_request"`                 // Include raw request in BifrostResponse
 	SendBackRawResponse      bool                              `json:"send_back_raw_response"`                // Include raw response in BifrostResponse
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
 	ConfigHash               string                            `json:"-"`
@@ -198,6 +199,11 @@ func (p *ProviderConfig) GenerateConfigHash(providerName string) (string, error)
 			return "", err
 		}
 		hash.Write(data)
+	}
+
+	// Hash SendBackRawRequest
+	if p.SendBackRawRequest {
+		hash.Write([]byte("sendBackRawRequest"))
 	}
 
 	// Hash SendBackRawResponse

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -211,6 +211,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			NetworkConfig:            providerConfig.NetworkConfig,
 			ConcurrencyAndBufferSize: providerConfig.ConcurrencyAndBufferSize,
 			ProxyConfig:              providerConfig.ProxyConfig,
+			SendBackRawRequest:       providerConfig.SendBackRawRequest,
 			SendBackRawResponse:      providerConfig.SendBackRawResponse,
 			CustomProviderConfig:     providerConfig.CustomProviderConfig,
 			ConfigHash:               providerConfig.ConfigHash,
@@ -331,6 +332,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 	dbProvider.NetworkConfig = configCopy.NetworkConfig
 	dbProvider.ConcurrencyAndBufferSize = configCopy.ConcurrencyAndBufferSize
 	dbProvider.ProxyConfig = configCopy.ProxyConfig
+	dbProvider.SendBackRawRequest = configCopy.SendBackRawRequest
 	dbProvider.SendBackRawResponse = configCopy.SendBackRawResponse
 	dbProvider.CustomProviderConfig = configCopy.CustomProviderConfig
 	dbProvider.ConfigHash = configCopy.ConfigHash
@@ -448,6 +450,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		NetworkConfig:            configCopy.NetworkConfig,
 		ConcurrencyAndBufferSize: configCopy.ConcurrencyAndBufferSize,
 		ProxyConfig:              configCopy.ProxyConfig,
+		SendBackRawRequest:       configCopy.SendBackRawRequest,
 		SendBackRawResponse:      configCopy.SendBackRawResponse,
 		CustomProviderConfig:     configCopy.CustomProviderConfig,
 		ConfigHash:               configCopy.ConfigHash,
@@ -643,6 +646,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 			NetworkConfig:            dbProvider.NetworkConfig,
 			ConcurrencyAndBufferSize: dbProvider.ConcurrencyAndBufferSize,
 			ProxyConfig:              dbProvider.ProxyConfig,
+			SendBackRawRequest:       dbProvider.SendBackRawRequest,
 			SendBackRawResponse:      dbProvider.SendBackRawResponse,
 			CustomProviderConfig:     dbProvider.CustomProviderConfig,
 			ConfigHash:               dbProvider.ConfigHash,

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -19,6 +19,7 @@ type TableProvider struct {
 	ConcurrencyBufferJSON    string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ConcurrencyAndBufferSize
 	ProxyConfigJSON          string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ProxyConfig
 	CustomProviderConfigJSON string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.CustomProviderConfig
+	SendBackRawRequest       bool      `json:"send_back_raw_request"`
 	SendBackRawResponse      bool      `json:"send_back_raw_response"`
 	CreatedAt                time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt                time.Time `gorm:"index;not null" json:"updated_at"`

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -103,8 +103,9 @@ type Log struct {
 	Status                string    `gorm:"type:varchar(50);index;not null" json:"status"` // "processing", "success", or "error"
 	ErrorDetails          string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.BifrostError
 	Stream                bool      `gorm:"default:false" json:"stream"`                   // true if this was a streaming response
-	ContentSummary        string    `gorm:"type:text" json:"-"`                            // For content search
-	RawResponse           string    `gorm:"type:text" json:"raw_response"`                 // Populated when `send-back-raw-response` is on
+	ContentSummary        string    `gorm:"type:text" json:"-"`
+	RawRequest            string    `gorm:"type:text" json:"raw_request"`  // Populated when `send-back-raw-request` is on
+	RawResponse           string    `gorm:"type:text" json:"raw_response"` // Populated when `send-back-raw-response` is on
 
 	// Denormalized token fields for easier querying
 	PromptTokens     int `gorm:"default:0" json:"-"`

--- a/framework/streaming/audio.go
+++ b/framework/streaming/audio.go
@@ -167,6 +167,10 @@ func (a *Accumulator) processAudioStreamingResponse(ctx *schemas.BifrostContext,
 				a.logger.Error("failed to process accumulated chunks for request %s: %v", requestID, processErr)
 				return nil, processErr
 			}
+			var rawRequest interface{}
+			if result != nil && result.SpeechStreamResponse != nil && result.SpeechStreamResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.SpeechStreamResponse.ExtraFields.RawRequest
+			}
 			return &ProcessedStreamResponse{
 				Type:       StreamResponseTypeFinal,
 				RequestID:  requestID,
@@ -174,6 +178,7 @@ func (a *Accumulator) processAudioStreamingResponse(ctx *schemas.BifrostContext,
 				Model:      model,
 				Provider:   provider,
 				Data:       data,
+				RawRequest: &rawRequest,
 			}, nil
 		}
 		return nil, nil

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -301,6 +301,10 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 				a.logger.Error("failed to process accumulated chunks for request %s: %v", requestID, processErr)
 				return nil, processErr
 			}
+			var rawRequest interface{}
+			if result != nil && result.ChatResponse != nil && result.ChatResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.ChatResponse.ExtraFields.RawRequest
+			}
 			return &ProcessedStreamResponse{
 				Type:       StreamResponseTypeFinal,
 				RequestID:  requestID,
@@ -308,6 +312,7 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 				Provider:   provider,
 				Model:      model,
 				Data:       data,
+				RawRequest: &rawRequest,
 			}, nil
 		}
 		return nil, nil

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -720,6 +720,10 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *schemas.BifrostCont
 			return nil, fmt.Errorf("failed to add responses stream chunk for request %s: %w", requestID, addErr)
 		}
 		if isFinalChunk {
+			var rawRequest interface{}
+			if result != nil && result.ResponsesStreamResponse != nil && result.ResponsesStreamResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.ResponsesStreamResponse.ExtraFields.RawRequest
+			}
 			shouldProcess := false
 			// Get the accumulator to check if processing has already been triggered
 			accumulator := a.getOrCreateStreamAccumulator(requestID)
@@ -782,6 +786,7 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *schemas.BifrostCont
 						Provider:   provider,
 						Model:      model,
 						Data:       data,
+						RawRequest: &rawRequest,
 					}, nil
 				} else {
 					return nil, nil
@@ -858,6 +863,11 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *schemas.BifrostCont
 				return nil, processErr
 			}
 
+			var rawRequest interface{}
+			if result != nil && result.ResponsesStreamResponse != nil && result.ResponsesStreamResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.ResponsesStreamResponse.ExtraFields.RawRequest
+			}
+
 			return &ProcessedStreamResponse{
 				Type:       StreamResponseTypeFinal,
 				RequestID:  requestID,
@@ -865,6 +875,7 @@ func (a *Accumulator) processResponsesStreamingResponse(ctx *schemas.BifrostCont
 				Provider:   provider,
 				Model:      model,
 				Data:       data,
+				RawRequest: &rawRequest,
 			}, nil
 		}
 		return nil, nil

--- a/framework/streaming/transcription.go
+++ b/framework/streaming/transcription.go
@@ -186,6 +186,10 @@ func (a *Accumulator) processTranscriptionStreamingResponse(ctx *schemas.Bifrost
 				a.logger.Error("failed to process accumulated chunks for request %s: %v", requestID, processErr)
 				return nil, processErr
 			}
+			var rawRequest interface{}
+			if result != nil && result.TranscriptionStreamResponse != nil && result.TranscriptionStreamResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.TranscriptionStreamResponse.ExtraFields.RawRequest
+			}
 			return &ProcessedStreamResponse{
 				Type:       StreamResponseTypeFinal,
 				RequestID:  requestID,
@@ -193,6 +197,7 @@ func (a *Accumulator) processTranscriptionStreamingResponse(ctx *schemas.Bifrost
 				Provider:   provider,
 				Model:      model,
 				Data:       data,
+				RawRequest: &rawRequest,
 			}, nil
 		}
 		return nil, nil

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -120,6 +120,7 @@ type ProcessedStreamResponse struct {
 	Provider   schemas.ModelProvider
 	Model      string
 	Data       *AccumulatedData
+	RawRequest *interface{}
 }
 
 // ToBifrostResponse converts a ProcessedStreamResponse to a BifrostResponse
@@ -154,6 +155,9 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			Provider:       p.Provider,
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
+		}
+		if p.RawRequest != nil {
+			resp.TextCompletionResponse.ExtraFields.RawRequest = p.RawRequest
 		}
 	case StreamTypeChat:
 		chatResp := &schemas.BifrostChatResponse{
@@ -204,6 +208,9 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
 		}
+		if p.RawRequest != nil {
+			resp.ChatResponse.ExtraFields.RawRequest = p.RawRequest
+		}
 	case StreamTypeResponses:
 		responsesResp := &schemas.BifrostResponsesResponse{}
 
@@ -219,6 +226,9 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
 		}
+		if p.RawRequest != nil {
+			responsesResp.ExtraFields.RawRequest = p.RawRequest
+		}
 		resp.ResponsesResponse = responsesResp
 	case StreamTypeAudio:
 		speechResp := p.Data.AudioOutput
@@ -232,6 +242,9 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
 		}
+		if p.RawRequest != nil {
+			resp.SpeechResponse.ExtraFields.RawRequest = p.RawRequest
+		}
 	case StreamTypeTranscription:
 		transcriptionResp := p.Data.TranscriptionOutput
 		if transcriptionResp == nil {
@@ -243,6 +256,9 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 			Provider:       p.Provider,
 			ModelRequested: p.Model,
 			Latency:        p.Data.Latency,
+		}
+		if p.RawRequest != nil {
+			resp.TranscriptionResponse.ExtraFields.RawRequest = p.RawRequest
 		}
 	}
 	return resp

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+feat: support for raw request logging

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -42,6 +42,7 @@ type UpdateLogData struct {
 	ErrorDetails        *schemas.BifrostError
 	SpeechOutput        *schemas.BifrostSpeechResponse        // For non-streaming speech responses
 	TranscriptionOutput *schemas.BifrostTranscriptionResponse // For non-streaming transcription responses
+	RawRequest          interface{}
 	RawResponse         interface{}
 }
 
@@ -496,6 +497,9 @@ func (p *LoggerPlugin) PostHook(ctx *schemas.BifrostContext, result *schemas.Bif
 				// Extract raw response
 				extraFields := result.GetExtraFields()
 				if p.disableContentLogging == nil || !*p.disableContentLogging {
+					if extraFields.RawRequest != nil {
+						updateData.RawRequest = extraFields.RawRequest
+					}
 					if extraFields.RawResponse != nil {
 						updateData.RawResponse = extraFields.RawResponse
 					}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -122,6 +122,16 @@ func (p *LoggerPlugin) updateLogEntry(
 				updates["transcription_output"] = tempEntry.TranscriptionOutput
 			}
 		}
+
+		// Handle raw request marshaling and logging
+		if data.RawRequest != nil {
+			rawRequestBytes, err := sonic.Marshal(data.RawRequest)
+			if err != nil {
+				p.logger.Error("failed to marshal raw request: %v", err)
+			} else {
+				updates["raw_request"] = string(rawRequestBytes)
+			}
+		}
 	}
 
 	if data.TokenUsage != nil {
@@ -168,7 +178,6 @@ func (p *LoggerPlugin) updateLogEntry(
 			updates["raw_response"] = string(rawResponseBytes)
 		}
 	}
-
 	return p.store.Update(ctx, requestID, updates)
 }
 
@@ -291,6 +300,15 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 				p.logger.Error("failed to serialize responses output: %v", err)
 			} else {
 				updates["responses_output"] = tempEntry.ResponsesOutput
+			}
+		}
+		// Handle raw request from stream updates
+		if streamResponse.RawRequest != nil && *streamResponse.RawRequest != nil {
+			rawRequestBytes, err := sonic.Marshal(*streamResponse.RawRequest)
+			if err != nil {
+				p.logger.Error("failed to marshal raw request: %v", err)
+			} else {
+				updates["raw_request"] = string(rawRequestBytes)
 			}
 		}
 		// Handle raw response from stream updates

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -58,6 +58,7 @@ type ProviderResponse struct {
 	NetworkConfig            schemas.NetworkConfig            `json:"network_config"`                   // Network-related settings
 	ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"`      // Concurrency settings
 	ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config"`                     // Proxy configuration
+	SendBackRawRequest       bool                             `json:"send_back_raw_request"`            // Include raw request in BifrostResponse
 	SendBackRawResponse      bool                             `json:"send_back_raw_response"`           // Include raw response in BifrostResponse
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"` // Custom provider configuration
 	Status                   ProviderStatus                   `json:"status"`                           // Status of the provider
@@ -175,6 +176,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		NetworkConfig            *schemas.NetworkConfig            `json:"network_config,omitempty"`              // Network-related settings
 		ConcurrencyAndBufferSize *schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size,omitempty"` // Concurrency settings
 		ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config,omitempty"`                // Proxy configuration
+		SendBackRawRequest       *bool                             `json:"send_back_raw_request,omitempty"`       // Include raw request in BifrostResponse
 		SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"`      // Include raw response in BifrostResponse
 		CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
 	}{}
@@ -245,6 +247,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		NetworkConfig:            payload.NetworkConfig,
 		ProxyConfig:              payload.ProxyConfig,
 		ConcurrencyAndBufferSize: payload.ConcurrencyAndBufferSize,
+		SendBackRawRequest:       payload.SendBackRawRequest != nil && *payload.SendBackRawRequest,
 		SendBackRawResponse:      payload.SendBackRawResponse != nil && *payload.SendBackRawResponse,
 		CustomProviderConfig:     payload.CustomProviderConfig,
 	}
@@ -273,6 +276,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			NetworkConfig:            config.NetworkConfig,
 			ConcurrencyAndBufferSize: config.ConcurrencyAndBufferSize,
 			ProxyConfig:              config.ProxyConfig,
+			SendBackRawRequest:       config.SendBackRawRequest,
 			SendBackRawResponse:      config.SendBackRawResponse,
 			CustomProviderConfig:     config.CustomProviderConfig,
 		}, ProviderStatusActive)
@@ -313,6 +317,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		NetworkConfig            schemas.NetworkConfig            `json:"network_config"`                   // Network-related settings
 		ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"`      // Concurrency settings
 		ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config,omitempty"`           // Proxy configuration
+		SendBackRawRequest       *bool                            `json:"send_back_raw_request,omitempty"`  // Include raw request in BifrostResponse
 		SendBackRawResponse      *bool                            `json:"send_back_raw_response,omitempty"` // Include raw response in BifrostResponse
 		CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"` // Custom provider configuration
 	}{}
@@ -423,6 +428,9 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	config.NetworkConfig = &nc
 	config.ProxyConfig = payload.ProxyConfig
 	config.CustomProviderConfig = payload.CustomProviderConfig
+	if payload.SendBackRawRequest != nil {
+		config.SendBackRawRequest = *payload.SendBackRawRequest
+	}
 	if payload.SendBackRawResponse != nil {
 		config.SendBackRawResponse = *payload.SendBackRawResponse
 	}
@@ -451,6 +459,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 			NetworkConfig:            config.NetworkConfig,
 			ConcurrencyAndBufferSize: config.ConcurrencyAndBufferSize,
 			ProxyConfig:              config.ProxyConfig,
+			SendBackRawRequest:       config.SendBackRawRequest,
 			SendBackRawResponse:      config.SendBackRawResponse,
 			CustomProviderConfig:     config.CustomProviderConfig,
 		}, ProviderStatusActive)
@@ -844,6 +853,7 @@ func (h *ProviderHandler) getProviderResponseFromConfig(provider schemas.ModelPr
 		NetworkConfig:            *config.NetworkConfig,
 		ConcurrencyAndBufferSize: *config.ConcurrencyAndBufferSize,
 		ProxyConfig:              config.ProxyConfig,
+		SendBackRawRequest:       config.SendBackRawRequest,
 		SendBackRawResponse:      config.SendBackRawResponse,
 		CustomProviderConfig:     config.CustomProviderConfig,
 		Status:                   status,

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -105,6 +105,7 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 		providerConfig.ConcurrencyAndBufferSize = schemas.DefaultConcurrencyAndBufferSize
 	}
 
+	providerConfig.SendBackRawRequest = config.SendBackRawRequest
 	providerConfig.SendBackRawResponse = config.SendBackRawResponse
 
 	if config.CustomProviderConfig != nil {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1691,6 +1691,7 @@ func loadDefaultProviders(ctx context.Context, config *Config) error {
 				NetworkConfig:            dbProvider.NetworkConfig,
 				ConcurrencyAndBufferSize: dbProvider.ConcurrencyAndBufferSize,
 				ProxyConfig:              dbProvider.ProxyConfig,
+				SendBackRawRequest:       dbProvider.SendBackRawRequest,
 				SendBackRawResponse:      dbProvider.SendBackRawResponse,
 				CustomProviderConfig:     dbProvider.CustomProviderConfig,
 			}
@@ -2099,6 +2100,7 @@ func (c *Config) GetProviderConfigRedacted(provider schemas.ModelProvider) (*con
 		NetworkConfig:            config.NetworkConfig,
 		ConcurrencyAndBufferSize: config.ConcurrencyAndBufferSize,
 		ProxyConfig:              config.ProxyConfig,
+		SendBackRawRequest:       config.SendBackRawRequest,
 		SendBackRawResponse:      config.SendBackRawResponse,
 		CustomProviderConfig:     config.CustomProviderConfig,
 	}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,5 @@
 feat: support for raw response accumulation for streaming
+feat: support for raw request logging and sending back in response
+feat: added support for reasoning in chat completions
+feat: enhanced reasoning support in responses api
+enhancement: improved internal inter provider conversions for integrations

--- a/ui/app/workspace/logs/views/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/views/logDetailsSheet.tsx
@@ -361,6 +361,31 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								/>
 							</>
 						)}
+						{log.raw_request && (
+							<>
+								<div className="mt-4 w-full text-left text-sm font-medium">
+									Raw Request sent to <span className="font-medium capitalize">{log.provider}</span>
+								</div>
+								<div className="w-full rounded-sm border">
+									<CodeEditor
+										className="z-0 w-full"
+										shouldAdjustInitialHeight={true}
+										maxHeight={250}
+										wrap={true}
+										code={(() => {
+											try {
+												return JSON.stringify(JSON.parse(log.raw_request), null, 2);
+											} catch {
+												return log.raw_request; // Fallback to raw string if parsing fails
+											}
+										})()}
+										lang="json"
+										readonly={true}
+										options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+									/>
+								</div>
+							</>
+						)}
 						{log.raw_response && (
 							<>
 								<div className="mt-4 w-full text-left text-sm font-medium">

--- a/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
@@ -32,6 +32,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 				concurrency: provider.concurrency_and_buffer_size?.concurrency ?? DefaultPerformanceConfig.concurrency,
 				buffer_size: provider.concurrency_and_buffer_size?.buffer_size ?? DefaultPerformanceConfig.buffer_size,
 			},
+			send_back_raw_request: provider.send_back_raw_request ?? false,
 			send_back_raw_response: provider.send_back_raw_response ?? false,
 		},
 	});
@@ -47,6 +48,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 				concurrency: provider.concurrency_and_buffer_size?.concurrency ?? DefaultPerformanceConfig.concurrency,
 				buffer_size: provider.concurrency_and_buffer_size?.buffer_size ?? DefaultPerformanceConfig.buffer_size,
 			},
+			send_back_raw_request: provider.send_back_raw_request ?? false,
 			send_back_raw_response: provider.send_back_raw_response ?? false,
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -60,6 +62,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 				concurrency: data.concurrency_and_buffer_size.concurrency,
 				buffer_size: data.concurrency_and_buffer_size.buffer_size,
 			},
+			send_back_raw_request: data.send_back_raw_request,
 			send_back_raw_response: data.send_back_raw_response,
 		};
 		updateProvider(updatedProvider)
@@ -120,6 +123,36 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 								)}
 							/>
 						</div>
+					</div>
+
+					<div className="mt-6 space-y-4">
+						<FormField
+							control={form.control}
+							name="send_back_raw_request"
+							render={({ field }) => (
+								<FormItem>
+									<div className="flex items-center justify-between space-x-2">
+										<div className="space-y-0.5">
+											<FormLabel>Include Raw Request</FormLabel>
+											<p className="text-muted-foreground text-xs">
+												Include the raw provider request alongside the parsed request for debugging and advanced use cases
+											</p>
+										</div>
+										<FormControl>
+											<Switch
+												size="md"
+												checked={field.value}
+												onCheckedChange={(checked) => {
+													field.onChange(checked);
+													form.trigger("send_back_raw_request");
+												}}
+											/>
+										</FormControl>
+									</div>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
 					</div>
 
 					<div className="mt-6 space-y-4">

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -71,6 +71,7 @@ export default function Providers() {
 							network_config: DefaultNetworkConfig,
 							custom_provider_config: undefined,
 							proxy_config: undefined,
+							send_back_raw_request: undefined,
 							send_back_raw_response: undefined,
 							status: "error",
 						}),
@@ -221,7 +222,7 @@ export default function Providers() {
 										e.preventDefault();
 										e.stopPropagation();
 										setShowCustomProviderDialog(true);
-									}}									
+									}}
 								>
 									<PlusIcon className="h-4 w-4" />
 									<div className="text-xs">Add New Provider</div>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -163,6 +163,7 @@ export interface ModelProviderConfig {
 	network_config?: NetworkConfig;
 	concurrency_and_buffer_size?: ConcurrencyAndBufferSize;
 	proxy_config?: ProxyConfig;
+	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 }
@@ -186,6 +187,7 @@ export interface AddProviderRequest {
 	network_config?: NetworkConfig;
 	concurrency_and_buffer_size?: ConcurrencyAndBufferSize;
 	proxy_config?: ProxyConfig;
+	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 }
@@ -196,6 +198,7 @@ export interface UpdateProviderRequest {
 	network_config: NetworkConfig;
 	concurrency_and_buffer_size: ConcurrencyAndBufferSize;
 	proxy_config: ProxyConfig;
+	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 }

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -279,6 +279,7 @@ export interface LogEntry {
 	error_details?: BifrostError;
 	stream: boolean; // true if this was a streaming response
 	created_at: string; // ISO string format from Go time.Time - when the log was first created
+	raw_request?: string; // Raw provider request
 	raw_response?: string; // Raw provider response
 }
 

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -369,6 +369,7 @@ export const modelProviderConfigSchema = z.object({
 	network_config: networkConfigSchema.optional(),
 	concurrency_and_buffer_size: concurrencyAndBufferSizeSchema.optional(),
 	proxy_config: proxyConfigSchema.optional(),
+	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 });
@@ -384,6 +385,7 @@ export const formModelProviderConfigSchema = z.object({
 	network_config: networkConfigSchema.optional(),
 	concurrency_and_buffer_size: concurrencyAndBufferSizeSchema.optional(),
 	proxy_config: proxyConfigSchema.optional(),
+	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: formCustomProviderConfigSchema.optional(),
 });
@@ -400,6 +402,7 @@ export const addProviderRequestSchema = z.object({
 	network_config: networkConfigSchema.optional(),
 	concurrency_and_buffer_size: concurrencyAndBufferSizeSchema.optional(),
 	proxy_config: proxyConfigSchema.optional(),
+	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 });
@@ -410,6 +413,7 @@ export const updateProviderRequestSchema = z.object({
 	network_config: networkConfigSchema,
 	concurrency_and_buffer_size: concurrencyAndBufferSizeSchema,
 	proxy_config: proxyConfigSchema,
+	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 });
@@ -479,6 +483,7 @@ export const performanceFormSchema = z.object({
 			.min(1, "Buffer size must be greater than 0")
 			.max(100000, "Buffer size must be less than 100000"),
 	}),
+	send_back_raw_request: z.boolean(),
 	send_back_raw_response: z.boolean(),
 });
 


### PR DESCRIPTION
## Summary

This PR adds the ability to send back raw requests in API responses, complementing the existing raw response functionality. This feature helps with debugging and advanced use cases by providing visibility into the exact request payload sent to provider APIs.

## Changes

- Added `SendBackRawRequest` field to provider configurations
- Modified provider implementations to capture and return raw request data
- Updated response handling to include raw requests in extra fields
- Added database migrations for storing raw requests in logs
- Enhanced UI to display raw requests in log details
- Added configuration options in the provider settings UI

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Enable the "Include Raw Request" option in a provider's settings
2. Make a request to that provider
3. Check the response for the `raw_request` field in `extra_fields`
4. View the request details in the logs UI to see the raw request

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Raw requests may contain sensitive information like API keys or user data. Users should be aware that enabling this feature will store this information in logs and return it in responses.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable