### PR TITLE
adds datadog native integration flow

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -910,6 +910,69 @@
                 }
               }
             }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "datadog"
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "config"
+              ],
+              "properties": {
+                "config": {
+                  "type": "object",
+                  "description": "Configuration for the Datadog APM and metrics plugin",
+                  "properties": {
+                    "service_name": {
+                      "type": "string",
+                      "description": "Name of the service to report to Datadog",
+                      "default": "bifrost"
+                    },
+                    "agent_addr": {
+                      "type": "string",
+                      "description": "Address of the Datadog Agent for APM traces",
+                      "default": "localhost:8126"
+                    },
+                    "dogstatsd_addr": {
+                      "type": "string",
+                      "description": "Address of the DogStatsD server for metrics",
+                      "default": "localhost:8125"
+                    },
+                    "env": {
+                      "type": "string",
+                      "description": "Environment tag (e.g., production, staging)"
+                    },
+                    "version": {
+                      "type": "string",
+                      "description": "Service version tag"
+                    },
+                    "custom_tags": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "Additional tags to add to all traces and metrics"
+                    },
+                    "enable_metrics": {
+                      "type": "boolean",
+                      "description": "Enable DogStatsD metrics (default: true)",
+                      "default": true
+                    },
+                    "enable_traces": {
+                      "type": "boolean",
+                      "description": "Enable APM traces (default: true)",
+                      "default": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
           }
         ],
         "additionalProperties": false

--- a/ui/app/_fallbacks/enterprise/components/data-connectors/datadog/datadogConnectorView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/data-connectors/datadog/datadogConnectorView.tsx
@@ -1,0 +1,16 @@
+import { Dog } from "lucide-react";
+import ContactUsView from "../../views/contactUsView";
+
+export default function DatadogConnectorView() {
+	return (
+		<div className="h-full w-full">
+			<ContactUsView
+				className="mx-auto min-h-[80vh]"
+				icon={<Dog className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+				title="Unlock native Datadog data ingestion for better observability"
+				description="This feature is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
+				readmeLink="https://docs.getbifrost.ai/enterprise/data-connectors/datadog"
+			/>
+		</div>
+	);
+}

--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -115,7 +115,7 @@ export default function LoginView() {
 				<div className="border-border bg-card w-full space-y-6 rounded-lg border p-8 shadow-sm">
 					{/* Logo */}
 					<div className="flex items-center justify-center">
-						<Image src={logoSrc} alt="Bifrost" width={200} height={26} priority className="" />
+						<Image src={logoSrc} alt="Bifrost" width={180} height={26} priority className="" />
 					</div>
 
 					<div className="space-y-2 text-center">

--- a/ui/app/workspace/observability/views/observabilityView.tsx
+++ b/ui/app/workspace/observability/views/observabilityView.tsx
@@ -37,7 +37,6 @@ const supportedPlatformsList = (resolvedTheme: string): SupportedPlatform[] => [
 				/>
 			</svg>
 		),
-		tag: "Beta",
 	},
 	{
 		id: "maxim",
@@ -48,7 +47,6 @@ const supportedPlatformsList = (resolvedTheme: string): SupportedPlatform[] => [
 		id: "datadog",
 		name: "Datadog",
 		icon: <Image alt="Datadog" src="/images/datadog-logo.png" width={32} height={32} />,
-		disabled: true,
 	},
 	{
 		id: "newrelic",
@@ -125,7 +123,7 @@ export default function ObservabilityView() {
 									aria-disabled={tab.disabled ? true : undefined}
 									aria-current={selectedPlugin?.name === tab.id ? "page" : undefined}
 									className={cn(
-										"mb-1 flex w-full items-center gap-2 rounded-sm border px-3 py-1.5 text-sm max-h-[32px]",
+										"mb-1 flex max-h-[32px] w-full items-center gap-2 rounded-sm border px-3 py-1.5 text-sm",
 										tab.disabled ? "opacity-50" : "",
 										selectedPlugin?.name === tab.id
 											? "bg-secondary opacity-100 hover:opacity-100"

--- a/ui/app/workspace/observability/views/plugins/datadogView.tsx
+++ b/ui/app/workspace/observability/views/plugins/datadogView.tsx
@@ -1,10 +1,5 @@
+import DatadogConnectorView from "@enterprise/components/data-connectors/datadog/datadogConnectorView";
+
 export default function DatadogView() {
-	return (
-		<div
-			style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "30vh" }}
-			className="bg-zinc-100/10 dark:bg-zinc-800/20"
-		>
-			<div className="text-muted-foreground text-xs font-medium">{"Coming soon".toUpperCase()}</div>
-		</div>
-	);
+	return <DatadogConnectorView />;
 }


### PR DESCRIPTION
## Summary

Added thread-safe plugin management and Datadog integration support to Bifrost.

## Changes

- Added `PluginsMutex` to `BifrostHTTPServer` for thread-safe plugin management
- Created a new `SyncLoadedPlugin` method to handle plugin synchronization with the Bifrost core
- Refactored `ReloadPlugin` to use the new `SyncLoadedPlugin` method
- Added proper mutex locking when updating the `Plugins` slice
- Added Datadog plugin configuration schema to support APM and metrics integration
- Created a Datadog connector UI component for enterprise users
- Removed "Beta" tag from Prometheus integration
- Enabled Datadog integration in the UI

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/server/...

# UI
cd ui
pnpm i
pnpm dev
# Navigate to Observability section and verify Datadog integration is available
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Adds support for Datadog observability integration

## Security considerations

The plugin management changes improve thread safety when handling plugin operations.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the UI changes render correctly