### PR TITLE
fixes bedrock tests

### DIFF
--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -72,6 +72,8 @@ type ComprehensiveTestConfig struct {
 	SpeechSynthesisFallbacks []schemas.Fallback // for speech synthesis tests
 	EmbeddingFallbacks       []schemas.Fallback // for embedding tests
 	SkipReason               string             // Reason to skip certain tests
+	BatchExtraParams         map[string]interface{} // Extra params for batch operations (e.g., role_arn, output_s3_uri for Bedrock)
+	FileExtraParams          map[string]interface{} // Extra params for file operations (e.g., s3_bucket for Bedrock)
 }
 
 // ComprehensiveTestAccount provides a test implementation of the Account interface for comprehensive testing.

--- a/core/internal/testutil/batch.go
+++ b/core/internal/testutil/batch.go
@@ -36,6 +36,7 @@ func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 				},
 			},
 			CompletionWindow: "24h",
+			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
 		response, err := client.BatchCreateRequest(ctx, request)
@@ -127,6 +128,7 @@ func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 				},
 			},
 			CompletionWindow: "24h",
+			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
 		createResponse, createErr := client.BatchCreateRequest(ctx, createRequest)
@@ -198,6 +200,7 @@ func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 				},
 			},
 			CompletionWindow: "24h",
+			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
 		createResponse, createErr := client.BatchCreateRequest(ctx, createRequest)
@@ -336,10 +339,11 @@ func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 `)
 
 		request := &schemas.BifrostFileUploadRequest{
-			Provider: testConfig.Provider,
-			File:     fileContent,
-			Filename: "test_batch.jsonl",
-			Purpose:  "batch",
+			Provider:    testConfig.Provider,
+			File:        fileContent,
+			Filename:    "test_batch.jsonl",
+			Purpose:     "batch",
+			ExtraParams: testConfig.FileExtraParams,
 		}
 
 		response, err := client.FileUploadRequest(ctx, request)
@@ -378,8 +382,9 @@ func RunFileListTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context,
 		t.Logf("[RUNNING] File List test for provider: %s", testConfig.Provider)
 
 		request := &schemas.BifrostFileListRequest{
-			Provider: testConfig.Provider,
-			Limit:    10,
+			Provider:    testConfig.Provider,
+			Limit:       10,
+			ExtraParams: testConfig.FileExtraParams,
 		}
 
 		response, err := client.FileListRequest(ctx, request)
@@ -417,10 +422,11 @@ func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Cont
 `)
 
 		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider: testConfig.Provider,
-			File:     fileContent,
-			Filename: "test_retrieve.jsonl",
-			Purpose:  "batch",
+			Provider:    testConfig.Provider,
+			File:        fileContent,
+			Filename:    "test_retrieve.jsonl",
+			Purpose:     "batch",
+			ExtraParams: testConfig.FileExtraParams,
 		}
 
 		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
@@ -479,10 +485,11 @@ func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 `)
 
 		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider: testConfig.Provider,
-			File:     fileContent,
-			Filename: "test_delete.jsonl",
-			Purpose:  "batch",
+			Provider:    testConfig.Provider,
+			File:        fileContent,
+			Filename:    "test_delete.jsonl",
+			Purpose:     "batch",
+			ExtraParams: testConfig.FileExtraParams,
 		}
 
 		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
@@ -541,10 +548,11 @@ func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 `)
 
 		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider: testConfig.Provider,
-			File:     originalContent,
-			Filename: "test_content.jsonl",
-			Purpose:  "batch",
+			Provider:    testConfig.Provider,
+			File:        originalContent,
+			Filename:    "test_content.jsonl",
+			Purpose:     "batch",
+			ExtraParams: testConfig.FileExtraParams,
 		}
 
 		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
@@ -643,10 +651,11 @@ func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx c
 `)
 
 		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider: testConfig.Provider,
-			File:     fileContent,
-			Filename: "integration_test_batch.jsonl",
-			Purpose:  "batch",
+			Provider:    testConfig.Provider,
+			File:        fileContent,
+			Filename:    "integration_test_batch.jsonl",
+			Purpose:     "batch",
+			ExtraParams: testConfig.FileExtraParams,
 		}
 
 		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
@@ -673,6 +682,7 @@ func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx c
 			InputFileID:      uploadResponse.ID,
 			Endpoint:         schemas.BatchEndpointChatCompletions,
 			CompletionWindow: "24h",
+			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
 		batchResponse, batchErr := client.BatchCreateRequest(ctx, batchRequest)

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1457,8 +1457,12 @@ func (provider *BedrockProvider) FileList(ctx context.Context, key schemas.Key, 
 	}
 
 	region := DefaultBedrockRegion
-	if key.BedrockKeyConfig.Region != nil {
-		region = *key.BedrockKeyConfig.Region
+	if key.BedrockKeyConfig != nil {
+		if key.BedrockKeyConfig.Region != nil {
+			region = *key.BedrockKeyConfig.Region
+		}
+	} else {
+		region = DefaultBedrockRegion
 	}
 
 	// Build S3 ListObjectsV2 request

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -42,6 +42,26 @@ func TestBedrock(t *testing.T) {
 	}
 	defer cancel()
 
+	// Get Bedrock-specific configuration from environment
+	s3Bucket := os.Getenv("AWS_S3_BUCKET")
+	roleArn := os.Getenv("AWS_BEDROCK_ROLE_ARN")
+
+	// Build extra params for batch and file operations
+	var batchExtraParams map[string]interface{}
+	var fileExtraParams map[string]interface{}
+
+	if s3Bucket != "" {
+		fileExtraParams = map[string]interface{}{
+			"s3_bucket": s3Bucket,
+		}
+		batchExtraParams = map[string]interface{}{
+			"output_s3_uri": "s3://" + s3Bucket + "/batch-output/",
+		}
+		if roleArn != "" {
+			batchExtraParams["role_arn"] = roleArn
+		}
+	}
+
 	testConfig := testutil.ComprehensiveTestConfig{
 		Provider:    schemas.Bedrock,
 		ChatModel:   "claude-4-sonnet",
@@ -50,8 +70,10 @@ func TestBedrock(t *testing.T) {
 			{Provider: schemas.Bedrock, Model: "claude-4-sonnet"},
 			{Provider: schemas.Bedrock, Model: "claude-4.5-sonnet"},
 		},
-		EmbeddingModel: "cohere.embed-v4:0",
-		ReasoningModel: "claude-4.5-sonnet",
+		EmbeddingModel:   "cohere.embed-v4:0",
+		ReasoningModel:   "claude-4.5-sonnet",
+		BatchExtraParams: batchExtraParams,
+		FileExtraParams:  fileExtraParams,
 		Scenarios: testutil.TestScenarios{
 			TextCompletion:        false, // Not supported
 			SimpleChat:            true,

--- a/core/utils.go
+++ b/core/utils.go
@@ -47,8 +47,8 @@ var rateLimitPatterns = []string{
 	"concurrent requests limit",
 }
 
-// IsModelRequired returns true if the request type requires a model
-func IsModelRequired(reqType schemas.RequestType) bool {
+// isModelRequired returns true if the request type requires a model
+func isModelRequired(reqType schemas.RequestType) bool {
 	return reqType == schemas.TextCompletionRequest || reqType == schemas.TextCompletionStreamRequest || reqType == schemas.ChatCompletionRequest || reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.ResponsesRequest || reqType == schemas.ResponsesStreamRequest || reqType == schemas.SpeechRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionRequest || reqType == schemas.TranscriptionStreamRequest || reqType == schemas.EmbeddingRequest
 }
 
@@ -97,7 +97,7 @@ func validateRequest(req *schemas.BifrostRequest) *schemas.BifrostError {
 	if provider == "" {
 		return newBifrostErrorFromMsg("provider is required")
 	}
-	if IsModelRequired(req.RequestType) && model == "" {
+	if isModelRequired(req.RequestType) && model == "" {
 		return newBifrostErrorFromMsg("model is required")
 	}
 

--- a/tests/integrations/config.json
+++ b/tests/integrations/config.json
@@ -135,7 +135,8 @@
                     "bedrock_key_config": {
                         "access_key": "env.AWS_ACCESS_KEY_ID",
                         "secret_key": "env.AWS_SECRET_ACCESS_KEY",
-                        "region": "env.AWS_REGION"
+                        "region": "env.AWS_REGION",
+                        "arn": "env.AWS_BEDROCK_ROLE_ARN"
                     },
                     "weight": 1
                 }


### PR DESCRIPTION
## Improve key selection for non-model-required operations

This PR enhances Bifrost's key selection logic to handle file operations and batch list operations more gracefully. When a model is not required for a request, the system now falls back to using the first available key for the provider instead of returning an error.

## Changes

- Modified `requestWorker` in `bifrost.go` to check if a model is required before returning an error during key selection
- For operations that don't require a model (like file operations), the system now selects the first available key
- Added support for extra parameters in batch and file operations for Bedrock provider
- Added `BatchExtraParams` and `FileExtraParams` to test configuration to support provider-specific parameters
- Updated Bedrock tests to use S3 bucket and role ARN from environment variables
- Made `IsModelRequired` function private (renamed to `isModelRequired`) as it's only used internally
- Fixed a potential nil pointer dereference in Bedrock's `FileList` method

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run Bedrock tests with AWS credentials and S3 bucket configured
export AWS_S3_BUCKET="your-s3-bucket"
export AWS_BEDROCK_ROLE_ARN="your-role-arn"
go test ./core/providers/bedrock/...

# Run all tests
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The PR handles AWS credentials and S3 bucket information more robustly, ensuring proper configuration for Bedrock batch operations.