### PR TITLE
rbac fixes

### DIFF
--- a/ui/app/workspace/config/views/pluginsForm.tsx
+++ b/ui/app/workspace/config/views/pluginsForm.tsx
@@ -238,8 +238,18 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 											id="ttl"
 											type="number"
 											min="1"
-											value={cacheConfig.ttl_seconds}
-											onChange={(e) => updateCacheConfigLocal({ ttl_seconds: parseInt(e.target.value) || 300 })}
+											value={cacheConfig.ttl_seconds === undefined || Number.isNaN(cacheConfig.ttl_seconds) ? '' : cacheConfig.ttl_seconds}
+											onChange={(e) => {
+												const value = e.target.value
+												if (value === '') {
+													updateCacheConfigLocal({ ttl_seconds: undefined })
+													return
+												}
+												const parsed = parseInt(value)
+												if (!Number.isNaN(parsed)) {
+													updateCacheConfigLocal({ ttl_seconds: parsed })
+												}
+											}}
 										/>
 									</div>
 									<div className="space-y-2">
@@ -250,8 +260,18 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 											min="0"
 											max="1"
 											step="0.01"
-											value={cacheConfig.threshold}
-											onChange={(e) => updateCacheConfigLocal({ threshold: parseFloat(e.target.value) || 0.8 })}
+											value={cacheConfig.threshold === undefined || Number.isNaN(cacheConfig.threshold) ? '' : cacheConfig.threshold}
+											onChange={(e) => {
+												const value = e.target.value
+												if (value === '') {
+													updateCacheConfigLocal({ threshold: undefined })
+													return
+												}
+												const parsed = parseFloat(value)
+												if (!Number.isNaN(parsed)) {
+													updateCacheConfigLocal({ threshold: parsed })
+												}
+											}}
 										/>
 									</div>
 									<div className="space-y-2">
@@ -260,8 +280,18 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 											id="dimension"
 											type="number"
 											min="0"
-											value={cacheConfig.dimension}
-											onChange={(e) => updateCacheConfigLocal({ dimension: parseInt(e.target.value) || 0 })}
+											value={cacheConfig.dimension === undefined || Number.isNaN(cacheConfig.dimension) ? '' : cacheConfig.dimension}
+											onChange={(e) => {
+												const value = e.target.value
+												if (value === '') {
+													updateCacheConfigLocal({ dimension: undefined })
+													return
+												}
+												const parsed = parseInt(value)
+												if (!Number.isNaN(parsed)) {
+													updateCacheConfigLocal({ dimension: parsed })
+												}
+											}}
 										/>
 									</div>
 								</div>

--- a/ui/app/workspace/observability/fragments/maximFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/maximFormFragment.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { RbacOperation, RbacResource, useRbac } from "@/app/enterprise/lib";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -22,6 +23,7 @@ interface MaximFormFragmentProps {
 }
 
 export function MaximFormFragment({ initialConfig, onSave, isLoading = false }: MaximFormFragmentProps) {
+	const hasMaximAccess = useRbac(RbacResource.Observability, RbacOperation.Update);
 	const [showApiKey, setShowApiKey] = useState(false);
 	const [isSaving, setIsSaving] = useState(false);
 
@@ -67,13 +69,14 @@ export function MaximFormFragment({ initialConfig, onSave, isLoading = false }: 
 									<FormLabel>API Key</FormLabel>
 									<FormControl>
 										<div className="relative">
-											<Input type={showApiKey ? "text" : "password"} placeholder="Enter your Maxim API key" {...field} className="pr-10" />
+											<Input type={showApiKey ? "text" : "password"} placeholder="Enter your Maxim API key" disabled={!hasMaximAccess} {...field} className="pr-10" />
 											<Button
 												type="button"
 												variant="ghost"
 												size="sm"
 												className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
 												onClick={() => setShowApiKey(!showApiKey)}
+												disabled={!hasMaximAccess}
 											>
 												{showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
 											</Button>
@@ -91,7 +94,7 @@ export function MaximFormFragment({ initialConfig, onSave, isLoading = false }: 
 								<FormItem>
 									<FormLabel>Log Repository ID (Optional)</FormLabel>
 									<FormControl>
-										<Input placeholder="Enter log repository ID" {...field} value={field.value ?? ""} />
+										<Input placeholder="Enter log repository ID" disabled={!hasMaximAccess} {...field} value={field.value ?? ""} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -108,7 +111,7 @@ export function MaximFormFragment({ initialConfig, onSave, isLoading = false }: 
 						render={({ field }) => (
 							<FormItem className="flex flex-row items-center gap-2">
 								<FormLabel>Enabled</FormLabel>
-								<Switch checked={form.watch("enabled")} onCheckedChange={field.onChange} disabled={isLoading || !form.formState.isValid} />
+								<Switch checked={form.watch("enabled")} onCheckedChange={field.onChange} disabled={!hasMaximAccess || isLoading || !form.formState.isValid} />
 							</FormItem>
 						)}
 					/>
@@ -125,14 +128,14 @@ export function MaximFormFragment({ initialConfig, onSave, isLoading = false }: 
 									},
 								});
 							}}
-							disabled={isLoading || !form.formState.isDirty}
+							disabled={!hasMaximAccess || isLoading || !form.formState.isDirty}
 						>
 							Reset
 						</Button>
 						<TooltipProvider>
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<Button type="submit" disabled={!form.formState.isDirty || !form.formState.isValid} isLoading={isSaving}>
+									<Button type="submit" disabled={!hasMaximAccess || !form.formState.isDirty || !form.formState.isValid} isLoading={isSaving}>
 										Save Maxim Configuration
 									</Button>
 								</TooltipTrigger>

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { RbacOperation, RbacResource, useRbac } from "@/app/enterprise/lib";
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
@@ -26,6 +27,7 @@ interface OtelFormFragmentProps {
 }
 
 export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoading = false }: OtelFormFragmentProps) {
+	const hasOtelAccess = useRbac(RbacResource.Observability, RbacOperation.Update);
 	const [isSaving, setIsSaving] = useState(false);
 	const form = useForm<OtelFormSchema, any, OtelFormSchema>({
 		resolver: zodResolver(otelFormSchema) as Resolver<OtelFormSchema, any, OtelFormSchema>,
@@ -92,7 +94,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 									<FormLabel>Service Name</FormLabel>
 									<FormDescription>If kept empty, the service name will be set to "bifrost"</FormDescription>
 									<FormControl>
-										<Input placeholder="bifrost" {...field} />
+										<Input placeholder="bifrost" disabled={!hasOtelAccess} {...field} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -114,6 +116,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 													? "https://otel-collector.example.com:4318/v1/traces"
 													: "otel-collector.example.com:4317"
 											}
+											disabled={!hasOtelAccess}
 											{...field}
 										/>
 									</FormControl>
@@ -127,7 +130,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 							render={({ field }) => (
 								<FormItem className="w-full">
 									<FormControl>
-										<HeadersTable value={field.value || {}} onChange={field.onChange} />
+										<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -140,7 +143,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 								render={({ field }) => (
 									<FormItem className="flex-1">
 										<FormLabel>Format</FormLabel>
-										<Select onValueChange={field.onChange} value={field.value ?? traceTypeOptions[0].value}>
+										<Select onValueChange={field.onChange} value={field.value ?? traceTypeOptions[0].value} disabled={!hasOtelAccess}>
 											<FormControl>
 												<SelectTrigger className="w-full">
 													<SelectValue placeholder="Select trace type" />
@@ -170,7 +173,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 								render={({ field }) => (
 									<FormItem className="flex-1">
 										<FormLabel>Protocol</FormLabel>
-										<Select onValueChange={field.onChange} value={field.value}>
+										<Select onValueChange={field.onChange} value={field.value} disabled={!hasOtelAccess}>
 											<FormControl>
 												<SelectTrigger className="w-full">
 													<SelectValue placeholder="Select protocol" />
@@ -205,7 +208,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 						render={({ field }) => (
 							<FormItem className="flex flex-row items-center gap-2">
 								<FormLabel>Enabled</FormLabel>
-								<Switch checked={form.watch("enabled")} onCheckedChange={field.onChange} disabled={isLoading || !form.formState.isValid} />
+								<Switch checked={form.watch("enabled")} onCheckedChange={field.onChange} disabled={!hasOtelAccess || isLoading || !form.formState.isValid} />
 							</FormItem>
 						)}
 					/>
@@ -219,14 +222,14 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, isLoadi
 									otel_config: undefined,
 								});
 							}}
-							disabled={isLoading || !form.formState.isDirty}
+							disabled={!hasOtelAccess || isLoading || !form.formState.isDirty}
 						>
 							Reset
 						</Button>
 						<TooltipProvider>
 							<Tooltip>
 								<TooltipTrigger asChild>
-									<Button type="submit" disabled={!form.formState.isDirty || !form.formState.isValid} isLoading={isSaving}>
+									<Button type="submit" disabled={!hasOtelAccess || !form.formState.isDirty || !form.formState.isValid} isLoading={isSaving}>
 										Save OTEL Configuration
 									</Button>
 								</TooltipTrigger>

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -2,19 +2,20 @@
 
 import { FormControl, FormField, FormItem, FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { BaseProvider, RequestType } from "@/lib/types/config";
 import { isRequestTypeDisabled } from "@/lib/utils/validation";
-import { Control, useFormContext } from "react-hook-form";
 import { Settings2 } from "lucide-react";
 import { useEffect, useMemo } from "react";
+import { Control, useFormContext } from "react-hook-form";
 
 interface AllowedRequestsFieldsProps {
 	control: Control<any>;
 	namePrefix?: string;
 	providerType?: BaseProvider;
+	disabled?: boolean;
 }
 
 // Provider-specific endpoint paths
@@ -73,7 +74,7 @@ const REQUEST_TYPES: Array<{ key: RequestType; label: string }> = [
 	{ key: "count_tokens", label: "Count Tokens" },
 ];
 
-export function AllowedRequestsFields({ control, namePrefix = "allowed_requests", providerType }: AllowedRequestsFieldsProps) {
+export function AllowedRequestsFields({ control, namePrefix = "allowed_requests", providerType, disabled = false }: AllowedRequestsFieldsProps) {
 	const leftColumn = REQUEST_TYPES.slice(0, 6);
 	const rightColumn = REQUEST_TYPES.slice(6);
 	const { getValues, setValue } = useFormContext();
@@ -106,7 +107,7 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 						</div>
 						<div className="flex items-center gap-2">
 							{/* Settings icon for path override - only show when enabled */}
-							{allowedField.value && !isDisabled && !isPathOverrideDisabled && (
+							{allowedField.value && !isDisabled && !isPathOverrideDisabled && !disabled && (
 								<FormField
 									control={control}
 									name={`request_path_overrides.${requestType.key}`}
@@ -148,7 +149,7 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 										</Tooltip>
 									</TooltipProvider>
 								) : (
-									<Switch checked={allowedField.value} onCheckedChange={allowedField.onChange} size="md" />
+									<Switch checked={allowedField.value} onCheckedChange={allowedField.onChange} size="md" disabled={disabled} />
 								)}
 							</FormControl>
 						</div>

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -133,7 +133,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 											</label>
 											<p className="text-muted-foreground text-sm">Whether the custom provider requires a key</p>
 										</div>
-										<Switch id="drop-excess-requests" size="md" checked={field.value} onCheckedChange={field.onChange} />
+										<Switch id="drop-excess-requests" size="md" checked={field.value} onCheckedChange={field.onChange} disabled={!hasUpdateProviderAccess} />
 									</div>
 								</FormItem>
 							)}
@@ -142,7 +142,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				</div>
 
 				{/* Allowed Requests Configuration */}
-				<AllowedRequestsFields control={form.control} providerType={form.watch("base_provider_type") as BaseProvider} />
+				<AllowedRequestsFields control={form.control} providerType={form.watch("base_provider_type") as BaseProvider} disabled={!hasUpdateProviderAccess} />
 
 				{/* Form Actions */}
 				<div className="flex justify-end space-x-2 py-2">

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -147,6 +147,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											placeholder={isCustomProvider ? "https://api.your-provider.com" : "https://api.example.com"}
 											{...field}
 											value={field.value || ""}
+											disabled={!hasUpdateProviderAccess}
 										/>
 									</FormControl>
 									<FormMessage />
@@ -164,14 +165,18 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											<Input
 												placeholder="30"
 												{...field}
+												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													if (isNaN(Number(e.target.value))) {
-														if (e.target.value.trim() === "") {
-															field.onChange(0);
-														}
-														return;
+													const value = e.target.value
+													if (value === '') {
+														field.onChange(undefined)
+														return
 													}
-													field.onChange(Number(e.target.value));
+													const parsed = Number(value)
+													if (!Number.isNaN(parsed)) {
+														field.onChange(parsed)
+													}
 												}}
 											/>
 										</FormControl>
@@ -187,7 +192,23 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 									<FormItem className="flex-1">
 										<FormLabel>Max Retries</FormLabel>
 										<FormControl>
-											<Input placeholder="0" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+											<Input
+												placeholder="0"
+												{...field}
+												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												disabled={!hasUpdateProviderAccess}
+												onChange={(e) => {
+													const value = e.target.value
+													if (value === '') {
+														field.onChange(undefined)
+														return
+													}
+													const parsed = Number(value)
+													if (!Number.isNaN(parsed)) {
+														field.onChange(parsed)
+													}
+												}}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -202,7 +223,23 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 									<FormItem className="flex-1">
 										<FormLabel>Initial Backoff (ms)</FormLabel>
 										<FormControl>
-											<Input placeholder="e.g 500" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+											<Input
+												placeholder="e.g 500"
+												{...field}
+												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												disabled={!hasUpdateProviderAccess}
+												onChange={(e) => {
+													const value = e.target.value
+													if (value === '') {
+														field.onChange(undefined)
+														return
+													}
+													const parsed = Number(value)
+													if (!Number.isNaN(parsed)) {
+														field.onChange(parsed)
+													}
+												}}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -215,7 +252,23 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 									<FormItem className="flex-1">
 										<FormLabel>Max Backoff (ms)</FormLabel>
 										<FormControl>
-											<Input placeholder="e.g 10000" {...field} onChange={(e) => field.onChange(Number(e.target.value))} />
+											<Input
+												placeholder="e.g 10000"
+												{...field}
+												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												disabled={!hasUpdateProviderAccess}
+												onChange={(e) => {
+													const value = e.target.value
+													if (value === '') {
+														field.onChange(undefined)
+														return
+													}
+													const parsed = Number(value)
+													if (!Number.isNaN(parsed)) {
+														field.onChange(parsed)
+													}
+												}}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -234,6 +287,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											keyPlaceholder="Header name"
 											valuePlaceholder="Header value"
 											label="Extra Headers"
+											disabled={!hasUpdateProviderAccess}
 										/>
 									</FormControl>
 									<FormMessage />

--- a/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
@@ -95,7 +95,19 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 												type="number"
 												placeholder="10"
 												{...field}
-												onChange={(e) => field.onChange(Number.parseInt(e.target.value) || 0)}
+												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												disabled={!hasUpdateProviderAccess}
+												onChange={(e) => {
+													const value = e.target.value
+													if (value === '') {
+														field.onChange(undefined)
+														return
+													}
+													const parsed = Number.parseInt(value)
+													if (!Number.isNaN(parsed)) {
+														field.onChange(parsed)
+													}
+												}}
 											/>
 										</FormControl>
 										<FormMessage />
@@ -115,7 +127,19 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 												type="number"
 												placeholder="10"
 												{...field}
-												onChange={(e) => field.onChange(Number.parseInt(e.target.value) || 0)}
+												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												disabled={!hasUpdateProviderAccess}
+												onChange={(e) => {
+													const value = e.target.value
+													if (value === '') {
+														field.onChange(undefined)
+														return
+													}
+													const parsed = Number.parseInt(value)
+													if (!Number.isNaN(parsed)) {
+														field.onChange(parsed)
+													}
+												}}
 											/>
 										</FormControl>
 										<FormMessage />
@@ -142,6 +166,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 											<Switch
 												size="md"
 												checked={field.value}
+												disabled={!hasUpdateProviderAccess}
 												onCheckedChange={(checked) => {
 													field.onChange(checked);
 													form.trigger("send_back_raw_request");
@@ -172,6 +197,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 											<Switch
 												size="md"
 												checked={field.value}
+												disabled={!hasUpdateProviderAccess}
 												onCheckedChange={(checked) => {
 													field.onChange(checked);
 													form.trigger("send_back_raw_response");

--- a/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
@@ -91,7 +91,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 							render={({ field }) => (
 								<FormItem>
 									<FormLabel>Proxy Type</FormLabel>
-									<Select onValueChange={field.onChange} value={field.value === "none" ? "" : field.value}>
+									<Select onValueChange={field.onChange} value={field.value === "none" ? "" : field.value} disabled={!hasUpdateProviderAccess}>
 										<FormControl>
 											<SelectTrigger className="w-48">
 												<SelectValue placeholder="Select type" />
@@ -122,7 +122,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 										<FormItem>
 											<FormLabel>Proxy URL</FormLabel>
 											<FormControl>
-												<Input placeholder="http://proxy.example.com" {...field} value={field.value || ""} />
+												<Input placeholder="http://proxy.example.com" {...field} value={field.value || ""} disabled={!hasUpdateProviderAccess} />
 											</FormControl>
 											<FormMessage />
 										</FormItem>
@@ -136,7 +136,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 											<FormItem>
 												<FormLabel>Username</FormLabel>
 												<FormControl>
-													<Input placeholder="Proxy username" {...field} value={field.value || ""} />
+													<Input placeholder="Proxy username" {...field} value={field.value || ""} disabled={!hasUpdateProviderAccess} />
 												</FormControl>
 												<FormMessage />
 											</FormItem>
@@ -149,7 +149,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 											<FormItem>
 												<FormLabel>Password</FormLabel>
 												<FormControl>
-													<Input type="password" placeholder="Proxy password" {...field} value={field.value || ""} />
+													<Input type="password" placeholder="Proxy password" {...field} value={field.value || ""} disabled={!hasUpdateProviderAccess} />
 												</FormControl>
 												<FormMessage />
 											</FormItem>
@@ -169,6 +169,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 													rows={6}
 													{...field}
 													value={field.value || ""}
+													disabled={!hasUpdateProviderAccess}
 												/>
 											</FormControl>
 											<FormDescription>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -13,8 +13,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { CardHeader, CardTitle } from "@/components/ui/card";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { getErrorMessage, useUpdateProviderMutation } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
@@ -31,6 +31,7 @@ interface Props {
 
 export default function ModelProviderKeysTableView({ provider, className }: Props) {
 	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const hasDeleteProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
 	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
 	const [showAddNewKeyDialog, setShowAddNewKeyDialog] = useState<{ show: boolean; keyIndex: number } | undefined>(undefined);
 	const [showDeleteKeyDialog, setShowDeleteKeyDialog] = useState<{ show: boolean; keyIndex: number } | undefined>(undefined);
@@ -53,7 +54,7 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 								Cancel
 							</AlertDialogCancel>
 							<AlertDialogAction
-								disabled={isUpdatingProvider}
+								disabled={isUpdatingProvider || !hasDeleteProviderAccess}
 								onClick={() => {
 									updateProvider({
 										...provider,
@@ -168,15 +169,16 @@ export default function ModelProviderKeysTableView({ provider, className }: Prop
 													>
 														<PencilIcon className="mr-1 h-4 w-4" />
 														Edit
-													</DropdownMenuItem>
-													<DropdownMenuItem
-														onClick={() => {
-															setShowDeleteKeyDialog({ show: true, keyIndex: index });
-														}}
-													>
-														<TrashIcon className="mr-1 h-4 w-4" />
-														Delete
-													</DropdownMenuItem>
+												</DropdownMenuItem>
+												<DropdownMenuItem
+													onClick={() => {
+														setShowDeleteKeyDialog({ show: true, keyIndex: index });
+													}}
+													disabled={!hasDeleteProviderAccess}
+												>
+													<TrashIcon className="mr-1 h-4 w-4" />
+													Delete
+												</DropdownMenuItem>
 												</DropdownMenuContent>
 											</DropdownMenu>
 										</div>

--- a/ui/app/workspace/user-groups/views/customerDialog.tsx
+++ b/ui/app/workspace/user-groups/views/customerDialog.tsx
@@ -180,7 +180,7 @@ export default function CustomerDialog({ customer, onSave, onCancel }: CustomerD
 							label="Maximum Spend (USD)"
 							value={formData.budgetMaxLimit?.toString() || ""}
 							selectValue={formData.budgetResetDuration}
-							onChangeNumber={(value) => updateField("budgetMaxLimit", parseFloat(value) || 0)}
+							onChangeNumber={(value) => updateField("budgetMaxLimit", value === '' ? undefined : parseFloat(value))}
 							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
 							options={resetDurationOptions}
 						/>

--- a/ui/app/workspace/user-groups/views/teamDialog.tsx
+++ b/ui/app/workspace/user-groups/views/teamDialog.tsx
@@ -208,7 +208,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 							label="Maximum Spend (USD)"
 							value={formData.budgetMaxLimit?.toString() || ""}
 							selectValue={formData.budgetResetDuration}
-							onChangeNumber={(value) => updateField("budgetMaxLimit", parseFloat(value) || 0)}
+							onChangeNumber={(value) => updateField("budgetMaxLimit", value === '' ? undefined : parseFloat(value))}
 							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
 							options={resetDurationOptions}
 						/>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -741,7 +741,7 @@ export default function AppSidebar() {
 			<SidebarHeader className="mt-1 ml-2 flex justify-between px-0 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:h-auto">
 				{/* Expanded state: horizontal layout */}
 				<div className="flex h-10 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
-					<Link href="/" className="group flex items-center gap-2 pl-2">
+					<Link href="/workspace/logs" className="group flex items-center gap-2 pl-2">
 						<Image className="h-[22px] w-auto" src={logoSrc} alt="Bifrost" width={70} height={70} />
 					</Link>
 					<button


### PR DESCRIPTION
## Summary

This PR improves form handling across the UI by enhancing input validation, adding RBAC access controls to form elements, and fixing numeric input handling to properly support empty/undefined values.

## Changes

- Added RBAC access controls to Maxim and OTEL configuration forms, disabling inputs when users lack update permissions
- Improved numeric input handling across multiple forms to properly handle empty values and undefined states
- Fixed form validation for cache configuration inputs (ttl_seconds, threshold, dimension)
- Added proper access control to provider configuration forms (network, performance, proxy settings)
- Enhanced the AllowedRequestsFields component to respect disabled state
- Fixed budget handling in customer and team dialogs to properly handle empty values

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Log in with different user roles to verify RBAC controls work correctly:
   - Users without update permissions should see disabled form controls
   - Users with proper permissions should be able to interact with all form elements

2. Test numeric inputs across forms:
   - Clear numeric fields and verify they don't default to 0
   - Enter valid numbers and verify they're properly saved
   - Enter invalid inputs and verify validation works correctly

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This PR improves security by properly enforcing RBAC permissions at the UI level, preventing unauthorized users from modifying settings they shouldn't have access to.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable