### PR TITLE
[DO NOT MERGE]fix: use correct message content types and IDs for Anthropic responses

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1295,7 +1295,7 @@ func GetRandomString(length int) string {
 		return ""
 	}
 	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
-	letters := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	letters := []rune("abcdef0123456789")
 	b := make([]rune, length)
 	for i := range b {
 		b[i] = letters[randomSource.Intn(len(letters))]


### PR DESCRIPTION
## Summary

Fix message type inconsistencies in Anthropic provider response handling to ensure proper content type assignment and message ID formatting.

## Changes

- Fixed system message content block type by using `ResponsesInputMessageContentBlockTypeText` instead of `ResponsesOutputMessageContentTypeText`
- Added logic to determine if messages should use output types based on role, ensuring assistant messages in conversation history use output_text
- Changed message ID prefix from "msg_" to "fc_" for output messages
- Modified random string generation to use hexadecimal characters only (a-f, 0-9) instead of alphanumeric

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Anthropic provider with various message types to ensure proper content type assignment:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects message type handling and ID formatting.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable