### PR TITLE
fixes parsing for health check for docker compose

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -230,7 +230,7 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
   # Check health status: count healthy and unhealthy (starting/unhealthy) services
   # Services without healthchecks will show empty health status
   HEALTH_OUTPUT=$(docker compose -f "$CONFIGS_DIR/docker-compose.yml" ps --format "{{.Name}}:{{.Health}}" 2>/dev/null)
-  HEALTHY_COUNT=$(echo "$HEALTH_OUTPUT" | grep -c ":healthy" || echo "0")
+  HEALTHY_COUNT=$(echo "$HEALTH_OUTPUT" | grep -c ":healthy") || HEALTHY_COUNT=0
   UNHEALTHY_COUNT=$(echo "$HEALTH_OUTPUT" | grep -E ":(starting|unhealthy)" | wc -l | tr -d ' ')
   
   # All services are ready when:


### PR DESCRIPTION
## Summary

Fix error handling in the Bifrost HTTP release script to properly handle the case when no healthy services are found.

## Changes

- Fixed the error handling in the `release-bifrost-http.sh` script when counting healthy services
- Modified the command to set `HEALTHY_COUNT=0` when the grep command fails, ensuring the script continues execution properly

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script in an environment where no services are initially healthy:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

The script should now properly handle the case when no healthy services are found and continue execution.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the release script would fail when no healthy services were found during startup.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable