### PR TITLE
feat(helm): add deploymentAnnotations and deploymentLabels support

### DIFF
--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "bifrost.labels" . | nindent 4 }}
+    {{- with .Values.deploymentLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -34,6 +34,17 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Annotations to add to the deployment metadata
+# Useful for tools like Keel (keel.sh) for automatic image updates
+# Example:
+#   deploymentAnnotations:
+#     keel.sh/policy: force
+#     keel.sh/trigger: poll
+deploymentAnnotations: {}
+
+# Labels to add to the deployment metadata (in addition to default labels)
+deploymentLabels: {}
+
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
Add support for deployment-level annotations and labels in the Helm chart. This enables integration with tools like Keel (keel.sh) for automatic image updates when using non-semver tags like 'latest'.

New values:
- deploymentAnnotations: Add annotations to the Deployment metadata
- deploymentLabels: Add labels to the Deployment metadata

Example usage for Keel auto-updates:
  deploymentAnnotations: keel.sh/policy: force keel.sh/trigger: poll keel.sh/pollSchedule: "@every 5m"

## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


