### PR TITLE
fix: ensure request ID is set in context before PreHooks

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2214,6 +2214,11 @@ func (bifrost *Bifrost) handleRequest(ctx context.Context, req *schemas.BifrostR
 
 	// Try the primary provider first
 	ctx = context.WithValue(ctx, schemas.BifrostContextKeyFallbackIndex, 0)
+	// Ensure request ID is set in context before PreHooks
+	if _, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string); !ok {
+		requestID := uuid.New().String()
+		ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestID, requestID)
+	}
 	primaryResult, primaryErr := bifrost.tryRequest(ctx, req)
 	if primaryErr != nil {
 		if primaryErr.Error != nil {
@@ -2307,6 +2312,11 @@ func (bifrost *Bifrost) handleStreamRequest(ctx context.Context, req *schemas.Bi
 
 	// Try the primary provider first
 	ctx = context.WithValue(ctx, schemas.BifrostContextKeyFallbackIndex, 0)
+	// Ensure request ID is set in context before PreHooks
+	if _, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string); !ok {
+		requestID := uuid.New().String()
+		ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestID, requestID)
+	}
 	primaryResult, primaryErr := bifrost.tryStreamRequest(ctx, req)
 
 	// Check if we should proceed with fallbacks

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: ensure request ID is consistently set in context before PreHooks are executed

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -19,7 +19,6 @@ var reservedKeys = []any{
 	BifrostContextKeySelectedKeyName,
 	BifrostContextKeyNumberOfRetries,
 	BifrostContextKeyFallbackIndex,
-	BifrostContextKeyStreamEndIndicator,
 	BifrostContextKeySkipKeySelection,
 	BifrostContextKeyExtraHeaders,
 	BifrostContextKeyURLPath,

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -398,11 +398,11 @@ func (plugin *Plugin) PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostR
 		ctx.SetValue(GenerationIDKey, generationID)
 
 		// Extract request ID from context, if not present, create a new one
-		var ok bool
-		requestID, ok = ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+		requestID, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
 		if !ok || requestID == "" {
+			// This should never happen since core/bifrost.go guarantees it's set before PreHooks
 			requestID = uuid.New().String()
-			ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
+			plugin.logger.Warn("%s request ID missing in PreHook, using fallback: %s", PluginLoggerPrefix, requestID)
 		}
 	}
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
 - fix: added missing logs filter checks in ui for live updates
+- fix: ensure request ID is consistently set in context before PreHooks are executed


### PR DESCRIPTION
## Summary

Ensure request ID is consistently set in context before PreHooks are executed, fixing an issue where request IDs might be missing or inconsistently generated.

## Changes

- Added request ID generation in `handleRequest` and `handleStreamRequest` functions to ensure it's set before PreHooks are executed
- Removed redundant request ID generation in the Maxim plugin's PreHook function, now relying on the guaranteed ID from the context
- Removed `BifrostContextKeyStreamEndIndicator` from the reserved keys list as it was no longer needed

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that request IDs are consistently present in logs and responses:

```sh
# Core/Transports
go version
go test ./...

# Test with Maxim plugin enabled
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-3.5-turbo", "messages":[{"role":"user", "content":"Hello"}]}'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes inconsistent request ID generation across the application.

## Security considerations

This change improves traceability by ensuring request IDs are consistently generated and available throughout the request lifecycle.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable