### PR TITLE
moves config views into their own paths

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
@@ -52,7 +52,7 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 				<AlertDescription>
 					<p className="text-md text-gray-600">
 						To generate API keys, you need to set up admin username and password first.{" "}
-						<Link href="/workspace/config?tab=security" className="text-md text-primary underline">
+						<Link href="/workspace/config/security" className="text-md text-primary underline">
 							Configure Security Settings
 						</Link>
 						.<br />

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -12,7 +12,7 @@ import { BifrostConfig } from "@/lib/types/config";
 import { RbacProvider } from "@enterprise/lib/contexts/rbacContext";
 import { usePathname } from "next/navigation";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { toast, Toaster } from "sonner";
 
 function AppContent({ children }: { children: React.ReactNode }) {

--- a/ui/app/workspace/config/api-keys/page.tsx
+++ b/ui/app/workspace/config/api-keys/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import APIKeysView from "@enterprise/components/api-keys/APIKeysView"
+
+export default function APIKeysPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <APIKeysView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/caching/page.tsx
+++ b/ui/app/workspace/config/caching/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import CachingView from "../views/cachingView"
+
+export default function CachingPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <CachingView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/client-settings/page.tsx
+++ b/ui/app/workspace/config/client-settings/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import ClientSettingsView from "../views/clientSettingsView"
+
+export default function ClientSettingsPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <ClientSettingsView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/governance/page.tsx
+++ b/ui/app/workspace/config/governance/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import GovernanceView from "../views/governanceView"
+
+export default function GovernancePage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <GovernanceView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/layout.tsx
+++ b/ui/app/workspace/config/layout.tsx
@@ -1,12 +1,21 @@
 "use client"
 
+import FullPageLoader from "@/components/fullPageLoader"
 import { NoPermissionView } from "@/components/noPermissionView"
+import { useGetCoreConfigQuery } from "@/lib/store"
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
 
 export default function ConfigLayout({ children }: { children: React.ReactNode }) {
   const hasConfigAccess = useRbac(RbacResource.Settings, RbacOperation.View)
+  const { isLoading } = useGetCoreConfigQuery({ fromDB: true })
+
   if (!hasConfigAccess) {
     return <NoPermissionView entity="configuration" />
   }
+
+  if (isLoading) {
+    return <FullPageLoader />
+  }
+
   return <div>{children}</div>
 }

--- a/ui/app/workspace/config/logging/page.tsx
+++ b/ui/app/workspace/config/logging/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import LoggingView from "../views/loggingView"
+
+export default function LoggingPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <LoggingView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/observability/page.tsx
+++ b/ui/app/workspace/config/observability/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import ObservabilityView from "../views/observabilityView"
+
+export default function ObservabilityPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <ObservabilityView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/page.tsx
+++ b/ui/app/workspace/config/page.tsx
@@ -1,63 +1,23 @@
 "use client";
 
-import FullPageLoader from "@/components/fullPageLoader";
-import { IS_ENTERPRISE } from "@/lib/constants/config";
-import { useGetCoreConfigQuery } from "@/lib/store";
-import APIKeysView from "@enterprise/components/api-keys/APIKeysView";
-import { useQueryState } from "nuqs";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import CachingView from "./views/cachingView";
-import ClientSettingsView from "./views/clientSettingsView";
-import GovernanceView from "./views/governanceView";
-import LoggingView from "./views/loggingView";
-import ObservabilityView from "./views/observabilityView";
-import PerformanceTuningView from "./views/performanceTuningView";
-import PricingConfigView from "./views/pricingConfigView";
-import ProxyView from "./views/proxyView";
-import SecurityView from "./views/securityView";
-
-const validTabs = [
-	"client-settings",
-	"pricing-config",
-	"logging",
-	"governance",
-	"caching",
-	"observability",
-	"security",
-	"proxy",
-	"api-keys",
-	"performance-tuning",
-];
 
 export default function ConfigPage() {
-	const [activeTab, setActiveTab] = useQueryState("tab");
-	const { isLoading } = useGetCoreConfigQuery({ fromDB: true });
+	const router = useRouter();
+	// Check permission
+	const hasConfigAccess = useRbac(RbacResource.Settings, RbacOperation.View);
 
-	// Redirect to default tab if none specified
 	useEffect(() => {
-		if (!activeTab || !validTabs.includes(activeTab)) {
-			setActiveTab("client-settings");
+		if (hasConfigAccess) {
+			router.replace("/workspace/config/client-settings");
 		}
-	}, [activeTab, setActiveTab]);
+	}, [hasConfigAccess, router]);
 
-	if (isLoading) {
-		return <FullPageLoader />;
+	if (!hasConfigAccess) {
+		return <NoPermissionView entity="configuration" />;
 	}
-
-	return (
-		<div className="mx-auto flex w-full max-w-7xl">
-			{activeTab === "client-settings" && <ClientSettingsView />}
-			{activeTab === "pricing-config" && <PricingConfigView />}
-			{activeTab === "logging" && <LoggingView />}
-			{activeTab === "governance" && <GovernanceView />}
-			{activeTab === "caching" && <CachingView />}
-			{activeTab === "observability" && <ObservabilityView />}
-			{activeTab === "security" && <SecurityView />}
-			{activeTab === "proxy" && IS_ENTERPRISE && <ProxyView />}
-			{activeTab === "api-keys" && <APIKeysView />}
-			{activeTab === "performance-tuning" && <PerformanceTuningView />}
-			{/* Fallback to client settings for invalid tabs */}
-			{activeTab && !validTabs.includes(activeTab) && <ClientSettingsView />}
-		</div>
-	);
+	return null;
 }

--- a/ui/app/workspace/config/performance-tuning/page.tsx
+++ b/ui/app/workspace/config/performance-tuning/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import PerformanceTuningView from "../views/performanceTuningView"
+
+export default function PerformanceTuningPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <PerformanceTuningView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/pricing-config/page.tsx
+++ b/ui/app/workspace/config/pricing-config/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import PricingConfigView from "../views/pricingConfigView"
+
+export default function PricingConfigPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <PricingConfigView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/proxy/page.tsx
+++ b/ui/app/workspace/config/proxy/page.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { IS_ENTERPRISE } from "@/lib/constants/config"
+import { redirect } from "next/navigation"
+import ProxyView from "../views/proxyView"
+
+export default function ProxyPage() {
+  if (!IS_ENTERPRISE) {
+    redirect("/workspace/config/client-settings")
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <ProxyView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/security/page.tsx
+++ b/ui/app/workspace/config/security/page.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import SecurityView from "../views/securityView"
+
+export default function SecurityPage() {
+  return (
+    <div className="mx-auto flex w-full max-w-7xl">
+      <SecurityView />
+    </div>
+  )
+}
+

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -185,7 +185,7 @@ export default function SecurityView() {
 						<Info className="h-4 w-4 text-blue-600" />
 						<AlertDescription>
 							You will need to use Basic Auth for all your inference calls (including MCP tool execution). You can disable it below. Check{" "}
-							<Link href="/workspace/config?tab=api-keys" className="text-md text-primary underline">
+							<Link href="/workspace/config/api-keys" className="text-md text-primary underline">
 								API Keys
 							</Link>
 						</AlertDescription>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -61,7 +61,6 @@ import { useTheme } from "next-themes";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import { ThemeToggle } from "./themeToggle";
 import { Badge } from "./ui/badge";
@@ -173,15 +172,9 @@ const SidebarItemView = ({
 	router: ReturnType<typeof useRouter>;
 }) => {
 	const hasSubItems = "subItems" in item && item.subItems && item.subItems.length > 0;
-	const [currentConfigTab] = useQueryState("tab");
 	const isAnySubItemActive =
 		hasSubItems &&
 		item.subItems?.some((subItem) => {
-			// For query param based subitems, check if tab matches
-			if (subItem.queryParam) {
-				return pathname === subItem.url && currentConfigTab === subItem.queryParam;
-			}
-			// For path based subitems, check if pathname starts with url
 			return pathname.startsWith(subItem.url);
 		});
 
@@ -242,9 +235,7 @@ const SidebarItemView = ({
 				<SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
 					{item.subItems?.map((subItem: SidebarItem) => {
 						// For query param based subitems, check if tab matches
-						const isSubItemActive = subItem.queryParam
-							? pathname === subItem.url && currentConfigTab === subItem.queryParam
-							: pathname.startsWith(subItem.url);
+						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : pathname.startsWith(subItem.url);
 						const SubItemIcon = subItem.icon;
 						return (
 							<SidebarMenuSubItem key={subItem.title}>
@@ -490,87 +481,77 @@ export default function AppSidebar() {
 			subItems: [
 				{
 					title: "Client Settings",
-					url: "/workspace/config",
+					url: "/workspace/config/client-settings",
 					icon: Settings,
 					description: "Client configuration settings",
 					hasAccess: hasSettingsAccess,
-					queryParam: "client-settings",
 				},
 				{
 					title: "Pricing Config",
-					url: "/workspace/config",
+					url: "/workspace/config/pricing-config",
 					icon: CircleDollarSign,
 					description: "Pricing configuration",
 					hasAccess: hasSettingsAccess,
-					queryParam: "pricing-config",
 				},
 				{
 					title: "Logging",
-					url: "/workspace/config",
+					url: "/workspace/config/logging",
 					icon: Logs,
 					description: "Logging configuration",
 					hasAccess: hasSettingsAccess,
-					queryParam: "logging",
 				},
 				{
 					title: "Governance",
-					url: "/workspace/config",
+					url: "/workspace/config/governance",
 					icon: Landmark,
 					description: "Governance settings",
 					hasAccess: hasSettingsAccess,
-					queryParam: "governance",
 				},
 				{
 					title: "Caching",
-					url: "/workspace/config",
+					url: "/workspace/config/caching",
 					icon: Zap,
 					description: "Caching configuration",
 					hasAccess: hasSettingsAccess,
-					queryParam: "caching",
 				},
 				{
 					title: "Observability",
-					url: "/workspace/config",
+					url: "/workspace/config/observability",
 					icon: Gauge,
 					description: "Observability settings",
 					hasAccess: hasSettingsAccess,
-					queryParam: "observability",
 				},
 				{
 					title: "Security",
-					url: "/workspace/config",
+					url: "/workspace/config/security",
 					icon: Shield,
 					description: "Security settings",
 					hasAccess: hasSettingsAccess,
-					queryParam: "security",
 				},
 				...(IS_ENTERPRISE
 					? [
 							{
 								title: "Proxy",
-								url: "/workspace/config",
+								url: "/workspace/config/proxy",
 								icon: Globe,
 								description: "Proxy configuration",
 								hasAccess: hasSettingsAccess,
-								queryParam: "proxy",
 							},
 						]
 					: []),
 				{
 					title: "API Keys",
-					url: "/workspace/config",
+					url: "/workspace/config/api-keys",
 					icon: KeyRound,
 					description: "API keys management",
 					hasAccess: hasSettingsAccess,
-					queryParam: "api-keys",
 				},
 				{
 					title: "Performance Tuning",
-					url: "/workspace/config",
+					url: "/workspace/config/performance-tuning",
 					icon: Zap,
 					description: "Performance tuning settings",
 					hasAccess: hasSettingsAccess,
-					queryParam: "performance-tuning",
 				},
 			],
 		},
@@ -734,7 +715,7 @@ export default function AppSidebar() {
 										isExpanded={expandedItems.has(item.title)}
 										onToggle={() => toggleItem(item.title)}
 										pathname={pathname}
-										router={router}
+										router={router}										
 									/>
 								);
 							})}


### PR DESCRIPTION
## Summary

Refactored the configuration pages to use dedicated routes instead of query parameters, improving navigation and URL structure.

## Changes

- Converted configuration tabs from query parameters to dedicated routes (e.g., `/workspace/config?tab=security` → `/workspace/config/security`)
- Created individual page components for each configuration section
- Updated links throughout the application to point to the new route structure
- Added loading state to the configuration layout
- Modified the main config page to redirect to client settings by default
- Updated sidebar navigation to work with the new route structure

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the workspace configuration section
2. Verify that each configuration section loads correctly with its own URL
3. Check that links to configuration sections (like from API Keys to Security) work properly
4. Verify that the sidebar navigation highlights the correct item based on the current route

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable