### PR TITLE
feat: add request metadata to error responses

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -237,6 +237,9 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 			Error: &schemas.ErrorField{
 				Message: "list models request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ListModelsRequest,
+			},
 		}
 	}
 	if req.Provider == "" {
@@ -244,6 +247,9 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "provider is required for list models request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ListModelsRequest,
 			},
 		}
 	}
@@ -265,6 +271,10 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 			Error: &schemas.ErrorField{
 				Message: "provider not found for list models request",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ListModelsRequest,
+				Provider:    req.Provider,
+			},
 		}
 	}
 
@@ -272,10 +282,20 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 	baseProvider := req.Provider
 	config, err := bifrost.account.GetConfigForProvider(req.Provider)
 	if err != nil {
-		return nil, newBifrostErrorFromMsg(fmt.Sprintf("failed to get config for provider %s: %v", req.Provider, err.Error()))
+		bifrostErr := newBifrostErrorFromMsg(fmt.Sprintf("failed to get config for provider %s: %v", req.Provider, err.Error()))
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ListModelsRequest,
+			Provider:    req.Provider,
+		}
+		return nil, bifrostErr
 	}
 	if config == nil {
-		return nil, newBifrostErrorFromMsg(fmt.Sprintf("config is nil for provider %s", req.Provider))
+		bifrostErr := newBifrostErrorFromMsg(fmt.Sprintf("config is nil for provider %s", req.Provider))
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ListModelsRequest,
+			Provider:    req.Provider,
+		}
+		return nil, bifrostErr
 	}
 	if config.CustomProviderConfig != nil && config.CustomProviderConfig.BaseProviderType != "" {
 		baseProvider = config.CustomProviderConfig.BaseProviderType
@@ -285,7 +305,12 @@ func (bifrost *Bifrost) ListModelsRequest(ctx context.Context, req *schemas.Bifr
 	if providerRequiresKey(baseProvider, config.CustomProviderConfig) {
 		keys, err = bifrost.getAllSupportedKeys(&ctx, req.Provider, baseProvider)
 		if err != nil {
-			return nil, newBifrostError(err)
+			bifrostErr := newBifrostError(err)
+			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ListModelsRequest,
+				Provider:    req.Provider,
+			}
+			return nil, bifrostErr
 		}
 	}
 
@@ -316,6 +341,9 @@ func (bifrost *Bifrost) ListAllModels(ctx context.Context, request *schemas.Bifr
 			Error: &schemas.ErrorField{
 				Message: err.Error(),
 				Error:   err,
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ListModelsRequest,
 			},
 		}
 	}
@@ -445,6 +473,9 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.
 			Error: &schemas.ErrorField{
 				Message: "text completion request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.TextCompletionRequest,
+			},
 		}
 	}
 	if req.Input == nil || (req.Input.PromptStr == nil && req.Input.PromptArray == nil) {
@@ -452,6 +483,11 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx context.Context, req *schemas.
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "prompt not provided for text completion request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.TextCompletionRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -476,6 +512,9 @@ func (bifrost *Bifrost) TextCompletionStreamRequest(ctx context.Context, req *sc
 			Error: &schemas.ErrorField{
 				Message: "text completion stream request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.TextCompletionStreamRequest,
+			},
 		}
 	}
 	if req.Input == nil || (req.Input.PromptStr == nil && req.Input.PromptArray == nil) {
@@ -483,6 +522,11 @@ func (bifrost *Bifrost) TextCompletionStreamRequest(ctx context.Context, req *sc
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "text not provided for text completion stream request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.TextCompletionStreamRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -500,6 +544,9 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 			Error: &schemas.ErrorField{
 				Message: "chat completion request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+			},
 		}
 	}
 	if req.Input == nil {
@@ -507,6 +554,11 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx context.Context, req *schemas.
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "chats not provided for chat completion request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.ChatCompletionRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -531,6 +583,9 @@ func (bifrost *Bifrost) ChatCompletionStreamRequest(ctx context.Context, req *sc
 			Error: &schemas.ErrorField{
 				Message: "chat completion stream request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ChatCompletionStreamRequest,
+			},
 		}
 	}
 	if req.Input == nil {
@@ -538,6 +593,11 @@ func (bifrost *Bifrost) ChatCompletionStreamRequest(ctx context.Context, req *sc
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "chats not provided for chat completion request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.ChatCompletionStreamRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -557,6 +617,9 @@ func (bifrost *Bifrost) ResponsesRequest(ctx context.Context, req *schemas.Bifro
 			Error: &schemas.ErrorField{
 				Message: "responses request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ResponsesRequest,
+			},
 		}
 	}
 	if req.Input == nil {
@@ -564,6 +627,11 @@ func (bifrost *Bifrost) ResponsesRequest(ctx context.Context, req *schemas.Bifro
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "responses not provided for responses request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.ResponsesRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -588,6 +656,9 @@ func (bifrost *Bifrost) ResponsesStreamRequest(ctx context.Context, req *schemas
 			Error: &schemas.ErrorField{
 				Message: "responses stream request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ResponsesStreamRequest,
+			},
 		}
 	}
 	if req.Input == nil {
@@ -595,6 +666,11 @@ func (bifrost *Bifrost) ResponsesStreamRequest(ctx context.Context, req *schemas
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "responses not provided for responses stream request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.ResponsesStreamRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -614,6 +690,9 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.Bifro
 			Error: &schemas.ErrorField{
 				Message: "embedding request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.EmbeddingRequest,
+			},
 		}
 	}
 	if req.Input == nil || (req.Input.Text == nil && req.Input.Texts == nil && req.Input.Embedding == nil && req.Input.Embeddings == nil) {
@@ -621,6 +700,11 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.Bifro
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "embedding input not provided for embedding request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.EmbeddingRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -645,6 +729,9 @@ func (bifrost *Bifrost) SpeechRequest(ctx context.Context, req *schemas.BifrostS
 			Error: &schemas.ErrorField{
 				Message: "speech request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.SpeechRequest,
+			},
 		}
 	}
 	if req.Input == nil || req.Input.Input == "" {
@@ -652,6 +739,11 @@ func (bifrost *Bifrost) SpeechRequest(ctx context.Context, req *schemas.BifrostS
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "speech input not provided for speech request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.SpeechRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -676,6 +768,9 @@ func (bifrost *Bifrost) SpeechStreamRequest(ctx context.Context, req *schemas.Bi
 			Error: &schemas.ErrorField{
 				Message: "speech stream request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.SpeechStreamRequest,
+			},
 		}
 	}
 	if req.Input == nil || req.Input.Input == "" {
@@ -683,6 +778,11 @@ func (bifrost *Bifrost) SpeechStreamRequest(ctx context.Context, req *schemas.Bi
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "speech input not provided for speech stream request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.SpeechStreamRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -702,6 +802,9 @@ func (bifrost *Bifrost) TranscriptionRequest(ctx context.Context, req *schemas.B
 			Error: &schemas.ErrorField{
 				Message: "transcription request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.TranscriptionRequest,
+			},
 		}
 	}
 	if req.Input == nil || req.Input.File == nil {
@@ -709,6 +812,11 @@ func (bifrost *Bifrost) TranscriptionRequest(ctx context.Context, req *schemas.B
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "transcription input not provided for transcription request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.TranscriptionRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -733,6 +841,9 @@ func (bifrost *Bifrost) TranscriptionStreamRequest(ctx context.Context, req *sch
 			Error: &schemas.ErrorField{
 				Message: "transcription stream request is nil",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.TranscriptionStreamRequest,
+			},
 		}
 	}
 	if req.Input == nil || req.Input.File == nil {
@@ -740,6 +851,11 @@ func (bifrost *Bifrost) TranscriptionStreamRequest(ctx context.Context, req *sch
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: "transcription input not provided for transcription stream request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.TranscriptionStreamRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
 			},
 		}
 	}
@@ -927,11 +1043,17 @@ func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error 
 					case <-time.After(5 * time.Second):
 						bifrost.logger.Warn("Failed to transfer buffered request to new queue within timeout")
 						// Send error response to avoid hanging the client
+						provider, model, _ := m.BifrostRequest.GetRequestFields()
 						select {
 						case m.Err <- schemas.BifrostError{
 							IsBifrostError: false,
 							Error: &schemas.ErrorField{
 								Message: "request failed during provider concurrency update",
+							},
+							ExtraFields: schemas.BifrostErrorExtraFields{
+								RequestType:    m.RequestType,
+								Provider:       provider,
+								ModelRequested: model,
 							},
 						}:
 						case <-time.After(1 * time.Second):
@@ -1109,6 +1231,9 @@ func (bifrost *Bifrost) ExecuteMCPTool(ctx context.Context, toolCall schemas.Cha
 			Error: &schemas.ErrorField{
 				Message: "MCP is not configured in this Bifrost instance",
 			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ChatCompletionRequest, // MCP tools are used with chat completions
+			},
 		}
 	}
 
@@ -1119,6 +1244,9 @@ func (bifrost *Bifrost) ExecuteMCPTool(ctx context.Context, toolCall schemas.Cha
 			Error: &schemas.ErrorField{
 				Message: err.Error(),
 				Error:   err,
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.ChatCompletionRequest, // MCP tools are used with chat completions
 			},
 		}
 	}
@@ -1757,10 +1885,16 @@ func (bifrost *Bifrost) handleStreamRequest(ctx context.Context, req *schemas.Bi
 // tryRequest is a generic function that handles common request processing logic
 // It consolidates queue setup, plugin pipeline execution, enqueue logic, and response handling
 func (bifrost *Bifrost) tryRequest(ctx context.Context, req *schemas.BifrostRequest) (*schemas.BifrostResponse, *schemas.BifrostError) {
-	provider, _, _ := req.GetRequestFields()
+	provider, model, _ := req.GetRequestFields()
 	queue, err := bifrost.getProviderQueue(provider)
 	if err != nil {
-		return nil, newBifrostError(err)
+		bifrostErr := newBifrostError(err)
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
 	}
 
 	// Add MCP tools to request if MCP is configured and requested
@@ -1794,7 +1928,13 @@ func (bifrost *Bifrost) tryRequest(ctx context.Context, req *schemas.BifrostRequ
 		}
 	}
 	if preReq == nil {
-		return nil, newBifrostErrorFromMsg("bifrost request after plugin hooks cannot be nil")
+		bifrostErr := newBifrostErrorFromMsg("bifrost request after plugin hooks cannot be nil")
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
 	}
 
 	msg := bifrost.getChannelMessage(*preReq)
@@ -1804,19 +1944,37 @@ func (bifrost *Bifrost) tryRequest(ctx context.Context, req *schemas.BifrostRequ
 		// Message was sent successfully
 	case <-ctx.Done():
 		bifrost.releaseChannelMessage(msg)
-		return nil, newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+		bifrostErr := newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
 	default:
 		if bifrost.dropExcessRequests.Load() {
 			bifrost.releaseChannelMessage(msg)
 			bifrost.logger.Warn("Request dropped: queue is full, please increase the queue size or set dropExcessRequests to false")
-			return nil, newBifrostErrorFromMsg("request dropped: queue is full")
+			bifrostErr := newBifrostErrorFromMsg("request dropped: queue is full")
+			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider,
+				ModelRequested: model,
+			}
+			return nil, bifrostErr
 		}
 		select {
 		case queue <- msg:
 			// Message was sent successfully
 		case <-ctx.Done():
 			bifrost.releaseChannelMessage(msg)
-			return nil, newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+			bifrostErr := newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider,
+				ModelRequested: model,
+			}
+			return nil, bifrostErr
 		}
 	}
 
@@ -1846,10 +2004,16 @@ func (bifrost *Bifrost) tryRequest(ctx context.Context, req *schemas.BifrostRequ
 // tryStreamRequest is a generic function that handles common request processing logic
 // It consolidates queue setup, plugin pipeline execution, enqueue logic, and response handling
 func (bifrost *Bifrost) tryStreamRequest(ctx context.Context, req *schemas.BifrostRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
-	provider, _, _ := req.GetRequestFields()
+	provider, model, _ := req.GetRequestFields()
 	queue, err := bifrost.getProviderQueue(provider)
 	if err != nil {
-		return nil, newBifrostError(err)
+		bifrostErr := newBifrostError(err)
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
 	}
 
 	// Add MCP tools to request if MCP is configured and requested
@@ -1938,7 +2102,13 @@ func (bifrost *Bifrost) tryStreamRequest(ctx context.Context, req *schemas.Bifro
 		}
 	}
 	if preReq == nil {
-		return nil, newBifrostErrorFromMsg("bifrost request after plugin hooks cannot be nil")
+		bifrostErr := newBifrostErrorFromMsg("bifrost request after plugin hooks cannot be nil")
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
 	}
 
 	msg := bifrost.getChannelMessage(*preReq)
@@ -1949,19 +2119,37 @@ func (bifrost *Bifrost) tryStreamRequest(ctx context.Context, req *schemas.Bifro
 		// Message was sent successfully
 	case <-ctx.Done():
 		bifrost.releaseChannelMessage(msg)
-		return nil, newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+		bifrostErr := newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
 	default:
 		if bifrost.dropExcessRequests.Load() {
 			bifrost.releaseChannelMessage(msg)
 			bifrost.logger.Warn("Request dropped: queue is full, please increase the queue size or set dropExcessRequests to false")
-			return nil, newBifrostErrorFromMsg("request dropped: queue is full")
+			bifrostErr := newBifrostErrorFromMsg("request dropped: queue is full")
+			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider,
+				ModelRequested: model,
+			}
+			return nil, bifrostErr
 		}
 		select {
 		case queue <- msg:
 			// Message was sent successfully
 		case <-ctx.Done():
 			bifrost.releaseChannelMessage(msg)
-			return nil, newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+			bifrostErr := newBifrostErrorFromMsg("request cancelled while waiting for queue space")
+			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider,
+				ModelRequested: model,
+			}
+			return nil, bifrostErr
 		}
 	}
 
@@ -2106,6 +2294,11 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 						Message: err.Error(),
 						Error:   err,
 					},
+					ExtraFields: schemas.BifrostErrorExtraFields{
+						Provider:       provider.GetProviderKey(),
+						ModelRequested: model,
+						RequestType:    req.RequestType,
+					},
 				}
 				continue
 			}
@@ -2232,10 +2425,16 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, req *Ch
 		}
 		response.TranscriptionResponse = transcriptionResponse
 	default:
+		_, model, _ := req.BifrostRequest.GetRequestFields()
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: fmt.Sprintf("unsupported request type: %s", req.RequestType),
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider.GetProviderKey(),
+				ModelRequested: model,
 			},
 		}
 	}
@@ -2256,10 +2455,16 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, r
 	case schemas.TranscriptionStreamRequest:
 		return provider.TranscriptionStream(req.Context, postHookRunner, key, req.BifrostRequest.TranscriptionRequest)
 	default:
+		_, model, _ := req.BifrostRequest.GetRequestFields()
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
 				Message: fmt.Sprintf("unsupported request type: %s", req.RequestType),
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider.GetProviderKey(),
+				ModelRequested: model,
 			},
 		}
 	}


### PR DESCRIPTION
## Summary

Enhanced error reporting by adding detailed context to BifrostError responses, making it easier to debug and trace issues.

## Changes

- Added `ExtraFields` to all error responses throughout the codebase
- Included request type, provider, and model information in error contexts
- Standardized error reporting format across all request types
- Improved error handling in queue management and request processing

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)

## How to test

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [x] No

## Related issues

Improves error observability and debugging capabilities

## Security considerations

No security implications as this only enhances error reporting with already available information.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)