### PR TITLE
fixes migration guide url

### DIFF
--- a/docs/changelogs/v1.4.0-prerelease1.mdx
+++ b/docs/changelogs/v1.4.0-prerelease1.mdx
@@ -46,7 +46,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - Added dependency: Requires `github.com/valyala/fasthttp` import
   - Flow control: Must explicitly call `next(ctx)` to continue the chain
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete migration instructions and code examples.
+  See [Plugin Migration Guide](/plugins/migration-guide) for complete migration instructions and code examples.
 
 </Update>
 <Update label="Core" description="1.3.0">
@@ -84,7 +84,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   2. If your plugin doesn't need HTTP transport interception, return `nil` from `HTTPTransportMiddleware()`
   3. Update tests to verify the new middleware signature
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for complete instructions and code examples.
+  See [Plugin Migration Guide](/plugins/migration-guide) for complete instructions and code examples.
 
 </Update>
 <Update label="Framework" description="1.2.0">
@@ -112,7 +112,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - Plugins compiled for core v1.2.x will fail to load with error: `plugin: symbol HTTPTransportMiddleware not found`
   - Recompile all dynamic plugins against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for migration instructions.
+  See [Plugin Migration Guide](/plugins/migration-guide) for migration instructions.
 
 </Update>
 <Update label="governance" description="1.4.0">
@@ -136,7 +136,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="jsonparser" description="1.4.0">
@@ -157,7 +157,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="logging" description="1.4.0">
@@ -179,7 +179,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="maxim" description="1.5.0">
@@ -200,7 +200,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="mocker" description="1.4.0">
@@ -221,7 +221,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="otel" description="1.1.0">
@@ -243,7 +243,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="semanticcache" description="1.4.0">
@@ -264,7 +264,7 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>
 <Update label="telemetry" description="1.4.0">
@@ -285,6 +285,6 @@ description: "v1.4.0-prerelease1 changelog - 2025-12-29"
   - If you extend this plugin, update your implementation to use `HTTPTransportMiddleware()`
   - Recompile any code that depends on this plugin against core v1.3.0+ and framework v1.2.0+
 
-  See [Plugin Migration Guide](/docs/plugins/migration-guide) for details.
+  See [Plugin Migration Guide](/plugins/migration-guide) for details.
 
 </Update>


### PR DESCRIPTION
## Summary

Update documentation links to the Plugin Migration Guide throughout the v1.4.0 prerelease changelog.

## Changes

- Updated all references to the Plugin Migration Guide from `/docs/plugins/migration-guide` to `/plugins/migration-guide` for consistency
- This change affects multiple plugin sections in the changelog including Core, Framework, governance, jsonparser, logging, maxim, mocker, otel, semanticcache, and telemetry

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that all links to the Plugin Migration Guide in the changelog now point to the correct path:

```sh
# Check that all links are updated
grep -r "/plugins/migration-guide" docs/changelogs/v1.4.0-prerelease1.mdx
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes incorrect documentation links in the prerelease changelog

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable