### PR TITLE
fixes plugin status sync from UI

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -755,12 +755,13 @@ func (s *BifrostHTTPServer) GetPluginStatus(ctx context.Context) []schemas.Plugi
 }
 
 // SyncLoadedPlugin syncs the loaded plugin to the Bifrost core.
-func (s *BifrostHTTPServer) SyncLoadedPlugin(ctx context.Context, plugin schemas.Plugin) error {
+// configName is the name from the configuration/database, used for status tracking.
+func (s *BifrostHTTPServer) SyncLoadedPlugin(ctx context.Context, configName string, plugin schemas.Plugin) error {
 	if err := s.Client.ReloadPlugin(plugin); err != nil {
-		s.UpdatePluginStatus(plugin.GetName(), schemas.PluginStatusError, []string{fmt.Sprintf("error reloading plugin %s: %v", plugin.GetName(), err)})
+		s.UpdatePluginStatus(configName, schemas.PluginStatusError, []string{fmt.Sprintf("error reloading plugin %s: %v", configName, err)})
 		return err
 	}
-	s.UpdatePluginStatus(plugin.GetName(), schemas.PluginStatusActive, []string{fmt.Sprintf("plugin %s reloaded successfully", plugin.GetName())})
+	s.UpdatePluginStatus(configName, schemas.PluginStatusActive, []string{fmt.Sprintf("plugin %s reloaded successfully", configName)})
 	// CAS retry loop (matching bifrost.go pattern)
 	for {
 		oldPlugins := s.Config.Plugins.Load()
@@ -805,7 +806,7 @@ func (s *BifrostHTTPServer) ReloadPlugin(ctx context.Context, name string, path 
 		s.UpdatePluginStatus(name, schemas.PluginStatusError, []string{fmt.Sprintf("error loading plugin %s: %v", name, err)})
 		return err
 	}
-	return s.SyncLoadedPlugin(ctx, newPlugin)
+	return s.SyncLoadedPlugin(ctx, name, newPlugin)
 }
 
 // ReloadPricingManager reloads the pricing manager

--- a/ui/app/workspace/plugins/page.tsx
+++ b/ui/app/workspace/plugins/page.tsx
@@ -121,7 +121,13 @@ export default function PluginsPage() {
 					}}
 				/>
 			</div>
-			<AddNewPluginSheet open={isSheetOpen} onClose={handleCloseSheet} />
+			<AddNewPluginSheet
+			open={isSheetOpen}
+			onClose={handleCloseSheet}
+			onCreate={(pluginName) => {
+				setSelectedPluginId(pluginName);
+			}}
+		/>
 		</div>
 	);
 }

--- a/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
@@ -55,10 +55,11 @@ type PluginFormData = z.infer<typeof pluginFormSchema>;
 interface AddNewPluginSheetProps {
 	open: boolean;
 	onClose: () => void;
+	onCreate?: (pluginName: string) => void;
 	plugin?: Plugin | null;
 }
 
-export default function AddNewPluginSheet({ open, onClose, plugin }: AddNewPluginSheetProps) {
+export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: AddNewPluginSheetProps) {
 	const hasCreatePluginAccess = useRbac(RbacResource.Plugins, RbacOperation.Create);
 	const hasUpdatePluginAccess = useRbac(RbacResource.Plugins, RbacOperation.Update);
 	const [createPlugin, { isLoading: isCreating }] = useCreatePluginMutation();
@@ -121,19 +122,21 @@ export default function AddNewPluginSheet({ open, onClose, plugin }: AddNewPlugi
 					},
 				}).unwrap();
 				toast.success("Plugin updated successfully");
-			} else {
-				// Create new plugin
-				await createPlugin({
-					name: data.name,
-					path: data.path,
-					enabled: true,
-					config: parsedConfig,
-				}).unwrap();
-				toast.success("Plugin created successfully");
-			}
+		} else {
+			// Create new plugin
+			await createPlugin({
+				name: data.name,
+				path: data.path,
+				enabled: true,
+				config: parsedConfig,
+			}).unwrap();
+			toast.success("Plugin created successfully");
+			// Notify parent with the config name to select it
+			onCreate?.(data.name);
+		}
 
-			form.reset();
-			onClose();
+		form.reset();
+		onClose();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}


### PR DESCRIPTION
## Fix plugin status tracking with configuration name

This PR fixes an issue where plugin status tracking was using the plugin's internal name instead of the configuration name, which could cause status tracking inconsistencies.

## Changes

- Modified `SyncLoadedPlugin` in the Bifrost HTTP server to accept a `configName` parameter, which is used for status tracking instead of the plugin's internal name
- Updated the `ReloadPlugin` function to pass the configuration name to `SyncLoadedPlugin`
- Enhanced the UI's `AddNewPluginSheet` component to automatically select newly created plugins by adding an `onCreate` callback
- Implemented the callback in the plugins page to set the selected plugin after creation

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create a new plugin through the UI
2. Verify the plugin is automatically selected after creation
3. Check that plugin status is correctly tracked using the configuration name

```sh
# Core/Transports
go test ./transports/bifrost-http/server/...

# UI
cd ui
pnpm i
pnpm test
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes inconsistent plugin status tracking when plugin internal names differ from configuration names.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)