### PR TITLE
feat: add handling for HTML and empty responses from providers

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,4 +1,5 @@
 - feat: add handling for HTML and empty responses from providers
+- feat: add audio token pricing support for models
 - feat: adds new parameter for each provider key config `use_for_batch_apis`. This helps users to select which APIs or accounts to be used for Batch APIs.
 - feat: adds s3 bucket config support for Bedrock provider. 
 - feat: prompt caching support for anthropic and bedrock(claude and nova models)

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- feat: add handling for HTML and empty responses from providers
 - feat: adds new parameter for each provider key config `use_for_batch_apis`. This helps users to select which APIs or accounts to be used for Batch APIs.
 - feat: adds s3 bucket config support for Bedrock provider. 
 - feat: prompt caching support for anthropic and bedrock(claude and nova models)

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -522,6 +522,17 @@ func (provider *ElevenlabsProvider) Transcription(ctx context.Context, key schem
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
 	}
 
+	// Check for empty response
+	trimmed := strings.TrimSpace(string(responseBody))
+	if len(trimmed) == 0 {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderResponseEmpty,
+			},
+		}
+	}
+
 	chunks, err := parseTranscriptionResponse(responseBody)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(err.Error(), nil, providerName)

--- a/core/providers/utils/html_response_handler_test.go
+++ b/core/providers/utils/html_response_handler_test.go
@@ -1,0 +1,302 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+func TestIsHTMLResponse(t *testing.T) {
+	tests := []struct {
+		name           string
+		contentType    string
+		body           []byte
+		expectedIsHTML bool
+		description    string
+	}{
+		{
+			name:           "HTML with Content-Type header",
+			contentType:    "text/html; charset=utf-8",
+			body:           []byte("<html><body>Error</body></html>"),
+			expectedIsHTML: true,
+			description:    "Should detect HTML from Content-Type header",
+		},
+		{
+			name:           "HTML without Content-Type",
+			contentType:    "application/octet-stream",
+			body:           []byte("<!DOCTYPE html><html><head><title>Error 500</title></head></html>"),
+			expectedIsHTML: true,
+			description:    "Should detect HTML from DOCTYPE",
+		},
+		{
+			name:           "HTML with h1 tag",
+			contentType:    "application/octet-stream",
+			body:           []byte("<h1>Service Unavailable</h1>"),
+			expectedIsHTML: true,
+			description:    "Should detect HTML from h1 tag",
+		},
+		{
+			name:           "JSON response",
+			contentType:    "application/json",
+			body:           []byte(`{"error": "invalid request"}`),
+			expectedIsHTML: false,
+			description:    "Should not detect JSON as HTML",
+		},
+		{
+			name:           "Plain text response",
+			contentType:    "text/plain",
+			body:           []byte("Invalid request"),
+			expectedIsHTML: false,
+			description:    "Should not detect plain text as HTML",
+		},
+		{
+			name:           "Empty body",
+			contentType:    "text/html",
+			body:           []byte(""),
+			expectedIsHTML: true,
+			description:    "Should detect HTML from Content-Type even with empty body",
+		},
+		{
+			name:           "Very short body",
+			contentType:    "application/json",
+			body:           []byte("abc"),
+			expectedIsHTML: false,
+			description:    "Should not detect very short body as HTML",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &fasthttp.Response{}
+			resp.Header.Set("Content-Type", tt.contentType)
+
+			result := IsHTMLResponse(resp, tt.body)
+			if result != tt.expectedIsHTML {
+				t.Errorf("isHTMLResponse() = %v, want %v. %s", result, tt.expectedIsHTML, tt.description)
+			}
+		})
+	}
+}
+
+func TestExtractHTMLErrorMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		htmlBody    []byte
+		expectMsg   string
+		description string
+	}{
+		{
+			name: "Extract from title tag",
+			htmlBody: []byte(`
+				<!DOCTYPE html>
+				<html>
+				<head><title>404 Not Found</title></head>
+				<body><p>The page was not found</p></body>
+				</html>
+			`),
+			expectMsg:   "404 Not Found",
+			description: "Should extract title from title tag",
+		},
+		{
+			name: "Extract from h1 tag",
+			htmlBody: []byte(`
+				<!DOCTYPE html>
+				<html>
+				<body>
+				<h1>Service Unavailable</h1>
+				<p>The service is currently unavailable</p>
+				</body>
+				</html>
+			`),
+			expectMsg:   "Service Unavailable",
+			description: "Should extract from h1 tag when title is missing",
+		},
+		{
+			name: "Extract from h2 tag",
+			htmlBody: []byte(`
+				<!DOCTYPE html>
+				<html>
+				<body>
+				<h2 class="error-header">Authentication Failed</h2>
+				<p>Please check your credentials</p>
+				</body>
+				</html>
+			`),
+			expectMsg:   "Authentication Failed",
+			description: "Should extract from h2 tag with attributes",
+		},
+		{
+			name: "Extract visible text when no headers",
+			htmlBody: []byte(`
+				<html>
+				<body>
+				<div>There was an error processing your request. Please try again later.</div>
+				</body>
+				</html>
+			`),
+			expectMsg:   "There was an error processing your request. Please try again later.",
+			description: "Should extract visible text from div when no headers found",
+		},
+		{
+			name: "Ignore script and style tags",
+			htmlBody: []byte(`
+				<html>
+				<head><title>Error</title></head>
+				<body>
+				<script>var x = 'ignore me';</script>
+				<style>.error { color: red; }</style>
+				<h1>Actual Error Message</h1>
+				</body>
+				</html>
+			`),
+			expectMsg:   "Actual Error Message",
+			description: "Should ignore script and style content",
+		},
+		{
+			name: "Extract from first valid h1",
+			htmlBody: []byte(`
+				<html>
+				<body>
+				<h1></h1>
+				<h1>Second header with actual content</h1>
+				</body>
+				</html>
+			`),
+			expectMsg:   "Second header with actual content",
+			description: "Should extract from first non-empty header",
+		},
+		{
+			name: "Handle meta description",
+			htmlBody: []byte(`
+				<html>
+				<head>
+				<meta name="description" content="Rate limit exceeded. Please wait 60 seconds.">
+				</head>
+				<body></body>
+				</html>
+			`),
+			expectMsg:   "Rate limit exceeded. Please wait 60 seconds.",
+			description: "Should extract from meta description",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractHTMLErrorMessage(tt.htmlBody)
+			if result != tt.expectMsg {
+				t.Errorf("extractHTMLErrorMessage() = %q, want %q. %s", result, tt.expectMsg, tt.description)
+			}
+		})
+	}
+}
+
+func TestHandleProviderAPIErrorWithHTML(t *testing.T) {
+	tests := []struct {
+		name              string
+		statusCode        int
+		contentType       string
+		body              []byte
+		description       string
+		expectedInMessage string
+	}{
+		{
+			name:        "HTML 500 error - lazy detection",
+			statusCode:  500,
+			contentType: "text/html; charset=utf-8",
+			body: []byte(`
+				<!DOCTYPE html>
+				<html>
+				<head><title>Internal Server Error</title></head>
+				<body><h1>Something went wrong</h1></body>
+				</html>
+			`),
+			description:       "Should detect and handle HTML only after JSON parse fails",
+			expectedInMessage: "Internal Server Error",
+		},
+		{
+			name:        "HTML 403 error - lazy detection",
+			statusCode:  403,
+			contentType: "text/html",
+			body: []byte(`
+				<html>
+				<body>
+				<h1>Forbidden</h1>
+				<p>Access denied</p>
+				</body>
+				</html>
+			`),
+			description:       "Should detect and extract message from HTML on parse failure",
+			expectedInMessage: "Forbidden",
+		},
+		{
+			name:              "Invalid JSON with HTML fallback",
+			statusCode:        400,
+			contentType:       "application/json",
+			body:              []byte(`not valid json`),
+			description:       "Should fall back to raw string when not HTML",
+			expectedInMessage: "provider API error",
+		},
+		{
+			name:              "Valid JSON error response",
+			statusCode:        400,
+			contentType:       "application/json",
+			body:              []byte(`{"error": {"message": "Invalid request"}, "code": "invalid_request"}`),
+			description:       "Should handle valid JSON without HTML detection",
+			expectedInMessage: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &fasthttp.Response{}
+			resp.SetStatusCode(tt.statusCode)
+			resp.Header.Set("Content-Type", tt.contentType)
+			resp.SetBody(tt.body)
+
+			var errorResp map[string]interface{}
+			bifrostErr := HandleProviderAPIError(resp, &errorResp)
+
+			if bifrostErr == nil {
+				t.Errorf("HandleProviderAPIError() returned nil error")
+				return
+			}
+
+			if bifrostErr.StatusCode == nil || *bifrostErr.StatusCode != tt.statusCode {
+				t.Errorf("HandleProviderAPIError() status code = %v, want %v", bifrostErr.StatusCode, tt.statusCode)
+			}
+
+			if bifrostErr.Error == nil {
+				t.Errorf("HandleProviderAPIError() error field is nil")
+				return
+			}
+
+			// Check if expected message is in the response
+			if tt.expectedInMessage != "" && !strings.Contains(bifrostErr.Error.Message, tt.expectedInMessage) {
+				t.Errorf("Expected message to contain %q, got %q", tt.expectedInMessage, bifrostErr.Error.Message)
+			}
+
+			t.Logf("Handled %s: status=%d, message=%q", tt.name, *bifrostErr.StatusCode, bifrostErr.Error.Message)
+		})
+	}
+}
+
+func BenchmarkIsHTMLResponse(b *testing.B) {
+	resp := &fasthttp.Response{}
+	resp.Header.Set("Content-Type", "text/html; charset=utf-8")
+	body := []byte(`<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Test Error</h1></body></html>`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		IsHTMLResponse(resp, body)
+	}
+}
+
+func BenchmarkExtractHTMLErrorMessage(b *testing.B) {
+	body := []byte(`<!DOCTYPE html><html><head><title>Internal Server Error</title></head><body><h1>Something went wrong</h1><p>This is a detailed error message</p></body></html>`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ExtractHTMLErrorMessage(body)
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -492,6 +492,7 @@ func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody
 	return nil, nil, nil
 }
 
+// ParseAndSetRawRequest parses the raw request body and sets it in the extra fields.
 func ParseAndSetRawRequest(extraFields *schemas.BifrostResponseExtraFields, jsonBody []byte) {
 	var rawRequest interface{}
 	if err := sonic.Unmarshal(jsonBody, &rawRequest); err != nil {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -314,12 +315,13 @@ func SetExtraHeadersHTTP(ctx context.Context, req *http.Request, extraHeaders ma
 // HandleProviderAPIError processes error responses from provider APIs.
 // It attempts to unmarshal the error response and returns a BifrostError
 // with the appropriate status code and error information.
-// errorResp must be a pointer to the target struct for unmarshaling.
+// HTML detection only runs if JSON parsing fails to avoid expensive regex operations
+// on responses that are almost certainly valid JSON. errorResp must be a pointer to
+// the target struct for unmarshaling.
 func HandleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.BifrostError {
 	statusCode := resp.StatusCode()
-	body := append([]byte(nil), resp.Body()...)
 
-	// decode body
+	// Decode body
 	decodedBody, err := CheckAndDecodeBody(resp)
 	if err != nil {
 		return &schemas.BifrostError{
@@ -331,24 +333,48 @@ func HandleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.Bif
 		}
 	}
 
-	body = decodedBody
-
-	if err := sonic.Unmarshal(body, errorResp); err != nil {
-		rawResponse := body
-		message := fmt.Sprintf("provider API error: %s", string(rawResponse))
+	// Check for empty response
+	trimmed := strings.TrimSpace(string(decodedBody))
+	if len(trimmed) == 0 {
 		return &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &statusCode,
 			Error: &schemas.ErrorField{
-				Message: message,
+				Message: schemas.ErrProviderResponseEmpty,
 			},
 		}
 	}
 
+	// Try JSON parsing first
+	if err := sonic.Unmarshal(decodedBody, errorResp); err == nil {
+		// JSON parsing succeeded, return success
+		return &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &statusCode,
+			Error:          &schemas.ErrorField{},
+		}
+	}
+
+	// JSON parsing failed - now check if it's an HTML response (expensive operation)
+	if IsHTMLResponse(resp, decodedBody) {
+		errorMessage := ExtractHTMLErrorMessage(decodedBody)
+		return &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &statusCode,
+			Error: &schemas.ErrorField{
+				Message: errorMessage,
+			},
+		}
+	}
+
+	// Not HTML either - return raw response as error message
+	message := fmt.Sprintf("provider API error: %s", string(decodedBody))
 	return &schemas.BifrostError{
 		IsBifrostError: false,
 		StatusCode:     &statusCode,
-		Error:          &schemas.ErrorField{},
+		Error: &schemas.ErrorField{
+			Message: message,
+		},
 	}
 }
 
@@ -356,7 +382,20 @@ func HandleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.Bif
 // It attempts to parse the response body into the provided response type
 // and returns either the parsed response or a BifrostError if parsing fails.
 // If sendBackRawResponse is true, it returns the raw response interface, otherwise nil.
+// HTML detection only runs if JSON parsing fails to avoid expensive regex operations
+// on responses that are almost certainly valid JSON.
 func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody []byte, sendBackRawRequest bool, sendBackRawResponse bool) (rawRequest interface{}, rawResponse interface{}, bifrostErr *schemas.BifrostError) {
+	// Check for empty response
+	trimmed := strings.TrimSpace(string(responseBody))
+	if len(trimmed) == 0 {
+		return nil, nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderResponseEmpty,
+			},
+		}
+	}
+
 	var wg sync.WaitGroup
 	var structuredErr, rawRequestErr, rawResponseErr error
 
@@ -394,6 +433,18 @@ func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody
 	wg.Wait()
 
 	if structuredErr != nil {
+		// JSON parsing failed - check if it's an HTML response (expensive operation)
+		if IsHTMLResponse(nil, responseBody) {
+			errorMessage := ExtractHTMLErrorMessage(responseBody)
+			return nil, nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Message: schemas.ErrProviderResponseHTML,
+					Error:   errors.New(errorMessage),
+				},
+			}
+		}
+
 		return nil, nil, &schemas.BifrostError{
 			IsBifrostError: true,
 			Error: &schemas.ErrorField{
@@ -493,6 +544,123 @@ func CheckAndDecodeBody(resp *fasthttp.Response) ([]byte, error) {
 	default:
 		return resp.Body(), nil
 	}
+}
+
+// IsHTMLResponse checks if the response is HTML by examining the Content-Type header
+// and/or the response body for HTML indicators.
+func IsHTMLResponse(resp *fasthttp.Response, body []byte) bool {
+	// Check Content-Type header first (most reliable indicator)
+	if resp != nil {
+		contentType := strings.ToLower(string(resp.Header.Peek("Content-Type")))
+		if strings.Contains(contentType, "text/html") {
+			return true
+		}
+	}
+
+	// If body is small, it's unlikely to be HTML
+	if len(body) < 20 {
+		return false
+	}
+
+	// Check for HTML indicators in body
+	bodyLower := strings.ToLower(string(body))
+
+	// Look for common HTML tags or DOCTYPE
+	htmlIndicators := []string{
+		"<!doctype html",
+		"<html",
+		"<head",
+		"<body",
+		"<title>",
+		"<h1>",
+		"<h2>",
+		"<h3>",
+		"<p>",
+		"<div",
+	}
+
+	for _, indicator := range htmlIndicators {
+		if strings.Contains(bodyLower, indicator) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Limit body size to prevent ReDoS on very large malicious responses
+const maxBodySize = 32 * 1024 // 32KB
+
+// ExtractHTMLErrorMessage extracts meaningful error information from an HTML response.
+// It attempts to find error messages from title tags, headers, and visible text.
+func ExtractHTMLErrorMessage(body []byte) string {
+	if len(body) > maxBodySize {
+		body = body[:maxBodySize]
+	}
+
+	bodyStr := string(body)
+	bodyLower := strings.ToLower(bodyStr)
+
+	// Try to extract title first
+	if idx := strings.Index(bodyLower, "<title>"); idx != -1 {
+		endIdx := strings.Index(bodyLower[idx:], "</title>")
+		if endIdx != -1 {
+			title := strings.TrimSpace(bodyStr[idx+7 : idx+endIdx])
+			if title != "" && title != "Error" {
+				return title
+			}
+		}
+	}
+
+	// Try to extract from h1, h2, h3 tags (common for error pages)
+	for _, tag := range []string{"h1", "h2", "h3"} {
+		pattern := fmt.Sprintf("<%s[^>]*>([^<]+)</%s>", tag, tag)
+		re := regexp.MustCompile("(?i)" + pattern)
+		if matches := re.FindStringSubmatch(bodyStr); len(matches) > 1 {
+			msg := strings.TrimSpace(matches[1])
+			if msg != "" {
+				return msg
+			}
+		}
+	}
+
+	// Try to extract from meta description
+	pattern := `<meta\s+name="description"\s+content="([^"]+)"`
+	re := regexp.MustCompile("(?i)" + pattern)
+	if matches := re.FindStringSubmatch(bodyStr); len(matches) > 1 {
+		msg := strings.TrimSpace(matches[1])
+		if msg != "" {
+			return msg
+		}
+	}
+
+	// Extract visible text: remove script and style tags, then extract text
+	// Remove script and style tags and their content
+	re = regexp.MustCompile(`(?i)<script[^>]*>.*?</script>|<style[^>]*>.*?</style>`)
+	cleaned := re.ReplaceAllString(bodyStr, "")
+
+	// Remove HTML tags
+	re = regexp.MustCompile(`<[^>]+>`)
+	cleaned = re.ReplaceAllString(cleaned, " ")
+
+	// Clean up whitespace and get first meaningful sentence
+	sentences := strings.FieldsFunc(cleaned, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	})
+
+	for _, sentence := range sentences {
+		trimmed := strings.TrimSpace(sentence)
+		if len(trimmed) > 10 && len(trimmed) < 500 {
+			// Limit to first 200 chars to avoid very long messages
+			if len(trimmed) > 200 {
+				trimmed = trimmed[:200] + "..."
+			}
+			return trimmed
+		}
+	}
+
+	// If all else fails, return a generic message with status code context
+	return "HTML error response received from provider"
 }
 
 // JSONLParseResult holds parsed items and any line-level errors encountered during parsing.

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -28,6 +28,8 @@ const (
 	ErrProviderDoRequest            = "failed to execute HTTP request to provider API"
 	ErrProviderResponseDecode       = "failed to decode response body from provider API"
 	ErrProviderResponseUnmarshal    = "failed to unmarshal response from provider API"
+	ErrProviderResponseEmpty        = "empty response received from provider"
+	ErrProviderResponseHTML         = "HTML response received from provider"
 	ErrProviderRawRequestUnmarshal  = "failed to unmarshal raw request from provider API"
 	ErrProviderRawResponseUnmarshal = "failed to unmarshal raw response from provider API"
 	ErrProviderResponseDecompress   = "failed to decompress provider's response"

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+- feat: add handling for HTML and empty responses from providers
 - feat: adds new parameter for each provider key config `use_for_batch_apis`. This helps users to select which APIs or accounts to be used for Batch APIs.
 - feat: adds recalculate missing costs for logs - [@hpbyte](https://github.com/hpbyte)
 - chore: increased provider-level timeout limit to 48 hours

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,4 +1,6 @@
 - feat: add handling for HTML and empty responses from providers
+- feat: added transcription support for mistral
+
 - feat: adds new parameter for each provider key config `use_for_batch_apis`. This helps users to select which APIs or accounts to be used for Batch APIs.
 - feat: adds recalculate missing costs for logs - [@hpbyte](https://github.com/hpbyte)
 - chore: increased provider-level timeout limit to 48 hours

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -134,13 +134,12 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 									<TableCell>
 										<Switch
 											checked={isKeyEnabled}
+											size="md"
 											disabled={!hasUpdateProviderAccess}
 											onCheckedChange={(checked) => {
 												updateProvider({
 													...provider,
-													keys: provider.keys.map((k, i) =>
-														i === index ? { ...k, enabled: checked } : k
-													),
+													keys: provider.keys.map((k, i) => (i === index ? { ...k, enabled: checked } : k)),
 												})
 													.unwrap()
 													.then(() => {


### PR DESCRIPTION
## Summary

Added support for handling HTML and empty responses from provider APIs, improving error handling and user experience when providers return unexpected response formats.

## Changes

- Added detection for HTML responses in provider API responses
- Implemented extraction of meaningful error messages from HTML responses
- Added handling for empty responses from providers
- Created comprehensive test suite for HTML response detection and message extraction
- Updated error constants and messages to provide clearer feedback

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Core/Transports
go test ./core/providers/utils/html_response_handler_test.go
```

## Breaking changes

- [x] No

## Security considerations

The HTML parsing is designed to be safe and only extract text content, avoiding any potential script execution or injection vulnerabilities.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)