### PR TITLE
increase timeout limit to 48 hours for providers

### DIFF
--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -19,6 +19,37 @@ import { toast } from "sonner";
 interface NetworkFormFragmentProps {
 	provider: ModelProvider;
 }
+
+// seconds to human readable time
+const secondsToHumanReadable = (seconds: number) => {
+	// Handle edge cases
+	if (!seconds || seconds < 0 || isNaN(seconds)) {
+		return "0 seconds";
+	}
+	seconds = Math.floor(seconds);
+	if (seconds < 60) {
+		return `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+	}
+	if (seconds < 3600) {
+		const minutes = Math.floor(seconds / 60);
+		return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+	}
+	if (seconds < 86400) {
+		const hours = Math.floor(seconds / 3600);
+		return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+	}
+	// For >= 1 day, only show non-zero components
+	const days = Math.floor(seconds / 86400);
+	const hours = Math.floor((seconds % 86400) / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	const remainingSeconds = seconds % 60;
+	const parts: string[] = [];
+	parts.push(`${days} ${days === 1 ? "day" : "days"}`);
+	if (hours > 0) parts.push(`${hours} ${hours === 1 ? "hour" : "hours"}`);
+	if (minutes > 0) parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`);
+	if (remainingSeconds > 0) parts.push(`${remainingSeconds} ${remainingSeconds === 1 ? "second" : "seconds"}`);
+	return parts.join(" ");
+};
 
 export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 	const dispatch = useAppDispatch();
@@ -130,8 +161,21 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 									<FormItem className="flex-1">
 										<FormLabel>Timeout (seconds)</FormLabel>
 										<FormControl>
-											<Input placeholder="30" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+											<Input
+												placeholder="30"
+												{...field}
+												onChange={(e) => {
+													if (isNaN(Number(e.target.value))) {
+														if (e.target.value.trim() === "") {
+															field.onChange(0);
+														}
+														return;
+													}
+													field.onChange(Number(e.target.value));
+												}}
+											/>
 										</FormControl>
+										<FormDescription>{secondsToHumanReadable(field.value)}</FormDescription>
 										<FormMessage />
 									</FormItem>
 								)}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -207,7 +207,7 @@ export const networkFormConfigSchema = z
 		default_request_timeout_in_seconds: z.coerce
 			.number("Timeout must be a number")
 			.min(1, "Timeout must be greater than 0 seconds")
-			.max(3600, "Timeout must be less than 3600 seconds"),
+			.max(172800, "Timeout must be less than 172800 seconds i.e. 48 hours"),
 		max_retries: z.coerce
 			.number("Max retries must be a number")
 			.min(0, "Max retries must be greater than 0")


### PR DESCRIPTION
## Summary

Added a human-readable time display for request timeout settings in the network configuration form and increased the maximum allowed timeout value.

## Changes

- Added a `secondsToHumanReadable` utility function that converts seconds to a human-readable time format (e.g., "2 days 3 hours 45 minutes 30 seconds")
- Added a `FormDescription` component to display the human-readable time below the timeout input field
- Increased the maximum allowed request timeout from 3600 seconds (1 hour) to 172800 seconds (48 hours)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the provider settings page
2. Go to the Network tab
3. Change the default request timeout value
4. Verify that the human-readable time display updates correctly
5. Try setting values above the previous limit (3600 seconds) and confirm they're accepted up to 48 hours

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

N/A

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable