### PR TITLE
fix: structured output in gemini and bedrock

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -300,7 +300,9 @@ func convertResponsesTextConfigToAnthropicOutputFormat(textConfig *schemas.Respo
 			schema["required"] = format.JSONSchema.Required
 		}
 
-		if format.JSONSchema.AdditionalProperties != nil {
+		if format.JSONSchema.Type != nil && *format.JSONSchema.Type == "object" {
+			schema["additionalProperties"] = false
+		} else if format.JSONSchema.AdditionalProperties != nil {
 			schema["additionalProperties"] = *format.JSONSchema.AdditionalProperties
 		}
 

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -929,7 +929,7 @@ func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key,
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockResponsesRequest(request) },
+		func() (any, error) { return ToBedrockResponsesRequest(&ctx, request) },
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -954,7 +954,7 @@ func (provider *BedrockProvider) Responses(ctx context.Context, key schemas.Key,
 	}
 
 	// Convert using the new response converter
-	bifrostResponse, err := bedrockResponse.ToBifrostResponsesResponse()
+	bifrostResponse, err := bedrockResponse.ToBifrostResponsesResponse(&ctx)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName)
 	}
@@ -997,7 +997,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx context.Context, postHookRu
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockResponsesRequest(request) },
+		func() (any, error) { return ToBedrockResponsesRequest(&ctx, request) },
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -457,6 +457,7 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 	trace := testTrace
 	latency := testLatency
 	props := testProps
+	ctx := context.Background()
 
 	tests := []struct {
 		name     string
@@ -945,9 +946,9 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 			var err error
 			if tt.input == nil {
 				var bedrockReq *bedrock.BedrockConverseRequest
-				actual, err = bedrockReq.ToBifrostResponsesRequest()
+				actual, err = bedrockReq.ToBifrostResponsesRequest(&ctx)
 			} else {
-				actual, err = tt.input.ToBifrostResponsesRequest()
+				actual, err = tt.input.ToBifrostResponsesRequest(&ctx)
 			}
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1526,6 +1527,7 @@ func TestBedrockToBifrostResponseConversion(t *testing.T) {
 	toolInput := map[string]interface{}{
 		"location": "NYC",
 	}
+	ctx := context.Background()
 
 	tests := []struct {
 		name     string
@@ -1669,9 +1671,9 @@ func TestBedrockToBifrostResponseConversion(t *testing.T) {
 			var err error
 			if tt.input == nil {
 				var bedrockResp *bedrock.BedrockConverseResponse
-				actual, err = bedrockResp.ToBifrostResponsesResponse()
+				actual, err = bedrockResp.ToBifrostResponsesResponse(&ctx)
 			} else {
-				actual, err = tt.input.ToBifrostResponsesResponse()
+				actual, err = tt.input.ToBifrostResponsesResponse(&ctx)
 			}
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -1736,7 +1738,8 @@ func TestToBedrockResponsesRequest_AdditionalFields(t *testing.T) {
 		},
 	}
 
-	bedrockReq, err := bedrock.ToBedrockResponsesRequest(req)
+	ctx := context.Background()
+	bedrockReq, err := bedrock.ToBedrockResponsesRequest(&ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, bedrockReq)
 
@@ -1762,7 +1765,8 @@ func TestToBedrockResponsesRequest_AdditionalFields_InterfaceSlice(t *testing.T)
 		},
 	}
 
-	bedrockReq, err := bedrock.ToBedrockResponsesRequest(req)
+	ctx := context.Background()
+	bedrockReq, err := bedrock.ToBedrockResponsesRequest(&ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, bedrockReq)
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -503,6 +503,52 @@ func convertResponseFormatToTool(ctx *context.Context, params *schemas.ChatParam
 	}
 }
 
+// convertTextFormatToTool converts a text config to a Bedrock tool for structured outpute
+func convertTextFormatToTool(ctx *context.Context, textConfig *schemas.ResponsesTextConfig) *BedrockTool {
+	if textConfig == nil || textConfig.Format == nil {
+		return nil
+	}
+
+	format := textConfig.Format
+	if format.Type != "json_schema" {
+		return nil
+	}
+
+	if format.JSONSchema == nil {
+		return nil
+	}
+
+	toolName := "json_response"
+	if format.Name != nil && strings.TrimSpace(*format.Name) != "" {
+		toolName = strings.TrimSpace(*format.Name)
+	}
+
+	description := "Returns structured JSON output"
+	if format.JSONSchema.Description != nil {
+		description = *format.JSONSchema.Description
+	}
+
+	toolName = fmt.Sprintf("bf_so_%s", toolName)
+	(*ctx) = context.WithValue(*ctx, schemas.BifrostContextKeyStructuredOutputToolName, toolName)
+
+	var schemaObj any
+	if format.JSONSchema.Schema != nil {
+		schemaObj = *format.JSONSchema.Schema
+	} else {
+		return nil // Schema is required for Bedrock tooling
+	}
+
+	return &BedrockTool{
+		ToolSpec: &BedrockToolSpec{
+			Name:        toolName,
+			Description: schemas.Ptr(description),
+			InputSchema: BedrockToolInputSchema{
+				JSON: schemaObj,
+			},
+		},
+	}
+}
+
 // convertInferenceConfig converts Bifrost parameters to Bedrock inference config
 func convertInferenceConfig(params *schemas.ChatParameters) *BedrockInferenceConfig {
 	var config BedrockInferenceConfig

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -31,7 +31,7 @@ func createBedrockConverseRouteConfig(pathPrefix string, handlerStore lib.Handle
 		},
 		RequestConverter: func(ctx *context.Context, req interface{}) (*schemas.BifrostRequest, error) {
 			if bedrockReq, ok := req.(*bedrock.BedrockConverseRequest); ok {
-				bifrostReq, err := bedrockReq.ToBifrostResponsesRequest()
+				bifrostReq, err := bedrockReq.ToBifrostResponsesRequest(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert bedrock request: %w", err)
 				}
@@ -65,7 +65,7 @@ func createBedrockConverseStreamRouteConfig(pathPrefix string, handlerStore lib.
 			if bedrockReq, ok := req.(*bedrock.BedrockConverseRequest); ok {
 				// Mark as streaming request
 				bedrockReq.Stream = true
-				bifrostReq, err := bedrockReq.ToBifrostResponsesRequest()
+				bifrostReq, err := bedrockReq.ToBifrostResponsesRequest(ctx)
 				if err != nil {
 					return nil, fmt.Errorf("failed to convert bedrock request: %w", err)
 				}


### PR DESCRIPTION
## Summary

Improves structured output handling across multiple providers by ensuring proper JSON schema conversion and adding support for structured outputs with thinking/reasoning features.

## Changes

- Added proper handling of `additionalProperties: false` for object types in Anthropic's JSON schema conversion
- Enhanced Bedrock provider to support structured outputs via tools, with context-aware conversion
- Improved Gemini provider's JSON schema handling for structured outputs
- Added support for structured outputs with thinking/reasoning budget enabled
- Updated response conversion functions to pass context through the conversion pipeline

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test structured output handling with various providers:

```sh
# Run core tests
go test ./core/providers/bedrock/...
go test ./core/providers/gemini/...
go test ./core/providers/anthropic/...

# Run integration tests for structured outputs with thinking
cd tests/integrations
python -m pytest tests/test_google.py::TestGoogleGenAI::test_28_structured_output_with_thinking -v
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with structured output handling across providers, particularly when combined with reasoning/thinking features.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable