### PR TITLE
bring back transport tests

### DIFF
--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -185,19 +185,18 @@ cd ..
 
 # Run integration tests with different configurations
 echo "🧪 Running integration tests with different configurations..."
-# CONFIGS_TO_TEST=(
-#   "default"
-#   "emptystate"
-#   "noconfigstorenologstore"
-#   "witconfigstorelogstorepostgres"
-#   "withconfigstore"
-#   "withconfigstorelogsstorepostgres"
-#   "withconfigstorelogsstoresqlite"
-#   "withdynamicplugin"
-#   "withobservability"
-#   "withsemanticcache"
-# )
-CONFIGS_TO_TEST=()
+CONFIGS_TO_TEST=(
+  "default"
+  "emptystate"
+  "noconfigstorenologstore"
+  "witconfigstorelogstorepostgres"
+  "withconfigstore"
+  "withconfigstorelogsstorepostgres"
+  "withconfigstorelogsstoresqlite"
+  "withdynamicplugin"
+  "withobservability"
+  "withsemanticcache"
+)
 
 TEST_BINARY="../tmp/bifrost-http"
 CONFIGS_DIR="../.github/workflows/configs"


### PR DESCRIPTION
## Summary

Re-enable integration tests for bifrost-http release workflow by uncommenting the test configurations array.

## Changes

- Uncommented the `CONFIGS_TO_TEST` array in the release-bifrost-http.sh script
- Removed the empty array declaration that was previously disabling all tests
- This ensures that integration tests will run with all 10 different configurations during the release process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script locally to verify that integration tests are executed with all configurations:

```sh
./.github/workflows/scripts/release-bifrost-http.sh
```

Verify that tests run for all configurations: default, emptystate, noconfigstorenologstore, etc.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable