### PR TITLE
fix: update hugging face vision model

### DIFF
--- a/core/providers/huggingface/huggingface_test.go
+++ b/core/providers/huggingface/huggingface_test.go
@@ -24,7 +24,7 @@ func TestHuggingface(t *testing.T) {
 	testConfig := testutil.ComprehensiveTestConfig{
 		Provider:             schemas.HuggingFace,
 		ChatModel:            "sambanova/meta-llama/Llama-3.1-8B-Instruct",
-		VisionModel:          "novita/zai-org/GLM-4.6V-Flash",
+		VisionModel:          "cohere/CohereLabs/aya-vision-32b",
 		EmbeddingModel:       "sambanova/intfloat/e5-mistral-7b-instruct",
 		TranscriptionModel:   "fal-ai/openai/whisper-large-v3",
 		SpeechSynthesisModel: "fal-ai/hexgrad/Kokoro-82M",


### PR DESCRIPTION
## Summary

Update the vision model used in Huggingface provider tests from `novita/zai-org/GLM-4.6V-Flash` to `cohere/CohereLabs/aya-vision-32b`.

## Changes

- Changed the vision model in the comprehensive test configuration for Huggingface provider tests to use Cohere's Aya Vision model instead of GLM-4.6V-Flash

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Run the Huggingface provider tests to ensure they pass with the new vision model:

```sh
source .env && go test ./core/providers/huggingface 
```

## Breaking changes

- [x] No

## Security considerations

N/A

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable