### PR TITLE
config resolution for first time vk

### DIFF
--- a/examples/configs/withvirtualkeys/config.json
+++ b/examples/configs/withvirtualkeys/config.json
@@ -64,7 +64,7 @@
                         "weight": 0.5
                     }
                 ],
-                "value": "sk-bf-vk-prod-assistant-us-01"
+                "value": "env.BIFROST_VK_PROD_ASSISTANT_US_01"
             },
             {
                 "id": "sk-bf-vk-prod-assistant-eu-01",


### PR DESCRIPTION
## Summary

Added environment variable support for virtual keys in the Bifrost HTTP transport, allowing virtual key values to be loaded from environment variables.

## Changes

- Modified the virtual key value in the example config to use environment variable syntax (`env.BIFROST_VK_PROD_ASSISTANT_US_01`)
- Enhanced the `mergeGovernanceConfig` function to process environment variables for virtual key values
- Added proper tracking of environment variables used for virtual keys in the `EnvKeys` map
- Fixed code formatting and alignment

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

1. Update a virtual key value in your config to use the environment variable syntax: `env.YOUR_ENV_VAR_NAME`
2. Set the corresponding environment variable
3. Start the server and verify the virtual key is correctly loaded with the value from the environment variable

```sh
# Set the environment variable
export BIFROST_VK_PROD_ASSISTANT_US_01="your-virtual-key-value"

# Run the server
go run main.go

# Verify the virtual key is loaded correctly
# Check logs or make a request that uses the virtual key
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change improves security by allowing virtual key values to be stored in environment variables rather than directly in configuration files, which is a security best practice for sensitive values.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)