### PR TITLE
docs updates

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -177,7 +177,14 @@
             "pages": [
               "plugins/getting-started",
               "plugins/building-dynamic-binary",
-              "plugins/writing-plugin",
+              {
+                "group": "Writing Plugins",
+                "icon": "code",
+                "pages": [
+                  "plugins/writing-go-plugin",
+                  "plugins/writing-wasm-plugin"
+                ]
+              },
               "plugins/migration-guide"
             ]
           },
@@ -354,7 +361,6 @@
           "changelogs/v1.4.0-prerelease5",
           "changelogs/v1.4.0-prerelease4",
           "changelogs/v1.4.0-prerelease3",
-          "changelogs/v1.3.61",
           "changelogs/v1.3.60",
           "changelogs/v1.3.59",
           "changelogs/v1.3.58",
@@ -460,6 +466,10 @@
     {
       "source": "/providers/huggingface",
       "destination": "/providers/supported-providers/huggingface"
+    },
+    {
+      "source": "/plugins/writing-plugin",
+      "destination": "/plugins/writing-go-plugin"
     }
   ],
   "footer": {

--- a/docs/enterprise/setting-up-okta.mdx
+++ b/docs/enterprise/setting-up-okta.mdx
@@ -71,9 +71,21 @@ Configure the following settings for your application:
 
 ---
 
-## Step 3: Configure Authorization Server
+## Step 3: Configure Authorization Server (optional)
 
-Bifrost uses Okta's Authorization Server to issue tokens. You can use the default authorization server or create a custom one.
+<Note>
+The default authorization server (`/oauth2/default`) is available to all Okta plans and **supports custom claims**, including role claims. The API Access Management paid add-on is only required to create additional custom authorization servers beyond the default.
+</Note>
+
+Bifrost uses Okta's Authorization Server to issue tokens. You have three options:
+
+1. **Use `/oauth2/default` with role claims (recommended)** — Complete Steps 4-7 to configure custom role claims on the default authorization server. This enables automatic RBAC synchronization.
+
+2. **Use `/oauth2/default` without role claims** — Skip Steps 4-7. The first user to sign in automatically receives the Admin role and can manage RBAC for all subsequent users through the Bifrost dashboard.
+
+3. **Skip Step 3 entirely** — Authorization is not configured through Okta. You'll need an alternative authentication mechanism.
+
+### Configuring the Authorization Server
 
 1. Navigate to **Security** → **API**
 2. Click on **Authorization Servers**
@@ -224,6 +236,10 @@ Adjust the group filter expression based on your naming convention. The example 
 
 4. Click **Save and Go Back**
 
+<Note>
+Role claims are available only when you configure custom claims on your authorization server. Ensure you add role claims to your chosen authorization server (for example, `/oauth2/default`) to enable RBAC. If you skipped Steps 4-7, the first user to sign in automatically receives the **Admin** role and can manage RBAC for all subsequent users through the Bifrost dashboard.
+</Note>
+
 ---
 
 ## Step 8: Configure Bifrost
@@ -239,7 +255,7 @@ Now configure Bifrost to use Okta as the identity provider.
 | Field | Value |
 |-------|-------|
 | **Client ID** | Your Okta application Client ID |
-| **Issuer URL** | `https://your-domain.okta.com/oauth2/default` |
+| **Issuer URL** | Issuer URL |
 | **Audience** | Your API audience (e.g., `api://default` or custom) |
 | **Client Secret** | Your Okta application Client Secret (optional, for token revocation) |
 

--- a/docs/plugins/getting-started.mdx
+++ b/docs/plugins/getting-started.mdx
@@ -104,5 +104,8 @@ Plugins execute in a specific order:
 
 ## Next Steps
 
-Ready to build your first plugin? Continue to [Writing Plugins](./writing-plugin) to learn how to create, build, and deploy custom plugins for Bifrost.
+Ready to build your first plugin? Choose your approach:
+
+- **[Writing Go Plugins](./writing-go-plugin)** - Native Go plugins using shared objects (`.so` files). Best for performance and full Go ecosystem access.
+- **[Writing WASM Plugins](./writing-wasm-plugin)** - Cross-platform plugins using WebAssembly. Write in TypeScript, Go (TinyGo), or Rust. No version matching required.
 

--- a/docs/plugins/migration-guide.mdx
+++ b/docs/plugins/migration-guide.mdx
@@ -6,7 +6,7 @@ icon: "arrow-up-right-dots"
 
 ## Overview
 
-Bifrost v1.4.x introduces a new plugin interface for HTTP transport layer interception. This guide helps you migrate existing plugins from the v1.3.x `TransportInterceptor` pattern to the v1.4.x `HTTPTransportMiddleware` pattern.
+Bifrost v1.4.x introduces a new plugin interface for HTTP transport layer interception. This guide helps you migrate existing plugins from the v1.3.x `TransportInterceptor` pattern to the v1.4.x `HTTPTransportIntercept` pattern.
 
 <Note>
 If your plugin doesn't use `TransportInterceptor`, no migration is needed. The `PreHook`, `PostHook`, `Init`, `GetName`, and `Cleanup` functions remain unchanged.
@@ -14,39 +14,42 @@ If your plugin doesn't use `TransportInterceptor`, no migration is needed. The `
 
 ## What Changed?
 
-The HTTP transport interception mechanism changed from a simple function that receives and returns headers/body to a middleware pattern that wraps the entire request handler chain.
+The HTTP transport interception mechanism changed from a simple function that receives and returns headers/body to a serializable intercept pattern that works with both native `.so` plugins and WASM plugins.
 
 ### Key Differences
 
-| Aspect | v1.3.x (TransportInterceptor) | v1.4.x+ (HTTPTransportMiddleware) |
-|--------|-------------------------------|-----------------------------------|
-| Function signature | `TransportInterceptor(ctx, url, headers, body)` | `HTTPTransportMiddleware()` |
-| Return type | `(headers, body, error)` | `BifrostHTTPMiddleware` |
-| Access scope | Headers and body as maps | Full `*fasthttp.RequestCtx` |
-| Flow control | Implicit (return modified values) | Explicit (`next(ctx)` call) |
-| Capability | Request modification only | Request AND response modification |
+| Aspect | v1.3.x (TransportInterceptor) | v1.4.x+ (HTTPTransportIntercept) |
+|--------|-------------------------------|----------------------------------|
+| Signature | `TransportInterceptor(ctx, url, headers, body)` | `HTTPTransportIntercept(ctx, req)` |
+| Return type | `(headers, body, error)` | `(*HTTPResponse, error)` |
+| Request type | Separate `headers map`, `body map` | Unified `*HTTPRequest` struct |
+| Modification | Return modified maps | Modify `req` in-place |
+| Short-circuit | Return error | Return `*HTTPResponse` |
+| WASM support | No | Yes |
+| Context | Limited `BifrostContext` | Full `*BifrostContext` |
 
 ### Why the Change?
 
-The new middleware pattern provides:
+The new intercept pattern provides:
 
-1. **Full HTTP control** - Access to the complete `*fasthttp.RequestCtx` including method, path, query params, and all headers
-2. **Response interception** - Ability to modify responses after they return from downstream handlers
-3. **Better composability** - Standard middleware pattern that chains naturally with other handlers
-4. **More flexibility** - Can short-circuit requests, add timing, implement retries, etc.
+1. **WASM plugin support** - Serializable types work across WASM boundary
+2. **Simpler API** - No middleware wrapper, direct function call
+3. **Better testability** - No fasthttp dependency in plugin tests
+4. **Full context access** - BifrostContext available for request metadata
+5. **Custom response short-circuits** - Return a full response to short-circuit
 
 ## Migration Steps
 
 ### Step 1: Update Imports
 
-Add the `fasthttp` import to your plugin:
+Remove the `fasthttp` import if present:
 
 ```go
 import (
 	"fmt"
 
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/valyala/fasthttp"  // Add this import
+	// Remove: "github.com/valyala/fasthttp"
 )
 ```
 
@@ -70,29 +73,26 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 **After (v1.4.x+):**
 
 ```go
-// HTTPTransportMiddleware returns a middleware for HTTP transport
-func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
-	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-		return func(ctx *fasthttp.RequestCtx) {
-			// Add custom header
-			ctx.Request.Header.Set("X-Custom-Header", "value")
-			
-			// Modify body (if needed)
-			// Note: Body modification requires parsing and re-serializing
-			// ctx.Request.SetBody(modifiedBody)
-			
-			// Call next handler in chain
-			next(ctx)
-			
-			// Can also modify response here after next() returns
-		}
-	}
+// HTTPTransportIntercept intercepts requests at the transport layer
+// Modify req in-place. Return (*HTTPResponse, nil) to short-circuit.
+func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	// Add custom header (in-place modification)
+	req.Headers["X-Custom-Header"] = "value"
+	
+	// Modify body (in-place modification)
+	var body map[string]any
+	sonic.Unmarshal(req.Body, &body)
+	body["custom_field"] = "custom_value"
+	req.Body, _ = sonic.Marshal(body)
+	
+	// Return nil to continue, or return &HTTPResponse{} to short-circuit
+	return nil, nil
 }
 ```
 
 ### Step 3: Update Body Modification Logic
 
-In v1.3.x, you received the body as a `map[string]any`. In v1.4.x, you work with raw bytes:
+In v1.3.x, you received the body as a `map[string]any`. In v1.4.x, you work with `req.Body` bytes:
 
 **Before (v1.3.x):**
 
@@ -109,46 +109,16 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 ```go
 import "github.com/bytedance/sonic"
 
-func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
-	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-		return func(ctx *fasthttp.RequestCtx) {
-			// Parse existing body
-			var body map[string]any
-			if err := sonic.Unmarshal(ctx.Request.Body(), &body); err == nil {
-				// Modify body
-				body["model"] = "gpt-4"
-				
-				// Re-serialize and set
-				if newBody, err := sonic.Marshal(body); err == nil {
-					ctx.Request.SetBody(newBody)
-				}
-			}
-			
-			next(ctx)
-		}
+func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	// Parse body
+	var body map[string]any
+	if err := sonic.Unmarshal(req.Body, &body); err == nil {
+		// Modify body
+		body["model"] = "gpt-4"
+		// Update req.Body in-place
+		req.Body, _ = sonic.Marshal(body)
 	}
-}
-```
-
-### Step 4: Handle Response Modification (New Capability)
-
-The new pattern allows you to modify responses, which wasn't possible in v1.3.x:
-
-```go
-func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
-	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-		return func(ctx *fasthttp.RequestCtx) {
-			// Before request
-			startTime := time.Now()
-			
-			// Process request
-			next(ctx)
-			
-			// After response - NEW CAPABILITY
-			duration := time.Since(startTime)
-			ctx.Response.Header.Set("X-Processing-Time", duration.String())
-		}
-	}
+	return nil, nil
 }
 ```
 
@@ -164,8 +134,8 @@ return headers, body, nil
 
 **v1.4.x+:**
 ```go
-ctx.Request.Header.Set("Authorization", "Bearer " + token)
-next(ctx)
+req.Headers["Authorization"] = "Bearer " + token
+return nil, nil
 ```
 
 ### Reading Headers
@@ -177,7 +147,7 @@ apiKey := headers["X-API-Key"]
 
 **v1.4.x+:**
 ```go
-apiKey := string(ctx.Request.Header.Peek("X-API-Key"))
+apiKey := req.Headers["X-API-Key"]
 ```
 
 ### Conditional Processing
@@ -195,21 +165,16 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 
 **v1.4.x+:**
 ```go
-func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
-	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-		return func(ctx *fasthttp.RequestCtx) {
-			if string(ctx.Request.Header.Peek("X-Skip-Processing")) == "true" {
-				next(ctx)
-				return
-			}
-			// Process...
-			next(ctx)
-		}
+func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if req.Headers["X-Skip-Processing"] == "true" {
+		return nil, nil // Continue without modification
 	}
+	// Process...
+	return nil, nil
 }
 ```
 
-### Error Handling
+### Error Handling / Short-Circuit
 
 **v1.3.x:**
 ```go
@@ -223,17 +188,38 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 
 **v1.4.x+:**
 ```go
-func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
-	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
-		return func(ctx *fasthttp.RequestCtx) {
-			if len(ctx.Request.Header.Peek("X-API-Key")) == 0 {
-				ctx.SetStatusCode(401)
-				ctx.SetBodyString(`{"error": "missing API key"}`)
-				return // Don't call next - short-circuit the request
-			}
-			next(ctx)
-		}
+func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if req.Headers["X-API-Key"] == "" {
+		// Return a custom response to short-circuit
+		return &schemas.HTTPResponse{
+			StatusCode: 401,
+			Headers:    map[string]string{"Content-Type": "application/json"},
+			Body:       []byte(`{"error": "missing API key"}`),
+		}, nil
 	}
+	return nil, nil
+}
+```
+
+### Accessing Request Method and Path
+
+**v1.3.x:**
+```go
+// url parameter contained the full URL
+func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	// Limited access to URL
+	return headers, body, nil
+}
+```
+
+**v1.4.x+:**
+```go
+func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	// Full access to request properties
+	method := req.Method      // "GET", "POST", etc.
+	path := req.Path          // "/v1/chat/completions"
+	query := req.Query        // map[string]string of query params
+	return nil, nil
 }
 ```
 
@@ -256,9 +242,9 @@ func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
      -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
    ```
 
-4. **Verify logs show the new middleware being called:**
+4. **Verify logs show the new intercept being called:**
    ```
-   HTTPTransportMiddleware called
+   HTTPTransportIntercept called
    PreHook called
    PostHook called
    ```
@@ -270,33 +256,38 @@ func HTTPTransportMiddleware() schemas.BifrostHTTPMiddleware {
 **Error:** `plugin: symbol TransportInterceptor not found`
 
 This error occurs if Bifrost v1.4.x is looking for the old function. Make sure:
-1. You've updated to `HTTPTransportMiddleware`
-2. The function signature matches exactly
+1. You've updated to `HTTPTransportIntercept`
+2. The function signature matches exactly: `func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)`
 3. You've rebuilt the plugin with the correct core version
 
 ### Body modification not working
 
-Make sure you're calling `ctx.Request.SetBody()` with the serialized bytes, not the map directly:
+Make sure you're assigning back to `req.Body`:
 
 ```go
-// Wrong
-ctx.Request.SetBody(body) // body is map[string]any
+// Wrong - body changes lost
+var body map[string]any
+sonic.Unmarshal(req.Body, &body)
+body["model"] = "gpt-4"
+// Missing: req.Body = ...
 
-// Correct
-bodyBytes, _ := sonic.Marshal(body)
-ctx.Request.SetBody(bodyBytes)
+// Correct - body changes applied
+var body map[string]any
+sonic.Unmarshal(req.Body, &body)
+body["model"] = "gpt-4"
+req.Body, _ = sonic.Marshal(body)  // Assign back!
 ```
 
 ### Headers not being set
 
-Remember that `fasthttp` header methods are case-sensitive for custom headers:
+Make sure you're modifying `req.Headers` directly:
 
 ```go
-// Set header
-ctx.Request.Header.Set("X-Custom-Header", "value")
+// Set header (case-sensitive keys)
+req.Headers["X-Custom-Header"] = "value"
 
-// Read header - use Peek for []byte or string conversion
-value := string(ctx.Request.Header.Peek("X-Custom-Header"))
+// Read header
+value := req.Headers["X-Custom-Header"]
 ```
 
 ## Need Help?

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -1,0 +1,845 @@
+---
+title: "Writing Go Plugins"
+description: "Step-by-step guide to creating native Go plugins for Bifrost using shared object (.so) files"
+icon: "golang"
+---
+
+## Overview
+
+This guide walks you through creating a native Go plugin for Bifrost using our [hello-world example](https://github.com/maximhq/bifrost/tree/main/examples/plugins/hello-world) as a reference. You'll learn how to structure your plugin, implement required functions, build the shared object, and integrate it with Bifrost.
+
+## Prerequisites
+
+Before you start, ensure you have:
+
+- **Go 1.25.5** installed (must match Bifrost's Go version)
+- **Linux or macOS** (Go plugins are not supported on Windows)
+- **Bifrost** installed and configured
+- Basic understanding of Go programming
+
+<Note>Make sure your go.mod has the go version pinned to 1.25.5</Note>
+
+## Project Structure
+
+A minimal plugin project should have the following structure:
+
+```
+hello-world/
+├── main.go          # Plugin implementation
+├── go.mod           # Go module definition
+├── go.sum           # Dependency checksums
+├── Makefile         # Build automation
+└── .gitignore       # Git ignore patterns
+```
+
+## Step 1: Initialize Your Plugin Project
+
+Create a new directory and initialize a Go module:
+
+```bash
+mkdir my-plugin
+cd my-plugin
+go mod init github.com/yourusername/my-plugin
+```
+
+Add Bifrost as a dependency:
+
+```bash
+go get github.com/maximhq/bifrost/core@latest
+```
+
+Your `go.mod` should look like this:
+
+```go
+module github.com/yourusername/my-plugin
+
+go 1.25.5
+
+require github.com/maximhq/bifrost/core v1.2.38
+```
+
+## Step 2: Implement the Plugin Interface
+
+Create `main.go` with the required plugin functions. Here's the complete hello-world example:
+
+<Tabs>
+  <Tab title="v1.4.x+">
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Init is called when the plugin is loaded
+// config contains the plugin configuration from config.json
+func Init(config any) error {
+	fmt.Println("Init called")
+	// Initialize your plugin here (database connections, API clients, etc.)
+	return nil
+}
+
+// GetName returns the plugin's unique identifier
+func GetName() string {
+	return "Hello World Plugin"
+}
+
+// HTTPTransportIntercept intercepts requests at the HTTP transport layer
+// Modify req in-place. Return (*HTTPResponse, nil) to short-circuit.
+// Only called when using HTTP transport (bifrost-http)
+func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	fmt.Println("HTTPTransportIntercept called")
+	// Modify request in-place (headers, body, query params)
+	req.Headers["X-Custom-Header"] = "custom-value"
+	// Return nil to continue, or return &schemas.HTTPResponse{} to short-circuit
+	return nil, nil
+}
+
+// PreHook is called before the request is sent to the provider
+// This is where you can modify requests or short-circuit the flow
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	fmt.Println("PreHook called")
+	// Modify the request or return a short-circuit to skip provider call
+	return req, nil, nil
+}
+
+// PostHook is called after receiving a response from the provider
+// This is where you can modify responses or handle errors
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	fmt.Println("PostHook called")
+	// Modify the response or error before returning to caller
+	return resp, bifrostErr, nil
+}
+
+// Cleanup is called when Bifrost shuts down
+func Cleanup() error {
+	fmt.Println("Cleanup called")
+	// Clean up resources (close connections, flush buffers, etc.)
+	return nil
+}
+```
+  </Tab>
+  <Tab title="v1.3.x">
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Init is called when the plugin is loaded
+// config contains the plugin configuration from config.json
+func Init(config any) error {
+	fmt.Println("Init called")
+	// Initialize your plugin here (database connections, API clients, etc.)
+	return nil
+}
+
+// GetName returns the plugin's unique identifier
+func GetName() string {
+	return "Hello World Plugin"
+}
+
+// TransportInterceptor modifies raw HTTP headers and body
+// Only called when using HTTP transport (bifrost-http)
+func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[string]string, body map[string]any) (map[string]string, map[string]any, error) {
+	fmt.Println("TransportInterceptor called")
+	// Modify headers or body before they enter Bifrost core
+	return headers, body, nil
+}
+
+// PreHook is called before the request is sent to the provider
+// This is where you can modify requests or short-circuit the flow
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	fmt.Println("PreHook called")
+	// Modify the request or return a short-circuit to skip provider call
+	return req, nil, nil
+}
+
+// PostHook is called after receiving a response from the provider
+// This is where you can modify responses or handle errors
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	fmt.Println("PostHook called")
+	// Modify the response or error before returning to caller
+	return resp, bifrostErr, nil
+}
+
+// Cleanup is called when Bifrost shuts down
+func Cleanup() error {
+	fmt.Println("Cleanup called")
+	// Clean up resources (close connections, flush buffers, etc.)
+	return nil
+}
+```
+  </Tab>
+</Tabs>
+
+### Understanding Each Function
+
+#### `Init(config any) error`
+
+Called once when the plugin is loaded. Use this to:
+- Parse plugin configuration
+- Initialize database connections
+- Set up API clients
+- Validate required environment variables
+
+```go
+func Init(config any) error {
+	// Parse configuration
+	cfg, ok := config.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("invalid config format")
+	}
+	
+	apiKey := cfg["api_key"].(string)
+	// Initialize your resources
+	return nil
+}
+```
+
+#### `GetName() string`
+
+Returns a unique identifier for your plugin. This name appears in logs and status reports.
+
+<Tabs>
+  <Tab title="v1.4.x+">
+#### `HTTPTransportIntercept(ctx, req)`
+
+**HTTP transport only.** Intercepts requests at the transport layer. Use this to:
+- Modify request headers, body, or query params in-place
+- Short-circuit with a custom response
+- Access `BifrostContext` for request metadata
+- Works with both native .so and WASM plugins
+
+Key points:
+- Receives serializable `*HTTPRequest` (not raw fasthttp)
+- Modify `req.Headers`, `req.Body`, `req.Query` directly
+- Return `(nil, nil)` to continue to next plugin/handler
+- Return `(*HTTPResponse, nil)` to short-circuit with response
+- Return `(nil, error)` to short-circuit with error
+
+<Warning>
+This function is **only called** when using `bifrost-http`. It's **not invoked** when using Bifrost as a Go SDK.
+</Warning>
+  </Tab>
+  <Tab title="v1.3.x">
+#### `TransportInterceptor(...)`
+
+**HTTP transport only.** Called before requests enter Bifrost core. Use this to:
+- Add or modify HTTP headers
+- Transform request body
+- Implement authentication at the transport layer
+
+<Warning>
+This function is **only called** when using `bifrost-http`. It's **not invoked** when using Bifrost as a Go SDK.
+</Warning>
+  </Tab>
+</Tabs>
+
+#### `PreHook(...)`
+
+Called before each provider request. Use this to:
+- Modify request parameters
+- Add logging or monitoring
+- Implement caching (check cache, return cached response)
+- Apply governance rules (rate limiting, budget checks)
+- **Short-circuit** to skip provider calls
+
+**Short-Circuiting Example:**
+
+```go
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	// Return cached response without calling provider
+	if cachedResponse := checkCache(req) {
+		return req, &schemas.PluginShortCircuit{
+			Response: cachedResponse,
+		}, nil
+	}
+	return req, nil, nil
+}
+```
+
+#### `PostHook(...)`
+
+Called after provider responses (or short-circuits). Use this to:
+- Transform responses
+- Log response data
+- Store responses in cache
+- Handle errors or implement fallback logic
+- Add custom metadata
+
+**Response Transformation Example:**
+
+```go
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	if resp != nil && resp.ChatResponse != nil {
+		// Add custom metadata
+		resp.ChatResponse.ExtraFields.RawResponse = map[string]interface{}{
+			"plugin_processed": true,
+			"timestamp": time.Now().Unix(),
+		}
+	}
+	return resp, bifrostErr, nil
+}
+```
+
+#### `Cleanup() error`
+
+Called on Bifrost shutdown. Use this to:
+- Close database connections
+- Flush buffers
+- Save state
+- Release resources
+
+## Step 3: Create a Makefile
+
+Create a `Makefile` to automate building your plugin:
+
+```makefile
+.PHONY: all build clean install help
+
+PLUGIN_NAME = my-plugin
+OUTPUT_DIR = build
+
+# Platform detection
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	PLUGIN_EXT = .so
+	PLATFORM = linux
+endif
+ifeq ($(UNAME_S),Darwin)
+	PLUGIN_EXT = .so
+	PLATFORM = darwin
+endif
+
+# Architecture detection
+UNAME_M := $(shell uname -m)
+ifeq ($(UNAME_M),x86_64)
+	ARCH = amd64
+endif
+ifeq ($(UNAME_M),arm64)
+	ARCH = arm64
+endif
+
+OUTPUT = $(OUTPUT_DIR)/$(PLUGIN_NAME)$(PLUGIN_EXT)
+
+build: ## Build the plugin for current platform
+	@echo "Building plugin for $(PLATFORM)/$(ARCH)..."
+	@mkdir -p $(OUTPUT_DIR)
+	go build -buildmode=plugin -o $(OUTPUT) main.go
+	@echo "Plugin built successfully: $(OUTPUT)"
+
+clean: ## Remove build artifacts
+	@rm -rf $(OUTPUT_DIR)
+
+install: build ## Build and install to Bifrost plugins directory
+	@mkdir -p ~/.bifrost/plugins
+	@cp $(OUTPUT) ~/.bifrost/plugins/
+	@echo "Plugin installed to ~/.bifrost/plugins/"
+```
+
+## Step 4: Build Your Plugin
+
+Build the plugin using the Makefile:
+
+```bash
+make build
+```
+
+This creates `build/my-plugin.so` in your project directory.
+
+For production, you may need to build for specific platforms:
+
+```bash
+# Build for Linux AMD64
+GOOS=linux GOARCH=amd64 go build -buildmode=plugin -o my-plugin-linux-amd64.so main.go
+
+# Build for Linux ARM64
+GOOS=linux GOARCH=arm64 go build -buildmode=plugin -o my-plugin-linux-arm64.so main.go
+
+# Build for macOS ARM64 (M1/M2)
+GOOS=darwin GOARCH=arm64 go build -buildmode=plugin -o my-plugin-darwin-arm64.so main.go
+```
+
+<Warning>
+**Cross-compilation doesn't work for plugins!** You must build on the target platform. If you need a Linux plugin, build it on a Linux machine or use Docker.
+</Warning>
+
+## Step 5: Configure Bifrost to Load Your Plugin
+
+Add your plugin to Bifrost's `config.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "my-plugin",
+      "path": "/path/to/my-plugin.so",
+      "version": 1,
+      "config": {
+        "api_key": "your-api-key",
+        "custom_setting": "value"
+      }
+    }
+  ]
+}
+```
+
+### Plugin Configuration Options
+
+- `enabled` - Set to `true` to load the plugin
+- `name` - Plugin identifier (used in logs)
+- `path` - Absolute or relative path to the `.so` file
+- `config` - Plugin-specific configuration passed to `Init()`
+- `version` - (Optional) Plugin version number (default: 1). Increment this value to force a reload of the plugin and database update when Bifrost restarts. Useful when you want to ensure config changes take effect without manually clearing plugin state.
+
+## Step 6: Test Your Plugin
+
+Start Bifrost and verify your plugin loads:
+
+```bash
+./bifrost-http
+```
+
+You should see output like:
+
+```
+Init called
+[INFO] Plugin loaded: Hello World Plugin
+```
+
+Make a test request:
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+Check the logs for plugin hook calls:
+
+<Tabs>
+  <Tab title="v1.4.x+">
+```
+HTTPTransportIntercept called
+PreHook called
+PostHook called
+```
+  </Tab>
+  <Tab title="v1.3.x">
+```
+TransportInterceptor called
+PreHook called
+PostHook called
+```
+  </Tab>
+</Tabs>
+
+## Advanced Plugin Patterns
+
+### Stateful Plugins
+
+For plugins that need to maintain state across requests:
+
+```go
+package main
+
+import (
+	"sync"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+var (
+	requestCount int64
+	mu           sync.Mutex
+)
+
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	mu.Lock()
+	requestCount++
+	count := requestCount
+	mu.Unlock()
+	
+	// Use count for rate limiting, metrics, etc.
+	return req, nil, nil
+}
+```
+
+### Error Handling with Fallbacks
+
+Control whether Bifrost should try fallback providers:
+
+```go
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	if bifrostErr != nil {
+		// Allow fallbacks for rate limit errors
+		if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type == "rate_limit" {
+			allowFallbacks := true
+			bifrostErr.AllowFallbacks = &allowFallbacks
+		} else {
+			// Don't try fallbacks for auth errors
+			allowFallbacks := false
+			bifrostErr.AllowFallbacks = &allowFallbacks
+		}
+	}
+	return resp, bifrostErr, nil
+}
+```
+
+### Caching Plugin Example
+
+```go
+var cache sync.Map
+
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	// Generate cache key from request
+	key := generateCacheKey(req)
+	
+	// Check cache
+	if cached, ok := cache.Load(key); ok {
+		return req, &schemas.PluginShortCircuit{
+			Response: cached.(*schemas.BifrostResponse),
+		}, nil
+	}
+	
+	return req, nil, nil
+}
+
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	if resp != nil && bifrostErr == nil {
+		// Store in cache
+		key := generateCacheKeyFromResponse(resp)
+		cache.Store(key, resp)
+	}
+	return resp, bifrostErr, nil
+}
+```
+
+## Troubleshooting
+
+### Plugin Fails to Load
+
+**Error**: `plugin: not a plugin file`
+
+**Solution**: Ensure you built with `-buildmode=plugin`:
+```bash
+go build -buildmode=plugin -o plugin.so main.go
+```
+
+### Version Mismatch Errors
+
+**Error**: `plugin was built with a different version of package`
+
+**Why this happens**: Go's plugin system requires **exact version matching** for:
+- The Go compiler version
+- **All shared packages** (especially `github.com/maximhq/bifrost/core`)
+- **Transitive dependencies** (packages that your dependencies depend on)
+
+This is more strict than typical Go builds. Even if only one transitive dependency differs by a patch version, the plugin will fail to load.
+
+**Solution**: Ensure your plugin is built with the exact same versions as Bifrost.
+
+**Step 1: Diagnose the mismatch**
+
+Use `go version -m` to inspect the build info of both your plugin and the Bifrost binary:
+
+```bash
+# Check what versions your plugin was built with:
+$ go version -m my-plugin.so
+my-plugin.so: go1.25.5
+  dep  github.com/maximhq/bifrost/core  v1.3.50
+  dep  github.com/valyala/fasthttp      v1.51.0
+
+# Check what versions Bifrost was built with:
+$ go version -m bifrost-http
+bifrost-http: go1.25.5
+  dep  github.com/maximhq/bifrost/core  v1.3.54   # <-- MISMATCH!
+  dep  github.com/valyala/fasthttp      v1.55.0   # <-- MISMATCH!
+```
+
+Notice that even though the Go version matches (`go1.25.5`), the **package versions** are different — this causes the error.
+
+**Step 2: Update your plugin dependencies**
+
+```bash
+# Update to match Bifrost's core version
+go get github.com/maximhq/bifrost/core@v1.3.54
+go mod tidy
+
+# Rebuild the plugin
+go build -buildmode=plugin -o my-plugin.so main.go
+```
+
+**Step 3: Verify the fix**
+
+```bash
+# Confirm versions now match
+$ go version -m my-plugin.so | grep bifrost
+  dep  github.com/maximhq/bifrost/core  v1.3.54  # Now matches!
+```
+
+<Tip>
+**Pro tip**: Pin exact versions in your `go.mod` and keep your plugin's dependencies in sync with the Bifrost version you're deploying. Consider building both Bifrost and your plugins in the same CI pipeline to guarantee version alignment.
+</Tip>
+
+### Platform/Architecture Mismatch
+
+**Error**: `cannot load plugin built for GOOS=linux on darwin`
+
+**Solution**: Build on the target platform or use the correct GOOS/GOARCH for your system.
+
+### Function Not Found
+
+**Error**: `plugin: symbol Init not found`
+
+**Solution**: Ensure all required functions are exported (start with capital letter) and have the correct signature.
+
+## Source Code Reference
+
+The complete hello-world example is available in the Bifrost repository:
+
+- **Full Example**: [examples/plugins/hello-world](https://github.com/maximhq/bifrost/tree/main/examples/plugins/hello-world)
+- **main.go**: [Plugin implementation](https://github.com/maximhq/bifrost/blob/main/examples/plugins/hello-world/main.go)
+- **Makefile**: [Build configuration](https://github.com/maximhq/bifrost/blob/main/examples/plugins/hello-world/Makefile)
+- **go.mod**: [Dependencies](https://github.com/maximhq/bifrost/blob/main/examples/plugins/hello-world/go.mod)
+
+## Real-World Plugin Examples
+
+Explore production-ready plugins in the Bifrost repository:
+
+- **[Mocker Plugin](https://github.com/maximhq/bifrost/tree/main/plugins/mocker)** - Mock responses for testing
+- **[Logging Plugin](https://github.com/maximhq/bifrost/tree/main/plugins/logging)** - Advanced request/response logging
+- **[Semantic Cache Plugin](https://github.com/maximhq/bifrost/tree/main/plugins/semanticcache)** - Cache based on semantic similarity
+- **[Governance Plugin](https://github.com/maximhq/bifrost/tree/main/plugins/governance)** - Rate limiting and budget controls
+- **[JSON Parser Plugin](https://github.com/maximhq/bifrost/tree/main/plugins/jsonparser)** - Parse and validate JSON responses
+
+## Frequently Asked Questions
+
+### Do I need to rebuild my plugin when upgrading Bifrost?
+
+**Yes, absolutely.** Plugins must be compiled against the exact same version of `github.com/maximhq/bifrost/core` that Bifrost is using. This is a fundamental requirement of Go's plugin system.
+
+When you upgrade Bifrost, you must:
+1. Update your plugin's `go.mod` to use the matching core version
+2. Rebuild the plugin with the same Go version
+3. Redeploy the plugin alongside the new Bifrost version
+
+**Example:**
+
+If upgrading from Bifrost v1.2.17 to v1.3.0:
+
+```bash
+# Update your plugin dependency
+go get github.com/maximhq/bifrost/core@v1.3.0
+go mod tidy
+
+# Rebuild the plugin
+go build -buildmode=plugin -o my-plugin.so main.go
+```
+
+<Warning>
+**Version mismatch will cause runtime errors!** If your plugin is compiled with v1.2.17 but Bifrost is running v1.3.0, the plugin will fail to load with cryptic errors about package versions.
+</Warning>
+
+### Should plugin builds be part of my deployment pipeline?
+
+**Yes, strongly recommended.** Your plugin build and deployment should be tightly coupled with your Bifrost deployment.
+
+**Recommended CI/CD Workflow:**
+
+```yaml
+# Example GitHub Actions workflow
+name: Deploy Bifrost with Plugins
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Checkout code
+      - uses: actions/checkout@v3
+      
+      # 2. Setup Go
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.25.5'
+      
+      # 3. Build Bifrost
+      - name: Build Bifrost
+        run: |
+          cd transports/bifrost-http
+          go build -o bifrost-http
+      
+      # 4. Build ALL plugins with matching version
+      - name: Build Plugins
+        run: |
+          cd plugins/my-plugin
+          # Ensure plugin uses same core version as Bifrost
+          go get github.com/maximhq/bifrost/core@${{ env.BIFROST_VERSION }}
+          go mod tidy
+          go build -buildmode=plugin -o my-plugin.so main.go
+      
+      # 5. Bundle everything together
+      - name: Create deployment bundle
+        run: |
+          mkdir -p deploy/plugins
+          cp transports/bifrost-http/bifrost-http deploy/
+          cp plugins/my-plugin/my-plugin.so deploy/plugins/
+          cp config.json deploy/
+      
+      # 6. Deploy bundle to your infrastructure
+      - name: Deploy to Production
+        run: |
+          # Upload to S3, copy to servers, deploy to K8s, etc.
+          ./deploy.sh
+```
+
+**Key Principles:**
+
+1. **Version Lock** - Pin your plugin dependencies to specific Bifrost versions
+2. **Atomic Deployment** - Deploy Bifrost and plugins together as a single unit
+3. **Build Verification** - Test plugin loading as part of CI
+4. **Rollback Strategy** - Keep previous plugin versions for rollbacks
+
+### How do I handle plugin versioning in production?
+
+Organize your plugin deployments by version:
+
+```
+/opt/bifrost/
+├── v1.3.0/
+│   ├── bifrost-http
+│   └── plugins/
+│       ├── my-plugin.so
+│       └── cache-plugin.so
+├── v1.2.17/
+│   ├── bifrost-http
+│   └── plugins/
+│       ├── my-plugin.so
+│       └── cache-plugin.so
+└── current -> v1.3.0/  # Symlink to active version
+```
+
+This allows easy rollbacks:
+
+```bash
+# Rollback to previous version
+ln -sfn /opt/bifrost/v1.2.17 /opt/bifrost/current
+systemctl restart bifrost
+```
+
+### Can I use different plugin versions for different Bifrost instances?
+
+**No.** Each plugin must match the exact core version of the Bifrost instance loading it. If you're running multiple Bifrost versions (e.g., staging vs production), you need separate plugin builds for each version.
+
+```
+staging/
+  bifrost-http (v1.3.0)
+  plugins/
+    my-plugin-v1.3.0.so
+
+production/
+  bifrost-http (v1.2.17)
+  plugins/
+    my-plugin-v1.2.17.so
+```
+
+### What happens if I forget to rebuild a plugin?
+
+You'll see errors like:
+
+```
+plugin: symbol Init not found in plugin github.com/you/plugin
+plugin was built with a different version of package github.com/maximhq/bifrost/core
+```
+
+**Solution:** Rebuild the plugin with the correct core version. See the [Version Mismatch Errors](#version-mismatch-errors) troubleshooting section for detailed diagnosis steps using `go version -m`.
+
+### How do I test plugins before production deployment?
+
+**Multi-stage testing approach:**
+
+1. **Unit Tests** - Test plugin logic in isolation
+   ```go
+   func TestPreHook(t *testing.T) {
+       req := &schemas.BifrostRequest{...}
+       modifiedReq, shortCircuit, err := PreHook(&ctx, req)
+       assert.NoError(t, err)
+       assert.Nil(t, shortCircuit)
+   }
+   ```
+
+2. **Integration Tests** - Load plugin in test Bifrost instance
+   ```bash
+   # Start test Bifrost with plugin
+   ./bifrost-http --config test-config.json
+   
+   # Run test requests
+   curl -X POST http://localhost:8080/v1/chat/completions ...
+   ```
+
+3. **Staging Environment** - Deploy to staging with production-like load
+
+4. **Canary Deployment** - Gradually roll out to production
+
+### Can I hot-reload plugins without restarting Bifrost?
+
+**Yes!** Bifrost supports hot-reloading plugins at runtime. You can update plugin configurations or reload plugin code without restarting the entire Bifrost instance.
+
+### How do I debug plugin loading issues?
+
+**Enable verbose logging:**
+
+```json
+{
+  "log_level": "debug",
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "my-plugin",
+      "path": "./plugins/my-plugin.so",
+      "config": {}
+    }
+  ]
+}
+```
+
+**Check plugin symbols:**
+
+```bash
+# List symbols exported by plugin
+go tool nm my-plugin.so | grep -E 'Init|GetName|PreHook'
+```
+
+**Verify Go version:**
+
+```bash
+# Check Go version used to build plugin
+go version -m my-plugin.so
+```
+
+**Common debugging steps:**
+
+1. Verify file exists and has correct permissions
+2. Check Go version matches Bifrost
+3. Confirm core package version matches
+4. Ensure all required symbols are exported
+5. Review Bifrost logs for detailed error messages
+
+## Need Help?
+
+- **Discord Community**: [Join our Discord](https://getmax.im/bifrost-discord)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
+- **Documentation**: [Browse all docs](/)

--- a/docs/plugins/writing-wasm-plugin.mdx
+++ b/docs/plugins/writing-wasm-plugin.mdx
@@ -1,0 +1,976 @@
+---
+title: "Writing WASM Plugins"
+description: "Build cross-platform Bifrost plugins using WebAssembly with TypeScript, Go, or Rust"
+icon: "puzzle-piece"
+---
+
+<Warning>
+**Beta Feature - Enterprise Only**
+
+WASM plugins are currently in beta and only available in Bifrost Enterprise builds. Contact your account team for access.
+</Warning>
+
+## Overview
+
+WebAssembly (WASM) plugins offer a powerful alternative to native Go plugins, providing cross-platform compatibility and sandboxed execution. Unlike native `.so` plugins, WASM plugins:
+
+- **Run anywhere** - Single `.wasm` binary works on any OS/architecture
+- **No version matching** - No need to match Go versions or dependency versions
+- **Sandboxed execution** - WASM provides memory-safe, isolated execution
+- **Multi-language support** - Write plugins in TypeScript, Go, Rust, or any WASM-compatible language
+
+## Plugin Interface
+
+All WASM plugins must export these functions:
+
+| Export | Signature | Description |
+|--------|-----------|-------------|
+| `malloc` | `(size: u32) -> u32` | Allocate memory for host to write data |
+| `free` | `(ptr: u32)` or `(ptr: u32, size: u32)` | Free allocated memory (Rust requires size for dealloc) |
+| `get_name` | `() -> u64` | Returns packed ptr+len of plugin name |
+| `init` | `(config_ptr, config_len: u32) -> i32` | Initialize with config (0 = success) |
+| `http_intercept` | `(input_ptr, input_len: u32) -> u64` | HTTP transport intercept |
+| `pre_hook` | `(input_ptr, input_len: u32) -> u64` | Pre-request hook |
+| `post_hook` | `(input_ptr, input_len: u32) -> u64` | Post-response hook |
+| `cleanup` | `() -> i32` | Cleanup resources (0 = success) |
+
+### Return Value Format
+
+Functions returning data use a packed `u64` format:
+- **Upper 32 bits**: pointer to data in WASM memory
+- **Lower 32 bits**: length of data
+
+### Data Exchange
+
+All complex data is exchanged as JSON strings. The host allocates memory using `malloc`, writes JSON data, and passes pointers to the plugin functions.
+
+## Getting Started
+
+Choose your preferred language:
+
+<Tabs>
+  <Tab title="TypeScript">
+
+### Prerequisites
+
+Install Node.js (v18+) for AssemblyScript compilation:
+
+**macOS:**
+```bash
+brew install node
+```
+
+**Linux (Ubuntu/Debian):**
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+
+### Project Structure
+
+```
+my-wasm-plugin/
+├── assembly/
+│   ├── index.ts       # Plugin implementation
+│   ├── memory.ts      # Memory management utilities
+│   ├── types.ts       # Type definitions
+│   └── tsconfig.json  # AssemblyScript config
+├── package.json
+└── Makefile
+```
+
+### Step 1: Initialize Project
+
+```bash
+mkdir my-wasm-plugin && cd my-wasm-plugin
+npm init -y
+npm install --save-dev assemblyscript json-as
+npx asinit .
+```
+
+### Step 2: Implement the Plugin
+
+Create `assembly/index.ts`:
+
+```typescript
+import { JSON } from 'json-as'
+
+// Memory management (simplified)
+let heap: ArrayBuffer = new ArrayBuffer(65536)
+let heapOffset: u32 = 0
+
+export function malloc(size: u32): u32 {
+  const ptr = heapOffset
+  heapOffset += size
+  return ptr
+}
+
+export function free(ptr: u32): void {
+  // Simple allocator - no-op for free
+}
+
+function readString(ptr: u32, len: u32): string {
+  const bytes = new Uint8Array(len)
+  for (let i: u32 = 0; i < len; i++) {
+    bytes[i] = load<u8>(ptr + i)
+  }
+  return String.UTF8.decode(bytes.buffer)
+}
+
+function writeString(str: string): u64 {
+  const encoded = String.UTF8.encode(str)
+  const bytes = Uint8Array.wrap(encoded)
+  const ptr = malloc(bytes.length)
+  for (let i = 0; i < bytes.length; i++) {
+    store<u8>(ptr + i, bytes[i])
+  }
+  // Pack pointer (upper 32 bits) and length (lower 32 bits)
+  return (u64(ptr) << 32) | u64(bytes.length)
+}
+
+// Plugin configuration
+let pluginConfig: string = ''
+
+export function get_name(): u64 {
+  return writeString('my-typescript-wasm-plugin')
+}
+
+export function init(configPtr: u32, configLen: u32): i32 {
+  pluginConfig = readString(configPtr, configLen)
+  return 0 // Success
+}
+
+export function http_intercept(inputPtr: u32, inputLen: u32): u64 {
+  const input = readString(inputPtr, inputLen)
+  
+  // Parse and modify as needed
+  // For pass-through, return the input with has_response: false
+  const output = '{"context":{},"request":null,"response":null,"has_response":false,"error":""}'
+  
+  return writeString(output)
+}
+
+export function pre_hook(inputPtr: u32, inputLen: u32): u64 {
+  const input = readString(inputPtr, inputLen)
+  
+  // Parse and modify as needed
+  // For pass-through, return with has_short_circuit: false
+  const output = '{"context":{},"request":null,"short_circuit":null,"has_short_circuit":false,"error":""}'
+  
+  return writeString(output)
+}
+
+export function post_hook(inputPtr: u32, inputLen: u32): u64 {
+  const input = readString(inputPtr, inputLen)
+  
+  // Parse and modify as needed
+  // For pass-through, return with has_error matching input
+  const output = '{"context":{},"response":null,"error":null,"has_error":false,"hook_error":""}'
+  
+  return writeString(output)
+}
+
+export function cleanup(): i32 {
+  pluginConfig = ''
+  return 0 // Success
+}
+```
+
+### Step 3: Build
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "asc assembly/index.ts -o build/plugin.wasm --runtime stub --optimize"
+  }
+}
+```
+
+Build:
+
+```bash
+npm run build
+```
+
+Output: `build/plugin.wasm`
+
+  </Tab>
+  <Tab title="Go (TinyGo)">
+
+### Prerequisites
+
+Install TinyGo for WASM compilation:
+
+**macOS:**
+```bash
+brew install tinygo
+```
+
+**Linux (Ubuntu/Debian):**
+```bash
+wget https://github.com/tinygo-org/tinygo/releases/download/v0.32.0/tinygo_0.32.0_amd64.deb
+sudo dpkg -i tinygo_0.32.0_amd64.deb
+```
+
+### Project Structure
+
+```
+my-wasm-plugin/
+├── main.go        # Plugin implementation
+├── memory.go      # Memory management utilities
+├── types.go       # Type definitions
+├── go.mod
+└── Makefile
+```
+
+### Step 1: Initialize Project
+
+```bash
+mkdir my-wasm-plugin && cd my-wasm-plugin
+go mod init github.com/yourusername/my-wasm-plugin
+```
+
+### Step 2: Implement Memory Management
+
+Create `memory.go`:
+
+```go
+package main
+
+import "unsafe"
+
+var heap = make([]byte, 1024*1024) // 1MB heap
+var heapOffset uint32 = 0
+
+//export plugin_malloc
+func plugin_malloc(size uint32) uint32 {
+	ptr := heapOffset
+	heapOffset += size
+	return ptr
+}
+
+//export plugin_free
+func plugin_free(ptr uint32) {
+	// Simple allocator - no-op
+}
+
+func readInput(ptr, length uint32) []byte {
+	if length == 0 {
+		return nil
+	}
+	data := make([]byte, length)
+	for i := uint32(0); i < length; i++ {
+		data[i] = *(*byte)(unsafe.Pointer(uintptr(ptr + i)))
+	}
+	return data
+}
+
+func writeBytes(data []byte) uint64 {
+	ptr := plugin_malloc(uint32(len(data)))
+	for i, b := range data {
+		*(*byte)(unsafe.Pointer(uintptr(ptr + uint32(i)))) = b
+	}
+	// Pack pointer (upper 32 bits) and length (lower 32 bits)
+	return (uint64(ptr) << 32) | uint64(len(data))
+}
+```
+
+### Step 3: Implement the Plugin
+
+Create `main.go`:
+
+```go
+package main
+
+import (
+	"encoding/json"
+)
+
+//export get_name
+func get_name() uint64 {
+	return writeBytes([]byte("my-go-wasm-plugin"))
+}
+
+//export init
+func init_plugin(configPtr, configLen uint32) int32 {
+	if configLen > 0 {
+		configData := readInput(configPtr, configLen)
+		// Parse and store config as needed
+		_ = configData
+	}
+	return 0 // Success
+}
+
+// HTTPInterceptInput represents the input to http_intercept
+type HTTPInterceptInput struct {
+	Context map[string]interface{} `json:"context"`
+	Request json.RawMessage        `json:"request"`
+}
+
+// HTTPInterceptOutput represents the output from http_intercept
+type HTTPInterceptOutput struct {
+	Context     map[string]interface{} `json:"context"`
+	Request     json.RawMessage        `json:"request,omitempty"`
+	Response    json.RawMessage        `json:"response,omitempty"`
+	HasResponse bool                   `json:"has_response"`
+	Error       string                 `json:"error"`
+}
+
+//export http_intercept
+func http_intercept(inputPtr, inputLen uint32) uint64 {
+	inputData := readInput(inputPtr, inputLen)
+	
+	var input HTTPInterceptInput
+	if err := json.Unmarshal(inputData, &input); err != nil {
+		output := HTTPInterceptOutput{Error: err.Error()}
+		data, _ := json.Marshal(output)
+		return writeBytes(data)
+	}
+	
+	// Add custom context value
+	input.Context["from-http"] = "wasm-plugin"
+	
+	// Pass through
+	output := HTTPInterceptOutput{
+		Context:     input.Context,
+		Request:     input.Request,
+		HasResponse: false,
+	}
+	
+	data, _ := json.Marshal(output)
+	return writeBytes(data)
+}
+
+// PreHookInput represents the input to pre_hook
+type PreHookInput struct {
+	Context map[string]interface{} `json:"context"`
+	Request json.RawMessage        `json:"request"`
+}
+
+// PreHookOutput represents the output from pre_hook
+type PreHookOutput struct {
+	Context         map[string]interface{} `json:"context"`
+	Request         json.RawMessage        `json:"request,omitempty"`
+	ShortCircuit    json.RawMessage        `json:"short_circuit,omitempty"`
+	HasShortCircuit bool                   `json:"has_short_circuit"`
+	Error           string                 `json:"error"`
+}
+
+//export pre_hook
+func pre_hook(inputPtr, inputLen uint32) uint64 {
+	inputData := readInput(inputPtr, inputLen)
+	
+	var input PreHookInput
+	if err := json.Unmarshal(inputData, &input); err != nil {
+		output := PreHookOutput{Error: err.Error()}
+		data, _ := json.Marshal(output)
+		return writeBytes(data)
+	}
+	
+	// Add custom context value
+	input.Context["from-pre-hook"] = "wasm-plugin"
+	
+	// Pass through
+	output := PreHookOutput{
+		Context:         input.Context,
+		Request:         input.Request,
+		HasShortCircuit: false,
+	}
+	
+	data, _ := json.Marshal(output)
+	return writeBytes(data)
+}
+
+// PostHookInput represents the input to post_hook
+type PostHookInput struct {
+	Context  map[string]interface{} `json:"context"`
+	Response json.RawMessage        `json:"response"`
+	Error    json.RawMessage        `json:"error"`
+	HasError bool                   `json:"has_error"`
+}
+
+// PostHookOutput represents the output from post_hook
+type PostHookOutput struct {
+	Context   map[string]interface{} `json:"context"`
+	Response  json.RawMessage        `json:"response,omitempty"`
+	Error     json.RawMessage        `json:"error,omitempty"`
+	HasError  bool                   `json:"has_error"`
+	HookError string                 `json:"hook_error"`
+}
+
+//export post_hook
+func post_hook(inputPtr, inputLen uint32) uint64 {
+	inputData := readInput(inputPtr, inputLen)
+	
+	var input PostHookInput
+	if err := json.Unmarshal(inputData, &input); err != nil {
+		output := PostHookOutput{HookError: err.Error()}
+		data, _ := json.Marshal(output)
+		return writeBytes(data)
+	}
+	
+	// Add custom context value
+	input.Context["from-post-hook"] = "wasm-plugin"
+	
+	// Pass through
+	output := PostHookOutput{
+		Context:  input.Context,
+		Response: input.Response,
+		Error:    input.Error,
+		HasError: input.HasError,
+	}
+	
+	data, _ := json.Marshal(output)
+	return writeBytes(data)
+}
+
+//export cleanup
+func cleanup() int32 {
+	return 0 // Success
+}
+
+func main() {}
+```
+
+### Step 4: Build
+
+```bash
+tinygo build -o build/plugin.wasm -target=wasi -scheduler=none .
+```
+
+Or create a `Makefile`:
+
+```makefile
+build:
+	@mkdir -p build
+	GOWORK=off tinygo build -o build/plugin.wasm -target=wasi -scheduler=none .
+
+clean:
+	@rm -rf build
+```
+
+Output: `build/plugin.wasm`
+
+  </Tab>
+  <Tab title="Rust">
+
+### Prerequisites
+
+Install Rust and add the WASM target:
+
+```bash
+# Install Rust (if not already installed)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Add WASM target
+rustup target add wasm32-unknown-unknown
+```
+
+Optional - Install `wasm-opt` for smaller binaries:
+
+```bash
+# macOS
+brew install binaryen
+
+# Linux
+apt install binaryen
+```
+
+### Project Structure
+
+```
+my-wasm-plugin/
+├── src/
+│   ├── lib.rs       # Plugin implementation
+│   ├── memory.rs    # Memory management
+│   └── types.rs     # Type definitions
+├── Cargo.toml
+└── Makefile
+```
+
+### Step 1: Initialize Project
+
+```bash
+cargo new --lib my-wasm-plugin
+cd my-wasm-plugin
+```
+
+Update `Cargo.toml`:
+
+```toml
+[package]
+name = "my-wasm-plugin"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[profile.release]
+opt-level = "s"
+lto = true
+```
+
+### Step 2: Implement Memory Management
+
+Create `src/memory.rs`:
+
+```rust
+use std::alloc::{alloc, dealloc, Layout};
+
+#[no_mangle]
+pub extern "C" fn malloc(size: u32) -> u32 {
+    let layout = Layout::from_size_align(size as usize, 1).unwrap();
+    unsafe { alloc(layout) as u32 }
+}
+
+#[no_mangle]
+pub extern "C" fn free(ptr: u32, size: u32) {
+    let layout = Layout::from_size_align(size as usize, 1).unwrap();
+    unsafe { dealloc(ptr as *mut u8, layout) }
+}
+
+pub fn read_string(ptr: u32, len: u32) -> String {
+    let slice = unsafe {
+        std::slice::from_raw_parts(ptr as *const u8, len as usize)
+    };
+    String::from_utf8_lossy(slice).to_string()
+}
+
+pub fn write_string(s: &str) -> u64 {
+    let bytes = s.as_bytes();
+    let ptr = malloc(bytes.len() as u32);
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            ptr as *mut u8,
+            bytes.len()
+        );
+    }
+    // Pack pointer (upper 32 bits) and length (lower 32 bits)
+    ((ptr as u64) << 32) | (bytes.len() as u64)
+}
+```
+
+### Step 3: Implement the Plugin
+
+Create `src/lib.rs`:
+
+```rust
+mod memory;
+
+use memory::{read_string, write_string};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// Plugin configuration storage
+static mut CONFIG: Option<String> = None;
+
+#[no_mangle]
+pub extern "C" fn get_name() -> u64 {
+    write_string("my-rust-wasm-plugin")
+}
+
+#[no_mangle]
+pub extern "C" fn init(config_ptr: u32, config_len: u32) -> i32 {
+    let config = read_string(config_ptr, config_len);
+    unsafe { CONFIG = Some(config); }
+    0 // Success
+}
+
+#[derive(Deserialize)]
+struct HTTPInterceptInput {
+    context: HashMap<String, serde_json::Value>,
+    request: serde_json::Value,
+}
+
+#[derive(Serialize, Default)]
+struct HTTPInterceptOutput {
+    context: HashMap<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response: Option<serde_json::Value>,
+    has_response: bool,
+    error: String,
+}
+
+#[no_mangle]
+pub extern "C" fn http_intercept(input_ptr: u32, input_len: u32) -> u64 {
+    let input_str = read_string(input_ptr, input_len);
+    
+    let input: HTTPInterceptInput = match serde_json::from_str(&input_str) {
+        Ok(i) => i,
+        Err(e) => {
+            let output = HTTPInterceptOutput {
+                error: format!("Parse error: {}", e),
+                ..Default::default()
+            };
+            return write_string(&serde_json::to_string(&output).unwrap());
+        }
+    };
+    
+    let mut context = input.context;
+    context.insert("from-http".to_string(), serde_json::json!("rust-wasm"));
+    
+    let output = HTTPInterceptOutput {
+        context,
+        request: Some(input.request),
+        has_response: false,
+        ..Default::default()
+    };
+    
+    write_string(&serde_json::to_string(&output).unwrap())
+}
+
+#[derive(Deserialize)]
+struct PreHookInput {
+    context: HashMap<String, serde_json::Value>,
+    request: serde_json::Value,
+}
+
+#[derive(Serialize, Default)]
+struct PreHookOutput {
+    context: HashMap<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    short_circuit: Option<serde_json::Value>,
+    has_short_circuit: bool,
+    error: String,
+}
+
+#[no_mangle]
+pub extern "C" fn pre_hook(input_ptr: u32, input_len: u32) -> u64 {
+    let input_str = read_string(input_ptr, input_len);
+    
+    let input: PreHookInput = match serde_json::from_str(&input_str) {
+        Ok(i) => i,
+        Err(e) => {
+            let output = PreHookOutput {
+                error: format!("Parse error: {}", e),
+                ..Default::default()
+            };
+            return write_string(&serde_json::to_string(&output).unwrap());
+        }
+    };
+    
+    let mut context = input.context;
+    context.insert("from-pre-hook".to_string(), serde_json::json!("rust-wasm"));
+    
+    let output = PreHookOutput {
+        context,
+        request: Some(input.request),
+        has_short_circuit: false,
+        ..Default::default()
+    };
+    
+    write_string(&serde_json::to_string(&output).unwrap())
+}
+
+#[derive(Deserialize)]
+struct PostHookInput {
+    context: HashMap<String, serde_json::Value>,
+    response: serde_json::Value,
+    error: serde_json::Value,
+    has_error: bool,
+}
+
+#[derive(Serialize, Default)]
+struct PostHookOutput {
+    context: HashMap<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<serde_json::Value>,
+    has_error: bool,
+    hook_error: String,
+}
+
+#[no_mangle]
+pub extern "C" fn post_hook(input_ptr: u32, input_len: u32) -> u64 {
+    let input_str = read_string(input_ptr, input_len);
+    
+    let input: PostHookInput = match serde_json::from_str(&input_str) {
+        Ok(i) => i,
+        Err(e) => {
+            let output = PostHookOutput {
+                hook_error: format!("Parse error: {}", e),
+                ..Default::default()
+            };
+            return write_string(&serde_json::to_string(&output).unwrap());
+        }
+    };
+    
+    let mut context = input.context;
+    context.insert("from-post-hook".to_string(), serde_json::json!("rust-wasm"));
+    
+    let output = PostHookOutput {
+        context,
+        response: Some(input.response),
+        error: Some(input.error),
+        has_error: input.has_error,
+        hook_error: String::new(),
+    };
+    
+    write_string(&serde_json::to_string(&output).unwrap())
+}
+
+#[no_mangle]
+pub extern "C" fn cleanup() -> i32 {
+    unsafe { CONFIG = None; }
+    0 // Success
+}
+```
+
+### Step 4: Build
+
+```bash
+cargo build --release --target wasm32-unknown-unknown
+cp target/wasm32-unknown-unknown/release/my_wasm_plugin.wasm build/plugin.wasm
+```
+
+Optional - Optimize with wasm-opt:
+
+```bash
+wasm-opt -Os -o build/plugin.wasm build/plugin.wasm
+```
+
+Output: `build/plugin.wasm`
+
+  </Tab>
+</Tabs>
+
+## Hook Input/Output Structures
+
+### http_intercept
+
+**Input:**
+```json
+{
+  "context": {
+    "request_id": "abc-123"
+  },
+  "request": {
+    "method": "POST",
+    "path": "/v1/chat/completions",
+    "headers": { "Content-Type": "application/json" },
+    "query": {},
+    "body": "<base64-encoded>"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "context": { "request_id": "abc-123", "custom_key": "value" },
+  "request": { ... },
+  "response": null,
+  "has_response": false,
+  "error": ""
+}
+```
+
+To short-circuit with a response:
+```json
+{
+  "context": { ... },
+  "request": null,
+  "response": {
+    "status_code": 200,
+    "headers": { "Content-Type": "application/json" },
+    "body": "<base64-encoded>"
+  },
+  "has_response": true,
+  "error": ""
+}
+```
+
+### pre_hook
+
+**Input:**
+```json
+{
+  "context": { "request_id": "abc-123" },
+  "request": {
+    "provider": "openai",
+    "model": "gpt-4",
+    "input": [{ "role": "user", "content": "Hello" }],
+    "params": { "temperature": 0.7 }
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "context": { "request_id": "abc-123", "plugin_processed": true },
+  "request": { ... },
+  "short_circuit": null,
+  "has_short_circuit": false,
+  "error": ""
+}
+```
+
+To short-circuit with a response:
+```json
+{
+  "context": { ... },
+  "request": null,
+  "short_circuit": {
+    "response": {
+      "chat_response": {
+        "id": "mock-123",
+        "model": "gpt-4",
+        "choices": [{ "index": 0, "message": { "role": "assistant", "content": "Mock response" } }]
+      }
+    }
+  },
+  "has_short_circuit": true,
+  "error": ""
+}
+```
+
+### post_hook
+
+**Input:**
+```json
+{
+  "context": { "request_id": "abc-123" },
+  "response": {
+    "chat_response": {
+      "id": "chatcmpl-123",
+      "model": "gpt-4",
+      "choices": [{ "index": 0, "message": { "role": "assistant", "content": "Hello!" } }],
+      "usage": { "prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15 }
+    }
+  },
+  "error": {},
+  "has_error": false
+}
+```
+
+**Output:**
+```json
+{
+  "context": { "request_id": "abc-123", "post_processed": true },
+  "response": { ... },
+  "error": {},
+  "has_error": false,
+  "hook_error": ""
+}
+```
+
+## Configuration
+
+Configure your WASM plugin in Bifrost's `config.json`:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "/path/to/plugin.wasm",
+      "name": "my-wasm-plugin",
+      "enabled": true,
+      "config": {
+        "custom_option": "value"
+      }
+    }
+  ]
+}
+```
+
+You can also load plugins from URLs:
+
+```json
+{
+  "plugins": [
+    {
+      "path": "https://example.com/plugins/my-plugin.wasm",
+      "name": "my-wasm-plugin",
+      "enabled": true
+    }
+  ]
+}
+```
+
+## Limitations vs Native Plugins
+
+WASM plugins have some trade-offs compared to native Go plugins:
+
+| Aspect | Native (.so) | WASM |
+|--------|-------------|------|
+| **Performance** | Fastest (in-process) | JSON serialization overhead |
+| **Cross-platform** | Build per platform | Single binary everywhere |
+| **Version matching** | Exact Go/package match required | No version requirements |
+| **Memory** | Shared process memory | Linear memory (limited) |
+| **Languages** | Go only | TypeScript, Go, Rust, etc. |
+| **Debugging** | Full Go tooling | Limited debugging support |
+| **Security** | Full process access | Sandboxed execution |
+
+## Source Code Reference
+
+Complete hello-world examples are available in the Bifrost repository:
+
+- **TypeScript**: [examples/plugins/hello-world-wasm-typescript](https://github.com/maximhq/bifrost/tree/main/examples/plugins/hello-world-wasm-typescript)
+- **Go (TinyGo)**: [examples/plugins/hello-world-wasm-go](https://github.com/maximhq/bifrost/tree/main/examples/plugins/hello-world-wasm-go)
+- **Rust**: [examples/plugins/hello-world-wasm-rust](https://github.com/maximhq/bifrost/tree/main/examples/plugins/hello-world-wasm-rust)
+
+## Troubleshooting
+
+### Module fails to load
+
+**Error**: `failed to instantiate WASM module`
+
+**Solution**: Ensure all required exports are present. Use a WASM inspection tool:
+
+```bash
+# List exports
+wasm-objdump -x plugin.wasm | grep -A 20 "Export"
+```
+
+### Memory allocation errors
+
+**Error**: `out of memory` or `invalid memory access`
+
+**Solution**: 
+- Increase heap size in your allocator
+- Ensure you're freeing memory after use
+- Check for memory leaks in long-running plugins
+
+### JSON parsing errors
+
+**Error**: `failed to parse input JSON`
+
+**Solution**: 
+- Validate your JSON structures match expected schemas
+- Handle optional/nullable fields properly
+- Add error logging to identify malformed data
+
+### Build errors (TinyGo)
+
+**Error**: `package not supported by TinyGo`
+
+**Solution**: TinyGo doesn't support all Go standard library packages. Avoid:
+- `reflect` (limited support)
+- `net/http` (use raw JSON instead)
+- Complex generics
+
+### Build errors (Rust)
+
+**Error**: `cannot find -lc`
+
+**Solution**: For `wasm32-unknown-unknown` target, don't link to libc. Ensure your `Cargo.toml` doesn't require native dependencies.
+
+## Need Help?
+
+- **Discord Community**: [Join our Discord](https://getmax.im/bifrost-discord)
+- **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
+- **Documentation**: [Browse all docs](/)


### PR DESCRIPTION
## Documentation Updates for Plugins and Okta Integration

This PR reorganizes the plugin documentation into separate guides for Go and WASM plugins, updates the Okta integration documentation with clearer instructions, and makes various improvements to the documentation structure.

## Changes

- Reorganized plugin documentation:
  - Split "Writing Plugins" into separate "Writing Go Plugins" and "Writing WASM Plugins" pages
  - Updated navigation structure to group plugin writing guides under a "Writing Plugins" section
  - Added redirect from old plugin page to new Go plugin page
- Updated plugin migration guide to reflect the new `HTTPTransportIntercept` pattern
- Enhanced Okta integration documentation:
  - Clarified that the default authorization server supports custom claims
  - Made authorization server configuration optional with clear alternatives
  - Added notes about role claim requirements for RBAC
- Removed v1.3.61 from the changelog navigation

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Build and preview the documentation site:
```sh
cd docs
npm install
npm run dev
```

2. Verify the new plugin documentation structure:
   - Check that "Writing Plugins" is now a group with Go and WASM subpages
   - Verify the redirect from `/plugins/writing-plugin` to `/plugins/writing-go-plugin`

3. Review the Okta integration page for clarity and correctness

## Breaking changes

- [x] No

## Related issues

Improves documentation for WASM plugins and clarifies Okta integration steps.

## Checklist

- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)