### PR TITLE
feat: x-bf-eh extra header key

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -125,7 +125,7 @@ const (
 	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"       // int (to store the fallback index (set by bifrost)) 0 for primary, 1 for first fallback, etc.
 	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator" // bool (set by bifrost)
 	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"   // bool (will pass an empty key to the provider)
-	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"        // map[string]string
+	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"        // map[string][]string
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"       // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
 	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -211,6 +211,59 @@ For cloud providers with deployment-based routing, Bifrost validates deployment 
 3. Exclude keys without proper deployment mapping
 4. Continue with standard weighted selection
 
+## Custom Key Usage (By Name)
+
+Bifrost also supports referencing a stored provider key by name instead of sending the raw secret. This can be useful when you want callers to reference logical key names (for example, `openai-key-1`) and let the gateway resolve the actual secret from configured provider keys.
+
+How to use:
+- Header: send `x-bf-api-key: <key-name>` on the request. The gateway will look up the named key and use its secret for the upstream provider call.
+- Context (server-side / Go): set the API key name in the Bifrost context so internal callers can request the named key. For example:
+
+From a client SDK call you can set the name directly on your request context:
+
+```go
+ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyName, "openai-key-1")
+```
+
+Note: `x-bf-api-key` and the `BifrostContextKeyAPIKeyName` value reference a stored key name (not the raw secret). The gateway will resolve the named key against configured provider keys and apply model filtering, deployment mapping and weighted selection as usual.
+
+```bash
+# Example: request referencing a stored key name that doesn't exist
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-bf-api-key: non_existant_key" \
+  -d '{
+    "model": "anthropic/claude-haiku-4-5",
+    "messages": [{"role": "user", "content": "Hello, Bifrost!"}]
+  }'
+```
+
+Response (example):
+
+```json
+{"is_bifrost_error":false,"error":{"error":"no key found with name \"non_existant_key\" for provider: anthropic","message":"no key found with name \"non_existant_key\" for provider: anthropic"},"extra_fields":{"provider":"anthropic","model_requested":"claude-haiku-4-5","request_type":"chat_completion"}}
+```
+
+# Example: request referencing a stored key name that exists but no configured keys support the requested model
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "x-bf-api-key: key_with_model_disabled" \
+  -d '{
+    "model": "anthropic/claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "Hello, Bifrost!"}]
+  }'
+```
+
+Response (example):
+
+```json
+{"is_bifrost_error":false,"error":{"error":"no keys found that support model: claude-sonnet-4-5","message":"no keys found that support model: claude-sonnet-4-5"},"extra_fields":{"provider":"anthropic","model_requested":"claude-sonnet-4-5","request_type":"chat_completion"}}
+```
+
+Note: This is not a weighted selection, by providing a specific key name you are explicitly telling Bifrost which stored key to use, so weighted distribution is bypassed. The example above demonstrates the error returned when a referenced key name cannot be resolved.
+
 ## Direct Key Bypass
 
 For scenarios requiring explicit key control, Bifrost supports bypassing the entire key management system:

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -574,6 +574,51 @@ curl --location 'http://localhost:8080/api/providers' \
 
 </Tabs>
 
+### Custom Headers Per Request
+
+Send custom headers with individual requests using the `x-bf-eh-*` prefix. Headers are automatically propagated to the provider and stored in the request context. This is useful for passing request-specific metadata, user identification, or custom tracking information.
+
+```bash
+ curl --location 'http://localhost:8080/v1/chat/completions' \
+    --header 'Content-Type: application/json' \
+    --header 'x-bf-eh-custom-data: example-value' \
+    --header 'x-bf-eh-tracking-id: trace-123' \
+    --data '{
+     "model": "openai/gpt-4o-mini",
+     "messages": [
+         {"role": "user", "content": "Hello!"}
+     ]
+    }'
+```
+
+
+Internally, Bifrost maintains a denylist of headers that are never forwarded to providers to prevent header-based overrides (authorization, host, content-length, etc.) and to block attempts to override API keys or virtual keys via `x-bf-eh-*` headers. For reference, the denylist looks like this:
+
+```go
+denylist := map[string]bool{
+    "authorization":       true,
+    "proxy-authorization": true,
+    "cookie":              true,
+    "host":                true,
+    "content-length":      true,
+    "connection":          true,
+    "transfer-encoding":   true,
+
+    // prevent auth/key overrides via x-bf-eh-*
+    "x-api-key":      true,
+    "x-goog-api-key": true,
+    "x-bf-api-key":   true,
+    "x-bf-vk":        true,
+}
+```
+
+This denylist is applied before propagating `x-bf-eh-*` headers to upstream providers.
+**Example use cases:**
+- User identification: `x-bf-eh-user-id`, `x-bf-eh-tenant-id`
+- Request tracking: `x-bf-eh-correlation-id`, `x-bf-eh-trace-id`
+- Custom metadata: `x-bf-eh-department`, `x-bf-eh-cost-center`
+- A/B testing: `x-bf-eh-experiment-id`, `x-bf-eh-variant`
+
 ### Setting Up a Proxy
 
 Route requests through proxies for compliance, security, or geographic requirements. This example shows both HTTP proxy for OpenAI and authenticated SOCKS5 proxy for Anthropic, useful for corporate environments or regional access.

--- a/docs/quickstart/go-sdk/provider-configuration.mdx
+++ b/docs/quickstart/go-sdk/provider-configuration.mdx
@@ -197,6 +197,75 @@ func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schem
 }
 ```
 
+### Custom Headers Per Request
+
+Send custom headers with individual requests by adding them to the request context. Headers are automatically propagated to the provider. This is useful for passing request-specific metadata, user identification, or custom tracking information.
+
+```go
+import (
+    "context"
+    "github.com/maximhq/bifrost/core/schemas"
+)
+
+func makeRequestWithCustomHeaders() {
+    // Create base context
+    ctx := context.Background()
+    
+    // Add custom headers using BifrostContextKeyExtraHeaders
+    extraHeaders := map[string][]string{
+        "user-id":       {"user-123"},
+        "session-id":    {"session-abc"},
+        "custom-metadata": {"value1", "value2"}, // Multiple values supported
+    }
+    ctx = context.WithValue(ctx, schemas.BifrostContextKeyExtraHeaders, extraHeaders)
+    
+    // Make request with custom headers
+    response, err := client.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+        Provider: schemas.OpenAI,
+        Model:    "gpt-4o-mini",
+        Input:    messages,
+    })
+    if err != nil {
+        // Handle error
+    }
+}
+```
+
+**How it works:**
+- Headers are stored as `map[string][]string` in the context
+- Multiple values per header name are supported
+- Header names are case-insensitive and normalized to lowercase
+- Headers are accessible throughout the request lifecycle
+- Sensitive headers (authorization, cookie, etc.) are blocked for security
+
+**Example use cases:**
+- User identification: `user-id`, `tenant-id`
+- Request tracking: `correlation-id`, `trace-id`
+- Custom metadata: `department`, `cost-center`
+- A/B testing: `experiment-id`, `variant`
+
+Internally, Bifrost maintains a denylist of headers that are never forwarded to providers to prevent header-based overrides (authorization, host, content-length, etc.) and to block attempts to override API keys or virtual keys via `x-bf-eh-*` headers. For reference, the denylist looks like this:
+
+```go
+denylist := map[string]bool{
+    "authorization":       true,
+    "proxy-authorization": true,
+    "cookie":              true,
+    "host":                true,
+    "content-length":      true,
+    "connection":          true,
+    "transfer-encoding":   true,
+
+    // prevent auth/key overrides via x-bf-eh-*
+    "x-api-key":      true,
+    "x-goog-api-key": true,
+    "x-bf-api-key":   true,
+    "x-bf-vk":        true,
+}
+```
+
+This denylist is applied before propagating `x-bf-eh-*` headers to upstream providers.
+
 ### Setting Up a Proxy
 
 Route requests through proxies for compliance, security, or geographic requirements. This example shows both HTTP proxy for OpenAI and authenticated SOCKS5 proxy for Anthropic, useful for corporate environments or regional access.

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,2 +1,3 @@
+- feat: added force sync function in pricing and pricing according to 200k token
 - feat: adds logging support for batch and file requests
 - chore: upgrades core to 1.2.38 and framework to 1.1.48

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,6 @@
+- feat: add `x-bf-api-key` header to send requests with a key by name
+- feat: parse `x-bf-eh-*` request headers as extra headers
+- feat: addded api endpoint for /api/pricing/force-syncfeat: support for raw response accumulation for streaming
 - feat: add support for enabling/disabling provider keys without deletion.
 - feat: add batch api support for OpenAI, Anthropic, Google Gemini and Bedrock <Badge color="blue">Beta</Badge>.
 - feat: new provider support - nebius.


### PR DESCRIPTION
## Summary

Added support for extra headers in Bifrost HTTP transport by collecting headers prefixed with `x-bf-eh-` and storing them in the context.

## Changes

- Added functionality to collect HTTP headers prefixed with `x-bf-eh-` during request processing
- Created an `extraHeaders` map to store these headers with the prefix removed
- Added the collected headers to the Bifrost context under `schemas.BifrostContextKeyExtraHeaders`

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test by sending HTTP requests with headers prefixed with `x-bf-eh-`:

```sh
# Send a request with extra headers
curl -X POST http://localhost:8080/v1/chat/completions \
     -H "x-bf-eh-custom-data: test-value" \ 
     -H "x-bf-eh-tracking-id: abc123"  \
     -H "Content-Type: application/json" \
     -d '{
         "model": "openai/gpt-4o-mini",
         "messages": [{"role": "user", "content": "Hello, Bifrost!"}]
      }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

#944

## Security considerations

None
## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable