### PR TITLE
fix: thought signature handling in gemini chat completion tool call

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -717,11 +717,10 @@ type ChatAssistantMessageAnnotationCitation struct {
 
 // ChatAssistantMessageToolCall represents a tool call in a message
 type ChatAssistantMessageToolCall struct {
-	Index        uint16                               `json:"index"`
-	Type         *string                              `json:"type,omitempty"`
-	ID           *string                              `json:"id,omitempty"`
-	Function     ChatAssistantMessageToolCallFunction `json:"function"`
-	ExtraContent map[string]interface{}               `json:"extra_content,omitempty"` // Provider-specific fields (e.g., thought_signature for Gemini)
+	Index    uint16                               `json:"index"`
+	Type     *string                              `json:"type,omitempty"`
+	ID       *string                              `json:"id,omitempty"`
+	Function ChatAssistantMessageToolCallFunction `json:"function"`
 }
 
 // ChatAssistantMessageToolCallFunction represents a call to a function.
@@ -762,6 +761,7 @@ const (
 
 // Not in OpenAI's spec, but needed to support inter provider reasoning capabilities.
 type ChatReasoningDetails struct {
+	ID        *string                     `json:"id,omitempty"`
 	Index     int                         `json:"index"`
 	Type      BifrostReasoningDetailsType `json:"type"`
 	Summary   *string                     `json:"summary,omitempty"`


### PR DESCRIPTION
## Summary

Refactored how thought signatures are handled for Gemini tool calls by moving them from `ExtraContent` to the `ReasoningDetails` structure with proper ID linking.

## Changes

- Removed thought signatures from tool call's `ExtraContent` map
- Added ID field to `ChatReasoningDetails` struct to link reasoning details to specific tool calls
- Modified the conversion logic to look up thought signatures in reasoning details using the tool call ID
- Enhanced the reasoning details creation to include tool call IDs when applicable
- Implemented a consistent ID format (`tool_call_<callID>`) for linking tool calls with their reasoning details

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Gemini provider with tool calls to ensure thought signatures are properly preserved:

```sh
# Core/Transports
go version
go test ./core/providers/gemini/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change maintains the same security properties for thought signatures but reorganizes how they're stored and retrieved in the data structures.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable