### PR TITLE
docs: added documentation for passing headers in integration sdks

### DIFF
--- a/docs/integrations/bedrock-sdk/overview.mdx
+++ b/docs/integrations/bedrock-sdk/overview.mdx
@@ -91,6 +91,49 @@ mistral_invoke_response = client.invoke_model(
 
 ---
 
+## Adding Custom Headers
+
+Pass custom headers required by Bifrost plugins (like governance, telemetry, etc.) using boto3's event system:
+
+<Tabs group="bedrock-sdk">
+<Tab title="Python">
+
+```python
+import boto3
+
+def add_bifrost_headers(request, **kwargs):
+    """Add custom Bifrost headers to the request before signing."""
+    request.headers.add_header("x-bf-vk", "vk_12345")  # Virtual key for governance
+    request.headers.add_header("x-bf-env", "production")  # Environment tag
+
+client = boto3.client(
+    service_name="bedrock-runtime",
+    endpoint_url="http://localhost:8080/bedrock",
+    region_name="us-west-2",
+    aws_access_key_id="bifrost-dummy-key",
+    aws_secret_access_key="bifrost-dummy-secret"
+)
+
+# Register the header injection for all Bedrock API calls
+client.meta.events.register_first(
+    "before-sign.bedrock-runtime.*",
+    add_bifrost_headers,
+)
+
+# Now make requests with custom headers
+response = client.converse(
+    modelId="anthropic.claude-3-5-sonnet-20240620-v1:0",
+    messages=[{"role": "user", "content": [{"text": "Hello with custom headers!"}]}]
+)
+```
+
+> **Note:** Use `register_first` to ensure headers are added before request signing. The event name format is `before-sign.<service-name>.<operation-name>`. You need to register for each API operation you plan to use (Converse, ConverseStream, InvokeModel, etc.).
+
+</Tab>
+</Tabs>
+
+---
+
 ## Streaming Examples
 
 ### Converse Stream

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -138,22 +138,134 @@ const googleResponse = await googleLlm.invoke("Hello Gemini!");
 
 ## Adding Custom Headers
 
-Add Bifrost-specific headers for governance and tracking:
+Add Bifrost-specific headers for governance and tracking. Different LangChain provider classes support different methods for adding custom headers:
 
 <Tabs group="langchain-sdk">
 <Tab title="Python">
+
+### ChatOpenAI
+
+Use `default_headers` parameter for OpenAI models:
 
 ```python
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 
-# Add custom headers for Bifrost features
 llm = ChatOpenAI(
     model="gpt-4o-mini",
     openai_api_base="http://localhost:8080/langchain",
     default_headers={
-        "x-bf-vk": "your-virtual-key",          # Virtual key for governance
+        "x-bf-vk": "your-virtual-key",
     }
+)
+
+response = llm.invoke([HumanMessage(content="Hello!")])
+print(response.content)
+```
+
+### ChatAnthropic
+
+Use `default_headers` parameter for Anthropic models:
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage
+
+llm = ChatAnthropic(
+    model="claude-3-sonnet-20240229",
+    anthropic_api_url="http://localhost:8080/langchain",
+    default_headers={
+        "x-bf-vk": "your-virtual-key",  # Virtual key for governance
+    }
+)
+
+response = llm.invoke([HumanMessage(content="Hello!")])
+print(response.content)
+```
+
+### ChatGoogleGenerativeAI
+
+Use `additional_headers` parameter for Google/Gemini models:
+
+```python
+from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_core.messages import HumanMessage
+
+llm = ChatGoogleGenerativeAI(
+    model="gemini-2.5-flash",
+    google_api_base="http://localhost:8080/langchain",
+    additional_headers={
+        "x-bf-vk": "your-virtual-key",  # Virtual key for governance
+    }
+)
+
+response = llm.invoke([HumanMessage(content="Hello!")])
+print(response.content)
+```
+### ChatBedrockConverse
+
+For Bedrock models, there are two approaches:
+
+**Method 1: Using the client's event system (after initialization)**
+
+```python
+from langchain_aws import ChatBedrockConverse
+from langchain_core.messages import HumanMessage
+
+llm = ChatBedrockConverse(
+    model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    region_name="us-west-2",
+    endpoint_url="http://localhost:8080/langchain",
+    aws_access_key_id="dummy-access-key",
+    aws_secret_access_key="dummy-secret-key",
+    max_tokens=2000
+)
+
+def add_bifrost_headers(request, **kwargs):
+    """Add custom headers to Bedrock requests"""
+    request.headers.add_header("x-bf-vk", "your-virtual-key")
+
+# Register header injection for all Bedrock operations
+llm.client.meta.events.register_first(
+    "before-sign.bedrock-runtime.*",
+    add_bifrost_headers
+)
+
+response = llm.invoke([HumanMessage(content="Hello!")])
+print(response.content)
+```
+
+**Method 2: Pre-configuring a boto3 client**
+
+```python
+from langchain_aws import ChatBedrockConverse
+from langchain_core.messages import HumanMessage
+import boto3
+
+# Create and configure boto3 client
+bedrock_client = boto3.client(
+    service_name="bedrock-runtime",
+    region_name="us-west-2",
+    endpoint_url="http://localhost:8080/langchain",
+    aws_access_key_id="dummy-access-key",
+    aws_secret_access_key="dummy-secret-key"
+)
+
+def add_bifrost_headers(request, **kwargs):
+    """Add custom headers to Bedrock requests"""
+    request.headers.add_header("x-bf-vk", "your-virtual-key")
+
+# Register header injection before creating LLM
+bedrock_client.meta.events.register_first(
+    "before-sign.bedrock-runtime.*",
+    add_bifrost_headers
+)
+
+# Pass the configured client to ChatBedrockConverse
+llm = ChatBedrockConverse(
+    model="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    client=bedrock_client,
+    max_tokens=2000
 )
 
 response = llm.invoke([HumanMessage(content="Hello!")])
@@ -163,17 +275,60 @@ print(response.content)
 </Tab>
 <Tab title="JavaScript">
 
+### ChatOpenAI
+
+Use `defaultHeaders` in configuration for OpenAI models:
+
 ```javascript
 import { ChatOpenAI } from "@langchain/openai";
 
-// Add custom headers for Bifrost features
 const llm = new ChatOpenAI({
   model: "gpt-4o-mini",
   configuration: {
     baseURL: "http://localhost:8080/langchain",
     defaultHeaders: {
-      "x-bf-vk": "your-virtual-key",          // Virtual key for governance
+      "x-bf-vk": "your-virtual-key",  // Virtual key for governance
     }
+  }
+});
+
+const response = await llm.invoke("Hello!");
+console.log(response.content);
+```
+
+### ChatAnthropic
+
+Use `defaultHeaders` in clientOptions for Anthropic models:
+
+```javascript
+import { ChatAnthropic } from "@langchain/anthropic";
+
+const llm = new ChatAnthropic({
+  model: "claude-3-sonnet-20240229",
+  clientOptions: {
+    baseURL: "http://localhost:8080/langchain",
+    defaultHeaders: {
+      "x-bf-vk": "your-virtual-key",  // Virtual key for governance
+    }
+  }
+});
+
+const response = await llm.invoke("Hello!");
+console.log(response.content);
+```
+
+### ChatGoogleGenerativeAI
+
+Use `additionalHeaders` for Google/Gemini models:
+
+```javascript
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+
+const llm = new ChatGoogleGenerativeAI({
+  model: "gemini-2.5-flash",
+  baseURL: "http://localhost:8080/langchain",
+  additionalHeaders: {
+    "x-bf-vk": "your-virtual-key",  // Virtual key for governance
   }
 });
 


### PR DESCRIPTION
## Summary

Added documentation for custom headers in Bedrock SDK and expanded LangChain SDK integration documentation with provider-specific header configuration examples.

## Changes

- Added a new section to Bedrock SDK documentation explaining how to add custom Bifrost headers using boto3's event system
- Expanded LangChain SDK documentation with detailed examples for adding custom headers to different providers:
  - ChatOpenAI (Python and JavaScript)
  - ChatAnthropic (Python and JavaScript)
  - ChatBedrockConverse (Python, with two implementation methods)
  - ChatGoogleGenerativeAI (Python and JavaScript)
- Included code samples demonstrating proper header configuration for each provider

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Build the documentation site locally:
```sh
cd docs
npm install
npm run dev
```

2. Navigate to the updated pages:
   - `/integrations/bedrock-sdk/overview` - Check the new "Adding Custom Headers" section
   - `/integrations/langchain-sdk` - Verify the expanded "Adding Custom Headers" section

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

Documentation includes examples of header-based authentication and governance mechanisms.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)