### PR TITLE
fix: gemini function declaration conversion

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 - fix: empty string handling in Anthropic provider to prevent sending empty content blocks in chat requests
+- fix: Gemini/Vertex tool conversion to append all function declarations to a single Tool object

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2076,12 +2076,10 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 
 // convertResponsesToolsToGemini converts Responses tools to Gemini tools
 func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
-	var geminiTools []Tool
+	geminiTool := Tool{}
 
 	for _, tool := range tools {
 		if tool.Type == "function" {
-			geminiTool := Tool{}
-
 			// Extract function information from ResponsesExtendedTool
 			if tool.ResponsesToolFunction != nil {
 				if tool.Name != nil && tool.ResponsesToolFunction != nil {
@@ -2100,17 +2098,16 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 							return nil
 						}(),
 					}
-					geminiTool.FunctionDeclarations = []*FunctionDeclaration{funcDecl}
+					geminiTool.FunctionDeclarations = append(geminiTool.FunctionDeclarations, funcDecl)
 				}
-			}
-
-			if len(geminiTool.FunctionDeclarations) > 0 {
-				geminiTools = append(geminiTools, geminiTool)
 			}
 		}
 	}
 
-	return geminiTools
+	if len(geminiTool.FunctionDeclarations) > 0 {
+		return []Tool{geminiTool}
+	}
+	return []Tool{}
 }
 
 // convertResponsesToolChoiceToGemini converts Responses tool choice to Gemini tool config

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -457,7 +457,7 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 
 // convertBifrostToolsToGemini converts Bifrost tools to Gemini format
 func convertBifrostToolsToGemini(bifrostTools []schemas.ChatTool) []Tool {
-	var geminiTools []Tool
+	geminiTool := Tool{}
 
 	for _, tool := range bifrostTools {
 		if tool.Type == "" {
@@ -473,14 +473,14 @@ func convertBifrostToolsToGemini(bifrostTools []schemas.ChatTool) []Tool {
 			if tool.Function.Description != nil {
 				fd.Description = *tool.Function.Description
 			}
-			geminiTool := Tool{
-				FunctionDeclarations: []*FunctionDeclaration{fd},
-			}
-			geminiTools = append(geminiTools, geminiTool)
+			geminiTool.FunctionDeclarations = append(geminiTool.FunctionDeclarations, fd)
 		}
 	}
 
-	return geminiTools
+	if len(geminiTool.FunctionDeclarations) > 0 {
+		return []Tool{geminiTool}
+	}
+	return []Tool{}
 }
 
 // convertFunctionParametersToSchema converts Bifrost function parameters to Gemini Schema

--- a/core/providers/vertex/vertex_test.go
+++ b/core/providers/vertex/vertex_test.go
@@ -36,7 +36,7 @@ func TestVertex(t *testing.T) {
 			MultiTurnConversation: true,
 			ToolCalls:             true,
 			ToolCallsStreaming:    true,
-			MultipleToolCalls:     false, // multiple tool calls supported on gemini endpoint only if all tools are search tools
+			MultipleToolCalls:     true,
 			End2EndToolCalling:    true,
 			AutomaticFunctionCall: true,
 			ImageURL:              true,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,3 @@
 - chore: added max_tokens -> max_completion_tokens mapping for chat completions
 - fix: empty string handling in Anthropic provider to prevent sending empty content blocks in chat requests
+- fix: Gemini/Vertex tool conversion to append all function declarations to a single Tool object


### PR DESCRIPTION
## Summary

Fix Gemini/Vertex tool handling to properly support multiple function declarations by appending them to a single Tool object rather than creating separate Tool objects for each function.

## Changes

- Modified `convertResponsesToolsToGemini` and `convertBifrostToolsToGemini` to append all function declarations to a single Tool object instead of creating multiple Tool objects
- Updated Vertex test to correctly indicate that multiple tool calls are supported
- Added the fix to both core and transports changelogs

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test that multiple function declarations work correctly with Gemini and Vertex:

```sh
# Core/Transports
go version
go test ./core/providers/gemini/...
go test ./core/providers/vertex/...
```

Also test with actual API calls to ensure multiple function tools are properly handled in a single request.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issue with Gemini/Vertex providers not properly handling multiple function tools.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable