### PR TITLE
fix: update Parasail test model

### DIFF
--- a/core/providers/parasail/parasail_test.go
+++ b/core/providers/parasail/parasail_test.go
@@ -24,7 +24,7 @@ func TestParasail(t *testing.T) {
 
 	testConfig := testutil.ComprehensiveTestConfig{
 		Provider:       schemas.Parasail,
-		ChatModel:      "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8",
+		ChatModel:      "parasail-llama-33-70b-fp8",
 		TextModel:      "", // Parasail doesn't support text completion
 		EmbeddingModel: "", // Parasail doesn't support embedding
 		Scenarios: testutil.TestScenarios{
@@ -34,7 +34,7 @@ func TestParasail(t *testing.T) {
 			MultiTurnConversation: true,
 			ToolCalls:             true,
 			ToolCallsStreaming:    true,
-			MultipleToolCalls:     true,
+			MultipleToolCalls:     false, // Not supported yet
 			End2EndToolCalling:    true,
 			AutomaticFunctionCall: true,
 			ImageURL:              false, // Not supported yet


### PR DESCRIPTION
## Summary

Update Parasail provider test configuration to use the correct model name and disable multiple tool calls testing.

## Changes

- Changed the chat model from `Qwen/Qwen3-VL-30B-A3B-Instruct-FP8` to `parasail-llama-33-70b-fp8` in the test configuration
- Disabled the `MultipleToolCalls` test scenario with a comment indicating it's not supported yet

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Parasail provider tests to verify they pass with the updated configuration:

```sh
go test ./core/providers/parasail/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable