### PR TITLE
fix: handle nil reasoning text in Bedrock responses

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -671,13 +671,13 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 				})
 
 				// If there's text content, also emit the delta
-				if reasoningDelta.Text != "" {
+				if reasoningDelta.Text != nil && *reasoningDelta.Text != "" {
 					deltaResponse := &schemas.BifrostResponsesStreamResponse{
 						Type:           schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
 						SequenceNumber: sequenceNumber + len(responses),
 						OutputIndex:    schemas.Ptr(outputIndex),
 						ContentIndex:   &contentBlockIndex,
-						Delta:          &reasoningDelta.Text,
+						Delta:          reasoningDelta.Text,
 						ItemID:         &itemID,
 					}
 					responses = append(responses, deltaResponse)
@@ -686,14 +686,14 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 				return responses, nil, false
 			} else {
 				// Subsequent reasoning deltas - just emit the delta
-				if reasoningDelta.Text != "" {
+				if reasoningDelta.Text != nil && *reasoningDelta.Text != "" {
 					itemID := state.ItemIDs[outputIndex]
 					response := &schemas.BifrostResponsesStreamResponse{
 						Type:           schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta,
 						SequenceNumber: sequenceNumber,
 						OutputIndex:    schemas.Ptr(outputIndex),
 						ContentIndex:   &contentBlockIndex,
-						Delta:          &reasoningDelta.Text,
+						Delta:          reasoningDelta.Text,
 					}
 					if itemID != "" {
 						response.ItemID = &itemID
@@ -1074,7 +1074,7 @@ func ToBedrockConverseStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 			// This is reasoning text delta
 			event.Delta = &BedrockContentBlockDelta{
 				ReasoningContent: &BedrockReasoningContentText{
-					Text: *bifrostResp.Delta,
+					Text: bifrostResp.Delta,
 				},
 			}
 		} else {
@@ -2665,7 +2665,7 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *context.Context, msg *Bed
 			if block.ReasoningContent.ReasoningText != nil {
 				reasoningContentBlocks = append(reasoningContentBlocks, schemas.ResponsesMessageContentBlock{
 					Type:      schemas.ResponsesOutputMessageContentTypeReasoning,
-					Text:      &block.ReasoningContent.ReasoningText.Text,
+					Text:      block.ReasoningContent.ReasoningText.Text,
 					Signature: block.ReasoningContent.ReasoningText.Signature,
 				})
 			}
@@ -2856,7 +2856,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 				reasoningBlock := BedrockContentBlock{
 					ReasoningContent: &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
-							Text:      *block.Text,
+							Text:      block.Text,
 							Signature: block.Signature,
 						},
 					},
@@ -2870,7 +2870,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 				reasoningBlock := BedrockContentBlock{
 					ReasoningContent: &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
-							Text: reasoningContent.Text,
+							Text: &reasoningContent.Text,
 						},
 					},
 				}
@@ -2883,7 +2883,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 			reasoningBlock := BedrockContentBlock{
 				ReasoningContent: &BedrockReasoningContent{
 					ReasoningText: &BedrockReasoningContentText{
-						Text: encryptedText,
+						Text: &encryptedText,
 					},
 				},
 			}
@@ -2921,7 +2921,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(content s
 				if block.Text != nil {
 					bedrockBlock.ReasoningContent = &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
-							Text:      *block.Text,
+							Text:      block.Text,
 							Signature: block.Signature,
 						},
 					}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -248,7 +248,7 @@ type BedrockReasoningContent struct {
 }
 
 type BedrockReasoningContentText struct {
-	Text      string  `json:"text"`
+	Text      *string `json:"text,omitempty"`
 	Signature *string `json:"signature,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Fixed handling of nullable text fields in Bedrock provider to prevent potential nil pointer dereferences when processing reasoning content. Closes #1173

## Changes

- Modified `BedrockReasoningContentText.Text` field type from `string` to `*string` to properly handle nullable text values
- Updated all references to this field throughout the codebase to handle the pointer type correctly
- Added nil checks before dereferencing text pointers to prevent runtime panics
- Fixed string concatenation operations to safely handle nil text values

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Bedrock provider with various reasoning content scenarios:

```sh
# Core/Transports
go version
go test ./core/providers/bedrock/...
```

Specifically test scenarios where reasoning text might be null or empty to ensure proper handling.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change prevents potential nil pointer dereferences which could lead to application crashes when processing Bedrock API responses with null text fields.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable