### PR TITLE
fixes documentation for remove a provider

### DIFF
--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -1075,12 +1075,13 @@
         "tags": [
           "Providers"
         ],
+        "description": "Note: Removing a provider is only supported for custom providers. If you are trying to delete a provider that is not a custom provider, you can use Update Provider instead.",
         "parameters": [
           {
             "name": "provider",
             "in": "path",
             "required": true,
-            "description": "The name of the provider to delete",
+            "description": "The name of the custom provider to delete",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
## Summary

Clarify that the Delete Provider API endpoint is only supported for custom providers, not built-in providers.

## Changes

- Added a description to the Delete Provider endpoint explaining that it's only for custom providers
- Updated the parameter description to specify "custom provider" instead of just "provider"
- Suggested using Update Provider as an alternative for non-custom providers

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the updated OpenAPI documentation renders correctly:

```sh
# If using a documentation preview tool
cd docs
# Run your documentation preview command
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

N/A

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable