### PR TITLE
feat: added structured outputs in cohere

### DIFF
--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -99,6 +99,11 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Cohe
 		cohereReq.FrequencyPenalty = bifrostReq.Params.FrequencyPenalty
 		cohereReq.PresencePenalty = bifrostReq.Params.PresencePenalty
 
+		// Convert response format
+		if bifrostReq.Params.ResponseFormat != nil {
+			cohereReq.ResponseFormat = convertResponseFormatToCohere(bifrostReq.Params.ResponseFormat)
+		}
+
 		// Convert extra params
 		if bifrostReq.Params.ExtraParams != nil {
 			// Handle thinking parameter
@@ -210,6 +215,9 @@ func (req *CohereChatRequest) ToBifrostChatRequest() *schemas.BifrostChatRequest
 	}
 	if req.PresencePenalty != nil {
 		bifrostReq.Params.PresencePenalty = req.PresencePenalty
+	}
+	if req.ResponseFormat != nil {
+		bifrostReq.Params.ResponseFormat = convertCohereResponseFormatToBifrost(req.ResponseFormat)
 	}
 
 	// Convert tools

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -28,6 +28,7 @@ type CohereChatRequest struct {
 	LogProbs         *bool                   `json:"log_probs,omitempty"`          // Optional: Log probabilities
 	StrictToolChoice *bool                   `json:"strict_tool_choice,omitempty"` // Optional: Strict tool choice
 	Thinking         *CohereThinking         `json:"thinking,omitempty"`           // Optional: Reasoning configuration
+	ResponseFormat   *CohereResponseFormat   `json:"response_format,omitempty"`    // Optional: Format for the response
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -178,6 +179,20 @@ type CohereThinkingType string
 const (
 	ThinkingTypeEnabled  CohereThinkingType = "enabled"
 	ThinkingTypeDisabled CohereThinkingType = "disabled"
+)
+
+// CohereResponseFormat represents the response format configuration for Cohere chat requests
+type CohereResponseFormat struct {
+	Type       CohereResponseFormatType `json:"type"`             // Required: Response format type
+	JSONSchema *interface{}             `json:"schema,omitempty"` // Optional: JSON schema for structured output (not used when type is "text")
+}
+
+// CohereResponseFormatType represents the type of response format
+type CohereResponseFormatType string
+
+const (
+	ResponseFormatTypeText       CohereResponseFormatType = "text"
+	ResponseFormatTypeJSONObject CohereResponseFormatType = "json_object"
 )
 
 // CohereToolChoice represents tool choice configuration


### PR DESCRIPTION
## Summary

Added support for response format configuration in Cohere provider, enabling structured JSON output and schema validation.

## Changes

- Added `ResponseFormat` field to `CohereChatRequest` struct
- Implemented conversion functions between Bifrost and Cohere response format structures
- Added support for JSON schema validation in response formats
- Implemented handling for different response format types (text, json_object)
- Added conversion for response formats in both chat and responses endpoints

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Cohere provider with response format configurations:

```sh
# Core/Transports
go version
go test ./...

# Test with JSON response format
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "cohere/command",
    "messages": [{"role": "user", "content": "List 3 fruits as JSON"}],
    "response_format": {"type": "json_object"}
  }'

# Test with JSON schema validation
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "cohere/command",
    "messages": [{"role": "user", "content": "List 3 fruits with their colors"}],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "schema": {
          "type": "object",
          "properties": {
            "fruits": {
              "type": "array",
              "items": {
                "type": "object",
                "properties": {
                  "name": {"type": "string"},
                  "color": {"type": "string"}
                },
                "required": ["name", "color"]
              }
            }
          },
          "required": ["fruits"]
        }
      }
    }
  }'
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Enhances JSON output capabilities for Cohere models, similar to functionality available in OpenAI.

## Security considerations

No additional security implications as this only affects response formatting.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable