### PR TITLE
build fix: fixes Model multiselect default options

### DIFF
--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -136,7 +136,7 @@ export function ModelMultiselect({
 			isCreatable={true}
 			dynamicOptionCreation={true}
 			createOptionText="Press enter to add new model"
-			defaultOptions={defaultOptions.length > 0 ? defaultOptions : true}
+			defaultOptions={defaultOptions.length > 0 ? defaultOptions : [] as Option<ModelOption>[]}
 			isLoading={isLoading}
 			placeholder={placeholder}
 			disabled={disabled || !provider}


### PR DESCRIPTION
## Summary

Fix ModelMultiselect component to properly handle empty default options by providing an empty array with correct typing instead of a boolean value.

## Changes

- Changed `defaultOptions={defaultOptions.length > 0 ? defaultOptions : true}` to `defaultOptions={defaultOptions.length > 0 ? defaultOptions : [] as Option<ModelOption>[]}`
- This ensures proper typing for the empty state and prevents potential type errors

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the ModelMultiselect component works correctly when no default options are provided:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Navigate to any page using the ModelMultiselect component and confirm it renders correctly with empty default options.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes type error in ModelMultiselect component when no default options are provided.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable