### PR TITLE
stream data deduplication fixes

### DIFF
--- a/framework/streaming/audio.go
+++ b/framework/streaming/audio.go
@@ -74,9 +74,8 @@ func (a *Accumulator) processAccumulatedAudioStreamingChunks(requestID string, b
 	data.EndTimestamp = accumulator.FinalTimestamp
 	data.AudioOutput = completeMessage
 	data.ErrorDetails = bifrostErr
-	// Update token usage from final chunk if available
-	if len(accumulator.AudioStreamChunks) > 0 {
-		lastChunk := accumulator.AudioStreamChunks[len(accumulator.AudioStreamChunks)-1]
+	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, CacheDebug)
+	if lastChunk := accumulator.getLastAudioChunk(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = &schemas.BifrostLLMUsage{
 				PromptTokens:     lastChunk.TokenUsage.InputTokens,
@@ -84,17 +83,9 @@ func (a *Accumulator) processAccumulatedAudioStreamingChunks(requestID string, b
 				TotalTokens:      lastChunk.TokenUsage.TotalTokens,
 			}
 		}
-	}
-	// Update cost from final chunk if available
-	if len(accumulator.AudioStreamChunks) > 0 {
-		lastChunk := accumulator.AudioStreamChunks[len(accumulator.AudioStreamChunks)-1]
 		if lastChunk.Cost != nil {
 			data.Cost = lastChunk.Cost
 		}
-	}
-	// Update semantic cache debug from final chunk if available
-	if len(accumulator.AudioStreamChunks) > 0 {
-		lastChunk := accumulator.AudioStreamChunks[len(accumulator.AudioStreamChunks)-1]
 		if lastChunk.SemanticCacheDebug != nil {
 			data.CacheDebug = lastChunk.SemanticCacheDebug
 		}

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -198,20 +198,14 @@ func (a *Accumulator) processAccumulatedChatStreamingChunks(requestID string, re
 		data.ToolCalls = data.OutputMessage.ChatAssistantMessage.ToolCalls
 	}
 	data.ErrorDetails = respErr
-	// Update token usage from final chunk if available
-	if len(accumulator.ChatStreamChunks) > 0 {
-		lastChunk := accumulator.ChatStreamChunks[len(accumulator.ChatStreamChunks)-1]
+	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, FinishReason)
+	if lastChunk := accumulator.getLastChatChunk(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = lastChunk.TokenUsage
 		}
-		// Handle cache debug
 		if lastChunk.SemanticCacheDebug != nil {
 			data.CacheDebug = lastChunk.SemanticCacheDebug
 		}
-	}
-	// Update cost from final chunk if available
-	if len(accumulator.ChatStreamChunks) > 0 {
-		lastChunk := accumulator.ChatStreamChunks[len(accumulator.ChatStreamChunks)-1]
 		if lastChunk.Cost != nil {
 			data.Cost = lastChunk.Cost
 		}

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -787,21 +787,14 @@ func (a *Accumulator) processAccumulatedResponsesStreamingChunks(requestID strin
 
 	data.ErrorDetails = respErr
 
-	// Update token usage from final chunk if available
-	if len(accumulator.ResponsesStreamChunks) > 0 {
-		lastChunk := accumulator.ResponsesStreamChunks[len(accumulator.ResponsesStreamChunks)-1]
+	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, FinishReason)
+	if lastChunk := accumulator.getLastResponsesChunk(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = lastChunk.TokenUsage
 		}
-		// Handle cache debug
 		if lastChunk.SemanticCacheDebug != nil {
 			data.CacheDebug = lastChunk.SemanticCacheDebug
 		}
-	}
-
-	// Update cost from final chunk if available
-	if len(accumulator.ResponsesStreamChunks) > 0 {
-		lastChunk := accumulator.ResponsesStreamChunks[len(accumulator.ResponsesStreamChunks)-1]
 		if lastChunk.Cost != nil {
 			data.Cost = lastChunk.Cost
 		}

--- a/framework/streaming/transcription.go
+++ b/framework/streaming/transcription.go
@@ -81,9 +81,8 @@ func (a *Accumulator) processAccumulatedTranscriptionStreamingChunks(requestID s
 	data.EndTimestamp = accumulator.FinalTimestamp
 	data.TranscriptionOutput = completeMessage
 	data.ErrorDetails = bifrostErr
-	// Update token usage from final chunk if available
-	if len(accumulator.TranscriptionStreamChunks) > 0 {
-		lastChunk := accumulator.TranscriptionStreamChunks[len(accumulator.TranscriptionStreamChunks)-1]
+	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, CacheDebug)
+	if lastChunk := accumulator.getLastTranscriptionChunk(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = &schemas.BifrostLLMUsage{}
 			if lastChunk.TokenUsage.InputTokens != nil {
@@ -96,17 +95,9 @@ func (a *Accumulator) processAccumulatedTranscriptionStreamingChunks(requestID s
 				data.TokenUsage.TotalTokens = *lastChunk.TokenUsage.TotalTokens
 			}
 		}
-	}
-	// Update cost from final chunk if available
-	if len(accumulator.TranscriptionStreamChunks) > 0 {
-		lastChunk := accumulator.TranscriptionStreamChunks[len(accumulator.TranscriptionStreamChunks)-1]
 		if lastChunk.Cost != nil {
 			data.Cost = lastChunk.Cost
 		}
-	}
-	// Update semantic cache debug from final chunk if available
-	if len(accumulator.TranscriptionStreamChunks) > 0 {
-		lastChunk := accumulator.TranscriptionStreamChunks[len(accumulator.TranscriptionStreamChunks)-1]
 		if lastChunk.SemanticCacheDebug != nil {
 			data.CacheDebug = lastChunk.SemanticCacheDebug
 		}

--- a/tests/integrations/tests/test_openai.py
+++ b/tests/integrations/tests/test_openai.py
@@ -273,9 +273,8 @@ class TestOpenAIIntegration:
         response = client.chat.completions.create(
             model=format_provider_model(provider, model),
             messages=SIMPLE_CHAT_MESSAGES,
-            max_tokens=100,
+            max_tokens=100,            
         )
-
         assert_valid_chat_response(response)
         assert response.choices[0].message.content is not None
         assert len(response.choices[0].message.content) > 0
@@ -582,6 +581,7 @@ class TestOpenAIIntegration:
             messages=STREAMING_CHAT_MESSAGES,
             max_tokens=200,
             stream=True,
+            extra_body={"reasoning": {"effort": "high"}}
         )
 
         content, chunk_count, tool_calls_detected = collect_streaming_content(


### PR DESCRIPTION
## Summary

Fix streaming accumulator to handle duplicate chunks from multiple plugins calling ProcessStreamingChunk, ensuring proper chunk ordering and preventing duplicates.

## Changes

- Modified the accumulator to check if a chunk already exists at a specific index before appending
- Added logic to overwrite existing chunks at the same index instead of always appending
- Updated this behavior for all stream types: chat, transcription, audio, and responses
- Added reasoning parameter to streaming test to better exercise the functionality

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the streaming tests to verify that duplicate chunks are handled correctly:

```sh
# Core/Transports
go version
go test ./framework/streaming/...

# Integration tests
cd tests/integrations
python -m pytest tests/test_openai.py::TestOpenAI::test_13_streaming -v
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where multiple plugins processing the same streaming chunks could cause duplicate entries in the accumulator.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable