### PR TITLE
heml with enterprise repo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ test-reports
 **/.pytest_cache/
 **/.coverage/
 **/.pytest_cache/
+
+
+# Cursor specific
+.cursor/

--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -6,6 +6,10 @@ icon: "helicopter-symbol"
 
 Deploy Bifrost on Kubernetes using the official Helm chart. This is the recommended way to deploy Bifrost on Kubernetes with production-ready defaults and flexible configuration.
 
+<Note>
+**Latest Chart Version:** 1.5.0 | [View on Artifact Hub](https://artifacthub.io/packages/helm/bifrost/bifrost)
+</Note>
+
 ## Prerequisites
 
 - Kubernetes cluster (v1.19+)
@@ -26,7 +30,7 @@ helm repo update
 ### Install Bifrost
 
 ```bash
-helm install bifrost bifrost/bifrost --set image.tag=v1.3.43
+helm install bifrost bifrost/bifrost --set image.tag=v1.5.0
 ```
 
 <Note>
@@ -56,7 +60,7 @@ Simple setup for local testing and development.
 
 ```bash
 helm install bifrost bifrost/bifrost \
-  --set image.tag=v1.3.43 \
+  --set image.tag=v1.5.0 \
   --set bifrost.providers.openai.keys[0].value="sk-your-key" \
   --set bifrost.providers.openai.keys[0].weight=1
 ```
@@ -83,7 +87,7 @@ High-availability setup with PostgreSQL and auto-scaling.
 ```yaml
 # production.yaml
 image:
-  tag: "v1.3.43"  # Required: specify the Bifrost version
+  tag: "v1.5.0"  # Required: specify the Bifrost version
 
 replicaCount: 3
 
@@ -181,7 +185,7 @@ Optimized for high-volume AI inference with caching.
 ```yaml
 # ai-workload.yaml
 image:
-  tag: "v1.3.43"  # Required: specify the Bifrost version
+  tag: "v1.5.0"  # Required: specify the Bifrost version
 
 storage:
   mode: postgres
@@ -253,7 +257,7 @@ Support multiple LLM providers with load balancing.
 ```yaml
 # multi-provider.yaml
 image:
-  tag: "v1.3.43"  # Required: specify the Bifrost version
+  tag: "v1.5.0"  # Required: specify the Bifrost version
 
 bifrost:
   encryptionKey: "your-encryption-key"
@@ -309,7 +313,7 @@ Use existing PostgreSQL instance.
 ```yaml
 # external-db.yaml
 image:
-  tag: "v1.3.43"  # Required: specify the Bifrost version
+  tag: "v1.5.0"  # Required: specify the Bifrost version
 
 storage:
   mode: postgres
@@ -377,7 +381,7 @@ kubectl create secret generic qdrant-credentials \
 ```yaml
 # secrets-config.yaml
 image:
-  tag: "v1.3.43"
+  tag: "v1.5.0"
 
 storage:
   mode: postgres
@@ -455,7 +459,7 @@ helm install bifrost bifrost/bifrost -f secrets-config.yaml
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `image.tag` | **Required.** Bifrost image version (e.g., v1.3.43) | `""` |
+| `image.tag` | **Required.** Bifrost image version (e.g., v1.5.0) | `""` |
 | `replicaCount` | Number of replicas | `1` |
 | `storage.mode` | Storage backend (sqlite/postgres) | `sqlite` |
 | `storage.persistence.size` | PVC size for SQLite | `10Gi` |
@@ -509,7 +513,7 @@ Or via command line:
 
 ```bash
 helm install bifrost bifrost/bifrost \
-  --set image.tag=v1.3.43 \
+  --set image.tag=v1.5.0 \
   --set bifrost.providers.openai.keys[0].value="sk-..." \
   --set bifrost.providers.openai.keys[0].weight=1
 ```
@@ -727,7 +731,7 @@ Create `my-values.yaml`:
 
 ```yaml
 image:
-  tag: "v1.3.43"  # Required: specify the Bifrost version
+  tag: "v1.5.0"  # Required: specify the Bifrost version
 
 replicaCount: 3
 
@@ -807,9 +811,314 @@ tolerations:
     effect: "NoSchedule"
 ```
 
+## Enterprise Deployment
+
+For enterprise customers, Bifrost provides dedicated container images hosted in private registries with additional features, support, and SLAs.
+
+<Note>
+[Book a demo](https://calendly.com/maximai/bifrost-demo) to know more about our enterprise features.
+</Note>
+
+### Private Container Registry
+
+Enterprise customers receive access to Bifrost images in a private container registry. To use your enterprise registry, override the `image.repository` with your provided registry URL:
+
+<Tabs>
+<Tab title="Google Artifact Registry">
+
+```yaml
+# enterprise-gcp.yaml
+image:
+  repository: us-west1-docker.pkg.dev/bifrost-enterprise/your-org/bifrost
+  tag: "v1.5.0"
+
+imagePullSecrets:
+  - name: gcr-secret
+```
+
+**Create the pull secret:**
+
+```bash
+kubectl create secret docker-registry gcr-secret \
+  --docker-server=us-west1-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat service-account-key.json)" \
+  --docker-email=your-email@example.com
+```
+
+</Tab>
+<Tab title="AWS ECR">
+
+```yaml
+# enterprise-aws.yaml
+image:
+  repository: 123456789.dkr.ecr.us-east-1.amazonaws.com/bifrost
+  tag: "v1.5.0"
+
+imagePullSecrets:
+  - name: ecr-secret
+```
+
+**Create the pull secret:**
+
+```bash
+kubectl create secret docker-registry ecr-secret \
+  --docker-server=123456789.dkr.ecr.us-east-1.amazonaws.com \
+  --docker-username=AWS \
+  --docker-password=$(aws ecr get-login-password --region us-east-1)
+```
+
+<Note>
+ECR tokens expire after 12 hours. Consider using [ECR Credential Helper](https://github.com/awslabs/amazon-ecr-credential-helper) or an operator like [ECR Registry Creds](https://github.com/upmc-enterprises/registry-creds) for automatic token refresh.
+</Note>
+
+</Tab>
+<Tab title="Azure ACR">
+
+```yaml
+# enterprise-azure.yaml
+image:
+  repository: yourregistry.azurecr.io/bifrost
+  tag: "v1.5.0"
+
+imagePullSecrets:
+  - name: acr-secret
+```
+
+**Create the pull secret:**
+
+```bash
+kubectl create secret docker-registry acr-secret \
+  --docker-server=yourregistry.azurecr.io \
+  --docker-username=<service-principal-id> \
+  --docker-password=<service-principal-password>
+```
+
+</Tab>
+<Tab title="Self-Hosted Registry">
+
+```yaml
+# enterprise-self-hosted.yaml
+image:
+  repository: registry.yourcompany.com/ai/bifrost
+  tag: "v1.5.0"
+
+imagePullSecrets:
+  - name: private-registry-secret
+```
+
+**Create the pull secret:**
+
+```bash
+kubectl create secret docker-registry private-registry-secret \
+  --docker-server=registry.yourcompany.com \
+  --docker-username=<username> \
+  --docker-password=<password>
+```
+
+</Tab>
+</Tabs>
+
+### Full Enterprise Configuration
+
+Complete example for enterprise deployments with all recommended settings:
+
+```yaml
+# enterprise-full.yaml
+image:
+  # Your enterprise registry URL (provided by Maxim)
+  repository: us-west1-docker.pkg.dev/bifrost-enterprise/your-org/bifrost
+  tag: "v1.5.0"
+
+imagePullSecrets:
+  - name: enterprise-registry-secret
+
+replicaCount: 3
+
+# Production-grade resources
+resources:
+  requests:
+    cpu: 1000m
+    memory: 2Gi
+  limits:
+    cpu: 4000m
+    memory: 8Gi
+
+# Auto-scaling for high availability
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 20
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# PostgreSQL storage
+storage:
+  mode: postgres
+
+postgresql:
+  enabled: true
+  auth:
+    password: "secure-password"  # Use existingSecret in production
+  primary:
+    persistence:
+      size: 100Gi
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 2Gi
+      limits:
+        cpu: 4000m
+        memory: 8Gi
+
+# Vector store for semantic caching
+vectorStore:
+  enabled: true
+  type: weaviate
+  weaviate:
+    enabled: true
+    persistence:
+      size: 100Gi
+
+# Ingress with TLS
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+  hosts:
+    - host: bifrost.yourcompany.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: bifrost-tls
+      hosts:
+        - bifrost.yourcompany.com
+
+# Bifrost configuration
+bifrost:
+  encryptionKeySecret:
+    name: "bifrost-encryption"
+    key: "key"
+  
+  client:
+    initialPoolSize: 1000
+    dropExcessRequests: true
+    enableLogging: true
+    disableContentLogging: false  # Set to true for compliance
+    logRetentionDays: 365
+    enableGovernance: true
+    enforceGovernanceHeader: true
+    allowDirectKeys: false
+    maxRequestBodySizeMb: 100
+    allowedOrigins:
+      - "https://yourcompany.com"
+      - "https://*.yourcompany.com"
+  
+  # Use secrets for provider keys
+  providers:
+    openai:
+      keys:
+        - value: "env.OPENAI_API_KEY"
+          weight: 1
+    anthropic:
+      keys:
+        - value: "env.ANTHROPIC_API_KEY"
+          weight: 1
+  
+  providerSecrets:
+    openai:
+      existingSecret: "provider-api-keys"
+      key: "openai-api-key"
+      envVar: "OPENAI_API_KEY"
+    anthropic:
+      existingSecret: "provider-api-keys"
+      key: "anthropic-api-key"
+      envVar: "ANTHROPIC_API_KEY"
+  
+  # Governance with authentication
+  governance:
+    authConfig:
+      isEnabled: true
+      disableAuthOnInference: false
+      existingSecret: "bifrost-admin-credentials"
+      usernameKey: "username"
+      passwordKey: "password"
+  
+  # Enable all plugins
+  plugins:
+    telemetry:
+      enabled: true
+    logging:
+      enabled: true
+    governance:
+      enabled: true
+      config:
+        is_vk_mandatory: true
+    semanticCache:
+      enabled: true
+      config:
+        provider: "openai"
+        embedding_model: "text-embedding-3-small"
+        dimension: 1536
+        threshold: 0.85
+        ttl: "1h"
+
+# Pod distribution
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: bifrost
+        topologyKey: kubernetes.io/hostname
+```
+
+### Enterprise Prerequisites
+
+Before deploying, create the required secrets:
+
+```bash
+# 1. Registry pull secret (see registry-specific instructions above)
+
+# 2. Encryption key
+kubectl create secret generic bifrost-encryption \
+  --from-literal=key='your-32-byte-encryption-key'
+
+# 3. Provider API keys
+kubectl create secret generic provider-api-keys \
+  --from-literal=openai-api-key='sk-...' \
+  --from-literal=anthropic-api-key='sk-ant-...'
+
+# 4. Admin credentials (for governance)
+kubectl create secret generic bifrost-admin-credentials \
+  --from-literal=username='admin' \
+  --from-literal=password='secure-admin-password'
+```
+
+### Install Enterprise Build
+
+```bash
+helm install bifrost bifrost/bifrost -f enterprise-full.yaml
+```
+
+### Enterprise Support
+
+Enterprise customers have access to:
+- Dedicated Slack channel for support
+- Priority bug fixes and feature requests
+- Custom feature development
+- SLA guarantees
+- Compliance documentation (SOC2, HIPAA, etc.)
+
+Contact [support@getmaxim.ai](mailto:support@getmaxim.ai) for enterprise support.
+
 ## Resources
 
 - [Helm Chart Repository](https://github.com/maximhq/bifrost/tree/main/helm-charts)
+- [Artifact Hub](https://artifacthub.io/packages/helm/bifrost/bifrost)
 - [Complete Installation Guide](https://github.com/maximhq/bifrost/blob/main/helm-charts/INSTALL.md)
 - [Example Configurations](https://github.com/maximhq/bifrost/tree/main/helm-charts/bifrost/values-examples)
 - [Kubernetes Secrets Example](https://github.com/maximhq/bifrost/blob/main/helm-charts/bifrost/values-examples/secrets-from-k8s.yaml)

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 1.4.3
-appVersion: "1.4.3"
+version: 1.5.0
+appVersion: "1.5.0"
 keywords:
   - ai
   - gateway

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -1,8 +1,10 @@
 # Bifrost Helm Charts
 
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/bifrost)](https://artifacthub.io/packages/search?repo=bifrost)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/bifrost)](https://artifacthub.io/packages/helm/bifrost/bifrost)
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
+
+**Latest Version:** 1.5.0
 
 ## Quick Start
 
@@ -14,7 +16,7 @@ helm repo add bifrost https://maximhq.github.io/bifrost/helm-charts
 helm repo update
 
 # Install Bifrost with default configuration (SQLite storage)
-helm install bifrost bifrost/bifrost --set image.tag=v1.3.37
+helm install bifrost bifrost/bifrost --set image.tag=v1.5.0
 ```
 
 ## Prerequisites
@@ -33,7 +35,7 @@ helm repo add bifrost https://maximhq.github.io/bifrost/helm-charts
 helm repo update
 
 # Install with default values
-helm install bifrost bifrost/bifrost --set image.tag=v1.3.37
+helm install bifrost bifrost/bifrost --set image.tag=v1.5.0
 
 # Or install with custom values
 helm install bifrost bifrost/bifrost -f my-values.yaml
@@ -70,6 +72,52 @@ cd bifrost/helm-charts/bifrost
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 
 > **Important:** You must specify the `image.tag`. See available tags at [Docker Hub](https://hub.docker.com/r/maximhq/bifrost/tags).
+
+### Enterprise Private Registry
+
+For enterprise customers with private container registries, simply override the `image.repository` with your full registry URL:
+
+```yaml
+# Google Artifact Registry
+image:
+  repository: us-west1-docker.pkg.dev/bifrost-enterprise/your-org/bifrost
+  tag: v1.5.0
+
+# AWS ECR
+image:
+  repository: 123456789.dkr.ecr.us-east-1.amazonaws.com/bifrost
+  tag: v1.5.0
+
+# Azure Container Registry
+image:
+  repository: yourregistry.azurecr.io/bifrost
+  tag: v1.5.0
+
+# Self-hosted registry
+image:
+  repository: registry.yourcompany.com/ai/bifrost
+  tag: v1.5.0
+```
+
+If your private registry requires authentication, configure `imagePullSecrets`:
+
+```yaml
+image:
+  repository: us-west1-docker.pkg.dev/bifrost-enterprise/your-org/bifrost
+  tag: v1.5.0
+
+imagePullSecrets:
+  - name: my-registry-secret
+```
+
+Create the secret beforehand:
+```bash
+kubectl create secret docker-registry my-registry-secret \
+  --docker-server=us-west1-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat key.json)" \
+  --docker-email=your-email@example.com
+```
 
 ### Storage Configuration
 

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -110,6 +110,19 @@ spec:
                   name: {{ .Values.bifrost.plugins.maxim.secretRef.name }}
                   key: {{ .Values.bifrost.plugins.maxim.secretRef.key | default "api-key" }}
             {{- end }}
+            {{- /* Governance auth credentials from existing secret */ -}}
+            {{- if and .Values.bifrost.governance .Values.bifrost.governance.authConfig .Values.bifrost.governance.authConfig.existingSecret }}
+            - name: BIFROST_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bifrost.governance.authConfig.existingSecret }}
+                  key: {{ .Values.bifrost.governance.authConfig.usernameKey | default "username" }}
+            - name: BIFROST_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bifrost.governance.authConfig.existingSecret }}
+                  key: {{ .Values.bifrost.governance.authConfig.passwordKey | default "password" }}
+            {{- end }}
             {{- /* Provider secrets */ -}}
             {{- range $provider, $secret := .Values.bifrost.providerSecrets }}
             {{- if and $secret.existingSecret $secret.envVar }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -6,10 +6,16 @@
 replicaCount: 1
 
 image:
+  # Container image repository
+  # Default: Docker Hub public image
+  # For enterprise customers with private registry, use full URL:
+  #   repository: us-west1-docker.pkg.dev/bifrost-enterprise/your-org/bifrost
+  #   repository: your-registry.example.com/your-org/bifrost
+  #   repository: 123456789.dkr.ecr.us-east-1.amazonaws.com/bifrost
   repository: docker.io/maximhq/bifrost
   pullPolicy: IfNotPresent
-  # REQUIRED: Specify the image tag (e.g., v1.3.5, v1.3.36, latest)
-  # Docker images are tagged with v prefix (e.g., v1.3.5)
+  # REQUIRED: Specify the image tag (e.g., v1.5.0, latest)
+  # Docker images are tagged with v prefix (e.g., v1.5.0)
   # See available tags at: https://hub.docker.com/r/maximhq/bifrost/tags
   tag: ""
 
@@ -126,12 +132,22 @@ bifrost:
     allowedOrigins:
       - "*"
     enableLogging: true
+    disableContentLogging: false
+    logRetentionDays: 365
     enableGovernance: true
     enforceGovernanceHeader: false
     allowDirectKeys: false
     maxRequestBodySizeMb: 100
     enableLitellmFallbacks: false
     prometheusLabels: []
+  
+  # Framework configuration
+  framework:
+    pricing:
+      # Custom pricing URL for model cost data
+      pricingUrl: ""
+      # Sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
+      pricingSyncInterval: 86400
   
   # Provider configurations (add your provider keys here)
   # You can specify API keys directly or use env.VAR_NAME syntax to reference environment variables
@@ -218,6 +234,135 @@ bifrost:
         collector_url: ""
         trace_type: "otel"
         protocol: "grpc"
+    
+    datadog:
+      enabled: false
+      config:
+        service_name: "bifrost"
+        agent_addr: "localhost:8126"
+        env: ""
+        version: ""
+        custom_tags: {}
+        enable_traces: true
+  
+  # Governance configuration for budgets, rate limits, customers, teams, and virtual keys
+  governance:
+    budgets: []
+      # - id: "budget-1"
+      #   max_limit: 100
+      #   reset_duration: "1M"
+    rateLimits: []
+      # - id: "rate-limit-1"
+      #   token_max_limit: 100000
+      #   token_reset_duration: "1d"
+      #   request_max_limit: 1000
+      #   request_reset_duration: "1h"
+    customers: []
+      # - id: "customer-1"
+      #   name: "Customer Name"
+      #   budget_id: "budget-1"
+    teams: []
+      # - id: "team-1"
+      #   name: "Team Name"
+      #   customer_id: "customer-1"
+      #   budget_id: "budget-1"
+    virtualKeys: []
+      # - id: "vk-1"
+      #   name: "Virtual Key 1"
+      #   value: "vk-..."
+      #   is_active: true
+      #   team_id: "team-1"
+      #   budget_id: "budget-1"
+      #   rate_limit_id: "rate-limit-1"
+    authConfig:
+      adminUsername: ""
+      adminPassword: ""
+      isEnabled: false
+      disableAuthOnInference: false
+      # Use existing Kubernetes secret for admin credentials
+      existingSecret: ""
+      usernameKey: "username"
+      passwordKey: "password"
+  
+  # Cluster mode configuration for distributed deployments
+  cluster:
+    enabled: false
+    peers: []
+      # - "bifrost-0.bifrost-headless:7946"
+      # - "bifrost-1.bifrost-headless:7946"
+    gossip:
+      port: 7946
+      config:
+        timeoutSeconds: 10
+        successThreshold: 3
+        failureThreshold: 3
+    discovery:
+      enabled: false
+      # Discovery type: kubernetes, dns, udp, consul, etcd, mdns
+      type: ""
+      allowedAddressSpace: []
+      # Kubernetes discovery
+      k8sNamespace: ""
+      k8sLabelSelector: ""
+      # DNS discovery
+      dnsNames: []
+      # UDP broadcast discovery
+      udpBroadcastPort: 0
+      # Consul discovery
+      consulAddress: ""
+      # Etcd discovery
+      etcdEndpoints: []
+      # mDNS discovery
+      mdnsService: ""
+  
+  # SAML/SCIM configuration for enterprise SSO
+  saml:
+    enabled: false
+    # Provider: okta, entra
+    provider: ""
+    config: {}
+      # Okta configuration:
+      # issuerUrl: "https://your-domain.okta.com/oauth2/default"
+      # clientId: ""
+      # clientSecret: ""
+      # audience: ""
+      # userIdField: "sub"
+      # teamIdsField: "groups"
+      # rolesField: "roles"
+      #
+      # Entra (Azure AD) configuration:
+      # tenantId: ""
+      # clientId: ""
+      # clientSecret: ""
+      # audience: ""
+      # appIdUri: ""
+      # userIdField: "oid"
+      # teamIdsField: "groups"
+      # rolesField: "roles"
+  
+  # Load balancer configuration for intelligent request routing
+  loadBalancer:
+    enabled: false
+    trackerConfig: {}
+    bootstrap: {}
+  
+  # Guardrails configuration for content moderation and policy enforcement
+  guardrails:
+    rules: []
+      # - id: 1
+      #   name: "Block PII"
+      #   description: "Block requests containing PII"
+      #   enabled: true
+      #   cel_expression: "!contains(request.body, 'SSN')"
+      #   apply_to: "input"
+      #   sampling_rate: 100
+      #   timeout: 1000
+    providers: []
+      # - id: 1
+      #   provider_name: "bedrock"
+      #   policy_name: "content-filter"
+      #   enabled: true
+      #   config: {}
 
 # Storage configuration
 storage:

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,28 @@ apiVersion: v1
 entries:
   bifrost:
   - apiVersion: v2
+    appVersion: 1.5.0
+    created: "2025-12-11T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.0.tgz
+    version: 1.5.0
+  - apiVersion: v2
     appVersion: 1.4.3
     created: "2025-12-10T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface


### PR DESCRIPTION
## Summary

Update Helm chart to version 1.5.0 and enhance documentation with enterprise deployment options.

## Changes

- Bumped Helm chart version from 1.4.3 to 1.5.0
- Updated all image tag references from v1.3.43 to v1.5.0
- Added enterprise deployment section to the documentation with private registry configuration
- Added note about latest chart version with link to Artifact Hub
- Enhanced templates to support new configuration options:
  - Content logging controls
  - Log retention settings
  - Governance authentication
  - Cluster configuration
  - SAML integration
  - Load balancer settings
  - Guardrails configuration
  - Datadog plugin support

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

```sh
# Validate the Helm chart
cd helm-charts/bifrost
helm lint .
helm template . --set image.tag=v1.5.0

# Test installation with new values
helm install bifrost-test . --set image.tag=v1.5.0 --dry-run
```

## Breaking changes

- [x] No

## Related issues

Supports the v1.5.0 release

## Security considerations

Documentation includes proper handling of secrets for enterprise deployments.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)