### PR TITLE
fix: dynamic thinking budget handling for gemini

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,3 +2,4 @@
 - feat: support computer-use-2025-11-24 in anthropic for claude-opus-4-5
 - refactor: use gemini native embedding endpoint for gemini embeddings
 - refactor: for fine-tuned or custom models in vertex use gemini native endpoint instead of openai compatible chat completions endpoint
+- fix: handle dynamic thinking budget (-1) in gemini and other providers

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1419,12 +1419,18 @@ func ToAnthropicResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*
 		}
 		if bifrostReq.Params.Reasoning != nil {
 			if bifrostReq.Params.Reasoning.MaxTokens != nil {
-				if *bifrostReq.Params.Reasoning.MaxTokens < MinimumReasoningMaxTokens {
+				budgetTokens := *bifrostReq.Params.Reasoning.MaxTokens
+				if *bifrostReq.Params.Reasoning.MaxTokens == -1 {
+					// anthropic does not support dynamic reasoning budget like gemini
+					// setting it to default max tokens
+					budgetTokens = MinimumReasoningMaxTokens
+				}
+				if budgetTokens < MinimumReasoningMaxTokens {
 					return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
 				}
 				anthropicReq.Thinking = &AnthropicThinking{
 					Type:         "enabled",
-					BudgetTokens: bifrostReq.Params.Reasoning.MaxTokens,
+					BudgetTokens: schemas.Ptr(budgetTokens),
 				}
 			} else {
 				if bifrostReq.Params.Reasoning.Effort != nil {

--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -104,10 +105,17 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Coh
 		// Convert reasoning
 		if bifrostReq.Params.Reasoning != nil {
 			if bifrostReq.Params.Reasoning.MaxTokens != nil {
-				cohereReq.Thinking = &CohereThinking{
-					Type:        ThinkingTypeEnabled,
-					TokenBudget: bifrostReq.Params.Reasoning.MaxTokens,
+				thinking := &CohereThinking{
+					Type: ThinkingTypeEnabled,
 				}
+				if *bifrostReq.Params.Reasoning.MaxTokens == -1 {
+					// cohere does not support dynamic reasoning budget like gemini
+					// setting it to minimum reasoning budget
+					thinking.TokenBudget = schemas.Ptr(anthropic.MinimumReasoningMaxTokens)
+				} else {
+					thinking.TokenBudget = bifrostReq.Params.Reasoning.MaxTokens
+				}
+				cohereReq.Thinking = thinking
 			} else if bifrostReq.Params.Reasoning.Effort != nil {
 				if *bifrostReq.Params.Reasoning.Effort != "none" {
 					maxCompletionTokens := DefaultCompletionMaxTokens

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2027,7 +2027,7 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 				config.ThinkingConfig.IncludeThoughts = false
 				config.ThinkingConfig.ThinkingBudget = schemas.Ptr(int32(0))
 			case -1: // dynamic thinking budget
-				config.ThinkingConfig.ThinkingBudget = nil
+				config.ThinkingConfig.ThinkingBudget = schemas.Ptr(int32(-1))
 			default: // constrained thinking budget
 				config.ThinkingConfig.ThinkingBudget = schemas.Ptr(int32(*params.Reasoning.MaxTokens))
 			}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -50,7 +50,8 @@ func (r *GeminiGenerationRequest) convertGenerationConfigToResponsesParameters()
 				params.Reasoning.Effort = schemas.Ptr("none")
 			case -1:
 				// dynamic thinking budget
-				params.Reasoning.MaxTokens = nil
+				params.Reasoning.Effort = schemas.Ptr("medium")
+				params.Reasoning.MaxTokens = schemas.Ptr(-1)
 			}
 		}
 	}

--- a/docs/integrations/genai-sdk/overview.mdx
+++ b/docs/integrations/genai-sdk/overview.mdx
@@ -280,6 +280,29 @@ const gptResponse = await gptModel.generateContent("Hello GPT!");
 
 ---
 
+## Dynamic Thinking Budget
+
+When `thinkingConfig.thinkingBudget` is set to `-1`, Bifrost handles it differently per provider:
+
+- **Gemini**: Preserves `-1` for native dynamic thinking support
+- **Anthropic**, **Bedrock**, **Cohere**: Converts to minimum reasoning budget value (1024)
+- **OpenAI**: Converts to medium reasoning effort
+
+```python
+response = client.models.glenerate_content(
+    model="gemini-2.5-flash",
+    contents="Complex reasoning task",
+    config={
+        "thinking_config": {
+            "include_thoughts": true,
+            "thinking_budget": -1  # Dynamic thinking
+        }
+    }
+)
+```
+
+---
+
 ## Supported Features
 
 The Google GenAI integration supports all features that are available in both the Google GenAI SDK and Bifrost core functionality. If the Google GenAI SDK supports a feature and Bifrost supports it, the integration will work seamlessly.

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -3,3 +3,4 @@
 - refactor: use gemini native embedding endpoint for gemini embeddings
 - refactor: for fine-tuned or custom models in vertex use gemini native endpoint instead of openai compatible chat completions endpoint
 - fix: append bedrock and cohere routes in langchain and litellm integration
+- fix: handle dynamic thinking budget (-1) in gemini and other providers


### PR DESCRIPTION
## Handle Dynamic Thinking Budget Across Providers

This PR implements support for dynamic thinking budget (-1) in Gemini and adapts the behavior for other providers that don't natively support this feature.

## Changes

- Added support for dynamic thinking budget (-1) in Gemini by properly preserving the value
- Implemented provider-specific handling for dynamic thinking budget:
  - Anthropic: Convert to maximum tokens value
  - Bedrock: Convert to default max tokens
  - Cohere: Remove token budget field entirely
- Updated documentation to explain how dynamic thinking budget is handled across providers

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Test dynamic thinking budget with different providers:

```sh
# Test with Gemini
curl -X POST "http://localhost:8080/v1/models/gemini-1.5-pro/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [{"role": "user", "content": "Complex reasoning task"}],
    "reasoning": {"max_tokens": -1}
  }'

# Test with Anthropic
curl -X POST "http://localhost:8080/v1/models/claude-3-opus-20240229/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [{"role": "user", "content": "Complex reasoning task"}],
    "reasoning": {"max_tokens": -1}
  }'

# Test with Cohere
curl -X POST "http://localhost:8080/v1/models/command-r-plus/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "messages": [{"role": "user", "content": "Complex reasoning task"}],
    "reasoning": {"max_tokens": -1}
  }'
```

## Breaking changes

- [x] No

## Related issues

Fixes issue with dynamic thinking budget handling across providers

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)