### PR TITLE
upgrades mocker plugin for semantic cache

### DIFF
--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.2.43
 	github.com/maximhq/bifrost/framework v1.1.53
-	github.com/maximhq/bifrost/plugins/mocker v1.3.40
+	github.com/maximhq/bifrost/plugins/mocker v1.4.0
 )
 
 require (


### PR DESCRIPTION
## Summary

Update the mocker plugin dependency from v1.3.40 to v1.4.0 in the semanticcache plugin.

## Changes

- Upgraded the `github.com/maximhq/bifrost/plugins/mocker` dependency from v1.3.40 to v1.4.0

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the semanticcache plugin works correctly with the updated mocker dependency:

```sh
# Core/Transports
cd plugins/semanticcache
go mod tidy
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a routine dependency update.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable