### PR TITLE
fix: x-stainless-timeout allowed header

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -28,7 +28,7 @@ func CorsMiddleware(config *lib.Config) lib.BifrostHTTPMiddleware {
 			if allowed {
 				ctx.Response.Header.Set("Access-Control-Allow-Origin", origin)
 				ctx.Response.Header.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
-				ctx.Response.Header.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
+				ctx.Response.Header.Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With, X-Stainless-Timeout")
 				ctx.Response.Header.Set("Access-Control-Allow-Credentials", "true")
 				ctx.Response.Header.Set("Access-Control-Max-Age", "86400")
 			}


### PR DESCRIPTION
## Summary

Add support for the `X-Stainless-Timeout` header in CORS configuration to allow clients to specify custom timeout values.

## Changes

- Added `X-Stainless-Timeout` to the list of allowed headers in the CORS middleware
- This enables clients to set custom timeout values for their requests through this header

## Type of change

- [x] Transports (HTTP)

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test that the CORS middleware properly allows the X-Stainless-Timeout header:

```sh
make dev &&
curl http://localhost:8080/v1/chat/completions \
-H "Content-Type: application/json" \
-H "x-stainless-timeout: 60000" \
-d '{
  "model": "anthropic/claude-sonnet-4-5",
  "messages": [{"role": "user", "content": "Hello, Bifrost!"}]
}'
```

## Breaking changes

- [x] No

## Related issues

#1074

## Security considerations

None

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable