### PR TITLE
feat: force sync datasheet and above 200k pricing

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -83,6 +83,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddBatchAndCachePricingColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAdd200kTokenPricingColumns(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationMoveKeysToProviderConfig(ctx, db); err != nil {
 		return err
 	}
@@ -1135,6 +1138,54 @@ func migrationAddBatchAndCachePricingColumns(ctx context.Context, db *gorm.DB) e
 			}
 			if err := migrator.DropColumn(&tables.TableModelPricing{}, "output_cost_per_token_batches"); err != nil {
 				return err
+			}
+			return nil
+		},
+	}})
+	return m.Migrate()
+}
+
+// migrationAdd200kTokenPricingColumns adds pricing columns for 200k token tier models
+func migrationAdd200kTokenPricingColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_200k_token_pricing_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			columns := []string{
+				"input_cost_per_token_above_200k_tokens",
+				"output_cost_per_token_above_200k_tokens",
+				"cache_creation_input_token_cost_above_200k_tokens",
+				"cache_read_input_token_cost_above_200k_tokens",
+			}
+
+			for _, field := range columns {
+				if !migrator.HasColumn(&tables.TableModelPricing{}, field) {
+					if err := migrator.AddColumn(&tables.TableModelPricing{}, field); err != nil {
+						return fmt.Errorf("failed to add column %s: %w", field, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			columns := []string{
+				"input_cost_per_token_above_200k_tokens",
+				"output_cost_per_token_above_200k_tokens",
+				"cache_creation_input_token_cost_above_200k_tokens",
+				"cache_read_input_token_cost_above_200k_tokens",
+			}
+
+			for _, field := range columns {
+				if migrator.HasColumn(&tables.TableModelPricing{}, field) {
+					if err := migrator.DropColumn(&tables.TableModelPricing{}, field); err != nil {
+						return fmt.Errorf("failed to drop column %s: %w", field, err)
+					}
+				}
 			}
 			return nil
 		},

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -27,6 +27,12 @@ type TableModelPricing struct {
 	OutputCostPerTokenAbove128kTokens         *float64 `gorm:"default:null" json:"output_cost_per_token_above_128k_tokens,omitempty"`
 	OutputCostPerCharacterAbove128kTokens     *float64 `gorm:"default:null" json:"output_cost_per_character_above_128k_tokens,omitempty"`
 
+	//Pricing above 200k tokens (for gemini and claude models)
+	InputCostPerTokenAbove200kTokens           *float64 `gorm:"default:null" json:"input_cost_per_token_above_200k_tokens,omitempty"`
+	OutputCostPerTokenAbove200kTokens          *float64 `gorm:"default:null" json:"output_cost_per_token_above_200k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove200kTokens *float64 `gorm:"default:null" json:"cache_creation_input_token_cost_above_200k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove200kTokens     *float64 `gorm:"default:null" json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
+
 	// Cache and batch pricing
 	CacheReadInputTokenCost     *float64 `gorm:"default:null" json:"cache_read_input_token_cost,omitempty"`
 	CacheCreationInputTokenCost *float64 `gorm:"default:null" json:"cache_creation_input_token_cost,omitempty"`

--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -1,0 +1,16 @@
+package modelcatalog
+
+import "time"
+
+const (
+	DefaultPricingSyncInterval = 24 * time.Hour
+	ConfigLastPricingSyncKey   = "LastModelPricingSync"
+	DefaultPricingURL          = "https://getbifrost.ai/datasheet"
+	DefaultPricingTimeout      = 45 * time.Second
+)
+
+// Config is the model pricing configuration.
+type Config struct {
+	PricingURL          *string        `json:"pricing_url,omitempty"`
+	PricingSyncInterval *time.Duration `json:"pricing_sync_interval,omitempty"`
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -223,12 +223,16 @@ func (mc *ModelCatalog) CalculateCostFromUsage(provider string, model string, de
 		// Use audio-specific token pricing if available
 		audioTokens := float64(audioTokenDetails.AudioTokens)
 		textTokens := float64(audioTokenDetails.TextTokens)
+		isAbove200k := totalTokens > TokenTierAbove200K
 		isAbove128k := totalTokens > TokenTierAbove128K
 
 		// Determine the appropriate token pricing rates
 		var inputTokenRate, outputTokenRate float64
 
-		if isAbove128k {
+		if isAbove200k {
+			inputTokenRate = getSafeFloat64(pricing.InputCostPerTokenAbove200kTokens, pricing.InputCostPerToken)
+			outputTokenRate = getSafeFloat64(pricing.OutputCostPerTokenAbove200kTokens, pricing.OutputCostPerToken)
+		} else if isAbove128k {
 			inputTokenRate = getSafeFloat64(pricing.InputCostPerTokenAbove128kTokens, pricing.InputCostPerToken)
 			outputTokenRate = getSafeFloat64(pricing.OutputCostPerTokenAbove128kTokens, pricing.OutputCostPerToken)
 		} else {

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -134,9 +134,8 @@ func (mc *ModelCatalog) syncPricing(ctx context.Context) error {
 // loadPricingFromURL loads pricing data from the remote URL
 func (mc *ModelCatalog) loadPricingFromURL(ctx context.Context) (map[string]PricingEntry, error) {
 	// Create HTTP client with timeout
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
+	client := &http.Client{}
+	client.Timeout = DefaultPricingTimeout
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mc.getPricingURL(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -96,6 +96,12 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 		OutputCostPerTokenAbove128kTokens:         entry.OutputCostPerTokenAbove128kTokens,
 		OutputCostPerCharacterAbove128kTokens:     entry.OutputCostPerCharacterAbove128kTokens,
 
+		//Pricing above 200k tokens (for gemini models)
+		InputCostPerTokenAbove200kTokens:           entry.InputCostPerTokenAbove200kTokens,
+		OutputCostPerTokenAbove200kTokens:          entry.OutputCostPerTokenAbove200kTokens,
+		CacheCreationInputTokenCostAbove200kTokens: entry.CacheCreationInputTokenCostAbove200kTokens,
+		CacheReadInputTokenCostAbove200kTokens:     entry.CacheReadInputTokenCostAbove200kTokens,
+
 		// Cache and batch pricing
 		CacheReadInputTokenCost:   entry.CacheReadInputTokenCost,
 		InputCostPerTokenBatches:  entry.InputCostPerTokenBatches,
@@ -108,25 +114,29 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 // convertTableModelPricingToPricingData converts the TableModelPricing struct to a DataSheetPricingEntry struct
 func convertTableModelPricingToPricingData(pricing *configstoreTables.TableModelPricing) *PricingEntry {
 	return &PricingEntry{
-		Provider:                                  pricing.Provider,
-		Mode:                                      pricing.Mode,
-		InputCostPerToken:                         pricing.InputCostPerToken,
-		OutputCostPerToken:                        pricing.OutputCostPerToken,
-		InputCostPerImage:                         pricing.InputCostPerImage,
-		InputCostPerVideoPerSecond:                pricing.InputCostPerVideoPerSecond,
-		InputCostPerAudioPerSecond:                pricing.InputCostPerAudioPerSecond,
-		InputCostPerCharacter:                     pricing.InputCostPerCharacter,
-		OutputCostPerCharacter:                    pricing.OutputCostPerCharacter,
-		InputCostPerTokenAbove128kTokens:          pricing.InputCostPerTokenAbove128kTokens,
-		InputCostPerCharacterAbove128kTokens:      pricing.InputCostPerCharacterAbove128kTokens,
-		InputCostPerImageAbove128kTokens:          pricing.InputCostPerImageAbove128kTokens,
-		InputCostPerVideoPerSecondAbove128kTokens: pricing.InputCostPerVideoPerSecondAbove128kTokens,
-		InputCostPerAudioPerSecondAbove128kTokens: pricing.InputCostPerAudioPerSecondAbove128kTokens,
-		OutputCostPerTokenAbove128kTokens:         pricing.OutputCostPerTokenAbove128kTokens,
-		OutputCostPerCharacterAbove128kTokens:     pricing.OutputCostPerCharacterAbove128kTokens,
-		CacheReadInputTokenCost:                   pricing.CacheReadInputTokenCost,
-		InputCostPerTokenBatches:                  pricing.InputCostPerTokenBatches,
-		OutputCostPerTokenBatches:                 pricing.OutputCostPerTokenBatches,
+		Provider:                                   pricing.Provider,
+		Mode:                                       pricing.Mode,
+		InputCostPerToken:                          pricing.InputCostPerToken,
+		OutputCostPerToken:                         pricing.OutputCostPerToken,
+		InputCostPerImage:                          pricing.InputCostPerImage,
+		InputCostPerVideoPerSecond:                 pricing.InputCostPerVideoPerSecond,
+		InputCostPerAudioPerSecond:                 pricing.InputCostPerAudioPerSecond,
+		InputCostPerCharacter:                      pricing.InputCostPerCharacter,
+		OutputCostPerCharacter:                     pricing.OutputCostPerCharacter,
+		InputCostPerTokenAbove128kTokens:           pricing.InputCostPerTokenAbove128kTokens,
+		InputCostPerCharacterAbove128kTokens:       pricing.InputCostPerCharacterAbove128kTokens,
+		InputCostPerImageAbove128kTokens:           pricing.InputCostPerImageAbove128kTokens,
+		InputCostPerVideoPerSecondAbove128kTokens:  pricing.InputCostPerVideoPerSecondAbove128kTokens,
+		InputCostPerAudioPerSecondAbove128kTokens:  pricing.InputCostPerAudioPerSecondAbove128kTokens,
+		OutputCostPerTokenAbove128kTokens:          pricing.OutputCostPerTokenAbove128kTokens,
+		OutputCostPerCharacterAbove128kTokens:      pricing.OutputCostPerCharacterAbove128kTokens,
+		InputCostPerTokenAbove200kTokens:           pricing.InputCostPerTokenAbove200kTokens,
+		OutputCostPerTokenAbove200kTokens:          pricing.OutputCostPerTokenAbove200kTokens,
+		CacheCreationInputTokenCostAbove200kTokens: pricing.CacheCreationInputTokenCostAbove200kTokens,
+		CacheReadInputTokenCostAbove200kTokens:     pricing.CacheReadInputTokenCostAbove200kTokens,
+		CacheReadInputTokenCost:                    pricing.CacheReadInputTokenCost,
+		InputCostPerTokenBatches:                   pricing.InputCostPerTokenBatches,
+		OutputCostPerTokenBatches:                  pricing.OutputCostPerTokenBatches,
 	}
 }
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -26,6 +26,7 @@ type ConfigManager interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
 	ReloadPricingManager(ctx context.Context) error
+	ForceReloadPricing(ctx context.Context) error
 	UpdateDropExcessRequests(ctx context.Context, value bool)
 	ReloadPlugin(ctx context.Context, name string, path *string, pluginConfig any) error
 	ReloadProxyConfig(ctx context.Context, config *configstoreTables.GlobalProxyConfig) error
@@ -55,6 +56,7 @@ func (h *ConfigHandler) RegisterRoutes(r *router.Router, middlewares ...lib.Bifr
 	r.GET("/api/version", lib.ChainMiddlewares(h.getVersion, middlewares...))
 	r.GET("/api/proxy-config", lib.ChainMiddlewares(h.getProxyConfig, middlewares...))
 	r.PUT("/api/proxy-config", lib.ChainMiddlewares(h.updateProxyConfig, middlewares...))
+	r.POST("/api/pricing/force-sync", lib.ChainMiddlewares(h.forceSyncPricing, middlewares...))
 }
 
 // getVersion handles GET /api/version - Get the current version
@@ -104,7 +106,7 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		} else if h.store.FrameworkConfig.Pricing != nil && h.store.FrameworkConfig.Pricing.PricingURL != nil {
 			mapConfig["framework_config"] = configstoreTables.TableFrameworkConfig{
 				PricingURL:          h.store.FrameworkConfig.Pricing.PricingURL,
-				PricingSyncInterval: bifrost.Ptr(int64(*h.store.FrameworkConfig.Pricing.PricingSyncInterval)),
+				PricingSyncInterval: bifrost.Ptr(int64((*h.store.FrameworkConfig.Pricing.PricingSyncInterval).Seconds())),
 			}
 		}
 	}
@@ -381,6 +383,26 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]any{
 		"status":  "success",
 		"message": "configuration updated successfully",
+	})
+}
+
+// forceSyncPricing triggers an immediate pricing sync and resets the pricing sync timer
+func (h *ConfigHandler) forceSyncPricing(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	if err := h.configManager.ForceReloadPricing(ctx); err != nil {
+		logger.Warn(fmt.Sprintf("failed to force pricing sync: %v", err))
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to force pricing sync: %v", err))
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": "pricing sync triggered",
 	})
 }
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -61,6 +61,7 @@ type ServerCallbacks interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
 	ReloadPricingManager(ctx context.Context) error
+	ForceReloadPricing(ctx context.Context) error
 	ReloadProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
 	UpdateDropExcessRequests(ctx context.Context, value bool)
 	ReloadTeam(ctx context.Context, id string) (*tables.TableTeam, error)
@@ -815,6 +816,14 @@ func (s *BifrostHTTPServer) ReloadPricingManager(ctx context.Context) error {
 		return fmt.Errorf("framework config not found")
 	}
 	return s.Config.PricingManager.ReloadPricing(ctx, s.Config.FrameworkConfig.Pricing)
+}
+
+// ForceReloadPricing triggers an immediate pricing sync and resets the sync timer
+func (s *BifrostHTTPServer) ForceReloadPricing(ctx context.Context) error {
+	if s.Config == nil || s.Config.PricingManager == nil {
+		return fmt.Errorf("pricing manager not found")
+	}
+	return s.Config.PricingManager.ForceReloadPricing(ctx)
 }
 
 // ReloadProxyConfig reloads the proxy configuration

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } from "@/lib/store";
+import { getErrorMessage, useForcePricingSyncMutation, useGetCoreConfigQuery, useUpdateCoreConfigMutation } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -19,6 +19,7 @@ export default function PricingConfigView() {
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const config = bifrostConfig?.framework_config;
 	const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
+	const [forcePricingSync, { isLoading: isForceSyncing }] = useForcePricingSyncMutation();
 
 	const {
 		register,
@@ -69,6 +70,15 @@ export default function PricingConfigView() {
 		}
 	};
 
+	const handleForceSync = async () => {
+		try {
+			await forcePricingSync().unwrap();
+			toast.success("Pricing sync triggered successfully.");
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
+
 	return (
 		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
 			<div className="flex items-center justify-between">
@@ -76,9 +86,19 @@ export default function PricingConfigView() {
 					<h2 className="text-2xl font-semibold tracking-tight">Pricing Configuration</h2>
 					<p className="text-muted-foreground text-sm">Configure custom pricing datasheet and sync intervals.</p>
 				</div>
-				<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
-					{isLoading ? "Saving..." : "Save Changes"}
-				</Button>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="outline"
+						type="button"
+						onClick={handleForceSync}
+						disabled={isForceSyncing || !hasSettingsUpdateAccess}
+					>
+						{isForceSyncing ? "Forcing..." : "Force Sync Now"}
+					</Button>
+					<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
+						{isLoading ? "Saving..." : "Save Changes"}
+					</Button>
+				</div>
 			</div>
 
 			<div className="space-y-4">

--- a/ui/lib/store/apis/configApi.ts
+++ b/ui/lib/store/apis/configApi.ts
@@ -86,6 +86,15 @@ export const configApi = baseApi.injectEndpoints({
 			}),
 			invalidatesTags: ["Config"],
 		}),
+
+		// Force a pricing sync immediately
+		forcePricingSync: builder.mutation<null, void>({
+			query: () => ({
+				url: "/pricing/force-sync",
+				method: "POST",
+			}),
+			invalidatesTags: ["Config"],
+		}),
 	}),
 });
 
@@ -94,6 +103,7 @@ export const {
 	useGetCoreConfigQuery,
 	useUpdateCoreConfigMutation,
 	useUpdateProxyConfigMutation,
+	useForcePricingSyncMutation,
 	useLazyGetCoreConfigQuery,
 	useGetLatestReleaseQuery,
 	useLazyGetLatestReleaseQuery,


### PR DESCRIPTION
## Summary
- Added force sync button for updating datasheet
- Added support for 200k token tier pricing for models like Gemini and Claude, including database migrations, UI controls, and pricing calculation logic.

## Changes

- Added new database columns for 200k token tier pricing in the model pricing table
- Created a database migration to add the new pricing columns
- Updated pricing calculation logic to consider the 200k token tier
- Added a "Force Sync Now" button in the UI to trigger immediate pricing data synchronization
- Implemented a new API endpoint `/api/pricing/force-sync` to manually trigger pricing updates

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshot 

![image.png](https://app.graphite.com/user-attachments/assets/f02a6c04-f10c-4339-87bc-d3e337fc7e40.png)

![image.png](https://app.graphite.com/user-attachments/assets/24c74ff7-9eef-4eb7-b7c0-eb4ec8b5a669.png)

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

#949 #993

## Security considerations
None

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable