### PR TITLE
feat: add document/file support for Anthropic, Bedrock, and Gemini

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- feat: add document/file support for Anthropic, Bedrock, and Gemini

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -251,6 +251,8 @@ func ToAnthropicChatRequest(bifrostReq *schemas.BifrostChatRequest) (*AnthropicM
 							})
 						} else if block.ImageURLStruct != nil {
 							content = append(content, ConvertToAnthropicImageBlock(block))
+						} else if block.File != nil {
+							content = append(content, ConvertToAnthropicDocumentBlock(block))
 						}
 					}
 				}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -203,6 +203,7 @@ type AnthropicContentBlockType string
 const (
 	AnthropicContentBlockTypeText             AnthropicContentBlockType = "text"
 	AnthropicContentBlockTypeImage            AnthropicContentBlockType = "image"
+	AnthropicContentBlockTypeDocument         AnthropicContentBlockType = "document"
 	AnthropicContentBlockTypeToolUse          AnthropicContentBlockType = "tool_use"
 	AnthropicContentBlockTypeServerToolUse    AnthropicContentBlockType = "server_tool_use"
 	AnthropicContentBlockTypeToolResult       AnthropicContentBlockType = "tool_result"
@@ -215,7 +216,7 @@ const (
 
 // AnthropicContentBlock represents content in Anthropic message format
 type AnthropicContentBlock struct {
-	Type         AnthropicContentBlockType `json:"type"`                    // "text", "image", "tool_use", "tool_result", "thinking"
+	Type         AnthropicContentBlockType `json:"type"`                    // "text", "image", "document", "tool_use", "tool_result", "thinking"
 	Text         *string                   `json:"text,omitempty"`          // For text content
 	Thinking     *string                   `json:"thinking,omitempty"`      // For thinking content
 	Signature    *string                   `json:"signature,omitempty"`     // For signature content
@@ -226,16 +227,24 @@ type AnthropicContentBlock struct {
 	Input        any                       `json:"input,omitempty"`         // For tool_use content
 	ServerName   *string                   `json:"server_name,omitempty"`   // For mcp_tool_use content
 	Content      *AnthropicContent         `json:"content,omitempty"`       // For tool_result content
-	Source       *AnthropicImageSource     `json:"source,omitempty"`        // For image content
+	Source       *AnthropicSource          `json:"source,omitempty"`        // For image/document content
 	CacheControl *schemas.CacheControl     `json:"cache_control,omitempty"` // For cache control content
+	Citations    *AnthropicCitationsConfig `json:"citations,omitempty"`     // For document content
+	Context      *string                   `json:"context,omitempty"`       // For document content
+	Title        *string                   `json:"title,omitempty"`         // For document content
 }
 
-// AnthropicImageSource represents image source in Anthropic format
-type AnthropicImageSource struct {
-	Type      string  `json:"type"`                 // "base64" or "url"
-	MediaType *string `json:"media_type,omitempty"` // "image/jpeg", "image/png", etc.
-	Data      *string `json:"data,omitempty"`       // Base64-encoded image data
-	URL       *string `json:"url,omitempty"`        // URL of the image
+// AnthropicSource represents image or document source in Anthropic format
+type AnthropicSource struct {
+	Type      string  `json:"type"`                 // "base64", "url", "text", "content_block"
+	MediaType *string `json:"media_type,omitempty"` // "image/jpeg", "image/png", "application/pdf", etc.
+	Data      *string `json:"data,omitempty"`       // Base64-encoded data (for base64 type)
+	URL       *string `json:"url,omitempty"`        // URL (for url type)
+}
+
+// AnthropicCitationsConfig represents citations configuration for documents
+type AnthropicCitationsConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 // AnthropicImageContent represents image content in Anthropic format

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -125,6 +125,44 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(ctx context.Conte
 				})
 				reasoningText += contentBlock.ReasoningContent.ReasoningText.Text + "\n"
 			}
+
+			// Handle document content
+			if contentBlock.Document != nil {
+				fileBlock := schemas.ChatContentBlock{
+					Type: schemas.ChatContentBlockTypeFile,
+					File: &schemas.ChatInputFile{},
+				}
+
+				// Set filename from document name
+				if contentBlock.Document.Name != "" {
+					fileBlock.File.Filename = &contentBlock.Document.Name
+				}
+
+				// Set file type based on format
+				if contentBlock.Document.Format != "" {
+					var fileType string
+					switch contentBlock.Document.Format {
+					case "pdf":
+						fileType = "application/pdf"
+					case "txt", "md", "html", "csv":
+						fileType = "text/plain"
+					default:
+						fileType = "application/pdf"
+					}
+					fileBlock.File.FileType = &fileType
+				}
+
+				// Convert document source data
+				if contentBlock.Document.Source != nil {
+					if contentBlock.Document.Source.Bytes != nil {
+						fileBlock.File.FileData = contentBlock.Document.Source.Bytes
+					} else if contentBlock.Document.Source.Text != nil {
+						fileBlock.File.FileData = contentBlock.Document.Source.Text
+					}
+				}
+
+				contentBlocks = append(contentBlocks, fileBlock)
+			}
 		}
 	}
 

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -213,14 +213,15 @@ type BedrockImageSourceData struct {
 
 // BedrockDocumentSource represents document content
 type BedrockDocumentSource struct {
-	Format string                    `json:"format"` // Required: Document format (pdf, csv, doc, docx, xls, xlsx, html, txt, md)
-	Name   string                    `json:"name"`   // Required: Document name
-	Source BedrockDocumentSourceData `json:"source"` // Required: Document source data
+	Format string                     `json:"format"` // Required: Document format (pdf, csv, doc, docx, xls, xlsx, html, txt, md)
+	Name   string                     `json:"name"`   // Required: Document name
+	Source *BedrockDocumentSourceData `json:"source"` // Required: Document source data
 }
 
 // BedrockDocumentSourceData represents the source of document data
 type BedrockDocumentSourceData struct {
 	Bytes *string `json:"bytes,omitempty"` // Base64-encoded document bytes
+	Text  *string `json:"text,omitempty"`  // Plain text content
 }
 
 // BedrockToolUse represents a tool use request

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -216,6 +216,40 @@ func isImageMimeType(mimeType string) bool {
 	return false
 }
 
+// convertFileDataToBytes converts file data (data URL or base64) to raw bytes for Gemini API.
+// Returns the bytes and an extracted mime type (if found in data URL).
+func convertFileDataToBytes(fileData string) ([]byte, string) {
+	var dataBytes []byte
+	var mimeType string
+
+	// Check if it's a data URL (e.g., "data:application/pdf;base64,...")
+	if strings.HasPrefix(fileData, "data:") {
+		urlInfo := schemas.ExtractURLTypeInfo(fileData)
+
+		if urlInfo.DataURLWithoutPrefix != nil {
+			// Decode the base64 content
+			decoded, err := base64.StdEncoding.DecodeString(*urlInfo.DataURLWithoutPrefix)
+			if err == nil {
+				dataBytes = decoded
+				if urlInfo.MediaType != nil {
+					mimeType = *urlInfo.MediaType
+				}
+			}
+		}
+	} else {
+		// Try to decode as plain base64
+		decoded, err := base64.StdEncoding.DecodeString(fileData)
+		if err == nil {
+			dataBytes = decoded
+		} else {
+			// Not base64 - treat as plain text
+			dataBytes = []byte(fileData)
+		}
+	}
+
+	return dataBytes, mimeType
+}
+
 var (
 	// Maps Gemini finish reasons to Bifrost format
 	geminiFinishReasonToBifrost = map[FinishReason]string{
@@ -577,6 +611,42 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) []Content {
 						parts = append(parts, &Part{
 							Text: *block.Text,
 						})
+					} else if block.File != nil {
+						// Handle file blocks - use FileID if available (uploaded file)
+						if block.File.FileID != nil && *block.File.FileID != "" {
+							mimeType := "application/pdf"
+							if block.File.FileType != nil {
+								mimeType = *block.File.FileType
+							}
+							parts = append(parts, &Part{
+								FileData: &FileData{
+									FileURI:  *block.File.FileID,
+									MIMEType: mimeType,
+								},
+							})
+						} else if block.File.FileData != nil {
+							// Inline file data - convert to InlineData (Blob)
+							fileData := *block.File.FileData
+							mimeType := "application/pdf"
+							if block.File.FileType != nil {
+								mimeType = *block.File.FileType
+							}
+
+							// Convert file data to bytes for Gemini Blob
+							dataBytes, extractedMimeType := convertFileDataToBytes(fileData)
+							if extractedMimeType != "" {
+								mimeType = extractedMimeType
+							}
+
+							if len(dataBytes) > 0 {
+								parts = append(parts, &Part{
+									InlineData: &Blob{
+										MIMEType: mimeType,
+										Data:     dataBytes,
+									},
+								})
+							}
+						}
 					}
 					// Handle other content block types as needed
 				}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -600,7 +600,7 @@ const (
 	ChatContentBlockTypeText       ChatContentBlockType = "text"
 	ChatContentBlockTypeImage      ChatContentBlockType = "image_url"
 	ChatContentBlockTypeInputAudio ChatContentBlockType = "input_audio"
-	ChatContentBlockTypeFile       ChatContentBlockType = "input_file"
+	ChatContentBlockTypeFile       ChatContentBlockType = "file"
 	ChatContentBlockTypeRefusal    ChatContentBlockType = "refusal"
 )
 
@@ -647,6 +647,7 @@ type ChatInputFile struct {
 	FileData *string `json:"file_data,omitempty"` // Base64 encoded file data
 	FileID   *string `json:"file_id,omitempty"`   // Reference to uploaded file
 	Filename *string `json:"filename,omitempty"`  // Name of the file
+	FileType *string `json:"file_type,omitempty"` // Type of the file
 }
 
 // ChatToolMessage represents a tool message in a chat conversation.

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -575,7 +575,7 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 					case ResponsesInputMessageContentBlockTypeImage:
 						chatBlockType = ChatContentBlockTypeImage // "input_image" -> "image_url"
 					case ResponsesInputMessageContentBlockTypeFile:
-						chatBlockType = ChatContentBlockTypeFile // "input_file" -> "input_file" (same)
+						chatBlockType = ChatContentBlockTypeFile // "input_file" -> "file"
 					case ResponsesInputMessageContentBlockTypeAudio:
 						chatBlockType = ChatContentBlockTypeInputAudio // "input_audio" -> "input_audio" (same)
 					default:

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -426,9 +426,10 @@ type ResponsesInputMessageContentBlockImage struct {
 }
 
 type ResponsesInputMessageContentBlockFile struct {
-	FileData *string `json:"file_data,omitempty"` // Base64 encoded file data
+	FileData *string `json:"file_data,omitempty"` // Base64 encoded file data or plain text
 	FileURL  *string `json:"file_url,omitempty"`  // Direct URL to file
 	Filename *string `json:"filename,omitempty"`  // Name of the file
+	FileType *string `json:"file_type,omitempty"` // MIME type (e.g., "application/pdf", "text/plain")
 }
 
 type ResponsesInputMessageContentBlockAudio struct {

--- a/tests/integrations/config.yml
+++ b/tests/integrations/config.yml
@@ -34,8 +34,9 @@ api:
 # Integrations (openai, anthropic, google, litellm, langchain) map to these providers
 providers:
   openai:
-    chat: "gpt-4o-mini"
+    chat: "gpt-4o"
     vision: "gpt-4o"
+    file: "gpt-5"
     tools: "gpt-4o-mini"
     speech: "tts-1"
     transcription: "whisper-1"
@@ -62,6 +63,7 @@ providers:
   anthropic:
     chat: "claude-sonnet-4-5-20250929"
     vision: "claude-3-7-sonnet-20250219"
+    file: "claude-sonnet-4-5-20250929"
     tools: "claude-sonnet-4-5-20250929"
     streaming: "claude-sonnet-4-5-20250929"
     thinking: "claude-opus-4-5"
@@ -85,6 +87,7 @@ providers:
     chat: "gemini-2.5-flash"
     vision: "gemini-2.5-flash"
     tools: "gemini-2.5-flash"
+    file: "gemini-2.5-flash"
     thinking: "gemini-3-pro-preview"
     speech: "gemini-2.5-flash-preview-tts"
     transcription: "gemini-2.5-flash"
@@ -112,6 +115,7 @@ providers:
   bedrock:
     chat: "global.anthropic.claude-sonnet-4-20250514-v1:0"
     vision: "global.anthropic.claude-sonnet-4-20250514-v1:0"
+    file: "global.anthropic.claude-sonnet-4-20250514-v1:0"
     tools: "global.anthropic.claude-sonnet-4-20250514-v1:0"
     streaming: "global.anthropic.claude-sonnet-4-20250514-v1:0"
     thinking: "us.anthropic.claude-opus-4-5-20251101-v1:0"
@@ -161,6 +165,7 @@ provider_scenarios:
     automatic_function_calling: true
     image_url: true
     image_base64: true
+    file_input: true
     multiple_images: true
     speech_synthesis: true
     speech_synthesis_streaming: true
@@ -200,6 +205,8 @@ provider_scenarios:
     automatic_function_calling: true
     image_url: true
     image_base64: true
+    file_input: true
+    file_input_text: true
     multiple_images: true
     speech_synthesis: false
     speech_synthesis_streaming: false
@@ -239,6 +246,7 @@ provider_scenarios:
     automatic_function_calling: true
     image_url: false  # Gemini requires base64 or file upload
     image_base64: true
+    file_input: true
     multiple_images: false
     speech_synthesis: true
     speech_synthesis_streaming: true
@@ -278,6 +286,8 @@ provider_scenarios:
     automatic_function_calling: true
     image_url: false
     image_base64: true
+    file_input: true
+    file_input_text: true
     multiple_images: false
     speech_synthesis: false
     speech_synthesis_streaming: false
@@ -360,6 +370,8 @@ scenario_capabilities:
   automatic_function_calling: "tools"
   image_url: "vision"
   image_base64: "vision"
+  file_input: "file"
+  file_input_text: "file"
   multiple_images: "vision"
   speech_synthesis: "speech"
   speech_synthesis_streaming: "speech"

--- a/tests/integrations/tests/utils/common.py
+++ b/tests/integrations/tests/utils/common.py
@@ -26,6 +26,21 @@ class Config:
 IMAGE_URL = "https://pub-cdead89c2f004d8f963fd34010c479d0.r2.dev/Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
 IMAGE_URL_SECONDARY = "https://goo.gle/instrument-img"
 
+FILE_DATA_BASE64 = (
+            "JVBERi0xLjcKCjEgMCBvYmogICUgZW50cnkgcG9pbnQKPDwKICAvVHlwZSAvQ2F0YWxvZwogIC"
+            "9QYWdlcyAyIDAgUgo+PgplbmRvYmoKCjIgMCBvYmoKPDwKICAvVHlwZSAvUGFnZXwKICAvTWV"
+            "kaWFCb3ggWyAwIDAgMjAwIDIwMCBdCiAgL0NvdW50IDEKICAvS2lkcyBbIDMgMCBSIF0KPj4K"
+            "ZW5kb2JqCgozIDAgb2JqCjw8CiAgL1R5cGUgL1BhZ2UKICAvUGFyZW50IDIgMCBSCiAgL1Jlc"
+            "291cmNlcyA8PAogICAgL0ZvbnQgPDwKICAgICAgL0YxIDQgMCBSCj4+CiAgPj4KICAvQ29udG"
+            "VudHMgNSAwIFIKPj4KZW5kb2JqCgo0IDAgb2JqCjw8CiAgL1R5cGUgL0ZvbnQKICAvU3VidHl"
+            "wZSAvVHlwZTEKICAvQmFzZUZvbnQgL1RpbWVzLVJvbWFuCj4+CmVuZG9iagoKNSAwIG9iago8"
+            "PAogIC9MZW5ndGggNDQKPj4Kc3RyZWFtCkJUCjcwIDUwIFRECi9GMSAxMiBUZgooSGVsbG8gV"
+            "29ybGQhKSBUagpFVAplbmRzdHJlYW0KZW5kb2JqCgp4cmVmCjAgNgowMDAwMDAwMDAwIDY1NT"
+            "M1IGYgCjAwMDAwMDAwMTAgMDAwMDAgbiAKMDAwMDAwMDA2MCAwMDAwMCBuIAowMDAwMDAwMTU"
+            "3IDAwMDAwIG4gCjAwMDAwMDAyNTUgMDAwMDAgbiAKMDAwMDAwMDM1MyAwMDAwMCBuIAp0cmFp"
+            "bGVyCjw8CiAgL1NpemUgNgogIC9Sb290IDEgMCBSCj4+CnN0YXJ0eHJlZgo0NDkKJSVFT0YK"
+        )
+
 # Small test image as base64 (1x1 pixel red PNG)
 BASE64_IMAGE = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- feat: add document/file support for Anthropic, Bedrock, and Gemini


### PR DESCRIPTION
## Summary

Update the content block type for files from "input_file" to "file" to align with the OpenAI API specification.

## Changes

- Changed `ChatContentBlockTypeFile` constant value from "input_file" to "file"
- Updated the corresponding comment in the `ToChatMessages` function to reflect this change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that file content blocks are properly handled with the updated type:

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

This changes the content block type for files from "input_file" to "file", which may affect clients that rely on the specific type string.

## Related issues

Aligns our implementation with the OpenAI API specification for file content blocks.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable