### PR TITLE
multiselect build fix

### DIFF
--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -136,7 +136,7 @@ export function ModelMultiselect({
 			isCreatable={true}
 			dynamicOptionCreation={true}
 			createOptionText="Press enter to add new model"
-			defaultOptions={defaultOptions.length > 0 ? defaultOptions : true}
+			defaultOptions={defaultOptions.length > 0 ? defaultOptions : ([] as ModelOption[])}
 			isLoading={isLoading}
 			placeholder={placeholder}
 			disabled={disabled || !provider}
@@ -152,7 +152,7 @@ export function ModelMultiselect({
 			noResultsFoundPlaceholder="No models found"
 			emptyResultPlaceholder={provider ? "Start typing to search models..." : "Please select a provider first"}
 			views={{
-				dropdownIndicator: () => <></>,				
+				dropdownIndicator: () => <></>,
 				multiValue: (multiValueProps: MultiValueProps<ModelOption>) => {
 					return (
 						<div


### PR DESCRIPTION
## Summary

Fix type error in ModelMultiselect component by properly typing the empty array fallback for defaultOptions.

## Changes

- Changed the fallback value for `defaultOptions` from `true` to an explicitly typed empty array `([] as ModelOption[])` to ensure type safety
- Removed trailing whitespace in the `dropdownIndicator` view function

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the ModelMultiselect component works correctly when no default options are provided:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Navigate to any page using the ModelMultiselect component and verify it renders correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes type error in ModelMultiselect component

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable