### PR TITLE
fixes openapi spec for extra fields

### DIFF
--- a/docs/apis/openapi.json
+++ b/docs/apis/openapi.json
@@ -8628,7 +8628,7 @@
             "description": "Unix timestamp of expiration"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8654,7 +8654,7 @@
             "type": "string"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8705,7 +8705,7 @@
             "type": "string"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8728,7 +8728,7 @@
             "type": "integer"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8748,7 +8748,7 @@
             "type": "boolean"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8837,7 +8837,7 @@
             "description": "Storage backend type"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8857,7 +8857,7 @@
             "type": "boolean"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8892,7 +8892,7 @@
             "type": "string"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },
@@ -8909,7 +8909,7 @@
             "type": "boolean"
           },
           "extra_fields": {
-            "$ref": "#/components/schemas/BifrostExtraFields"
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
           }
         }
       },


### PR DESCRIPTION
## Summary

Update Bifrost schema references in OpenAPI specification to use the more specific `BifrostResponseExtraFields` schema instead of the generic `BifrostExtraFields`.

## Changes

- Replaced all references to `BifrostExtraFields` with `BifrostResponseExtraFields` in the OpenAPI schema
- This change ensures more accurate API documentation by using the correct schema reference for response objects

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the OpenAPI schema is valid and correctly references the `BifrostResponseExtraFields` schema:

```sh
# Validate OpenAPI schema
npx @apidevtools/swagger-cli validate docs/apis/openapi.json
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is a documentation-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable