### PR TITLE
refactor: openai and mistral audio refactored

### DIFF
--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -366,9 +366,10 @@ func (provider *MistralProvider) TranscriptionStream(ctx context.Context, postHo
 	if mistralReq == nil {
 		return nil, providerUtils.NewBifrostOperationError("transcription input is not provided", nil, providerName)
 	}
+	mistralReq.Stream = schemas.Ptr(true)
 
 	// Create multipart form body with stream=true
-	body, contentType, bifrostErr := createMistralTranscriptionStreamMultipartBody(mistralReq, providerName)
+	body, contentType, bifrostErr := createMistralTranscriptionMultipartBody(mistralReq, providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}

--- a/core/providers/mistral/transcription_test.go
+++ b/core/providers/mistral/transcription_test.go
@@ -969,9 +969,9 @@ func TestCreateMistralTranscriptionStreamMultipartBody(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		request        *MistralTranscriptionRequest
-		expectedFields map[string]string
+		name                string
+		request             *MistralTranscriptionRequest
+		expectedFields      map[string]string
 		expectedArrayFields map[string][]string
 	}{
 		{
@@ -1016,7 +1016,7 @@ func TestCreateMistralTranscriptionStreamMultipartBody(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			body, contentType, err := createMistralTranscriptionStreamMultipartBody(tt.request, schemas.Mistral)
+			body, contentType, err := createMistralTranscriptionMultipartBody(tt.request, schemas.Mistral)
 
 			require.Nil(t, err)
 			require.NotNil(t, body)

--- a/core/providers/mistral/types.go
+++ b/core/providers/mistral/types.go
@@ -40,12 +40,13 @@ type MistralListModelsResponse struct {
 // MistralTranscriptionRequest represents a Mistral audio transcription request.
 // Based on: https://docs.mistral.ai/capabilities/audio_transcription
 type MistralTranscriptionRequest struct {
-	Model          string   `json:"model"`                      // Required: e.g., "mistral-audio-transcribe"
-	File           []byte   `json:"file"`                       // Required: Binary audio data
-	Language       *string  `json:"language,omitempty"`         // Optional: ISO 639-1 language code
-	Prompt         *string  `json:"prompt,omitempty"`           // Optional: Context hint for transcription
-	ResponseFormat *string  `json:"response_format,omitempty"`  // Optional: "json", "text", "srt", "verbose_json", "vtt"
-	Temperature    *float64 `json:"temperature,omitempty"`      // Optional: Sampling temperature (0 to 1)
+	Model                  string   `json:"model"`                             // Required: e.g., "mistral-audio-transcribe"
+	File                   []byte   `json:"file"`                              // Required: Binary audio data
+	Language               *string  `json:"language,omitempty"`                // Optional: ISO 639-1 language code
+	Prompt                 *string  `json:"prompt,omitempty"`                  // Optional: Context hint for transcription
+	ResponseFormat         *string  `json:"response_format,omitempty"`         // Optional: "json", "text", "srt", "verbose_json", "vtt"
+	Temperature            *float64 `json:"temperature,omitempty"`             // Optional: Sampling temperature (0 to 1)
+	Stream                 *bool    `json:"stream,omitempty"`                  // Optional: Enable streaming mode
 	TimestampGranularities []string `json:"timestamp_granularities,omitempty"` // Optional: "word" or "segment"
 }
 
@@ -99,8 +100,8 @@ const (
 
 // MistralTranscriptionStreamEvent represents a streaming transcription event from Mistral.
 type MistralTranscriptionStreamEvent struct {
-	Event string                           `json:"event"`
-	Data  *MistralTranscriptionStreamData  `json:"data,omitempty"`
+	Event string                          `json:"event"`
+	Data  *MistralTranscriptionStreamData `json:"data,omitempty"`
 }
 
 // MistralTranscriptionStreamData represents the data payload for streaming events.
@@ -115,8 +116,8 @@ type MistralTranscriptionStreamData struct {
 	Segment *MistralTranscriptionStreamSegment `json:"segment,omitempty"`
 
 	// For transcription.done events
-	Model string                        `json:"model,omitempty"`
-	Usage *MistralTranscriptionUsage    `json:"usage,omitempty"`
+	Model string                     `json:"model,omitempty"`
+	Usage *MistralTranscriptionUsage `json:"usage,omitempty"`
 }
 
 // MistralTranscriptionStreamSegment represents a segment in streaming response.

--- a/core/providers/openai/transcription.go
+++ b/core/providers/openai/transcription.go
@@ -1,6 +1,11 @@
 package openai
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"mime/multipart"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
 
 // ToBifrostTranscriptionRequest converts an OpenAI transcription request to Bifrost format
 func (request *OpenAITranscriptionRequest) ToBifrostTranscriptionRequest() *schemas.BifrostTranscriptionRequest {
@@ -36,4 +41,53 @@ func ToOpenAITranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReques
 	}
 
 	return openaiReq
+}
+
+// parseTranscriptionFormDataBodyFromRequest parses the transcription request and writes it to the multipart form.
+func parseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, openaiReq *OpenAITranscriptionRequest, providerName schemas.ModelProvider) *schemas.BifrostError {
+	// Add file field
+	fileWriter, err := writer.CreateFormFile("file", "audio.mp3") // OpenAI requires a filename
+	if err != nil {
+		return providerUtils.NewBifrostOperationError("failed to create form file", err, providerName)
+	}
+	if _, err := fileWriter.Write(openaiReq.File); err != nil {
+		return providerUtils.NewBifrostOperationError("failed to write file data", err, providerName)
+	}
+
+	// Add model field
+	if err := writer.WriteField("model", openaiReq.Model); err != nil {
+		return providerUtils.NewBifrostOperationError("failed to write model field", err, providerName)
+	}
+
+	// Add optional fields
+	if openaiReq.Language != nil {
+		if err := writer.WriteField("language", *openaiReq.Language); err != nil {
+			return providerUtils.NewBifrostOperationError("failed to write language field", err, providerName)
+		}
+	}
+
+	if openaiReq.Prompt != nil {
+		if err := writer.WriteField("prompt", *openaiReq.Prompt); err != nil {
+			return providerUtils.NewBifrostOperationError("failed to write prompt field", err, providerName)
+		}
+	}
+
+	if openaiReq.ResponseFormat != nil {
+		if err := writer.WriteField("response_format", *openaiReq.ResponseFormat); err != nil {
+			return providerUtils.NewBifrostOperationError("failed to write response_format field", err, providerName)
+		}
+	}
+
+	if openaiReq.Stream != nil && *openaiReq.Stream {
+		if err := writer.WriteField("stream", "true"); err != nil {
+			return providerUtils.NewBifrostOperationError("failed to write stream field", err, providerName)
+		}
+	}
+
+	// Close the multipart writer
+	if err := writer.Close(); err != nil {
+		return providerUtils.NewBifrostOperationError("failed to close multipart writer", err, providerName)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

Refactors audio processing code to reduce duplication and improve maintainability across providers by extracting shared functionality into reusable handler functions.

## Changes

- Consolidated duplicate code in Mistral's transcription functionality by merging `createMistralTranscriptionStreamMultipartBody` and `createMistralTranscriptionMultipartBody` into a single function
- Added a `Stream` parameter to the Mistral transcription request structure for better control
- Created reusable handler functions in OpenAI provider for speech, speech streaming, transcription, and transcription streaming operations
- Fixed raw request handling in OpenAI's speech endpoint to properly return request data when enabled
- Improved error handling and logging consistency across audio processing functions

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the audio processing functionality with both OpenAI and Mistral providers:

```sh
# Run all tests
go test ./core/providers/mistral/... ./core/providers/openai/...

# Test specific transcription functionality
go test ./core/providers/mistral -run TestCreateMistralTranscriptionMultipartBody
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Improves code maintainability and reduces duplication in audio processing code.

## Security considerations

No security implications as this is a refactoring of existing functionality.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable