### PR TITLE
fixes release pipeline to add missing env variables

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -115,6 +115,8 @@ jobs:
           VERTEX_CREDENTIALS: ${{ secrets.VERTEX_CREDENTIALS }}
           VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_BEDROCK_ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
         run: ./.github/workflows/scripts/release-core.sh "${{ needs.detect-changes.outputs.core-version }}"
 
   framework-release:


### PR DESCRIPTION
## Summary

Add AWS S3 bucket and Bedrock role ARN secrets to the core release workflow.

## Changes

- Added `AWS_S3_BUCKET` and `AWS_BEDROCK_ROLE_ARN` environment variables to the core release job
- These secrets are now passed to the release-core.sh script during execution

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)

## How to test

The changes can be verified by running a core release job and confirming that the AWS credentials are properly passed to the release script.

## Breaking changes

- [x] No

## Security considerations

This PR adds access to AWS secrets in the release pipeline. These secrets are properly handled through GitHub's secret management system and only exposed to the release script during execution.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable