### PR TITLE
fix: reroute requests incoming from integrations for full compatibility in custom providers

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -671,6 +671,19 @@ func HandleAnthropicChatCompletionStreaming(
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *AnthropicProvider) Responses(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+		if ctx, shouldFallback := providerUtils.ShouldAttemptIntegrationFallback(ctx); shouldFallback {
+			chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
+			if err != nil {
+				return nil, err
+			}
+
+			response := chatResponse.ToBifrostResponsesResponse()
+			response.ExtraFields.RequestType = schemas.ResponsesRequest
+			response.ExtraFields.Provider = provider.GetProviderKey()
+			response.ExtraFields.ModelRequested = request.Model
+
+			return response, nil
+		}
 		return nil, err
 	}
 
@@ -719,6 +732,15 @@ func (provider *AnthropicProvider) Responses(ctx context.Context, key schemas.Ke
 // ResponsesStream performs a streaming responses request to the Anthropic API.
 func (provider *AnthropicProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
+		if ctx, shouldFallback := providerUtils.ShouldAttemptIntegrationFallback(ctx); shouldFallback {
+			ctx = context.WithValue(ctx, schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+			return provider.ChatCompletionStream(
+				ctx,
+				postHookRunner,
+				key,
+				request.ToChatRequest(),
+			)
+		}
 		return nil, err
 	}
 

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -916,6 +916,19 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+		if ctx, shouldFallback := providerUtils.ShouldAttemptIntegrationFallback(ctx); shouldFallback {
+			chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
+			if err != nil {
+				return nil, err
+			}
+
+			response := chatResponse.ToBifrostResponsesResponse()
+			response.ExtraFields.RequestType = schemas.ResponsesRequest
+			response.ExtraFields.Provider = provider.GetProviderKey()
+			response.ExtraFields.ModelRequested = request.Model
+
+			return response, nil
+		}
 		return nil, err
 	}
 
@@ -989,6 +1002,15 @@ func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key,
 // Returns a channel for streaming BifrostResponse objects or an error if the request fails.
 func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
+		if ctx, shouldFallback := providerUtils.ShouldAttemptIntegrationFallback(ctx); shouldFallback {
+			ctx = context.WithValue(ctx, schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+			return provider.ChatCompletionStream(
+				ctx,
+				postHookRunner,
+				key,
+				request.ToChatRequest(),
+			)
+		}
 		return nil, err
 	}
 

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -504,6 +504,19 @@ func (provider *CohereProvider) ChatCompletionStream(ctx context.Context, postHo
 func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	// Check if chat completion is allowed
 	if err := providerUtils.CheckOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+		if ctx, shouldFallback := providerUtils.ShouldAttemptIntegrationFallback(ctx); shouldFallback {
+			chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
+			if err != nil {
+				return nil, err
+			}
+
+			response := chatResponse.ToBifrostResponsesResponse()
+			response.ExtraFields.RequestType = schemas.ResponsesRequest
+			response.ExtraFields.Provider = provider.GetProviderKey()
+			response.ExtraFields.ModelRequested = request.Model
+
+			return response, nil
+		}
 		return nil, err
 	}
 
@@ -558,6 +571,15 @@ func (provider *CohereProvider) Responses(ctx context.Context, key schemas.Key, 
 func (provider *CohereProvider) ResponsesStream(ctx context.Context, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	// Check if responses stream is allowed
 	if err := providerUtils.CheckOperationAllowed(schemas.Cohere, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
+		if ctx, shouldFallback := providerUtils.ShouldAttemptIntegrationFallback(ctx); shouldFallback {
+			ctx = context.WithValue(ctx, schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+			return provider.ChatCompletionStream(
+				ctx,
+				postHookRunner,
+				key,
+				request.ToChatRequest(),
+			)
+		}
 		return nil, err
 	}
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1119,3 +1119,23 @@ func GetBudgetTokensFromReasoningEffort(
 
 	return budget, nil
 }
+
+// ShouldAttemptIntegrationFallback checks if an integration fallback should be attempted.
+// It returns:
+// - modified context with fallback flag set (if fallback should proceed)
+// - boolean indicating whether to proceed with fallback
+func ShouldAttemptIntegrationFallback(ctx context.Context) (context.Context, bool) {
+	// Check if this is an integration request
+	if _, ok := ctx.Value(schemas.BifrostContextKeyIntegrationRequest).(bool); !ok {
+		return ctx, false
+	}
+
+	// Check if fallback has already been attempted
+	if attempted, _ := ctx.Value(schemas.BifrostContextKeyIntegrationFallbackAttempted).(bool); attempted {
+		return ctx, false
+	}
+
+	// Mark fallback as attempted and return modified context
+	ctx = context.WithValue(ctx, schemas.BifrostContextKeyIntegrationFallbackAttempted, true)
+	return ctx, true
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -102,18 +102,20 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                      // string
-	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                   // string
-	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"          // string
-	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"           // Key struct
-	BifrostContextKeySelectedKeyID                       BifrostContextKey = "bifrost-selected-key-id"      // string (to store the selected key ID (set by bifrost))
-	BifrostContextKeySelectedKeyName                     BifrostContextKey = "bifrost-selected-key-name"    // string (to store the selected key name (set by bifrost))
-	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"    // int (to store the number of retries (set by bifrost))
-	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"       // int (to store the fallback index (set by bifrost)) 0 for primary, 1 for first fallback, etc.
-	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator" // bool (set by bifrost)
-	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"   // bool (will pass an empty key to the provider)
-	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"        // map[string]string
-	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"       // string
+	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                                // string
+	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                             // string
+	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"                    // string
+	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"                     // Key struct
+	BifrostContextKeyIntegrationRequest                  BifrostContextKey = "bifrost-integration-request"            // bool (set by bifrost)
+	BifrostContextKeyIntegrationFallbackAttempted        BifrostContextKey = "bifrost-integration-fallback-attempted" // bool (set by bifrost)
+	BifrostContextKeySelectedKeyID                       BifrostContextKey = "bifrost-selected-key-id"                // string (to store the selected key ID (set by bifrost))
+	BifrostContextKeySelectedKeyName                     BifrostContextKey = "bifrost-selected-key-name"              // string (to store the selected key name (set by bifrost))
+	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"              // int (to store the number of retries (set by bifrost))
+	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"                 // int (to store the fallback index (set by bifrost)) 0 for primary, 1 for first fallback, etc.
+	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"           // bool (set by bifrost)
+	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"             // bool (will pass an empty key to the provider)
+	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"                  // map[string]string
+	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                 // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -375,6 +375,9 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			}
 		}
 
+		// set context value to indicate this request is being handled by a bifrost integration
+		*bifrostCtx = context.WithValue(*bifrostCtx, schemas.BifrostContextKeyIntegrationRequest, true)
+
 		if isStreaming {
 			g.handleStreamingRequest(ctx, config, bifrostReq, bifrostCtx, cancel)
 		} else {


### PR DESCRIPTION
## Summary

Implement cross-endpoint fallback for integration requests, allowing chat completion requests to fall back to responses endpoints and vice versa when a specific endpoint is disabled.

## Changes

- Added fallback mechanism between chat completion and responses endpoints for integration requests
- When an endpoint is disabled but the request comes from an integration, the system now attempts to convert and route the request to the alternative endpoint
- Implemented fallback for both streaming and non-streaming requests
- Added context flags to track when fallbacks are being used
- Modified providers (OpenAI, Anthropic, Bedrock, Cohere) to support this fallback behavior

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Test integration requests when specific endpoints are disabled:

```sh
# Test with disabled chat completion endpoint
go run main.go --disable-chat-completion
# Make an integration request to chat completion endpoint

# Test with disabled responses endpoint
go run main.go --disable-responses
# Make an integration request to responses endpoint

# Verify both streaming and non-streaming requests
go test ./...
```

## Breaking changes

- [x] No

## Related issues

Improves integration flexibility by allowing requests to succeed even when specific endpoints are disabled.

## Security considerations

No additional security implications as this only affects request routing for integration requests.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable