### PR TITLE
fix: improve tracer lifecycle management and stream accumulator handling

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -68,7 +68,6 @@ func TestExecuteRequestWithRetries_SuccessScenarios(t *testing.T) {
 			schemas.ChatCompletionRequest,
 			schemas.OpenAI,
 			"gpt-4",
-			schemas.DefaultTracer(),
 			nil,
 		)
 
@@ -103,7 +102,6 @@ func TestExecuteRequestWithRetries_SuccessScenarios(t *testing.T) {
 			schemas.ChatCompletionRequest,
 			schemas.OpenAI,
 			"gpt-4",
-			schemas.DefaultTracer(),
 			nil,
 		)
 
@@ -138,7 +136,6 @@ func TestExecuteRequestWithRetries_RetryLimits(t *testing.T) {
 			schemas.ChatCompletionRequest,
 			schemas.OpenAI,
 			"gpt-4",
-			schemas.DefaultTracer(),
 			nil,
 		)
 
@@ -202,7 +199,6 @@ func TestExecuteRequestWithRetries_NonRetryableErrors(t *testing.T) {
 				schemas.ChatCompletionRequest,
 				schemas.OpenAI,
 				"gpt-4",
-				schemas.DefaultTracer(),
 				nil,
 			)
 
@@ -276,7 +272,6 @@ func TestExecuteRequestWithRetries_RetryableConditions(t *testing.T) {
 				schemas.ChatCompletionRequest,
 				schemas.OpenAI,
 				"gpt-4",
-				schemas.DefaultTracer(),
 				nil,
 			)
 
@@ -506,7 +501,6 @@ func TestExecuteRequestWithRetries_LoggingAndCounting(t *testing.T) {
 		schemas.ChatCompletionRequest,
 		schemas.OpenAI,
 		"gpt-4",
-		schemas.DefaultTracer(),
 		nil,
 	)
 

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: tracer lifecycle management fixes

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -13,7 +13,6 @@ type SpanHandle interface{}
 // StreamAccumulatorResult contains the accumulated data from streaming chunks.
 // This is the return type for tracer's streaming accumulation methods.
 type StreamAccumulatorResult struct {
-	IsFinal             bool                          // Whether this is the final chunk
 	RequestID           string                        // Request ID
 	Model               string                        // Model used
 	Provider            ModelProvider                 // Provider used
@@ -143,7 +142,8 @@ func (n *NoOpTracer) AddEvent(_ SpanHandle, _ string, _ map[string]any) {}
 func (n *NoOpTracer) PopulateLLMRequestAttributes(_ SpanHandle, _ *BifrostRequest) {}
 
 // PopulateLLMResponseAttributes does nothing.
-func (n *NoOpTracer) PopulateLLMResponseAttributes(_ SpanHandle, _ *BifrostResponse, _ *BifrostError) {}
+func (n *NoOpTracer) PopulateLLMResponseAttributes(_ SpanHandle, _ *BifrostResponse, _ *BifrostError) {
+}
 
 // StoreDeferredSpan does nothing.
 func (n *NoOpTracer) StoreDeferredSpan(_ string, _ SpanHandle) {}
@@ -184,4 +184,3 @@ func DefaultTracer() Tracer {
 
 // Ensure NoOpTracer implements Tracer at compile time
 var _ Tracer = (*NoOpTracer)(nil)
-

--- a/core/utils.go
+++ b/core/utils.go
@@ -198,6 +198,18 @@ func IsStreamRequestType(reqType schemas.RequestType) bool {
 	return reqType == schemas.TextCompletionStreamRequest || reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.ResponsesStreamRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionStreamRequest
 }
 
+func GetTracerFromContext(ctx *schemas.BifrostContext) (schemas.Tracer, string, error) {
+	tracer, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	if !ok || tracer == nil {
+		return nil, "", fmt.Errorf("tracer not found in context")
+	}
+	traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string)
+	if !ok || traceID == "" {
+		return nil, "", fmt.Errorf("traceID not found in context")
+	}
+	return tracer, traceID, nil
+}
+
 // isBatchRequestType returns true if the given request type is a batch API operation.
 func isBatchRequestType(reqType schemas.RequestType) bool {
 	return reqType == schemas.BatchCreateRequest || reqType == schemas.BatchListRequest || reqType == schemas.BatchRetrieveRequest || reqType == schemas.BatchCancelRequest || reqType == schemas.BatchResultsRequest

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,3 @@
 - feat: added flush session functionality to config store to clear all existing sessions
+- fix: stream accumulator reference count management fixes
+- fix: stream accumulator deduplication fixes

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,1 +1,2 @@
 - chore: update framework version to 1.1.59
+- fix: streaming tracer cleanup fixes

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -250,14 +250,6 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		streamType = streaming.StreamTypeChat
 	}
 
-	// Determine response type
-	var responseType streaming.StreamResponseType
-	if result.IsFinal {
-		responseType = streaming.StreamResponseTypeFinal
-	} else {
-		responseType = streaming.StreamResponseTypeDelta
-	}
-
 	// Build accumulated data
 	data := &streaming.AccumulatedData{
 		RequestID:           result.RequestID,
@@ -283,7 +275,6 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 	}
 
 	resp := &streaming.ProcessedStreamResponse{
-		Type:       responseType,
 		RequestID:  result.RequestID,
 		StreamType: streamType,
 		Provider:   result.Provider,

--- a/plugins/maxim/changelog.md
+++ b/plugins/maxim/changelog.md
@@ -1,1 +1,2 @@
 - chore: update framework version to 1.1.59
+- fix: streaming tracer cleanup fixes

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -316,8 +316,6 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 func (m *TracingMiddleware) completeAndFlushTrace(traceID string) {
 	go func() {
 		// Clean up the stream accumulator for this trace
-		// This must happen before EndTrace to ensure all accumulated data is available
-		m.tracer.Load().CleanupStreamAccumulator(traceID)
 
 		// Get completed trace from store
 		completedTrace := m.tracer.Load().EndTrace(traceID)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,5 @@
 - feat: remove restart required for auth config changes
 - fix: resolved issue where new auth configs were not being created
 - ci: added workflow to auto-generate openapi.json documentation when openapi yaml files change
+- fix: tracer lifecycle management fixes
+- fix: stream accumulator deduplication fixes


### PR DESCRIPTION
## Summary

Fix tracer lifecycle management and stream accumulator reference counting to prevent memory leaks and ensure proper cleanup of streaming resources.

## Changes

- Added proper reference counting for stream accumulators to track concurrent access
- Fixed tracer context management to ensure streaming goroutines have access to tracers
- Improved deep copying of streaming data structures to prevent shared pointer mutation
- Made stream accumulator processing idempotent to handle multiple plugin calls
- Fixed cleanup timing to ensure resources are properly released
- Removed redundant IsFinal flag from StreamAccumulatorResult
- Added GetTracerFromContext utility function for consistent tracer access

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that streaming requests properly clean up resources by running load tests with streaming endpoints:

```sh
# Core/Transports
go version
go test ./...

# Run load test with streaming endpoints
go run cmd/bifrost/main.go
# In another terminal:
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello"}],"stream":true}'
```

Monitor memory usage during repeated streaming requests to ensure no leaks.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes memory leaks in streaming requests and ensures proper cleanup of resources.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable