### PR TITLE
feat: add tool-level binding option for MCP code mode

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1886,7 +1886,7 @@ func (bifrost *Bifrost) ReconnectMCPClient(id string) error {
 
 // UpdateToolManagerConfig updates the tool manager config for the MCP manager.
 // This allows for hot-reloading of the tool manager config at runtime.
-func (bifrost *Bifrost) UpdateToolManagerConfig(maxAgentDepth int, toolExecutionTimeoutInSeconds int) error {
+func (bifrost *Bifrost) UpdateToolManagerConfig(maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string) error {
 	if bifrost.mcpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
@@ -1894,6 +1894,7 @@ func (bifrost *Bifrost) UpdateToolManagerConfig(maxAgentDepth int, toolExecution
 	bifrost.mcpManager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        maxAgentDepth,
 		ToolExecutionTimeout: time.Duration(toolExecutionTimeoutInSeconds) * time.Second,
+		CodeModeBindingLevel: schemas.CodeModeBindingLevel(codeModeBindingLevel),
 	})
 	return nil
 }

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,3 @@
-- fix: gemini thought signature handling in multi-turn conversations
+- feat: added code mode to mcp
+- feat: added health monitoring to mcp
+- feat: added responses format tool execution support to mcp

--- a/core/mcp/codemode_listfiles.go
+++ b/core/mcp/codemode_listfiles.go
@@ -10,24 +10,39 @@ import (
 
 // createListToolFilesTool creates the listToolFiles tool definition for code mode.
 // This tool allows listing all available virtual .d.ts declaration files for connected MCP servers.
+// The description is dynamically generated based on the configured CodeModeBindingLevel.
 //
 // Returns:
 //   - schemas.ChatTool: The tool definition for listing tool files
 func (m *ToolsManager) createListToolFilesTool() schemas.ChatTool {
+	bindingLevel := m.GetCodeModeBindingLevel()
+	var description string
+
+	if bindingLevel == schemas.CodeModeBindingLevelServer {
+		description = "Returns a tree structure listing all virtual .d.ts declaration files available for connected MCP servers. " +
+			"Each server has a corresponding file (e.g., servers/<serverName>.d.ts) that contains definitions for all tools in that server. " +
+			"Use readToolFile to read a specific server file and see all available tools. " +
+			"In code, access tools via: await serverName.toolName({ args }). " +
+			"The server names used in code correspond to the human-readable names shown in this listing. " +
+			"This tool is generic and works with any set of servers connected at runtime. " +
+			"Always check this tool whenever you are unsure about what tools you have available or if you want to verify available servers and their tools. " +
+			"If you have even the SLIGHTEST DOUBT that the current tools might not be useful for the task, check listToolFiles to discover all available tools."
+	} else {
+		description = "Returns a tree structure listing all virtual .d.ts declaration files available for connected MCP servers, organized by individual tool. " +
+			"Each tool has a corresponding file (e.g., servers/<serverName>/<toolName>.d.ts) that contains definitions for that specific tool. " +
+			"Use readToolFile to read a specific tool file and see its parameters and usage. " +
+			"In code, access tools via: await serverName.toolName({ args }). " +
+			"The server names used in code correspond to the human-readable names shown in this listing. " +
+			"This tool is generic and works with any set of servers connected at runtime. " +
+			"Always check this tool whenever you are unsure about what tools you have available or if you want to verify available servers and their tools. " +
+			"If you have even the SLIGHTEST DOUBT that the current tools might not be useful for the task, check listToolFiles to discover all available tools."
+	}
+
 	return schemas.ChatTool{
 		Type: schemas.ChatToolTypeFunction,
 		Function: &schemas.ChatToolFunction{
 			Name: ToolTypeListToolFiles,
-			Description: schemas.Ptr(
-				"Returns a tree structure listing all virtual .d.ts declaration files available for connected MCP servers. " +
-					"Each connected server has a corresponding virtual file that can be read using readToolFile. " +
-					"The filenames follow the pattern <serverDisplayName>.d.ts where serverDisplayName is the human-readable " +
-					"name reported by each connected server. Note that the code-level bindings (used in executeToolCode) use " +
-					"configuration keys from SERVER_CONFIGS, which may differ from these display names. " +
-					"This tool is generic and works with any set of servers connected at runtime. " +
-					"Always check this tool whenever you are unsure about what tools you have available or if you want to verify available servers and their tools. " +
-					"If you have even the SLIGHTEST DOUBT that the current tools might not be useful for the task, check listToolFiles to discover all available tools.",
-			),
+			Description: schemas.Ptr(description),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type:       "object",
 				Properties: &schemas.OrderedMap{},
@@ -39,6 +54,9 @@ func (m *ToolsManager) createListToolFilesTool() schemas.ChatTool {
 
 // handleListToolFiles handles the listToolFiles tool call.
 // It builds a tree structure listing all virtual .d.ts files available for code mode clients.
+// The structure depends on the CodeModeBindingLevel:
+// - "server": servers/<name>.d.ts (one file per server)
+// - "tool": servers/<name>/<toolName>.d.ts (one file per tool)
 //
 // Parameters:
 //   - ctx: Context for accessing client tools
@@ -56,10 +74,14 @@ func (m *ToolsManager) handleListToolFiles(ctx context.Context, toolCall schemas
 		return createToolResponseMessage(toolCall, responseText), nil
 	}
 
-	// Build tree structure
-	treeLines := []string{"servers/"}
+	// Get the code mode binding level
+	bindingLevel := m.GetCodeModeBindingLevel()
+
+	// Build file list based on binding level
+	var files []string
 	codeModeServerCount := 0
-	for clientName := range availableToolsPerClient {
+
+	for clientName, tools := range availableToolsPerClient {
 		client := m.clientManager.GetClientByName(clientName)
 		if client == nil {
 			logger.Warn(fmt.Sprintf("%s Client %s not found, skipping", MCPLogPrefix, clientName))
@@ -69,7 +91,19 @@ func (m *ToolsManager) handleListToolFiles(ctx context.Context, toolCall schemas
 			continue
 		}
 		codeModeServerCount++
-		treeLines = append(treeLines, fmt.Sprintf("  %s.d.ts", clientName))
+
+		if bindingLevel == schemas.CodeModeBindingLevelServer {
+			// Server-level: one file per server
+			files = append(files, fmt.Sprintf("servers/%s.d.ts", clientName))
+		} else {
+			// Tool-level: one file per tool
+			for _, tool := range tools {
+				if tool.Function != nil && tool.Function.Name != "" {
+					toolFileName := fmt.Sprintf("servers/%s/%s.d.ts", clientName, tool.Function.Name)
+					files = append(files, toolFileName)
+				}
+			}
+		}
 	}
 
 	if codeModeServerCount == 0 {
@@ -78,6 +112,118 @@ func (m *ToolsManager) handleListToolFiles(ctx context.Context, toolCall schemas
 		return createToolResponseMessage(toolCall, responseText), nil
 	}
 
-	responseText := strings.Join(treeLines, "\n")
+	// Build tree structure from file list
+	responseText := buildVFSTree(files)
 	return createToolResponseMessage(toolCall, responseText), nil
+}
+
+// VFS tree node structure for building hierarchical file structure
+type treeNode struct {
+	isDirectory bool
+	children    map[string]*treeNode
+}
+
+// buildVFSTree creates a hierarchical tree structure from a flat list of file paths.
+// It groups files by directory and formats them with proper indentation.
+//
+// Example input:
+//   - ["servers/calculator.d.ts", "servers/youtube.d.ts"]
+//   - ["servers/calculator/add.d.ts", "servers/youtube/GET_CHANNELS.d.ts"]
+//
+// Example output for server-level:
+//   servers/
+//     calculator.d.ts
+//     youtube.d.ts
+//
+// Example output for tool-level:
+//   servers/
+//     calculator/
+//       add.d.ts
+//     youtube/
+//       GET_CHANNELS.d.ts
+func buildVFSTree(files []string) string {
+	if len(files) == 0 {
+		return ""
+	}
+
+	root := &treeNode{
+		isDirectory: true,
+		children:    make(map[string]*treeNode),
+	}
+
+	// Parse all files and build tree structure
+	for _, file := range files {
+		parts := strings.Split(file, "/")
+		current := root
+
+		// Create all intermediate directories and final file
+		for i, part := range parts {
+			if _, exists := current.children[part]; !exists {
+				current.children[part] = &treeNode{
+					isDirectory: i < len(parts)-1, // Last part is file, not directory
+					children:    make(map[string]*treeNode),
+				}
+			}
+			current = current.children[part]
+		}
+	}
+
+	// Render tree structure with proper indentation
+	var lines []string
+	renderTreeNode(root, "", &lines, true)
+
+	return strings.Join(lines, "\n")
+}
+
+// renderTreeNode recursively renders a tree node and its children with proper indentation.
+func renderTreeNode(node *treeNode, indent string, lines *[]string, isRoot bool) {
+	// Get sorted keys for consistent output
+	var keys []string
+	for key := range node.children {
+		keys = append(keys, key)
+	}
+
+	// Simple bubble sort for small lists (good enough for this use case)
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if keys[j] < keys[i] {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+
+	for _, key := range keys {
+		child := node.children[key]
+
+		// Format the line
+		var line string
+		if isRoot {
+			// Root level - no indentation
+			if child.isDirectory {
+				line = key + "/"
+			} else {
+				line = key
+			}
+		} else {
+			// Non-root levels - add indentation
+			if child.isDirectory {
+				line = indent + key + "/"
+			} else {
+				line = indent + key
+			}
+		}
+
+		*lines = append(*lines, line)
+
+		// Recurse into children
+		if child.isDirectory && len(child.children) > 0 {
+			var nextIndent string
+			if isRoot {
+				nextIndent = "  "
+			} else {
+				nextIndent = indent + "  "
+			}
+			renderTreeNode(child, nextIndent, lines, false)
+		}
+	}
 }

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -23,13 +23,22 @@ type MCPConfig struct {
 }
 
 type MCPToolManagerConfig struct {
-	ToolExecutionTimeout time.Duration `json:"tool_execution_timeout"`
-	MaxAgentDepth        int           `json:"max_agent_depth"`
+	ToolExecutionTimeout     time.Duration        `json:"tool_execution_timeout"`
+	MaxAgentDepth            int                  `json:"max_agent_depth"`
+	CodeModeBindingLevel     CodeModeBindingLevel `json:"code_mode_binding_level,omitempty"` // How tools are exposed in VFS: "server" or "tool"
 }
 
 const (
 	DefaultMaxAgentDepth        = 10
 	DefaultToolExecutionTimeout = 30 * time.Second
+)
+
+// CodeModeBindingLevel defines how tools are exposed in the VFS for code execution
+type CodeModeBindingLevel string
+
+const (
+	CodeModeBindingLevelServer CodeModeBindingLevel = "server"
+	CodeModeBindingLevelTool   CodeModeBindingLevel = "tool"
 )
 
 // MCPClientConfig defines tool filtering for an MCP client.

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,0 @@
-- chore: upgraded version of core to 1.2.41

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -49,6 +49,7 @@ type ClientConfig struct {
 	EnableLiteLLMFallbacks  bool     `json:"enable_litellm_fallbacks"`            // Enable litellm-specific fallbacks for text completion for Groq
 	MCPAgentDepth           int      `json:"mcp_agent_depth"`                     // The maximum depth for MCP agent mode tool execution
 	MCPToolExecutionTimeout int      `json:"mcp_tool_execution_timeout"`          // The timeout for individual tool execution in seconds
+	MCPCodeModeBindingLevel string   `json:"mcp_code_mode_binding_level"`         // Code mode binding level: "server" or "tool"
 	ConfigHash              string   `json:"-"`                                   // Config hash for reconciliation (not serialized)
 }
 
@@ -110,6 +111,12 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 		hash.Write([]byte("mcpToolExecutionTimeout:" + strconv.Itoa(c.MCPToolExecutionTimeout)))
 	} else {
 		hash.Write([]byte("mcpToolExecutionTimeout:0"))
+	}
+
+	if c.MCPCodeModeBindingLevel != "" {
+		hash.Write([]byte("mcpCodeModeBindingLevel:" + c.MCPCodeModeBindingLevel))
+	} else {
+		hash.Write([]byte("mcpCodeModeBindingLevel:server"))
 	}
 
 	// Hash integer fields

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -44,6 +44,7 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		EnableLiteLLMFallbacks:  config.EnableLiteLLMFallbacks,
 		MCPAgentDepth:           config.MCPAgentDepth,
 		MCPToolExecutionTimeout: config.MCPToolExecutionTimeout,
+		MCPCodeModeBindingLevel: config.MCPCodeModeBindingLevel,
 	}
 	// Delete existing client config and create new one in a transaction
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -199,6 +200,7 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		EnableLiteLLMFallbacks:  dbConfig.EnableLiteLLMFallbacks,
 		MCPAgentDepth:           dbConfig.MCPAgentDepth,
 		MCPToolExecutionTimeout: dbConfig.MCPToolExecutionTimeout,
+		MCPCodeModeBindingLevel: dbConfig.MCPCodeModeBindingLevel,
 	}, nil
 }
 
@@ -764,6 +766,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 	toolManagerConfig := schemas.MCPToolManagerConfig{
 		ToolExecutionTimeout: time.Duration(clientConfig.MCPToolExecutionTimeout) * time.Second,
 		MaxAgentDepth:        clientConfig.MCPAgentDepth,
+		CodeModeBindingLevel: schemas.CodeModeBindingLevel(clientConfig.MCPCodeModeBindingLevel),
 	}
 	return &schemas.MCPConfig{
 		ClientConfigs:     clientConfigs,

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -22,7 +22,9 @@ type TableClientConfig struct {
 	AllowDirectKeys         bool   `gorm:"" json:"allow_direct_keys"`
 	MaxRequestBodySizeMB    int    `gorm:"default:100" json:"max_request_body_size_mb"`
 	MCPAgentDepth           int    `gorm:"default:10" json:"mcp_agent_depth"`
-	MCPToolExecutionTimeout int    `gorm:"default:30" json:"mcp_tool_execution_timeout"` // Timeout for individual tool execution in seconds (default: 30)
+	MCPToolExecutionTimeout int    `gorm:"default:30" json:"mcp_tool_execution_timeout"`      // Timeout for individual tool execution in seconds (default: 30)
+	MCPCodeModeBindingLevel string `gorm:"default:server" json:"mcp_code_mode_binding_level"` // How tools are exposed in VFS: "server" or "tool"
+
 	// LiteLLM fallback flag
 	EnableLiteLLMFallbacks bool `gorm:"column:enable_litellm_fallbacks;default:false" json:"enable_litellm_fallbacks"`
 

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -79,6 +79,7 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 	} else {
 		c.HeadersJSON = "{}"
 	}
+
 	return nil
 }
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -232,6 +232,7 @@ var DefaultClientConfig = configstore.ClientConfig{
 	MaxRequestBodySizeMB:    100,
 	MCPAgentDepth:           10,
 	MCPToolExecutionTimeout: 30,
+	MCPCodeModeBindingLevel: string(schemas.CodeModeBindingLevelServer),
 	EnableLiteLLMFallbacks:  false,
 }
 
@@ -508,6 +509,9 @@ func loadClientConfigFromFile(ctx context.Context, config *Config, configData *C
 			}
 			if config.ClientConfig.MCPToolExecutionTimeout == 0 && configData.Client.MCPToolExecutionTimeout != 0 {
 				config.ClientConfig.MCPToolExecutionTimeout = configData.Client.MCPToolExecutionTimeout
+			}
+			if config.ClientConfig.MCPCodeModeBindingLevel == "" && configData.Client.MCPCodeModeBindingLevel != "" {
+				config.ClientConfig.MCPCodeModeBindingLevel = configData.Client.MCPCodeModeBindingLevel
 			}
 			// Update store with merged config
 			if config.ConfigStore != nil {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -66,7 +66,7 @@ type ServerCallbacks interface {
 	ForceReloadPricing(ctx context.Context) error
 	ReloadProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
 	UpdateDropExcessRequests(ctx context.Context, value bool)
-	UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int) error
+	UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string) error
 	ReloadTeam(ctx context.Context, id string) (*tables.TableTeam, error)
 	RemoveTeam(ctx context.Context, id string) error
 	ReloadCustomer(ctx context.Context, id string) (*tables.TableCustomer, error)
@@ -708,11 +708,11 @@ func (s *BifrostHTTPServer) UpdateDropExcessRequests(ctx context.Context, value 
 }
 
 // UpdateMCPToolManagerConfig updates the MCP tool manager config
-func (s *BifrostHTTPServer) UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int) error {
+func (s *BifrostHTTPServer) UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string) error {
 	if s.Config == nil {
 		return fmt.Errorf("config not found")
 	}
-	return s.Client.UpdateToolManagerConfig(maxAgentDepth, toolExecutionTimeoutInSeconds)
+	return s.Client.UpdateToolManagerConfig(maxAgentDepth, toolExecutionTimeoutInSeconds, codeModeBindingLevel)
 }
 
 // UpdatePluginStatus updates the status of a plugin

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,4 @@
-- fix: gemini thought signature handling in multi-turn conversations
+- feat: added code mode to mcp
+- feat: added health monitoring to mcp
+- feat: added responses format tool execution support to mcp
+- refactor: governance plugin refactored for extensibility and optimization

--- a/ui/app/workspace/config/logging/page.tsx
+++ b/ui/app/workspace/config/logging/page.tsx
@@ -1,12 +1,11 @@
-"use client"
+"use client";
 
-import LoggingView from "../views/loggingView"
+import LoggingView from "../views/loggingView";
 
 export default function LoggingPage() {
-  return (
-    <div className="mx-auto flex w-full max-w-7xl">
-      <LoggingView />
-    </div>
-  )
+	return (
+		<div className="mx-auto flex w-full max-w-7xl">
+			<LoggingView />
+		</div>
+	);
 }
-

--- a/ui/app/workspace/config/mcp-gateway/page.tsx
+++ b/ui/app/workspace/config/mcp-gateway/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import MCPGatewayView from "../views/mcpView";
+
+export default function MCPGatewayPage() {
+	return (
+		<div className="mx-auto flex w-full max-w-7xl">
+			<MCPGatewayView />
+		</div>
+	);
+}

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -23,6 +23,7 @@ const defaultConfig: CoreConfig = {
 	log_retention_days: 365,
 	mcp_agent_depth: 10,
 	mcp_tool_execution_timeout: 30,
+	mcp_code_mode_binding_level: "server",
 };
 
 export default function ClientSettingsView() {
@@ -72,7 +73,7 @@ export default function ClientSettingsView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4 w-full max-w-4xl mx-auto">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Client Settings</h2>

--- a/ui/app/workspace/config/views/governanceView.tsx
+++ b/ui/app/workspace/config/views/governanceView.tsx
@@ -23,6 +23,7 @@ const defaultConfig: CoreConfig = {
 	enable_litellm_fallbacks: false,
 	mcp_agent_depth: 10,
 	mcp_tool_execution_timeout: 30,
+	mcp_code_mode_binding_level: "server",
 };
 
 export default function GovernanceView() {
@@ -63,7 +64,7 @@ export default function GovernanceView() {
 	}, [bifrostConfig, localConfig, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4 mx-auto w-full max-w-4xl">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Governance</h2>

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -25,6 +25,7 @@ const defaultConfig: CoreConfig = {
 	enable_litellm_fallbacks: false,
 	mcp_agent_depth: 10,
 	mcp_tool_execution_timeout: 30,
+	mcp_code_mode_binding_level: "server",
 };
 
 export default function LoggingView() {

--- a/ui/app/workspace/config/views/observabilityView.tsx
+++ b/ui/app/workspace/config/views/observabilityView.tsx
@@ -26,6 +26,7 @@ const defaultConfig: CoreConfig = {
 	log_retention_days: 365,
 	mcp_agent_depth: 10,
 	mcp_tool_execution_timeout: 30,
+	mcp_code_mode_binding_level: "server",
 };
 
 export default function ObservabilityView() {

--- a/ui/app/workspace/config/views/performanceTuningView.tsx
+++ b/ui/app/workspace/config/views/performanceTuningView.tsx
@@ -25,6 +25,7 @@ const defaultConfig: CoreConfig = {
 	log_retention_days: 365,
 	mcp_agent_depth: 10,
 	mcp_tool_execution_timeout: 30,
+	mcp_code_mode_binding_level: "server",
 };
 
 export default function PerformanceTuningView() {
@@ -105,7 +106,7 @@ export default function PerformanceTuningView() {
 	}, [bifrostConfig, localConfig, localValues, updateCoreConfig]);
 
 	return (
-		<div className="space-y-4 mx-auto w-full max-w-4xl">
+		<div className="mx-auto w-full max-w-4xl space-y-4">
 			<div className="flex items-center justify-between">
 				<div>
 					<h2 className="text-2xl font-semibold tracking-tight">Performance Tuning</h2>

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -33,6 +33,7 @@ const defaultConfig: CoreConfig = {
 	log_retention_days: 365,
 	mcp_agent_depth: 10,
 	mcp_tool_execution_timeout: 30,
+	mcp_code_mode_binding_level: "server",
 };
 
 export default function SecurityView() {

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -487,6 +487,13 @@ export default function AppSidebar() {
 					hasAccess: hasSettingsAccess,
 				},
 				{
+					title: "MCP Gateway",
+					url: "/workspace/config/mcp-gateway",
+					icon: MCPIcon,
+					description: "MCP gateway configuration",
+					hasAccess: hasMCPGatewayAccess,
+				},
+				{
 					title: "Pricing Config",
 					url: "/workspace/config/pricing-config",
 					icon: CircleDollarSign,
@@ -715,7 +722,7 @@ export default function AppSidebar() {
 										isExpanded={expandedItems.has(item.title)}
 										onToggle={() => toggleItem(item.title)}
 										pathname={pathname}
-										router={router}										
+										router={router}
 									/>
 								);
 							})}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -325,6 +325,7 @@ export interface CoreConfig {
 	enable_litellm_fallbacks: boolean;
 	mcp_agent_depth: number;
 	mcp_tool_execution_timeout: number;
+	mcp_code_mode_binding_level?: string;
 }
 
 // Semantic cache configuration types

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -91,11 +91,11 @@ export const s3BucketConfigSchema = z.object({
 	bucket_name: z.string().min(1, "Bucket name is required"),
 	prefix: z.string().optional(),
 	is_default: z.boolean().optional(),
-})
+});
 
 export const batchS3ConfigSchema = z.object({
 	buckets: z.array(s3BucketConfigSchema).optional(),
-})
+});
 
 // Bedrock key config schema
 export const bedrockKeyConfigSchema = z
@@ -462,6 +462,7 @@ export const coreConfigSchema = z.object({
 	max_request_body_size_mb: z.number().min(1).default(100),
 	mcp_agent_depth: z.number().min(1).default(10),
 	mcp_tool_execution_timeout: z.number().min(1).default(30),
+	mcp_code_mode_binding_level: z.enum(["server", "tool"]).default("server"),
 });
 
 // Bifrost config schema
@@ -647,7 +648,7 @@ export const mcpClientUpdateSchema = z.object({
 });
 
 // Global proxy type schema
-export const globalProxyTypeSchema = z.enum(['http', 'socks5', 'tcp']);
+export const globalProxyTypeSchema = z.enum(["http", "socks5", "tcp"]);
 
 // Global proxy configuration schema
 export const globalProxyConfigSchema = z
@@ -674,8 +675,8 @@ export const globalProxyConfigSchema = z
 			return true;
 		},
 		{
-			message: 'Proxy URL is required when proxy is enabled',
-			path: ['url'],
+			message: "Proxy URL is required when proxy is enabled",
+			path: ["url"],
 		},
 	)
 	.refine(
@@ -692,8 +693,8 @@ export const globalProxyConfigSchema = z
 			return true;
 		},
 		{
-			message: 'Must be a valid URL (e.g., http://proxy.example.com:8080)',
-			path: ['url'],
+			message: "Must be a valid URL (e.g., http://proxy.example.com:8080)",
+			path: ["url"],
 		},
 	);
 


### PR DESCRIPTION
## Summary

Added a configurable code mode binding level for MCP tools, allowing tools to be exposed in the virtual file system (VFS) at either server-level or tool-level granularity.

## Changes

- Added a new `CodeModeBindingLevel` configuration option with two possible values:
  - `server`: All tools for a server are exposed in a single file (e.g., `servers/calculator.d.ts`)
  - `tool`: Each tool is exposed in its own file (e.g., `servers/calculator/add.d.ts`)
- Enhanced the `listToolFiles` and `readToolFile` tools to support both binding levels
- Implemented a tree-based VFS structure for better organization of tool files
- Added UI configuration in the MCP Gateway settings page with visual examples
- Updated database schema and migrations to store the new configuration

## Type of change

- [x] Feature
- [x] UI (Next.js)

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)

## How to test

1. Configure the code mode binding level in the UI:
   - Navigate to Workspace → Config → MCP Gateway
   - Select either "Server-Level" or "Tool-Level" binding
   - Save changes

2. Test with code mode in a chat:
   ```typescript
   // First list available tools
   await listToolFiles()
   
   // Read tool definitions based on binding level
   // For server-level:
   await readToolFile({ fileName: "servers/calculator.d.ts" })
   
   // For tool-level:
   await readToolFile({ fileName: "servers/calculator/add.d.ts" })
   
   // Execute tool code as usual
   await executeToolCode(`
     const result = await calculator.add({ a: 5, b: 3 });
     return result;
   `)
   ```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No additional security implications. This change only affects how tools are organized and presented in the virtual file system.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)