### PR TITLE
fixed skipping azure for file and batch unsupported test

### DIFF
--- a/core/internal/testutil/batch.go
+++ b/core/internal/testutil/batch.go
@@ -59,7 +59,6 @@ func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 			t.Error("BatchCreate returned empty batch ID")
 			return
 		}
-		
 
 		t.Logf("[SUCCESS] Batch Create test passed for provider: %s, batch ID: %s", testConfig.Provider, response.ID)
 	})
@@ -283,14 +282,15 @@ func RunBatchUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx context.
 		return
 	}
 
-	// We are skipping azure from this for now
-	// TODO remove this once azure is officially supported
-	if testConfig.Provider != schemas.Azure {
-		return
-	}
-
 	t.Run("BatchUnsupported", func(t *testing.T) {
 		t.Logf("[RUNNING] Batch Unsupported test for provider: %s", testConfig.Provider)
+
+		// TODO remove this once azure is officially supported
+		// We are skipping azure from this for now
+		if testConfig.Provider == schemas.Azure {
+			t.Skipf("Skipping batch unsupported test for provider: %s", testConfig.Provider)
+			return
+		}
 
 		// Try to create a batch - should fail with unsupported error
 		request := &schemas.BifrostBatchCreateRequest{
@@ -372,7 +372,7 @@ func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 			t.Error("FileUpload returned empty file ID")
 			return
 		}
-		
+
 		t.Logf("[SUCCESS] File Upload test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
 	})
 }
@@ -615,6 +615,13 @@ func RunFileUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 	t.Run("FileUnsupported", func(t *testing.T) {
 		t.Logf("[RUNNING] File Unsupported test for provider: %s", testConfig.Provider)
 
+		// TODO remove this once azure is officially supported
+		// We are skipping azure from this for now
+		if testConfig.Provider == schemas.Azure {
+			t.Skipf("Skipping batch unsupported test for provider: %s", testConfig.Provider)
+			return
+		}
+
 		// Try to upload a file - should fail with unsupported error
 		request := &schemas.BifrostFileUploadRequest{
 			Provider: testConfig.Provider,
@@ -710,4 +717,3 @@ func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx c
 			testConfig.Provider, uploadResponse.ID, batchResponse.ID)
 	})
 }
-


### PR DESCRIPTION
## Summary

Improve test handling for Azure provider in batch and file operations by properly skipping unsupported tests rather than returning early.

## Changes

- Moved the Azure provider check inside the test functions instead of returning early
- Added proper test skipping with `t.Skipf()` for Azure in both batch and file unsupported tests
- Added the same Azure skip logic to the file unsupported test that was previously only in the batch test
- Removed some unnecessary whitespace

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the tests to verify that Azure provider tests are properly skipped:

```sh
# Core/Transports
go version
go test ./core/internal/testutil/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a test-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable