### PR TITLE
increased timeout for docker

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -216,7 +216,7 @@ docker compose -f "$CONFIGS_DIR/docker-compose.yml" up -d
 
 # Wait for services to be healthy with polling
 echo "⏳ Waiting for Docker services to be ready..."
-MAX_WAIT=90
+MAX_WAIT=300
 ELAPSED=0
 SERVICES_READY=false
 


### PR DESCRIPTION
## Summary

Increase the maximum wait time for Docker services to be ready in the Bifrost HTTP release script.

## Changes

- Extended the `MAX_WAIT` timeout from 90 to 300 seconds in the release-bifrost-http.sh script
- This allows more time for Docker services to reach a healthy state during the release process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script and verify that services have sufficient time to become healthy:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses timeout issues during the Bifrost HTTP release process

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable