### PR TITLE
[fix] pass service_tier correctly to/from Bedrock

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -85,6 +85,7 @@ func TestBifrostToBedrockRequestConversion(t *testing.T) {
 	stop := testStop
 	trace := testTrace
 	latency := testLatency
+	serviceTier := "priority"
 	props := testProps
 
 	tests := []struct {
@@ -203,6 +204,73 @@ func TestBifrostToBedrockRequestConversion(t *testing.T) {
 					Temperature:   &temp,
 					TopP:          &topP,
 					StopSequences: stop,
+				},
+			},
+		},
+		{
+			name: "ServiceTierProvided",
+			input: &schemas.BifrostChatRequest{
+				Model: "claude-3-sonnet",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hello!"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					ServiceTier: &serviceTier,
+				},
+			},
+			expected: &bedrock.BedrockConverseRequest{
+				ModelID: "claude-3-sonnet",
+				Messages: []bedrock.BedrockMessage{
+					{
+						Role: bedrock.BedrockMessageRoleUser,
+						Content: []bedrock.BedrockContentBlock{
+							{
+								Text: schemas.Ptr("Hello!"),
+							},
+						},
+					},
+				},
+				InferenceConfig: &bedrock.BedrockInferenceConfig{},
+				ServiceTier: &bedrock.BedrockServiceTier{
+					Type: serviceTier,
+				},
+			},
+		},
+		{
+			name: "ServiceTierNotProvided",
+			input: &schemas.BifrostChatRequest{
+				Model: "claude-3-sonnet",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hello!"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					Temperature: &temp,
+				},
+			},
+			expected: &bedrock.BedrockConverseRequest{
+				ModelID: "claude-3-sonnet",
+				Messages: []bedrock.BedrockMessage{
+					{
+						Role: bedrock.BedrockMessageRoleUser,
+						Content: []bedrock.BedrockContentBlock{
+							{
+								Text: schemas.Ptr("Hello!"),
+							},
+						},
+					},
+				},
+				InferenceConfig: &bedrock.BedrockInferenceConfig{
+					Temperature: &temp,
 				},
 			},
 		},

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -178,6 +178,10 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(model string) (*s
 		},
 	}
 
+	if response.ServiceTier != nil && *response.ServiceTier != "" {
+		bifrostResponse.ServiceTier = response.ServiceTier
+	}
+
 	return bifrostResponse, nil
 }
 

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -178,8 +178,8 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(model string) (*s
 		},
 	}
 
-	if response.ServiceTier != nil && *response.ServiceTier != "" {
-		bifrostResponse.ServiceTier = response.ServiceTier
+	if response.ServiceTier != nil && response.ServiceTier.Type != "" {
+		bifrostResponse.ServiceTier = &response.ServiceTier.Type
 	}
 
 	return bifrostResponse, nil

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -477,7 +477,9 @@ func ToBedrockResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Be
 		bedrockReq.InferenceConfig = inferenceConfig
 
 		if bifrostReq.Params.ServiceTier != nil {
-			bedrockReq.ServiceTier = bifrostReq.Params.ServiceTier
+			bedrockReq.ServiceTier = &BedrockServiceTier{
+				Type: *bifrostReq.Params.ServiceTier,
+			}
 		}
 	}
 
@@ -659,8 +661,8 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse() (*schemas.
 		bifrostResp.Output = outputMessages
 	}
 
-	if response.ServiceTier != nil && *response.ServiceTier != "" {
-		bifrostResp.ServiceTier = response.ServiceTier
+	if response.ServiceTier != nil && response.ServiceTier.Type != "" {
+		bifrostResp.ServiceTier = &response.ServiceTier.Type
 	}
 
 	return bifrostResp, nil

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -475,6 +475,10 @@ func ToBedrockResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Be
 		}
 
 		bedrockReq.InferenceConfig = inferenceConfig
+
+		if bifrostReq.Params.ServiceTier != nil {
+			bedrockReq.ServiceTier = bifrostReq.Params.ServiceTier
+		}
 	}
 
 	// Convert tools
@@ -653,6 +657,10 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse() (*schemas.
 	if response.Output != nil && response.Output.Message != nil {
 		outputMessages := convertBedrockMessageToResponsesMessages(*response.Output.Message)
 		bifrostResp.Output = outputMessages
+	}
+
+	if response.ServiceTier != nil && *response.ServiceTier != "" {
+		bifrostResp.ServiceTier = response.ServiceTier
 	}
 
 	return bifrostResp, nil

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -53,6 +53,7 @@ type BedrockConverseRequest struct {
 	PerformanceConfig                 *BedrockPerformanceConfig        `json:"performanceConfig,omitempty"`                 // Performance configuration
 	PromptVariables                   map[string]BedrockPromptVariable `json:"promptVariables,omitempty"`                   // Prompt variables for prompt management
 	RequestMetadata                   map[string]string                `json:"requestMetadata,omitempty"`                   // Request metadata
+	ServiceTier                       *string                          `json:"service_tier,omitempty"`                      // Service tier ("reserved" | "priority" | "default" | "flex")
 	Stream                            bool                             `json:"-"`                                           // Whether streaming is requested (internal, not in JSON)
 }
 
@@ -255,6 +256,7 @@ type BedrockConverseResponse struct {
 	Metrics                       *BedrockConverseMetrics   `json:"metrics"`                                 // Required: Response metrics
 	AdditionalModelResponseFields map[string]interface{}    `json:"additionalModelResponseFields,omitempty"` // Optional: Additional model-specific response fields
 	PerformanceConfig             *BedrockPerformanceConfig `json:"performanceConfig,omitempty"`             // Optional: Performance configuration used
+	ServiceTier                   *string                   `json:"service_tier,omitempty"`                  // Optional: Service tier that was used
 	Trace                         *BedrockConverseTrace     `json:"trace,omitempty"`                         // Optional: Guardrail trace information
 }
 

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -40,6 +40,10 @@ func (r *BedrockTextCompletionRequest) IsStreamingRequested() bool {
 	return r.Stream
 }
 
+type BedrockServiceTier struct {
+	Type string `json:"type"` // Service tier type: "reserved" | "priority" | "default" | "flex"
+}
+
 // BedrockConverseRequest represents a Bedrock Converse API request
 type BedrockConverseRequest struct {
 	ModelID                           string                           `json:"-"`                                           // Model ID (sent in URL path, not body)
@@ -53,7 +57,7 @@ type BedrockConverseRequest struct {
 	PerformanceConfig                 *BedrockPerformanceConfig        `json:"performanceConfig,omitempty"`                 // Performance configuration
 	PromptVariables                   map[string]BedrockPromptVariable `json:"promptVariables,omitempty"`                   // Prompt variables for prompt management
 	RequestMetadata                   map[string]string                `json:"requestMetadata,omitempty"`                   // Request metadata
-	ServiceTier                       *string                          `json:"service_tier,omitempty"`                      // Service tier ("reserved" | "priority" | "default" | "flex")
+	ServiceTier                       *BedrockServiceTier              `json:"serviceTier,omitempty"`                       // Service tier configuration (note: camelCase in both request and response)
 	Stream                            bool                             `json:"-"`                                           // Whether streaming is requested (internal, not in JSON)
 }
 
@@ -256,7 +260,7 @@ type BedrockConverseResponse struct {
 	Metrics                       *BedrockConverseMetrics   `json:"metrics"`                                 // Required: Response metrics
 	AdditionalModelResponseFields map[string]interface{}    `json:"additionalModelResponseFields,omitempty"` // Optional: Additional model-specific response fields
 	PerformanceConfig             *BedrockPerformanceConfig `json:"performanceConfig,omitempty"`             // Optional: Performance configuration used
-	ServiceTier                   *string                   `json:"service_tier,omitempty"`                  // Optional: Service tier that was used
+	ServiceTier                   *BedrockServiceTier       `json:"serviceTier,omitempty"`                   // Optional: Service tier that was used
 	Trace                         *BedrockConverseTrace     `json:"trace,omitempty"`                         // Optional: Guardrail trace information
 }
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -42,7 +42,9 @@ func convertChatParameters(bifrostReq *schemas.BifrostChatRequest, bedrockReq *B
 		}
 	}
 	if bifrostReq.Params.ServiceTier != nil {
-		bedrockReq.ServiceTier = bifrostReq.Params.ServiceTier
+		bedrockReq.ServiceTier = &BedrockServiceTier{
+			Type: *bifrostReq.Params.ServiceTier,
+		}
 	}
 	// Add extra parameters
 	if len(bifrostReq.Params.ExtraParams) > 0 {

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -41,6 +41,9 @@ func convertChatParameters(bifrostReq *schemas.BifrostChatRequest, bedrockReq *B
 			},
 		}
 	}
+	if bifrostReq.Params.ServiceTier != nil {
+		bedrockReq.ServiceTier = bifrostReq.Params.ServiceTier
+	}
 	// Add extra parameters
 	if len(bifrostReq.Params.ExtraParams) > 0 {
 		// Handle guardrail configuration

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -29,7 +29,7 @@ type BifrostChatResponse struct {
 	Created           int                        `json:"created"` // The Unix timestamp (in seconds).
 	Model             string                     `json:"model"`
 	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
-	ServiceTier       string                     `json:"service_tier"`
+	ServiceTier       *string                    `json:"service_tier,omitempty"`
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`
 	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -479,7 +479,9 @@ func completeResourceSpan(
 			params = append(params, kvStr("gen_ai.chat.object", resp.ChatResponse.Object))
 			params = append(params, kvStr("gen_ai.chat.system_fingerprint", resp.ChatResponse.SystemFingerprint))
 			params = append(params, kvStr("gen_ai.chat.created", fmt.Sprintf("%d", resp.ChatResponse.Created)))
-			params = append(params, kvStr("gen_ai.chat.service_tier", resp.ChatResponse.ServiceTier))
+			if resp.ChatResponse.ServiceTier != nil {
+				params = append(params, kvStr("gen_ai.chat.service_tier", *resp.ChatResponse.ServiceTier))
+			}
 			outputMessages := []*AnyValue{}
 			for _, choice := range resp.ChatResponse.Choices {
 				var role string


### PR DESCRIPTION
## Summary

This PR fixes the way Bifrost passes `service_tier` parameter to/from Bedrock when making non-streaming `/v1/chat/completions` requests. Without this fix it is impossible to use eg. Pydantic AI with Bifrost, when using Bedrock as LLM provider as Pydantic AI's validation of the response from `/v1/chat/completions` will fail.

Closes #1056 .

I was unsure if I should bump `core/version` so I left that one untouched.

## Changes

- Don't return `service_tier` when it is either `nil` or an empty string `""`.
- Assume correct data structure when handling Bedrock's Converse API response.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Make eg. a cURL request to `/v1/chat/completions` with or without `service_tier` parameter.

### Without service_tier parameter

```bash
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
    "messages": [
      {"role": "user", "content": "Hello!"}
    ]
  }'
```

Response, correctly without `service_tier` set at all (removed most of uninteresting parts of the response):

```json
{
  "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
  "object": "chat.completion",
  "system_fingerprint": "",
  "extra_fields": {
    "request_type": "chat_completion",
    "provider": "bedrock",
    "model_requested": "anthropic.claude-sonnet-4-5-20250929-v1:0",
    "model_deployment": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
  }
}
```

### With service_tier set to the request

```bash
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
    "messages": [
      {"role": "user", "content": "Hello!"}
    ],
    "service_tier": "default"
  }'
```

Response, with `service_tier` set correctly:

```json
{
  "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
  "object": "chat.completion",
  "service_tier": "default",
  "system_fingerprint": "",
  "extra_fields": {
    "request_type": "chat_completion",
    "provider": "bedrock",
    "model_requested": "anthropic.claude-sonnet-4-5-20250929-v1:0",
    "model_deployment": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
    "latency": 1791,
    "chunk_index": 0
  }
}
```

## Breaking changes

Should not be a breaking change, as far as I could tell.

- [ ] Yes
- [x] No

## Related issues

Closes #1056 

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


