### PR TITLE
feat: add max_tokens to max_completion_tokens mapping for chat completions

### DIFF
--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -142,7 +142,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, hea
 				return strings.EqualFold(s, headerName)
 			}) {
 				return false
-				
+
 			}
 		}
 		return true

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
+- chore: added max_tokens -> max_completion_tokens mapping for chat completions
 - fix: empty string handling in Anthropic provider to prevent sending empty content blocks in chat requests


### PR DESCRIPTION
## Summary

Added support for the legacy `max_tokens` parameter in chat completions by mapping it to `max_completion_tokens` when the latter is not specified.

## Changes

- Added logic to map the `max_tokens` parameter to `max_completion_tokens` in chat completion requests
- When `max_completion_tokens` is nil and `max_tokens` exists in extra parameters, the value is transferred
- Removed `max_tokens` from extra parameters after mapping to avoid duplication
- Added handling for both float64 and int types since JSON numbers can be unmarshaled as float64
- Updated changelog to reflect this change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test chat completion requests with the legacy `max_tokens` parameter:

```sh
# Core/Transports
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "your-model",
    "messages": [{"role": "user", "content": "Hello"}],
    "max_tokens": 100
  }'

# Verify the response is properly limited to 100 tokens
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves compatibility with OpenAI API clients that use the legacy `max_tokens` parameter.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable