### PR TITLE
fix: remove non reasoning variant from grok reasoning models list

### DIFF
--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -1,0 +1,317 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestApplyXAICompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		request  *OpenAIChatRequest
+		validate func(t *testing.T, req *OpenAIChatRequest)
+	}{
+		{
+			name:  "grok-3: preserves frequency_penalty and stop, clears presence_penalty and reasoning_effort",
+			model: "grok-3",
+			request: &OpenAIChatRequest{
+				Model:    "grok-3",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+					Stop:             []string{"STOP"},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("high"),
+					},
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// frequency_penalty should be preserved
+				if req.FrequencyPenalty == nil || *req.FrequencyPenalty != 0.5 {
+					t.Errorf("Expected FrequencyPenalty to be preserved at 0.5, got %v", req.FrequencyPenalty)
+				}
+
+				// stop should be preserved
+				if len(req.Stop) != 1 || req.Stop[0] != "STOP" {
+					t.Errorf("Expected Stop to be preserved as ['STOP'], got %v", req.Stop)
+				}
+
+				// presence_penalty should be cleared
+				if req.PresencePenalty != nil {
+					t.Errorf("Expected PresencePenalty to be cleared (nil), got %v", *req.PresencePenalty)
+				}
+
+				// reasoning_effort should be cleared for non-mini grok-3
+				if req.Reasoning == nil {
+					t.Fatal("Expected Reasoning to remain non-nil")
+				}
+				if req.Reasoning.Effort != nil {
+					t.Errorf("Expected Reasoning.Effort to be cleared (nil) for grok-3, got %v", *req.Reasoning.Effort)
+				}
+			},
+		},
+		{
+			name:  "grok-3-mini: clears all penalties and stop, preserves reasoning_effort",
+			model: "grok-3-mini",
+			request: &OpenAIChatRequest{
+				Model:    "grok-3-mini",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+					Stop:             []string{"STOP"},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("medium"),
+					},
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// presence_penalty should be cleared
+				if req.PresencePenalty != nil {
+					t.Errorf("Expected PresencePenalty to be cleared (nil), got %v", *req.PresencePenalty)
+				}
+
+				// frequency_penalty should be cleared for grok-3-mini
+				if req.FrequencyPenalty != nil {
+					t.Errorf("Expected FrequencyPenalty to be cleared (nil) for grok-3-mini, got %v", *req.FrequencyPenalty)
+				}
+
+				// stop should be cleared for grok-3-mini
+				if req.Stop != nil {
+					t.Errorf("Expected Stop to be cleared (nil) for grok-3-mini, got %v", req.Stop)
+				}
+
+				// reasoning_effort should be preserved for grok-3-mini
+				if req.Reasoning == nil || req.Reasoning.Effort == nil {
+					t.Fatal("Expected Reasoning.Effort to be preserved for grok-3-mini")
+				}
+				if *req.Reasoning.Effort != "medium" {
+					t.Errorf("Expected Reasoning.Effort to be 'medium', got %v", *req.Reasoning.Effort)
+				}
+			},
+		},
+		{
+			name:  "grok-4: clears all penalties, stop, and reasoning_effort",
+			model: "grok-4",
+			request: &OpenAIChatRequest{
+				Model:    "grok-4",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+					Stop:             []string{"STOP"},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("high"),
+					},
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// presence_penalty should be cleared
+				if req.PresencePenalty != nil {
+					t.Errorf("Expected PresencePenalty to be cleared (nil), got %v", *req.PresencePenalty)
+				}
+
+				// frequency_penalty should be cleared for grok-4
+				if req.FrequencyPenalty != nil {
+					t.Errorf("Expected FrequencyPenalty to be cleared (nil) for grok-4, got %v", *req.FrequencyPenalty)
+				}
+
+				// stop should be cleared for grok-4
+				if req.Stop != nil {
+					t.Errorf("Expected Stop to be cleared (nil) for grok-4, got %v", req.Stop)
+				}
+
+				// reasoning_effort should be cleared for grok-4
+				if req.Reasoning == nil {
+					t.Fatal("Expected Reasoning to remain non-nil")
+				}
+				if req.Reasoning.Effort != nil {
+					t.Errorf("Expected Reasoning.Effort to be cleared (nil) for grok-4, got %v", *req.Reasoning.Effort)
+				}
+			},
+		},
+		{
+			name:  "grok-4-fast-reasoning: clears all penalties, stop, and reasoning_effort",
+			model: "grok-4-fast-reasoning",
+			request: &OpenAIChatRequest{
+				Model:    "grok-4-fast-reasoning",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+					Stop:             []string{"STOP", "END"},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("high"),
+					},
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// presence_penalty should be cleared
+				if req.PresencePenalty != nil {
+					t.Errorf("Expected PresencePenalty to be cleared (nil), got %v", *req.PresencePenalty)
+				}
+
+				// frequency_penalty should be cleared
+				if req.FrequencyPenalty != nil {
+					t.Errorf("Expected FrequencyPenalty to be cleared (nil), got %v", *req.FrequencyPenalty)
+				}
+
+				// stop should be cleared
+				if req.Stop != nil {
+					t.Errorf("Expected Stop to be cleared (nil), got %v", req.Stop)
+				}
+
+				// reasoning_effort should be cleared
+				if req.Reasoning == nil {
+					t.Fatal("Expected Reasoning to remain non-nil")
+				}
+				if req.Reasoning.Effort != nil {
+					t.Errorf("Expected Reasoning.Effort to be cleared (nil), got %v", *req.Reasoning.Effort)
+				}
+			},
+		},
+		{
+			name:  "grok-code-fast-1: clears all penalties, stop, and reasoning_effort",
+			model: "grok-code-fast-1",
+			request: &OpenAIChatRequest{
+				Model:    "grok-code-fast-1",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.2),
+					PresencePenalty:  schemas.Ptr(0.1),
+					Stop:             []string{"END"},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("low"),
+					},
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// presence_penalty should be cleared
+				if req.PresencePenalty != nil {
+					t.Errorf("Expected PresencePenalty to be cleared (nil), got %v", *req.PresencePenalty)
+				}
+
+				// frequency_penalty should be cleared
+				if req.FrequencyPenalty != nil {
+					t.Errorf("Expected FrequencyPenalty to be cleared (nil), got %v", *req.FrequencyPenalty)
+				}
+
+				// stop should be cleared
+				if req.Stop != nil {
+					t.Errorf("Expected Stop to be cleared (nil), got %v", req.Stop)
+				}
+
+				// reasoning_effort should be cleared
+				if req.Reasoning == nil {
+					t.Fatal("Expected Reasoning to remain non-nil")
+				}
+				if req.Reasoning.Effort != nil {
+					t.Errorf("Expected Reasoning.Effort to be cleared (nil), got %v", *req.Reasoning.Effort)
+				}
+			},
+		},
+		{
+			name:  "non-reasoning grok model: no changes applied",
+			model: "grok-2-latest",
+			request: &OpenAIChatRequest{
+				Model:    "grok-2-latest",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+					Stop:             []string{"STOP"},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("high"),
+					},
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// All parameters should be preserved for non-reasoning models
+				if req.FrequencyPenalty == nil || *req.FrequencyPenalty != 0.5 {
+					t.Errorf("Expected FrequencyPenalty to be preserved at 0.5, got %v", req.FrequencyPenalty)
+				}
+
+				if req.PresencePenalty == nil || *req.PresencePenalty != 0.3 {
+					t.Errorf("Expected PresencePenalty to be preserved at 0.3, got %v", req.PresencePenalty)
+				}
+
+				if len(req.Stop) != 1 || req.Stop[0] != "STOP" {
+					t.Errorf("Expected Stop to be preserved as ['STOP'], got %v", req.Stop)
+				}
+
+				if req.Reasoning == nil || req.Reasoning.Effort == nil {
+					t.Fatal("Expected Reasoning.Effort to be preserved")
+				}
+				if *req.Reasoning.Effort != "high" {
+					t.Errorf("Expected Reasoning.Effort to be 'high', got %v", *req.Reasoning.Effort)
+				}
+			},
+		},
+		{
+			name:  "grok-3: handles nil reasoning gracefully",
+			model: "grok-3",
+			request: &OpenAIChatRequest{
+				Model:    "grok-3",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+					Stop:             []string{"STOP"},
+					Reasoning:        nil,
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// Should handle nil reasoning without panicking
+				if req.Reasoning != nil {
+					t.Errorf("Expected Reasoning to remain nil, got %v", req.Reasoning)
+				}
+
+				// Other parameters should still be processed
+				if req.PresencePenalty != nil {
+					t.Errorf("Expected PresencePenalty to be cleared (nil), got %v", *req.PresencePenalty)
+				}
+
+				if req.FrequencyPenalty == nil || *req.FrequencyPenalty != 0.5 {
+					t.Errorf("Expected FrequencyPenalty to be preserved at 0.5, got %v", req.FrequencyPenalty)
+				}
+			},
+		},
+		{
+			name:  "grok-3: preserves other parameters like temperature",
+			model: "grok-3",
+			request: &OpenAIChatRequest{
+				Model:    "grok-3",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					Temperature:      schemas.Ptr(0.8),
+					TopP:             schemas.Ptr(0.9),
+					FrequencyPenalty: schemas.Ptr(0.5),
+					PresencePenalty:  schemas.Ptr(0.3),
+				},
+			},
+			validate: func(t *testing.T, req *OpenAIChatRequest) {
+				// Unrelated parameters should be preserved
+				if req.Temperature == nil || *req.Temperature != 0.8 {
+					t.Errorf("Expected Temperature to be preserved at 0.8, got %v", req.Temperature)
+				}
+
+				if req.TopP == nil || *req.TopP != 0.9 {
+					t.Errorf("Expected TopP to be preserved at 0.9, got %v", req.TopP)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Apply the compatibility function
+			tt.request.applyXAICompatibility(tt.model)
+
+			// Validate the results
+			tt.validate(t, tt.request)
+		})
+	}
+}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1162,7 +1162,6 @@ var grokReasoningModels = []string{
 	"grok-3-mini",
 	"grok-4",
 	"grok-4-fast-reasoning",
-	"grok-4-fast-non-reasoning",
 	"grok-4-1-fast-reasoning",
 	"grok-code-fast-1",
 }
@@ -1172,7 +1171,7 @@ func IsGrokReasoningModel(model string) bool {
 	// Check if the model matches any of the reasoning models
 	for _, reasoningModel := range grokReasoningModels {
 		if strings.Contains(model, reasoningModel) {
-			// Make sure it's not a non-reasoning variant like "grok-4-fast-non-reasoning"
+			// Make sure it's not a non-reasoning variant. Safety check for variants
 			if strings.Contains(model, "non-reasoning") {
 				return false
 			}


### PR DESCRIPTION
## Summary

Remove `grok-4-fast-non-reasoning` from the list of Grok reasoning models and update the comment in the `IsGrokReasoningModel` function.

## Changes

- Removed `grok-4-fast-non-reasoning` from the `grokReasoningModels` slice as it's no longer needed in the list of reasoning models
- Updated the comment in the `IsGrokReasoningModel` function to be more generic about safety checking for variants

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./core/schemas/...
```

Verify that the `IsGrokReasoningModel` function correctly identifies reasoning models while excluding non-reasoning variants.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a minor update to model identification logic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable