### PR TITLE
fixed parsing error in changelog

### DIFF
--- a/docs/changelogs/v1.3.44.mdx
+++ b/docs/changelogs/v1.3.44.mdx
@@ -18,7 +18,7 @@ description: "v1.3.44 changelog - 2025-12-10"
 
 <Update label="Bifrost(HTTP)" description="1.3.44">
 - feat: adds rbac support across all pages
-- fix: fixes config.json <-> config store streaming cases for virtual keys, providers and keys. Improved test coverage for this flow.
+- fix: fixes config.json - config store streaming cases for virtual keys, providers and keys. Improved test coverage for this flow.
 - fix: adds support for text streaming logging
 
 </Update>


### PR DESCRIPTION
## Summary

Fix HTML entity in changelog documentation for better readability and correctness.

## Changes

- Changed HTML entity `<->` to a hyphen `-` in the changelog documentation to properly display the relationship between config.json and config store streaming cases

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the changelog displays correctly in the documentation:

```sh
# Build and serve docs
cd docs
npm install
npm run dev
```

Navigate to the v1.3.44 changelog page and confirm the text appears correctly with a hyphen instead of HTML entities.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable