### PR TITLE
fix: return raw HTML in error responses instead of extracting messages

### DIFF
--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -321,11 +321,11 @@ func (provider *MistralProvider) Transcription(ctx context.Context, key schemas.
 	var mistralResponse MistralTranscriptionResponse
 	if err := sonic.Unmarshal(copiedResponseBody, &mistralResponse); err != nil {
 		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
-			errorMessage := providerUtils.ExtractHTMLErrorMessage(copiedResponseBody)
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: &schemas.ErrorField{
-					Message: errorMessage,
+					Message: schemas.ErrProviderResponseHTML,
+					Error:   errors.New(string(copiedResponseBody)),
 				},
 			}
 		}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -2006,11 +2006,11 @@ func HandleOpenAITranscriptionRequest(
 	if err := sonic.Unmarshal(copiedResponseBody, response); err != nil {
 		// Check if it's an HTML response
 		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
-			errorMessage := providerUtils.ExtractHTMLErrorMessage(copiedResponseBody)
 			return nil, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: &schemas.ErrorField{
-					Message: errorMessage,
+					Message: schemas.ErrProviderResponseHTML,
+					Error:   errors.New(string(copiedResponseBody)),
 				},
 			}
 		}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -357,12 +357,12 @@ func HandleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.Bif
 
 	// JSON parsing failed - now check if it's an HTML response (expensive operation)
 	if IsHTMLResponse(resp, decodedBody) {
-		errorMessage := ExtractHTMLErrorMessage(decodedBody)
 		return &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &statusCode,
 			Error: &schemas.ErrorField{
-				Message: errorMessage,
+				Message: schemas.ErrProviderResponseHTML,
+				Error:   errors.New(string(decodedBody)),
 			},
 		}
 	}
@@ -435,12 +435,11 @@ func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody
 	if structuredErr != nil {
 		// JSON parsing failed - check if it's an HTML response (expensive operation)
 		if IsHTMLResponse(nil, responseBody) {
-			errorMessage := ExtractHTMLErrorMessage(responseBody)
 			return nil, nil, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: &schemas.ErrorField{
 					Message: schemas.ErrProviderResponseHTML,
-					Error:   errors.New(errorMessage),
+					Error:   errors.New(string(responseBody)),
 				},
 			}
 		}
@@ -594,6 +593,7 @@ const maxBodySize = 32 * 1024 // 32KB
 
 // ExtractHTMLErrorMessage extracts meaningful error information from an HTML response.
 // It attempts to find error messages from title tags, headers, and visible text.
+// UNUSED for now but could be useful in the future
 func ExtractHTMLErrorMessage(body []byte) string {
 	if len(body) > maxBodySize {
 		body = body[:maxBodySize]

--- a/core/providers/vertex/errors.go
+++ b/core/providers/vertex/errors.go
@@ -1,6 +1,7 @@
 package vertex
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -53,12 +54,12 @@ func parseVertexError(resp *fasthttp.Response, meta *providerUtils.RequestMetada
 
 	// Check for HTML error response before attempting JSON parsing
 	if providerUtils.IsHTMLResponse(resp, decodedBody) {
-		errorMsg := providerUtils.ExtractHTMLErrorMessage(decodedBody)
 		bifrostErr := &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     schemas.Ptr(resp.StatusCode()),
 			Error: &schemas.ErrorField{
-				Message: errorMsg,
+				Message: schemas.ErrProviderResponseHTML,
+				Error:   errors.New(string(decodedBody)),
 			},
 		}
 		if meta != nil {

--- a/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/api-keys/APIKeysView.tsx
@@ -50,7 +50,7 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 			<Alert variant="default">
 				<InfoIcon className="text-muted h-4 w-4" />
 				<AlertDescription>
-					<p className="text-md text-gray-600">
+					<p className="text-md text-muted-foreground">
 						To generate API keys, you need to set up admin username and password first.{" "}
 						<Link href="/workspace/config/security" className="text-md text-primary underline">
 							Configure Security Settings
@@ -67,14 +67,15 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 	const isInferenceAuthDisabled = bifrostConfig?.auth_config?.disable_auth_on_inference ?? false;
 
 	return (
-		<div className="space-y-4 mx-auto w-full max-w-4xl">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<Alert variant="default">
 				<InfoIcon className="text-muted h-4 w-4" />
 				<AlertDescription>
-					<p className="text-md text-gray-600">
+					<p className="text-md text-muted-foreground">
 						{isInferenceAuthDisabled ? (
 							<>
-								Authentication is currently <strong>disabled for inference API calls</strong>. You can make inference requests without authentication. Dashboard and admin API calls still require Basic auth with your admin credentials encoded in the standard{" "}
+								Authentication is currently <strong>disabled for inference API calls</strong>. You can make inference requests without
+								authentication. Dashboard and admin API calls still require Basic auth with your admin credentials encoded in the standard{" "}
 								<code className="bg-muted rounded px-1 py-0.5 text-sm">username:password</code> format with base64 encoding.
 							</>
 						) : (
@@ -87,30 +88,23 @@ curl --location 'http://localhost:8080/v1/chat/completions'
 					{!isInferenceAuthDisabled && (
 						<>
 							<br />
-							<p className="text-md text-gray-600">
+							<p className="text-md text-muted-foreground">
 								<strong>Example:</strong>
 							</p>
 
 							<div className="relative mt-2 w-full min-w-0 overflow-x-auto">
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => copyToClipboard(curlExample)}
-									className="absolute right-2 top-2 h-8 z-10"
-								>
+								<Button variant="ghost" size="sm" onClick={() => copyToClipboard(curlExample)} className="absolute top-2 right-2 z-10 h-8">
 									<Copy className="h-4 w-4" />
 								</Button>
-								<pre className="bg-muted min-w-max rounded p-3 pr-12 font-mono text-sm whitespace-pre">
-									{curlExample}
-								</pre>
+								<pre className="bg-muted min-w-max rounded p-3 pr-12 font-mono text-sm whitespace-pre">{curlExample}</pre>
 							</div>
 						</>
 					)}
 				</AlertDescription>
 			</Alert>
-			
+
 			<ContactUsView
-				className=" mt-4 rounded-md border px-3 py-8"
+				className="mt-4 rounded-md border px-3 py-8"
 				icon={<KeyRound size={48} />}
 				title="Scope Based API Keys"
 				description="Need granular access control with scope-based API keys? Enterprise customers can create multiple API keys with specific permissions for different services, teams, or environments."


### PR DESCRIPTION
## Summary

Improved error handling for HTML responses by returning the full HTML body instead of attempting to extract specific error messages.

## Changes

- Modified error handling in multiple provider files to return the raw HTML body as the error message
- Kept the `ExtractHTMLErrorMessage` function but marked it as unused for potential future use
- This change affects Mistral, OpenAI, and Vertex providers, as well as the common provider utilities

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test error scenarios where providers return HTML responses:

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The change now returns full HTML responses in error messages, which could potentially include more information than before, but this is necessary for proper debugging of provider errors.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)