### PR TITLE
docker fixes for health checks

### DIFF
--- a/.github/workflows/configs/docker-compose.yml
+++ b/.github/workflows/configs/docker-compose.yml
@@ -43,6 +43,11 @@ services:
         - "9000:8080"
     volumes:
         - weaviate_data:/var/lib/weaviate
+    healthcheck:
+        test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/v1/.well-known/ready"]
+        interval: 10s
+        timeout: 5s
+        retries: 5
     networks:
         bifrost_network:
             ipv4_address: 172.38.0.12
@@ -69,6 +74,7 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.16.0
     ports:
+        - "6333:6333"  # REST API
         - "6334:6334"  # gRPC API
     volumes:
         - qdrant_data:/qdrant/storage


### PR DESCRIPTION
## Summary

Improve Docker service health checking in the CI/CD pipeline to ensure more reliable deployments.

## Changes

- Added healthcheck configuration for Weaviate service to properly detect when it's ready
- Exposed Qdrant's REST API port (6333) in addition to the existing gRPC port
- Enhanced the service readiness detection logic in the release script:
  - Increased maximum wait time from 60 to 90 seconds
  - Improved service status reporting with more detailed progress information
  - Added better detection of service health states by counting running, healthy, and unhealthy services
  - Added support for services without explicit healthchecks

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Run the release script to verify improved service health detection:

```sh
.github/workflows/scripts/release-bifrost-http.sh
```

Verify that:
1. The script properly waits for all services to be ready
2. Weaviate's healthcheck is properly detected
3. Qdrant's REST API is accessible on port 6333

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves reliability of CI/CD pipeline and service deployment

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable