### PR TITLE
fix: bedrock tests fixes

### DIFF
--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -136,13 +136,14 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *context.Context
 					Region:       bifrost.Ptr(getEnvWithDefault("AWS_REGION", "us-east-1")),
 					ARN:          bifrost.Ptr(os.Getenv("AWS_ARN")),
 					Deployments: map[string]string{
-						"claude-sonnet-4":   "global.anthropic.claude-sonnet-4-20250514-v1:0",
 						"claude-3.7-sonnet": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+						"claude-4-sonnet":   "global.anthropic.claude-sonnet-4-20250514-v1:0",
+						"claude-4.5-sonnet": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
 					},
 				},
 			},
 			{
-				Models: []string{"anthropic.claude-3-5-sonnet-20240620-v1:0", "cohere.embed-v4:0"},
+				Models: []string{"cohere.embed-v4:0"},
 				Weight: 1.0,
 				BedrockKeyConfig: &schemas.BedrockKeyConfig{
 					AccessKey:    os.Getenv("AWS_ACCESS_KEY_ID"),

--- a/core/providers/anthropic/anthropic_test.go
+++ b/core/providers/anthropic/anthropic_test.go
@@ -2,6 +2,7 @@ package anthropic_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestAnthropic(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) == "" {
 		t.Skip("Skipping Anthropic tests because ANTHROPIC_API_KEY is not set")
 	}
 

--- a/core/providers/azure/azure_test.go
+++ b/core/providers/azure/azure_test.go
@@ -2,6 +2,7 @@ package azure_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -12,7 +13,7 @@ import (
 func TestAzure(t *testing.T) {
 	t.Parallel()
 
-	if os.Getenv("AZURE_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("AZURE_API_KEY")) == "" {
 		t.Skip("Skipping Azure tests because AZURE_API_KEY is not set")
 	}
 

--- a/core/providers/cerebras/cerebras_test.go
+++ b/core/providers/cerebras/cerebras_test.go
@@ -2,6 +2,7 @@ package cerebras_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestCerebras(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("CEREBRAS_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("CEREBRAS_API_KEY")) == "" {
 		t.Skip("Skipping Cerebras tests because CEREBRAS_API_KEY is not set")
 	}
 

--- a/core/providers/cohere/cohere_test.go
+++ b/core/providers/cohere/cohere_test.go
@@ -2,6 +2,7 @@ package cohere_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestCohere(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("COHERE_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("COHERE_API_KEY")) == "" {
 		t.Skip("Skipping Cohere tests because COHERE_API_KEY is not set")
 	}
 

--- a/core/providers/elevenlabs/elevenlabs_test.go
+++ b/core/providers/elevenlabs/elevenlabs_test.go
@@ -2,6 +2,7 @@ package elevenlabs_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestElevenlabs(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("ELEVENLABS_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("ELEVENLABS_API_KEY")) == "" {
 		t.Skip("Skipping Elevenlabs tests because ELEVENLABS_API_KEY is not set")
 	}
 

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -2,6 +2,7 @@ package gemini_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestGemini(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("GEMINI_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("GEMINI_API_KEY")) == "" {
 		t.Skip("Skipping Gemini tests because GEMINI_API_KEY is not set")
 	}
 

--- a/core/providers/groq/groq_test.go
+++ b/core/providers/groq/groq_test.go
@@ -3,6 +3,7 @@ package groq_test
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -12,7 +13,7 @@ import (
 
 func TestGroq(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("GROQ_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("GROQ_API_KEY")) == "" {
 		t.Skip("Skipping Groq tests because GROQ_API_KEY is not set")
 	}
 

--- a/core/providers/mistral/mistral_test.go
+++ b/core/providers/mistral/mistral_test.go
@@ -2,6 +2,7 @@ package mistral_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestMistral(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("MISTRAL_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("MISTRAL_API_KEY")) == "" {
 		t.Skip("Skipping Mistral tests because MISTRAL_API_KEY is not set")
 	}
 

--- a/core/providers/ollama/ollama_test.go
+++ b/core/providers/ollama/ollama_test.go
@@ -2,6 +2,7 @@ package ollama_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestOllama(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("OLLAMA_BASE_URL") == "" {
+	if strings.TrimSpace(os.Getenv("OLLAMA_BASE_URL")) == "" {
 		t.Skip("Skipping Ollama tests because OLLAMA_BASE_URL is not set")
 	}
 

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -2,6 +2,7 @@ package openai_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestOpenAI(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("OPENAI_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
 		t.Skip("Skipping OpenAI tests because OPENAI_API_KEY is not set")
 	}
 

--- a/core/providers/openrouter/openrouter_test.go
+++ b/core/providers/openrouter/openrouter_test.go
@@ -2,6 +2,7 @@ package openrouter_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestOpenRouter(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("OPENROUTER_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")) == "" {
 		t.Skip("Skipping OpenRouter tests because OPENROUTER_API_KEY is not set")
 	}
 

--- a/core/providers/parasail/parasail_test.go
+++ b/core/providers/parasail/parasail_test.go
@@ -2,6 +2,7 @@ package parasail_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestParasail(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("PARASAIL_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("PARASAIL_API_KEY")) == "" {
 		t.Skip("Skipping Parasail tests because PARASAIL_API_KEY is not set")
 	}
 

--- a/core/providers/perplexity/perplexity_test.go
+++ b/core/providers/perplexity/perplexity_test.go
@@ -2,6 +2,7 @@ package perplexity_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestPerplexity(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("PERPLEXITY_API_KEY") == "" {
+	if strings.TrimSpace(os.Getenv("PERPLEXITY_API_KEY")) == "" {
 		t.Skip("Skipping Perplexity tests because PERPLEXITY_API_KEY is not set")
 	}
 

--- a/core/providers/vertex/vertex_test.go
+++ b/core/providers/vertex/vertex_test.go
@@ -2,6 +2,7 @@ package vertex_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
@@ -11,7 +12,7 @@ import (
 
 func TestVertex(t *testing.T) {
 	t.Parallel()
-	if os.Getenv("VERTEX_API_KEY") == "" && (os.Getenv("VERTEX_PROJECT_ID") == "" || os.Getenv("VERTEX_CREDENTIALS") == "") {
+	if strings.TrimSpace(os.Getenv("VERTEX_API_KEY")) == "" && (strings.TrimSpace(os.Getenv("VERTEX_PROJECT_ID")) == "" || strings.TrimSpace(os.Getenv("VERTEX_CREDENTIALS")) == "") {
 		t.Skip("Skipping Vertex tests because VERTEX_API_KEY is not set and VERTEX_PROJECT_ID or VERTEX_CREDENTIALS is not set")
 	}
 


### PR DESCRIPTION
## Summary

Improved test robustness and added comprehensive Bedrock provider tests to ensure proper functionality with AWS services.

## Changes

- Added comprehensive test suite for Bedrock provider
- Updated Claude model names in test account configuration (renamed claude-sonnet-4 to claude-4-sonnet and added claude-4.5-sonnet)
- Improved environment variable handling in tests by trimming whitespace before checking if they're empty
- Fixed package declaration in bedrock_test.go to follow Go testing conventions
- Removed anthropic.claude-3-5-sonnet model from test configuration

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Bedrock provider tests with appropriate AWS credentials:

```sh
# Set required environment variables
export AWS_ACCESS_KEY_ID=your_access_key
export AWS_SECRET_ACCESS_KEY=your_secret_key
export AWS_REGION=us-east-1

# Run Bedrock tests
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Tests require valid AWS credentials to run properly, but they're only used for testing purposes and not stored in the codebase.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable