### PR TITLE
fixes blur issue on char type in Headers table

### DIFF
--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -97,10 +97,8 @@ export function HeadersTable({
 					</TableHeader>
 					<TableBody>
 						{rows.map(([key, value], index) => {
-							// Use key for existing entries, index for the empty row
-							const rowKey = key !== "" ? key : `empty-${index}`;
 							return (
-								<TableRow key={rowKey} className="border-b last:border-0">
+								<TableRow key={index} className="border-b last:border-0">
 									<TableCell className="p-2">
 										<Input
 											placeholder={keyPlaceholder}


### PR DESCRIPTION
## Summary

Fixed a key generation issue in the HeadersTable component by using array index as the React key instead of attempting to use header key values.

## Changes

- Changed the key prop in TableRow from using a conditional logic to simply using the array index
- Removed the unnecessary rowKey variable and comment that was explaining the previous approach
- This ensures consistent and reliable key generation for all table rows, including empty ones

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the headers table renders correctly and maintains proper state when adding/removing rows:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Navigate to any page with the HeadersTable component and verify that rows can be added, edited, and removed without issues.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable