### PR TITLE
moves config items into sidebar

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Mock time.Sleep to avoid real delays in tests
@@ -397,8 +399,8 @@ func TestIsRateLimitError_AllPatterns(t *testing.T) {
 			}
 
 			// Test case insensitive - mixed case
-			if !IsRateLimitErrorMessage(strings.Title(pattern)) {
-				t.Errorf("Title case pattern '%s' should be detected as rate limit error", strings.Title(pattern))
+			if !IsRateLimitErrorMessage(cases.Title(language.English).String(pattern)) {
+				t.Errorf("Title case pattern '%s' should be detected as rate limit error", cases.Title(language.English).String(pattern))
 			}
 
 			// Test as part of larger message

--- a/core/chatbot_test.go
+++ b/core/chatbot_test.go
@@ -41,14 +41,6 @@ type ChatSession struct {
 // ComprehensiveTestAccount provides a test implementation of the Account interface for comprehensive testing.
 type ComprehensiveTestAccount struct{}
 
-// getEnvWithDefault returns the value of the environment variable if set, otherwise returns the default value
-func getEnvWithDefault(envVar, defaultValue string) string {
-	if value := os.Getenv(envVar); value != "" {
-		return value
-	}
-	return defaultValue
-}
-
 // GetConfiguredProviders returns the list of initially supported providers.
 func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
 	return []schemas.ModelProvider{
@@ -515,7 +507,7 @@ func (s *ChatSession) SendMessage(message string) (string, error) {
 	s.history = append(s.history, *assistantMessage)
 
 	// Check if assistant wants to use tools
-	if assistantMessage.ToolCalls != nil && len(assistantMessage.ToolCalls) > 0 {
+	if len(assistantMessage.ToolCalls) > 0 {
 		return s.handleToolCalls(*assistantMessage)
 	}
 
@@ -523,7 +515,7 @@ func (s *ChatSession) SendMessage(message string) (string, error) {
 	var responseText string
 	if assistantMessage.Content.ContentStr != nil {
 		responseText = *assistantMessage.Content.ContentStr
-	} else if assistantMessage.Content.ContentBlocks != nil && len(assistantMessage.Content.ContentBlocks) > 0 {
+	} else if len(assistantMessage.Content.ContentBlocks) > 0 {
 		var textParts []string
 		for _, block := range assistantMessage.Content.ContentBlocks {
 			if block.Text != nil {

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1504,7 +1504,7 @@ func (provider *AzureProvider) BatchList(ctx context.Context, keys []schemas.Key
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	if len(keys) == 0 {
-		return nil, providerUtils.NewConfigurationError("no Azure keys available for file content operation", providerName)
+		return nil, providerUtils.NewConfigurationError("no Azure keys available for batch list operation", providerName)
 	}
 
 	// Initialize serial pagination helper
@@ -1724,7 +1724,6 @@ func (provider *AzureProvider) BatchCancel(ctx context.Context, keys []schemas.K
 		return nil, providerUtils.NewConfigurationError("no Azure keys available for batch cancel operation", providerName)
 	}
 
-
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
@@ -1839,7 +1838,7 @@ func (provider *AzureProvider) BatchResults(ctx context.Context, keys []schemas.
 	providerName := provider.GetProviderKey()
 
 	// First, retrieve the batch to get the output_file_id (using all keys)
-	batchResp, bifrostErr := provider.BatchRetr	ieve(ctx, keys, &schemas.BifrostBatchRetrieveRequest{
+	batchResp, bifrostErr := provider.BatchRetrieve(ctx, keys, &schemas.BifrostBatchRetrieveRequest{
 		Provider: request.Provider,
 		BatchID:  request.BatchID,
 	})

--- a/core/providers/bedrock/s3.go
+++ b/core/providers/bedrock/s3.go
@@ -85,8 +85,14 @@ func deriveInputS3URIFromOutput(outputS3URI, inputKey string) string {
 // ConvertBedrockRequestsToJSONL converts batch request items to JSONL format for Bedrock.
 // Bedrock uses a specific format for batch inference requests.
 func ConvertBedrockRequestsToJSONL(requests []schemas.BatchRequestItem, modelID *string) ([]byte, error) {
+	// Model ID is required for Bedrock batch JSONL conversion
+	if modelID == nil || *modelID == "" {
+		return nil, fmt.Errorf("modelID is required for Bedrock batch JSONL conversion")
+	}
+	// Initialize the buffer
 	var buf bytes.Buffer
 
+	// Iterate over the requests
 	for _, req := range requests {
 		// Build the Bedrock batch request format
 		bedrockReq := map[string]interface{}{

--- a/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
@@ -67,7 +67,7 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 	const isInferenceAuthDisabled = bifrostConfig?.auth_config?.disable_auth_on_inference ?? false;
 
 	return (
-		<div className="space-y-4">
+		<div className="space-y-4 mx-auto w-full max-w-4xl">
 			<Alert variant="default">
 				<InfoIcon className="text-muted h-4 w-4" />
 				<AlertDescription>

--- a/ui/app/workspace/config/page.tsx
+++ b/ui/app/workspace/config/page.tsx
@@ -3,9 +3,7 @@
 import FullPageLoader from "@/components/fullPageLoader";
 import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { useGetCoreConfigQuery } from "@/lib/store";
-import { cn } from "@/lib/utils";
 import APIKeysView from "@enterprise/components/api-keys/APIKeysView";
-import { Gauge, Globe, KeyRound, Landmark, Settings, Shield, Telescope, Zap } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useEffect } from "react";
 import CachingView from "./views/cachingView";
@@ -18,70 +16,27 @@ import PricingConfigView from "./views/pricingConfigView";
 import ProxyView from "./views/proxyView";
 import SecurityView from "./views/securityView";
 
-const baseTabs = [
-	{
-		id: "client-settings",
-		label: "Client Settings",
-		icon: <Settings className="size-4" />,
-	},
-	{
-		id: "pricing-config",
-		label: "Pricing Config",
-		icon: <Landmark className="size-4" />,
-	},
-	{
-		id: "logging",
-		label: "Logging",
-		icon: <Telescope className="size-4" />,
-	},
-	{
-		id: "governance",
-		label: "Governance",
-		icon: <Landmark className="size-4" />,
-	},
-	{
-		id: "caching",
-		label: "Caching",
-		icon: <Zap className="size-4" />,
-	},
-	{
-		id: "observability",
-		label: "Observability",
-		icon: <Gauge className="size-4" />,
-	},
-	{
-		id: "security",
-		label: "Security",
-		icon: <Shield className="size-4" />,
-	},
-	{
-		id: "proxy",
-		label: "Proxy",
-		icon: <Globe className="size-4" />,
-		enterpriseOnly: true,
-	},
-	{
-		id: "api-keys",
-		label: "API Keys",
-		icon: <KeyRound className="size-4" />,
-	},
-	{
-		id: "performance-tuning",
-		label: "Performance Tuning",
-		icon: <Zap className="size-4" />,
-	},
+const validTabs = [
+	"client-settings",
+	"pricing-config",
+	"logging",
+	"governance",
+	"caching",
+	"observability",
+	"security",
+	"proxy",
+	"api-keys",
+	"performance-tuning",
 ];
-
-const tabs = baseTabs.filter((tab) => !tab.enterpriseOnly || IS_ENTERPRISE);
 
 export default function ConfigPage() {
 	const [activeTab, setActiveTab] = useQueryState("tab");
 	const { isLoading } = useGetCoreConfigQuery({ fromDB: true });
 
+	// Redirect to default tab if none specified
 	useEffect(() => {
-		const validTabIds = tabs.map((t) => t.id);
-		if (!activeTab || !validTabIds.includes(activeTab)) {
-			setActiveTab(tabs[0].id);
+		if (!activeTab || !validTabs.includes(activeTab)) {
+			setActiveTab("client-settings");
 		}
 	}, [activeTab, setActiveTab]);
 
@@ -90,37 +45,19 @@ export default function ConfigPage() {
 	}
 
 	return (
-		<div className="mx-auto flex w-full max-w-7xl flex-row gap-4">
-			<div className="flex min-w-[250px] flex-col gap-1 rounded-md bg-zinc-50/50 p-4 dark:bg-zinc-800/20">
-				{tabs.map((tab) => (
-					<button
-						key={tab.id}
-						className={cn(
-							"mb-1 flex w-full items-center gap-2 rounded-sm border px-3 py-1.5 text-sm",
-							activeTab === tab.id
-								? "bg-secondary opacity-100 hover:opacity-100"
-								: "hover:bg-secondary cursor-pointer border-transparent opacity-100 hover:border",
-						)}
-						onClick={() => setActiveTab(tab.id)}
-						type="button"
-					>
-						{tab.icon}
-						<div>{tab.label}</div>
-					</button>
-				))}
-			</div>
-			<div className="w-full pt-4">
-				{activeTab === "client-settings" && <ClientSettingsView />}
-				{activeTab === "pricing-config" && <PricingConfigView />}
-				{activeTab === "logging" && <LoggingView />}
-				{activeTab === "governance" && <GovernanceView />}
-				{activeTab === "caching" && <CachingView />}
-				{activeTab === "observability" && <ObservabilityView />}
-				{activeTab === "security" && <SecurityView />}
-				{activeTab === "proxy" && IS_ENTERPRISE && <ProxyView />}
-				{activeTab === "api-keys" && <APIKeysView />}
-				{activeTab === "performance-tuning" && <PerformanceTuningView />}
-			</div>
+		<div className="mx-auto flex w-full max-w-7xl">
+			{activeTab === "client-settings" && <ClientSettingsView />}
+			{activeTab === "pricing-config" && <PricingConfigView />}
+			{activeTab === "logging" && <LoggingView />}
+			{activeTab === "governance" && <GovernanceView />}
+			{activeTab === "caching" && <CachingView />}
+			{activeTab === "observability" && <ObservabilityView />}
+			{activeTab === "security" && <SecurityView />}
+			{activeTab === "proxy" && IS_ENTERPRISE && <ProxyView />}
+			{activeTab === "api-keys" && <APIKeysView />}
+			{activeTab === "performance-tuning" && <PerformanceTuningView />}
+			{/* Fallback to client settings for invalid tabs */}
+			{activeTab && !validTabs.includes(activeTab) && <ClientSettingsView />}
 		</div>
 	);
 }

--- a/ui/app/workspace/config/views/cachingView.tsx
+++ b/ui/app/workspace/config/views/cachingView.tsx
@@ -7,7 +7,7 @@ export default function CachingView() {
 	const { data: bifrostConfig, isLoading, error: configError } = useGetCoreConfigQuery({ fromDB: true });
 
 	return (
-		<div className="space-y-4">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div>
 				<h2 className="text-2xl font-semibold tracking-tight">Caching</h2>
 				<p className="text-muted-foreground text-sm">Configure semantic caching for requests.</p>

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -66,7 +66,7 @@ export default function ClientSettingsView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4">
+		<div className="space-y-4 w-full max-w-4xl mx-auto">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Client Settings</h2>

--- a/ui/app/workspace/config/views/governanceView.tsx
+++ b/ui/app/workspace/config/views/governanceView.tsx
@@ -61,7 +61,7 @@ export default function GovernanceView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4">
+		<div className="space-y-4 mx-auto w-full max-w-4xl">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Governance</h2>

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -76,7 +76,7 @@ export default function LoggingView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Logging</h2>

--- a/ui/app/workspace/config/views/observabilityView.tsx
+++ b/ui/app/workspace/config/views/observabilityView.tsx
@@ -76,7 +76,7 @@ export default function ObservabilityView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Observability Settings</h2>

--- a/ui/app/workspace/config/views/performanceTuningView.tsx
+++ b/ui/app/workspace/config/views/performanceTuningView.tsx
@@ -99,7 +99,7 @@ export default function PerformanceTuningView() {
 	}, [bifrostConfig, localConfig, localValues, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4">
+		<div className="space-y-4 mx-auto w-full max-w-4xl">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Performance Tuning</h2>

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -80,83 +80,82 @@ export default function PricingConfigView() {
 	};
 
 	return (
-		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-			<div className="flex items-center justify-between">
-				<div>
-					<h2 className="text-2xl font-semibold tracking-tight">Pricing Configuration</h2>
-					<p className="text-muted-foreground text-sm">Configure custom pricing datasheet and sync intervals.</p>
-				</div>
-				<div className="flex items-center gap-2">
-					<Button
-						variant="outline"
-						type="button"
-						onClick={handleForceSync}
-						disabled={isForceSyncing || !hasSettingsUpdateAccess}
-					>
-						{isForceSyncing ? "Forcing..." : "Force Sync Now"}
-					</Button>
-					<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
-						{isLoading ? "Saving..." : "Save Changes"}
-					</Button>
-				</div>
-			</div>
-
-			<div className="space-y-4">
-				{/* Pricing Datasheet URL */}
-				<div className="space-y-2 rounded-lg border p-4">
-					<div className="space-y-0.5">
-						<Label htmlFor="pricing-datasheet-url">Pricing Datasheet URL</Label>
-						<p className="text-muted-foreground text-sm">URL to a custom pricing datasheet. Leave empty to use default pricing.</p>
+		<div className="mx-auto w-full max-w-4xl space-y-4">
+			<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+				<div className="flex items-center justify-between">
+					<div>
+						<h2 className="text-2xl font-semibold tracking-tight">Pricing Configuration</h2>
+						<p className="text-muted-foreground text-sm">Configure custom pricing datasheet and sync intervals.</p>
 					</div>
-					<Input
-						id="pricing-datasheet-url"
-						type="text"
-						placeholder="https://example.com/pricing.json"
-						{...register("pricing_datasheet_url", {
-							pattern: {
-								value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))([\/\w \.-]*)*\/?$/,
-								message: "Please enter a valid URL.",
-							},
-							validate: {
-								checkIfHttp: (value) => {
-									if (!value) return true; // Allow empty
-									return value.startsWith("http://") || value.startsWith("https://") || "URL must start with http:// or https://";
-								},
-							},
-						})}
-						className={errors.pricing_datasheet_url ? "border-destructive" : ""}
-					/>
-					{errors.pricing_datasheet_url && <p className="text-destructive text-sm">{errors.pricing_datasheet_url.message}</p>}
+					<div className="flex items-center gap-2">
+						<Button variant="outline" type="button" onClick={handleForceSync} disabled={isForceSyncing || !hasSettingsUpdateAccess}>
+							{isForceSyncing ? "Forcing..." : "Force Sync Now"}
+						</Button>
+						<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
+							{isLoading ? "Saving..." : "Save Changes"}
+						</Button>
+					</div>
 				</div>
 
-				{/* Pricing Sync Interval */}
-				<div className="space-y-2 rounded-lg border p-4">
-					<div className="space-y-2">
+				<div className="space-y-4">
+					{/* Pricing Datasheet URL */}
+					<div className="space-y-2 rounded-lg border p-4">
 						<div className="space-y-0.5">
-							<Label htmlFor="pricing-sync-interval">Pricing Sync Interval (hours)</Label>
-							<p className="text-muted-foreground text-sm">How often to sync pricing data from the datasheet URL.</p>
+							<Label htmlFor="pricing-datasheet-url">Pricing Datasheet URL</Label>
+							<p className="text-muted-foreground text-sm">URL to a custom pricing datasheet. Leave empty to use default pricing.</p>
 						</div>
 						<Input
-							id="pricing-sync-interval"
-							type="number"
-							className={errors.pricing_sync_interval_hours ? "border-destructive" : ""}
-							{...register("pricing_sync_interval_hours", {
-								required: "Pricing sync interval is required",
-								min: {
-									value: 1,
-									message: "Sync interval must be at least 1 hour",
+							id="pricing-datasheet-url"
+							type="text"
+							placeholder="https://example.com/pricing.json"
+							{...register("pricing_datasheet_url", {
+								pattern: {
+									value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))([\/\w \.-]*)*\/?$/,
+									message: "Please enter a valid URL.",
 								},
-								max: {
-									value: 8760,
-									message: "Sync interval cannot exceed 8760 hours (1 year)",
+								validate: {
+									checkIfHttp: (value) => {
+										if (!value) return true; // Allow empty
+										return value.startsWith("http://") || value.startsWith("https://") || "URL must start with http:// or https://";
+									},
 								},
-								valueAsNumber: true,
 							})}
+							className={errors.pricing_datasheet_url ? "border-destructive" : ""}
 						/>
-						{errors.pricing_sync_interval_hours && <p className="text-destructive text-sm">{errors.pricing_sync_interval_hours.message}</p>}
+						{errors.pricing_datasheet_url && <p className="text-destructive text-sm">{errors.pricing_datasheet_url.message}</p>}
+					</div>
+
+					{/* Pricing Sync Interval */}
+					<div className="space-y-2 rounded-lg border p-4">
+						<div className="space-y-2">
+							<div className="space-y-0.5">
+								<Label htmlFor="pricing-sync-interval">Pricing Sync Interval (hours)</Label>
+								<p className="text-muted-foreground text-sm">How often to sync pricing data from the datasheet URL.</p>
+							</div>
+							<Input
+								id="pricing-sync-interval"
+								type="number"
+								className={errors.pricing_sync_interval_hours ? "border-destructive" : ""}
+								{...register("pricing_sync_interval_hours", {
+									required: "Pricing sync interval is required",
+									min: {
+										value: 1,
+										message: "Sync interval must be at least 1 hour",
+									},
+									max: {
+										value: 8760,
+										message: "Sync interval cannot exceed 8760 hours (1 year)",
+									},
+									valueAsNumber: true,
+								})}
+							/>
+							{errors.pricing_sync_interval_hours && (
+								<p className="text-destructive text-sm">{errors.pricing_sync_interval_hours.message}</p>
+							)}
+						</div>
 					</div>
 				</div>
-			</div>
-		</form>
+			</form>
+		</div>
 	);
 }

--- a/ui/app/workspace/config/views/proxyView.tsx
+++ b/ui/app/workspace/config/views/proxyView.tsx
@@ -1,399 +1,349 @@
-'use client'
+"use client";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
-import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Switch } from '@/components/ui/switch'
-import { Textarea } from '@/components/ui/textarea'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { IS_ENTERPRISE } from '@/lib/constants/config'
-import { getErrorMessage, useGetCoreConfigQuery, useUpdateProxyConfigMutation } from '@/lib/store'
-import { DefaultGlobalProxyConfig, GlobalProxyConfig } from '@/lib/types/config'
-import { globalProxyConfigSchema } from '@/lib/types/schemas'
-import { cn } from '@/lib/utils'
-import { RbacOperation, RbacResource, useRbac } from '@enterprise/lib'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { AlertTriangle, Info } from 'lucide-react'
-import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
-import { toast } from 'sonner'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { getErrorMessage, useGetCoreConfigQuery, useUpdateProxyConfigMutation } from "@/lib/store";
+import { DefaultGlobalProxyConfig, GlobalProxyConfig } from "@/lib/types/config";
+import { globalProxyConfigSchema } from "@/lib/types/schemas";
+import { cn } from "@/lib/utils";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertTriangle, Info } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
-export default function ProxyView () {
-  const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update)
-  const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true })
-  const proxyConfig = bifrostConfig?.proxy_config
-  const [updateProxyConfig, { isLoading }] = useUpdateProxyConfigMutation()
+export default function ProxyView() {
+	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
+	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
+	const proxyConfig = bifrostConfig?.proxy_config;
+	const [updateProxyConfig, { isLoading }] = useUpdateProxyConfigMutation();
 
-  const form = useForm<GlobalProxyConfig>({
-    resolver: zodResolver(globalProxyConfigSchema),
-    mode: 'onChange',
-    reValidateMode: 'onChange',
-    defaultValues: DefaultGlobalProxyConfig
-  })
+	const form = useForm<GlobalProxyConfig>({
+		resolver: zodResolver(globalProxyConfigSchema),
+		mode: "onChange",
+		reValidateMode: "onChange",
+		defaultValues: DefaultGlobalProxyConfig,
+	});
 
-  useEffect(() => {
-    if (proxyConfig) {
-      form.reset({
-        ...DefaultGlobalProxyConfig,
-        ...proxyConfig
-      })
-    }
-  }, [proxyConfig, form])
+	useEffect(() => {
+		if (proxyConfig) {
+			form.reset({
+				...DefaultGlobalProxyConfig,
+				...proxyConfig,
+			});
+		}
+	}, [proxyConfig, form]);
 
-  const watchedEnabled = form.watch('enabled')
-  const watchedType = form.watch('type')
+	const watchedEnabled = form.watch("enabled");
+	const watchedType = form.watch("type");
 
-  const onSubmit = async (data: GlobalProxyConfig) => {
-    try {
-      await updateProxyConfig(data).unwrap()
-      toast.success('Proxy configuration updated successfully.')
-    } catch (error) {
-      toast.error(getErrorMessage(error))
-    }
-  }
+	const onSubmit = async (data: GlobalProxyConfig) => {
+		try {
+			await updateProxyConfig(data).unwrap();
+			toast.success("Proxy configuration updated successfully.");
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
 
-  const isTypeUnsupported = watchedType === 'socks5' || watchedType === 'tcp'
+	const isTypeUnsupported = watchedType === "socks5" || watchedType === "tcp";
 
-  return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-2xl font-semibold tracking-tight">Proxy Settings</h2>
-            <p className="text-muted-foreground text-sm">
-              Configure global proxy settings for outbound requests.
-            </p>
-          </div>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span tabIndex={!hasSettingsUpdateAccess ? 0 : undefined}>
-                <Button
-                  type="submit"
-                  disabled={!form.formState.isDirty || !form.formState.isValid || isLoading || !hasSettingsUpdateAccess}
-                >
-                  {isLoading ? 'Saving...' : 'Save Changes'}
-                </Button>
-              </span>
-            </TooltipTrigger>
-            {!hasSettingsUpdateAccess && (
-              <TooltipContent>
-                You don't have permission to update settings
-              </TooltipContent>
-            )}
-          </Tooltip>
-        </div>
+	return (
+		<div className="mx-auto w-full max-w-4xl space-y-4">
+			<Form {...form}>
+				<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+					<div className="flex items-center justify-between">
+						<div>
+							<h2 className="text-2xl font-semibold tracking-tight">Proxy Settings</h2>
+							<p className="text-muted-foreground text-sm">Configure global proxy settings for outbound requests.</p>
+						</div>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span tabIndex={!hasSettingsUpdateAccess ? 0 : undefined}>
+									<Button
+										type="submit"
+										disabled={!form.formState.isDirty || !form.formState.isValid || isLoading || !hasSettingsUpdateAccess}
+									>
+										{isLoading ? "Saving..." : "Save Changes"}
+									</Button>
+								</span>
+							</TooltipTrigger>
+							{!hasSettingsUpdateAccess && <TooltipContent>You don't have permission to update settings</TooltipContent>}
+						</Tooltip>
+					</div>
 
-        <fieldset disabled={!hasSettingsUpdateAccess} className="space-y-4">
-          {/* Enable Proxy */}
-          <div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
-            <div className="space-y-0.5">
-              <FormLabel className="text-sm font-medium">Enable Proxy</FormLabel>
-              <p className="text-muted-foreground text-sm">
-                Enable global proxy for outbound HTTP requests.
-              </p>
-            </div>
-            <FormField
-              control={form.control}
-              name="enabled"
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-          </div>
+					<fieldset disabled={!hasSettingsUpdateAccess} className="space-y-4">
+						{/* Enable Proxy */}
+						<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+							<div className="space-y-0.5">
+								<FormLabel className="text-sm font-medium">Enable Proxy</FormLabel>
+								<p className="text-muted-foreground text-sm">Enable global proxy for outbound HTTP requests.</p>
+							</div>
+							<FormField
+								control={form.control}
+								name="enabled"
+								render={({ field }) => (
+									<FormItem>
+										<FormControl>
+											<Switch checked={field.value} onCheckedChange={field.onChange} />
+										</FormControl>
+									</FormItem>
+								)}
+							/>
+						</div>
 
-          {/* Proxy Configuration Section */}
-          <div className={cn(
-            'space-y-4 rounded-lg border p-4 transition-opacity',
-            !watchedEnabled && 'opacity-50 pointer-events-none'
-          )}>
-            <h3 className="text-lg font-medium">Proxy Configuration</h3>
+						{/* Proxy Configuration Section */}
+						<div className={cn("space-y-4 rounded-lg border p-4 transition-opacity", !watchedEnabled && "pointer-events-none opacity-50")}>
+							<h3 className="text-lg font-medium">Proxy Configuration</h3>
 
-            {/* Proxy Type */}
-            <FormField
-              control={form.control}
-              name="type"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Proxy Type</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
-                    disabled={!watchedEnabled}
-                  >
-                    <FormControl>
-                      <SelectTrigger className="w-48">
-                        <SelectValue placeholder="Select type" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="http">HTTP / HTTPS</SelectItem>
-                      <SelectItem value="socks5" disabled>
-                        SOCKS5 <Badge variant="outline" className="ml-2 text-xs">Coming soon</Badge>
-                      </SelectItem>
-                      <SelectItem value="tcp" disabled>
-                        TCP <Badge variant="outline" className="ml-2 text-xs">Coming soon</Badge>
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <FormDescription>
-                    Select the proxy protocol type. Currently only HTTP proxy is supported.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+							{/* Proxy Type */}
+							<FormField
+								control={form.control}
+								name="type"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Proxy Type</FormLabel>
+										<Select onValueChange={field.onChange} value={field.value} disabled={!watchedEnabled}>
+											<FormControl>
+												<SelectTrigger className="w-48">
+													<SelectValue placeholder="Select type" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value="http">HTTP / HTTPS</SelectItem>
+												<SelectItem value="socks5" disabled>
+													SOCKS5{" "}
+													<Badge variant="outline" className="ml-2 text-xs">
+														Coming soon
+													</Badge>
+												</SelectItem>
+												<SelectItem value="tcp" disabled>
+													TCP{" "}
+													<Badge variant="outline" className="ml-2 text-xs">
+														Coming soon
+													</Badge>
+												</SelectItem>
+											</SelectContent>
+										</Select>
+										<FormDescription>Select the proxy protocol type. Currently only HTTP proxy is supported.</FormDescription>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-            {isTypeUnsupported && watchedEnabled && (
-              <Alert variant="destructive">
-                <AlertTriangle className="h-4 w-4" />
-                <AlertDescription>
-                  {watchedType.toUpperCase()} proxy is not yet supported. Please use HTTP proxy.
-                </AlertDescription>
-              </Alert>
-            )}
+							{isTypeUnsupported && watchedEnabled && (
+								<Alert variant="destructive">
+									<AlertTriangle className="h-4 w-4" />
+									<AlertDescription>{watchedType.toUpperCase()} proxy is not yet supported. Please use HTTP proxy.</AlertDescription>
+								</Alert>
+							)}
 
-            {/* Proxy URL */}
-            <FormField
-              control={form.control}
-              name="url"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Proxy URL</FormLabel>
-                  <FormControl>
-                    <Input
-                      placeholder="http://proxy.example.com:8080"
-                      disabled={!watchedEnabled}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    Full URL of the proxy server including protocol and port.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+							{/* Proxy URL */}
+							<FormField
+								control={form.control}
+								name="url"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Proxy URL</FormLabel>
+										<FormControl>
+											<Input placeholder="http://proxy.example.com:8080" disabled={!watchedEnabled} {...field} />
+										</FormControl>
+										<FormDescription>Full URL of the proxy server including protocol and port.</FormDescription>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-            {/* Authentication Section */}
-            <div className="space-y-4 rounded-md border p-4 bg-muted/20">
-              <h4 className="text-sm font-medium">Authentication (Optional)</h4>
-              <div className="grid grid-cols-2 gap-4">
-                <FormField
-                  control={form.control}
-                  name="username"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Username</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder="Proxy username"
-                          disabled={!watchedEnabled}
-                          {...field}
-                          value={field.value || ''}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="password"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Password</FormLabel>
-                      <FormControl>
-                        <Input
-                          type="password"
-                          placeholder="Proxy password"
-                          disabled={!watchedEnabled}
-                          {...field}
-                          value={field.value || ''}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
+							{/* Authentication Section */}
+							<div className="bg-muted/20 space-y-4 rounded-md border p-4">
+								<h4 className="text-sm font-medium">Authentication (Optional)</h4>
+								<div className="grid grid-cols-2 gap-4">
+									<FormField
+										control={form.control}
+										name="username"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Username</FormLabel>
+												<FormControl>
+													<Input placeholder="Proxy username" disabled={!watchedEnabled} {...field} value={field.value || ""} />
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={form.control}
+										name="password"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Password</FormLabel>
+												<FormControl>
+													<Input
+														type="password"
+														placeholder="Proxy password"
+														disabled={!watchedEnabled}
+														{...field}
+														value={field.value || ""}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</div>
+							</div>
 
-            {/* Advanced Settings */}
-            <div className="space-y-4 rounded-md border p-4 bg-muted/20">
-              <h4 className="text-sm font-medium">Advanced Settings</h4>
+							{/* Advanced Settings */}
+							<div className="bg-muted/20 space-y-4 rounded-md border p-4">
+								<h4 className="text-sm font-medium">Advanced Settings</h4>
 
-              {/* No Proxy */}
-              <FormField
-                control={form.control}
-                name="no_proxy"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>No Proxy Hosts</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        placeholder="localhost, 127.0.0.1, .internal.example.com"
-                        className="h-20"
-                        disabled={!watchedEnabled}
-                        {...field}
-                        value={field.value || ''}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      Comma-separated list of hosts that should bypass the proxy.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+								{/* No Proxy */}
+								<FormField
+									control={form.control}
+									name="no_proxy"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>No Proxy Hosts</FormLabel>
+											<FormControl>
+												<Textarea
+													placeholder="localhost, 127.0.0.1, .internal.example.com"
+													className="h-20"
+													disabled={!watchedEnabled}
+													{...field}
+													value={field.value || ""}
+												/>
+											</FormControl>
+											<FormDescription>Comma-separated list of hosts that should bypass the proxy.</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 
-              {/* Timeout */}
-              <FormField
-                control={form.control}
-                name="timeout"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Connection Timeout (seconds)</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        min={0}
-                        max={300}
-                        placeholder="30"
-                        className="w-32"
-                        disabled={!watchedEnabled}
-                        {...field}
-                        value={field.value ?? ''}
-                        onChange={(e) => field.onChange(e.target.value !== '' ? parseInt(e.target.value, 10) : undefined)}
-                      />
-                    </FormControl>
-                    <FormDescription>
-                      Timeout for establishing proxy connections. 0 means no timeout.
-                      Default is 60 seconds.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+								{/* Timeout */}
+								<FormField
+									control={form.control}
+									name="timeout"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Connection Timeout (seconds)</FormLabel>
+											<FormControl>
+												<Input
+													type="number"
+													min={0}
+													max={300}
+													placeholder="30"
+													className="w-32"
+													disabled={!watchedEnabled}
+													{...field}
+													value={field.value ?? ""}
+													onChange={(e) => field.onChange(e.target.value !== "" ? parseInt(e.target.value, 10) : undefined)}
+												/>
+											</FormControl>
+											<FormDescription>
+												Timeout for establishing proxy connections. 0 means no timeout. Default is 60 seconds.
+											</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 
-              {/* Skip TLS Verify */}
-              <div className="flex items-center justify-between">
-                <div className="space-y-0.5">
-                  <FormLabel className="text-sm font-medium">Skip TLS Verification</FormLabel>
-                  <p className="text-muted-foreground text-sm">
-                    Disable TLS certificate verification for HTTPS proxies. Not recommended for production.
-                  </p>
-                </div>
-                <FormField
-                  control={form.control}
-                  name="skip_tls_verify"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                          disabled={!watchedEnabled}
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
-          </div>
+								{/* Skip TLS Verify */}
+								<div className="flex items-center justify-between">
+									<div className="space-y-0.5">
+										<FormLabel className="text-sm font-medium">Skip TLS Verification</FormLabel>
+										<p className="text-muted-foreground text-sm">
+											Disable TLS certificate verification for HTTPS proxies. Not recommended for production.
+										</p>
+									</div>
+									<FormField
+										control={form.control}
+										name="skip_tls_verify"
+										render={({ field }) => (
+											<FormItem>
+												<FormControl>
+													<Switch checked={field.value} onCheckedChange={field.onChange} disabled={!watchedEnabled} />
+												</FormControl>
+											</FormItem>
+										)}
+									/>
+								</div>
+							</div>
+						</div>
 
-          {/* Entity Enablement Section */}
-          <div className={cn(
-            'space-y-4 rounded-lg border p-4 transition-opacity',
-            !watchedEnabled && 'opacity-50 pointer-events-none'
-          )}>
-            <div className="space-y-1">
-              <h3 className="text-lg font-medium">Enable Proxy For</h3>
-              <p className="text-muted-foreground text-sm">
-                Select which components should use the proxy for outbound requests.
-              </p>
-            </div>
+						{/* Entity Enablement Section */}
+						<div className={cn("space-y-4 rounded-lg border p-4 transition-opacity", !watchedEnabled && "pointer-events-none opacity-50")}>
+							<div className="space-y-1">
+								<h3 className="text-lg font-medium">Enable Proxy For</h3>
+								<p className="text-muted-foreground text-sm">Select which components should use the proxy for outbound requests.</p>
+							</div>
 
-            {/* SCIM - Enterprise only */}
-            {IS_ENTERPRISE && (
-              <div className="flex items-center justify-between rounded-md border p-4">
-                <div className="space-y-0.5">
-                  <div className="flex items-center gap-2">
-                    <FormLabel className="text-sm font-medium">SCIM</FormLabel>
-                    <Badge variant="secondary">Enterprise</Badge>
-                  </div>
-                  <p className="text-muted-foreground text-sm">
-                    Use proxy for SCIM directory sync requests.
-                  </p>
-                </div>
-                <FormField
-                  control={form.control}
-                  name="enable_for_scim"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Switch
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                          disabled={!watchedEnabled}
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </div>
-            )}
+							{/* SCIM - Enterprise only */}
+							{IS_ENTERPRISE && (
+								<div className="flex items-center justify-between rounded-md border p-4">
+									<div className="space-y-0.5">
+										<div className="flex items-center gap-2">
+											<FormLabel className="text-sm font-medium">SCIM</FormLabel>
+											<Badge variant="secondary">Enterprise</Badge>
+										</div>
+										<p className="text-muted-foreground text-sm">Use proxy for SCIM directory sync requests.</p>
+									</div>
+									<FormField
+										control={form.control}
+										name="enable_for_scim"
+										render={({ field }) => (
+											<FormItem>
+												<FormControl>
+													<Switch checked={field.value} onCheckedChange={field.onChange} disabled={!watchedEnabled} />
+												</FormControl>
+											</FormItem>
+										)}
+									/>
+								</div>
+							)}
 
-            {/* Inference - Coming Soon */}
-            <div className="flex items-center justify-between rounded-md border p-4 opacity-60">
-              <div className="space-y-0.5">
-                <div className="flex items-center gap-2">
-                  <FormLabel className="text-sm font-medium">Inference</FormLabel>
-                  <Badge variant="outline">Coming soon</Badge>
-                </div>
-                <p className="text-muted-foreground text-sm">
-                  Use proxy for LLM inference requests to model providers.
-                </p>
-              </div>
-              <Switch disabled checked={false} />
-            </div>
+							{/* Inference - Coming Soon */}
+							<div className="flex items-center justify-between rounded-md border p-4 opacity-60">
+								<div className="space-y-0.5">
+									<div className="flex items-center gap-2">
+										<FormLabel className="text-sm font-medium">Inference</FormLabel>
+										<Badge variant="outline">Coming soon</Badge>
+									</div>
+									<p className="text-muted-foreground text-sm">Use proxy for LLM inference requests to model providers.</p>
+								</div>
+								<Switch disabled checked={false} />
+							</div>
 
-            {/* API - Coming Soon */}
-            <div className="flex items-center justify-between rounded-md border p-4 opacity-60">
-              <div className="space-y-0.5">
-                <div className="flex items-center gap-2">
-                  <FormLabel className="text-sm font-medium">API</FormLabel>
-                  <Badge variant="outline">Coming soon</Badge>
-                </div>
-                <p className="text-muted-foreground text-sm">
-                  Use proxy for external API calls and webhooks.
-                </p>
-              </div>
-              <Switch disabled checked={false} />
-            </div>
+							{/* API - Coming Soon */}
+							<div className="flex items-center justify-between rounded-md border p-4 opacity-60">
+								<div className="space-y-0.5">
+									<div className="flex items-center gap-2">
+										<FormLabel className="text-sm font-medium">API</FormLabel>
+										<Badge variant="outline">Coming soon</Badge>
+									</div>
+									<p className="text-muted-foreground text-sm">Use proxy for external API calls and webhooks.</p>
+								</div>
+								<Switch disabled checked={false} />
+							</div>
 
-            {!IS_ENTERPRISE && (
-              <Alert>
-                <Info className="h-4 w-4" />
-                <AlertDescription>
-                  SCIM proxy support is available in Bifrost Enterprise.
-                </AlertDescription>
-              </Alert>
-            )}
-          </div>
-        </fieldset>
-      </form>
-    </Form>
-  )
+							{!IS_ENTERPRISE && (
+								<Alert>
+									<Info className="h-4 w-4" />
+									<AlertDescription>SCIM proxy support is available in Bifrost Enterprise.</AlertDescription>
+								</Alert>
+							)}
+						</div>
+					</fieldset>
+				</form>
+			</Form>
+		</div>
+	);
 }
-

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -167,7 +167,7 @@ export default function SecurityView() {
 	}, [bifrostConfig, localConfig, authConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Security Settings</h2>

--- a/ui/app/workspace/logs/views/filters.tsx
+++ b/ui/app/workspace/logs/views/filters.tsx
@@ -264,10 +264,7 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 						<CommandList>
 							<CommandEmpty>No filters found.</CommandEmpty>
 							<CommandGroup>
-								<CommandItem
-									className="cursor-pointer"
-									onSelect={() => onFiltersChange({ ...filters, missing_cost_only: !filters.missing_cost_only })}
-								>
+								<CommandItem className="cursor-pointer">
 									<Checkbox
 										className={cn(
 											"border-primary opacity-50",
@@ -327,12 +324,15 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 						<MoreVertical className="h-4 w-4" />
 					</Button>
 				</PopoverTrigger>
-				<PopoverContent className="w-[200px] bg-white p-2" align="end">
+				<PopoverContent className="w-[250px] bg-white p-2" align="end">
 					<Command>
 						<CommandList>
 							<CommandItem className="cursor-pointer" onSelect={handleRecalculateCosts}>
 								<Calculator className="text-muted-foreground size-4" />
-								<span className="text-sm">Recalculate costs</span>
+								<div className="flex flex-col">
+									<span className="text-sm">Recalculate costs</span>
+									<span className="text-muted-foreground text-xs">For all logs that don't have a cost</span>
+								</div>
 							</CommandItem>
 						</CommandList>
 					</Command>


### PR DESCRIPTION
## Summary

This PR improves the UI layout of configuration pages by standardizing the width and centering content, while also removing the sidebar tabs in favor of a more organized navigation structure through the main sidebar.

## Changes

- Fixed a typo in the Azure provider's `BatchRetrieve` method call
- Improved configuration page layouts by adding consistent max width and centering content
- Removed the configuration page sidebar tabs in favor of using the main application sidebar for navigation
- Added detailed configuration sub-items to the main sidebar with proper query parameter handling
- Enhanced the logs recalculate costs menu item with a more descriptive tooltip

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the configuration pages via the sidebar
2. Verify that each configuration page is properly centered with a consistent width
3. Check that the sidebar navigation correctly highlights the active configuration section
4. Verify that clicking on configuration sub-items in the sidebar correctly navigates to the appropriate tab
5. Test the Azure provider's batch functionality to ensure the typo fix works correctly

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm dev || npm run dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable