### PR TITLE
adds new file-supported-batch flag for tests

### DIFF
--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -51,6 +51,7 @@ type TestScenarios struct {
 	FileRetrieve          bool // File API retrieve functionality
 	FileDelete            bool // File API delete functionality
 	FileContent           bool // File API content download functionality
+	FileBatchInput        bool // Whether batch create supports file-based input (InputFileID)
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios

--- a/core/internal/testutil/batch.go
+++ b/core/internal/testutil/batch.go
@@ -627,10 +627,10 @@ func RunFileUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 
 // RunFileAndBatchIntegrationTest tests the integration between file upload and batch create
 func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
-	// Skip if either file upload or batch create is not supported
-	if !testConfig.Scenarios.FileUpload || !testConfig.Scenarios.BatchCreate {
-		t.Logf("[SKIPPED] File and Batch Integration: FileUpload=%v, BatchCreate=%v for provider %s",
-			testConfig.Scenarios.FileUpload, testConfig.Scenarios.BatchCreate, testConfig.Provider)
+	// Skip if file-based batch input is not supported
+	if !testConfig.Scenarios.FileBatchInput {
+		t.Logf("[SKIPPED] File and Batch Integration: FileBatchInput=%v for provider %s",
+			testConfig.Scenarios.FileBatchInput, testConfig.Provider)
 		return
 	}
 

--- a/core/internal/testutil/tests.go
+++ b/core/internal/testutil/tests.go
@@ -115,7 +115,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"FileDelete", testConfig.Scenarios.FileDelete},
 		{"FileContent", testConfig.Scenarios.FileContent},
 		{"FileUnsupported", !testConfig.Scenarios.FileUpload && !testConfig.Scenarios.FileList && !testConfig.Scenarios.FileRetrieve && !testConfig.Scenarios.FileDelete && !testConfig.Scenarios.FileContent},
-		{"FileAndBatchIntegration", testConfig.Scenarios.FileUpload && testConfig.Scenarios.BatchCreate},
+		{"FileAndBatchIntegration", testConfig.Scenarios.FileBatchInput},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/anthropic_test.go
+++ b/core/providers/anthropic/anthropic_test.go
@@ -57,7 +57,8 @@ func TestAnthropic(t *testing.T) {
 			FileList:              true,
 			FileRetrieve:          true,
 			FileDelete:            true,
-			FileContent:           true,
+			FileContent:           false,
+			FileBatchInput:        false, // Anthropic batch API only supports inline requests, not file-based input
 		},
 	}
 

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -79,6 +79,7 @@ func TestBedrock(t *testing.T) {
 			FileRetrieve:          true,
 			FileDelete:            true,
 			FileContent:           true,
+			FileBatchInput:        true,
 		},
 	}
 

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -63,7 +63,8 @@ func TestGemini(t *testing.T) {
 			FileList:              true,
 			FileRetrieve:          true,
 			FileDelete:            true,
-			FileContent:           true,
+			FileContent:           false,
+			FileBatchInput:        true,
 		},
 	}
 

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -70,6 +70,7 @@ func TestOpenAI(t *testing.T) {
 			FileRetrieve:          true,
 			FileDelete:            true,
 			FileContent:           true,
+			FileBatchInput:        true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Added support for file-based batch input testing and improved batch request handling in the Gemini provider.

## Changes

- Added a new `FileBatchInput` flag to test scenarios to explicitly track whether a provider supports file-based input for batch operations
- Updated the file and batch integration test to check for `FileBatchInput` instead of requiring both `FileUpload` and `BatchCreate`
- Improved message extraction in Gemini's batch request handling to support multiple data formats
- Updated provider test configurations to accurately reflect file capabilities:
  - Anthropic: Disabled file content and file batch input support
  - Bedrock: Enabled file batch input support
  - Gemini: Disabled file content but enabled file batch input support
  - OpenAI: Enabled file batch input support

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the provider tests to verify file and batch integration:

```sh
# Test all providers
go test ./core/providers/...

# Test specific providers
go test ./core/providers/gemini/...
go test ./core/providers/anthropic/...
go test ./core/providers/bedrock/...
go test ./core/providers/openai/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable