### PR TITLE
fix(mcp): ensure properties field is always set for tools

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix(mcp): ensure properties field is always set for tools

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -808,18 +808,30 @@ func (m *MCPManager) shouldSkipToolForRequest(clientID, toolName string, ctx con
 // convertMCPToolToBifrostSchema converts an MCP tool definition to Bifrost format.
 func (m *MCPManager) convertMCPToolToBifrostSchema(mcpTool *mcp.Tool) schemas.ChatTool {
 	var properties *schemas.OrderedMap
+	schemaType := mcpTool.InputSchema.Type
+
 	if len(mcpTool.InputSchema.Properties) > 0 {
 		orderedProps := make(schemas.OrderedMap, len(mcpTool.InputSchema.Properties))
 		maps.Copy(orderedProps, mcpTool.InputSchema.Properties)
 		properties = &orderedProps
+	} else {
+		// Ensure properties is set when there are no properties (required by OpenAI API validation)
+		// OpenAI function calling API always expects object schemas with properties field present
+		emptyProps := make(schemas.OrderedMap)
+		properties = &emptyProps
+		// Default to "object" type if empty (OpenAI function calling always uses object schemas)
+		if schemaType == "" {
+			schemaType = "object"
+		}
 	}
+
 	return schemas.ChatTool{
 		Type: schemas.ChatToolTypeFunction,
 		Function: &schemas.ChatToolFunction{
 			Name:        mcpTool.Name,
 			Description: Ptr(mcpTool.Description),
 			Parameters: &schemas.ToolFunctionParameters{
-				Type:       mcpTool.InputSchema.Type,
+				Type:       schemaType,
 				Properties: properties,
 				Required:   mcpTool.InputSchema.Required,
 			},

--- a/core/mcp.go
+++ b/core/mcp.go
@@ -810,19 +810,20 @@ func (m *MCPManager) convertMCPToolToBifrostSchema(mcpTool *mcp.Tool) schemas.Ch
 	var properties *schemas.OrderedMap
 	schemaType := mcpTool.InputSchema.Type
 
+	// Ensure properties is always set (required by OpenAI API validation)
 	if len(mcpTool.InputSchema.Properties) > 0 {
 		orderedProps := make(schemas.OrderedMap, len(mcpTool.InputSchema.Properties))
 		maps.Copy(orderedProps, mcpTool.InputSchema.Properties)
 		properties = &orderedProps
 	} else {
-		// Ensure properties is set when there are no properties (required by OpenAI API validation)
 		// OpenAI function calling API always expects object schemas with properties field present
 		emptyProps := make(schemas.OrderedMap)
 		properties = &emptyProps
-		// Default to "object" type if empty (OpenAI function calling always uses object schemas)
-		if schemaType == "" {
-			schemaType = "object"
-		}
+	}
+
+	// Default to "object" type if empty (OpenAI function calling always uses object schemas)
+	if schemaType == "" {
+		schemaType = "object"
 	}
 
 	return schemas.ChatTool{


### PR DESCRIPTION
## Summary

When MCP tools have no parameters (empty properties), the schema conversion was setting `Properties` to `nil`. OpenAI's API validation requires object schemas to always have a `properties` field present, even if empty, causing validation errors like "object schema missing properties".

**Error example:**
```
{"error":{"type":"invalid_request_error","code":"invalid_function_parameters","message":"Invalid schema for function 'unlock_blockchain_analysis': In context=(), object schema missing properties."}}
```

### Solution
- Always set `Properties` to an empty `OrderedMap` when there are no properties
- Default `Type` to "object" when empty and there are no properties  
- Ensures all MCP tools from the same server are handled consistently

### Testing
- [x] Tested locally with MCP tools that have no parameters
- [x] Verified fix works for multiple tools from the same server (`__unlock_blockchain_analysis__` and `get_chains_list`)
- [x] Ran `make test` - all 231 tests pass
- [x] `mcp.go` code formatted with `gofmt`

## Changes
- Modified `convertMCPToolToBifrostSchema` in `core/mcp.go` to ensure `Properties` is always set to an empty `OrderedMap` when there are no properties to pass OpenAI validation
- Added logic to default `Type` to "object" when empty to pass OpenAI validation

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
make setup-workspace
make dev

# add MCP server which has parameter-less tools, like Cloudflare's Documentation MCP server
curl 'http://localhost:8080/api/mcp/client' \
  -H 'accept: */*' \
  -H 'content-type: application/json' \
  --data-raw '{"name":"cloudflare-documentation","connection_type":"http","connection_string":"https://docs.mcp.cloudflare.com/mcp","tools_to_execute":["*"]}'
  
# add a provider key (example: OpenAI)

# call chat completion or responses
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "openai/gpt-4o-mini",
    "messages": [
      {"role": "user", "content": "Hello!"}
    ]
  }'
```

On Bifrost v1.3.50, this response is received:
```json
{
  "is_bifrost_error": false,
  "status_code": 400,
  "error": {
    "type": "invalid_request_error",
    "code": "invalid_function_parameters",
    "message": "Invalid schema for function 'migrate_pages_to_workers_guide': In context=(), object schema missing properties.",
    "param": "tools[0].function.parameters"
  },
  "extra_fields": {
    "provider": "openai",
    "model_requested": "gpt-4o-mini",
    "request_type": "chat_completion"
  }
}
```

On this PR's branch, this response is received:
```json
{
  "id": "chatcmpl-CoELoLXfeisOXhEmKGfeLEJGb3j63",
  "choices": [
    {
      "index": 0,
      "finish_reason": "stop",
      "message": {
        "role": "assistant",
        "content": "Hello! How can I assist you today?"
      }
    }
  ],
  "created": 1766087600,
  "model": "gpt-4o-mini-2024-07-18",
  "object": "chat.completion",
  "service_tier": "default",
  "system_fingerprint": "fp_5c83f7ae50",
  "usage": {
    "prompt_tokens": 197,
    "prompt_tokens_details": {},
    "completion_tokens": 10,
    "completion_tokens_details": {},
    "total_tokens": 207
  },
  "extra_fields": {
    "request_type": "chat_completion",
    "provider": "openai",
    "model_requested": "gpt-4o-mini",
    "latency": 505,
    "chunk_index": 0
  }
}
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


