### PR TITLE
adds global proxy support

### DIFF
--- a/core/network/http.go
+++ b/core/network/http.go
@@ -1,0 +1,351 @@
+// Package network provides centralized HTTP client management with proxy support.
+// It allows runtime proxy configuration updates that propagate to all HTTP clients.
+package network
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttpproxy"
+)
+
+// ClientPurpose defines the intended use of an HTTP client for proxy filtering
+type ClientPurpose string
+
+const (
+	// ClientPurposeSCIM is used for SCIM/OAuth provider requests
+	ClientPurposeSCIM ClientPurpose = "scim"
+	// ClientPurposeInference is used for LLM inference requests
+	ClientPurposeInference ClientPurpose = "inference"
+	// ClientPurposeAPI is used for general API requests (guardrails, etc.)
+	ClientPurposeAPI ClientPurpose = "api"
+)
+
+// DefaultClientConfig holds default timeout values for HTTP clients
+var DefaultClientConfig = struct {
+	ReadTimeout         time.Duration
+	WriteTimeout        time.Duration
+	MaxIdleConnDuration time.Duration
+	MaxConnsPerHost     int
+}{
+	ReadTimeout:         60 * time.Second,
+	WriteTimeout:        60 * time.Second,
+	MaxIdleConnDuration: 120 * time.Second,
+	MaxConnsPerHost:     200,
+}
+
+// HTTPClientFactory manages HTTP clients with centralized proxy configuration.
+// It supports both fasthttp and standard net/http clients with purpose-based
+// proxy enablement (SCIM, Inference, API).
+type HTTPClientFactory struct {
+	mu          sync.RWMutex
+	proxyConfig *configstoreTables.GlobalProxyConfig
+
+	// Cached clients per purpose - lazily initialized
+	fasthttpClients map[ClientPurpose]*fasthttp.Client
+	httpClients     map[ClientPurpose]*http.Client
+
+	logger schemas.Logger
+}
+
+// NewHTTPClientFactory creates a new HTTP client factory with the given proxy configuration.
+// Pass nil for proxyConfig if proxy is not yet configured.
+func NewHTTPClientFactory(proxyConfig *configstoreTables.GlobalProxyConfig, logger schemas.Logger) *HTTPClientFactory {
+	return &HTTPClientFactory{
+		proxyConfig:     proxyConfig,
+		fasthttpClients: make(map[ClientPurpose]*fasthttp.Client, 3),
+		httpClients:     make(map[ClientPurpose]*http.Client, 3),
+		logger:          logger,
+	}
+}
+
+// UpdateProxyConfig updates the proxy configuration and recreates all cached clients.
+// This is thread-safe and can be called at runtime.
+func (f *HTTPClientFactory) UpdateProxyConfig(config *configstoreTables.GlobalProxyConfig) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	f.proxyConfig = config
+
+	// Clear cached clients - they will be recreated on next request
+	f.fasthttpClients = make(map[ClientPurpose]*fasthttp.Client, 3)
+	f.httpClients = make(map[ClientPurpose]*http.Client, 3)
+}
+
+// GetProxyConfig returns the current proxy configuration (thread-safe read)
+func (f *HTTPClientFactory) GetProxyConfig() *configstoreTables.GlobalProxyConfig {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.proxyConfig
+}
+
+// isProxyEnabledForPurpose checks if proxy should be used for the given purpose
+func (f *HTTPClientFactory) isProxyEnabledForPurpose(purpose ClientPurpose) bool {
+	if f.proxyConfig == nil || !f.proxyConfig.Enabled {
+		return false
+	}
+
+	switch purpose {
+	case ClientPurposeSCIM:
+		return f.proxyConfig.EnableForSCIM
+	case ClientPurposeInference:
+		return f.proxyConfig.EnableForInference
+	case ClientPurposeAPI:
+		return f.proxyConfig.EnableForAPI
+	default:
+		return false
+	}
+}
+
+// shouldBypassProxy checks if a host matches a noProxy pattern
+// Supported patterns:
+//   - "*" matches all hosts
+//   - ".example.com" matches example.com and all subdomains
+//   - "*.example.com" matches subdomains of example.com only
+//   - exact host match
+func shouldBypassProxy(host, pattern string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	pattern = strings.ToLower(strings.TrimSpace(pattern))
+
+	if pattern == "*" {
+		return true
+	}
+	if pattern == host {
+		return true
+	}
+	// .example.com matches example.com and *.example.com
+	if strings.HasPrefix(pattern, ".") {
+		suffix := pattern[1:] // remove leading dot
+		return host == suffix || strings.HasSuffix(host, pattern)
+	}
+	// *.example.com matches subdomains only
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[1:] // keep the dot, e.g., ".example.com"
+		return strings.HasSuffix(host, suffix)
+	}
+	return false
+}
+
+// GetFasthttpClient returns a fasthttp client configured for the given purpose.
+// If proxy is enabled for this purpose, the client will be configured with proxy settings.
+// Clients are cached and reused until proxy config changes.
+func (f *HTTPClientFactory) GetFasthttpClient(purpose ClientPurpose) *fasthttp.Client {
+	f.mu.RLock()
+	if client, ok := f.fasthttpClients[purpose]; ok {
+		f.mu.RUnlock()
+		return client
+	}
+	f.mu.RUnlock()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if client, ok := f.fasthttpClients[purpose]; ok {
+		return client
+	}
+
+	client := f.createFasthttpClient(purpose)
+	f.fasthttpClients[purpose] = client
+	return client
+}
+
+// GetHTTPClient returns a standard net/http client configured for the given purpose.
+// If proxy is enabled for this purpose, the client will be configured with proxy settings.
+// Clients are cached and reused until proxy config changes.
+func (f *HTTPClientFactory) GetHTTPClient(purpose ClientPurpose) *http.Client {
+	f.mu.RLock()
+	if client, ok := f.httpClients[purpose]; ok {
+		f.mu.RUnlock()
+		return client
+	}
+	f.mu.RUnlock()
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if client, ok := f.httpClients[purpose]; ok {
+		return client
+	}
+
+	client := f.createHTTPClient(purpose)
+	f.httpClients[purpose] = client
+	return client
+}
+
+// createFasthttpClient creates a new fasthttp client with appropriate proxy settings
+func (f *HTTPClientFactory) createFasthttpClient(purpose ClientPurpose) *fasthttp.Client {
+	client := &fasthttp.Client{
+		ReadTimeout:         DefaultClientConfig.ReadTimeout,
+		WriteTimeout:        DefaultClientConfig.WriteTimeout,
+		MaxIdleConnDuration: DefaultClientConfig.MaxIdleConnDuration,
+		MaxConnsPerHost:     DefaultClientConfig.MaxConnsPerHost,
+	}
+
+	// Configure proxy if enabled for this purpose
+	if f.isProxyEnabledForPurpose(purpose) {
+		f.configureFasthttpProxy(client)
+	}
+
+	// Configure TLS if skip verification is set
+	if f.proxyConfig != nil {
+		if f.proxyConfig.SkipTLSVerify {
+			f.logger.Warn("skipping TLS verification for fasthttp client because skip TLS verify is set to true. It's not recommended to use this in production.")
+		}
+		client.TLSConfig = &tls.Config{
+			InsecureSkipVerify: f.proxyConfig.SkipTLSVerify,
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
+
+	return client
+}
+
+// buildProxyURLWithAuth adds authentication to a proxy URL if credentials are provided
+func (f *HTTPClientFactory) buildProxyURLWithAuth() string {
+	proxyURL := f.proxyConfig.URL
+	if f.proxyConfig.Username != "" && f.proxyConfig.Password != "" {
+		parsedURL, err := url.Parse(f.proxyConfig.URL)
+		if err == nil {
+			parsedURL.User = url.UserPassword(f.proxyConfig.Username, f.proxyConfig.Password)
+			proxyURL = parsedURL.String()
+		}
+	}
+	return proxyURL
+}
+
+// configureFasthttpProxy configures proxy for a fasthttp client
+func (f *HTTPClientFactory) configureFasthttpProxy(client *fasthttp.Client) {
+	if f.proxyConfig == nil || f.proxyConfig.URL == "" {
+		return
+	}
+
+	proxyURL := f.buildProxyURLWithAuth()
+	var dialFunc fasthttp.DialFunc
+
+	switch f.proxyConfig.Type {
+	case configstoreTables.GlobalProxyTypeHTTP:
+		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
+	case configstoreTables.GlobalProxyTypeSOCKS5:
+		dialFunc = fasthttpproxy.FasthttpSocksDialer(proxyURL)
+	}
+
+	proxyCfg := f.proxyConfig
+	if dialFunc != nil {
+		client.Dial = func(addr string) (net.Conn, error) {
+			if proxyCfg.NoProxy != "" {
+				host := strings.Split(addr, ":")[0]
+				if host == "" {
+					host = addr
+				}
+				if shouldBypassProxy(host, proxyCfg.NoProxy) {
+					return net.Dial("tcp", addr)
+				}
+			}
+			return dialFunc(addr)
+		}
+	}
+}
+
+// createHTTPClient creates a new standard net/http client with appropriate proxy settings
+func (f *HTTPClientFactory) createHTTPClient(purpose ClientPurpose) *http.Client {
+	transport := &http.Transport{
+		MaxIdleConns:          DefaultClientConfig.MaxConnsPerHost,
+		MaxIdleConnsPerHost:   DefaultClientConfig.MaxConnsPerHost,
+		IdleConnTimeout:       DefaultClientConfig.MaxIdleConnDuration,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: DefaultClientConfig.ReadTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableCompression:    false,
+		DisableKeepAlives:     false,
+	}
+
+	// Configure proxy if enabled for this purpose
+	if f.isProxyEnabledForPurpose(purpose) {
+		f.configureHTTPProxy(transport)
+	}
+
+	// Configure TLS if skip verification is set
+	if f.proxyConfig != nil {
+		if f.proxyConfig.SkipTLSVerify {
+			f.logger.Warn("skipping TLS verification for fasthttp client because skip TLS verify is set to true. It's not recommended to use this in production.")
+		}
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: f.proxyConfig.SkipTLSVerify,
+			MinVersion:         tls.VersionTLS12,
+		}
+	}
+
+	timeout := DefaultClientConfig.ReadTimeout
+	if f.proxyConfig != nil && f.proxyConfig.Timeout > 0 {
+		timeout = time.Duration(f.proxyConfig.Timeout) * time.Second
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   timeout,
+	}
+}
+
+// configureHTTPProxy configures proxy for a standard net/http transport
+func (f *HTTPClientFactory) configureHTTPProxy(transport *http.Transport) {
+	if f.proxyConfig == nil || f.proxyConfig.URL == "" {
+		return
+	}
+
+	proxyURL, err := url.Parse(f.proxyConfig.URL)
+	if err != nil {
+		return
+	}
+
+	// Add authentication if provided
+	if f.proxyConfig.Username != "" && f.proxyConfig.Password != "" {
+		proxyURL.User = url.UserPassword(f.proxyConfig.Username, f.proxyConfig.Password)
+
+		// For HTTPS requests through HTTP proxy, the CONNECT method is used to establish a tunnel.
+		// Proxy authentication must be sent via ProxyConnectHeader for the CONNECT request.
+		// Without this, the proxy will reject/reset the connection before the TLS handshake.
+		basicAuth := "Basic " + base64.StdEncoding.EncodeToString(
+			[]byte(f.proxyConfig.Username+":"+f.proxyConfig.Password),
+		)
+		transport.ProxyConnectHeader = http.Header{
+			"Proxy-Authorization": {basicAuth},
+		}
+	}
+
+	// Capture noProxy patterns at creation time to avoid data race with UpdateProxyConfig.
+	// The closure below is called for each request and would otherwise read f.proxyConfig
+	// concurrently with writes from UpdateProxyConfig.
+	var noProxyPatterns []string
+	if f.proxyConfig.NoProxy != "" {
+		noProxyPatterns = strings.Split(f.proxyConfig.NoProxy, ",")
+	}
+
+	proxyCfg := f.proxyConfig
+	transport.Proxy = func(req *http.Request) (*url.URL, error) {
+		// Use Hostname() to get the host without port for matching.
+		// req.URL.Host is "host:port" but no_proxy patterns are host-only.
+		if proxyCfg.NoProxy != "" {
+			host := req.URL.Hostname()
+			if host == "" {
+				host = req.URL.Host
+			}
+			for _, np := range noProxyPatterns {
+				if shouldBypassProxy(host, np) {
+					return nil, nil
+				}
+			}
+		}
+		return proxyURL, nil
+	}
+}

--- a/examples/configs/docker-compose.yml
+++ b/examples/configs/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  # mitmproxy - HTTP proxy with Web UI for debugging
+  # Web UI: http://localhost:8081
+  # Proxy: http://localhost:8082
+  mitmproxy:
+      image: mitmproxy/mitmproxy:latest
+      container_name: bifrost-mitmproxy
+      command: mitmweb --web-host 0.0.0.0 --web-port 8081 --listen-host 0.0.0.0 --listen-port 8082 --set proxyauth=bifrost:secret-token --set web_password=secret-token
+      ports:
+          - "8082:8082"   # Proxy port
+          - "8081:8081"   # Web UI
+      networks:
+          bifrost_network:
+              ipv4_address: 172.38.0.16
+
+networks:
+  bifrost_network:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.38.0.0/16
+          gateway: 172.38.0.1

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -119,6 +119,10 @@ type ConfigStore interface {
 	GetAuthConfig(ctx context.Context) (*AuthConfig, error)
 	UpdateAuthConfig(ctx context.Context, config *AuthConfig) error
 
+	// Proxy config CRUD
+	GetProxyConfig(ctx context.Context) (*tables.GlobalProxyConfig, error)
+	UpdateProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
+
 	// Session CRUD
 	GetSession(ctx context.Context, token string) (*tables.SessionsTable, error)
 	CreateSession(ctx context.Context, session *tables.SessionsTable) error

--- a/framework/configstore/tables/config.go
+++ b/framework/configstore/tables/config.go
@@ -1,11 +1,37 @@
 package tables
 
 const (
-	ConfigAdminUsernameKey = "admin_username"
-	ConfigAdminPasswordKey = "admin_password"
-	ConfigIsAuthEnabledKey = "is_auth_enabled"
+	ConfigAdminUsernameKey          = "admin_username"
+	ConfigAdminPasswordKey          = "admin_password"
+	ConfigIsAuthEnabledKey          = "is_auth_enabled"
 	ConfigDisableAuthOnInferenceKey = "disable_auth_on_inference"
+	ConfigProxyKey                  = "proxy_config"
 )
+
+// GlobalProxyType represents the type of global proxy
+type GlobalProxyType string
+
+const (
+	GlobalProxyTypeHTTP   GlobalProxyType = "http"
+	GlobalProxyTypeSOCKS5 GlobalProxyType = "socks5"
+	GlobalProxyTypeTCP    GlobalProxyType = "tcp"
+)
+
+// GlobalProxyConfig represents the global proxy configuration
+type GlobalProxyConfig struct {
+	Enabled       bool            `json:"enabled"`
+	Type          GlobalProxyType `json:"type"`                     // "http", "socks5", "tcp"
+	URL           string    `json:"url"`                      // Proxy URL (e.g., http://proxy.example.com:8080)
+	Username      string    `json:"username,omitempty"`       // Optional authentication username
+	Password      string    `json:"password,omitempty"`       // Optional authentication password
+	NoProxy       string    `json:"no_proxy,omitempty"`       // Comma-separated list of hosts to bypass proxy
+	Timeout       int       `json:"timeout,omitempty"`        // Connection timeout in seconds
+	SkipTLSVerify bool      `json:"skip_tls_verify,omitempty"`// Skip TLS certificate verification
+	// Entity enablement flags
+	EnableForSCIM      bool `json:"enable_for_scim"`      // Enable proxy for SCIM requests (enterprise only)
+	EnableForInference bool `json:"enable_for_inference"` // Enable proxy for inference requests
+	EnableForAPI       bool `json:"enable_for_api"`       // Enable proxy for API requests
+}
 
 // TableGovernanceConfig represents generic configuration key-value pairs
 type TableGovernanceConfig struct {

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -27,6 +27,7 @@ type ConfigManager interface {
 	ReloadPricingManager(ctx context.Context) error
 	UpdateDropExcessRequests(ctx context.Context, value bool)
 	ReloadPlugin(ctx context.Context, name string, path *string, pluginConfig any) error
+	ReloadProxyConfig(ctx context.Context, config *configstoreTables.GlobalProxyConfig) error
 }
 
 // ConfigHandler manages runtime configuration updates for Bifrost.
@@ -51,6 +52,8 @@ func (h *ConfigHandler) RegisterRoutes(r *router.Router, middlewares ...lib.Bifr
 	r.GET("/api/config", lib.ChainMiddlewares(h.getConfig, middlewares...))
 	r.PUT("/api/config", lib.ChainMiddlewares(h.updateConfig, middlewares...))
 	r.GET("/api/version", lib.ChainMiddlewares(h.getVersion, middlewares...))
+	r.GET("/api/proxy-config", lib.ChainMiddlewares(h.getProxyConfig, middlewares...))
+	r.PUT("/api/proxy-config", lib.ChainMiddlewares(h.updateProxyConfig, middlewares...))
 }
 
 // getVersion handles GET /api/version - Get the current version
@@ -127,7 +130,7 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 				"disable_auth_on_inference": authConfig.DisableAuthOnInference,
 			}
 		}
-	}else{
+	} else {
 		mapConfig["auth_config"] = map[string]any{
 			"admin_username":            "",
 			"admin_password":            "",
@@ -138,6 +141,19 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 	mapConfig["is_db_connected"] = h.store.ConfigStore != nil
 	mapConfig["is_cache_connected"] = h.store.VectorStore != nil
 	mapConfig["is_logs_connected"] = h.store.LogsStore != nil
+	// Fetching proxy config
+	if h.store.ConfigStore != nil {
+		proxyConfig, err := h.store.ConfigStore.GetProxyConfig(ctx)
+		if err != nil {
+			logger.Warn(fmt.Sprintf("failed to get proxy config from store: %v", err))
+		} else if proxyConfig != nil {
+			// Redact password if present
+			if proxyConfig.Password != "" {
+				proxyConfig.Password = "<redacted>"
+			}
+			mapConfig["proxy_config"] = proxyConfig
+		}
+	}
 	SendJSON(ctx, mapConfig)
 }
 
@@ -162,7 +178,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Validating framework config
-	if payload.FrameworkConfig.PricingURL != nil && *payload.FrameworkConfig.PricingURL != modelcatalog.DefaultPricingURL {		
+	if payload.FrameworkConfig.PricingURL != nil && *payload.FrameworkConfig.PricingURL != modelcatalog.DefaultPricingURL {
 		// Checking the accessibility of the pricing URL
 		resp, err := http.Get(*payload.FrameworkConfig.PricingURL)
 		if err != nil {
@@ -260,7 +276,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 	// Updating framework config
 	shouldReloadFrameworkConfig := false
-	if payload.FrameworkConfig.PricingURL != nil && *payload.FrameworkConfig.PricingURL != *frameworkConfig.PricingURL {				
+	if payload.FrameworkConfig.PricingURL != nil && *payload.FrameworkConfig.PricingURL != *frameworkConfig.PricingURL {
 		// Checking the accessibility of the pricing URL
 		resp, err := http.Get(*payload.FrameworkConfig.PricingURL)
 		if err != nil {
@@ -364,5 +380,136 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]any{
 		"status":  "success",
 		"message": "configuration updated successfully",
+	})
+}
+
+// getProxyConfig handles GET /api/proxy-config - Get the current proxy configuration
+func (h *ConfigHandler) getProxyConfig(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+	proxyConfig, err := h.store.ConfigStore.GetProxyConfig(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get proxy config: %v", err))
+		return
+	}
+	if proxyConfig == nil {
+		// Return default empty config
+		SendJSON(ctx, configstoreTables.GlobalProxyConfig{
+			Enabled: false,
+			Type:    configstoreTables.GlobalProxyTypeHTTP,
+		})
+		return
+	}
+	// Redact password if present
+	if proxyConfig.Password != "" {
+		proxyConfig.Password = "<redacted>"
+	}
+	SendJSON(ctx, proxyConfig)
+}
+
+// updateProxyConfig handles PUT /api/proxy-config - Update the proxy configuration
+func (h *ConfigHandler) updateProxyConfig(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "config store not initialized")
+		return
+	}
+
+	var payload configstoreTables.GlobalProxyConfig
+	if err := json.Unmarshal(ctx.PostBody(), &payload); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid request format: %v", err))
+		return
+	}
+
+	// Validate proxy config
+	if payload.Enabled {
+		// Validate proxy type
+		switch payload.Type {
+		case configstoreTables.GlobalProxyTypeHTTP:
+			// HTTP proxy is supported
+			// Make sure the URL is provided
+			if payload.URL == "" {
+				SendError(ctx, fasthttp.StatusBadRequest, "proxy URL is required when proxy is enabled")
+				return
+			}
+			// Validate timeout if provided
+			if payload.Timeout < 0 {
+				SendError(ctx, fasthttp.StatusBadRequest, "proxy timeout must be non-negative")
+				return
+			}
+		case configstoreTables.GlobalProxyTypeSOCKS5, configstoreTables.GlobalProxyTypeTCP:
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("proxy type %s is not yet supported", payload.Type))
+			return
+		default:
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid proxy type: %s", payload.Type))
+			return
+		}
+
+		// Validate URL is provided when enabled
+		if payload.URL == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "proxy URL is required when proxy is enabled")
+			return
+		}
+
+		// Validate timeout if provided
+		if payload.Timeout < 0 {
+			SendError(ctx, fasthttp.StatusBadRequest, "proxy timeout must be non-negative")
+			return
+		}
+	}
+
+	// Handle password - if it's "<redacted>", keep the existing password
+	if payload.Password == "<redacted>" {
+		existingConfig, err := h.store.ConfigStore.GetProxyConfig(ctx)
+		if err != nil && !errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing proxy config: %v", err))
+			return
+		}
+		if existingConfig != nil {
+			payload.Password = existingConfig.Password
+		} else {
+			payload.Password = ""
+		}
+	}
+
+	// Save proxy config
+	if err := h.store.ConfigStore.UpdateProxyConfig(ctx, &payload); err != nil {
+		logger.Warn(fmt.Sprintf("failed to save proxy configuration: %v", err))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to save proxy configuration: %v", err))
+		return
+	}
+
+	// Pulling the proxy config from the config store
+	newProxyConfig, err := h.store.ConfigStore.GetProxyConfig(ctx)
+	if err != nil {
+		logger.Warn(fmt.Sprintf("failed to get proxy config from store: %v", err))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get proxy config from store: %v", err))
+		return
+	}
+	if newProxyConfig == nil {
+		newProxyConfig = &configstoreTables.GlobalProxyConfig{
+			Enabled:       false,
+			Type:          configstoreTables.GlobalProxyTypeHTTP,
+			URL:           "",
+			Username:      "",
+			Password:      "",
+			NoProxy:       "",
+			Timeout:       0,
+			SkipTLSVerify: false,
+		}
+	}
+
+	// Reload proxy config in the server
+	if err := h.configManager.ReloadProxyConfig(ctx, newProxyConfig); err != nil {
+		logger.Warn(fmt.Sprintf("failed to reload proxy config: %v", err))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to reload proxy config: %v", err))
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": "proxy configuration updated successfully",
 	})
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -161,6 +161,7 @@ type Config struct {
 	MCPConfig        *schemas.MCPConfig
 	GovernanceConfig *configstore.GovernanceConfig
 	FrameworkConfig  *framework.FrameworkConfig
+	ProxyConfig      *configstoreTables.GlobalProxyConfig
 
 	// Track which keys come from environment variables
 	EnvKeys map[string][]configstore.EnvKeyInfo

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -56,6 +56,7 @@ type ServerCallbacks interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
 	ReloadPricingManager(ctx context.Context) error
+	ReloadProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
 	UpdateDropExcessRequests(ctx context.Context, value bool)
 	ReloadTeam(ctx context.Context, id string) (*tables.TableTeam, error)
 	RemoveTeam(ctx context.Context, id string) error
@@ -798,6 +799,17 @@ func (s *BifrostHTTPServer) ReloadPricingManager(ctx context.Context) error {
 		return fmt.Errorf("framework config not found")
 	}
 	return s.Config.PricingManager.ReloadPricing(ctx, s.Config.FrameworkConfig.Pricing)
+}
+
+// ReloadProxyConfig reloads the proxy configuration
+func (s *BifrostHTTPServer) ReloadProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error {
+	if s.Config == nil {
+		return fmt.Errorf("config not found")
+	}
+	// Store the proxy config in memory for use by components that need it
+	s.Config.ProxyConfig = config
+	logger.Info("proxy configuration reloaded: enabled=%t, type=%s", config.Enabled, config.Type)
+	return nil
 }
 
 // RefetchModelsForProvider deletes existing models for a provider and re-fetches them from the provider

--- a/ui/app/workspace/config/page.tsx
+++ b/ui/app/workspace/config/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import FullPageLoader from "@/components/fullPageLoader";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { useGetCoreConfigQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import APIKeysView from "@enterprise/components/api-keys/APIKeysView";
-import { Gauge, KeyRound, Landmark, Settings, Shield, Telescope, Zap } from "lucide-react";
+import { Gauge, Globe, KeyRound, Landmark, Settings, Shield, Telescope, Zap } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useEffect } from "react";
 import CachingView from "./views/cachingView";
@@ -14,9 +15,10 @@ import LoggingView from "./views/loggingView";
 import ObservabilityView from "./views/observabilityView";
 import PerformanceTuningView from "./views/performanceTuningView";
 import PricingConfigView from "./views/pricingConfigView";
+import ProxyView from "./views/proxyView";
 import SecurityView from "./views/securityView";
 
-const tabs = [
+const baseTabs = [
 	{
 		id: "client-settings",
 		label: "Client Settings",
@@ -53,6 +55,12 @@ const tabs = [
 		icon: <Shield className="size-4" />,
 	},
 	{
+		id: "proxy",
+		label: "Proxy",
+		icon: <Globe className="size-4" />,
+		enterpriseOnly: true,
+	},
+	{
 		id: "api-keys",
 		label: "API Keys",
 		icon: <KeyRound className="size-4" />,
@@ -64,12 +72,15 @@ const tabs = [
 	},
 ];
 
+const tabs = baseTabs.filter((tab) => !tab.enterpriseOnly || IS_ENTERPRISE);
+
 export default function ConfigPage() {
 	const [activeTab, setActiveTab] = useQueryState("tab");
 	const { isLoading } = useGetCoreConfigQuery({ fromDB: true });
 
 	useEffect(() => {
-		if (!activeTab) {
+		const validTabIds = tabs.map((t) => t.id);
+		if (!activeTab || !validTabIds.includes(activeTab)) {
 			setActiveTab(tabs[0].id);
 		}
 	}, [activeTab, setActiveTab]);
@@ -79,7 +90,7 @@ export default function ConfigPage() {
 	}
 
 	return (
-		<div className="flex w-full flex-row gap-4 max-w-7xl mx-auto">
+		<div className="mx-auto flex w-full max-w-7xl flex-row gap-4">
 			<div className="flex min-w-[250px] flex-col gap-1 rounded-md bg-zinc-50/50 p-4 dark:bg-zinc-800/20">
 				{tabs.map((tab) => (
 					<button
@@ -106,6 +117,7 @@ export default function ConfigPage() {
 				{activeTab === "caching" && <CachingView />}
 				{activeTab === "observability" && <ObservabilityView />}
 				{activeTab === "security" && <SecurityView />}
+				{activeTab === "proxy" && IS_ENTERPRISE && <ProxyView />}
 				{activeTab === "api-keys" && <APIKeysView />}
 				{activeTab === "performance-tuning" && <PerformanceTuningView />}
 			</div>

--- a/ui/app/workspace/config/views/proxyView.tsx
+++ b/ui/app/workspace/config/views/proxyView.tsx
@@ -1,0 +1,399 @@
+'use client'
+
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { IS_ENTERPRISE } from '@/lib/constants/config'
+import { getErrorMessage, useGetCoreConfigQuery, useUpdateProxyConfigMutation } from '@/lib/store'
+import { DefaultGlobalProxyConfig, GlobalProxyConfig } from '@/lib/types/config'
+import { globalProxyConfigSchema } from '@/lib/types/schemas'
+import { cn } from '@/lib/utils'
+import { RbacOperation, RbacResource, useRbac } from '@enterprise/lib'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { AlertTriangle, Info } from 'lucide-react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+
+export default function ProxyView () {
+  const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update)
+  const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true })
+  const proxyConfig = bifrostConfig?.proxy_config
+  const [updateProxyConfig, { isLoading }] = useUpdateProxyConfigMutation()
+
+  const form = useForm<GlobalProxyConfig>({
+    resolver: zodResolver(globalProxyConfigSchema),
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    defaultValues: DefaultGlobalProxyConfig
+  })
+
+  useEffect(() => {
+    if (proxyConfig) {
+      form.reset({
+        ...DefaultGlobalProxyConfig,
+        ...proxyConfig
+      })
+    }
+  }, [proxyConfig, form])
+
+  const watchedEnabled = form.watch('enabled')
+  const watchedType = form.watch('type')
+
+  const onSubmit = async (data: GlobalProxyConfig) => {
+    try {
+      await updateProxyConfig(data).unwrap()
+      toast.success('Proxy configuration updated successfully.')
+    } catch (error) {
+      toast.error(getErrorMessage(error))
+    }
+  }
+
+  const isTypeUnsupported = watchedType === 'socks5' || watchedType === 'tcp'
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold tracking-tight">Proxy Settings</h2>
+            <p className="text-muted-foreground text-sm">
+              Configure global proxy settings for outbound requests.
+            </p>
+          </div>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={!hasSettingsUpdateAccess ? 0 : undefined}>
+                <Button
+                  type="submit"
+                  disabled={!form.formState.isDirty || !form.formState.isValid || isLoading || !hasSettingsUpdateAccess}
+                >
+                  {isLoading ? 'Saving...' : 'Save Changes'}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            {!hasSettingsUpdateAccess && (
+              <TooltipContent>
+                You don't have permission to update settings
+              </TooltipContent>
+            )}
+          </Tooltip>
+        </div>
+
+        <fieldset disabled={!hasSettingsUpdateAccess} className="space-y-4">
+          {/* Enable Proxy */}
+          <div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+            <div className="space-y-0.5">
+              <FormLabel className="text-sm font-medium">Enable Proxy</FormLabel>
+              <p className="text-muted-foreground text-sm">
+                Enable global proxy for outbound HTTP requests.
+              </p>
+            </div>
+            <FormField
+              control={form.control}
+              name="enabled"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Proxy Configuration Section */}
+          <div className={cn(
+            'space-y-4 rounded-lg border p-4 transition-opacity',
+            !watchedEnabled && 'opacity-50 pointer-events-none'
+          )}>
+            <h3 className="text-lg font-medium">Proxy Configuration</h3>
+
+            {/* Proxy Type */}
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Proxy Type</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    value={field.value}
+                    disabled={!watchedEnabled}
+                  >
+                    <FormControl>
+                      <SelectTrigger className="w-48">
+                        <SelectValue placeholder="Select type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="http">HTTP / HTTPS</SelectItem>
+                      <SelectItem value="socks5" disabled>
+                        SOCKS5 <Badge variant="outline" className="ml-2 text-xs">Coming soon</Badge>
+                      </SelectItem>
+                      <SelectItem value="tcp" disabled>
+                        TCP <Badge variant="outline" className="ml-2 text-xs">Coming soon</Badge>
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Select the proxy protocol type. Currently only HTTP proxy is supported.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {isTypeUnsupported && watchedEnabled && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  {watchedType.toUpperCase()} proxy is not yet supported. Please use HTTP proxy.
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Proxy URL */}
+            <FormField
+              control={form.control}
+              name="url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Proxy URL</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="http://proxy.example.com:8080"
+                      disabled={!watchedEnabled}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Full URL of the proxy server including protocol and port.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Authentication Section */}
+            <div className="space-y-4 rounded-md border p-4 bg-muted/20">
+              <h4 className="text-sm font-medium">Authentication (Optional)</h4>
+              <div className="grid grid-cols-2 gap-4">
+                <FormField
+                  control={form.control}
+                  name="username"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Username</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Proxy username"
+                          disabled={!watchedEnabled}
+                          {...field}
+                          value={field.value || ''}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Password</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="password"
+                          placeholder="Proxy password"
+                          disabled={!watchedEnabled}
+                          {...field}
+                          value={field.value || ''}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+
+            {/* Advanced Settings */}
+            <div className="space-y-4 rounded-md border p-4 bg-muted/20">
+              <h4 className="text-sm font-medium">Advanced Settings</h4>
+
+              {/* No Proxy */}
+              <FormField
+                control={form.control}
+                name="no_proxy"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>No Proxy Hosts</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="localhost, 127.0.0.1, .internal.example.com"
+                        className="h-20"
+                        disabled={!watchedEnabled}
+                        {...field}
+                        value={field.value || ''}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Comma-separated list of hosts that should bypass the proxy.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Timeout */}
+              <FormField
+                control={form.control}
+                name="timeout"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Connection Timeout (seconds)</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={300}
+                        placeholder="30"
+                        className="w-32"
+                        disabled={!watchedEnabled}
+                        {...field}
+                        value={field.value ?? ''}
+                        onChange={(e) => field.onChange(e.target.value !== '' ? parseInt(e.target.value, 10) : undefined)}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Timeout for establishing proxy connections. 0 means no timeout.
+                      Default is 60 seconds.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Skip TLS Verify */}
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <FormLabel className="text-sm font-medium">Skip TLS Verification</FormLabel>
+                  <p className="text-muted-foreground text-sm">
+                    Disable TLS certificate verification for HTTPS proxies. Not recommended for production.
+                  </p>
+                </div>
+                <FormField
+                  control={form.control}
+                  name="skip_tls_verify"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          disabled={!watchedEnabled}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Entity Enablement Section */}
+          <div className={cn(
+            'space-y-4 rounded-lg border p-4 transition-opacity',
+            !watchedEnabled && 'opacity-50 pointer-events-none'
+          )}>
+            <div className="space-y-1">
+              <h3 className="text-lg font-medium">Enable Proxy For</h3>
+              <p className="text-muted-foreground text-sm">
+                Select which components should use the proxy for outbound requests.
+              </p>
+            </div>
+
+            {/* SCIM - Enterprise only */}
+            {IS_ENTERPRISE && (
+              <div className="flex items-center justify-between rounded-md border p-4">
+                <div className="space-y-0.5">
+                  <div className="flex items-center gap-2">
+                    <FormLabel className="text-sm font-medium">SCIM</FormLabel>
+                    <Badge variant="secondary">Enterprise</Badge>
+                  </div>
+                  <p className="text-muted-foreground text-sm">
+                    Use proxy for SCIM directory sync requests.
+                  </p>
+                </div>
+                <FormField
+                  control={form.control}
+                  name="enable_for_scim"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Switch
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                          disabled={!watchedEnabled}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+            )}
+
+            {/* Inference - Coming Soon */}
+            <div className="flex items-center justify-between rounded-md border p-4 opacity-60">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-2">
+                  <FormLabel className="text-sm font-medium">Inference</FormLabel>
+                  <Badge variant="outline">Coming soon</Badge>
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  Use proxy for LLM inference requests to model providers.
+                </p>
+              </div>
+              <Switch disabled checked={false} />
+            </div>
+
+            {/* API - Coming Soon */}
+            <div className="flex items-center justify-between rounded-md border p-4 opacity-60">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-2">
+                  <FormLabel className="text-sm font-medium">API</FormLabel>
+                  <Badge variant="outline">Coming soon</Badge>
+                </div>
+                <p className="text-muted-foreground text-sm">
+                  Use proxy for external API calls and webhooks.
+                </p>
+              </div>
+              <Switch disabled checked={false} />
+            </div>
+
+            {!IS_ENTERPRISE && (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertDescription>
+                  SCIM proxy support is available in Bifrost Enterprise.
+                </AlertDescription>
+              </Alert>
+            )}
+          </div>
+        </fieldset>
+      </form>
+    </Form>
+  )
+}
+

--- a/ui/lib/store/apis/configApi.ts
+++ b/ui/lib/store/apis/configApi.ts
@@ -1,5 +1,5 @@
 import { IS_ENTERPRISE } from "@/lib/constants/config";
-import { BifrostConfig, LatestReleaseResponse } from "@/lib/types/config";
+import { BifrostConfig, GlobalProxyConfig, LatestReleaseResponse } from "@/lib/types/config";
 import axios from "axios";
 import { baseApi } from "./baseApi";
 
@@ -76,6 +76,16 @@ export const configApi = baseApi.injectEndpoints({
 			}),
 			invalidatesTags: ["Config"],
 		}),
+
+		// Update proxy configuration
+		updateProxyConfig: builder.mutation<null, GlobalProxyConfig>({
+			query: (data) => ({
+				url: "/proxy-config",
+				method: "PUT",
+				body: data,
+			}),
+			invalidatesTags: ["Config"],
+		}),
 	}),
 });
 
@@ -83,6 +93,7 @@ export const {
 	useGetVersionQuery,
 	useGetCoreConfigQuery,
 	useUpdateCoreConfigMutation,
+	useUpdateProxyConfigMutation,
 	useLazyGetCoreConfigQuery,
 	useGetLatestReleaseQuery,
 	useLazyGetLatestReleaseQuery,

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -234,11 +234,45 @@ export interface AuthConfig {
 	disable_auth_on_inference?: boolean;
 }
 
+// Global proxy type (for global proxy configuration, not per-provider)
+export type GlobalProxyType = 'http' | 'socks5' | 'tcp'
+
+// Global proxy configuration matching Go's tables.GlobalProxyConfig
+export interface GlobalProxyConfig {
+	enabled: boolean;
+	type: GlobalProxyType;
+	url: string;
+	username?: string;
+	password?: string;
+	no_proxy?: string;
+	timeout?: number;
+	skip_tls_verify?: boolean;
+	enable_for_scim: boolean;
+	enable_for_inference: boolean;
+	enable_for_api: boolean;
+}
+
+// Default GlobalProxyConfig
+export const DefaultGlobalProxyConfig: GlobalProxyConfig = {
+	enabled: false,
+	type: 'http',
+	url: '',
+	username: '',
+	password: '',
+	no_proxy: '',
+	timeout: 30,
+	skip_tls_verify: false,
+	enable_for_scim: false,
+	enable_for_inference: false,
+	enable_for_api: false,
+}
+
 // Bifrost Config
 export interface BifrostConfig {
 	client_config: CoreConfig;
 	framework_config: FrameworkConfig;
 	auth_config?: AuthConfig;
+	proxy_config?: GlobalProxyConfig;
 	is_db_connected: boolean;
 	is_cache_connected: boolean;
 	is_logs_connected: boolean;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -600,6 +600,61 @@ export const mcpClientUpdateSchema = z.object({
 		),
 });
 
+// Global proxy type schema
+export const globalProxyTypeSchema = z.enum(['http', 'socks5', 'tcp']);
+
+// Global proxy configuration schema
+export const globalProxyConfigSchema = z
+	.object({
+		enabled: z.boolean(),
+		type: globalProxyTypeSchema,
+		url: z.string(),
+		username: z.string().optional(),
+		password: z.string().optional(),
+		no_proxy: z.string().optional(),
+		timeout: z.number().min(0).optional(),
+		skip_tls_verify: z.boolean().optional(),
+		enable_for_scim: z.boolean(),
+		enable_for_inference: z.boolean(),
+		enable_for_api: z.boolean(),
+	})
+	.refine(
+		(data) => {
+			// URL is required when proxy is enabled
+			if (data.enabled && (!data.url || data.url.trim().length === 0)) {
+				return false;
+			}
+			return true;
+		},
+		{
+			message: 'Proxy URL is required when proxy is enabled',
+			path: ['url'],
+		},
+	)
+	.refine(
+		(data) => {
+			// Validate URL format when provided and enabled
+			if (data.enabled && data.url && data.url.trim().length > 0) {
+				try {
+					new URL(data.url);
+					return true;
+				} catch {
+					return false;
+				}
+			}
+			return true;
+		},
+		{
+			message: 'Must be a valid URL (e.g., http://proxy.example.com:8080)',
+			path: ['url'],
+		},
+	);
+
+// Global proxy form schema for the ProxyView
+export const globalProxyFormSchema = z.object({
+	proxy_config: globalProxyConfigSchema,
+});
+
 // Export type inference helpers
 export type MCPClientUpdateSchema = z.infer<typeof mcpClientUpdateSchema>;
 export type ModelProviderKeySchema = z.infer<typeof modelProviderKeySchema>;
@@ -615,3 +670,5 @@ export type MaximFormSchema = z.infer<typeof maximFormSchema>;
 export type NetworkOnlyFormSchema = z.infer<typeof networkOnlyFormSchema>;
 export type PerformanceFormSchema = z.infer<typeof performanceFormSchema>;
 export type CustomProviderConfigSchema = z.infer<typeof customProviderConfigSchema>;
+export type GlobalProxyConfigSchema = z.infer<typeof globalProxyConfigSchema>;
+export type GlobalProxyFormSchema = z.infer<typeof globalProxyFormSchema>;


### PR DESCRIPTION
## Summary

Add HTTP proxy support for outbound requests with a configurable global proxy system. This enables organizations to route Bifrost traffic through corporate proxies for security and compliance requirements.

## Changes

- Added database models and CRUD operations for storing proxy configuration
- Implemented proxy configuration API endpoints for retrieving and updating settings
- Created a new UI view in the admin settings for managing proxy configuration
- Added support for HTTP proxies with authentication, timeout, and TLS verification options
- Implemented selective proxy enablement for different components (SCIM, inference, API)
- Added a sample docker-compose configuration for local proxy testing with mitmproxy

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Start a local proxy server using the provided docker-compose configuration:

```sh
cd examples/configs
docker-compose up -d
```

2. Configure the proxy in Bifrost UI:
   - Navigate to Workspace → Config → Proxy
   - Enable proxy and set URL to `http://localhost:8082`
   - Set username to `bifrost` and password to `secret-token`
   - Save changes

3. Verify proxy is working by checking the mitmproxy web UI at http://localhost:8081

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

- Proxy passwords are stored encrypted in the database
- Passwords are redacted in API responses
- TLS verification can be disabled but is not recommended for production

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable