### PR TITLE
fix: add missing logs filter checks for live updates

### DIFF
--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: added missing logs filter checks in ui for live updates

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -447,6 +447,15 @@ export default function LogsPage() {
 		if (filters.status?.length && !filters.status.includes(log.status)) {
 			return false;
 		}
+		if (filters.objects?.length && !filters.objects.includes(log.object)) {
+			return false;
+		}
+		if (filters.selected_key_ids?.length && !filters.selected_key_ids.includes(log.selected_key_id)) {
+			return false;
+		}
+		if (filters.virtual_key_ids?.length && log.virtual_key_id && !filters.virtual_key_ids.includes(log.virtual_key_id)) {
+			return false;
+		}
 		if (filters.start_time && new Date(log.timestamp) < new Date(filters.start_time)) {
 			return false;
 		}


### PR DESCRIPTION
## Summary

Fixed missing filter checks in the UI for live log updates, ensuring that logs are properly filtered by objects, selected key IDs, and virtual key IDs.

## Changes

- Added missing filter conditions in the logs page to check for:
  - Object filters
  - Selected key ID filters
  - Virtual key ID filters
- Updated the changelog to document this bug fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Apply filters for objects, selected key IDs, or virtual key IDs in the logs UI
2. Verify that live log updates respect these filters
3. Check that only logs matching the selected filters appear in the UI

```sh
# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where logs filtering was incomplete for live updates.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable