### PR TITLE
fix: don't show error_logs under show_missing_cost

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -63,8 +63,12 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		baseQuery = baseQuery.Where("cost <= ?", *filters.MaxCost)
 	}
 	if filters.MissingCostOnly {
-		baseQuery = baseQuery.Where("cost IS NULL OR cost <= 0")
+		baseQuery = baseQuery.
+			Where("status != ?", "error").
+			Where("token_usage IS NOT NULL").
+			Where("cost IS NULL")
 	}
+
 	if filters.ContentSearch != "" {
 		baseQuery = baseQuery.Where("content_summary LIKE ?", "%"+filters.ContentSearch+"%")
 	}


### PR DESCRIPTION
## Summary

fixes #1248 
PR fixes doesn't  show ``error_logs`` under the ``show_missing_cost``.  

## Changes
- changed the logic from ``cost IS NULL OR cost <= 0`` to ``Where("status != ?", "error").
			Where("token_usage IS NOT NULL").
			Where("cost IS NULL")``


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


