### PR TITLE
fix(perplexity): correct search_domain_filter json tag

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+fix(perplexity): correct search_domain_filter json tag

--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -46,7 +46,7 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 				perplexityReq.LanguagePreference = languagePreference
 			}
 
-			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filters"]); ok {
+			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
 				perplexityReq.SearchDomainFilters = searchDomainFilters
 			}
 

--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -46,8 +46,8 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 				perplexityReq.LanguagePreference = languagePreference
 			}
 
-			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
-				perplexityReq.SearchDomainFilters = searchDomainFilters
+			if searchDomainFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
+				perplexityReq.SearchDomainFilter = searchDomainFilter
 			}
 
 			if returnImages, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_images"]); ok {

--- a/core/providers/perplexity/responses.go
+++ b/core/providers/perplexity/responses.go
@@ -41,7 +41,7 @@ func ToPerplexityResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *
 				perplexityReq.LanguagePreference = languagePreference
 			}
 
-			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filters"]); ok {
+			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
 				perplexityReq.SearchDomainFilters = searchDomainFilters
 			}
 

--- a/core/providers/perplexity/responses.go
+++ b/core/providers/perplexity/responses.go
@@ -41,8 +41,8 @@ func ToPerplexityResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *
 				perplexityReq.LanguagePreference = languagePreference
 			}
 
-			if searchDomainFilters, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
-				perplexityReq.SearchDomainFilters = searchDomainFilters
+			if searchDomainFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
+				perplexityReq.SearchDomainFilter = searchDomainFilter
 			}
 
 			if returnImages, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_images"]); ok {

--- a/core/providers/perplexity/types.go
+++ b/core/providers/perplexity/types.go
@@ -12,7 +12,7 @@ type PerplexityChatRequest struct {
 	Temperature             *float64              `json:"temperature,omitempty"`                // Optional: Sampling temperature
 	TopP                    *float64              `json:"top_p,omitempty"`                      // Optional: Top-p sampling
 	LanguagePreference      *string               `json:"language_preference,omitempty"`        // Optional: Language preference
-	SearchDomainFilters     []string              `json:"search_domain_filters,omitempty"`      // Optional: Search domain filters
+	SearchDomainFilters     []string              `json:"search_domain_filter,omitempty" `      // Optional: Search domain filters
 	ReturnImages            *bool                 `json:"return_images,omitempty"`              // Optional: Return images
 	ReturnRelatedQuestions  *bool                 `json:"return_related_questions,omitempty"`   // Optional: Return related questions
 	SearchRecencyFilter     *string               `json:"search_recency_filter,omitempty"`      // Optional: Search recency filter

--- a/core/providers/perplexity/types.go
+++ b/core/providers/perplexity/types.go
@@ -12,7 +12,7 @@ type PerplexityChatRequest struct {
 	Temperature             *float64              `json:"temperature,omitempty"`                // Optional: Sampling temperature
 	TopP                    *float64              `json:"top_p,omitempty"`                      // Optional: Top-p sampling
 	LanguagePreference      *string               `json:"language_preference,omitempty"`        // Optional: Language preference
-	SearchDomainFilters     []string              `json:"search_domain_filter,omitempty" `      // Optional: Search domain filters
+	SearchDomainFilters     []string              `json:"search_domain_filter,omitempty"`       // Optional: Search domain filters
 	ReturnImages            *bool                 `json:"return_images,omitempty"`              // Optional: Return images
 	ReturnRelatedQuestions  *bool                 `json:"return_related_questions,omitempty"`   // Optional: Return related questions
 	SearchRecencyFilter     *string               `json:"search_recency_filter,omitempty"`      // Optional: Search recency filter

--- a/core/providers/perplexity/types.go
+++ b/core/providers/perplexity/types.go
@@ -12,7 +12,7 @@ type PerplexityChatRequest struct {
 	Temperature             *float64              `json:"temperature,omitempty"`                // Optional: Sampling temperature
 	TopP                    *float64              `json:"top_p,omitempty"`                      // Optional: Top-p sampling
 	LanguagePreference      *string               `json:"language_preference,omitempty"`        // Optional: Language preference
-	SearchDomainFilters     []string              `json:"search_domain_filter,omitempty"`       // Optional: Search domain filters
+	SearchDomainFilter      []string              `json:"search_domain_filter,omitempty"`       // Optional: Search domain filter
 	ReturnImages            *bool                 `json:"return_images,omitempty"`              // Optional: Return images
 	ReturnRelatedQuestions  *bool                 `json:"return_related_questions,omitempty"`   // Optional: Return related questions
 	SearchRecencyFilter     *string               `json:"search_recency_filter,omitempty"`      // Optional: Search recency filter


### PR DESCRIPTION
## Summary

This PR fixes a discrepancy in the Perplexity provider implementation where the request schema sent to the API did not match the official documentation. specifically regarding the `search_domain_filter` parameter.

## Changes

- Updated the `json` tag for the `SearchDomainFilters` field in `bifrost/core/providers/perplexity/types.go`.
  - **Before:** `search_domain_filters` (plural)
  - **After:** `search_domain_filter` (singular)
- This change aligns the implementation with the [Perplexity API Reference (Chat Completions)](https://docs.perplexity.ai/api-reference/chat-completions-post).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the field name against the official documentation.
Run the standard Go tests to ensure no regressions in the codebase.

```sh
# Verify unit tests pass
go fmt ./...
go test ./...
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

N/A (Backend logic change only)

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. This is a schema correction and does not involve auth or secrets.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


