### PR TITLE
fix: added status field in bifrost responses response

### DIFF
--- a/core/internal/testutil/response_validation.go
+++ b/core/internal/testutil/response_validation.go
@@ -740,6 +740,17 @@ func validateResponsesBasicStructure(response *schemas.BifrostResponsesResponse,
 				fmt.Sprintf("Expected %d choices, got %d", expectations.ExpectedChoiceCount, actualCount))
 		}
 	}
+
+	provider := response.ExtraFields.Provider
+	model := response.ExtraFields.ModelDeployment
+
+	// Verify top level status is present for OpenAI and Azure with  non-Claude models
+	if provider != "" && (provider == schemas.OpenAI || provider == schemas.Azure) && !strings.Contains(strings.ToLower(model), "claude") {
+		if response.Status == nil {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected status but not present")
+		}
+	}
 }
 
 // validateResponsesContent checks the content of the Responses API response

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -64,6 +64,7 @@ type BifrostResponsesResponse struct {
 	Reasoning          *ResponsesParametersReasoning       `json:"reasoning,omitempty"`         // Configuration options for reasoning models
 	SafetyIdentifier   *string                             `json:"safety_identifier,omitempty"` // Safety identifier
 	ServiceTier        *string                             `json:"service_tier,omitempty"`
+	Status             *string                             `json:"status,omitempty"` // completed, failed, in_progress, cancelled, queued, or incomplete
 	StreamOptions      *ResponsesStreamOptions             `json:"stream_options,omitempty"`
 	Store              *bool                               `json:"store,omitempty"`
 	Temperature        *float64                            `json:"temperature,omitempty"`


### PR DESCRIPTION
## Summary

Added a `status` field to the Bifrost Responses API response schema and implemented validation to ensure it's present for OpenAI and Azure providers.

## Changes

- Added a `Status` field to the `BifrostResponsesResponse` struct with appropriate JSON mapping and documentation
- Implemented validation in `validateResponsesBasicStructure` to verify the status field is present for OpenAI and Azure providers (except when using Claude models)
- The status field can have values: "completed", "failed", "in_progress", "cancelled", "queued", or "incomplete"

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Core/Transports
go test ./core/internal/testutil/...
go test ./core/schemas/...
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is adding a new informational field to the response schema.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)