### PR TITLE
adds retries to file tests

### DIFF
--- a/core/internal/testutil/file_base64.go
+++ b/core/internal/testutil/file_base64.go
@@ -176,8 +176,7 @@ func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 			CreateDocumentResponsesMessage("What is the main content of this PDF document? Summarize it.", HelloWorldPDFBase64),
 		}
 
-		// Use retry framework for document input requests
-		retryConfig := GetTestRetryConfigForScenario("FileInput", testConfig)
+		// Set up retry context for document input requests
 		retryContext := TestRetryContext{
 			ScenarioName: "FileBase64-Responses",
 			ExpectedBehavior: map[string]interface{}{
@@ -205,14 +204,7 @@ func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 			"unable to read", "no file", "corrupted", "unsupported",
 		}...) // PDF processing failure indicators
 
-		responsesRetryConfig := ResponsesRetryConfig{
-			MaxAttempts: retryConfig.MaxAttempts,
-			BaseDelay:   retryConfig.BaseDelay,
-			MaxDelay:    retryConfig.MaxDelay,
-			Conditions:  []ResponsesRetryCondition{},
-			OnRetry:     retryConfig.OnRetry,
-			OnFinalFail: retryConfig.OnFinalFail,
-		}
+		responsesRetryConfig := FileInputResponsesRetryConfig()
 
 		response, responsesError := WithResponsesTestRetry(t, responsesRetryConfig, retryContext, expectations, "FileBase64", func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)

--- a/core/internal/testutil/file_url.go
+++ b/core/internal/testutil/file_url.go
@@ -167,8 +167,7 @@ func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx context.
 			CreateFileURLResponsesMessage("What is this document about? Please provide a summary of its main topics.", TestFileURL),
 		}
 
-		// Use retry framework for file URL requests
-		retryConfig := GetTestRetryConfigForScenario("FileInput", testConfig)
+		// Set up retry context for file URL requests
 		retryContext := TestRetryContext{
 			ScenarioName: "FileURL-Responses",
 			ExpectedBehavior: map[string]interface{}{
@@ -198,14 +197,7 @@ func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx context.
 			"cannot fetch", "download failed", "url not found",
 		}...) // File URL processing failure indicators
 
-		responsesRetryConfig := ResponsesRetryConfig{
-			MaxAttempts: retryConfig.MaxAttempts,
-			BaseDelay:   retryConfig.BaseDelay,
-			MaxDelay:    retryConfig.MaxDelay,
-			Conditions:  []ResponsesRetryCondition{},
-			OnRetry:     retryConfig.OnRetry,
-			OnFinalFail: retryConfig.OnFinalFail,
-		}
+		responsesRetryConfig := FileInputResponsesRetryConfig()
 
 		response, responsesError := WithResponsesTestRetry(t, responsesRetryConfig, retryContext, expectations, "FileURL", func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)

--- a/core/internal/testutil/test_retry_framework.go
+++ b/core/internal/testutil/test_retry_framework.go
@@ -849,6 +849,24 @@ func FileInputRetryConfig() TestRetryConfig {
 	}
 }
 
+// FileInputResponsesRetryConfig creates a retry config for file/document input tests using Responses API
+func FileInputResponsesRetryConfig() ResponsesRetryConfig {
+	return ResponsesRetryConfig{
+		MaxAttempts: 10,
+		BaseDelay:   2000 * time.Millisecond,
+		MaxDelay:    10 * time.Second,
+		Conditions: []ResponsesRetryCondition{
+			&ResponsesEmptyCondition{},
+			&ResponsesFileNotProcessedCondition{},
+			&ResponsesGenericResponseCondition{},
+			&ResponsesContentValidationCondition{},
+		},
+		OnRetry: func(attempt int, reason string, t *testing.T) {
+			t.Logf("🔄 Retrying file input test (attempt %d): %s", attempt, reason)
+		},
+	}
+}
+
 // StreamingRetryConfig creates a retry config for streaming tests
 func StreamingRetryConfig() TestRetryConfig {
 	return TestRetryConfig{


### PR DESCRIPTION
## Enhance file input test retry framework for Responses API

This PR improves the reliability of file input tests by implementing specialized retry conditions for the Responses API. It extracts common retry logic into a reusable function and adds dedicated conditions to handle file processing failures.

## Changes

- Created `FileInputResponsesRetryConfig()` function to provide consistent retry configuration for file-based tests
- Added specialized retry conditions for Responses API:
  - `ResponsesEmptyCondition`: Detects empty responses
  - `ResponsesFileNotProcessedCondition`: Identifies when files aren't properly processed
  - `ResponsesGenericResponseCondition`: Catches generic/template responses
  - `ResponsesContentValidationCondition`: Validates response content against expected keywords
- Refactored file_base64.go and file_url.go to use the new retry configuration

## Type of change

- [x] Refactor
- [x] Feature

## Affected areas

- [x] Core (Go)

## How to test

Run the file input tests to verify they handle transient failures properly:

```sh
go test ./core/internal/testutil -run TestFileBase64Responses
go test ./core/internal/testutil -run TestFileURLResponses
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this only affects test infrastructure.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable