### PR TITLE
fix: append bedrock and cohere routes in langchain and litellm and docs fixes --skip-pipeline

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,4 @@
 - fix: gemini thought signature handling in multi-turn conversations
 - feat: support computer-use-2025-11-24 in anthropic for claude-opus-4-5
+- refactor: use gemini native embedding endpoint for gemini embeddings
+- refactor: for fine-tuned or custom models in vertex use gemini native endpoint instead of openai compatible chat completions endpoint

--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -1021,7 +1021,7 @@ var AllProviderConfigs = []ComprehensiveTestConfig{
 	{
 		Provider:             schemas.HuggingFace,
 		ChatModel:            "groq/openai/gpt-oss-120b",
-		VisionModel:          "fireworks-ai/Qwen/Qwen2.5-VL-32B-Instruct",
+		VisionModel:          "novita/zai-org/GLM-4.6V-Flash",
 		EmbeddingModel:       "sambanova/intfloat/e5-mistral-7b-instruct",
 		TranscriptionModel:   "fal-ai/openai/whisper-large-v3",
 		SpeechSynthesisModel: "fal-ai/hexgrad/Kokoro-82M",

--- a/core/providers/huggingface/huggingface_test.go
+++ b/core/providers/huggingface/huggingface_test.go
@@ -24,7 +24,7 @@ func TestHuggingface(t *testing.T) {
 	testConfig := testutil.ComprehensiveTestConfig{
 		Provider:             schemas.HuggingFace,
 		ChatModel:            "sambanova/meta-llama/Llama-3.1-8B-Instruct",
-		VisionModel:          "fireworks-ai/Qwen/Qwen2.5-VL-32B-Instruct",
+		VisionModel:          "novita/zai-org/GLM-4.6V-Flash",
 		EmbeddingModel:       "sambanova/intfloat/e5-mistral-7b-instruct",
 		TranscriptionModel:   "fal-ai/openai/whisper-large-v3",
 		SpeechSynthesisModel: "fal-ai/hexgrad/Kokoro-82M",

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -414,22 +414,16 @@ Both Anthropic Claude and Amazon Nova models support reasoning/thinking capabili
 #### Anthropic Claude Models
 
 ```python
-import boto3
 from langchain_aws import ChatBedrockConverse
 from langchain_core.messages import HumanMessage
-
-# Configure Bedrock client to use Bifrost
-client_kwargs = {
-    "service_name": "bedrock-runtime",
-    "region_name": "us-west-2",
-    "endpoint_url": "http://localhost:8080/langchain",
-}
-bedrock_client = boto3.client(**client_kwargs)
 
 # Bedrock Claude with reasoning control
 llm = ChatBedrockConverse(
     model="us.anthropic.claude-opus-4-5-20251101-v1:0",
-    client=bedrock_client,
+    region_name="dummy-region",
+    endpoint_url="http://localhost:8080/langchain",
+    aws_access_key_id="dummy-access-key",
+    aws_secret_access_key="dummy-secret-key",
     max_tokens=2000,
     additional_model_request_fields={  # Anthropic format
         "reasoning_config": {
@@ -445,22 +439,16 @@ response = llm.invoke([HumanMessage(content="Reason through this problem...")])
 #### Amazon Nova Models
 
 ```python
-import boto3
 from langchain_aws import ChatBedrockConverse
 from langchain_core.messages import HumanMessage
-
-# Configure Bedrock client to use Bifrost
-client_kwargs = {
-    "service_name": "bedrock-runtime",
-    "region_name": "us-west-2",
-    "endpoint_url": "http://localhost:8080/langchain",
-}
-bedrock_client = boto3.client(**client_kwargs)
 
 # Bedrock Nova with reasoning control
 llm = ChatBedrockConverse(
     model="global.amazon.nova-2-lite-v1:0",
-    client=bedrock_client,
+    region_name="dummy-region",
+    endpoint_url="http://localhost:8080/langchain",
+    aws_access_key_id="dummy-access-key",
+    aws_secret_access_key="dummy-secret-key",
     max_tokens=2000,
     additional_model_request_fields={  # Nova format
         "reasoningConfig": {
@@ -495,7 +483,7 @@ from langchain_core.messages import HumanMessage
 
 # Gemini with thinking budget control
 llm = ChatGoogleGenerativeAI(
-    model="gemini/gemini-2.5-flash",
+    model="gemini/gemini-2.5-flash",  # or "vertex/gemini-2.5-flash"
     base_url="http://localhost:8080/langchain",
     api_key="dummy-key",
     max_tokens=4000,

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -179,8 +179,8 @@ func createBedrockInvokeRouteConfig(pathPrefix string, handlerStore lib.HandlerS
 	}
 }
 
-// createBedrockRouteConfigs creates route configurations for Bedrock endpoints
-func createBedrockRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) []RouteConfig {
+// CreateBedrockRouteConfigs creates route configurations for Bedrock endpoints
+func CreateBedrockRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) []RouteConfig {
 	return []RouteConfig{
 		createBedrockConverseRouteConfig(pathPrefix, handlerStore),
 		createBedrockConverseStreamRouteConfig(pathPrefix, handlerStore),
@@ -570,7 +570,7 @@ func extractBedrockJobArnFromPath(handlerStore lib.HandlerStore) PreRequestCallb
 
 // NewBedrockRouter creates a new BedrockRouter with the given bifrost client
 func NewBedrockRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *BedrockRouter {
-	routes := createBedrockRouteConfigs("/bedrock", handlerStore)
+	routes := CreateBedrockRouteConfigs("/bedrock", handlerStore)
 	routes = append(routes, createBedrockBatchRouteConfigs("/bedrock", handlerStore)...)
 	routes = append(routes, createBedrockFilesRouteConfigs("/bedrock/files", handlerStore)...)
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -78,7 +78,7 @@ func Test_parseS3URI(t *testing.T) {
 
 func Test_createBedrockRouteConfigs(t *testing.T) {
 	handlerStore := &mockHandlerStore{allowDirectKeys: true}
-	routes := createBedrockRouteConfigs("/bedrock", handlerStore)
+	routes := CreateBedrockRouteConfigs("/bedrock", handlerStore)
 
 	assert.Len(t, routes, 4, "should have 4 bedrock routes")
 
@@ -530,12 +530,12 @@ func Test_extractBedrockJobArnFromPath(t *testing.T) {
 	handlerStore := &mockHandlerStore{allowDirectKeys: false}
 
 	tests := []struct {
-		name          string
-		jobArn        interface{}
-		provider      schemas.ModelProvider
-		wantErr       bool
-		wantJobArn    string
-		errContains   string
+		name        string
+		jobArn      interface{}
+		provider    schemas.ModelProvider
+		wantErr     bool
+		wantJobArn  string
+		errContains string
 	}{
 		{
 			name:       "valid job ARN for Bedrock",

--- a/transports/bifrost-http/integrations/langchain.go
+++ b/transports/bifrost-http/integrations/langchain.go
@@ -27,6 +27,12 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	// Add GenAI routes to LangChain for Vertex AI compatibility
 	routes = append(routes, CreateGenAIRouteConfigs("/langchain")...)
 
+	// Add Bedrock routes to LangChain for AWS Bedrock API compatibility
+	routes = append(routes, CreateBedrockRouteConfigs("/langchain", handlerStore)...)
+
+	// Add Cohere routes to LangChain for Cohere API compatibility
+	routes = append(routes, CreateCohereRouteConfigs("/langchain")...)
+
 	return &LangChainRouter{
 		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
 	}

--- a/transports/bifrost-http/integrations/litellm.go
+++ b/transports/bifrost-http/integrations/litellm.go
@@ -27,6 +27,12 @@ func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, lo
 	// Add GenAI routes to LiteLLM for Vertex AI compatibility
 	routes = append(routes, CreateGenAIRouteConfigs("/litellm")...)
 
+	// Add Bedrock routes to LiteLLM for AWS Bedrock API compatibility
+	routes = append(routes, CreateBedrockRouteConfigs("/litellm", handlerStore)...)
+
+	// Add Cohere routes to LiteLLM for Cohere API compatibility
+	routes = append(routes, CreateCohereRouteConfigs("/litellm")...)
+
 	return &LiteLLMRouter{
 		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
 	}

--- a/transports/bifrost-http/integrations/pydanticai.go
+++ b/transports/bifrost-http/integrations/pydanticai.go
@@ -31,7 +31,7 @@ func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore,
 	routes = append(routes, CreateCohereRouteConfigs("/pydanticai")...)
 	// Add Bedrock routes to Pydantic AI for AWS Bedrock API compatibility
 	// Supports: converse, converse-stream, invoke, invoke-with-response-stream
-	routes = append(routes, createBedrockRouteConfigs("/pydanticai", handlerStore)...)
+	routes = append(routes, CreateBedrockRouteConfigs("/pydanticai", handlerStore)...)
 	return &PydanticAIRouter{
 		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
 	}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,5 @@
 - fix: gemini thought signature handling in multi-turn conversations
 - feat: support computer-use-2025-11-24 in anthropic for claude-opus-4-5
+- refactor: use gemini native embedding endpoint for gemini embeddings
+- refactor: for fine-tuned or custom models in vertex use gemini native endpoint instead of openai compatible chat completions endpoint
+- fix: append bedrock and cohere routes in langchain and litellm integration


### PR DESCRIPTION
## Add AWS Bedrock and Cohere API support to LangChain and LiteLLM integrations

## Changes

- Added AWS Bedrock API compatibility to both LangChain and LiteLLM routers
- Added Cohere API compatibility to both LangChain and LiteLLM routers
- Updated LangChain documentation examples for Anthropic Claude and Amazon Nova models to use direct authentication parameters instead of boto3 client
- Added a comment clarifying Vertex AI model option for Gemini in documentation

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Docs

## How to test

Test the new API compatibility with LangChain and LiteLLM:

```sh
# Start Bifrost with LangChain and LiteLLM endpoints
go run main.go

# Test AWS Bedrock API with LangChain
curl -X POST http://localhost:8080/langchain/bedrock-runtime/model/anthropic.claude-3-opus-20240229-v1:0/invoke \
  -H "Content-Type: application/json" \
  -d '{"prompt": "Hello, Claude!"}'

# Test Cohere API with LiteLLM
curl -X POST http://localhost:8080/litellm/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model": "command", "messages": [{"role": "user", "content": "Hello, Cohere!"}]}'
```

## Breaking changes

- [x] No

## Related issues

Enhances API compatibility for LangChain and LiteLLM integrations

## Security considerations

The implementation uses dummy credentials in examples which should be replaced with proper authentication in production environments.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)