### PR TITLE
adds support for CA in proxy settings

### DIFF
--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -155,10 +155,11 @@ const (
 
 // ProxyConfig holds the configuration for proxy settings.
 type ProxyConfig struct {
-	Type     ProxyType `json:"type"`     // Type of proxy to use
-	URL      string    `json:"url"`      // URL of the proxy server
-	Username string    `json:"username"` // Username for proxy authentication
-	Password string    `json:"password"` // Password for proxy authentication
+	Type      ProxyType `json:"type"`        // Type of proxy to use
+	URL       string    `json:"url"`         // URL of the proxy server
+	Username  string    `json:"username"`    // Username for proxy authentication
+	Password  string    `json:"password"`    // Password for proxy authentication
+	CACertPEM string    `json:"ca_cert_pem"` // PEM-encoded CA certificate to trust for TLS connections through the proxy
 }
 
 // AllowedRequests controls which operations are permitted.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5,6 +5,10 @@
     "dark": "/media/bifrost-logo-dark.png",
     "light": "/media/bifrost-logo.png"
   },
+  "banner": {
+    "content": "Try Bifrost Enterprise free for 14 days. [Explore now](https://www.getmaxim.ai/bifrost/enterprise)",
+    "dismissible": true
+  },
   "theme": "mint",
   "colors": {
     "primary": "#0C3B43",
@@ -21,19 +25,21 @@
     "name": "Dashboard",
     "url": "https://www.getbifrost.ai"
   },
-  "anchors": [
-    {
-      "name": "Community",
-      "icon": "discord",
-      "url": "https://getmax.im/bifrost-discord"
-    },
-    {
-      "name": "Blog",
-      "icon": "newspaper",
-      "url": "https://getmaxim.ai/blog"
-    }
-  ],
   "navigation": {
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Discord",
+          "icon": "discord",
+          "href": "https://getmax.im/bifrost-discord"
+        },
+        {
+          "anchor": "Try Enterprise",
+          "icon": "building",
+          "href": "https://www.getmaxim.ai/bifrost/enterprise"
+        }
+      ]
+    },
     "tabs": [
       {
         "tab": "Documentation",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1842,6 +1842,10 @@
         "password": {
           "type": "string",
           "description": "Password for proxy authentication"
+        },
+        "ca_cert_pem": {
+          "type": "string",
+          "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (for SSL-intercepting proxies)"
         }
       },
       "required": [

--- a/ui/app/workspace/config/views/proxyView.tsx
+++ b/ui/app/workspace/config/views/proxyView.tsx
@@ -256,6 +256,31 @@ export default function ProxyView() {
 									)}
 								/>
 
+								{/* CA Certificate */}
+								<FormField
+									control={form.control}
+									name="ca_cert_pem"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+											<FormControl>
+												<Textarea
+													placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+													className="font-mono text-xs"
+													rows={6}
+													disabled={!watchedEnabled}
+													{...field}
+													value={field.value || ""}
+												/>
+											</FormControl>
+											<FormDescription>
+												PEM-encoded CA certificate to trust for TLS connections through SSL-intercepting proxies.
+											</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
 								{/* Skip TLS Verify */}
 								<div className="flex items-center justify-between">
 									<div className="space-y-0.5">

--- a/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider } from "@/lib/types/config";
@@ -33,6 +34,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 				url: provider.proxy_config?.url || "",
 				username: provider.proxy_config?.username || "",
 				password: provider.proxy_config?.password || "",
+				ca_cert_pem: provider.proxy_config?.ca_cert_pem || "",
 			},
 		},
 	});
@@ -48,6 +50,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 				url: provider.proxy_config?.url || "",
 				username: provider.proxy_config?.username || "",
 				password: provider.proxy_config?.password || "",
+				ca_cert_pem: provider.proxy_config?.ca_cert_pem || "",
 			},
 		});
 	}, [form, provider.name, provider.proxy_config]);
@@ -62,6 +65,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 				url: data.proxy_config?.url || undefined,
 				username: data.proxy_config?.username || undefined,
 				password: data.proxy_config?.password || undefined,
+				ca_cert_pem: data.proxy_config?.ca_cert_pem || undefined,
 			},
 		})
 			.unwrap()
@@ -152,6 +156,28 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 										)}
 									/>
 								</div>
+								<FormField
+									control={form.control}
+									name="proxy_config.ca_cert_pem"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+											<FormControl>
+												<Textarea
+													placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+													className="font-mono text-xs"
+													rows={6}
+													{...field}
+													value={field.value || ""}
+												/>
+											</FormControl>
+											<FormDescription>
+												PEM-encoded CA certificate to trust for TLS connections through SSL-intercepting proxies
+											</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
 							</div>
 						</div>
 					</div>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -131,6 +131,7 @@ export interface ProxyConfig {
 	url?: string;
 	username?: string;
 	password?: string;
+	ca_cert_pem?: string;
 }
 
 // Request types matching Go's schemas.RequestType
@@ -272,6 +273,7 @@ export interface GlobalProxyConfig {
 	url: string;
 	username?: string;
 	password?: string;
+	ca_cert_pem?: string;
 	no_proxy?: string;
 	timeout?: number;
 	skip_tls_verify?: boolean;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -255,6 +255,7 @@ export const proxyConfigSchema = z
 		url: z.url("Must be a valid URL"),
 		username: z.string().optional(),
 		password: z.string().optional(),
+		ca_cert_pem: z.string().optional(),
 	})
 	.refine((data) => !(data.type === "http" || data.type === "socks5") || (data.url && data.url.trim().length > 0), {
 		message: "Proxy URL is required when using HTTP or SOCKS5 proxy",
@@ -282,6 +283,7 @@ export const proxyFormConfigSchema = z
 		url: z.string().optional(),
 		username: z.string().optional(),
 		password: z.string().optional(),
+		ca_cert_pem: z.string().optional(),
 	})
 	.refine(
 		(data) => {
@@ -629,6 +631,7 @@ export const globalProxyConfigSchema = z
 		url: z.string(),
 		username: z.string().optional(),
 		password: z.string().optional(),
+		ca_cert_pem: z.string().optional(),
 		no_proxy: z.string().optional(),
 		timeout: z.number().min(0).optional(),
 		skip_tls_verify: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Enhanced proxy support by adding custom CA certificate capabilities and HTTP proxy authentication, allowing Bifrost to work with SSL-intercepting proxies and authenticated proxies.

## Changes

- Added support for custom CA certificates in proxy configurations
- Implemented HTTP proxy authentication using username and password
- Added UI fields for CA certificate input in both global and provider-specific proxy settings
- Updated JSON schema to include the new `ca_cert_pem` field
- Updated documentation site with enterprise banner and navigation links

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

1. Configure a proxy with authentication:
```
{
  "type": "http",
  "url": "http://proxy.example.com:8080",
  "username": "user",
  "password": "pass"
}
```

2. Configure a proxy with a custom CA certificate:
```
{
  "type": "http",
  "url": "http://proxy.example.com:8080",
  "ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
}
```

3. Test connections through an SSL-intercepting proxy that requires a custom CA certificate

## Breaking changes

- [x] No

## Security considerations

- The implementation properly handles TLS certificate validation by appending custom CA certificates to the system root CA pool
- Proxy authentication credentials are properly encoded in the proxy URL
- PEM certificate validation is performed to ensure only valid certificates are accepted

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)