### PR TITLE
minor ux uplift, restart required status storage

### DIFF
--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -123,6 +123,11 @@ type ConfigStore interface {
 	GetProxyConfig(ctx context.Context) (*tables.GlobalProxyConfig, error)
 	UpdateProxyConfig(ctx context.Context, config *tables.GlobalProxyConfig) error
 
+	// Restart required config CRUD
+	GetRestartRequiredConfig(ctx context.Context) (*tables.RestartRequiredConfig, error)
+	SetRestartRequiredConfig(ctx context.Context, config *tables.RestartRequiredConfig) error
+	ClearRestartRequiredConfig(ctx context.Context) error
+
 	// Session CRUD
 	GetSession(ctx context.Context, token string) (*tables.SessionsTable, error)
 	CreateSession(ctx context.Context, session *tables.SessionsTable) error

--- a/framework/configstore/tables/config.go
+++ b/framework/configstore/tables/config.go
@@ -8,7 +8,15 @@ const (
 	ConfigIsAuthEnabledKey          = "is_auth_enabled"
 	ConfigDisableAuthOnInferenceKey = "disable_auth_on_inference"
 	ConfigProxyKey                  = "proxy_config"
+	ConfigRestartRequiredKey        = "restart_required"
 )
+
+// RestartRequiredConfig represents the restart required configuration
+// This is set when a config change requires a server restart to take effect
+type RestartRequiredConfig struct {
+	Required bool   `json:"required"`
+	Reason   string `json:"reason,omitempty"`
+}
 
 
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -411,6 +411,10 @@ func initStoresFromFile(ctx context.Context, config *Config, configData *ConfigD
 			return err
 		}
 		logger.Info("config store initialized")
+		// Clear restart required flag on server startup
+		if err = config.ConfigStore.ClearRestartRequiredConfig(ctx); err != nil {
+			logger.Warn("failed to clear restart required config: %v", err)
+		}
 	}
 
 	// Initialize log store
@@ -1520,6 +1524,11 @@ func loadConfigFromDefaults(ctx context.Context, config *Config, configDBPath, l
 	// Initialize default config store
 	if err = initDefaultConfigStore(ctx, config, configDBPath); err != nil {
 		return nil, err
+	}
+
+	// Clear restart required flag on server startup
+	if err = config.ConfigStore.ClearRestartRequiredConfig(ctx); err != nil {
+		logger.Warn("failed to clear restart required config: %v", err)
 	}
 
 	// Load or create default client config

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -89,7 +89,7 @@ export default function PricingConfigView() {
 					</div>
 					<div className="flex items-center gap-2">
 						<Button variant="outline" type="button" onClick={handleForceSync} disabled={isForceSyncing || !hasSettingsUpdateAccess}>
-							{isForceSyncing ? "Forcing..." : "Force Sync Now"}
+							{isForceSyncing ? "Syncing..." : "Force Sync Now"}
 						</Button>
 						<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
 							{isLoading ? "Saving..." : "Save Changes"}

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -238,7 +238,7 @@ export default function SecurityView() {
 										onChange={(e) => handleAuthFieldChange("admin_password", e.target.value)}
 									/>
 								</div>
-								<div className="flex items-center justify-between rounded-lg border p-4">
+								<div className="flex items-center justify-between">
 									<div className="space-y-0.5">
 										<Label htmlFor="disable-auth-inference" className="text-sm font-medium">
 											Disable authentication on inference calls

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -1,13 +1,13 @@
-"use client"
+"use client";
 
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons"
-import { ProviderName, RequestTypeColors, RequestTypeLabels, Status, StatusColors } from "@/lib/constants/logs"
-import { LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs"
-import { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown, Trash2 } from "lucide-react"
-import moment from "moment"
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderName, RequestTypeColors, RequestTypeLabels, Status, StatusBarColors } from "@/lib/constants/logs";
+import { LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
+import { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown, Trash2 } from "lucide-react";
+import moment from "moment";
 
 function getMessage(log?: LogEntry) {
 	if (log?.input_history && log.input_history.length > 0) {
@@ -48,14 +48,12 @@ function getMessage(log?: LogEntry) {
 export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess = true): ColumnDef<LogEntry>[] => [
 	{
 		accessorKey: "status",
-		header: "Status",
+		header: "",
+		size: 8,
+		maxSize: 8,
 		cell: ({ row }) => {
 			const status = row.original.status as Status;
-			return (
-				<Badge variant="secondary" className={`${StatusColors[status] ?? ""} font-mono text-xs uppercase`}>
-					{status}
-				</Badge>
-			);
+			return <div className={`h-full min-h-[24px] w-1 rounded-sm ${StatusBarColors[status]}`} />;
 		},
 	},
 	{
@@ -68,7 +66,7 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 		),
 		cell: ({ row }) => {
 			const timestamp = row.original.timestamp;
-			return <div className="font-mono text-xs">{moment(timestamp).format("YYYY-MM-DD hh:mm:ss A (Z)")}</div>;
+			return <div className="text-xs">{moment(timestamp).format("YYYY-MM-DD hh:mm:ss A (Z)")}</div>;
 		},
 	},
 	{
@@ -174,12 +172,12 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 	{
 		id: "actions",
 		cell: ({ row }) => {
-			const log = row.original
+			const log = row.original;
 			return (
 				<Button variant="outline" size="icon" onClick={() => onDelete(log)} disabled={!hasDeleteAccess}>
 					<Trash2 />
 				</Button>
-			)
+			);
 		},
 	},
-]
+];

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -628,6 +628,20 @@ export default function AppSidebar() {
 	// Memoize promo cards array to prevent duplicates and unnecessary re-renders
 	const promoCards = useMemo(() => {
 		const cards = [];
+		// Restart required card - non-dismissible, shown first
+		if (coreConfig?.restart_required?.required) {
+			cards.push({
+				id: "restart-required",
+				title: "Restart Required",
+				description: (
+					<div className="text-xs text-amber-700 dark:text-amber-300/80">
+						{coreConfig.restart_required.reason || "Configuration changes require a server restart to take effect."}
+					</div>
+				),
+				dismissible: false,
+				variant: "warning" as const,
+			});
+		}
 		if (showNewReleaseBanner && latestRelease) {
 			cards.push({
 				id: "new-release",
@@ -651,7 +665,7 @@ export default function AppSidebar() {
 			cards.push(productionSetupHelpCard);
 		}
 		return cards;
-	}, [showNewReleaseBanner, latestRelease, newReleaseImage]);
+	}, [coreConfig?.restart_required, showNewReleaseBanner, latestRelease, newReleaseImage]);
 
 	// Reset areCardsEmpty when promoCards changes
 	useEffect(() => {

--- a/ui/components/ui/promoCardStack.tsx
+++ b/ui/components/ui/promoCardStack.tsx
@@ -10,6 +10,7 @@ interface PromoCardItem {
 	title: string | React.ReactElement;
 	description: string | React.ReactElement;
 	dismissible?: boolean;
+	variant?: "default" | "warning";
 }
 
 interface PromoCardStackProps {
@@ -20,10 +21,12 @@ interface PromoCardStackProps {
 
 export function PromoCardStack({ cards, className = "", onCardsEmpty }: PromoCardStackProps) {
 	const [items, setItems] = useState(() => {
+		// Sort so non-dismissible cards appear at the top
 		return [...cards].sort((a, b) => {
 			const aDismissible = a.dismissible !== false;
 			const bDismissible = b.dismissible !== false;
-			return bDismissible === aDismissible ? 0 : aDismissible ? -1 : 1;
+			if (aDismissible === bDismissible) return 0;
+			return aDismissible ? 1 : -1; // Non-dismissible first
 		});
 	});
 	const [removingId, setRemovingId] = useState<string | null>(null);
@@ -31,10 +34,12 @@ export function PromoCardStack({ cards, className = "", onCardsEmpty }: PromoCar
 	const prevLenRef = React.useRef(items.length);
 
 	useEffect(() => {
+		// Sort so non-dismissible cards appear at the top
 		const sortedCards = [...cards].sort((a, b) => {
 			const aDismissible = a.dismissible !== false;
 			const bDismissible = b.dismissible !== false;
-			return bDismissible === aDismissible ? 0 : aDismissible ? -1 : 1;
+			if (aDismissible === bDismissible) return 0;
+			return aDismissible ? 1 : -1; // Non-dismissible first
 		});
 		setItems(sortedCards);
 	}, [cards]);
@@ -93,9 +98,13 @@ export function PromoCardStack({ cards, className = "", onCardsEmpty }: PromoCar
 							className={cn(
 								"flex h-full w-full flex-col gap-0 rounded-lg px-2.5 py-2",
 								visibleCards.length < 2 ? "shadow-none" : "shadow-md",
+								card.variant === "warning" && "border-amber-500/50 bg-amber-50 dark:border-amber-500/70 dark:bg-amber-950/20",
 							)}
 						>
-							<CardHeader className="text-muted-foreground flex-shrink-0 p-1 text-sm font-medium">
+							<CardHeader className={cn(
+								"flex-shrink-0 p-1 text-sm font-medium",
+								card.variant === "warning" ? "text-amber-800 dark:text-amber-400" : "text-muted-foreground",
+							)}>
 								<div className="flex items-start justify-between">
 									<div className="min-w-0 flex-1">{typeof card.title === "string" ? card.title : card.title}</div>
 									{card.dismissible !== false && isTopCard && (

--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -72,11 +72,11 @@ function SheetContent({
 					className={cn(
 						"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col shadow-lg transition-all ease-in-out data-[state=closed]:duration-100 data-[state=open]:duration-100",
 						side === "right" &&
-							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 bottom-2 right-0 h-auto w-3/4 border-l rounded-l-lg",
+							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 right-0 bottom-2 h-auto w-3/4 rounded-l-lg border-l",
 						side === "right" && (!expandable || !expanded) && "sm:max-w-2xl",
 						side === "right" && expandable && expanded && "sm:max-w-5xl",
 						side === "left" &&
-							"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-0 h-auto w-3/4 border-r rounded-r-lg sm:max-w-sm",
+							"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-0 h-auto w-3/4 rounded-r-lg border-r sm:max-w-sm",
 						side === "top" && "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
 						side === "bottom" &&
 							"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
@@ -91,36 +91,36 @@ function SheetContent({
 	);
 }
 
-function SheetHeader({ className, children, ...props }: React.ComponentProps<"div">) {
+function SheetHeader({
+	className,
+	children,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<"div"> & { showCloseButton?: boolean }) {
 	const sheetContext = useSheetContext();
 
 	return (
-		<div
-			data-slot="sheet-header"
-			className={cn("flex items-center gap-3 mb-6", sheetContext?.expandable ? "p-4" : "mb-6")}
-			{...props}
-		>
+		<div data-slot="sheet-header" className={cn("flex items-center", sheetContext?.expandable ? "p-0" : "mb-6")} {...props}>
 			{sheetContext?.expandable && sheetContext?.side === "right" && (
 				<button
 					type="button"
 					onClick={() => sheetContext?.setExpanded(!sheetContext?.expanded)}
-					className="opacity-70 transition-opacity hover:opacity-100 cursor-pointer hover:scale-105 shrink-0 -ml-5"
+					className="-ml-5 shrink-0 cursor-pointer opacity-70 transition-opacity hover:scale-105 hover:opacity-100"
 				>
-					{sheetContext?.expanded ? (
-						<ArrowRightFromLineIcon className="size-4" />
-					) : (
-						<ArrowLeftFromLineIcon className="size-4" />
-					)}
+					{sheetContext?.expanded ? <ArrowRightFromLineIcon className="size-4" /> : <ArrowLeftFromLineIcon className="size-4" />}
 					<span className="sr-only">{sheetContext?.expanded ? "Collapse" : "Expand"}</span>
 				</button>
 			)}
-			<div className={cn("flex flex-row flex-1 min-w-0 h-full items-center", className)}>
+
+			<div className={cn("flex h-full min-w-0 flex-1 flex-row items-center", sheetContext?.expandable ? "ml-1" : "", className)}>
 				{children}
 			</div>
-			<SheetPrimitive.Close className="opacity-70 transition-opacity hover:opacity-100 cursor-pointer hover:scale-105 shrink-0">
-				<XIcon className="size-4" />
-				<span className="sr-only">Close</span>
-			</SheetPrimitive.Close>
+			{showCloseButton && (
+				<SheetPrimitive.Close className="hover:bg-accent shrink-0 cursor-pointer rounded-md p-2 opacity-70 transition-opacity hover:scale-105 hover:opacity-100">
+					<XIcon className="size-4" />
+					<span className="sr-only">Close</span>
+				</SheetPrimitive.Close>
+			)}
 		</div>
 	);
 }
@@ -138,4 +138,3 @@ function SheetDescription({ className, ...props }: React.ComponentProps<typeof S
 }
 
 export { Sheet, SheetClose, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle, SheetTrigger };
-

--- a/ui/components/ui/toggle.tsx
+++ b/ui/components/ui/toggle.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { Switch } from "./switch";
+import { cn } from "./utils";
 
 interface Props {
+	className?: string;
 	label?: string;
 	val: boolean;
 	setVal: React.Dispatch<React.SetStateAction<boolean>> | ((val: boolean) => void);
@@ -10,11 +12,14 @@ interface Props {
 	caption?: string;
 }
 
-const Toggle = ({ label, val, setVal, required = false, disabled = false, caption }: Props) => {
+const Toggle = ({ className, label, val, setVal, required = false, disabled = false, caption }: Props) => {
 	return (
 		<div className="w-full">
 			<label
-				className={`dark:bg-input/30 flex w-full items-center justify-between gap-2 rounded-lg border px-2 py-2 text-sm select-none ${disabled ? "cursor-default" : "cursor-pointer"}`}
+				className={cn(
+					`dark:bg-input/30 flex w-full items-center justify-between gap-2 py-2 text-sm select-none ${disabled ? "cursor-default" : "cursor-pointer"}`,
+					className,
+				)}
 			>
 				{label && (
 					<div className="">

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -81,6 +81,13 @@ export const StatusColors = {
 	cancelled: "bg-gray-100 text-gray-800",
 } as const;
 
+export const StatusBarColors = {
+	success: "bg-green-500",
+	error: "bg-red-500",
+	processing: "bg-blue-500",
+	cancelled: "bg-gray-400",
+} as const;
+
 export const RequestTypeLabels = {
 	"chat.completion": "Chat",
 	response: "Responses",

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -299,12 +299,19 @@ export const DefaultGlobalProxyConfig: GlobalProxyConfig = {
 	enable_for_api: false,
 };
 
+// Restart required configuration
+export interface RestartRequiredConfig {
+	required: boolean;
+	reason?: string;
+}
+
 // Bifrost Config
 export interface BifrostConfig {
 	client_config: CoreConfig;
 	framework_config: FrameworkConfig;
 	auth_config?: AuthConfig;
 	proxy_config?: GlobalProxyConfig;
+	restart_required?: RestartRequiredConfig;
 	is_db_connected: boolean;
 	is_cache_connected: boolean;
 	is_logs_connected: boolean;


### PR DESCRIPTION
## Summary

Adds a restart required notification system to inform users when configuration changes require a server restart to take full effect.

## Changes

- Added `RestartRequiredConfig` data structure to track when a restart is needed
- Implemented database methods to get, set, and clear restart required status
- Added logic to set restart flag when specific configuration changes are made
- Created a non-dismissible warning banner in the UI sidebar when restart is required
- Improved UI components for better visual indication of restart requirements
- Automatically clears restart flag on server startup

## Type of change

- [x] Feature
- [x] UI (Next.js)

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)

## How to test

1. Start the server
2. Make configuration changes that require restart (e.g., change auth settings, proxy config)
3. Verify the restart warning appears in the sidebar
4. Restart the server and verify the warning disappears

```sh
# Core/Transports
go run cmd/bifrost/main.go

# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is a UI notification feature.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable