### PR TITLE
v1.4.0 docs

### DIFF
--- a/docs/changelogs/v1.3.47.mdx
+++ b/docs/changelogs/v1.3.47.mdx
@@ -17,28 +17,28 @@ description: "v1.3.47 changelog - 2025-12-12"
 </Tabs>
 
 <Update label="Bifrost(HTTP)" description="1.3.47">
-feat: support for raw response accumulation for streaming
-feat: support for raw request logging and sending back in response
-feat: added support for reasoning in chat completions
-feat: enhanced reasoning support in responses api
-enhancement: improved internal inter provider conversions for integrations
-feat: switched to gemini native api
+- feat: support for raw response accumulation for streaming
+- feat: support for raw request logging and sending back in response
+- feat: added support for reasoning in chat completions
+- feat: enhanced reasoning support in responses api
+- enhancement: improved internal inter provider conversions for integrations
+- feat: switched to gemini native api
 
 </Update>
 <Update label="Core" description="1.2.37">
-feat: send back raw request in extra fields
-feat: added support for reasoning in chat completions
-feat: enhanced reasoning support in responses api
-enhancement: improved internal inter provider conversions for integrations
-feat: switched to gemini native api
-feat: fallback to supported request type for custom models used in integration
+- feat: send back raw request in extra fields
+- feat: added support for reasoning in chat completions
+- feat: enhanced reasoning support in responses api
+- enhancement: improved internal inter provider conversions for integrations
+- feat: switched to gemini native api
+- feat: fallback to supported request type for custom models used in integration
 
 </Update>
 <Update label="Framework" description="1.1.47">
-feat: support raw response accumulation in stream accumulator
-feat: support raw request configuration and logging
-feat: added support for reasoning accumulation in stream accumulator
-chore: updating core to 1.2.37 and framework to 1.1.47
+- feat: support raw response accumulation in stream accumulator
+- feat: support raw request configuration and logging
+- feat: added support for reasoning accumulation in stream accumulator
+- chore: updating core to 1.2.37 and framework to 1.1.47
 
 </Update>
 <Update label="governance" description="1.3.48">

--- a/docs/changelogs/v1.4.0-prerelease1.mdx
+++ b/docs/changelogs/v1.4.0-prerelease1.mdx
@@ -1,0 +1,290 @@
+---
+title: "v1.4.0-prerelease1"
+description: "v1.4.0-prerelease1 changelog - 2025-12-29"
+---
+<Tabs>
+  <Tab title="NPX">
+    ```bash
+    npx -y @maximhq/bifrost --transport-version v1.4.0-prerelease1
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull maximhq/bifrost:v1.4.0-prerelease1
+    docker run -p 8080:8080 maximhq/bifrost:v1.4.0-prerelease1
+    ```
+  </Tab>
+</Tabs>
+
+<Update label="Bifrost(HTTP)" description="1.4.0-prerelease1">
+- refactor: governance plugin refactored for extensibility and optimization
+- feat: new MCP gateway (server including) along with code mode
+- feat: added health monitoring to mcp
+- feat: added responses format tool execution support to mcp
+- feat: new e2e tracing
+- fix: gemini thought signature handling in multi-turn conversations
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor removed, replaced with HTTPTransportMiddleware**
+
+  The `TransportInterceptor` function has been removed from the plugin interface. Plugins using HTTP transport interception must migrate to `HTTPTransportMiddleware`.
+
+  **Migration summary:**
+  ```
+  // v1.3.x (removed)
+  TransportInterceptor(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
+
+  // v1.4.x+ (new)
+  HTTPTransportMiddleware() BifrostHTTPMiddleware
+  // where BifrostHTTPMiddleware = func(next fasthttp.RequestHandler) fasthttp.RequestHandler
+  ```
+
+  **Key API changes:**
+  - Function renamed: `TransportInterceptor` -> `HTTPTransportMiddleware`
+  - Signature changed: Now returns a middleware wrapper instead of accepting/returning header/body maps
+  - Added dependency: Requires `github.com/valyala/fasthttp` import
+  - Flow control: Must explicitly call `next(ctx)` to continue the chain
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete migration instructions and code examples.
+
+</Update>
+<Update label="Core" description="1.3.0">
+- feat: added code mode to mcp
+- feat: added health monitoring to mcp
+- feat: added responses format tool execution support to mcp
+- feat: adds central tracer for e2e tracing
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor removed, replaced with HTTPTransportMiddleware**
+
+  The `TransportInterceptor` method has been removed from the `Plugin` interface in `schemas/plugin.go`. All plugins must now implement `HTTPTransportMiddleware()` instead.
+
+  **Old API (removed in core v1.3.0):**
+  ```go
+  TransportInterceptor(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
+  ```
+
+  **New API (core v1.3.0+):**
+  ```go
+  HTTPTransportMiddleware() BifrostHTTPMiddleware
+  // where BifrostHTTPMiddleware = func(next fasthttp.RequestHandler) fasthttp.RequestHandler
+  ```
+
+  **Key changes:**
+  - Method renamed: `TransportInterceptor` -> `HTTPTransportMiddleware`
+  - Return type changed: Now returns a middleware function instead of modified headers/body
+  - New import required: `github.com/valyala/fasthttp`
+  - Flow control: Must call `next(ctx)` explicitly to continue the middleware chain
+  - New capability: Can now intercept and modify responses (not just requests)
+
+  **Migration for plugin consumers:**
+  1. Update your plugin to implement `HTTPTransportMiddleware()` instead of `TransportInterceptor()`
+  2. If your plugin doesn't need HTTP transport interception, return `nil` from `HTTPTransportMiddleware()`
+  3. Update tests to verify the new middleware signature
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete instructions and code examples.
+
+</Update>
+<Update label="Framework" description="1.2.0">
+- feat: adds new tracing framework for allowing plugins to enable e2e tracing
+
+### BREAKING CHANGES
+
+- **DynamicPlugin: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  The `DynamicPlugin` loader now expects plugins to export `HTTPTransportMiddleware` instead of `TransportInterceptor`.
+
+  **Old symbol lookup (removed in framework v1.2.0):**
+  ```go
+  plugin.Lookup("TransportInterceptor")
+  // Expected: func(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
+  ```
+
+  **New symbol lookup (framework v1.2.0+):**
+  ```go
+  plugin.Lookup("HTTPTransportMiddleware")
+  // Expected: func() BifrostHTTPMiddleware
+  ```
+
+  **Impact on dynamic plugins (.so files):**
+  - Plugins compiled for core v1.2.x will fail to load with error: `plugin: symbol HTTPTransportMiddleware not found`
+  - Recompile all dynamic plugins against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for migration instructions.
+
+</Update>
+<Update label="governance" description="1.4.0">
+- refactor: extracted governance store into an interface for extensibility
+- refactor: extended the way governance store handles rate limits
+- chore: added e2e tests for governance plugin
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="jsonparser" description="1.4.0">
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="logging" description="1.4.0">
+- feat: logging now uses central accumulator vs its own; reducing total memory consumption during runtime
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="maxim" description="1.5.0">
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="mocker" description="1.4.0">
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="otel" description="1.1.0">
+- feat: otel now uses central accumulator reducing the total amount of memory consumed in runtime
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="semanticcache" description="1.4.0">
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>
+<Update label="telemetry" description="1.4.0">
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+
+### BREAKING CHANGES
+
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -132,7 +132,8 @@
             "pages": [
               "plugins/getting-started",
               "plugins/building-dynamic-binary",
-              "plugins/writing-plugin"
+              "plugins/writing-plugin",
+              "plugins/migration-guide"
             ]
           },
           {
@@ -306,6 +307,7 @@
         "tab": "Changelogs",
         "icon": "bolt",
         "pages": [
+          "changelogs/v1.4.0-prerelease1",
           "changelogs/v1.3.54",
           "changelogs/v1.3.53",
           "changelogs/v1.3.52",

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -565,7 +565,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 {
   "error": {
     "type": "virtual_key_required",
-    "message": "x-bf-vk header is missing"
+    "message": "virtual key is missing in headers"
   }
 }
 ```
@@ -615,7 +615,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 {
   "error": {
     "type": "budget_exceeded",
-    "message": "Budget check failed: VK budget exceeded: 105.50 > 100.00 dollars"
+    "message": "Budget exceeded: VK budget exceeded: 105.50 > 100.00 dollars"
   }
 }
 ```

--- a/docs/plugins/getting-started.mdx
+++ b/docs/plugins/getting-started.mdx
@@ -48,12 +48,24 @@ go build -buildmode=plugin -o myplugin.so main.go
 
 This generates a `.so` file that exports specific functions matching Bifrost's plugin interface:
 
-- `Init(config any) error` - Initialize the plugin with configuration
-- `GetName() string` - Return the plugin name
-- `PreHook()` - Intercept requests before they reach providers
-- `PostHook()` - Process responses after provider calls
-- `TransportInterceptor()` - Modify raw HTTP headers/body (HTTP transport only)
-- `Cleanup() error` - Clean up resources on shutdown
+<Tabs>
+  <Tab title="v1.4.x+">
+    - `Init(config any) error` - Initialize the plugin with configuration
+    - `GetName() string` - Return the plugin name
+    - `PreHook()` - Intercept requests before they reach providers
+    - `PostHook()` - Process responses after provider calls
+    - `HTTPTransportMiddleware()` - Middleware for HTTP transport layer (HTTP transport only)
+    - `Cleanup() error` - Clean up resources on shutdown
+  </Tab>
+  <Tab title="v1.3.x">
+    - `Init(config any) error` - Initialize the plugin with configuration
+    - `GetName() string` - Return the plugin name
+    - `PreHook()` - Intercept requests before they reach providers
+    - `PostHook()` - Process responses after provider calls
+    - `TransportInterceptor()` - Modify raw HTTP headers/body (HTTP transport only)
+    - `Cleanup() error` - Clean up resources on shutdown
+  </Tab>
+</Tabs>
 
 ### Platform Requirements
 
@@ -74,10 +86,21 @@ This means if you're running Bifrost on Linux AMD64, you must build your plugin 
 4. **Cleanup** - Calls `Cleanup()` when Bifrost shuts down
 
 Plugins execute in a specific order:
-1. `TransportInterceptor` - Modifies raw HTTP requests (HTTP transport only)
-2. `PreHook` - Executes in registration order, can short-circuit requests
-3. Provider call (if not short-circuited)
-4. `PostHook` - Executes in reverse order of PreHooks
+
+<Tabs>
+  <Tab title="v1.4.x+">
+    1. `HTTPTransportMiddleware` - HTTP transport middleware (HTTP transport only)
+    2. `PreHook` - Executes in registration order, can short-circuit requests
+    3. Provider call (if not short-circuited)
+    4. `PostHook` - Executes in reverse order of PreHooks
+  </Tab>
+  <Tab title="v1.3.x">
+    1. `TransportInterceptor` - Modifies raw HTTP requests (HTTP transport only)
+    2. `PreHook` - Executes in registration order, can short-circuit requests
+    3. Provider call (if not short-circuited)
+    4. `PostHook` - Executes in reverse order of PreHooks
+  </Tab>
+</Tabs>
 
 ## Next Steps
 

--- a/docs/plugins/migration-guide.mdx
+++ b/docs/plugins/migration-guide.mdx
@@ -1,0 +1,308 @@
+---
+title: "Plugin Migration Guide"
+description: "How to migrate your Bifrost plugins from v1.3.x to v1.4.x"
+icon: "arrow-up-right-dots"
+---
+
+## Overview
+
+Bifrost v1.4.x introduces a new plugin interface for HTTP transport layer interception. This guide helps you migrate existing plugins from the v1.3.x `TransportInterceptor` pattern to the v1.4.x `HTTPTransportMiddleware` pattern.
+
+<Note>
+If your plugin doesn't use `TransportInterceptor`, no migration is needed. The `PreHook`, `PostHook`, `Init`, `GetName`, and `Cleanup` functions remain unchanged.
+</Note>
+
+## What Changed?
+
+The HTTP transport interception mechanism changed from a simple function that receives and returns headers/body to a middleware pattern that wraps the entire request handler chain.
+
+### Key Differences
+
+| Aspect | v1.3.x (TransportInterceptor) | v1.4.x+ (HTTPTransportMiddleware) |
+|--------|-------------------------------|-----------------------------------|
+| Function signature | `TransportInterceptor(ctx, url, headers, body)` | `HTTPTransportMiddleware()` |
+| Return type | `(headers, body, error)` | `BifrostHTTPMiddleware` |
+| Access scope | Headers and body as maps | Full `*fasthttp.RequestCtx` |
+| Flow control | Implicit (return modified values) | Explicit (`next(ctx)` call) |
+| Capability | Request modification only | Request AND response modification |
+
+### Why the Change?
+
+The new middleware pattern provides:
+
+1. **Full HTTP control** - Access to the complete `*fasthttp.RequestCtx` including method, path, query params, and all headers
+2. **Response interception** - Ability to modify responses after they return from downstream handlers
+3. **Better composability** - Standard middleware pattern that chains naturally with other handlers
+4. **More flexibility** - Can short-circuit requests, add timing, implement retries, etc.
+
+## Migration Steps
+
+### Step 1: Update Imports
+
+Add the `fasthttp` import to your plugin:
+
+```go
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"  // Add this import
+)
+```
+
+### Step 2: Replace the Function
+
+**Before (v1.3.x):**
+
+```go
+// TransportInterceptor modifies raw HTTP headers and body
+func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	// Add custom header
+	headers["X-Custom-Header"] = "value"
+	
+	// Modify body
+	body["custom_field"] = "custom_value"
+	
+	return headers, body, nil
+}
+```
+
+**After (v1.4.x+):**
+
+```go
+// HTTPTransportMiddleware returns a middleware for HTTP transport
+func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			// Add custom header
+			ctx.Request.Header.Set("X-Custom-Header", "value")
+			
+			// Modify body (if needed)
+			// Note: Body modification requires parsing and re-serializing
+			// ctx.Request.SetBody(modifiedBody)
+			
+			// Call next handler in chain
+			next(ctx)
+			
+			// Can also modify response here after next() returns
+		}
+	}
+}
+```
+
+### Step 3: Update Body Modification Logic
+
+In v1.3.x, you received the body as a `map[string]any`. In v1.4.x, you work with raw bytes:
+
+**Before (v1.3.x):**
+
+```go
+func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	// Direct map access
+	body["model"] = "gpt-4"
+	return headers, body, nil
+}
+```
+
+**After (v1.4.x+):**
+
+```go
+import "github.com/bytedance/sonic"
+
+func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			// Parse existing body
+			var body map[string]any
+			if err := sonic.Unmarshal(ctx.Request.Body(), &body); err == nil {
+				// Modify body
+				body["model"] = "gpt-4"
+				
+				// Re-serialize and set
+				if newBody, err := sonic.Marshal(body); err == nil {
+					ctx.Request.SetBody(newBody)
+				}
+			}
+			
+			next(ctx)
+		}
+	}
+}
+```
+
+### Step 4: Handle Response Modification (New Capability)
+
+The new pattern allows you to modify responses, which wasn't possible in v1.3.x:
+
+```go
+func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			// Before request
+			startTime := time.Now()
+			
+			// Process request
+			next(ctx)
+			
+			// After response - NEW CAPABILITY
+			duration := time.Since(startTime)
+			ctx.Response.Header.Set("X-Processing-Time", duration.String())
+		}
+	}
+}
+```
+
+## Common Migration Patterns
+
+### Adding Headers
+
+**v1.3.x:**
+```go
+headers["Authorization"] = "Bearer " + token
+return headers, body, nil
+```
+
+**v1.4.x+:**
+```go
+ctx.Request.Header.Set("Authorization", "Bearer " + token)
+next(ctx)
+```
+
+### Reading Headers
+
+**v1.3.x:**
+```go
+apiKey := headers["X-API-Key"]
+```
+
+**v1.4.x+:**
+```go
+apiKey := string(ctx.Request.Header.Peek("X-API-Key"))
+```
+
+### Conditional Processing
+
+**v1.3.x:**
+```go
+func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	if headers["X-Skip-Processing"] == "true" {
+		return headers, body, nil
+	}
+	// Process...
+	return headers, body, nil
+}
+```
+
+**v1.4.x+:**
+```go
+func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			if string(ctx.Request.Header.Peek("X-Skip-Processing")) == "true" {
+				next(ctx)
+				return
+			}
+			// Process...
+			next(ctx)
+		}
+	}
+}
+```
+
+### Error Handling
+
+**v1.3.x:**
+```go
+func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	if headers["X-API-Key"] == "" {
+		return nil, nil, fmt.Errorf("missing API key")
+	}
+	return headers, body, nil
+}
+```
+
+**v1.4.x+:**
+```go
+func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			if len(ctx.Request.Header.Peek("X-API-Key")) == 0 {
+				ctx.SetStatusCode(401)
+				ctx.SetBodyString(`{"error": "missing API key"}`)
+				return // Don't call next - short-circuit the request
+			}
+			next(ctx)
+		}
+	}
+}
+```
+
+## Testing Your Migration
+
+1. **Build your updated plugin:**
+   ```bash
+   go build -buildmode=plugin -o my-plugin.so main.go
+   ```
+
+2. **Update Bifrost to v1.4.x:**
+   ```bash
+   go get github.com/maximhq/bifrost/core@v1.4.0
+   ```
+
+3. **Test with a simple request:**
+   ```bash
+   curl -X POST http://localhost:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
+   ```
+
+4. **Verify logs show the new middleware being called:**
+   ```
+   HTTPTransportMiddleware called
+   PreHook called
+   PostHook called
+   ```
+
+## Troubleshooting
+
+### Plugin fails to load after migration
+
+**Error:** `plugin: symbol TransportInterceptor not found`
+
+This error occurs if Bifrost v1.4.x is looking for the old function. Make sure:
+1. You've updated to `HTTPTransportMiddleware`
+2. The function signature matches exactly
+3. You've rebuilt the plugin with the correct core version
+
+### Body modification not working
+
+Make sure you're calling `ctx.Request.SetBody()` with the serialized bytes, not the map directly:
+
+```go
+// Wrong
+ctx.Request.SetBody(body) // body is map[string]any
+
+// Correct
+bodyBytes, _ := sonic.Marshal(body)
+ctx.Request.SetBody(bodyBytes)
+```
+
+### Headers not being set
+
+Remember that `fasthttp` header methods are case-sensitive for custom headers:
+
+```go
+// Set header
+ctx.Request.Header.Set("X-Custom-Header", "value")
+
+// Read header - use Peek for []byte or string conversion
+value := string(ctx.Request.Header.Peek("X-Custom-Header"))
+```
+
+## Need Help?
+
+- **Discord Community**: [Join our Discord](https://getmax.im/bifrost-discord)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
+- **Writing Plugins Guide**: [Full plugin documentation](./writing-plugin)
+
+

--- a/docs/plugins/writing-plugin.mdx
+++ b/docs/plugins/writing-plugin.mdx
@@ -62,6 +62,70 @@ require github.com/maximhq/bifrost/core v1.2.38
 
 Create `main.go` with the required plugin functions. Here's the complete hello-world example:
 
+<Tabs>
+  <Tab title="v1.4.x+">
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// Init is called when the plugin is loaded
+// config contains the plugin configuration from config.json
+func Init(config any) error {
+	fmt.Println("Init called")
+	// Initialize your plugin here (database connections, API clients, etc.)
+	return nil
+}
+
+// GetName returns the plugin's unique identifier
+func GetName() string {
+	return "Hello World Plugin"
+}
+
+// HTTPTransportMiddleware returns a middleware for HTTP transport
+// Only called when using HTTP transport (bifrost-http)
+func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			fmt.Println("HTTPTransportMiddleware called")
+			// Modify request headers/body via ctx.Request before calling next
+			// Call next handler in the chain
+			next(ctx)
+			// Can also modify response via ctx.Response after next returns
+		}
+	}
+}
+
+// PreHook is called before the request is sent to the provider
+// This is where you can modify requests or short-circuit the flow
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	fmt.Println("PreHook called")
+	// Modify the request or return a short-circuit to skip provider call
+	return req, nil, nil
+}
+
+// PostHook is called after receiving a response from the provider
+// This is where you can modify responses or handle errors
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	fmt.Println("PostHook called")
+	// Modify the response or error before returning to caller
+	return resp, bifrostErr, nil
+}
+
+// Cleanup is called when Bifrost shuts down
+func Cleanup() error {
+	fmt.Println("Cleanup called")
+	// Clean up resources (close connections, flush buffers, etc.)
+	return nil
+}
+```
+  </Tab>
+  <Tab title="v1.3.x">
 ```go
 package main
 
@@ -115,6 +179,8 @@ func Cleanup() error {
 	return nil
 }
 ```
+  </Tab>
+</Tabs>
 
 ### Understanding Each Function
 
@@ -144,6 +210,23 @@ func Init(config any) error {
 
 Returns a unique identifier for your plugin. This name appears in logs and status reports.
 
+<Tabs>
+  <Tab title="v1.4.x+">
+#### `HTTPTransportMiddleware()`
+
+**HTTP transport only.** Returns a middleware that wraps the HTTP request handler chain. Use this to:
+- Intercept and modify requests before they enter Bifrost core
+- Intercept and modify responses before they're returned to clients
+- Implement authentication or logging at the transport layer
+- Access raw `*fasthttp.RequestCtx` for full HTTP control
+
+The middleware pattern requires calling `next(ctx)` to pass control to subsequent handlers.
+
+<Warning>
+This function is **only called** when using `bifrost-http`. It's **not invoked** when using Bifrost as a Go SDK.
+</Warning>
+  </Tab>
+  <Tab title="v1.3.x">
 #### `TransportInterceptor(...)`
 
 **HTTP transport only.** Called before requests enter Bifrost core. Use this to:
@@ -154,6 +237,8 @@ Returns a unique identifier for your plugin. This name appears in logs and statu
 <Warning>
 This function is **only called** when using `bifrost-http`. It's **not invoked** when using Bifrost as a Go SDK.
 </Warning>
+  </Tab>
+</Tabs>
 
 #### `PreHook(...)`
 
@@ -341,11 +426,22 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 
 Check the logs for plugin hook calls:
 
+<Tabs>
+  <Tab title="v1.4.x+">
+```
+HTTPTransportMiddleware called
+PreHook called
+PostHook called
+```
+  </Tab>
+  <Tab title="v1.3.x">
 ```
 TransportInterceptor called
 PreHook called
 PostHook called
 ```
+  </Tab>
+</Tabs>
 
 ## Advanced Plugin Patterns
 


### PR DESCRIPTION
## Update Changelog Format and Add v1.4.0 Prerelease Documentation

This PR updates the formatting of the v1.3.47 changelog to use bullet points for better readability and adds comprehensive documentation for the upcoming v1.4.0-prerelease1 release, including a new plugin migration guide.

## Changes

- Reformatted v1.3.47 changelog entries to use bullet points for better readability
- Added v1.4.0-prerelease1 changelog with detailed information about new features and breaking changes
- Created a new plugin migration guide to help developers transition from v1.3.x to v1.4.x
- Updated plugin documentation to support both v1.3.x and v1.4.x API patterns using tabs
- Updated governance documentation to reflect message changes in error responses
- Added the migration guide to the docs navigation

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Review the changelog formatting in v1.3.47
2. Check the new v1.4.0-prerelease1 changelog for completeness
3. Verify the plugin migration guide provides clear instructions for transitioning from TransportInterceptor to HTTPTransportMiddleware
4. Ensure the tabbed documentation in plugin guides correctly shows both v1.3.x and v1.4.x patterns

## Breaking changes

- [x] Yes
- [ ] No

The v1.4.0 release contains breaking changes to the plugin interface. The `TransportInterceptor` method has been removed and replaced with `HTTPTransportMiddleware`. The migration guide provides detailed instructions for plugin developers to update their code.

## Related issues

Documents the breaking changes in the plugin interface for v1.4.0

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable