### PR TITLE
[Docs] update direct-key doc links

### DIFF
--- a/docs/integrations/anthropic-sdk/overview.mdx
+++ b/docs/integrations/anthropic-sdk/overview.mdx
@@ -223,7 +223,7 @@ const response = await anthropic.messages.create({
 
 Pass API keys directly in requests to bypass Bifrost's load balancing. You can pass any provider's API key (OpenAI, Anthropic, Mistral, etc.) since Bifrost only looks for `Authorization` or `x-api-key` headers. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../../quickstart/README) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 <Tabs group="anthropic-sdk">
 <Tab title="Python">

--- a/docs/integrations/bedrock-sdk/overview.mdx
+++ b/docs/integrations/bedrock-sdk/overview.mdx
@@ -172,7 +172,7 @@ for event in response.get("body"):
 
 Pass AWS credentials or Bedrock API keys directly in requests to bypass Bifrost's load balancing. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../../../quickstart) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../../../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 When direct keys are enabled, you can pass your AWS credentials directly to the boto3 client instead of using dummy credentials.
 

--- a/docs/integrations/genai-sdk/overview.mdx
+++ b/docs/integrations/genai-sdk/overview.mdx
@@ -199,7 +199,7 @@ const response = await model.generateContent("Hello with custom headers!");
 
 Pass API keys directly in requests to bypass Bifrost's load balancing. You can pass any provider's API key (OpenAI, Anthropic, Mistral, etc.) since Bifrost only looks for `Authorization`, `x-api-key` and `x-goog-api-key` headers. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../../quickstart/README) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 <Tabs group="genai-sdk">
 <Tab title="Python">

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -190,7 +190,7 @@ console.log(response.content);
 
 Pass API keys directly to bypass Bifrost's key management. You can pass any provider's API key since Bifrost only looks for `Authorization` or `x-api-key` headers. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../quickstart/README) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 <Tabs group="langchain-sdk">
 <Tab title="Python">

--- a/docs/integrations/litellm-sdk.mdx
+++ b/docs/integrations/litellm-sdk.mdx
@@ -115,7 +115,7 @@ print(response.choices[0].message.content)
 
 Pass API keys directly to bypass Bifrost's key management. You can pass any provider's API key since Bifrost only looks for `Authorization` or `x-api-key` headers. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../quickstart/README) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 <Tabs group="litellm-sdk">
 <Tab title="Python">

--- a/docs/integrations/openai-sdk/overview.mdx
+++ b/docs/integrations/openai-sdk/overview.mdx
@@ -209,7 +209,7 @@ const response = await openai.chat.completions.create({
 
 Pass API keys directly in requests to bypass Bifrost's load balancing. You can pass any provider's API key (OpenAI, Anthropic, Mistral, etc.) since Bifrost only looks for `Authorization` or `x-api-key` headers. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../../quickstart/README) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 <Tabs group="openai-sdk">
 <Tab title="Python">

--- a/docs/integrations/pydanticai-sdk.mdx
+++ b/docs/integrations/pydanticai-sdk.mdx
@@ -295,7 +295,7 @@ print(result.output)
 
 Pass API keys directly to bypass Bifrost's key management. This requires the **Allow Direct API keys** option to be enabled in Bifrost configuration.
 
-> **Learn more:** See [Quickstart Configuration](../quickstart/README) for enabling direct API key usage.
+> **Learn more:** See [Key Management](../features/keys-management#direct-key-bypass) for enabling direct API key usage.
 
 <Tabs group="pydanticai-sdk">
 <Tab title="Python">


### PR DESCRIPTION
## Summary

The current quickstart page does not contain information RE:direct api keys
https://docs.getbifrost.ai/features/keys-management#direct-key-bypass

## Changes

- Updated doc links to point to direct api key docs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ X ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ X ] Docs
