### PR TITLE
docs updates

### DIFF
--- a/docs/changelogs/v1.4.0-prerelease4.mdx
+++ b/docs/changelogs/v1.4.0-prerelease4.mdx
@@ -1,0 +1,68 @@
+---
+title: "v1.4.0-prerelease4"
+description: "v1.4.0-prerelease4 changelog - 2026-01-05"
+---
+<Tabs>
+  <Tab title="NPX">
+    ```bash
+    npx -y @maximhq/bifrost --transport-version v1.4.0-prerelease4
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull maximhq/bifrost:v1.4.0-prerelease4
+    docker run -p 8080:8080 maximhq/bifrost:v1.4.0-prerelease4
+    ```
+  </Tab>
+</Tabs>
+
+<Update label="Bifrost(HTTP)" description="1.4.0-prerelease4">
+- feat: added support for multiple types in gemini and anthropic structured outputs properties
+- fix: added missing logs filter checks in ui for live updates
+- fix: ensure request ID is consistently set in context before PreHooks are executed
+- docs: updated docs for xai provider
+- fix: correct conversion of thinking level to thinking budget and vice versa in gemini
+
+</Update>
+<Update label="Core" description="1.3.3">
+- feat: added support for multiple types in gemini and anthropic structured outputs properties
+- fix: ensure request ID is consistently set in context before PreHooks are executed
+- fix: correct conversion of thinking level to thinking budget and vice versa in gemini
+
+</Update>
+<Update label="Framework" description="1.2.3">
+- chore: upgrades core to 1.2.47
+
+</Update>
+<Update label="governance" description="1.4.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="jsonparser" description="1.4.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="logging" description="1.4.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="maxim" description="1.5.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="mocker" description="1.4.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="otel" description="1.1.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="semanticcache" description="1.4.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>
+<Update label="telemetry" description="1.4.3">
+- chore: upgrades core to 1.2.47  and framework to 1.1.58
+
+</Update>

--- a/docs/changelogs/v1.4.0-prerelease5.mdx
+++ b/docs/changelogs/v1.4.0-prerelease5.mdx
@@ -1,0 +1,23 @@
+---
+title: "v1.4.0-prerelease5"
+description: "v1.4.0-prerelease5 changelog - 2026-01-05"
+---
+<Tabs>
+  <Tab title="NPX">
+    ```bash
+    npx -y @maximhq/bifrost --transport-version v1.4.0-prerelease5
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull maximhq/bifrost:v1.4.0-prerelease5
+    docker run -p 8080:8080 maximhq/bifrost:v1.4.0-prerelease5
+    ```
+  </Tab>
+</Tabs>
+
+<Update label="Bifrost(HTTP)" description="1.4.0-prerelease5">
+fix: non-streaming integration LLM calls requiring virtual keys
+fix: UI crash when disabling new plugin
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -351,6 +351,8 @@
         "tab": "Changelogs",
         "icon": "bolt",
         "pages": [
+          "changelogs/v1.4.0-prerelease5",
+          "changelogs/v1.4.0-prerelease4",
           "changelogs/v1.4.0-prerelease3",
           "changelogs/v1.3.59",
           "changelogs/v1.3.58",


### PR DESCRIPTION
## Summary

Added changelogs for v1.4.0-prerelease4 and v1.4.0-prerelease5 to document recent updates and fixes.

## Changes

- Added changelog for v1.4.0-prerelease4 documenting:
  - Support for multiple types in Gemini and Anthropic structured outputs
  - Fixed missing logs filter checks in UI for live updates
  - Ensured consistent request ID setting in context before PreHooks execution
  - Updated XAI provider documentation
  - Fixed conversion of thinking level to thinking budget in Gemini
  - Various dependency upgrades across plugins

- Added changelog for v1.4.0-prerelease5 documenting:
  - Fixed non-streaming integration LLM calls requiring virtual keys
  - Fixed UI crash when disabling new plugins

- Updated docs.json to include the new changelog entries in the navigation

## Type of change

- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Docs

## How to test

Verify the new changelog entries appear correctly in the documentation:

```sh
# UI
cd ui
pnpm i || npm i
pnpm dev || npm run dev
```

Navigate to the changelogs section to ensure the new entries for v1.4.0-prerelease4 and v1.4.0-prerelease5 are displayed properly.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)