### PR TITLE
chore: test fixes

### DIFF
--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -327,9 +327,10 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *context.Context
 	case schemas.HuggingFace:
 		return []schemas.Key{
 			{
-				Value:  os.Getenv("HUGGING_FACE_API_KEY"),
-				Models: []string{},
-				Weight: 1.0,
+				Value:          os.Getenv("HUGGING_FACE_API_KEY"),
+				Models:         []string{},
+				Weight:         1.0,
+				UseForBatchAPI: bifrost.Ptr(true),
 			},
 		}, nil
 	case schemas.Nebius:

--- a/core/providers/utils/html_response_handler_test.go
+++ b/core/providers/utils/html_response_handler_test.go
@@ -212,7 +212,7 @@ func TestHandleProviderAPIErrorWithHTML(t *testing.T) {
 				</html>
 			`),
 			description:       "Should detect and handle HTML only after JSON parse fails",
-			expectedInMessage: "Internal Server Error",
+			expectedInMessage: "HTML response received from provider",
 		},
 		{
 			name:        "HTML 403 error - lazy detection",
@@ -226,8 +226,8 @@ func TestHandleProviderAPIErrorWithHTML(t *testing.T) {
 				</body>
 				</html>
 			`),
-			description:       "Should detect and extract message from HTML on parse failure",
-			expectedInMessage: "Forbidden",
+			description:       "Should detect HTML on parse failure",
+			expectedInMessage: "HTML response received from provider",
 		},
 		{
 			name:              "Invalid JSON with HTML fallback",


### PR DESCRIPTION
## Summary

Improve error handling for HTML responses from providers and enable batch API support for HuggingFace.

## Changes

- Updated error messages for HTML responses to be more descriptive and consistent, changing from specific HTTP status messages to a generic "HTML response received from provider"
- Added `UseForBatchAPI` flag to HuggingFace API key configuration to enable batch processing capabilities

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test HTML error handling:
```sh
go test ./core/providers/utils/html_response_handler_test.go
```

Test HuggingFace batch API functionality:
```sh
# Set HUGGING_FACE_API_KEY environment variable
export HUGGING_FACE_API_KEY=your_key_here
# Run tests that utilize the batch API functionality
go test ./core/providers/huggingface/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only affects error handling and API functionality configuration.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable