### PR TITLE
fixed core tests

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -638,7 +638,7 @@ func (ma *MockAccount) GetConfigForProvider(provider schemas.ModelProvider) (*sc
 	return nil, fmt.Errorf("provider %s not configured", provider)
 }
 
-func (ma *MockAccount) GetKeysForProvider(ctx *schemas.BifrostContext, provider schemas.ModelProvider) ([]schemas.Key, error) {
+func (ma *MockAccount) GetKeysForProvider(ctx context.Context, provider schemas.ModelProvider) ([]schemas.Key, error) {
 	if keys, exists := ma.keys[provider]; exists {
 		return keys, nil
 	}

--- a/core/chatbot_test.go
+++ b/core/chatbot_test.go
@@ -56,7 +56,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 }
 
 // GetKeysForProvider returns the API keys and associated models for a given provider.
-func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	switch providerKey {
 	case schemas.OpenAI:
 		return []schemas.Key{

--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -4,6 +4,7 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -122,7 +123,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 }
 
 // GetKeysForProvider returns the API keys and associated models for a given provider.
-func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	switch providerKey {
 	case schemas.OpenAI:
 		return []schemas.Key{

--- a/core/internal/testutil/automatic_function_calling.go
+++ b/core/internal/testutil/automatic_function_calling.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunAutomaticFunctionCallingTest executes the automatic function calling test scenario using dual API testing framework
-func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.AutomaticFunctionCall {
 		t.Logf("Automatic function calling not supported for provider %s", testConfig.Provider)
 		return
@@ -64,6 +65,7 @@ func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx 
 
 		// Create operations for both Chat Completions and Responses API
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -84,10 +86,11 @@ func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx 
 				Fallbacks: testConfig.Fallbacks,
 			}
 
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -106,7 +109,7 @@ func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx 
 				Fallbacks: testConfig.Fallbacks,
 			}
 
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test - passes only if BOTH APIs succeed

--- a/core/internal/testutil/batch.go
+++ b/core/internal/testutil/batch.go
@@ -2,6 +2,7 @@
 package testutil
 
 import (
+	"context"
 	"testing"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -9,7 +10,7 @@ import (
 )
 
 // RunBatchCreateTest tests the batch create functionality
-func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.BatchCreate {
 		t.Logf("[SKIPPED] Batch Create: Not supported by provider %s", testConfig.Provider)
 		return
@@ -37,8 +38,8 @@ func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 			CompletionWindow: "24h",
 			ExtraParams:      testConfig.BatchExtraParams,
 		}
-
-		response, err := client.BatchCreateRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.BatchCreateRequest(bfCtx, request)
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
@@ -64,7 +65,7 @@ func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 }
 
 // RunBatchListTest tests the batch list functionality
-func RunBatchListTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunBatchListTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.BatchList {
 		t.Logf("[SKIPPED] Batch List: Not supported by provider %s", testConfig.Provider)
 		return
@@ -78,7 +79,8 @@ func RunBatchListTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 			Limit:    10,
 		}
 
-		response, err := client.BatchListRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.BatchListRequest(bfCtx, request)
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
@@ -99,7 +101,7 @@ func RunBatchListTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 }
 
 // RunBatchRetrieveTest tests the batch retrieve functionality
-func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.BatchRetrieve {
 		t.Logf("[SKIPPED] Batch Retrieve: Not supported by provider %s", testConfig.Provider)
 		return
@@ -129,7 +131,8 @@ func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
-		createResponse, createErr := client.BatchCreateRequest(ctx, createRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		createResponse, createErr := client.BatchCreateRequest(bfCtx, createRequest)
 		if createErr != nil {
 			// Check if this is an unsupported operation error
 			if createErr.Error != nil && (createErr.Error.Code != nil && *createErr.Error.Code == "unsupported_operation") {
@@ -151,7 +154,8 @@ func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 			BatchID:  createResponse.ID,
 		}
 
-		response, err := client.BatchRetrieveRequest(ctx, retrieveRequest)
+		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.BatchRetrieveRequest(bfCtx2, retrieveRequest)
 		if err != nil {
 			t.Errorf("BatchRetrieve failed: %v", err)
 			return
@@ -172,7 +176,7 @@ func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 }
 
 // RunBatchCancelTest tests the batch cancel functionality
-func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.BatchCancel {
 		t.Logf("[SKIPPED] Batch Cancel: Not supported by provider %s", testConfig.Provider)
 		return
@@ -201,7 +205,8 @@ func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
-		createResponse, createErr := client.BatchCreateRequest(ctx, createRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		createResponse, createErr := client.BatchCreateRequest(bfCtx, createRequest)
 		if createErr != nil {
 			// Check if this is an unsupported operation error
 			if createErr.Error != nil && (createErr.Error.Code != nil && *createErr.Error.Code == "unsupported_operation") {
@@ -223,7 +228,8 @@ func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 			BatchID:  createResponse.ID,
 		}
 
-		response, err := client.BatchCancelRequest(ctx, cancelRequest)
+		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.BatchCancelRequest(bfCtx2, cancelRequest)
 		if err != nil {
 			// Note: Cancel might fail if batch has already completed
 			t.Logf("[WARNING] BatchCancel failed (batch may have already completed): %v", err)
@@ -240,7 +246,7 @@ func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 }
 
 // RunBatchResultsTest tests the batch results functionality
-func RunBatchResultsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunBatchResultsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.BatchResults {
 		t.Logf("[SKIPPED] Batch Results: Not supported by provider %s", testConfig.Provider)
 		return
@@ -260,7 +266,8 @@ func RunBatchResultsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bif
 			BatchID:  "test-batch-id", // This would be a real batch ID in practice
 		}
 
-		_, err := client.BatchResultsRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		_, err := client.BatchResultsRequest(bfCtx, request)
 		if err != nil {
 			// This is expected to fail with a "batch not found" error since we're using a fake ID
 			// In a real test, you would use an actual completed batch ID
@@ -273,7 +280,7 @@ func RunBatchResultsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bif
 }
 
 // RunBatchUnsupportedTest tests that unsupported providers return appropriate errors
-func RunBatchUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunBatchUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	// Only run this test for providers that don't support batch
 	if testConfig.Scenarios.BatchCreate || testConfig.Scenarios.BatchList ||
 		testConfig.Scenarios.BatchRetrieve || testConfig.Scenarios.BatchCancel ||
@@ -309,7 +316,8 @@ func RunBatchUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas
 			},
 		}
 
-		_, err := client.BatchCreateRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		_, err := client.BatchCreateRequest(bfCtx, request)
 		if err == nil {
 			t.Error("BatchCreate should have failed for unsupported provider")
 			return
@@ -330,7 +338,7 @@ func RunBatchUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas
 // ============================================================================
 
 // RunFileUploadTest tests the file upload functionality
-func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileUpload {
 		t.Logf("[SKIPPED] File Upload: Not supported by provider %s", testConfig.Provider)
 		return
@@ -351,7 +359,8 @@ func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 			ExtraParams: testConfig.FileExtraParams,
 		}
 
-		response, err := client.FileUploadRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.FileUploadRequest(bfCtx, request)
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
@@ -377,7 +386,7 @@ func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 }
 
 // RunFileListTest tests the file list functionality
-func RunFileListTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileListTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileList {
 		t.Logf("[SKIPPED] File List: Not supported by provider %s", testConfig.Provider)
 		return
@@ -392,7 +401,8 @@ func RunFileListTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifrost
 			ExtraParams: testConfig.FileExtraParams,
 		}
 
-		response, err := client.FileListRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.FileListRequest(bfCtx, request)
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
@@ -413,7 +423,7 @@ func RunFileListTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifrost
 }
 
 // RunFileRetrieveTest tests the file retrieve functionality
-func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileRetrieve {
 		t.Logf("[SKIPPED] File Retrieve: Not supported by provider %s", testConfig.Provider)
 		return
@@ -434,7 +444,8 @@ func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bif
 			ExtraParams: testConfig.FileExtraParams,
 		}
 
-		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
@@ -455,7 +466,8 @@ func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bif
 			FileID:   uploadResponse.ID,
 		}
 
-		response, err := client.FileRetrieveRequest(ctx, retrieveRequest)
+		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.FileRetrieveRequest(bfCtx2, retrieveRequest)
 		if err != nil {
 			t.Errorf("FileRetrieve failed: %v", err)
 			return
@@ -476,7 +488,7 @@ func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bif
 }
 
 // RunFileDeleteTest tests the file delete functionality
-func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileDelete {
 		t.Logf("[SKIPPED] File Delete: Not supported by provider %s", testConfig.Provider)
 		return
@@ -497,7 +509,8 @@ func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 			ExtraParams: testConfig.FileExtraParams,
 		}
 
-		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
@@ -518,7 +531,8 @@ func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 			FileID:   uploadResponse.ID,
 		}
 
-		response, err := client.FileDeleteRequest(ctx, deleteRequest)
+		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.FileDeleteRequest(bfCtx2, deleteRequest)
 		if err != nil {
 			t.Errorf("FileDelete failed: %v", err)
 			return
@@ -539,7 +553,7 @@ func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 }
 
 // RunFileContentTest tests the file content download functionality
-func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileContent {
 		t.Logf("[SKIPPED] File Content: Not supported by provider %s", testConfig.Provider)
 		return
@@ -560,7 +574,8 @@ func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 			ExtraParams: testConfig.FileExtraParams,
 		}
 
-		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
@@ -581,7 +596,8 @@ func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 			FileID:   uploadResponse.ID,
 		}
 
-		response, err := client.FileContentRequest(ctx, contentRequest)
+		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.FileContentRequest(bfCtx2, contentRequest)
 		if err != nil {
 			t.Errorf("FileContent failed: %v", err)
 			return
@@ -603,7 +619,7 @@ func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 }
 
 // RunFileUnsupportedTest tests that unsupported providers return appropriate errors for file operations
-func RunFileUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	// Only run this test for providers that don't support any file operations
 	if testConfig.Scenarios.FileUpload || testConfig.Scenarios.FileList ||
 		testConfig.Scenarios.FileRetrieve || testConfig.Scenarios.FileDelete ||
@@ -629,7 +645,8 @@ func RunFileUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 			Purpose:  "batch",
 		}
 
-		_, err := client.FileUploadRequest(ctx, request)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		_, err := client.FileUploadRequest(bfCtx, request)
 		if err == nil {
 			t.Error("FileUpload should have failed for unsupported provider")
 			return
@@ -646,7 +663,7 @@ func RunFileUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 }
 
 // RunFileAndBatchIntegrationTest tests the integration between file upload and batch create
-func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	// Skip if file-based batch input is not supported
 	if !testConfig.Scenarios.FileBatchInput {
 		t.Logf("[SKIPPED] File and Batch Integration: FileBatchInput=%v for provider %s",
@@ -670,7 +687,8 @@ func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx *
 			ExtraParams: testConfig.FileExtraParams,
 		}
 
-		uploadResponse, uploadErr := client.FileUploadRequest(ctx, uploadRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
@@ -697,7 +715,8 @@ func RunFileAndBatchIntegrationTest(t *testing.T, client *bifrost.Bifrost, ctx *
 			ExtraParams:      testConfig.BatchExtraParams,
 		}
 
-		batchResponse, batchErr := client.BatchCreateRequest(ctx, batchRequest)
+		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		batchResponse, batchErr := client.BatchCreateRequest(bfCtx2, batchRequest)
 		if batchErr != nil {
 			if batchErr.Error != nil && (batchErr.Error.Code != nil && *batchErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for batch create", testConfig.Provider)

--- a/core/internal/testutil/chat_audio.go
+++ b/core/internal/testutil/chat_audio.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunChatAudioTest executes the chat audio test scenario
-func RunChatAudioTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunChatAudioTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ChatAudio || testConfig.ChatAudioModel == "" {
 		t.Logf("Chat audio not supported for provider %s", testConfig.Provider)
 		return
@@ -73,7 +74,8 @@ func RunChatAudioTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			response, err := client.ChatCompletionRequest(ctx, chatReq)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			response, err := client.ChatCompletionRequest(bfCtx, chatReq)
 			if err != nil {
 				return nil, err
 			}
@@ -148,7 +150,7 @@ func RunChatAudioTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 }
 
 // RunChatAudioStreamTest executes the chat audio streaming test scenario
-func RunChatAudioStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunChatAudioStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ChatAudio || testConfig.ChatAudioModel == "" {
 		t.Logf("Chat audio streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -201,7 +203,8 @@ func RunChatAudioStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 		}
 
 		responseChannel, bifrostErr := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-			return client.ChatCompletionStreamRequest(ctx, chatReq)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ChatCompletionStreamRequest(bfCtx, chatReq)
 		})
 
 		// Enhanced error handling

--- a/core/internal/testutil/chat_completion_stream.go
+++ b/core/internal/testutil/chat_completion_stream.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RunChatCompletionStreamTest executes the chat completion stream test scenario
-func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.CompletionStream {
 		t.Logf("Chat completion stream not supported for provider %s", testConfig.Provider)
 		return
@@ -55,7 +55,8 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 
 		// Use proper streaming retry wrapper for the stream request
 		responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-			return client.ChatCompletionStreamRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ChatCompletionStreamRequest(bfCtx, request)
 		})
 
 		// Enhanced error handling
@@ -259,7 +260,8 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 				retryConfig,
 				retryContext,
 				func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					return client.ChatCompletionStreamRequest(ctx, request)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.ChatCompletionStreamRequest(bfCtx, request)
 				},
 				func(responseChannel chan *schemas.BifrostStream) ChatStreamValidationResult {
 					var toolCallDetected bool
@@ -401,7 +403,8 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 
 			// Use proper streaming retry wrapper for the stream request
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.ChatCompletionStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ChatCompletionStreamRequest(bfCtx, request)
 			})
 
 			RequireNoError(t, err, "Chat completion stream with reasoning failed")
@@ -578,7 +581,8 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 				retryConfig,
 				retryContext,
 				func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					return client.ChatCompletionStreamRequest(ctx, request)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.ChatCompletionStreamRequest(bfCtx, request)
 				},
 				func(responseChannel chan *schemas.BifrostStream) ChatStreamValidationResult {
 					var reasoningDetected bool

--- a/core/internal/testutil/complete_end_to_end.go
+++ b/core/internal/testutil/complete_end_to_end.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunCompleteEnd2EndTest executes the complete end-to-end test scenario
-func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.CompleteEnd2End {
 		t.Logf("Complete end-to-end not supported for provider %s", testConfig.Provider)
 		return
@@ -59,6 +60,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 
 		// Create operations for both APIs
 		chatOperation1 := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -72,10 +74,11 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation1 := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -88,7 +91,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 					MaxOutputTokens: bifrost.Ptr(150),
 				},
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test for Step 1
@@ -196,6 +199,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 
 		// Create operations for both APIs - Step 2 (processing tool results)
 		chatOperation2 := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -205,10 +209,11 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation2 := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -217,7 +222,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 					MaxOutputTokens: bifrost.Ptr(200),
 				},
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test for Step 2 (processing tool results)
@@ -332,6 +337,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 
 		// Create operations for both APIs - Step 3
 		chatOperation3 := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    model,
@@ -341,10 +347,11 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation3 := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    model,
@@ -353,7 +360,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 					MaxOutputTokens: bifrost.Ptr(200),
 				},
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test for Step 3

--- a/core/internal/testutil/count_tokens.go
+++ b/core/internal/testutil/count_tokens.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -10,7 +11,7 @@ import (
 
 // RunCountTokenTest validates the CountTokens API for the configured provider/model.
 // It sends a simple prompt as Responses messages and asserts token counts and metadata.
-func RunCountTokenTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunCountTokenTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.CountTokens {
 		t.Logf("Count tokens not supported for provider %s", testConfig.Provider)
 		return
@@ -69,7 +70,8 @@ func RunCountTokenTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 			expectations,
 			"CountTokens",
 			func() (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
-				return client.CountTokensRequest(ctx, countTokensReq)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.CountTokensRequest(bfCtx, countTokensReq)
 			},
 		)
 

--- a/core/internal/testutil/cross_provider_test.go
+++ b/core/internal/testutil/cross_provider_test.go
@@ -101,11 +101,13 @@ func TestCrossProviderScenarios(t *testing.T) {
 	for _, scenario := range scenariosList {
 		// Test each scenario with both Chat Completions and Responses API
 		t.Run(scenario.Name+"_ChatCompletions", func(t *testing.T) {
-			RunCrossProviderScenarioTest(t, client, ctx, testConfig, scenario, false) // false = Chat Completions API
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			RunCrossProviderScenarioTest(t, client, bfCtx, testConfig, scenario, false) // false = Chat Completions API
 		})
 
 		t.Run(scenario.Name+"_ResponsesAPI", func(t *testing.T) {
-			RunCrossProviderScenarioTest(t, client, ctx, testConfig, scenario, true) // true = Responses API
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			RunCrossProviderScenarioTest(t, client, bfCtx, testConfig, scenario, true) // true = Responses API
 		})
 	}
 }
@@ -138,10 +140,12 @@ func TestCrossProviderConsistency(t *testing.T) {
 
 	// Test same prompt across different providers
 	t.Run("SamePrompt_DifferentProviders_ChatCompletions", func(t *testing.T) {
-		RunCrossProviderConsistencyTest(t, client, ctx, testConfig, false) // Chat Completions
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		RunCrossProviderConsistencyTest(t, client, bfCtx, testConfig, false) // Chat Completions
 	})
 
 	t.Run("SamePrompt_DifferentProviders_ResponsesAPI", func(t *testing.T) {
-		RunCrossProviderConsistencyTest(t, client, ctx, testConfig, true) // Responses API
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		RunCrossProviderConsistencyTest(t, client, bfCtx, testConfig, true) // Responses API
 	})
 }

--- a/core/internal/testutil/embedding.go
+++ b/core/internal/testutil/embedding.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -35,7 +36,7 @@ func cosineSimilarity(a, b []float32) float64 {
 }
 
 // RunEmbeddingTest executes the embedding test scenario
-func RunEmbeddingTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunEmbeddingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.Embedding {
 		t.Logf("Embedding not supported for provider %s", testConfig.Provider)
 		return
@@ -98,7 +99,8 @@ func RunEmbeddingTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 		}
 
 		embeddingResponse, bifrostErr := WithEmbeddingTestRetry(t, embeddingRetryConfig, retryContext, expectations, "Embedding", func() (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-			return client.EmbeddingRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.EmbeddingRequest(bfCtx, request)
 		})
 
 		if bifrostErr != nil {

--- a/core/internal/testutil/end_to_end_tool_calling.go
+++ b/core/internal/testutil/end_to_end_tool_calling.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunEnd2EndToolCallingTest executes the end-to-end tool calling test scenario
-func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.End2EndToolCalling {
 		t.Logf("End-to-end tool calling not supported for provider %s", testConfig.Provider)
 		return
@@ -57,6 +58,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 
 		// Create operations for both APIs
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -67,10 +69,11 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -79,7 +82,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 					Tools: []schemas.ResponsesTool{*responsesTool},
 				},
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test for Step 1
@@ -173,6 +176,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 
 		// Create operations for both APIs - Step 2
 		chatOperation2 := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -182,10 +186,11 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation2 := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -194,7 +199,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 					MaxOutputTokens: bifrost.Ptr(200),
 				},
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test for Step 2

--- a/core/internal/testutil/file_base64.go
+++ b/core/internal/testutil/file_base64.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -64,7 +65,7 @@ func CreateDocumentResponsesMessage(text, documentBase64 string) schemas.Respons
 }
 
 // RunFileBase64Test executes the PDF file input test scenario with separate subtests for each API
-func RunFileBase64Test(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileBase64Test(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileBase64 {
 		t.Logf("File base64 not supported for provider %s", testConfig.Provider)
 		return
@@ -78,7 +79,7 @@ func RunFileBase64Test(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 }
 
 // RunFileBase64ChatCompletionsTest executes the file base64 test using Chat Completions API
-func RunFileBase64ChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileBase64ChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileBase64 {
 		t.Logf("File base64 not supported for provider %s", testConfig.Provider)
 		return
@@ -133,6 +134,7 @@ func RunFileBase64ChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx
 		}
 
 		response, chatError := WithChatTestRetry(t, chatRetryConfig, retryContext, expectations, "FileBase64", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -142,7 +144,7 @@ func RunFileBase64ChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		})
 
 		if chatError != nil {
@@ -158,7 +160,7 @@ func RunFileBase64ChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx
 }
 
 // RunFileBase64ResponsesTest executes the file base64 test using Responses API
-func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileBase64 {
 		t.Logf("File base64 not supported for provider %s", testConfig.Provider)
 		return
@@ -213,6 +215,7 @@ func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *sche
 		}
 
 		response, responsesError := WithResponsesTestRetry(t, responsesRetryConfig, retryContext, expectations, "FileBase64", func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -222,7 +225,7 @@ func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *sche
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		})
 
 		if responsesError != nil {

--- a/core/internal/testutil/file_url.go
+++ b/core/internal/testutil/file_url.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -47,7 +48,7 @@ func CreateFileURLResponsesMessage(text, fileURL string) schemas.ResponsesMessag
 }
 
 // RunFileURLTest executes the file URL input test scenario with separate subtests for each API
-func RunFileURLTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileURLTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileURL {
 		t.Logf("File URL not supported for provider %s", testConfig.Provider)
 		return
@@ -61,7 +62,7 @@ func RunFileURLTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostC
 }
 
 // RunFileURLChatCompletionsTest executes the file URL test using Chat Completions API
-func RunFileURLChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileURLChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileURL {
 		t.Logf("File URL not supported for provider %s", testConfig.Provider)
 		return
@@ -124,6 +125,7 @@ func RunFileURLChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx *s
 		}
 
 		response, chatError := WithChatTestRetry(t, chatRetryConfig, retryContext, expectations, "FileURL", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -133,7 +135,7 @@ func RunFileURLChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx *s
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		})
 
 		if chatError != nil {
@@ -149,7 +151,7 @@ func RunFileURLChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx *s
 }
 
 // RunFileURLResponsesTest executes the file URL test using Responses API
-func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.FileURL {
 		t.Logf("File URL not supported for provider %s", testConfig.Provider)
 		return
@@ -206,6 +208,7 @@ func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas
 		}
 
 		response, responsesError := WithResponsesTestRetry(t, responsesRetryConfig, retryContext, expectations, "FileURL", func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -215,7 +218,7 @@ func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		})
 
 		if responsesError != nil {

--- a/core/internal/testutil/image_base64.go
+++ b/core/internal/testutil/image_base64.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunImageBase64Test executes the image base64 test scenario using dual API testing framework
-func RunImageBase64Test(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunImageBase64Test(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ImageBase64 {
 		t.Logf("Image base64 not supported for provider %s", testConfig.Provider)
 		return
@@ -65,6 +66,7 @@ func RunImageBase64Test(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 
 		// Create operations for both Chat Completions and Responses API
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.VisionModel,
@@ -74,10 +76,11 @@ func RunImageBase64Test(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.VisionModel,
@@ -87,7 +90,7 @@ func RunImageBase64Test(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifr
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test - passes only if BOTH APIs succeed

--- a/core/internal/testutil/image_url.go
+++ b/core/internal/testutil/image_url.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunImageURLTest executes the image URL test scenario using dual API testing framework
-func RunImageURLTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunImageURLTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ImageURL {
 		t.Logf("Image URL not supported for provider %s", testConfig.Provider)
 		return
@@ -56,6 +57,7 @@ func RunImageURLTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifrost
 
 		// Create operations for both Chat Completions and Responses API
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.VisionModel,
@@ -65,10 +67,11 @@ func RunImageURLTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifrost
 				Fallbacks: testConfig.Fallbacks,
 			}
 			chatReq.Input = chatMessages
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.VisionModel,
@@ -78,7 +81,7 @@ func RunImageURLTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifrost
 				Fallbacks: testConfig.Fallbacks,
 			}
 			responsesReq.Input = responsesMessages
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test - passes only if BOTH APIs succeed

--- a/core/internal/testutil/list_models.go
+++ b/core/internal/testutil/list_models.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // RunListModelsTest executes the list models test scenario
-func RunListModelsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunListModelsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ListModels {
 		t.Logf("List models not supported for provider %s", testConfig.Provider)
 		return
@@ -58,7 +59,8 @@ func RunListModelsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 		}
 
 		response, bifrostErr := WithListModelsTestRetry(t, listModelsRetryConfig, retryContext, expectations, "ListModels", func() (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-			return client.ListModelsRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ListModelsRequest(bfCtx, request)
 		})
 
 		if bifrostErr != nil {
@@ -107,7 +109,7 @@ func RunListModelsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 }
 
 // RunListModelsPaginationTest executes pagination test for list models
-func RunListModelsPaginationTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunListModelsPaginationTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ListModels {
 		t.Logf("List models not supported for provider %s", testConfig.Provider)
 		return
@@ -159,7 +161,8 @@ func RunListModelsPaginationTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 		}
 
 		response, bifrostErr := WithListModelsTestRetry(t, listModelsRetryConfig, retryContext, expectations, "ListModelsPagination", func() (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-			return client.ListModelsRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ListModelsRequest(bfCtx, request)
 		})
 
 		if bifrostErr != nil {
@@ -201,7 +204,8 @@ func RunListModelsPaginationTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 			}
 
 			nextPageResponse, nextPageErr := WithListModelsTestRetry(t, listModelsRetryConfig, nextPageRetryContext, expectations, "ListModelsPagination_NextPage", func() (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-				return client.ListModelsRequest(ctx, nextPageRequest)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ListModelsRequest(bfCtx, nextPageRequest)
 			})
 
 			if nextPageErr != nil {

--- a/core/internal/testutil/multi_turn_conversation.go
+++ b/core/internal/testutil/multi_turn_conversation.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // RunMultiTurnConversationTest executes the multi-turn conversation test scenario
-func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.MultiTurnConversation {
 		t.Logf("Multi-turn conversation not supported for provider %s", testConfig.Provider)
 		return
@@ -65,7 +66,8 @@ func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 		expectations1 = ModifyExpectationsForProvider(expectations1, testConfig.Provider)
 
 		response1, bifrostErr := WithChatTestRetry(t, chatRetryConfig1, retryContext1, expectations1, "MultiTurnConversation_Step1", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-			return client.ChatCompletionRequest(ctx, firstRequest)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ChatCompletionRequest(bfCtx, firstRequest)
 		})
 
 		if bifrostErr != nil {
@@ -132,7 +134,8 @@ func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 		expectations2.ShouldNotContainWords = []string{"don't know", "can't remember", "forgot"} // Memory failure indicators
 
 	response2, bifrostErr := WithChatTestRetry(t, chatRetryConfig2, retryContext2, expectations2, "MultiTurnConversation_Step2", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-		return client.ChatCompletionRequest(ctx, secondRequest)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		return client.ChatCompletionRequest(bfCtx, secondRequest)
 	})
 
 	if bifrostErr != nil {

--- a/core/internal/testutil/multiple_images.go
+++ b/core/internal/testutil/multiple_images.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 )
 
 // RunMultipleImagesTest executes the multiple images test scenario
-func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.MultipleImages {
 		t.Logf("Multiple images not supported for provider %s", testConfig.Provider)
 		return
@@ -99,7 +100,8 @@ func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.B
 		}...) // Failure to process multiple images indicators
 
 		response, bifrostError := WithChatTestRetry(t, chatRetryConfig, retryContext, expectations, "MultipleImages", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-			return client.ChatCompletionRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ChatCompletionRequest(bfCtx, request)
 		})
 
 		// Validation now happens inside WithTestRetry - no need to check again

--- a/core/internal/testutil/multiple_tool_calls.go
+++ b/core/internal/testutil/multiple_tool_calls.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -18,7 +19,7 @@ func getKeysFromMap(m map[string]bool) []string {
 }
 
 // RunMultipleToolCallsTest executes the multiple tool calls test scenario using dual API testing framework
-func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.MultipleToolCalls {
 		t.Logf("Multiple tool calls not supported for provider %s", testConfig.Provider)
 		return
@@ -72,6 +73,7 @@ func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schema
 
 		// Create operations for both Chat Completions and Responses API
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -81,10 +83,11 @@ func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schema
 				Fallbacks: testConfig.Fallbacks,
 			}
 			chatReq.Input = chatMessages
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -94,7 +97,7 @@ func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schema
 				Fallbacks: testConfig.Fallbacks,
 			}
 			responsesReq.Input = responsesMessages
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test - passes only if BOTH APIs succeed

--- a/core/internal/testutil/prompt_caching.go
+++ b/core/internal/testutil/prompt_caching.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -272,7 +273,7 @@ func GetPromptCachingTools() []schemas.ChatTool {
 // This test verifies that OpenAI's prompt caching works correctly with tools
 // by making multiple requests with the same long prefix and tools, and verifying
 // that cached tokens increase in subsequent requests.
-func RunPromptCachingTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunPromptCachingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.SimpleChat {
 		t.Logf("Prompt caching test requires SimpleChat support")
 		return
@@ -379,7 +380,8 @@ func RunPromptCachingTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 
 				// Execute with retry framework
 				operation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-					return client.ChatCompletionRequest(ctx, chatReq)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.ChatCompletionRequest(bfCtx, chatReq)
 				}
 
 				response, err := WithChatTestRetry(t, retryConfig, retryContext, expectations, query.name, operation)

--- a/core/internal/testutil/reasoning.go
+++ b/core/internal/testutil/reasoning.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // RunResponsesReasoningTest executes the reasoning test scenario to test thinking capabilities via Responses API only
-func RunResponsesReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunResponsesReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.Reasoning {
 		t.Logf("⏭️ Reasoning not supported for provider %s", testConfig.Provider)
 		return
@@ -84,7 +85,8 @@ func RunResponsesReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx *schem
 		expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 
 		response, responsesError := WithResponsesTestRetry(t, responsesRetryConfig, retryContext, expectations, "Reasoning", func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-			return client.ResponsesRequest(ctx, responsesReq)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		})
 
 		if responsesError != nil {
@@ -198,7 +200,7 @@ func validateResponsesAPIReasoning(t *testing.T, response *schemas.BifrostRespon
 }
 
 // RunChatCompletionReasoningTest executes the reasoning test scenario to test thinking capabilities via Chat Completions API
-func RunChatCompletionReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunChatCompletionReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.Reasoning {
 		t.Logf("⏭️ Reasoning not supported for provider %s", testConfig.Provider)
 		return
@@ -277,7 +279,8 @@ func RunChatCompletionReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx *
 		expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 
 		response, chatError := WithChatTestRetry(t, chatRetryConfig, retryContext, expectations, "Reasoning", func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-			return client.ChatCompletionRequest(ctx, chatReq)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		})
 
 		if chatError != nil {

--- a/core/internal/testutil/responses_stream.go
+++ b/core/internal/testutil/responses_stream.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RunResponsesStreamTest executes the responses streaming test scenario
-func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.CompletionStream {
 		t.Logf("Responses completion stream not supported for provider %s", testConfig.Provider)
 		return
@@ -63,7 +63,8 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 		// Use validation retry wrapper that validates stream content and retries on validation failures
 		validationResult := WithResponsesStreamValidationRetry(t, retryConfig, retryContext,
 			func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.ResponsesStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ResponsesStreamRequest(bfCtx, request)
 			},
 			func(responseChannel chan *schemas.BifrostStream) ResponsesStreamValidationResult {
 				var fullContent strings.Builder
@@ -332,7 +333,8 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 
 			// Use proper streaming retry wrapper for the stream request
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.ResponsesStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ResponsesStreamRequest(bfCtx, request)
 			})
 
 			RequireNoError(t, err, "Responses stream with tools failed")
@@ -465,7 +467,8 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 
 			// Use proper streaming retry wrapper for the stream request
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.ResponsesStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ResponsesStreamRequest(bfCtx, request)
 			})
 
 			RequireNoError(t, err, "Responses stream with reasoning failed")
@@ -589,7 +592,8 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 		// Use validation retry wrapper that validates lifecycle events and retries on validation failures
 		validationResult := WithResponsesStreamValidationRetry(t, retryConfig, retryContext,
 			func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.ResponsesStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ResponsesStreamRequest(bfCtx, request)
 			},
 			func(responseChannel chan *schemas.BifrostStream) ResponsesStreamValidationResult {
 				// Track lifecycle events

--- a/core/internal/testutil/setup.go
+++ b/core/internal/testutil/setup.go
@@ -48,8 +48,8 @@ func getBifrost(ctx context.Context) (*bifrost.Bifrost, error) {
 }
 
 // SetupTest initializes a test environment with timeout context
-func SetupTest() (*bifrost.Bifrost, *schemas.BifrostContext, context.CancelFunc, error) {
-	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), TestTimeout)
+func SetupTest() (*bifrost.Bifrost, context.Context, context.CancelFunc, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), TestTimeout)
 	client, err := getBifrost(ctx)
 	if err != nil {
 		cancel()

--- a/core/internal/testutil/simple_chat.go
+++ b/core/internal/testutil/simple_chat.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // RunSimpleChatTest executes the simple chat test scenario using dual API testing framework
-func RunSimpleChatTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunSimpleChatTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.SimpleChat {
 		t.Logf("Simple chat not supported for provider %s", testConfig.Provider)
 		return
@@ -69,6 +70,7 @@ func RunSimpleChatTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 
 		// Test Chat Completions API
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -78,7 +80,7 @@ func RunSimpleChatTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			response, err := client.ChatCompletionRequest(ctx, chatReq)
+			response, err := client.ChatCompletionRequest(bfCtx, chatReq)
 			if err != nil {
 				return nil, err
 			}
@@ -97,13 +99,14 @@ func RunSimpleChatTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifro
 
 		// Test Responses API
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider:  testConfig.Provider,
 				Model:     testConfig.ChatModel,
 				Input:     responsesMessages,
 				Fallbacks: testConfig.Fallbacks,
 			}
-			response, err := client.ResponsesRequest(ctx, responsesReq)
+			response, err := client.ResponsesRequest(bfCtx, responsesReq)
 			if err != nil {
 				return nil, err
 			}

--- a/core/internal/testutil/speech_synthesis.go
+++ b/core/internal/testutil/speech_synthesis.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RunSpeechSynthesisTest executes the speech synthesis test scenario
-func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.SpeechSynthesis {
 		t.Logf("Speech synthesis not supported for provider %s", testConfig.Provider)
 		return
@@ -110,9 +110,9 @@ func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 					OnFinalFail: retryConfig.OnFinalFail,
 				}
 
-				requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
+				
 				speechResponse, bifrostErr := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "SpeechSynthesis_"+tc.name, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+					requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 					return client.SpeechRequest(requestCtx, request)
 				})
 
@@ -147,7 +147,7 @@ func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.
 }
 
 // RunSpeechSynthesisAdvancedTest executes advanced speech synthesis test scenarios
-func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.SpeechSynthesis {
 		t.Logf("Speech synthesis not supported for provider %s", testConfig.Provider)
 		return
@@ -216,9 +216,10 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *
 				OnFinalFail: retryConfig.OnFinalFail,
 			}
 
-			requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			
 
 			speechResponse, bifrostErr := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "SpeechSynthesis_HD", func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+				requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 				return client.SpeechRequest(requestCtx, request)
 			})
 			if bifrostErr != nil {
@@ -298,9 +299,9 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *
 						OnFinalFail: voiceRetryConfig.OnFinalFail,
 					}
 
-					requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
+					
 					speechResponse, bifrostErr := WithSpeechTestRetry(t, voiceSpeechRetryConfig, voiceRetryContext, expectations, "SpeechSynthesis_VoiceType_"+voiceType, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+						requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 						return client.SpeechRequest(requestCtx, request)
 					})
 

--- a/core/internal/testutil/speech_synthesis_stream.go
+++ b/core/internal/testutil/speech_synthesis_stream.go
@@ -14,7 +14,7 @@ import (
 )
 
 // RunSpeechSynthesisStreamTest executes the streaming speech synthesis test scenario
-func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.SpeechSynthesisStream {
 		t.Logf("Speech synthesis streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -115,9 +115,10 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 					},
 				}
 
-				requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
+					requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 					return client.SpeechStreamRequest(requestCtx, request)
 				})
 
@@ -249,7 +250,7 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 }
 
 // RunSpeechSynthesisStreamAdvancedTest executes advanced streaming speech synthesis test scenarios
-func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.SpeechSynthesisStream {
 		t.Logf("Speech synthesis streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -306,9 +307,9 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 				},
 			}
 
-			requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
+			
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
+				requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 				return client.SpeechStreamRequest(requestCtx, request)
 			})
 
@@ -452,16 +453,16 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 						},
 					}
 
-					requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
+					
 					// Use retry framework with stream validation
 					var accumulatedAudio bytes.Buffer // Accumulate audio for codec validation
 					validationResult := WithSpeechStreamValidationRetry(
 						t,
 						retryConfig,
 						retryContext,
-						func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
+						func() (chan *schemas.BifrostStream, *schemas.BifrostError) {							
 							accumulatedAudio.Reset() // Reset buffer on retry
+							requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 							return client.SpeechStreamRequest(requestCtx, request)
 						},
 						func(responseChannel chan *schemas.BifrostStream) SpeechStreamValidationResult {

--- a/core/internal/testutil/structured_outputs.go
+++ b/core/internal/testutil/structured_outputs.go
@@ -42,7 +42,7 @@ var structuredOutputSchema = map[string]interface{}{
 }
 
 // RunStructuredOutputChatTest tests structured outputs with Chat Completions API (non-streaming)
-func RunStructuredOutputChatTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunStructuredOutputChatTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.StructuredOutputs {
 		t.Logf("Structured outputs not supported for provider %s", testConfig.Provider)
 		return
@@ -65,7 +65,7 @@ func RunStructuredOutputChatTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 	})
 }
 
-func testStructuredOutputChatWithValue(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig, expectValue bool) {
+func testStructuredOutputChatWithValue(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig, expectValue bool) {
 	var chatMessages []schemas.ChatMessage
 	if expectValue {
 		chatMessages = []schemas.ChatMessage{
@@ -102,7 +102,7 @@ func testStructuredOutputChatWithValue(t *testing.T, client *bifrost.Bifrost, ct
 
 	chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 		// Add Anthropic beta header for structured outputs if model contains "claude"
-		reqCtx := ctx
+		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
@@ -200,7 +200,7 @@ func testStructuredOutputChatWithValue(t *testing.T, client *bifrost.Bifrost, ct
 }
 
 // RunStructuredOutputChatStreamTest tests structured outputs with Chat Completions API (streaming)
-func RunStructuredOutputChatStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunStructuredOutputChatStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.StructuredOutputs || !testConfig.Scenarios.CompletionStream {
 		t.Logf("Structured outputs streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -217,7 +217,7 @@ func RunStructuredOutputChatStreamTest(t *testing.T, client *bifrost.Bifrost, ct
 		}
 
 		// Add Anthropic beta header for structured outputs if model contains "claude"
-		reqCtx := ctx
+		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
@@ -356,7 +356,7 @@ func RunStructuredOutputChatStreamTest(t *testing.T, client *bifrost.Bifrost, ct
 }
 
 // RunStructuredOutputResponsesTest tests structured outputs with Responses API (non-streaming)
-func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.StructuredOutputs {
 		t.Logf("Structured outputs not supported for provider %s", testConfig.Provider)
 		return
@@ -373,7 +373,7 @@ func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx
 		}
 
 		// Add Anthropic beta header for structured outputs if model contains "claude"
-		reqCtx := ctx
+		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
@@ -488,7 +488,7 @@ func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx
 }
 
 // RunStructuredOutputResponsesStreamTest tests structured outputs with Responses API (streaming)
-func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.StructuredOutputs || !testConfig.Scenarios.CompletionStream {
 		t.Logf("Structured outputs streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -510,7 +510,7 @@ func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifros
 		}
 
 		// Add Anthropic beta header for structured outputs if model contains "claude"
-		reqCtx := ctx
+		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},

--- a/core/internal/testutil/tests.go
+++ b/core/internal/testutil/tests.go
@@ -1,18 +1,18 @@
 package testutil
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	bifrost "github.com/maximhq/bifrost/core"
-	"github.com/maximhq/bifrost/core/schemas"
 )
 
 // TestScenarioFunc defines the function signature for test scenario functions
-type TestScenarioFunc func(*testing.T, *bifrost.Bifrost, *schemas.BifrostContext, ComprehensiveTestConfig)
+type TestScenarioFunc func(*testing.T, *bifrost.Bifrost, context.Context, ComprehensiveTestConfig)
 
 // RunAllComprehensiveTests executes all comprehensive test scenarios for a given configuration
-func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if testConfig.SkipReason != "" {
 		t.Skipf("Skipping %s: %s", testConfig.Provider, testConfig.SkipReason)
 		return

--- a/core/internal/testutil/text_completion.go
+++ b/core/internal/testutil/text_completion.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 )
 
 // RunTextCompletionTest tests text completion functionality
-func RunTextCompletionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunTextCompletionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.TextCompletion || testConfig.TextModel == "" {
 		t.Logf("⏭️ Text completion not supported for provider %s", testConfig.Provider)
 		return
@@ -65,7 +66,8 @@ func RunTextCompletionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.B
 		}
 
 		response, bifrostErr := WithTextCompletionTestRetry(t, textCompletionRetryConfig, retryContext, expectations, "TextCompletion", func() (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
-			return client.TextCompletionRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.TextCompletionRequest(bfCtx, request)
 		})
 
 		if bifrostErr != nil {

--- a/core/internal/testutil/text_completion_stream.go
+++ b/core/internal/testutil/text_completion_stream.go
@@ -13,7 +13,7 @@ import (
 )
 
 // RunTextCompletionStreamTest executes the text completion streaming test scenario
-func RunTextCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunTextCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.TextCompletionStream {
 		t.Logf("Text completion stream not supported for provider %s", testConfig.Provider)
 		return
@@ -64,7 +64,8 @@ func RunTextCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 
 		// Use proper streaming retry wrapper for the stream request
 		responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-			return client.TextCompletionStreamRequest(ctx, request)
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.TextCompletionStreamRequest(bfCtx, request)
 		})
 
 		// Enhanced error handling
@@ -263,7 +264,8 @@ func RunTextCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 				}
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					return client.TextCompletionStreamRequest(ctx, request)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.TextCompletionStreamRequest(bfCtx, request)
 				})
 
 				RequireNoError(t, err, "Text completion stream with varied prompts failed")
@@ -405,7 +407,8 @@ func RunTextCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sch
 				}
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					return client.TextCompletionStreamRequest(ctx, request)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.TextCompletionStreamRequest(bfCtx, request)
 				})
 
 				RequireNoError(t, err, "Text completion stream with parameters failed")

--- a/core/internal/testutil/tool_calls.go
+++ b/core/internal/testutil/tool_calls.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"strings"
@@ -12,7 +13,7 @@ import (
 )
 
 // RunToolCallsTest executes the tool calls test scenario using dual API testing framework
-func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.ToolCalls {
 		t.Logf("Tool calls not supported for provider %s", testConfig.Provider)
 		return
@@ -59,6 +60,7 @@ func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 
 		// Create operations for both Chat Completions and Responses API
 		chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)	
 			chatReq := &schemas.BifrostChatRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -69,10 +71,11 @@ func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
-			return client.ChatCompletionRequest(ctx, chatReq)
+			return client.ChatCompletionRequest(bfCtx, chatReq)
 		}
 
 		responsesOperation := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			responsesReq := &schemas.BifrostResponsesRequest{
 				Provider: testConfig.Provider,
 				Model:    testConfig.ChatModel,
@@ -81,7 +84,7 @@ func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bifros
 					Tools: []schemas.ResponsesTool{*responsesTool},
 				},
 			}
-			return client.ResponsesRequest(ctx, responsesReq)
+			return client.ResponsesRequest(bfCtx, responsesReq)
 		}
 
 		// Execute dual API test - passes only if BOTH APIs succeed

--- a/core/internal/testutil/transcription.go
+++ b/core/internal/testutil/transcription.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,7 @@ import (
 )
 
 // RunTranscriptionTest executes the transcription test scenario
-func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.Transcription {
 		t.Logf("Transcription not supported for provider %s", testConfig.Provider)
 		return
@@ -138,7 +139,8 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 					}
 
 					ttsResponse, err := WithSpeechTestRetry(t, speechRetryConfig, ttsRetryContext, ttsExpectations, "Transcription_RoundTrip_TTS_"+tc.name, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-						return client.SpeechRequest(ctx, ttsRequest)
+						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)	
+						return client.SpeechRequest(bfCtx, ttsRequest)
 					})
 					if err != nil {
 						t.Fatalf("❌ TTS generation failed for round-trip test after retries: %v", GetErrorMessage(err))
@@ -206,7 +208,8 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 				}
 
 				transcriptionResponse, bifrostErr := WithTranscriptionTestRetry(t, transcriptionRetryConfig, retryContext, expectations, "Transcription_RoundTrip_"+tc.name, func() (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-					return client.TranscriptionRequest(ctx, transcriptionRequest)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.TranscriptionRequest(bfCtx, transcriptionRequest)
 				})
 
 				if bifrostErr != nil {
@@ -314,7 +317,8 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 					}
 
 					response, err := WithTranscriptionTestRetry(t, customTranscriptionRetryConfig, customRetryContext, customExpectations, "Transcription_Custom_"+tc.name, func() (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-						return client.TranscriptionRequest(ctx, request)
+						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+						return client.TranscriptionRequest(bfCtx, request)
 					})
 					if err != nil {
 						errorMsg := GetErrorMessage(err)
@@ -338,7 +342,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.Bi
 }
 
 // RunTranscriptionAdvancedTest executes advanced transcription test scenarios
-func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.Transcription {
 		t.Logf("Transcription not supported for provider %s", testConfig.Provider)
 		return
@@ -423,7 +427,8 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 					}
 
 					response, err := WithTranscriptionTestRetry(t, formatTranscriptionRetryConfig, formatRetryContext, formatExpectations, "Transcription_Format_"+format, func() (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-						return client.TranscriptionRequest(ctx, request)
+						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+						return client.TranscriptionRequest(bfCtx, request)
 					})
 					if err != nil {
 						errorMsg := GetErrorMessage(err)
@@ -518,7 +523,8 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 			}
 
 			response, err := WithTranscriptionTestRetry(t, advancedTranscriptionRetryConfig, advancedRetryContext, advancedExpectations, "Transcription_Advanced_CustomParams", func() (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-				return client.TranscriptionRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.TranscriptionRequest(bfCtx, request)
 			})
 			if err != nil {
 				errorMsg := GetErrorMessage(err)
@@ -615,7 +621,8 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *sc
 					}
 
 					response, err := WithTranscriptionTestRetry(t, langTranscriptionRetryConfig, langRetryContext, langExpectations, "Transcription_Language_"+lang, func() (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-						return client.TranscriptionRequest(ctx, request)
+						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+						return client.TranscriptionRequest(bfCtx, request)
 					})
 					if err != nil {
 						errorMsg := GetErrorMessage(err)

--- a/core/internal/testutil/transcription_stream.go
+++ b/core/internal/testutil/transcription_stream.go
@@ -14,7 +14,7 @@ import (
 )
 
 // RunTranscriptionStreamTest executes the streaming transcription test scenario
-func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.TranscriptionStream {
 		t.Logf("Transcription streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -113,7 +113,8 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sche
 				}
 
 				ttsResponse, err := WithSpeechTestRetry(t, ttsSpeechRetryConfig, ttsRetryContext, ttsExpectations, "TranscriptionStream_TTS", func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-					return client.SpeechRequest(ctx, ttsRequest)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.SpeechRequest(bfCtx, ttsRequest)
 				})
 				if err != nil {
 					t.Fatalf("❌ TTS generation failed for stream round-trip test after retries: %v", GetErrorMessage(err))
@@ -170,7 +171,8 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sche
 				}
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-					return client.TranscriptionStreamRequest(ctx, streamRequest)
+					bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					return client.TranscriptionStreamRequest(bfCtx, streamRequest)
 				})
 
 				RequireNoError(t, err, "Transcription stream initiation failed")
@@ -332,7 +334,7 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx *sche
 }
 
 // RunTranscriptionStreamAdvancedTest executes advanced streaming transcription test scenarios
-func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx *schemas.BifrostContext, testConfig ComprehensiveTestConfig) {
+func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.TranscriptionStream {
 		t.Logf("Transcription streaming not supported for provider %s", testConfig.Provider)
 		return
@@ -387,7 +389,8 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			}
 
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.TranscriptionStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.TranscriptionStreamRequest(bfCtx, request)
 			})
 
 			RequireNoError(t, err, "JSON streaming failed")
@@ -487,7 +490,8 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 					}
 
 					responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-						return client.TranscriptionStreamRequest(ctx, request)
+						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+						return client.TranscriptionStreamRequest(bfCtx, request)
 					})
 
 					RequireNoError(t, err, fmt.Sprintf("Streaming failed for language %s", lang))
@@ -581,7 +585,8 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 			}
 
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStream, *schemas.BifrostError) {
-				return client.TranscriptionStreamRequest(ctx, request)
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.TranscriptionStreamRequest(bfCtx, request)
 			})
 
 			RequireNoError(t, err, "Custom prompt streaming failed")

--- a/core/internal/testutil/utils.go
+++ b/core/internal/testutil/utils.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -567,7 +568,7 @@ func getEmbeddingVector(embedding schemas.EmbeddingData) ([]float32, error) {
 
 // GenerateTTSAudioForTest generates real audio using TTS and writes a temp file.
 // Returns audio bytes and temp filepath. Caller’s t will clean it up.
-func GenerateTTSAudioForTest(ctx *schemas.BifrostContext, t *testing.T, client *bifrost.Bifrost, provider schemas.ModelProvider, ttsModel string, text string, voiceType string, format string) ([]byte, string) {
+func GenerateTTSAudioForTest(ctx context.Context, t *testing.T, client *bifrost.Bifrost, provider schemas.ModelProvider, ttsModel string, text string, voiceType string, format string) ([]byte, string) {
 	// inline import guard comment: context/testing/os are required at call sites; Go compiler will include them.
 	voice := GetProviderVoice(provider, voiceType)
 	if voice == "" {
@@ -615,7 +616,8 @@ func GenerateTTSAudioForTest(ctx *schemas.BifrostContext, t *testing.T, client *
 	}
 
 	resp, err := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "GenerateTTSAudioForTest", func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-		return client.SpeechRequest(ctx, req)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		return client.SpeechRequest(bfCtx, req)
 	})
 	if err != nil {
 		t.Fatalf("TTS request failed after retries: %v", GetErrorMessage(err))

--- a/core/providers/groq/groq_test.go
+++ b/core/providers/groq/groq_test.go
@@ -1,6 +1,7 @@
 package groq_test
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -57,7 +58,7 @@ func TestGroq(t *testing.T) {
 		},
 	}
 
-	ctx.SetValue(schemas.BifrostContextKey("x-litellm-fallback"), "true")
+	ctx = context.WithValue(ctx, schemas.BifrostContextKey("x-litellm-fallback"), "true")
 
 	t.Run("GroqTests", func(t *testing.T) {
 		testutil.RunAllComprehensiveTests(t, client, ctx, testConfig)

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -1,6 +1,8 @@
 // Package schemas defines the core schemas and types used by the Bifrost system.
 package schemas
 
+import "context"
+
 // Key represents an API key and its associated configuration for a provider.
 // It contains the key value, supported models, and a weight for load balancing.
 type Key struct {
@@ -86,7 +88,7 @@ type Account interface {
 	// The context can carry data from any source that sets values before the Bifrost request,
 	// including but not limited to plugin pre-hooks, application logic, or any in app middleware sharing the context.
 	// This enables dynamic key selection based on any context values present during the request.
-	GetKeysForProvider(ctx *BifrostContext, providerKey ModelProvider) ([]Key, error)
+	GetKeysForProvider(ctx context.Context, providerKey ModelProvider) ([]Key, error)
 
 	// GetConfigForProvider returns the configuration for a specific provider.
 	// This includes network settings, authentication details, and other provider-specific

--- a/plugins/jsonparser/plugin_test.go
+++ b/plugins/jsonparser/plugin_test.go
@@ -23,7 +23,7 @@ func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvide
 
 // GetKeysForProvider returns a mock API key configuration for testing.
 // Uses the OPENAI_API_KEY environment variable for authentication.
-func (baseAccount *BaseAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (baseAccount *BaseAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	return []schemas.Key{
 		{
 			Value:  os.Getenv("OPENAI_API_KEY"),

--- a/plugins/maxim/plugin_test.go
+++ b/plugins/maxim/plugin_test.go
@@ -54,7 +54,7 @@ func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvide
 
 // GetKeysForProvider returns a mock API key configuration for testing.
 // Uses the OPENAI_API_KEY environment variable for authentication.
-func (baseAccount *BaseAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (baseAccount *BaseAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	return []schemas.Key{
 		{
 			Value:  os.Getenv("OPENAI_API_KEY"),

--- a/plugins/mocker/plugin_test.go
+++ b/plugins/mocker/plugin_test.go
@@ -21,7 +21,7 @@ func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvide
 // GetKeysForProvider returns a dummy API key configuration for testing.
 // Since we're testing the mocker plugin, these keys should never be used
 // as the plugin intercepts requests before they reach the actual providers.
-func (baseAccount *BaseAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (baseAccount *BaseAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	return []schemas.Key{
 		{
 			Value:  "dummy-api-key-for-testing", // Dummy key

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -206,7 +206,7 @@ func (pa *PluginAccount) GetConfiguredProviders() ([]schemas.ModelProvider, erro
 	return []schemas.ModelProvider{pa.provider}, nil
 }
 
-func (pa *PluginAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (pa *PluginAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	return pa.keys, nil
 }
 

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -85,7 +85,7 @@ func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvide
 	return []schemas.ModelProvider{schemas.OpenAI}, nil
 }
 
-func (baseAccount *BaseAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (baseAccount *BaseAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	return []schemas.Key{
 		{
 			Value:  os.Getenv("OPENAI_API_KEY"),

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -3,6 +3,7 @@
 package lib
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -35,7 +36,7 @@ func (baseAccount *BaseAccount) GetConfiguredProviders() ([]schemas.ModelProvide
 // GetKeysForProvider returns the API keys configured for a specific provider.
 // Keys are already processed (environment variables resolved) by the store.
 // Implements the Account interface.
-func (baseAccount *BaseAccount) GetKeysForProvider(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
+func (baseAccount *BaseAccount) GetKeysForProvider(ctx context.Context, providerKey schemas.ModelProvider) ([]schemas.Key, error) {
 	if baseAccount.store == nil {
 		return nil, fmt.Errorf("store not initialized")
 	}


### PR DESCRIPTION
## Summary

Add debugging support for core provider tests by enabling Delve debugger with the `make test-core DEBUG=1` command.

## Changes

- Updated the Makefile to support debugging core provider tests with Delve
- Modified the `test-core` target to conditionally install Delve when DEBUG=1 is specified
- Added logic to use Delve instead of gotestsum when DEBUG flag is enabled
- Updated help text to document the DEBUG flag can be used with test-core
- Changed the Account interface to use standard context.Context instead of BifrostContext for GetKeysForProvider
- Updated all implementations of GetKeysForProvider to match the new interface

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run core tests with debugging enabled:

```sh
# Run all tests for a provider with debugging
make test-core PROVIDER=openai DEBUG=1

# Run a specific test with debugging
make test-core PROVIDER=openai TESTCASE=TestOpenAI/OpenAITests/SimpleChat DEBUG=1

# Run tests matching a pattern with debugging
make test-core PROVIDER=openai PATTERN=SimpleChat DEBUG=1
```

When DEBUG=1 is specified, Delve will start in headless mode and listen on port 2345. You can connect your IDE or debugger to this port.

## Breaking changes

- [x] Yes
- [ ] No

The Account interface has been modified to use standard context.Context instead of BifrostContext for the GetKeysForProvider method. All implementations need to be updated accordingly.

## Security considerations

No security implications as this is a development/testing feature only.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)