### PR TITLE
adds back e2e tests

### DIFF
--- a/.github/workflows/scripts/install-cross-compilers.sh
+++ b/.github/workflows/scripts/install-cross-compilers.sh
@@ -28,7 +28,7 @@ echo "🍎 Setting up Darwin cross-compilation..."
 
 # Where to install SDK
 SDK_DIR="/opt/MacOSX11.3.sdk"
-SDK_URL="https://github.com/joseluisq/macosx-sdks/releases/download/11.3/MacOSX11.3.sdk.tar.xz"
+SDK_URL="https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz"
 
 # Download and extract macOS SDK if not already installed
 if [ ! -d "$SDK_DIR" ]; then
@@ -36,7 +36,7 @@ if [ ! -d "$SDK_DIR" ]; then
   # Use -f to fail on HTTP errors, -L to follow redirects
   if ! curl -fL "$SDK_URL" -o /tmp/MacOSX11.3.sdk.tar.xz; then
     echo "❌ Failed to download macOS SDK from primary URL, trying alternative..."
-    SDK_URL_ALT="https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/MacOSX11.3.sdk.tar.xz"
+    SDK_URL_ALT="https://github.com/joseluisq/macosx-sdks/releases/download/11.3/MacOSX11.3.sdk.tar.xz"
     curl -fL "$SDK_URL_ALT" -o /tmp/MacOSX11.3.sdk.tar.xz
   fi
   sudo mkdir -p /opt

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -200,111 +200,150 @@ CONFIGS_TO_TEST=(
 
 TEST_BINARY="../tmp/bifrost-http"
 CONFIGS_DIR="../.github/workflows/configs"
+
+# Cleanup function to ensure Docker services are stopped
+cleanup_docker() {
+  echo "🧹 Cleaning up Docker services..."
+  docker compose -f "$CONFIGS_DIR/docker-compose.yml" down 2>/dev/null || true
+}
+
+# Register cleanup handler to run on script exit (success or failure)
+trap cleanup_docker EXIT
+
 # Running docker compose
-# echo "🐳 Starting Docker services (PostgreSQL, Weaviate, Redis)..."
-# docker compose -f "$CONFIGS_DIR/docker-compose.yml" up -d
+echo "🐳 Starting Docker services (PostgreSQL, Weaviate, Redis)..."
+docker compose -f "$CONFIGS_DIR/docker-compose.yml" up -d
 
-# # Wait for services to be healthy
-# echo "⏳ Waiting for Docker services to be ready..."
-# sleep 10
+# Wait for services to be healthy with polling
+echo "⏳ Waiting for Docker services to be ready..."
+MAX_WAIT=60
+ELAPSED=0
+SERVICES_READY=false
 
-# for config in "${CONFIGS_TO_TEST[@]}"; do
-#   echo "  🔍 Testing with config: $config"
-#   config_path="$CONFIGS_DIR/$config"
+while [ $ELAPSED -lt $MAX_WAIT ]; do
+  # Check if all services are healthy by looking for "healthy" in docker compose ps output
+  HEALTH_STATUS=$(docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps --format json 2>/dev/null | grep -o '"Health":"[^"]*"' | grep -v '"Health":"healthy"' || true)
+  
+  if [ -z "$HEALTH_STATUS" ]; then
+    # All services are healthy (no non-healthy status found)
+    RUNNING_COUNT=$(docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps --status running -q 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$RUNNING_COUNT" -gt 0 ]; then
+      SERVICES_READY=true
+      echo "✅ All Docker services are healthy and ready (${ELAPSED}s)"
+      break
+    fi
+  fi
+  
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  echo "   ⏳ Waiting for services to be healthy... (${ELAPSED}s/${MAX_WAIT}s)"
+done
 
-#   # Clean up databases before each config test for a clean slate
-#   echo "    🧹 Resetting PostgreSQL database..."
-#   # Note: DROP DATABASE cannot run inside a transaction, so we use separate -c flags
-#   # First terminate any active connections, then drop and recreate the database
-#   docker exec "$(docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps -q postgres)" \
-#     psql -U bifrost -d postgres \
-#     -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'bifrost' AND pid <> pg_backend_pid();" \
-#     -c "DROP DATABASE IF EXISTS bifrost;" \
-#     -c "CREATE DATABASE bifrost;"
+if [ "$SERVICES_READY" = false ]; then
+  echo "❌ Docker services failed to become healthy within ${MAX_WAIT}s"
+  echo "   Current service status:"
+  docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps
+  exit 1
+fi
 
-#   echo "    🧹 Cleaning up SQLite database files for config: $config..."
-#   find "$config_path" -type f \( -name "*.db" -o -name "*.db-shm" -o -name "*.db-wal" \) -delete 2>/dev/null || true
-#   echo "    ✅ Database cleanup complete"
+for config in "${CONFIGS_TO_TEST[@]}"; do
+  echo "  🔍 Testing with config: $config"
+  config_path="$CONFIGS_DIR/$config"
+
+  # Clean up databases before each config test for a clean slate
+  echo "    🧹 Resetting PostgreSQL database..."
+  # Note: DROP DATABASE cannot run inside a transaction, so we use separate -c flags
+  # First terminate any active connections, then drop and recreate the database
+  # PGPASSWORD is required for psql authentication (matches POSTGRES_PASSWORD in docker-compose.yml)
+  docker exec -e PGPASSWORD=bifrost_password "$(docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps -q postgres)" \
+    psql -U bifrost -d postgres \
+    -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'bifrost' AND pid <> pg_backend_pid();" \
+    -c "DROP DATABASE IF EXISTS bifrost;" \
+    -c "CREATE DATABASE bifrost;"
+
+  echo "    🧹 Cleaning up SQLite database files for config: $config..."
+  find "$config_path" -type f \( -name "*.db" -o -name "*.db-shm" -o -name "*.db-wal" \) -delete 2>/dev/null || true
+  echo "    ✅ Database cleanup complete"
   
-#   if [ ! -d "$config_path" ]; then
-#     echo "    ⚠️  Warning: Config directory not found: $config_path (skipping)"
-#     continue
-#   fi
+  if [ ! -d "$config_path" ]; then
+    echo "    ⚠️  Warning: Config directory not found: $config_path (skipping)"
+    continue
+  fi
   
-#   # Create a temporary log file for server output
-#   SERVER_LOG=$(mktemp)
+  # Create a temporary log file for server output
+  SERVER_LOG=$(mktemp)
   
-#   # Start the server in background with a timeout, logging to file and console
-#   timeout 30s $TEST_BINARY --app-dir "$config_path" --port 18080 --log-level debug 2>&1 | tee "$SERVER_LOG" &
-#   SERVER_PID=$!
+  # Start the server in background with a timeout, logging to file and console
+  timeout 180s $TEST_BINARY --app-dir "$config_path" --port 18080 --log-level debug 2>&1 | tee "$SERVER_LOG" &
+  SERVER_PID=$!
   
-#   # Wait for server to be ready by looking for the startup message
-#   echo "    ⏳ Waiting for server to start..."
-#   MAX_WAIT=30
-#   ELAPSED=0
-#   SERVER_READY=false
+  # Wait for server to be ready by looking for the startup message
+  echo "    ⏳ Waiting for server to start..."
+  MAX_WAIT=30
+  ELAPSED=0
+  SERVER_READY=false
   
-#   while [ $ELAPSED -lt $MAX_WAIT ]; do
-#     if grep -q "successfully started bifrost, serving UI on http://localhost:18080" "$SERVER_LOG" 2>/dev/null; then
-#       SERVER_READY=true
-#       echo "    ✅ Server started successfully with config: $config"
-#       break
-#     fi
+  while [ $ELAPSED -lt $MAX_WAIT ]; do
+    if grep -q "successfully started bifrost, serving UI on http://localhost:18080" "$SERVER_LOG" 2>/dev/null; then
+      SERVER_READY=true
+      echo "    ✅ Server started successfully with config: $config"
+      break
+    fi
     
-#     # Check if server process is still running
-#     if ! kill -0 $SERVER_PID 2>/dev/null; then
-#       echo "    ❌ Server process died before starting with config: $config"
-#       rm -f "$SERVER_LOG"
-#       exit 1
-#     fi
+    # Check if server process is still running
+    if ! kill -0 $SERVER_PID 2>/dev/null; then
+      echo "    ❌ Server process died before starting with config: $config"
+      rm -f "$SERVER_LOG"
+      exit 1
+    fi
     
-#     sleep 1
-#     ELAPSED=$((ELAPSED + 1))
-#   done
+    sleep 1
+    ELAPSED=$((ELAPSED + 1))
+  done
   
-#   if [ "$SERVER_READY" = false ]; then
-#     echo "    ❌ Server failed to start within ${MAX_WAIT}s with config: $config"
-#     kill $SERVER_PID 2>/dev/null || true
-#     wait $SERVER_PID 2>/dev/null || true
-#     rm -f "$SERVER_LOG"
-#     exit 1
-#   fi
+  if [ "$SERVER_READY" = false ]; then
+    echo "    ❌ Server failed to start within ${MAX_WAIT}s with config: $config"
+    kill $SERVER_PID 2>/dev/null || true
+    wait $SERVER_PID 2>/dev/null || true
+    rm -f "$SERVER_LOG"
+    exit 1
+  fi
   
-#   # Run get_curls.sh to test all GET endpoints
-#   echo "    🧪 Running API endpoint tests..."
-#   echo "    🔍 DEBUG: SCRIPT_DIR=$SCRIPT_DIR"
-#   echo "    🔍 DEBUG: PWD=$(pwd)"
-#   GET_CURLS_SCRIPT="$SCRIPT_DIR/get_curls.sh"
-#   echo "    🔍 DEBUG: GET_CURLS_SCRIPT=$GET_CURLS_SCRIPT"
-#   echo "    🔍 DEBUG: File exists check: $([ -f "$GET_CURLS_SCRIPT" ] && echo 'YES' || echo 'NO')"
+  # Run get_curls.sh to test all GET endpoints
+  echo "    🧪 Running API endpoint tests..."
+  echo "    🔍 DEBUG: SCRIPT_DIR=$SCRIPT_DIR"
+  echo "    🔍 DEBUG: PWD=$(pwd)"
+  GET_CURLS_SCRIPT="$SCRIPT_DIR/get_curls.sh"
+  echo "    🔍 DEBUG: GET_CURLS_SCRIPT=$GET_CURLS_SCRIPT"
+  echo "    🔍 DEBUG: File exists check: $([ -f "$GET_CURLS_SCRIPT" ] && echo 'YES' || echo 'NO')"
   
-#   if [ -f "$GET_CURLS_SCRIPT" ]; then
-#     BASE_URL="http://localhost:18080" "$GET_CURLS_SCRIPT"
-#     CURL_EXIT_CODE=$?
+  if [ -f "$GET_CURLS_SCRIPT" ]; then
+    BASE_URL="http://localhost:18080" "$GET_CURLS_SCRIPT"
+    CURL_EXIT_CODE=$?
     
-#     if [ $CURL_EXIT_CODE -eq 0 ]; then
-#       echo "    ✅ API endpoint tests passed for config: $config"
-#     else
-#       echo "    ❌ API endpoint tests failed for config: $config (exit code: $CURL_EXIT_CODE)"
-#       kill $SERVER_PID 2>/dev/null || true
-#       wait $SERVER_PID 2>/dev/null || true
-#       rm -f "$SERVER_LOG"
-#       exit 1
-#     fi
-#   else
-#     echo "    ⚠️  Warning: get_curls.sh not found at $GET_CURLS_SCRIPT (skipping endpoint tests)"
-#   fi
+    if [ $CURL_EXIT_CODE -eq 0 ]; then
+      echo "    ✅ API endpoint tests passed for config: $config"
+    else
+      echo "    ❌ API endpoint tests failed for config: $config (exit code: $CURL_EXIT_CODE)"
+      kill $SERVER_PID 2>/dev/null || true
+      wait $SERVER_PID 2>/dev/null || true
+      rm -f "$SERVER_LOG"
+      exit 1
+    fi
+  else
+    echo "    ⚠️  Warning: get_curls.sh not found at $GET_CURLS_SCRIPT (skipping endpoint tests)"
+  fi
   
-#   # Kill the server
-#   kill $SERVER_PID 2>/dev/null || true
-#   wait $SERVER_PID 2>/dev/null || true
+  # Kill the server
+  kill $SERVER_PID 2>/dev/null || true
+  wait $SERVER_PID 2>/dev/null || true
   
-#   # Clean up log file
-#   rm -f "$SERVER_LOG"
+  # Clean up log file
+  rm -f "$SERVER_LOG"
   
-#   # Clean up any lingering processes
-#   sleep 1
-# done
+  # Clean up any lingering processes
+  sleep 1
+done
 
 cd ..
 echo "✅ Transport build validation successful"


### PR DESCRIPTION
## Summary

Re-enables the Docker-based integration tests in the Bifrost HTTP release script that were previously commented out.

## Changes

- Uncommented the Docker-based integration test code in the release-bifrost-http.sh script
- This restores the functionality that starts Docker services (PostgreSQL, Weaviate, Redis), tests various configurations, and validates API endpoints

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script to verify that the integration tests execute properly:

```sh
cd .github/workflows/scripts
./release-bifrost-http.sh
```

The script should now run the Docker services, test various configurations, and validate API endpoints.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only affects the CI/CD pipeline.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable