### PR TITLE
docs update

### DIFF
--- a/docs/changelogs/v1.3.62.mdx
+++ b/docs/changelogs/v1.3.62.mdx
@@ -1,0 +1,9 @@
+---
+title: "v1.3.62"
+description: "v1.3.62 changelog - 2026-01-07"
+---
+ 
+This version exists only in the multiverse where our CTO (masquerading as an intern that day) didn't fat-finger the version bump from 61 straight to 63.
+
+> "To err is human; to blame it on the intern is management."
+> — Ancient DevOps Proverb

--- a/docs/changelogs/v1.4.0-prerelease6.mdx
+++ b/docs/changelogs/v1.4.0-prerelease6.mdx
@@ -1,0 +1,77 @@
+---
+title: "v1.4.0-prerelease6"
+description: "v1.4.0-prerelease6 changelog - 2026-01-07"
+---
+<Tabs>
+  <Tab title="NPX">
+    ```bash
+    npx -y @maximhq/bifrost --transport-version v1.4.0-prerelease6
+    ```
+  </Tab>
+  <Tab title="Docker">
+    ```bash
+    docker pull maximhq/bifrost:v1.4.0-prerelease6
+    docker run -p 8080:8080 maximhq/bifrost:v1.4.0-prerelease6
+    ```
+  </Tab>
+</Tabs>
+
+<Update label="Bifrost(HTTP)" description="1.4.0-prerelease6">
+- feat: remove restart required for auth config changes
+- fix: resolved issue where new auth configs were not being created
+- ci: added workflow to auto-generate openapi.json documentation when openapi yaml files change
+- fix: tracer lifecycle management fixes
+- fix: stream accumulator deduplication fixes
+- fix: image url and input audio handling in gemini chat converters
+- fix: support both responseJsonSchema and responseSchema for JSON response formatting in gemini
+- fix: disable auth on inference routes not working correctly
+- fix: fixes Anthropic to Azure/OpenAI for input_text/output_text
+
+</Update>
+<Update label="Core" description="1.3.5">
+- fix: tracer lifecycle management fixes
+- fix: image url and input audio handling in gemini chat converters
+- fix: support both responseJsonSchema and responseSchema for JSON response formatting in gemini
+- fix: fixes Anthropic to Azure/OpenAI for input_text/output_text
+
+</Update>
+<Update label="Framework" description="1.2.5">
+- feat: added flush session functionality to config store to clear all existing sessions
+- fix: stream accumulator reference count management fixes
+- fix: stream accumulator deduplication fixes
+
+</Update>
+<Update label="governance" description="1.4.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+
+</Update>
+<Update label="jsonparser" description="1.4.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+
+</Update>
+<Update label="logging" description="1.4.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+- fix: streaming tracer cleanup fixes
+
+</Update>
+<Update label="maxim" description="1.5.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+- fix: streaming tracer cleanup fixes
+
+</Update>
+<Update label="mocker" description="1.4.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+
+</Update>
+<Update label="otel" description="1.1.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+
+</Update>
+<Update label="semanticcache" description="1.4.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+
+</Update>
+<Update label="telemetry" description="1.4.5">
+- chore: upgrades core to v1.3.4 and framework to 1.2.4
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -358,10 +358,13 @@
         "tab": "Changelogs",
         "icon": "bolt",
         "pages": [
+          "changelogs/v1.4.0-prerelease6",
           "changelogs/v1.4.0-prerelease5",
           "changelogs/v1.4.0-prerelease4",
           "changelogs/v1.4.0-prerelease3",
           "changelogs/v1.3.63",
+          "changelogs/v1.3.62",
+          "changelogs/v1.3.61",
           "changelogs/v1.3.60",
           "changelogs/v1.3.59",
           "changelogs/v1.3.58",


### PR DESCRIPTION
## Summary

Add changelog for v1.4.0-prerelease6 and update the docs navigation to display the latest prerelease.

## Changes

- Added new changelog file for v1.4.0-prerelease6 with release date 2026-01-07
- Updated the docs.json to include the new changelog in the navigation
- Removed v1.3.63 from the navigation to maintain a clean list of recent releases
- Documented various fixes and improvements across components including:
  - Auth configuration changes without restart
  - Tracer lifecycle management
  - Stream accumulator fixes
  - Gemini chat converter improvements
  - JSON response formatting support
  - Various cross-provider compatibility fixes

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the new changelog appears correctly in the documentation site:

```sh
# Start the docs site locally
cd docs
pnpm i
pnpm dev

# Navigate to the changelogs section and verify v1.4.0-prerelease6 appears
# and is properly formatted
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

N/A

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified the docs build succeeds locally