### PR TITLE
refactor: use gemini endpoint for fine tuned models in vertex --skip-pipeline

### DIFF
--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -84,3 +84,30 @@ func getRequestBodyForAnthropicResponses(ctx context.Context, request *schemas.B
 
 	return jsonBody, nil
 }
+
+// getCompleteURLForGeminiEndpoint constructs the complete URL for the Gemini endpoint, for both streaming and non-streaming requests
+// for custom/fine-tuned models, it uses the projectNumber
+// for gemini models, it uses the projectID
+func getCompleteURLForGeminiEndpoint(deployment string, region string, projectID string, projectNumber string, isStreaming bool) string {
+	var url string
+	method := ":generateContent"
+	if isStreaming {
+		method = ":streamGenerateContent"
+	}
+	if schemas.IsAllDigitsASCII(deployment) {
+		// Custom/fine-tuned models use projectNumber
+		if region == "global" {
+			url = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/%s%s", projectNumber, deployment, method)
+		} else {
+			url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/%s%s", region, projectNumber, region, deployment, method)
+		}
+	} else {
+		// Gemini models use projectID
+		if region == "global" {
+			url = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s%s", projectID, deployment, method)
+		} else {
+			url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s%s", region, projectID, region, deployment, method)
+		}
+	}
+	return url
+}


### PR DESCRIPTION
## Summary

Add support for fine-tuned Gemini models in Vertex AI by enabling custom models with numeric IDs to use the Gemini API endpoints.

## Changes

- Added a new utility function `getCompleteURLForGeminiEndpoint` to centralize URL construction logic for both standard Gemini models and custom/fine-tuned models
- Modified the code to treat numeric model IDs (custom/fine-tuned models) similar to Gemini models for request handling
- Updated endpoint URLs for custom models to use the `:generateContent` and `:streamGenerateContent` methods instead of `/chat/completions`
- Added proper validation for project number when using fine-tuned models
- Implemented consistent URL construction across all relevant methods (ChatCompletion, ChatCompletionStream, Responses, ResponsesStream)

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Test with a standard Gemini model
curl -X POST "http://localhost:8080/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer vertex.PROJECT_ID.REGION.API_KEY" \
  -d '{
    "model": "gemini-1.5-pro",
    "messages": [{"role": "user", "content": "Hello, how are you?"}]
  }'

# Test with a fine-tuned Gemini model (numeric ID)
curl -X POST "http://localhost:8080/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer vertex.PROJECT_ID.REGION.API_KEY.PROJECT_NUMBER" \
  -d '{
    "model": "1234567890123456789",
    "messages": [{"role": "user", "content": "Hello, how are you?"}]
  }'
```

## Breaking changes

- [x] No

## Related issues

Enables support for fine-tuned Gemini models in Vertex AI

## Security considerations

No new security implications. The code continues to use the existing authentication mechanisms.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)