### PR TITLE
fixes helchart to expose gossip protocol port

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 1.5.1
-appVersion: "1.5.1"
+version: 1.5.2
+appVersion: "1.5.2"
 keywords:
   - ai
   - gateway

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -45,6 +45,14 @@ spec:
             - name: http
               containerPort: {{ .Values.bifrost.port }}
               protocol: TCP
+            {{- if .Values.bifrost.cluster.enabled }}
+            - name: gossip
+              containerPort: {{ .Values.bifrost.cluster.gossip.port }}
+              protocol: TCP
+            - name: gossip-udp
+              containerPort: {{ .Values.bifrost.cluster.gossip.port }}
+              protocol: UDP
+            {{- end }}
           env:
             - name: APP_DIR
               value: {{ .Values.bifrost.appDir | quote }}

--- a/helm-charts/bifrost/templates/service.yaml
+++ b/helm-charts/bifrost/templates/service.yaml
@@ -16,5 +16,15 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.bifrost.cluster.enabled }}
+    - port: {{ .Values.bifrost.cluster.gossip.port }}
+      targetPort: gossip
+      protocol: TCP
+      name: gossip
+    - port: {{ .Values.bifrost.cluster.gossip.port }}
+      targetPort: gossip-udp
+      protocol: UDP
+      name: gossip-udp
+    {{- end }}
   selector:
     {{- include "bifrost.selectorLabels" . | nindent 4 }}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,28 @@ apiVersion: v1
 entries:
   bifrost:
   - apiVersion: v2
+    appVersion: 1.5.2
+    created: "2026-01-05T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.2.tgz
+    version: 1.5.2
+  - apiVersion: v2
     appVersion: 1.5.1
     created: "2025-12-12T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
@@ -135,4 +157,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2025-12-10T12:00:00.000000+00:00"
+generated: "2026-01-05T12:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Added support for cluster mode in Bifrost Helm chart by exposing gossip ports and bumped chart version to 1.5.2.

## Changes

- Bumped Helm chart and app version from 1.5.1 to 1.5.2
- Added conditional gossip TCP and UDP ports to the deployment template when cluster mode is enabled
- Updated service template to expose gossip ports when cluster mode is enabled
- Updated Helm chart index with the new 1.5.2 version

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

Deploy Bifrost with cluster mode enabled and verify that gossip ports are properly exposed:

```sh
# Install the chart with cluster mode enabled
helm install bifrost ./helm-charts/bifrost --set bifrost.cluster.enabled=true

# Verify the ports are exposed in the deployment
kubectl get deployment bifrost -o jsonpath='{.spec.template.spec.containers[0].ports}'

# Verify the service exposes the gossip ports
kubectl get service bifrost -o jsonpath='{.spec.ports}'
```

## Breaking changes

- [x] No

## Related issues

Supports cluster mode functionality for horizontal scaling.

## Security considerations

Gossip ports should be properly secured in production environments to prevent unauthorized access to cluster communication.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)