### PR TITLE
fix: bedrock tool call in chat completion

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -676,7 +676,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx context.Context, key schemas
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockChatCompletionRequest(request) },
+		func() (any, error) { return ToBedrockChatCompletionRequest(&ctx, request) },
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -701,7 +701,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx context.Context, key schemas
 	}
 
 	// Convert using the new response converter
-	bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(request.Model)
+	bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName)
 	}
@@ -737,7 +737,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx context.Context, postH
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockChatCompletionRequest(request) },
+		func() (any, error) { return ToBedrockChatCompletionRequest(&ctx, request) },
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -1,6 +1,7 @@
 package bedrock_test
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -364,7 +365,8 @@ func TestBifrostToBedrockRequestConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := bedrock.ToBedrockChatCompletionRequest(tt.input)
+			ctx := context.Background()
+			actual, err := bedrock.ToBedrockChatCompletionRequest(&ctx, tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, actual)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -117,6 +117,7 @@ const (
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"                     // bool
 	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool
 	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost)
+	BifrostContextKeyStructuredOutputToolName            BifrostContextKey = "bifrost-structured-output-tool-name"              // string (to store the name of the structured output tool (set by bifrost))
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,


### PR DESCRIPTION
## Summary

Improve structured output handling in Bedrock provider by properly tracking and processing JSON response formats through context.

## Changes

- Added context parameter to `ToBedrockChatCompletionRequest` and `ToBifrostChatResponse` functions to maintain state
- Created a new context key `BifrostContextKeyStructuredOutputToolName` to track structured output tool names
- Modified the response processing logic to properly identify and handle structured JSON outputs
- Added a prefix `bf_so_` to structured output tool names for better identification
- Updated the tool conversion logic to store the tool name in context for later reference

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Bedrock provider with structured output requests:

```sh
# Core/Transports
go version
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves JSON structured output handling for Bedrock provider

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable