### PR TITLE
feat: count tokens request

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -685,6 +685,45 @@ func (bifrost *Bifrost) ResponsesStreamRequest(ctx context.Context, req *schemas
 	return bifrost.handleStreamRequest(ctx, bifrostReq)
 }
 
+// CountTokensRequest sends a count tokens request to the specified provider.
+func (bifrost *Bifrost) CountTokensRequest(ctx context.Context, req *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	if req == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "count tokens request is nil",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType: schemas.CountTokensRequest,
+			},
+		}
+	}
+	if req.Input == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "input not provided for count tokens request",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    schemas.CountTokensRequest,
+				Provider:       req.Provider,
+				ModelRequested: req.Model,
+			},
+		}
+	}
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.CountTokensRequest
+	bifrostReq.CountTokensRequest = req
+
+	response, err := bifrost.handleRequest(ctx, bifrostReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.CountTokensResponse, nil
+}
+
 // EmbeddingRequest sends an embedding request to the specified provider.
 func (bifrost *Bifrost) EmbeddingRequest(ctx context.Context, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
 	if req == nil {
@@ -2103,6 +2142,13 @@ func (bifrost *Bifrost) prepareFallbackRequest(req *schemas.BifrostRequest, fall
 		fallbackReq.ResponsesRequest = &tmp
 	}
 
+	if req.CountTokensRequest != nil {
+		tmp := *req.CountTokensRequest
+		tmp.Provider = fallback.Provider
+		tmp.Model = fallback.Model
+		fallbackReq.CountTokensRequest = &tmp
+	}
+
 	if req.EmbeddingRequest != nil {
 		tmp := *req.EmbeddingRequest
 		tmp.Provider = fallback.Provider
@@ -2871,6 +2917,12 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, req *Ch
 			return nil, bifrostError
 		}
 		response.ResponsesResponse = responsesResponse
+	case schemas.CountTokensRequest:
+		countTokensResponse, bifrostError := provider.CountTokens(req.Context, key, req.BifrostRequest.CountTokensRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.CountTokensResponse = countTokensResponse
 	case schemas.EmbeddingRequest:
 		embeddingResponse, bifrostError := provider.Embedding(req.Context, key, req.BifrostRequest.EmbeddingRequest)
 		if bifrostError != nil {
@@ -3153,6 +3205,7 @@ func resetBifrostRequest(req *schemas.BifrostRequest) {
 	req.TextCompletionRequest = nil
 	req.ChatRequest = nil
 	req.ResponsesRequest = nil
+	req.CountTokensRequest = nil
 	req.EmbeddingRequest = nil
 	req.SpeechRequest = nil
 	req.TranscriptionRequest = nil

--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -53,6 +53,7 @@ type TestScenarios struct {
 	FileDelete            bool // File API delete functionality
 	FileContent           bool // File API content download functionality
 	FileBatchInput        bool // Whether batch create supports file-based input (InputFileID)
+	CountTokens           bool // Count tokens functionality
 	ChatAudio             bool // Chat completion with audio input/output functionality
 }
 

--- a/core/internal/testutil/count_tokens.go
+++ b/core/internal/testutil/count_tokens.go
@@ -1,0 +1,91 @@
+package testutil
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunCountTokenTest validates the CountTokens API for the configured provider/model.
+// It sends a simple prompt as Responses messages and asserts token counts and metadata.
+func RunCountTokenTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.CountTokens {
+		t.Logf("Count tokens not supported for provider %s", testConfig.Provider)
+		return
+	}
+
+	t.Run("CountTokens", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		messages := []schemas.ResponsesMessage{
+			CreateBasicResponsesMessage("Hello! What's the capital of France?"),
+		}
+
+		countTokensReq := &schemas.BifrostResponsesRequest{
+			Provider:  testConfig.Provider,
+			Model:     testConfig.ChatModel,
+			Input:     messages,
+			Params:    &schemas.ResponsesParameters{Temperature: bifrost.Ptr(0.2)},
+			Fallbacks: testConfig.Fallbacks,
+		}
+
+		retryConfig := GetTestRetryConfigForScenario("CountTokens", testConfig)
+		retryContext := TestRetryContext{
+			ScenarioName: "CountTokens",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_token_counts": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+				"model":    testConfig.ChatModel,
+			},
+		}
+
+		expectations := GetExpectationsForScenario("CountTokens", testConfig, map[string]interface{}{})
+		expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
+		if expectations.ProviderSpecific == nil {
+			expectations.ProviderSpecific = make(map[string]interface{})
+		}
+		expectations.ProviderSpecific["expected_provider"] = string(testConfig.Provider)
+
+		// Create CountTokens retry config with default conditions preserved
+		countTokensRetryConfig := CountTokensRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []CountTokensRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		countTokensResp, countTokensErr := WithCountTokensTestRetry(
+			t,
+			countTokensRetryConfig,
+			retryContext,
+			expectations,
+			"CountTokens",
+			func() (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+				return client.CountTokensRequest(ctx, countTokensReq)
+			},
+		)
+
+		if countTokensErr != nil {
+			t.Fatalf("❌ CountTokens request failed: %s", GetErrorMessage(countTokensErr))
+		}
+		if countTokensResp == nil {
+			t.Fatal("❌ CountTokens response is nil")
+		}
+
+		// Validations are handled inside WithCountTokensTestRetry via ValidateCountTokensResponse
+		if countTokensResp.TotalTokens != nil {
+			t.Logf("✅ CountTokens test passed: input=%d, total=%d", countTokensResp.InputTokens, *countTokensResp.TotalTokens)
+		} else {
+			t.Logf("✅ CountTokens test passed: input=%d", countTokensResp.InputTokens)
+		}
+	})
+}

--- a/core/internal/testutil/test_retry_framework.go
+++ b/core/internal/testutil/test_retry_framework.go
@@ -158,6 +158,12 @@ type EmbeddingRetryCondition interface {
 	GetConditionName() string
 }
 
+// CountTokensRetryCondition defines an interface for checking if a count tokens test operation should be retried
+type CountTokensRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostCountTokensResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
 // ListModelsRetryCondition defines an interface for checking if a list models test operation should be retried
 type ListModelsRetryCondition interface {
 	ShouldRetry(response *schemas.BifrostListModelsResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
@@ -238,6 +244,16 @@ type EmbeddingRetryConfig struct {
 	BaseDelay   time.Duration                                    // Base delay between retries
 	MaxDelay    time.Duration                                    // Maximum delay between retries
 	Conditions  []EmbeddingRetryCondition                        // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// CountTokensRetryConfig configures retry behavior for count tokens test scenarios
+type CountTokensRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []CountTokensRetryCondition                      // Conditions that trigger retries
 	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
 	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
 }
@@ -937,6 +953,22 @@ func DefaultEmbeddingRetryConfig() TestRetryConfig {
 	}
 }
 
+// DefaultCountTokensRetryConfig creates a retry config for count tokens tests
+func DefaultCountTokensRetryConfig() TestRetryConfig {
+	return TestRetryConfig{
+		MaxAttempts: 10,
+		BaseDelay:   2000 * time.Millisecond,
+		MaxDelay:    10 * time.Second,
+		Conditions: []TestRetryCondition{
+			&EmptyCountTokensCondition{},
+			&InvalidCountTokensCondition{},
+		},
+		OnRetry: func(attempt int, reason string, t *testing.T) {
+			t.Logf("🔄 Retrying count tokens test (attempt %d): %s", attempt, reason)
+		},
+	}
+}
+
 // DefaultListModelsRetryConfig creates a retry config for list models tests
 // IMPORTANT: List models should ALWAYS retry on any failure (errors, nil response, empty data, validation failures)
 func DefaultListModelsRetryConfig() TestRetryConfig {
@@ -1133,6 +1165,8 @@ func GetTestRetryConfigForScenario(scenarioName string, testConfig Comprehensive
 		return StreamingRetryConfig()
 	case "Embedding":
 		return DefaultEmbeddingRetryConfig()
+	case "CountTokens":
+		return DefaultCountTokensRetryConfig()
 	case "SpeechSynthesis", "SpeechSynthesisHD", "SpeechSynthesis_Voice": // 🔊 Speech synthesis tests
 		return DefaultSpeechRetryConfig()
 	case "SpeechSynthesisStream", "SpeechSynthesisStreamHD", "SpeechSynthesisStreamVoice": // 🔊 Streaming speech tests
@@ -1826,6 +1860,154 @@ func checkEmbeddingRetryConditions(response *schemas.BifrostEmbeddingResponse, e
 		}
 	}
 
+	return false, ""
+}
+
+// WithCountTokensTestRetry wraps a count tokens test operation with retry logic for LLM behavior inconsistencies
+func WithCountTokensTestRetry(
+	t *testing.T,
+	config CountTokensRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostCountTokensResponse, *schemas.BifrostError),
+) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostCountTokensResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		// Execute the operation
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		// If we have a response, validate it FIRST
+		if response != nil {
+			validationResult := ValidateCountTokensResponse(t, response, err, expectations, scenarioName)
+
+			// If validation passes, we're done!
+			if validationResult.Passed {
+				return response, err
+			}
+
+			if attempt < config.MaxAttempts {
+				// ALWAYS retry on timeout errors - this takes precedence over all other conditions
+				if err != nil && isTimeoutError(err) {
+					retryReason := fmt.Sprintf("❌ timeout error detected: %s", GetErrorMessage(err))
+					if config.OnRetry != nil {
+						config.OnRetry(attempt, retryReason, t)
+					}
+
+					delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+					time.Sleep(delay)
+					continue
+				}
+
+				// Check other retry conditions first (for logging/debugging)
+				shouldRetryFromConditions, conditionReason := checkCountTokensRetryConditions(response, err, context, config.Conditions)
+
+				// ALWAYS retry on validation failures
+				shouldRetry := len(validationResult.Errors) > 0
+				var retryReason string
+
+				if shouldRetry {
+					retryReason = fmt.Sprintf("❌ validation failure (content/functionality check): %s", strings.Join(validationResult.Errors, "; "))
+					if shouldRetryFromConditions && conditionReason != "" {
+						retryReason += fmt.Sprintf(" | also: %s", conditionReason)
+					}
+				} else if shouldRetryFromConditions {
+					shouldRetry = true
+					if !strings.Contains(conditionReason, "❌") {
+						retryReason = fmt.Sprintf("❌ %s", conditionReason)
+					} else {
+						retryReason = conditionReason
+					}
+				}
+
+				if shouldRetry {
+					if config.OnRetry != nil {
+						config.OnRetry(attempt, retryReason, t)
+					}
+
+					delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+					time.Sleep(delay)
+					continue
+				}
+			}
+
+			// All retries failed validation - create a BifrostError to force test failure
+			validationErrors := strings.Join(validationResult.Errors, "; ")
+
+			if config.OnFinalFail != nil {
+				finalErr := fmt.Errorf("❌ validation failed after %d attempts: %s", attempt, validationErrors)
+				config.OnFinalFail(attempt, finalErr, t)
+			}
+
+			statusCode := 400
+			testFailureError := &schemas.BifrostError{
+				IsBifrostError: true,
+				StatusCode:     &statusCode,
+				Error: &schemas.ErrorField{
+					Message: fmt.Sprintf("❌ Validation failed after %d attempts: %s", attempt, validationErrors),
+				},
+			}
+			return nil, testFailureError
+		}
+
+		// If we have an error without a response, check if we should retry
+		if err != nil && attempt < config.MaxAttempts {
+			// ALWAYS retry on timeout errors - this takes precedence over other conditions
+			if isTimeoutError(err) {
+				retryReason := fmt.Sprintf("❌ timeout error detected: %s", GetErrorMessage(err))
+				if config.OnRetry != nil {
+					config.OnRetry(attempt, retryReason, t)
+				}
+
+				delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+				time.Sleep(delay)
+				continue
+			}
+
+			shouldRetry, retryReason := checkCountTokensRetryConditions(response, err, context, config.Conditions)
+			if shouldRetry {
+				if config.OnRetry != nil {
+					config.OnRetry(attempt, retryReason, t)
+				}
+
+				delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+				time.Sleep(delay)
+				continue
+			}
+		}
+
+		break
+	}
+
+	// Final failure callback
+	if config.OnFinalFail != nil && lastError != nil {
+		errorMsg := "unknown error"
+		if lastError.Error != nil {
+			errorMsg = lastError.Error.Message
+		}
+		if !strings.Contains(errorMsg, "❌") {
+			errorMsg = fmt.Sprintf("❌ %s", errorMsg)
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("❌ final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// checkCountTokensRetryConditions checks if any count tokens retry conditions are met
+func checkCountTokensRetryConditions(response *schemas.BifrostCountTokensResponse, err *schemas.BifrostError, context TestRetryContext, conditions []CountTokensRetryCondition) (bool, string) {
+	for _, condition := range conditions {
+		if shouldRetry, reason := condition.ShouldRetry(response, err, context); shouldRetry {
+			return true, fmt.Sprintf("%s: %s", condition.GetConditionName(), reason)
+		}
+	}
 	return false, ""
 }
 

--- a/core/internal/testutil/tests.go
+++ b/core/internal/testutil/tests.go
@@ -64,6 +64,7 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunFileContentTest,
 		RunFileUnsupportedTest,
 		RunFileAndBatchIntegrationTest,
+		RunCountTokenTest,
 		RunChatAudioTest,
 		RunChatAudioStreamTest,
 	}
@@ -118,6 +119,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"FileContent", testConfig.Scenarios.FileContent},
 		{"FileUnsupported", !testConfig.Scenarios.FileUpload && !testConfig.Scenarios.FileList && !testConfig.Scenarios.FileRetrieve && !testConfig.Scenarios.FileDelete && !testConfig.Scenarios.FileContent},
 		{"FileAndBatchIntegration", testConfig.Scenarios.FileBatchInput},
+		{"CountTokens", testConfig.Scenarios.CountTokens},
 		{"ChatAudio", testConfig.Scenarios.ChatAudio && testConfig.ChatAudioModel != ""},
 		{"ChatAudioStream", testConfig.Scenarios.ChatAudio && testConfig.ChatAudioModel != ""},
 	}

--- a/core/internal/testutil/validation_presets.go
+++ b/core/internal/testutil/validation_presets.go
@@ -112,6 +112,20 @@ func EmbeddingExpectations(expectedTexts []string) ResponseExpectations {
 	}
 }
 
+// CountTokensExpectations returns validation expectations for count tokens scenarios
+func CountTokensExpectations() ResponseExpectations {
+	return ResponseExpectations{
+		ShouldHaveContent:    false, // CountTokens doesn't return text content
+		ExpectedChoiceCount:  0,
+		ShouldHaveUsageStats: true,
+		ShouldHaveModel:      true,
+		ShouldHaveLatency:    true,
+		ProviderSpecific: map[string]interface{}{
+			"response_type": "count_tokens",
+		},
+	}
+}
+
 // StreamingExpectations returns validation expectations for streaming scenarios
 func StreamingExpectations() ResponseExpectations {
 	expectations := BasicChatExpectations()
@@ -275,6 +289,9 @@ func GetExpectationsForScenario(scenarioName string, testConfig ComprehensiveTes
 			return EmbeddingExpectations(texts)
 		}
 		return EmbeddingExpectations([]string{"Hello, world!", "Hi, world!", "Goodnight, moon!"})
+
+	case "CountTokens":
+		return CountTokensExpectations()
 
 	case "CompleteEnd2End":
 		return ConversationExpectations([]string{"complete", "comprehensive", "full"})

--- a/core/providers/anthropic/anthropic_test.go
+++ b/core/providers/anthropic/anthropic_test.go
@@ -61,6 +61,7 @@ func TestAnthropic(t *testing.T) {
 			FileDelete:            true,
 			FileContent:           false,
 			FileBatchInput:        false, // Anthropic batch API only supports inline requests, not file-based input
+			CountTokens:           true,
 		},
 	}
 

--- a/core/providers/anthropic/count_tokens.go
+++ b/core/providers/anthropic/count_tokens.go
@@ -1,0 +1,34 @@
+package anthropic
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToBifrostCountTokensResponse converts an Anthropic count tokens response to Bifrost format
+func (resp *AnthropicCountTokensResponse) ToBifrostCountTokensResponse(model string) *schemas.BifrostCountTokensResponse {
+	if resp == nil {
+		return nil
+	}
+
+	totalTokens := resp.InputTokens
+
+	bifrostResp := &schemas.BifrostCountTokensResponse{
+		Model:       model,
+		InputTokens: resp.InputTokens,
+		TotalTokens: &totalTokens,
+		Object:      "response.input_tokens",
+	}
+
+	return bifrostResp
+}
+
+// ToAnthropicCountTokensResponse converts a Bifrost count tokens response to Anthropic format.
+func ToAnthropicCountTokensResponse(bifrostResp *schemas.BifrostCountTokensResponse) *AnthropicCountTokensResponse {
+	if bifrostResp == nil {
+		return nil
+	}
+
+	return &AnthropicCountTokensResponse{
+		InputTokens: bifrostResp.InputTokens,
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 
+	"github.com/maximhq/bifrost/core/providers/utils"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 )
 
@@ -2200,7 +2200,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + utils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -2228,7 +2228,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			// Handle redacted thinking (encrypted content)
 			if block.Data != nil {
 				bifrostMsg := schemas.ResponsesMessage{
-					ID:   schemas.Ptr("rs_" + utils.GetRandomString(50)),
+					ID:   schemas.Ptr("rs_" + providerUtils.GetRandomString(50)),
 					Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
 					ResponsesReasoning: &schemas.ResponsesReasoning{
 						Summary:          []schemas.ResponsesReasoningSummary{},
@@ -2311,7 +2311,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 			Role: role,
 		}
 		if isOutputMessage {
-			bifrostMsg.ID = schemas.Ptr("msg_" + utils.GetRandomString(50))
+			bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 			bifrostMsg.Content = &schemas.ResponsesMessageContent{
 				ContentBlocks: accumulatedTextContent,
 			}
@@ -2331,7 +2331,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				},
 			}
 			if isOutputMessage {
-				bifrostMsg.ID = schemas.Ptr("msg_" + utils.GetRandomString(50))
+				bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 			}
 
 			// Check for computer tool use
@@ -2368,7 +2368,7 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 				if isOutputMessage {
 					// For output messages, use ContentBlocks with ResponsesOutputMessageContentTypeText
 					bifrostMsg = schemas.ResponsesMessage{
-						ID:   schemas.Ptr("msg_" + utils.GetRandomString(50)),
+						ID:   schemas.Ptr("msg_" + providerUtils.GetRandomString(50)),
 						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
 						Role: role,
 						Content: &schemas.ResponsesMessageContent{
@@ -2409,7 +2409,7 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + utils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -2425,7 +2425,7 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 		case AnthropicContentBlockTypeRedactedThinking:
 			if block.Data != nil {
 				bifrostMsg := schemas.ResponsesMessage{
-					ID:   schemas.Ptr("rs_" + utils.GetRandomString(50)),
+					ID:   schemas.Ptr("rs_" + providerUtils.GetRandomString(50)),
 					Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
 					ResponsesReasoning: &schemas.ResponsesReasoning{
 						Summary:          []schemas.ResponsesReasoningSummary{},
@@ -2446,7 +2446,7 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + utils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 				}
 
 				// here need to check for computer tool use
@@ -2537,7 +2537,7 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("msg_" + utils.GetRandomString(50))
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 				}
 				// Initialize the nested struct before any writes
 				bifrostMsg.ResponsesToolMessage.Output = &schemas.ResponsesToolMessageOutputStruct{}
@@ -2578,7 +2578,7 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 	// This ensures reasoning comes before any text/tool blocks (Bedrock compatibility)
 	if len(reasoningContentBlocks) > 0 {
 		reasoningMessage := schemas.ResponsesMessage{
-			ID:   schemas.Ptr("rs_" + utils.GetRandomString(50)),
+			ID:   schemas.Ptr("rs_" + providerUtils.GetRandomString(50)),
 			Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
 			ResponsesReasoning: &schemas.ResponsesReasoning{
 				Summary: []schemas.ResponsesReasoningSummary{},

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -599,3 +599,8 @@ func parseAnthropicFileTimestamp(timestamp string) int64 {
 	}
 	return t.Unix()
 }
+
+// AnthropicCountTokensResponse models the payload returned by Anthropic's count tokens endpoint.
+type AnthropicCountTokensResponse struct {
+	InputTokens int `json:"input_tokens"`
+}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2208,3 +2208,8 @@ func (provider *AzureProvider) BatchResults(ctx context.Context, keys []schemas.
 
 	return batchResultsResp, nil
 }
+
+// CountTokens is not supported by the Azure provider.
+func (provider *AzureProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2742,3 +2742,7 @@ func (provider *BedrockProvider) getModelPath(basePath string, model string, key
 	}
 	return path, deployment
 }
+
+func (provider *BedrockProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -104,6 +104,7 @@ func TestBedrock(t *testing.T) {
 			FileDelete:            true,
 			FileContent:           true,
 			FileBatchInput:        true,
+			CountTokens:           false, // Not supported
 		},
 	}
 

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -260,3 +260,8 @@ func (provider *CerebrasProvider) BatchCancel(_ context.Context, _ []schemas.Key
 func (provider *CerebrasProvider) BatchResults(_ context.Context, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Cerebras provider.
+func (provider *CerebrasProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/cohere/cohere_test.go
+++ b/core/providers/cohere/cohere_test.go
@@ -46,6 +46,7 @@ func TestCohere(t *testing.T) {
 			Embedding:             true,
 			Reasoning:             true,
 			ListModels:            true,
+			CountTokens:           true,
 		},
 	}
 

--- a/core/providers/cohere/count_tokens.go
+++ b/core/providers/cohere/count_tokens.go
@@ -1,0 +1,119 @@
+package cohere
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToBifrostResponsesRequest converts a Cohere count tokens request to Bifrost format.
+func (req *CohereCountTokensRequest) ToBifrostResponsesRequest() *schemas.BifrostResponsesRequest {
+	if req == nil {
+		return nil
+	}
+
+	provider, model := schemas.ParseModelString(req.Model, schemas.Cohere)
+
+	userRole := schemas.ResponsesInputMessageRoleUser
+	return &schemas.BifrostResponsesRequest{
+		Provider: provider,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: &userRole,
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: &req.Text,
+				},
+			},
+		},
+	}
+}
+
+// ToCohereCountTokensRequest converts a Bifrost count tokens request to Cohere's tokenize payload.
+func ToCohereCountTokensRequest(bifrostReq *schemas.BifrostResponsesRequest) (*CohereCountTokensRequest, error) {
+	if bifrostReq == nil {
+		return nil, nil
+	}
+
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("count tokens input is not provided")
+	}
+
+	text := buildCohereCountTokensText(bifrostReq.Input)
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil, fmt.Errorf("count tokens text is empty after conversion")
+	}
+	runeCount := utf8.RuneCountInString(trimmed)
+	if runeCount < cohereTokenizeMinTextLength || runeCount > cohereTokenizeMaxTextLength {
+		return nil, fmt.Errorf("count tokens text length must be between %d and %d characters", cohereTokenizeMinTextLength, cohereTokenizeMaxTextLength)
+	}
+
+	return &CohereCountTokensRequest{
+		Model: bifrostReq.Model,
+		Text:  trimmed,
+	}, nil
+}
+
+// ToBifrostCountTokensResponse converts a Cohere tokenize response to Bifrost format.
+func (resp *CohereCountTokensResponse) ToBifrostCountTokensResponse(model string) *schemas.BifrostCountTokensResponse {
+	if resp == nil {
+		return nil
+	}
+
+	inputTokens := len(resp.Tokens)
+	if inputTokens == 0 && len(resp.TokenStrings) > 0 {
+		inputTokens = len(resp.TokenStrings)
+	}
+	totalTokens := inputTokens
+
+	return &schemas.BifrostCountTokensResponse{
+		Model:        model,
+		InputTokens:  inputTokens,
+		TotalTokens:  &totalTokens,
+		TokenStrings: resp.TokenStrings,
+		Tokens:       resp.Tokens,
+		Object:       "response.input_tokens",
+	}
+}
+
+// buildCohereCountTokensText flattens Responses messages into a plain text payload for tokenization.
+func buildCohereCountTokensText(messages []schemas.ResponsesMessage) string {
+	var parts []string
+
+	for _, msg := range messages {
+		var contentParts []string
+
+		if msg.Content != nil {
+			if msg.Content.ContentStr != nil {
+				contentParts = append(contentParts, *msg.Content.ContentStr)
+			}
+			for _, block := range msg.Content.ContentBlocks {
+				if block.Text != nil {
+					contentParts = append(contentParts, *block.Text)
+				}
+				if block.ResponsesOutputMessageContentRefusal != nil && block.ResponsesOutputMessageContentRefusal.Refusal != "" {
+					contentParts = append(contentParts, block.ResponsesOutputMessageContentRefusal.Refusal)
+				}
+			}
+		}
+
+		if msg.ResponsesReasoning != nil {
+			for _, summary := range msg.ResponsesReasoning.Summary {
+				if summary.Text != "" {
+					contentParts = append(contentParts, summary.Text)
+				}
+			}
+		}
+
+		if len(contentParts) == 0 {
+			continue
+		}
+
+		parts = append(parts, strings.Join(contentParts, "\n"))
+	}
+
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -10,6 +10,11 @@ import (
 
 const MinimumReasoningMaxTokens = 1
 const DefaultCompletionMaxTokens = 4096 // Only used for relative reasoning max token calculation - not passed in body by default
+// Limits for tokenize input api call https://docs.cohere.com/reference/tokenize#request
+const (
+	cohereTokenizeMinTextLength = 1
+	cohereTokenizeMaxTextLength = 65536
+)
 
 // ==================== REQUEST TYPES ====================
 
@@ -236,6 +241,12 @@ type CohereTool struct {
 	ParameterDefinitions map[string]CohereParameterDefinition `json:"parameter_definitions"` // Definitions of the tool's parameters
 }
 
+// CohereCountTokensRequest represents a Cohere tokenize request
+type CohereCountTokensRequest struct {
+	Model string `json:"model"` // Required: Model whose tokenizer should be used
+	Text  string `json:"text"`  // Required: Text to tokenize (1-65536 chars)
+}
+
 // CohereEmbeddingRequest represents a Cohere embedding request
 type CohereEmbeddingRequest struct {
 	Model           string                 `json:"model"`                      // Required: ID of embedding model
@@ -298,6 +309,23 @@ type CohereEmbeddingAPIVersion struct {
 }
 
 // ==================== RESPONSE TYPES ====================
+
+// CohereCountTokensResponse represents the response from the tokenize endpoint
+type CohereCountTokensResponse struct {
+	Tokens       []int               `json:"tokens"`
+	TokenStrings []string            `json:"token_strings,omitempty"`
+	Meta         *CohereTokenizeMeta `json:"meta,omitempty"`
+}
+
+// CohereTokenizeMeta captures metadata returned by the tokenize endpoint
+type CohereTokenizeMeta struct {
+	APIVersion *CohereTokenizeAPIVersion `json:"api_version,omitempty"`
+}
+
+// CohereTokenizeAPIVersion describes API version metadata
+type CohereTokenizeAPIVersion struct {
+	Version *string `json:"version,omitempty"`
+}
 
 // CohereChatResponse represents a Cohere  chat completion response
 type CohereChatResponse struct {

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -772,3 +772,8 @@ func (provider *ElevenlabsProvider) FileDelete(_ context.Context, _ []schemas.Ke
 func (provider *ElevenlabsProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Elevenlabs provider.
+func (provider *ElevenlabsProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/gemini/count_tokens.go
+++ b/core/providers/gemini/count_tokens.go
@@ -1,0 +1,80 @@
+package gemini
+
+import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToBifrostCountTokensResponse converts a Gemini count tokens response to Bifrost format.
+func (resp *GeminiCountTokensResponse) ToBifrostCountTokensResponse(model string) *schemas.BifrostCountTokensResponse {
+	if resp == nil {
+		return nil
+	}
+
+	// Sum prompt tokens and map modality-specific counts
+	inputTokens := 0
+	inputDetails := &schemas.ResponsesResponseInputTokens{}
+
+	for _, m := range resp.PromptTokensDetails {
+		if m == nil {
+			continue
+		}
+		inputTokens += int(m.TokenCount)
+		mod := strings.ToLower(m.Modality)
+		// handle audio modality
+		if strings.Contains(mod, "audio") {
+			inputDetails.AudioTokens += int(m.TokenCount)
+		}
+	}
+
+	// Set cached tokens from top-level field if present
+	if resp.CachedContentTokenCount != 0 {
+		inputDetails.CachedTokens = int(resp.CachedContentTokenCount)
+	} else if resp.CacheTokensDetails != nil {
+		// If cache tokens details present, sum them
+		cachedSum := 0
+		for _, m := range resp.CacheTokensDetails {
+			if m == nil {
+				continue
+			}
+			cachedSum += int(m.TokenCount)
+			if strings.Contains(strings.ToLower(m.Modality), "audio") {
+				// also populate audio tokens from cache into AudioTokens (additive)
+				inputDetails.AudioTokens += int(m.TokenCount)
+			}
+		}
+		inputDetails.CachedTokens = cachedSum
+	}
+
+	total := int(resp.TotalTokens)
+
+	return &schemas.BifrostCountTokensResponse{
+		Model:              model,
+		Object:             "response.input_tokens",
+		InputTokens:        inputTokens,
+		InputTokensDetails: inputDetails,
+		TotalTokens:        &total,
+		ExtraFields:        schemas.BifrostResponseExtraFields{},
+	}
+}
+
+// ToGeminiCountTokensResponse converts a Bifrost count tokens response to Gemini format.
+func ToGeminiCountTokensResponse(bifrostResp *schemas.BifrostCountTokensResponse) *GeminiCountTokensResponse {
+	if bifrostResp == nil {
+		return nil
+	}
+
+	response := &GeminiCountTokensResponse{
+		TotalTokens: int32(bifrostResp.InputTokens),
+	}
+
+	// Map cached content token count if available
+	if bifrostResp.InputTokensDetails != nil && bifrostResp.InputTokensDetails.CachedTokens > 0 {
+		response.CachedContentTokenCount = int32(bifrostResp.InputTokensDetails.CachedTokens)
+	} else {
+		response.CachedContentTokenCount = 0
+	}
+
+	return response
+}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2834,3 +2834,105 @@ func (provider *GeminiProvider) FileContent(ctx context.Context, keys []schemas.
 		providerName,
 	)
 }
+
+// CountTokens performs a token counting request to Gemini's countTokens endpoint.
+func (provider *GeminiProvider) CountTokens(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.CountTokensRequest); err != nil {
+		return nil, err
+	}
+
+	// Build JSON body from Bifrost request
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return ToGeminiResponsesRequest(request), nil },
+		provider.GetProviderKey(),
+	)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	var payload map[string]any
+	if err := sonic.Unmarshal(jsonData, &payload); err == nil {
+		delete(payload, "toolConfig")
+		delete(payload, "generationConfig")
+		delete(payload, "systemInstruction")
+		newData, err := sonic.Marshal(payload)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, provider.GetProviderKey())
+		}
+		jsonData = newData
+	}
+
+	providerName := provider.GetProviderKey()
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	if strings.TrimSpace(request.Model) == "" {
+		return nil, providerUtils.NewBifrostOperationError("model is required for Gemini count tokens request", fmt.Errorf("missing model"), providerName)
+	}
+
+	// Determine native model name (e.g., parse any provider prefix)
+	_, model := schemas.ParseModelString(request.Model, schemas.Gemini)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	path := fmt.Sprintf("/models/%s:countTokens", model)
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, path))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	if key.Value != "" {
+		req.Header.Set("x-goog-api-key", key.Value)
+	}
+	req.SetBody(jsonData)
+
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, parseGeminiError(resp, &providerUtils.RequestMetadata{
+			Provider:    providerName,
+			RequestType: schemas.CountTokensRequest,
+		})
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
+
+	responseBody := append([]byte(nil), body...)
+
+	geminiResponse := &GeminiCountTokensResponse{}
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(
+		responseBody,
+		geminiResponse,
+		jsonData,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+	)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	response := geminiResponse.ToBifrostCountTokensResponse(request.Model)
+
+	// Set ExtraFields
+	response.ExtraFields.Provider = provider.GetProviderKey()
+	response.ExtraFields.ModelRequested = request.Model
+	response.ExtraFields.RequestType = schemas.CountTokensRequest
+	response.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		response.ExtraFields.RawResponse = rawResponse
+	}
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		response.ExtraFields.RawRequest = rawRequest
+	}
+
+	return response, nil
+}

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -65,6 +65,7 @@ func TestGemini(t *testing.T) {
 			FileDelete:            true,
 			FileContent:           false,
 			FileBatchInput:        true,
+			CountTokens:           true,
 		},
 	}
 

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -71,6 +71,7 @@ type GeminiGenerationRequest struct {
 	IsEmbedding       bool                     `json:"-"` // Internal field to track if this is an embedding request
 	IsTranscription   bool                     `json:"-"` // Internal field to track if this is a transcription request
 	IsSpeech          bool                     `json:"-"` // Internal field to track if this is a speech request
+	IsCountTokens     bool                     `json:"-"` // Internal field to track if this is a count tokens request
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
 	Fallbacks []string `json:"fallbacks,omitempty"`
@@ -1701,4 +1702,17 @@ type GeminiFileRetrieveRequest struct {
 // GeminiFileDeleteRequest request represents the request for deleting a file.
 type GeminiFileDeleteRequest struct {
 	FileID string `json:"file_id"`
+}
+
+// GeminiCountTokensResponse represents the response from Google Gemini's count tokens API.
+type GeminiCountTokensResponse struct {
+	// Response from models.countTokens
+	// TotalTokens is the number of tokens that the Model tokenizes the prompt into.
+	TotalTokens int32 `json:"totalTokens,omitempty"`
+	// Number of tokens in the cached part of the prompt (the cached content).
+	CachedContentTokenCount int32 `json:"cachedContentTokenCount,omitempty"`
+	// Output only. List of modalities that were processed in the request input.
+	PromptTokensDetails []*ModalityTokenCount `json:"promptTokensDetails,omitempty"`
+	// Output only. List of modalities that were processed in the cached content.
+	CacheTokensDetails []*ModalityTokenCount `json:"cacheTokensDetails,omitempty"`
 }

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -298,3 +298,8 @@ func (provider *GroqProvider) FileDelete(_ context.Context, _ []schemas.Key, _ *
 func (provider *GroqProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Groq provider.
+func (provider *GroqProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -909,3 +909,8 @@ func (provider *HuggingFaceProvider) FileDelete(_ context.Context, _ []schemas.K
 func (provider *HuggingFaceProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -630,3 +630,8 @@ func (provider *MistralProvider) FileDelete(_ context.Context, _ []schemas.Key, 
 func (provider *MistralProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Mistral provider.
+func (provider *MistralProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -284,3 +284,8 @@ func (provider *NebiusProvider) FileDelete(_ context.Context, _ []schemas.Key, _
 func (provider *NebiusProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by Nebius provider.
+func (provider *NebiusProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -272,3 +272,7 @@ func (provider *OllamaProvider) FileDelete(_ context.Context, _ []schemas.Key, _
 func (provider *OllamaProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+func (provider *OllamaProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -2271,6 +2271,110 @@ func HandleOpenAITranscriptionStreamRequest(
 	return responseChan, nil
 }
 
+// CountTokens performs a count tokens request to the OpenAI API.
+func (provider *OpenAIProvider) CountTokens(ctx context.Context, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.CountTokensRequest); err != nil {
+		return nil, err
+	}
+
+	return HandleOpenAICountTokensRequest(
+		ctx,
+		provider.client,
+		provider.buildRequestURL(ctx, "/v1/responses/input_tokens", schemas.CountTokensRequest),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		provider.logger,
+	)
+}
+
+// HandleOpenAICountTokensRequest handles a count tokens request to OpenAI's API.
+func HandleOpenAICountTokensRequest(
+	ctx context.Context,
+	client *fasthttp.Client,
+	url string,
+	request *schemas.BifrostResponsesRequest,
+	key schemas.Key,
+	extraHeaders map[string]string,
+	sendBackRawRequest bool,
+	sendBackRawResponse bool,
+	providerName schemas.ModelProvider,
+	logger schemas.Logger,
+) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set any extra headers from network config
+	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
+
+	req.SetRequestURI(url)
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+
+	if key.Value != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value)
+	}
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (any, error) { return ToOpenAIResponsesRequest(request), nil },
+		providerName,
+	)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	req.SetBody(jsonData)
+
+	// Make request
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		logger.Debug(fmt.Sprintf("error from %s provider: %s", providerName, string(resp.Body())))
+		return nil, ParseOpenAIError(resp, schemas.CountTokensRequest, providerName, request.Model)
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
+
+	response := &schemas.BifrostCountTokensResponse{}
+
+	// Use enhanced response handler with pre-allocated response
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	response.Model = request.Model
+	response.ExtraFields.Provider = providerName
+	response.ExtraFields.RequestType = schemas.CountTokensRequest
+	response.ExtraFields.ModelRequested = request.Model
+	response.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest) {
+		response.ExtraFields.RawRequest = rawRequest
+	}
+
+	if providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse) {
+		response.ExtraFields.RawResponse = rawResponse
+	}
+
+	return response, nil
+}
+
 // FileUpload uploads a file to OpenAI.
 func (provider *OpenAIProvider) FileUpload(ctx context.Context, key schemas.Key, request *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.FileUploadRequest); err != nil {

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -72,6 +72,7 @@ func TestOpenAI(t *testing.T) {
 			FileDelete:            true,
 			FileContent:           true,
 			FileBatchInput:        true,
+			CountTokens:           true,
 			ChatAudio:             true,
 		},
 	}

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -331,3 +331,8 @@ func (provider *OpenRouterProvider) FileDelete(_ context.Context, _ []schemas.Ke
 func (provider *OpenRouterProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the OpenRouter provider.
+func (provider *OpenRouterProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -231,3 +231,8 @@ func (provider *ParasailProvider) BatchCancel(_ context.Context, _ []schemas.Key
 func (provider *ParasailProvider) BatchResults(_ context.Context, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Parasail provider.
+func (provider *ParasailProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -301,3 +301,8 @@ func (provider *PerplexityProvider) FileDelete(_ context.Context, _ []schemas.Ke
 func (provider *PerplexityProvider) FileContent(_ context.Context, _ []schemas.Key, _ *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -269,3 +269,8 @@ func (provider *SGLProvider) BatchCancel(_ context.Context, _ []schemas.Key, _ *
 func (provider *SGLProvider) BatchResults(_ context.Context, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
 }
+
+// CountTokens is not supported by the SGL provider.
+func (provider *SGLProvider) CountTokens(_ context.Context, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}

--- a/core/providers/vertex/count_tokens.go
+++ b/core/providers/vertex/count_tokens.go
@@ -1,0 +1,27 @@
+package vertex
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func (resp *VertexCountTokensResponse) ToBifrostCountTokensResponse(model string) *schemas.BifrostCountTokensResponse {
+	if resp == nil {
+		return nil
+	}
+
+	inputDetails := &schemas.ResponsesResponseInputTokens{}
+	inputTokens := int(resp.TotalTokens) // Vertex response typically represents prompt tokens for countTokens
+	total := int(resp.TotalTokens)
+
+	if resp.CachedContentTokenCount > 0 {
+		inputDetails.CachedTokens = int(resp.CachedContentTokenCount)
+	}
+
+	return &schemas.BifrostCountTokensResponse{
+		Model:              model,
+		Object:             "response.input_tokens",
+		InputTokens:        inputTokens,
+		InputTokensDetails: inputDetails,
+		TotalTokens:        &total,
+	}
+}

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -158,3 +158,10 @@ type VertexValidationError struct {
 		Type  string `json:"type"`  // error type (e.g., "extra_forbidden", "missing")
 	} `json:"detail"`
 }
+
+// VertexCountTokensResponse models the response payload for Vertex's Gemini-style countTokens.
+// Vertex uses camelCase unlike other request json body.
+type VertexCountTokensResponse struct {
+	TotalTokens             int32 `json:"totalTokens,omitempty"`
+	CachedContentTokenCount int32 `json:"cachedContentTokenCount,omitempty"`
+}

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -87,12 +87,8 @@ func getRequestBodyForAnthropicResponses(ctx context.Context, request *schemas.B
 // getCompleteURLForGeminiEndpoint constructs the complete URL for the Gemini endpoint, for both streaming and non-streaming requests
 // for custom/fine-tuned models, it uses the projectNumber
 // for gemini models, it uses the projectID
-func getCompleteURLForGeminiEndpoint(deployment string, region string, projectID string, projectNumber string, isStreaming bool) string {
+func getCompleteURLForGeminiEndpoint(deployment string, region string, projectID string, projectNumber string, method string) string {
 	var url string
-	method := ":generateContent"
-	if isStreaming {
-		method = ":streamGenerateContent"
-	}
 	if schemas.IsAllDigitsASCII(deployment) {
 		// Custom/fine-tuned models use projectNumber
 		if region == "global" {

--- a/core/providers/vertex/vertex_test.go
+++ b/core/providers/vertex/vertex_test.go
@@ -46,6 +46,7 @@ func TestVertex(t *testing.T) {
 			Embedding:             true,
 			Reasoning:             false, // Not supported right now because we are not using native gemini converters
 			ListModels:            false,
+			CountTokens:           true,
 		},
 	}
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -110,6 +110,7 @@ const (
 	FileRetrieveRequest         RequestType = "file_retrieve"
 	FileDeleteRequest           RequestType = "file_delete"
 	FileContentRequest          RequestType = "file_content"
+	CountTokensRequest          RequestType = "count_tokens"
 	UnknownRequest              RequestType = "unknown"
 )
 
@@ -157,6 +158,7 @@ type Fallback struct {
 // - TextCompletionRequest
 // - ChatRequest
 // - ResponsesRequest
+// - CountTokensRequest
 // - EmbeddingRequest
 // - SpeechRequest
 // - TranscriptionRequest
@@ -168,6 +170,7 @@ type BifrostRequest struct {
 	TextCompletionRequest *BifrostTextCompletionRequest
 	ChatRequest           *BifrostChatRequest
 	ResponsesRequest      *BifrostResponsesRequest
+	CountTokensRequest    *BifrostResponsesRequest
 	EmbeddingRequest      *BifrostEmbeddingRequest
 	SpeechRequest         *BifrostSpeechRequest
 	TranscriptionRequest  *BifrostTranscriptionRequest
@@ -192,6 +195,8 @@ func (br *BifrostRequest) GetRequestFields() (provider ModelProvider, model stri
 		return br.ChatRequest.Provider, br.ChatRequest.Model, br.ChatRequest.Fallbacks
 	case br.ResponsesRequest != nil:
 		return br.ResponsesRequest.Provider, br.ResponsesRequest.Model, br.ResponsesRequest.Fallbacks
+	case br.CountTokensRequest != nil:
+		return br.CountTokensRequest.Provider, br.CountTokensRequest.Model, br.CountTokensRequest.Fallbacks
 	case br.EmbeddingRequest != nil:
 		return br.EmbeddingRequest.Provider, br.EmbeddingRequest.Model, br.EmbeddingRequest.Fallbacks
 	case br.SpeechRequest != nil:
@@ -260,6 +265,8 @@ func (br *BifrostRequest) SetProvider(provider ModelProvider) {
 		br.ChatRequest.Provider = provider
 	case br.ResponsesRequest != nil:
 		br.ResponsesRequest.Provider = provider
+	case br.CountTokensRequest != nil:
+		br.CountTokensRequest.Provider = provider
 	case br.EmbeddingRequest != nil:
 		br.EmbeddingRequest.Provider = provider
 	case br.SpeechRequest != nil:
@@ -277,6 +284,8 @@ func (br *BifrostRequest) SetModel(model string) {
 		br.ChatRequest.Model = model
 	case br.ResponsesRequest != nil:
 		br.ResponsesRequest.Model = model
+	case br.CountTokensRequest != nil:
+		br.CountTokensRequest.Model = model
 	case br.EmbeddingRequest != nil:
 		br.EmbeddingRequest.Model = model
 	case br.SpeechRequest != nil:
@@ -294,6 +303,8 @@ func (br *BifrostRequest) SetFallbacks(fallbacks []Fallback) {
 		br.ChatRequest.Fallbacks = fallbacks
 	case br.ResponsesRequest != nil:
 		br.ResponsesRequest.Fallbacks = fallbacks
+	case br.CountTokensRequest != nil:
+		br.CountTokensRequest.Fallbacks = fallbacks
 	case br.EmbeddingRequest != nil:
 		br.EmbeddingRequest.Fallbacks = fallbacks
 	case br.SpeechRequest != nil:
@@ -311,6 +322,8 @@ func (br *BifrostRequest) SetRawRequestBody(rawRequestBody []byte) {
 		br.ChatRequest.RawRequestBody = rawRequestBody
 	case br.ResponsesRequest != nil:
 		br.ResponsesRequest.RawRequestBody = rawRequestBody
+	case br.CountTokensRequest != nil:
+		br.CountTokensRequest.RawRequestBody = rawRequestBody
 	case br.EmbeddingRequest != nil:
 		br.EmbeddingRequest.RawRequestBody = rawRequestBody
 	case br.SpeechRequest != nil:
@@ -328,6 +341,7 @@ type BifrostResponse struct {
 	ChatResponse                *BifrostChatResponse
 	ResponsesResponse           *BifrostResponsesResponse
 	ResponsesStreamResponse     *BifrostResponsesStreamResponse
+	CountTokensResponse         *BifrostCountTokensResponse
 	EmbeddingResponse           *BifrostEmbeddingResponse
 	SpeechResponse              *BifrostSpeechResponse
 	SpeechStreamResponse        *BifrostSpeechStreamResponse
@@ -355,6 +369,8 @@ func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 		return &r.ResponsesResponse.ExtraFields
 	case r.ResponsesStreamResponse != nil:
 		return &r.ResponsesStreamResponse.ExtraFields
+	case r.CountTokensResponse != nil:
+		return &r.CountTokensResponse.ExtraFields
 	case r.EmbeddingResponse != nil:
 		return &r.EmbeddingResponse.ExtraFields
 	case r.SpeechResponse != nil:

--- a/core/schemas/count_tokens.go
+++ b/core/schemas/count_tokens.go
@@ -1,0 +1,14 @@
+package schemas
+
+// BifrostCountTokensResponse captures token counts for a provided input.
+type BifrostCountTokensResponse struct {
+	Object             string                        `json:"object,omitempty"`
+	Model              string                        `json:"model"`
+	InputTokens        int                           `json:"input_tokens"`
+	InputTokensDetails *ResponsesResponseInputTokens `json:"input_tokens_details,omitempty"`
+	Tokens             []int                         `json:"tokens"`
+	TokenStrings       []string                      `json:"token_strings,omitempty"`
+	OutputTokens       *int                          `json:"output_tokens,omitempty"`
+	TotalTokens        *int                          `json:"total_tokens"`
+	ExtraFields        BifrostResponseExtraFields    `json:"extra_fields"`
+}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -173,6 +173,7 @@ type AllowedRequests struct {
 	ChatCompletionStream bool `json:"chat_completion_stream"`
 	Responses            bool `json:"responses"`
 	ResponsesStream      bool `json:"responses_stream"`
+	CountTokens          bool `json:"count_tokens"`
 	Embedding            bool `json:"embedding"`
 	Speech               bool `json:"speech"`
 	SpeechStream         bool `json:"speech_stream"`
@@ -211,6 +212,8 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 		return ar.Responses
 	case ResponsesStreamRequest:
 		return ar.ResponsesStream
+	case CountTokensRequest:
+		return ar.CountTokens
 	case EmbeddingRequest:
 		return ar.Embedding
 	case SpeechRequest:
@@ -329,6 +332,8 @@ type Provider interface {
 	Responses(ctx context.Context, key Key, request *BifrostResponsesRequest) (*BifrostResponsesResponse, *BifrostError)
 	// ResponsesStream performs a completion request using the Responses API stream (uses chat completion stream request internally for non-openai providers)
 	ResponsesStream(ctx context.Context, postHookRunner PostHookRunner, key Key, request *BifrostResponsesRequest) (chan *BifrostStream, *BifrostError)
+	// CountTokens performs a count tokens request
+	CountTokens(ctx context.Context, key Key, request *BifrostResponsesRequest) (*BifrostCountTokensResponse, *BifrostError)
 	// Embedding performs an embedding request
 	Embedding(ctx context.Context, key Key, request *BifrostEmbeddingRequest) (*BifrostEmbeddingResponse, *BifrostError)
 	// Speech performs a text to speech request

--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -37,6 +37,10 @@
       "description": "Endpoints for creating vector embeddings from text."
     },
     {
+      "name": "Tokens",
+      "description": "Endpoints for token counting operations."
+    },
+    {
       "name": "Audio",
       "description": "Endpoints for audio processing, including speech synthesis and transcription."
     },
@@ -301,6 +305,39 @@
               "text/event-stream": {
                 "schema": {
                   "$ref": "#/components/schemas/BifrostStream"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/count_tokens": {
+      "post": {
+        "summary": "Count Tokens",
+        "description": "Counts tokens for the provided messages and model.",
+        "operationId": "countTokens",
+        "tags": [
+          "Bifrost Core",
+          "Tokens"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CountTokensRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token count response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountTokensResponse"
                 }
               }
             }
@@ -6787,6 +6824,245 @@
           }
         }
       },
+      "BifrostCost": {
+        "type": "object",
+        "properties": {
+          "input_tokens_cost": {
+            "type": "number"
+          },
+          "output_tokens_cost": {
+            "type": "number"
+          },
+          "request_cost": {
+            "type": "number"
+          },
+          "total_cost": {
+            "type": "number"
+          }
+        }
+      },
+      "ResponsesResponseInputTokens": {
+        "type": "object",
+        "properties": {
+          "text_tokens": {
+            "type": "integer"
+          },
+          "audio_tokens": {
+            "type": "integer"
+          },
+          "image_tokens": {
+            "type": "integer"
+          },
+          "cached_tokens": {
+            "type": "integer",
+            "description": "Tokens read from or used to create cache entries."
+          }
+        }
+      },
+      "ResponsesResponseOutputTokens": {
+        "type": "object",
+        "properties": {
+          "text_tokens": {
+            "type": "integer"
+          },
+          "accepted_prediction_tokens": {
+            "type": "integer"
+          },
+          "audio_tokens": {
+            "type": "integer"
+          },
+          "reasoning_tokens": {
+            "type": "integer"
+          },
+          "rejected_prediction_tokens": {
+            "type": "integer"
+          },
+          "citation_tokens": {
+            "type": "integer"
+          },
+          "num_search_queries": {
+            "type": "integer"
+          },
+          "cached_tokens": {
+            "type": "integer",
+            "description": "Tokens used to create cache entries."
+          }
+        }
+      },
+      "ResponsesResponseUsage": {
+        "type": "object",
+        "properties": {
+          "input_tokens": {
+            "type": "integer"
+          },
+          "input_tokens_details": {
+            "$ref": "#/components/schemas/ResponsesResponseInputTokens"
+          },
+          "output_tokens": {
+            "type": "integer"
+          },
+          "output_tokens_details": {
+            "$ref": "#/components/schemas/ResponsesResponseOutputTokens"
+          },
+          "total_tokens": {
+            "type": "integer"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/BifrostCost"
+          }
+        }
+      },
+      "CountTokensRequest": {
+        "type": "object",
+        "required": [
+          "model",
+          "input"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model identifier in 'provider/model' format"
+          },
+          "input": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResponsesMessage"
+            },
+            "description": "Messages to tokenize",
+            "minItems": 1
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fallback models in 'provider/model' format"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResponsesTool"
+            }
+          },
+          "stream": {
+            "type": "boolean"
+          },
+          "stream_format": {
+            "type": "string"
+          },
+          "background": {
+            "type": "boolean"
+          },
+          "conversation": {
+            "type": "string"
+          },
+          "include": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "max_output_tokens": {
+            "type": "integer"
+          },
+          "max_tool_calls": {
+            "type": "integer"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "parallel_tool_calls": {
+            "type": "boolean"
+          },
+          "previous_response_id": {
+            "type": "string"
+          },
+          "prompt_cache_key": {
+            "type": "string"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/ResponsesParametersReasoning"
+          },
+          "safety_identifier": {
+            "type": "string"
+          },
+          "service_tier": {
+            "type": "string"
+          },
+          "stream_options": {
+            "$ref": "#/components/schemas/ResponsesStreamOptions"
+          },
+          "store": {
+            "type": "boolean"
+          },
+          "temperature": {
+            "type": "number"
+          },
+          "text": {
+            "$ref": "#/components/schemas/ResponsesTextConfig"
+          },
+          "top_logprobs": {
+            "type": "integer"
+          },
+          "top_p": {
+            "type": "number"
+          },
+          "tool_choice": {
+            "$ref": "#/components/schemas/ResponsesToolChoice"
+          },
+          "truncation": {
+            "type": "string"
+          }
+        }
+      },
+      "CountTokensResponse": {
+        "type": "object",
+        "properties": {
+          "object": {
+            "type": "string",
+            "description": "Response object type"
+          },
+          "model": {
+            "type": "string"
+          },
+          "input_tokens": {
+            "type": "integer"
+          },
+          "input_tokens_details": {
+            "$ref": "#/components/schemas/ResponsesResponseInputTokens",
+            "description": "Detailed input token breakdown. Only populated for Vertex and Gemini providers."
+          },
+          "tokens": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Array of token IDs"
+          },
+          "token_strings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of token strings (if available)"
+          },
+          "output_tokens": {
+            "type": "integer",
+            "nullable": true
+          },
+          "total_tokens": {
+            "type": "integer",
+            "nullable": true
+          },
+          "extra_fields": {
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
       "ResponsesParametersReasoning": {
         "type": "object",
         "properties": {
@@ -7691,9 +7967,29 @@
       "BifrostLLMUsage": {
         "type": "object",
         "properties": {
-          "prompt_tokens": { "type": "integer" },
-          "completion_tokens": { "type": "integer" },
-          "total_tokens": { "type": "integer" }
+          "prompt_tokens": {
+            "type": "integer",
+            "description": "Number of prompt tokens"
+          },
+          "prompt_tokens_details": {
+            "$ref": "#/components/schemas/ResponsesResponseInputTokens",
+            "description": "Breakdown of prompt tokens"
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "description": "Number of completion tokens"
+          },
+          "completion_tokens_details": {
+            "$ref": "#/components/schemas/ResponsesResponseOutputTokens",
+            "description": "Breakdown of completion tokens"
+          },
+          "total_tokens": {
+            "type": "integer",
+            "description": "Total tokens for the request"
+          },
+          "cost": {
+            "$ref": "#/components/schemas/BifrostCost"
+          }
         }
       },
       "SpeechInput": {

--- a/docs/providers/supported-providers.mdx
+++ b/docs/providers/supported-providers.mdx
@@ -15,26 +15,27 @@ Bifrost can also act as a provider-compatible gateway (for example, <u>[Anthropi
 
 The following table summarizes which operations are supported by each provider via Bifrost’s unified interface.
 
-| Provider | Models | Text | Text (stream) | Chat | Chat (stream) | Responses | Responses (stream) | Embeddings | TTS | TTS (stream) | STT | STT (stream) | Files | Batch |
-|----------|--------|------|----------------|------|---------------|-----------|--------------------|------------|-----|-------------|-----|--------------|-------|-------|
-| Anthropic (`anthropic/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Azure (`azure/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
-| Bedrock (`bedrock/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Cerebras (`cerebras/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Cohere (`cohere/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Elevenlabs (`elevenlabs/<model>`) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Gemini (`gemini/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Groq (`groq/<model>`) | ✅ | 🟡 | 🟡 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Hugging Face (`huggingface/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Mistral (`mistral/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| Nebius (`nebius/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |❌ | ❌ |
-| Ollama (`ollama/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| OpenAI (`openai/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| OpenRouter (`openrouter/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Parasail (`parasail/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Perplexity (`perplexity/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| SGL (`sgl/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Vertex AI (`vertex/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Provider | Models | Text | Text (stream) | Chat | Chat (stream) | Responses | Responses (stream) | Embeddings | TTS | TTS (stream) | STT | STT (stream) | Files | Batch | Count tokens |
+|----------|--------|------|----------------|------|---------------|-----------|--------------------|------------|-----|-------------|-----|--------------|-------|-------|--------------|
+| Anthropic (`anthropic/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| Azure (`azure/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| Bedrock (`bedrock/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ |
+| Cerebras (`cerebras/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Cohere (`cohere/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Elevenlabs (`elevenlabs/<model>`) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Gemini (`gemini/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Groq (`groq/<model>`) | ✅ | 🟡 | 🟡 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Hugging Face (`huggingface/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Mistral (`mistral/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| Nebius (`nebius/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |❌ | ❌ | ❌ |
+| Ollama (`ollama/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| OpenAI (`openai/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| OpenRouter (`openrouter/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Parasail (`parasail/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Perplexity (`perplexity/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| SGL (`sgl/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Vertex AI (`vertex/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+
 
 - 🟡 Not supported by the downstream provider, but internally implemented by Bifrost as a fallback.
 - ❌ Not supported by the downstream provider, hence not supported by Bifrost.
@@ -60,8 +61,6 @@ Notes:
 ## Response Format
 
 All providers return responses in the OpenAI-compatible format. Bifrost handles the translation between different provider-specific formats automatically.
-
-<Tabs group="unified-interface">
 
 <Tab title="Gateway">
 
@@ -125,8 +124,6 @@ response, err := client.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
 
 </Tab>
 
-
-</Tabs>
 
 ## Custom Providers
 

--- a/tests/integrations/config.yml
+++ b/tests/integrations/config.yml
@@ -52,6 +52,7 @@ providers:
     file_retrieve: "gpt-4o-mini"
     file_delete: "gpt-4o-mini"
     file_content: "gpt-4o-mini"
+    count_tokens: "gpt-4o-mini"
     alternatives:
       - "gpt-4"
       - "gpt-4-turbo-preview"
@@ -73,6 +74,7 @@ providers:
     file_list: "claude-sonnet-4-20250514"
     file_delete: "claude-sonnet-4-20250514"
     file_content: "claude-sonnet-4-20250514"
+    count_tokens: "claude-sonnet-4-5-20250929"
     alternatives:
       - "claude-3-sonnet-20240229"
       - "claude-3-opus-20240229"
@@ -100,6 +102,7 @@ providers:
     file_content: "gemini-2.0-flash"
     file_download: "gemini-2.0-flash"
     file_delete: "gemini-2.0-flash"
+    count_tokens: "gemini-2.5-flash"
     alternatives:
       - "gemini-1.5-pro"
       - "gemini-1.5-flash"
@@ -133,6 +136,7 @@ providers:
     tools: "command-a-03-2025"
     embeddings: "embed-v4.0"
     streaming: "command-a-03-2025"
+    count_tokens: "command-a-03-2025"
     alternatives:
       - "command-r-plus"
 
@@ -184,6 +188,7 @@ provider_scenarios:
     file_retrieve: true
     file_delete: true
     file_content: true
+    count_tokens: true
     
   anthropic:
     simple_chat: true
@@ -222,6 +227,7 @@ provider_scenarios:
     file_retrieve: false
     file_delete: true
     file_content: false
+    count_tokens: true
     
   gemini:
     simple_chat: true
@@ -260,6 +266,7 @@ provider_scenarios:
     file_retrieve: true
     file_delete: true
     file_content: false  # Gemini doesn't support direct file download
+    count_tokens: true
     
   bedrock:
     simple_chat: true
@@ -336,6 +343,7 @@ provider_scenarios:
     file_retrieve: false
     file_delete: false
     file_content: false
+    count_tokens: true
 
 # Scenario to capability mapping
 # Maps test scenario names to their corresponding capability types
@@ -376,6 +384,7 @@ scenario_capabilities:
   file_retrieve: "file_retrieve"  # Uses file_retrieve model directly
   file_delete: "file_delete"  # Uses file_delete model directly
   file_content: "file_content"  # Uses file_content model directly
+  count_tokens: "chat"
 
 # Model capabilities matrix
 model_capabilities:

--- a/tests/integrations/tests/test_bedrock.py
+++ b/tests/integrations/tests/test_bedrock.py
@@ -40,36 +40,37 @@ Prompt Caching Tests:
 23. Prompt caching with tools checkpoint
 """
 
-import pytest
-import boto3
-import json
 import base64
+import json
 import time
 import urllib.request
-from typing import List, Dict, Any
+from typing import Any, Dict, List
+
+import boto3
+import pytest
 
 from .utils.common import (
-    Config,
     BASE64_IMAGE,
-    WEATHER_TOOL,
     CALCULATOR_TOOL,
-    PROMPT_CACHING_TOOLS,
-    SIMPLE_CHAT_MESSAGES,
+    LOCATION_KEYWORDS,
     MULTI_TURN_MESSAGES,
     MULTIPLE_TOOL_CALL_MESSAGES,
     PROMPT_CACHING_LARGE_CONTEXT,
-    mock_tool_response,
-    assert_valid_chat_response,
-    assert_has_tool_calls,
-    extract_tool_calls,
-    skip_if_no_api_key,
+    PROMPT_CACHING_TOOLS,
+    SIMPLE_CHAT_MESSAGES,
     WEATHER_KEYWORDS,
-    LOCATION_KEYWORDS,
+    WEATHER_TOOL,
+    Config,
+    assert_has_tool_calls,
+    assert_valid_chat_response,
+    extract_tool_calls,
+    mock_tool_response,
+    skip_if_no_api_key,
 )
-from .utils.config_loader import get_model, get_config, get_integration_url
+from .utils.config_loader import get_config, get_integration_url, get_model
 from .utils.parametrize import (
-    get_cross_provider_params_for_scenario,
     format_provider_model,
+    get_cross_provider_params_for_scenario,
 )
 
 
@@ -1496,7 +1497,7 @@ class TestBedrockIntegration:
 
             job_arn = create_response["jobArn"]
 
-            print(f"stopping the job")
+            print("stopping the job")
 
             # Cancel the job
             bedrock_client.stop_model_invocation_job(jobIdentifier=job_arn)

--- a/tests/integrations/tests/test_litellm.py
+++ b/tests/integrations/tests/test_litellm.py
@@ -80,6 +80,10 @@ from .utils.common import (
     collect_streaming_transcription_content,
     get_provider_voice,
     get_provider_voices,
+    # Token counting test data
+    INPUT_TOKENS_SIMPLE_TEXT,
+    INPUT_TOKENS_LONG_TEXT,
+    INPUT_TOKENS_WITH_SYSTEM,
 )
 from .utils.config_loader import get_model
 from .utils.parametrize import (
@@ -782,6 +786,92 @@ class TestLiteLLMIntegration:
             assert any(
                 word in content for word in ["tokyo", "japan"]
             ), f"Model {model} should mention Tokyo. Got: {content}"
+
+    @pytest.mark.parametrize(
+        "provider, model",
+        get_cross_provider_params_for_scenario(
+            "count_tokens", exclude_providers=LITELLM_EXCLUDED_PROVIDERS
+        ),
+    )
+    def test_20_token_counter_simple_text(self, test_config, provider, model):
+        """Test Case 20: Count tokens from simple text using LiteLLM token_counter"""
+        if provider == "_no_providers_" or model == "_no_model_":
+            pytest.skip("No providers configured for this scenario")
+
+        try:
+            # Count tokens using text parameter
+            token_count = litellm.token_counter(
+                model=model,
+                text=INPUT_TOKENS_SIMPLE_TEXT,
+            )
+
+            # Validate token count
+            assert isinstance(token_count, int), "Token count should be an integer"
+            assert token_count > 0, "Token count should be positive"
+            # Simple text should have a reasonable token count (between 3-20 tokens)
+            assert 3 <= token_count <= 20, (
+                f"Simple text should have 3-20 tokens, got {token_count}"
+            )
+
+        except Exception as e:
+            pytest.skip(f"Token counting not available for {provider}/{model}: {e}")
+
+    @pytest.mark.parametrize(
+        "provider, model",
+        get_cross_provider_params_for_scenario(
+            "count_tokens", exclude_providers=LITELLM_EXCLUDED_PROVIDERS
+        ),
+    )
+    def test_21_token_counter_with_messages(self, test_config, provider, model):
+        """Test Case 21: Count tokens from messages with system message using LiteLLM token_counter"""
+        if provider == "_no_providers_" or model == "_no_model_":
+            pytest.skip("No providers configured for this scenario")
+
+        try:
+            # Count tokens using messages parameter
+            token_count = litellm.token_counter(
+                model=model,
+                messages=INPUT_TOKENS_WITH_SYSTEM,
+            )
+
+            # Validate token count
+            assert isinstance(token_count, int), "Token count should be an integer"
+            assert token_count > 0, "Token count should be positive"
+            # With system message should have more tokens than simple text
+            assert token_count > 2, (
+                f"With system message should have >2 tokens, got {token_count}"
+            )
+
+        except Exception as e:
+            pytest.skip(f"Token counting not available for {provider}/{model}: {e}")
+
+    @pytest.mark.parametrize(
+        "provider, model",
+        get_cross_provider_params_for_scenario(
+            "count_tokens", exclude_providers=LITELLM_EXCLUDED_PROVIDERS
+        ),
+    )
+    def test_22_token_counter_long_text(self, test_config, provider, model):
+        """Test Case 22: Count tokens from long text using LiteLLM token_counter"""
+        if provider == "_no_providers_" or model == "_no_model_":
+            pytest.skip("No providers configured for this scenario")
+
+        try:
+            # Count tokens using text parameter with long text
+            token_count = litellm.token_counter(
+                model=model,
+                text=INPUT_TOKENS_LONG_TEXT,
+            )
+
+            # Validate token count
+            assert isinstance(token_count, int), "Token count should be an integer"
+            assert token_count > 100, (
+                f"Long text should have >100 tokens, got {token_count}"
+            )
+
+        except Exception as e:
+            pytest.skip(f"Token counting not available for {provider}/{model}: {e}")
+
 
 
 # Additional helper functions specific to LiteLLM

--- a/tests/integrations/tests/utils/config_loader.py
+++ b/tests/integrations/tests/utils/config_loader.py
@@ -6,11 +6,11 @@ for constructing integration URLs through the Bifrost gateway.
 """
 
 import os
-import yaml
-from typing import Dict, Any, Optional, List
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
+import yaml
 
 # Integration to provider mapping
 # Maps integration names to their underlying provider configurations
@@ -277,15 +277,15 @@ class ConfigLoader:
 
         # Bifrost configuration
         bifrost = self.get_bifrost_config()
-        print(f"\n🌉 BIFROST GATEWAY:")
+        print("\n🌉 BIFROST GATEWAY:")
         print(f"  Base URL: {bifrost.base_url}")
-        print(f"  Endpoints:")
+        print("  Endpoints:")
         for integration, endpoint in bifrost.endpoints.items():
             full_url = f"{bifrost.base_url.rstrip('/')}/{endpoint}"
             print(f"    {integration}: {full_url}")
 
         # Model configurations
-        print(f"\n🤖 MODEL CONFIGURATIONS (via providers):")
+        print("\n🤖 MODEL CONFIGURATIONS (via providers):")
         for integration, provider in INTEGRATION_TO_PROVIDER_MAP.items():
             if "providers" in self._config and provider in self._config["providers"]:
                 models = self._config["providers"][provider]
@@ -298,7 +298,7 @@ class ConfigLoader:
 
         # API settings
         api_config = self.get_api_config()
-        print(f"\n⚙️  API SETTINGS:")
+        print("\n⚙️  API SETTINGS:")
         print(f"  Timeout: {api_config['timeout']}s")
         print(f"  Max Retries: {api_config['max_retries']}")
         print(f"  Retry Delay: {api_config['retry_delay']}s")

--- a/transports/bifrost-http/integrations/langchain.go
+++ b/transports/bifrost-http/integrations/langchain.go
@@ -23,6 +23,8 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 
 	// Add Anthropic routes to LangChain for Anthropic API compatibility
 	routes = append(routes, CreateAnthropicRouteConfigs("/langchain")...)
+	// Add Anthropic count tokens route for LangChain to ensure token counting uses the dedicated endpoint
+	routes = append(routes, CreateAnthropicCountTokensRouteConfigs("/langchain", handlerStore)...)
 
 	// Add GenAI routes to LangChain for Vertex AI compatibility
 	routes = append(routes, CreateGenAIRouteConfigs("/langchain")...)

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -170,8 +170,12 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *context.
 	}
 	ctx.SetContentType("application/json")
 
-	errorBody, err := sonic.Marshal(errorConverter(bifrostCtx, bifrostErr))
+	// Marshal the error for response and log the error for diagnostics
+	responseObj := errorConverter(bifrostCtx, bifrostErr)
+	errorBody, err := sonic.Marshal(responseObj)
 	if err != nil {
+		// Log the marshal failure and return a plain text error
+		g.logger.Error("failed to marshal error response", "err", err, "path", extractExactPath(ctx))
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 		ctx.SetBodyString(fmt.Sprintf("failed to encode error response: %v", err))
 		return

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -52,6 +52,7 @@ export default function AddCustomProviderSheet({ show, onClose, onSave }: Props)
 				speech_stream: true,
 				transcription: true,
 				transcription_stream: true,
+				count_tokens: true,
 				list_models: true,
 			},
 			request_path_overrides: undefined,

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -32,6 +32,7 @@ const PROVIDER_ENDPOINTS: Partial<Record<BaseProvider, Partial<Record<RequestTyp
 		speech_stream: "/v1/audio/speech",
 		transcription: "/v1/audio/transcriptions",
 		transcription_stream: "/v1/audio/transcriptions",
+		count_tokens: "/v1/responses/tokens",
 	},
 	anthropic: {
 		chat_completion: "/v1/messages",
@@ -69,6 +70,7 @@ const REQUEST_TYPES: Array<{ key: RequestType; label: string }> = [
 	{ key: "speech_stream", label: "Speech Stream" },
 	{ key: "transcription", label: "Transcription" },
 	{ key: "transcription_stream", label: "Transcription Stream" },
+	{ key: "count_tokens", label: "Count Tokens" },
 ];
 
 export function AllowedRequestsFields({ control, namePrefix = "allowed_requests", providerType }: AllowedRequestsFieldsProps) {

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -49,6 +49,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				speech_stream: provider.custom_provider_config?.allowed_requests?.speech_stream ?? true,
 				transcription: provider.custom_provider_config?.allowed_requests?.transcription ?? true,
 				transcription_stream: provider.custom_provider_config?.allowed_requests?.transcription_stream ?? true,
+				count_tokens: provider.custom_provider_config?.allowed_requests?.count_tokens ?? true,
 				list_models: provider.custom_provider_config?.allowed_requests?.list_models ?? true,
 			},
 			request_path_overrides: provider.custom_provider_config?.request_path_overrides ?? undefined,

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -105,8 +105,9 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 		"speech_stream",
 		"transcription",
 		"transcription_stream",
+		"count_tokens",
 	],
-	anthropic: ["list_models", "chat_completion", "chat_completion_stream", "responses", "responses_stream"],
+	anthropic: ["list_models", "chat_completion", "chat_completion_stream", "responses", "responses_stream", "count_tokens"],
 	gemini: [
 		"list_models",
 		"chat_completion",
@@ -118,8 +119,9 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 		"transcription_stream",
 		"speech",
 		"speech_stream",
+		"count_tokens",
 	],
-	cohere: ["list_models", "chat_completion", "chat_completion_stream", "responses", "responses_stream", "embedding"],
+	cohere: ["list_models", "chat_completion", "chat_completion_stream", "responses", "responses_stream", "embedding", "count_tokens"],
 	bedrock: ["list_models", "text_completion", "chat_completion", "chat_completion_stream", "responses", "responses_stream", "embedding"],
 };
 

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -39,6 +39,7 @@ export const RequestTypes = [
 	"speech_stream",
 	"transcription",
 	"transcription_stream",
+	"count_tokens",
 ] as const;
 
 export const ProviderLabels: Record<ProviderName, string> = {
@@ -105,6 +106,7 @@ export const RequestTypeLabels = {
 	speech_stream: "Speech Stream",
 	transcription: "Transcription",
 	transcription_stream: "Transcription Stream",
+	count_tokens: "Count Tokens",
 
 	batch_create: "Batch Create",
 	batch_list: "Batch List",
@@ -146,6 +148,7 @@ export const RequestTypeColors = {
 	speech_stream: "bg-pink-100 text-pink-800",
 	transcription: "bg-orange-100 text-orange-800",
 	transcription_stream: "bg-lime-100 text-lime-800",
+	count_tokens: "bg-cyan-100 text-cyan-800",
 
 	batch_create: "bg-green-100 text-green-800",
 	batch_list: "bg-blue-100 text-blue-800",

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -148,6 +148,7 @@ export type RequestType =
 	| "speech_stream"
 	| "transcription"
 	| "transcription_stream"
+	| "count_tokens"
 	| "batch_create"
 	| "batch_list"
 	| "batch_retrieve"
@@ -172,6 +173,7 @@ export interface AllowedRequests {
 	speech_stream: boolean;
 	transcription: boolean;
 	transcription_stream: boolean;
+	count_tokens: boolean;
 	list_models: boolean;
 }
 

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -334,6 +334,7 @@ export const allowedRequestsSchema = z.object({
 	speech_stream: z.boolean(),
 	transcription: z.boolean(),
 	transcription_stream: z.boolean(),
+	count_tokens: z.boolean(),
 	list_models: z.boolean(),
 });
 


### PR DESCRIPTION
## Summary

This PR adds a new `CountTokens` API to Bifrost, allowing clients to count tokens for a given model and input without generating a response. This is useful for estimating costs, validating input lengths, and managing token budgets.

## Changes

- Added a new `CountTokensRequest` API endpoint to the core Bifrost interface
- Implemented token counting for Anthropic, Bedrock, Cohere, Gemini, OpenAI, and Vertex providers
- Added comprehensive test utilities for token counting functionality
- Added fallback support for token counting requests
- Implemented provider-specific token counting request/response conversions

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new token counting functionality with supported providers:

```sh
# Run all tests including token counting
source .env
go test ./...

# Test specific providers with token counting
go test ./core/providers/openai -run TestOpenAI/OpenAiTests/CountTokens
go test ./core/providers/anthropic -run TestAnthropic/AnthropicTests/CountTokens
go test ./core/providers/gemini -run TestGemini/GeminiTests/CountTokens
go test ./core/providers/cohere -run TestCohere/CohereTests/CountTokens
go test ./core/providers/bedrock -run TestBedrock/BedrockTests/CountTokens
go test ./core/providers/vertex -run TestVertex/VertexTests/CountTokens
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

#970

## Security considerations

None

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally