### PR TITLE
fixes core tests for batches

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -69,6 +69,16 @@ func TestBedrock(t *testing.T) {
 			Embedding:             true,
 			ListModels:            true,
 			Reasoning:             true,
+			BatchCreate:           true,
+			BatchList:             true,
+			BatchRetrieve:         true,
+			BatchCancel:           true,
+			BatchResults:          true,
+			FileUpload:            true,
+			FileList:              true,
+			FileRetrieve:          true,
+			FileDelete:            true,
+			FileContent:           true,
 		},
 	}
 

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -54,6 +54,16 @@ func TestGemini(t *testing.T) {
 			SpeechSynthesisStream: true,
 			Reasoning:             true,
 			ListModels:            true,
+			BatchCreate:           true,
+			BatchList:             true,
+			BatchRetrieve:         true,
+			BatchCancel:           true,
+			BatchResults:          true,
+			FileUpload:            true,
+			FileList:              true,
+			FileRetrieve:          true,
+			FileDelete:            true,
+			FileContent:           true,
 		},
 	}
 

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -60,6 +60,16 @@ func TestOpenAI(t *testing.T) {
 			Embedding:             true,
 			Reasoning:             true,
 			ListModels:            true,
+			BatchCreate:           true,
+			BatchList:             true,
+			BatchRetrieve:         true,
+			BatchCancel:           true,
+			BatchResults:          true,
+			FileUpload:            true,
+			FileList:              true,
+			FileRetrieve:          true,
+			FileDelete:            true,
+			FileContent:           true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Added batch processing and file management capabilities to provider test configurations for Bedrock, Gemini, and OpenAI.

## Changes

- Added batch processing capabilities (`BatchCreate`, `BatchList`, `BatchRetrieve`, `BatchCancel`, `BatchResults`) to test configurations for Bedrock, Gemini, and OpenAI providers
- Added file management capabilities (`FileUpload`, `FileList`, `FileRetrieve`, `FileDelete`, `FileContent`) to test configurations for the same providers
- All new capabilities are set to `true` in the test configurations

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Run provider tests
go test ./core/providers/bedrock/...
go test ./core/providers/gemini/...
go test ./core/providers/openai/...
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only affects test configurations.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)