### PR TITLE
feat: custom key selection by name using headers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2748,6 +2748,22 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *context.Context, requ
 		return schemas.Key{}, fmt.Errorf("no keys found that support model: %s", model)
 	}
 
+	var requestedKeyName string
+	if ctx != nil {
+		if keyName, ok := (*ctx).Value(schemas.BifrostContextKeyAPIKeyName).(string); ok {
+			requestedKeyName = strings.TrimSpace(keyName)
+		}
+	}
+
+	if requestedKeyName != "" {
+		for _, key := range supportedKeys {
+			if key.Name == requestedKeyName {
+				return key, nil
+			}
+		}
+		return schemas.Key{}, fmt.Errorf("no key found with name %q for provider: %v", requestedKeyName, providerKey)
+	}
+
 	if len(supportedKeys) == 1 {
 		return supportedKeys[0], nil
 	}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -103,6 +103,7 @@ type BifrostContextKey string
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
 	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                      // string
+	BifrostContextKeyAPIKeyName                          BifrostContextKey = "x-bf-api-key"                 // string (explicit key name selection)
 	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                   // string
 	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"          // string
 	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"           // Key struct

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -11,6 +11,7 @@ var NoDeadline time.Time
 
 var reservedKeys = []any{
 	BifrostContextKeyVirtualKey,
+	BifrostContextKeyAPIKeyName,
 	BifrostContextKeyRequestID,
 	BifrostContextKeyFallbackRequestID,
 	BifrostContextKeyDirectKey,

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -162,6 +162,12 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool) (*c
 			bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKeyVirtualKey, string(value))
 			return true
 		}
+		if keyStr == "x-bf-api-key" {
+			if keyName := strings.TrimSpace(string(value)); keyName != "" {
+				bifrostCtx = context.WithValue(bifrostCtx, schemas.BifrostContextKeyAPIKeyName, keyName)
+			}
+			return true
+		}
 		// Handle cache key header (x-bf-cache-key)
 		if keyStr == "x-bf-cache-key" {
 			bifrostCtx = context.WithValue(bifrostCtx, semanticcache.CacheKey, string(value))


### PR DESCRIPTION
## Summary

Added support for explicit API key selection via a new context key. This allows clients to request a specific API key by name when making requests to Bifrost.

## Changes

- Added a new context key `BifrostContextKeyAPIKeyName` to allow explicit selection of API keys by name
- Implemented key selection logic in `selectKeyFromProviderForModel` to prioritize explicitly requested keys
- Added support for the `x-bf-api-key` HTTP header in the HTTP transport
- Updated the reserved keys list to include the new context key

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

1. Configure multiple API keys for a provider using ui
2. Make a request to Bifrost with the `x-bf-api-key` header set to a specific key name
3. Verify that the specified key is used for the request

```sh
# Test with curl
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-bf-api-key: <API_KEY_NAME>" \
  -d '{
    "model": "anthropic/claude-haiku-4-5",
    "messages": [{"role": "user", "content": "Hello, Bifrost!"}]
  }'
```

## Breaking changes

- [x] No

## Related issues

#901

## Security considerations

None

## Checklist

- [X] I read docs/contributing/README.md and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)