### PR TITLE
fix: array items handling in Gemini tool conversion

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/testutil"
+	"github.com/maximhq/bifrost/core/providers/gemini"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -73,4 +76,416 @@ func TestGemini(t *testing.T) {
 		testutil.RunAllComprehensiveTests(t, client, ctx, testConfig)
 	})
 	client.Shutdown()
+}
+
+// TestBifrostToGeminiToolConversion tests the conversion of tools from Bifrost to Gemini format
+func TestBifrostToGeminiToolConversion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *schemas.BifrostChatRequest
+		validate func(t *testing.T, result *gemini.GeminiGenerationRequest)
+	}{
+		{
+			name: "ComprehensiveToolWithArrayAndEnum",
+			input: &schemas.BifrostChatRequest{
+				Model: "gemini-2.0-flash",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test comprehensive tool"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					Tools: []schemas.ChatTool{
+						{
+							Type: schemas.ChatToolTypeFunction,
+							Function: &schemas.ChatToolFunction{
+								Name:        "search_products",
+								Description: schemas.Ptr("Search for products with filters"),
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: &schemas.OrderedMap{
+										"query": map[string]interface{}{
+											"type":        "string",
+											"description": "Search query",
+										},
+										"category": map[string]interface{}{
+											"type":        "string",
+											"description": "Product category",
+											"enum":        []interface{}{"electronics", "books", "clothing"},
+										},
+										"tags": map[string]interface{}{
+											"type":        "array",
+											"description": "Filter tags",
+											"items": map[string]interface{}{
+												"type":        "string",
+												"description": "A tag",
+											},
+										},
+									},
+									Required: []string{"query"},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				require.Len(t, result.Tools, 1)
+				fd := result.Tools[0].FunctionDeclarations[0]
+
+				// Basic validation
+				assert.Equal(t, "search_products", fd.Name)
+				assert.Equal(t, "Search for products with filters", fd.Description)
+				assert.Equal(t, []string{"query"}, fd.Parameters.Required)
+
+				// String property
+				queryProp := fd.Parameters.Properties["query"]
+				assert.Equal(t, gemini.Type("string"), queryProp.Type)
+
+				// Enum property
+				categoryProp := fd.Parameters.Properties["category"]
+				assert.Equal(t, gemini.Type("string"), categoryProp.Type)
+				assert.Equal(t, []string{"electronics", "books", "clothing"}, categoryProp.Enum)
+
+				// Array with items (the critical bug fix)
+				tagsProp := fd.Parameters.Properties["tags"]
+				assert.Equal(t, gemini.Type("array"), tagsProp.Type)
+				require.NotNil(t, tagsProp.Items, "items field must be present - this was the bug")
+				assert.Equal(t, gemini.Type("string"), tagsProp.Items.Type)
+			},
+		},
+		{
+			name: "ComplexNestedStructures",
+			input: &schemas.BifrostChatRequest{
+				Model: "gemini-2.0-flash",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test nested structures"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					Tools: []schemas.ChatTool{
+						{
+							Type: schemas.ChatToolTypeFunction,
+							Function: &schemas.ChatToolFunction{
+								Name:        "process_order",
+								Description: schemas.Ptr("Process customer order"),
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: &schemas.OrderedMap{
+										"customer": map[string]interface{}{
+											"type": "object",
+											"properties": map[string]interface{}{
+												"name": map[string]interface{}{
+													"type": "string",
+												},
+												"email": map[string]interface{}{
+													"type": "string",
+												},
+											},
+											"required": []string{"name", "email"},
+										},
+										"items": map[string]interface{}{
+											"type": "array",
+											"items": map[string]interface{}{
+												"type": "object",
+												"properties": map[string]interface{}{
+													"product_id": map[string]interface{}{
+														"type": "string",
+													},
+													"quantity": map[string]interface{}{
+														"type": "integer",
+													},
+												},
+												"required": []string{"product_id", "quantity"},
+											},
+										},
+									},
+									Required: []string{"customer", "items"},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				require.Len(t, result.Tools, 1)
+				fd := result.Tools[0].FunctionDeclarations[0]
+
+				// Nested object
+				customerProp := fd.Parameters.Properties["customer"]
+				assert.Equal(t, gemini.Type("object"), customerProp.Type)
+				assert.Contains(t, customerProp.Properties, "name")
+				assert.Contains(t, customerProp.Properties, "email")
+				assert.Equal(t, []string{"name", "email"}, customerProp.Required)
+
+				// Array of objects
+				itemsProp := fd.Parameters.Properties["items"]
+				assert.Equal(t, gemini.Type("array"), itemsProp.Type)
+				require.NotNil(t, itemsProp.Items, "array items must be present")
+				assert.Equal(t, gemini.Type("object"), itemsProp.Items.Type)
+				assert.Contains(t, itemsProp.Items.Properties, "product_id")
+				assert.Contains(t, itemsProp.Items.Properties, "quantity")
+				assert.Equal(t, []string{"product_id", "quantity"}, itemsProp.Items.Required)
+			},
+		},
+		{
+			name: "EmptyItemsObject",
+			input: &schemas.BifrostChatRequest{
+				Model: "gemini-2.0-flash",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Edge case test"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					Tools: []schemas.ChatTool{
+						{
+							Type: schemas.ChatToolTypeFunction,
+							Function: &schemas.ChatToolFunction{
+								Name: "test_tool",
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: &schemas.OrderedMap{
+										"data": map[string]interface{}{
+											"type":  "array",
+											"items": map[string]interface{}{}, // Empty items object
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				fd := result.Tools[0].FunctionDeclarations[0]
+				dataProp := fd.Parameters.Properties["data"]
+
+				// Even empty items should be converted (not nil)
+				assert.NotNil(t, dataProp.Items, "empty items object should still be present")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gemini.ToGeminiChatCompletionRequest(tt.input)
+			require.NotNil(t, result, "Conversion should not return nil")
+			tt.validate(t, result)
+		})
+	}
+}
+
+// TestBifrostResponsesToGeminiToolConversion tests the conversion of tools from Bifrost Responses API to Gemini format
+func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *schemas.BifrostResponsesRequest
+		validate func(t *testing.T, result *gemini.GeminiGenerationRequest)
+	}{
+		{
+			name: "ResponsesAPI_ArrayWithItems",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-2.0-flash",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Test array items"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type:        schemas.ResponsesToolTypeFunction,
+							Name:        schemas.Ptr("filter_data"),
+							Description: schemas.Ptr("Filter data with criteria"),
+							ResponsesToolFunction: &schemas.ResponsesToolFunction{
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: &schemas.OrderedMap{
+										"filters": map[string]interface{}{
+											"type":        "array",
+											"description": "List of filters",
+											"items": map[string]interface{}{
+												"type":        "string",
+												"description": "Filter criterion",
+											},
+										},
+										"sort_order": map[string]interface{}{
+											"type": "string",
+											"enum": []interface{}{"asc", "desc"},
+										},
+									},
+									Required: []string{"filters"},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				require.Len(t, result.Tools, 1)
+				fd := result.Tools[0].FunctionDeclarations[0]
+
+				assert.Equal(t, "filter_data", fd.Name)
+				assert.Equal(t, "Filter data with criteria", fd.Description)
+
+				// Array with items - critical test
+				filtersProp := fd.Parameters.Properties["filters"]
+				assert.Equal(t, gemini.Type("array"), filtersProp.Type)
+				require.NotNil(t, filtersProp.Items, "items field must be present in Responses API conversion")
+				assert.Equal(t, gemini.Type("string"), filtersProp.Items.Type)
+				assert.Equal(t, "Filter criterion", filtersProp.Items.Description)
+
+				// Enum validation
+				sortProp := fd.Parameters.Properties["sort_order"]
+				assert.Equal(t, []string{"asc", "desc"}, sortProp.Enum)
+			},
+		},
+		{
+			name: "ResponsesAPI_ComplexNestedArrayOfObjects",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-2.0-flash",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Complex test"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type:        schemas.ResponsesToolTypeFunction,
+							Name:        schemas.Ptr("batch_update"),
+							Description: schemas.Ptr("Update multiple records"),
+							ResponsesToolFunction: &schemas.ResponsesToolFunction{
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: &schemas.OrderedMap{
+										"updates": map[string]interface{}{
+											"type": "array",
+											"items": map[string]interface{}{
+												"type": "object",
+												"properties": map[string]interface{}{
+													"id": map[string]interface{}{
+														"type": "string",
+													},
+													"fields": map[string]interface{}{
+														"type": "object",
+														"properties": map[string]interface{}{
+															"name": map[string]interface{}{
+																"type": "string",
+															},
+															"status": map[string]interface{}{
+																"type": "string",
+																"enum": []string{"active", "inactive"},
+															},
+														},
+													},
+												},
+												"required": []string{"id", "fields"},
+											},
+										},
+									},
+									Required: []string{"updates"},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				require.Len(t, result.Tools, 1)
+				fd := result.Tools[0].FunctionDeclarations[0]
+
+				updatesProp := fd.Parameters.Properties["updates"]
+				assert.Equal(t, gemini.Type("array"), updatesProp.Type)
+
+				// Nested object in array items
+				require.NotNil(t, updatesProp.Items)
+				assert.Equal(t, gemini.Type("object"), updatesProp.Items.Type)
+				assert.Contains(t, updatesProp.Items.Properties, "id")
+				assert.Contains(t, updatesProp.Items.Properties, "fields")
+				assert.Equal(t, []string{"id", "fields"}, updatesProp.Items.Required)
+
+				// Deeply nested object
+				fieldsProp := updatesProp.Items.Properties["fields"]
+				assert.Equal(t, gemini.Type("object"), fieldsProp.Type)
+				assert.Contains(t, fieldsProp.Properties, "name")
+				assert.Contains(t, fieldsProp.Properties, "status")
+
+				// Nested enum
+				statusProp := fieldsProp.Properties["status"]
+				assert.Equal(t, []string{"active", "inactive"}, statusProp.Enum)
+			},
+		},
+		{
+			name: "ResponsesAPI_EmptyItems",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-2.0-flash",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Edge case"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type: schemas.ResponsesToolTypeFunction,
+							Name: schemas.Ptr("edge_case_tool"),
+							ResponsesToolFunction: &schemas.ResponsesToolFunction{
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: &schemas.OrderedMap{
+										"any_array": map[string]interface{}{
+											"type":  "array",
+											"items": map[string]interface{}{}, // Empty items
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				fd := result.Tools[0].FunctionDeclarations[0]
+				arrayProp := fd.Parameters.Properties["any_array"]
+
+				// Empty items should still be converted
+				assert.NotNil(t, arrayProp.Items, "empty items must be present in Responses API")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gemini.ToGeminiResponsesRequest(tt.input)
+			require.NotNil(t, result, "Responses API conversion should not return nil")
+			tt.validate(t, result)
+		})
+	}
 }

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2095,7 +2095,7 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 						}(),
 						Parameters: func() *Schema {
 							if tool.ResponsesToolFunction.Parameters != nil {
-								return convertFunctionParametersToGeminiSchema(*tool.ResponsesToolFunction.Parameters)
+								return convertFunctionParametersToSchema(*tool.ResponsesToolFunction.Parameters)
 							}
 							return nil
 						}(),
@@ -2156,80 +2156,6 @@ func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice)
 	}
 
 	return config
-}
-
-// convertFunctionParametersToGeminiSchema converts function parameters to Gemini Schema
-func convertFunctionParametersToGeminiSchema(params schemas.ToolFunctionParameters) *Schema {
-	schema := &Schema{
-		Type: Type(params.Type),
-	}
-
-	if params.Description != nil {
-		schema.Description = *params.Description
-	}
-
-	if params.Properties != nil {
-		schema.Properties = make(map[string]*Schema)
-		for key, prop := range *params.Properties {
-			propSchema := convertPropertyToGeminiSchema(prop)
-			schema.Properties[key] = propSchema
-		}
-	}
-
-	if len(params.Required) > 0 {
-		schema.Required = params.Required
-	}
-
-	return schema
-}
-
-// convertPropertyToGeminiSchema converts a property to Gemini Schema
-func convertPropertyToGeminiSchema(prop interface{}) *Schema {
-	schema := &Schema{}
-
-	// Handle property as map[string]interface{}
-	if propMap, ok := prop.(map[string]interface{}); ok {
-		if propType, exists := propMap["type"]; exists {
-			if typeStr, ok := propType.(string); ok {
-				schema.Type = Type(typeStr)
-			}
-		}
-
-		if desc, exists := propMap["description"]; exists {
-			if descStr, ok := desc.(string); ok {
-				schema.Description = descStr
-			}
-		}
-
-		if enum, exists := propMap["enum"]; exists {
-			if enumSlice, ok := enum.([]interface{}); ok {
-				var enumStrs []string
-				for _, item := range enumSlice {
-					if str, ok := item.(string); ok {
-						enumStrs = append(enumStrs, str)
-					}
-				}
-				schema.Enum = enumStrs
-			}
-		}
-
-		// Handle nested properties for object types
-		if props, exists := propMap["properties"]; exists {
-			if propsMap, ok := props.(map[string]interface{}); ok {
-				schema.Properties = make(map[string]*Schema)
-				for key, nestedProp := range propsMap {
-					schema.Properties[key] = convertPropertyToGeminiSchema(nestedProp)
-				}
-			}
-		}
-
-		// Handle array items
-		if items, exists := propMap["items"]; exists {
-			schema.Items = convertPropertyToGeminiSchema(items)
-		}
-	}
-
-	return schema
 }
 
 // convertResponsesMessagesToGeminiContents converts Responses messages to Gemini contents


### PR DESCRIPTION
## Summary

Fix a critical bug in the Gemini provider's tool conversion logic where array items were not properly handled, causing tool calls to fail when using array parameters.

## Changes

- Fixed the tool conversion logic to properly handle array items in function parameters
- Consolidated duplicate code by removing `convertFunctionParametersToGeminiSchema` and using the existing `convertFunctionParametersToSchema` function
- Enhanced the property conversion to properly handle nested structures, enums, and required fields
- Added comprehensive tests to verify the tool conversion logic works correctly with various parameter types

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the new tests to verify the tool conversion logic:

```sh
go test ./core/providers/gemini -run TestBifrostToGeminiToolConversion
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where tool calls with array parameters would fail when using the Gemini provider.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable