### PR TITLE
langfuse + otel integration

### DIFF
--- a/docs/changelogs/v1.3.62.mdx
+++ b/docs/changelogs/v1.3.62.mdx
@@ -1,0 +1,9 @@
+---
+title: "v1.3.62"
+description: "v1.3.62 changelog - 2026-01-07"
+---
+ 
+This version exists only in the multiverse where our CTO (masquerading as an intern that day) didn't fat-finger the version bump from 61 straight to 63.
+
+> "To err is human; to blame it on the intern is management."
+> — Ancient DevOps Proverb

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -541,6 +541,66 @@ export HONEYCOMB_API_KEY="your-api-key"
 ```
 
 </Tab>
+<Tab title="Langfuse">
+
+[Langfuse](https://langfuse.com) is an open-source LLM observability platform that accepts OpenTelemetry traces via its OTLP endpoint.
+
+<Tabs>
+<Tab title="UI">
+
+Configure the OTel plugin with the following settings:
+
+| Field | Value |
+|-------|-------|
+| **Collector URL** | `https://cloud.langfuse.com/api/public/otel` (EU) or `https://us.cloud.langfuse.com/api/public/otel` (US) |
+| **Trace Type** | `genai_extension` |
+| **Protocol** | `http` (required - Langfuse does not support gRPC) |
+| **Headers** | `Authorization`: `env.LANGFUSE_AUTH` |
+
+</Tab>
+<Tab title="config.json">
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "otel",
+      "config": {
+        "service_name": "bifrost",
+        "collector_url": "https://cloud.langfuse.com/api/public/otel",
+        "trace_type": "genai_extension",
+        "protocol": "http",
+        "headers": {
+          "Authorization": "env.LANGFUSE_AUTH"
+        }
+      }
+    }
+  ]
+}
+```
+
+For US region, use `https://us.cloud.langfuse.com/api/public/otel` instead.
+
+</Tab>
+</Tabs>
+
+Set up the environment variable with your Langfuse API keys:
+
+```bash
+# Generate base64 auth string from your Langfuse API keys
+export LANGFUSE_AUTH="Basic $(echo -n 'pk-lf-xxx:sk-lf-xxx' | base64)"
+```
+
+Replace `pk-lf-xxx` and `sk-lf-xxx` with your Langfuse public and secret keys from your project settings.
+
+<Note>
+Langfuse only supports HTTP protocol. Do not use gRPC.
+</Note>
+
+See the [Langfuse OpenTelemetry documentation](https://langfuse.com/integrations/native/opentelemetry) for more details.
+
+</Tab>
 <Tab title="Self-Hosted">
 
 Use the included Docker Compose stack or point to your own collector:


### PR DESCRIPTION
## Summary

Add Langfuse as an OpenTelemetry integration option and create a changelog entry for version 1.3.62.## 

## Changes

- Added Langfuse as a new OpenTelemetry integration option with configuration instructions
- Created a humorous changelog entry for version 1.3.62, referencing a fictional version skip

## Fixes

Closes #866

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

To test the Langfuse integration:

1. Configure the OTel plugin with the Langfuse endpoint
2. Set up the environment variable with Langfuse API keys:

```sh
# Generate base64 auth string from your Langfuse API keys
export LANGFUSE_AUTH="Basic $(echo -n 'pk-lf-xxx:sk-lf-xxx' | base64)"
```

1. Verify traces are being sent to Langfuse dashboard

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The PR includes instructions for handling Langfuse API keys securely through environment variables.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable