### PR TITLE
adds router based redirect to proxy view

### DIFF
--- a/ui/app/workspace/config/proxy/page.tsx
+++ b/ui/app/workspace/config/proxy/page.tsx
@@ -1,18 +1,26 @@
-"use client"
+"use client";
 
-import { IS_ENTERPRISE } from "@/lib/constants/config"
-import { redirect } from "next/navigation"
-import ProxyView from "../views/proxyView"
+import { IS_ENTERPRISE } from "@/lib/constants/config";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import ProxyView from "../views/proxyView";
 
 export default function ProxyPage() {
-  if (!IS_ENTERPRISE) {
-    redirect("/workspace/config/client-settings")
-  }
+	const router = useRouter();
 
-  return (
-    <div className="mx-auto flex w-full max-w-7xl">
-      <ProxyView />
-    </div>
-  )
+	useEffect(() => {
+		if (!IS_ENTERPRISE) {
+			router.replace("/workspace/config/client-settings");
+		}
+	}, [router]);
+
+	if (!IS_ENTERPRISE) {
+		return null;
+	}
+
+	return (
+		<div className="mx-auto flex w-full max-w-7xl">
+			<ProxyView />
+		</div>
+	);
 }
-


### PR DESCRIPTION
## Summary

Improved the enterprise feature redirection in the proxy configuration page by using client-side navigation instead of server-side redirects.

## Changes

- Replaced `redirect()` from Next.js navigation with `useRouter().replace()` for client-side redirection
- Added a `useEffect` hook to handle the redirection logic
- Added a null return when not in enterprise mode to prevent flash of content
- Fixed semicolon consistency in the file

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Run the application in non-enterprise mode:
```sh
cd ui
pnpm i
pnpm dev
```
2. Navigate to `/workspace/config/proxy`
3. Verify you are redirected to `/workspace/config/client-settings` without any errors or flash of content

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is a UI navigation change only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable