### PR TITLE
feat: allow specifying CA cert for OTEL collector endpoint with TLS

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -35,6 +35,7 @@ The plugin supports multiple trace formats to match your observability platform:
 | `trace_type` | `string` | ✅ Yes | One of: `genai_extension`, `vercel`, `open_inference` |
 | `protocol` | `string` | ✅ Yes | Transport protocol: `http` or `grpc` |
 | `headers` | `object` | ❌ No | Custom headers for authentication (supports `env.VAR_NAME`) |
+| `tls_ca_cert` | `string` | ❌ No | File path to client CA certificate for TLS. Optional. Works with both gRPC and HTTP protocol |
 
 ### Environment Variable Substitution
 
@@ -121,6 +122,29 @@ For Gateway mode, configure via `config.json`:
         "collector_url": "http://localhost:4318",
         "trace_type": "genai_extension",
         "protocol": "http",
+        "headers": {
+          "Authorization": "env.OTEL_API_KEY"
+        }
+      }
+    }
+  ]
+}
+```
+
+If you need to connect to an OTEL collector that requires TLS, configure `tls_ca_cert`:
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "otel",
+      "config": {
+        "service_name": "bifrost",
+        "collector_url": "localhost:4317",
+        "trace_type": "genai_extension",
+        "protocol": "grpc",
+        "tls_ca_cert": "/path/to/your/ca.cert",
         "headers": {
           "Authorization": "env.OTEL_API_KEY"
         }

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -57,6 +57,7 @@ type Config struct {
 	Headers      map[string]string `json:"headers"`
 	TraceType    TraceType         `json:"trace_type"`
 	Protocol     Protocol          `json:"protocol"`
+	TLSCACert    string            `json:"tls_ca_cert"`
 }
 
 // OtelPlugin is the plugin for OpenTelemetry
@@ -121,13 +122,13 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
-		p.client, err = NewOtelClientGRPC(config.CollectorURL, config.Headers)
+		p.client, err = NewOtelClientGRPC(config.CollectorURL, config.Headers, config.TLSCACert)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if config.Protocol == ProtocolHTTP {
-		p.client, err = NewOtelClientHTTP(config.CollectorURL, config.Headers)
+		p.client, err = NewOtelClientHTTP(config.CollectorURL, config.Headers, config.TLSCACert)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Fix a bug woth OTEL plugin not using passed headers with gRPC protocol, and add support for TLS.

## Changes

OTEL plugins:
- Fix headers not being passed as metadata for gRPC collector endpoint
- Allow user to provide CA cert for TLS gRPC and HTTP collector endpoint

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

N/A

If adding new configs or environment variables, document them here.

Add `tls_ca_cert` config key for OTEL plugin, allowing user to give a path to a X509 CA certificate for OTEL collector endpoints that requires TLS.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

N/A

## Security considerations

N/A

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


