### PR TITLE
feat: support instructions parameter as fallback for system messages

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: gemini system message conversion and added support for using instructions parameter as a fallback when no system message

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1502,6 +1502,17 @@ func ToAnthropicResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*
 		// Set system message if present
 		if systemContent != nil {
 			anthropicReq.System = systemContent
+		} else if bifrostReq.Params != nil && bifrostReq.Params.Instructions != nil {
+			// if no system content, check if instructions are present
+			// system messages take precedence over instructions
+			anthropicReq.System = &AnthropicContent{
+				ContentBlocks: []AnthropicContentBlock{
+					{
+						Type: AnthropicContentBlockTypeText,
+						Text: bifrostReq.Params.Instructions,
+					},
+				},
+			}
 		}
 
 		// Set regular messages

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1452,6 +1452,15 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 		bedrockReq.Messages = messages
 		if len(systemMessages) > 0 {
 			bedrockReq.System = systemMessages
+		} else {
+			if bifrostReq.Params != nil && bifrostReq.Params.Instructions != nil {
+				// if no system messages, check if instructions are present
+				bedrockReq.System = []BedrockSystemMessage{
+					{
+						Text: bifrostReq.Params.Instructions,
+					},
+				}
+			}
 		}
 	}
 

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -1031,7 +1031,7 @@ func ToCohereResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Coh
 
 	// Process ResponsesInput (which contains the Responses items)
 	if bifrostReq.Input != nil {
-		cohereReq.Messages = ConvertBifrostMessagesToCohereMessages(bifrostReq.Input)
+		cohereReq.Messages = ConvertBifrostMessagesToCohereMessages(bifrostReq.Input, bifrostReq.Params)
 	}
 
 	return cohereReq, nil
@@ -1082,7 +1082,7 @@ func (response *CohereChatResponse) ToBifrostResponsesResponse() *schemas.Bifros
 
 // ConvertBifrostMessagesToCohereMessages converts an array of Bifrost ResponsesMessage to Cohere message format
 // This is the main conversion method from Bifrost to Cohere - handles all message types and returns messages
-func ConvertBifrostMessagesToCohereMessages(bifrostMessages []schemas.ResponsesMessage) []CohereMessage {
+func ConvertBifrostMessagesToCohereMessages(bifrostMessages []schemas.ResponsesMessage, params *schemas.ResponsesParameters) []CohereMessage {
 	var cohereMessages []CohereMessage
 	var systemContent []string
 	var pendingReasoningContentBlocks []CohereContentBlock
@@ -1210,6 +1210,13 @@ func ConvertBifrostMessagesToCohereMessages(bifrostMessages []schemas.ResponsesM
 		systemMsg := CohereMessage{
 			Role:    "system",
 			Content: NewStringContent(strings.Join(systemContent, "\n")),
+		}
+		cohereMessages = append([]CohereMessage{systemMsg}, cohereMessages...)
+	} else if params != nil && params.Instructions != nil {
+		// if no system messages, check if instructions are present
+		systemMsg := CohereMessage{
+			Role:    "system",
+			Content: NewStringContent(*params.Instructions),
 		}
 		cohereMessages = append([]CohereMessage{systemMsg}, cohereMessages...)
 	}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -27,23 +27,25 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest() *schemas.Bif
 
 	params := request.convertGenerationConfigToResponsesParameters()
 
-	// Convert Contents to Input messages
-	if len(request.Contents) > 0 {
-		bifrostReq.Input = convertGeminiContentsToResponsesMessages(request.Contents)
+	// Convert SystemInstruction to system messages first
+	var inputMessages []schemas.ResponsesMessage
+	if request.SystemInstruction != nil && len(request.SystemInstruction.Parts) > 0 {
+		systemMsg := convertGeminiSystemInstructionToResponsesMessage(request.SystemInstruction)
+		if systemMsg != nil {
+			inputMessages = append(inputMessages, *systemMsg)
+		}
 	}
 
-	if request.SystemInstruction != nil {
-		var systemInstructionText string
-		if len(request.SystemInstruction.Parts) > 0 {
-			for _, part := range request.SystemInstruction.Parts {
-				if part.Text != "" {
-					systemInstructionText += part.Text
-				}
-			}
+	// Convert Contents to Input messages
+	if len(request.Contents) > 0 {
+		contentsMessages := convertGeminiContentsToResponsesMessages(request.Contents)
+		if len(contentsMessages) > 0 {
+			inputMessages = append(inputMessages, contentsMessages...)
 		}
-		if systemInstructionText != "" {
-			params.Instructions = &systemInstructionText
-		}
+	}
+
+	if len(inputMessages) > 0 {
+		bifrostReq.Input = inputMessages
 	}
 
 	if len(request.Tools) > 0 {
@@ -106,14 +108,27 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Gemi
 		}
 	}
 
-	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
-		if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
-			if settings, ok := safetySettings.([]SafetySetting); ok {
-				geminiReq.SafetySettings = settings
+	if bifrostReq.Params != nil {
+		if bifrostReq.Params.Instructions != nil {
+			// check if system instruction is already set
+			if geminiReq.SystemInstruction == nil {
+				geminiReq.SystemInstruction = &Content{
+					Parts: []*Part{
+						{Text: *bifrostReq.Params.Instructions},
+					},
+				}
 			}
 		}
-		if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
-			geminiReq.CachedContent = cachedContent
+
+		if bifrostReq.Params.ExtraParams != nil {
+			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
+				if settings, ok := safetySettings.([]SafetySetting); ok {
+					geminiReq.SafetySettings = settings
+				}
+			}
+			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
+				geminiReq.CachedContent = cachedContent
+			}
 		}
 	}
 
@@ -1360,6 +1375,48 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, usage *GenerateCont
 // FinalizeGeminiResponsesStream finalizes the stream by closing any open items and emitting completed event
 func FinalizeGeminiResponsesStream(state *GeminiResponsesStreamState, usage *GenerateContentResponseUsageMetadata, sequenceNumber int) []*schemas.BifrostResponsesStreamResponse {
 	return closeGeminiOpenItems(state, usage, sequenceNumber)
+}
+
+// convertGeminiSystemInstructionToResponsesMessage converts Gemini SystemInstruction to a system role message
+func convertGeminiSystemInstructionToResponsesMessage(systemInstruction *Content) *schemas.ResponsesMessage {
+	if systemInstruction == nil || len(systemInstruction.Parts) == 0 {
+		return nil
+	}
+
+	var contentBlocks []schemas.ResponsesMessageContentBlock
+	var hasTextContent bool
+
+	for _, part := range systemInstruction.Parts {
+		if part.Text != "" {
+			contentBlocks = append(contentBlocks, schemas.ResponsesMessageContentBlock{
+				Type: schemas.ResponsesInputMessageContentBlockTypeText,
+				Text: &part.Text,
+			})
+			hasTextContent = true
+		}
+	}
+
+	if !hasTextContent {
+		return nil
+	}
+
+	// If single text block, use ContentStr
+	if len(contentBlocks) == 1 {
+		return &schemas.ResponsesMessage{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: contentBlocks[0].Text,
+			},
+		}
+	}
+
+	// Multiple blocks, use ContentBlocks
+	return &schemas.ResponsesMessage{
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: contentBlocks,
+		},
+	}
 }
 
 func convertGeminiContentsToResponsesMessages(contents []Content) []schemas.ResponsesMessage {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: gemini system message conversion and added support for using instructions parameter as a fallback when no system message


### PR DESCRIPTION
## Summary

Added support for using `instructions` parameter as a fallback when no system message is present across multiple providers (Anthropic, Bedrock, Cohere, and Gemini). This ensures consistent handling of system instructions across different LLM providers.

## Changes

- Added fallback logic in Anthropic provider to use `instructions` parameter when no system content is present
- Implemented similar fallback logic in Bedrock provider to convert instructions to system messages
- Updated Cohere message conversion to check for instructions when no system messages exist
- Enhanced Gemini provider to properly handle system instructions and convert them to system role messages
- Added integration tests for system instructions with the Google provider

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Test the system instruction fallback with different providers:

```sh
# Run the integration tests for Google provider
go test ./tests/integrations/tests/test_google.py -v

# Test with other providers
curl -X POST "http://localhost:8080/api/v1/responses" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-3-opus-20240229",
    "params": {
      "instructions": "You are a helpful assistant that always responds in exactly 5 words."
    },
    "input": [
      {"role": "user", "content": "What is 2 + 2?"}
    ]
  }'
```

## Breaking changes

- [x] No

## Related issues

Improves system message handling across providers for more consistent behavior.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)