### PR TITLE
docs update

### DIFF
--- a/docs/changelogs/v1.4.0-prerelease1.mdx
+++ b/docs/changelogs/v1.4.0-prerelease1.mdx
@@ -2,7 +2,6 @@
 title: "v1.4.0-prerelease1"
 description: "v1.4.0-prerelease1 changelog - 2025-12-29"
 ---
-
 <Tabs>
   <Tab title="NPX">
     ```bash
@@ -18,278 +17,274 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
 </Tabs>
 
 <Update label="Bifrost(HTTP)" description="1.4.0-prerelease1">
-  - refactor: governance plugin refactored for extensibility and optimization
-  - feat: new MCP gateway (server including) along with code mode
-  - feat: added health monitoring to mcp
-  - feat: added responses format tool execution support to mcp
-  - feat: new e2e tracing
-  - fix: gemini thought signature handling in multi-turn conversations
+- refactor: governance plugin refactored for extensibility and optimization
+- feat: new MCP gateway (server including) along with code mode
+- feat: added health monitoring to mcp
+- feat: added responses format tool execution support to mcp
+- feat: new e2e tracing
+- fix: gemini thought signature handling in multi-turn conversations
 
-  ### 💥 BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor removed, replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor removed, replaced with HTTPTransportMiddleware**
 
-    The `TransportInterceptor` function has been removed from the plugin interface. Plugins using HTTP transport interception must migrate to `HTTPTransportMiddleware`.
+  The `TransportInterceptor` function has been removed from the plugin interface. Plugins using HTTP transport interception must migrate to `HTTPTransportMiddleware`.
 
-    **Migration summary:**
+  **Migration summary:**
+  ```
+  // v1.3.x (removed)
+  TransportInterceptor(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
 
-    ```
-    // v1.3.x (removed)
-    TransportInterceptor(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
-    
-    // v1.4.x+ (new)
-    HTTPTransportMiddleware() BifrostHTTPMiddleware
-    // where BifrostHTTPMiddleware = func(next fasthttp.RequestHandler) fasthttp.RequestHandler
-    ```
+  // v1.4.x+ (new)
+  HTTPTransportMiddleware() BifrostHTTPMiddleware
+  // where BifrostHTTPMiddleware = func(next fasthttp.RequestHandler) fasthttp.RequestHandler
+  ```
 
-    **Key API changes:**
-    - Function renamed: `TransportInterceptor` -\> `HTTPTransportMiddleware`
-    - Signature changed: Now returns a middleware wrapper instead of accepting/returning header/body maps
-    - Added dependency: Requires `github.com/valyala/fasthttp` import
-    - Flow control: Must explicitly call `next(ctx)` to continue the chain
+  **Key API changes:**
+  - Function renamed: `TransportInterceptor` -> `HTTPTransportMiddleware`
+  - Signature changed: Now returns a middleware wrapper instead of accepting/returning header/body maps
+  - Added dependency: Requires `github.com/valyala/fasthttp` import
+  - Flow control: Must explicitly call `next(ctx)` to continue the chain
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete migration instructions and code examples.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete migration instructions and code examples.
+
 </Update>
-
 <Update label="Core" description="1.3.0">
-  - feat: added code mode to mcp
-  - feat: added health monitoring to mcp
-  - feat: added responses format tool execution support to mcp
-  - feat: adds central tracer for e2e tracing
+- feat: added code mode to mcp
+- feat: added health monitoring to mcp
+- feat: added responses format tool execution support to mcp
+- feat: adds central tracer for e2e tracing
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor removed, replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor removed, replaced with HTTPTransportMiddleware**
 
-    The `TransportInterceptor` method has been removed from the `Plugin` interface in `schemas/plugin.go`. All plugins must now implement `HTTPTransportMiddleware()` instead.
+  The `TransportInterceptor` method has been removed from the `Plugin` interface in `schemas/plugin.go`. All plugins must now implement `HTTPTransportMiddleware()` instead.
 
-    **Old API (removed in core v1.3.0):**
+  **Old API (removed in core v1.3.0):**
+  ```go
+  TransportInterceptor(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
+  ```
 
-    ```go
-    TransportInterceptor(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
-    ```
+  **New API (core v1.3.0+):**
+  ```go
+  HTTPTransportMiddleware() BifrostHTTPMiddleware
+  // where BifrostHTTPMiddleware = func(next fasthttp.RequestHandler) fasthttp.RequestHandler
+  ```
 
-    **New API (core v1.3.0+):**
+  **Key changes:**
+  - Method renamed: `TransportInterceptor` -> `HTTPTransportMiddleware`
+  - Return type changed: Now returns a middleware function instead of modified headers/body
+  - New import required: `github.com/valyala/fasthttp`
+  - Flow control: Must call `next(ctx)` explicitly to continue the middleware chain
+  - New capability: Can now intercept and modify responses (not just requests)
 
-    ```go
-    HTTPTransportMiddleware() BifrostHTTPMiddleware
-    // where BifrostHTTPMiddleware = func(next fasthttp.RequestHandler) fasthttp.RequestHandler
-    ```
+  **Migration for plugin consumers:**
+  1. Update your plugin to implement `HTTPTransportMiddleware()` instead of `TransportInterceptor()`
+  2. If your plugin doesn't need HTTP transport interception, return `nil` from `HTTPTransportMiddleware()`
+  3. Update tests to verify the new middleware signature
 
-    **Key changes:**
-    - Method renamed: `TransportInterceptor` -\> `HTTPTransportMiddleware`
-    - Return type changed: Now returns a middleware function instead of modified headers/body
-    - New import required: `github.com/valyala/fasthttp`
-    - Flow control: Must call `next(ctx)` explicitly to continue the middleware chain
-    - New capability: Can now intercept and modify responses (not just requests)
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete instructions and code examples.
 
-    **Migration for plugin consumers:**
-    1. Update your plugin to implement `HTTPTransportMiddleware()` instead of `TransportInterceptor()`
-    2. If your plugin doesn't need HTTP transport interception, return `nil` from `HTTPTransportMiddleware()`
-    3. Update tests to verify the new middleware signature
-
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete instructions and code examples.
 </Update>
-
 <Update label="Framework" description="1.2.0">
-  - feat: adds new tracing framework for allowing plugins to enable e2e tracing
+- feat: adds new tracing framework for allowing plugins to enable e2e tracing
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **DynamicPlugin: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **DynamicPlugin: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    The `DynamicPlugin` loader now expects plugins to export `HTTPTransportMiddleware` instead of `TransportInterceptor`.
+  The `DynamicPlugin` loader now expects plugins to export `HTTPTransportMiddleware` instead of `TransportInterceptor`.
 
-    **Old symbol lookup (removed in framework v1.2.0):**
+  **Old symbol lookup (removed in framework v1.2.0):**
+  ```go
+  plugin.Lookup("TransportInterceptor")
+  // Expected: func(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
+  ```
 
-    ```go
-    plugin.Lookup("TransportInterceptor")
-    // Expected: func(ctx *BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error)
-    ```
+  **New symbol lookup (framework v1.2.0+):**
+  ```go
+  plugin.Lookup("HTTPTransportMiddleware")
+  // Expected: func() BifrostHTTPMiddleware
+  ```
 
-    **New symbol lookup (framework v1.2.0+):**
+  **Impact on dynamic plugins (.so files):**
+  - Plugins compiled for core v1.2.x will fail to load with error: `plugin: symbol HTTPTransportMiddleware not found`
+  - Recompile all dynamic plugins against core v1.3.0+ and framework v1.2.0+
 
-    ```go
-    plugin.Lookup("HTTPTransportMiddleware")
-    // Expected: func() BifrostHTTPMiddleware
-    ```
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for migration instructions.
 
-    **Impact on dynamic plugins (.so files):**
-    - Plugins compiled for core v1.2.x will fail to load with error: `plugin: symbol HTTPTransportMiddleware not found`
-    - Recompile all dynamic plugins against core v1.3.0+ and framework v1.2.0+
-
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for migration instructions.
 </Update>
-
 <Update label="governance" description="1.4.0">
-  - refactor: extracted governance store into an interface for extensibility
-  - refactor: extended the way governance store handles rate limits
-  - chore: added e2e tests for governance plugin
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- refactor: extracted governance store into an interface for extensibility
+- refactor: extended the way governance store handles rate limits
+- chore: added e2e tests for governance plugin
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="jsonparser" description="1.4.0">
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="logging" description="1.4.0">
-  - feat: logging now uses central accumulator vs its own; reducing total memory consumption during runtime
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- feat: logging now uses central accumulator vs its own; reducing total memory consumption during runtime
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="maxim" description="1.5.0">
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="mocker" description="1.4.0">
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="otel" description="1.1.0">
-  - feat: otel now uses central accumulator reducing the total amount of memory consumed in runtime
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- feat: otel now uses central accumulator reducing the total amount of memory consumed in runtime
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="semanticcache" description="1.4.0">
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>
-
 <Update label="telemetry" description="1.4.0">
-  - chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
+- chore: upgraded versions of core to 1.3.0 and framework to 1.2.0
 
-  ### BREAKING CHANGES
+### BREAKING CHANGES
 
-  - **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
+- **Plugin Interface: TransportInterceptor replaced with HTTPTransportMiddleware**
 
-    This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
+  This plugin now implements `HTTPTransportMiddleware()` instead of `TransportInterceptor()` to comply with core v1.3.0.
 
-    **What changed:**
-    - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
-    - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
+  **What changed:**
+  - Old: `TransportInterceptor(ctx, url, headers, body) (headers, body, error)`
+  - New: `HTTPTransportMiddleware() BifrostHTTPMiddleware`
 
-    **For plugin consumers:**
-    - If you import this plugin directly, no code changes are required
-    - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
-    - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
+  **For plugin consumers:**
+  - If you import this plugin directly, no code changes are required
+  - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
+  - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-    See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+
 </Update>

--- a/docs/changelogs/v1.4.0-prerelease2.mdx
+++ b/docs/changelogs/v1.4.0-prerelease2.mdx
@@ -1,0 +1,71 @@
+---
+title: "v1.4.0-prerelease2"
+description: "v1.4.0-prerelease2 changelog - 2025-12-30"
+---
+<Tabs>
+  <Tab title="NPX">
+    ```bash
+    npx -y @maximhq/bifrost --transport-version v1.4.0-prerelease2
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull maximhq/bifrost:v1.4.0-prerelease2
+    docker run -p 8080:8080 maximhq/bifrost:v1.4.0-prerelease2
+    ```
+  </Tab>
+</Tabs>
+
+<Update label="Bifrost(HTTP)" description="1.4.0-prerelease2">
+- fix: handling of nullable text fields in bedrock reasoning content
+- fix: gemini tool conversion with array parameters
+- fix: file name normalization in bedrock document blocks
+- fix: plugin status sync using configuration name
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+- fix: adds parser for parent span id and root span parent to fix distributed tracing for datadog
+
+</Update>
+<Update label="Core" description="1.3.1">
+- fix: handling of nullable text fields in bedrock reasoning content
+- fix: gemini tool conversion with array parameters
+- fix: file name normalization in bedrock document blocks
+- fix: adds parser for parent span id and root span parent to fix distributed tracing for datadog
+
+</Update>
+<Update label="Framework" description="1.2.1">
+- fix: adds parser for parent span id and root span parent to fix distributed tracing for datadog
+- chore: upgrade core to 1.3.1
+
+</Update>
+<Update label="governance" description="1.4.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="jsonparser" description="1.4.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="logging" description="1.4.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="maxim" description="1.5.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="mocker" description="1.4.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="otel" description="1.1.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="semanticcache" description="1.4.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>
+<Update label="telemetry" description="1.4.1">
+- chore: upgrade core to 1.3.1 and framework to 1.2.1
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -307,8 +307,8 @@
         "tab": "Changelogs",
         "icon": "bolt",
         "pages": [
+          "changelogs/v1.4.0-prerelease2",
           "changelogs/v1.4.0-prerelease1",
-          "changelogs/v1.3.55",
           "changelogs/v1.3.54",
           "changelogs/v1.3.53",
           "changelogs/v1.3.52",


### PR DESCRIPTION
## Summary

Added v1.4.0-prerelease2 changelog and updated the docs navigation to include it as the most recent changelog.

## Changes

- Added new v1.4.0-prerelease2.mdx changelog file documenting the latest changes
- Updated the changelog for v1.4.0-prerelease1 with minor formatting improvements
- Updated docs.json to include the new changelog and adjust the navigation order

## Type of change

- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Docs

## How to test

Verify the new changelog appears correctly in the documentation:

```sh
# Start the docs server
cd docs
pnpm i || npm i
pnpm dev || npm run dev

# Navigate to the changelogs section and verify v1.4.0-prerelease2 appears
# and is properly formatted
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is a documentation-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)