### PR TITLE
feat: send back raw request with bifrost errors

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2390,6 +2390,8 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 				RequestType:    req.RequestType,
 				Provider:       provider,
 				ModelRequested: model,
+				RawRequest:     primaryErr.ExtraFields.RawRequest,
+				RawResponse:    primaryErr.ExtraFields.RawResponse,
 			}
 		}
 		return primaryResult, primaryErr
@@ -2437,6 +2439,8 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 				RequestType:    req.RequestType,
 				Provider:       fallback.Provider,
 				ModelRequested: fallback.Model,
+				RawRequest:     fallbackErr.ExtraFields.RawRequest,
+				RawResponse:    fallbackErr.ExtraFields.RawResponse,
 			}
 			return nil, fallbackErr
 		}
@@ -2447,6 +2451,8 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 			RequestType:    req.RequestType,
 			Provider:       provider,
 			ModelRequested: model,
+			RawRequest:     primaryErr.ExtraFields.RawRequest,
+			RawResponse:    primaryErr.ExtraFields.RawResponse,
 		}
 	}
 
@@ -2495,6 +2501,8 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				RequestType:    req.RequestType,
 				Provider:       provider,
 				ModelRequested: model,
+				RawRequest:     primaryErr.ExtraFields.RawRequest,
+				RawResponse:    primaryErr.ExtraFields.RawResponse,
 			}
 		}
 		return primaryResult, primaryErr
@@ -2540,6 +2548,8 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				RequestType:    req.RequestType,
 				Provider:       fallback.Provider,
 				ModelRequested: fallback.Model,
+				RawRequest:     fallbackErr.ExtraFields.RawRequest,
+				RawResponse:    fallbackErr.ExtraFields.RawResponse,
 			}
 			return nil, fallbackErr
 		}
@@ -2550,6 +2560,8 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 			RequestType:    req.RequestType,
 			Provider:       provider,
 			ModelRequested: model,
+			RawRequest:     primaryErr.ExtraFields.RawRequest,
+			RawResponse:    primaryErr.ExtraFields.RawResponse,
 		}
 	}
 
@@ -3154,6 +3166,8 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				Provider:       provider.GetProviderKey(),
 				ModelRequested: model,
 				RequestType:    req.RequestType,
+				RawRequest:     bifrostError.ExtraFields.RawRequest,
+				RawResponse:    bifrostError.ExtraFields.RawResponse,
 			}
 
 			// Send error with context awareness to prevent deadlock

--- a/core/providers/anthropic/errors.go
+++ b/core/providers/anthropic/errors.go
@@ -66,11 +66,9 @@ func parseAnthropicError(resp *fasthttp.Response, meta *providerUtils.RequestMet
 		bifrostErr.Error.Message = errorResp.Error.Message
 	}
 	if meta != nil {
-		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-			Provider:       meta.Provider,
-			ModelRequested: meta.Model,
-			RequestType:    meta.RequestType,
-		}
+		bifrostErr.ExtraFields.Provider = meta.Provider
+		bifrostErr.ExtraFields.ModelRequested = meta.Model
+		bifrostErr.ExtraFields.RequestType = meta.RequestType
 	}
 	return bifrostErr
 }

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -164,6 +164,11 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 	if resp.StatusCode != http.StatusOK {
 		var errorResp BedrockError
 
+		var rawErrorResponse interface{}
+		if err := sonic.Unmarshal(body, &rawErrorResponse); err != nil {
+			rawErrorResponse = string(body)
+		}
+
 		if err := sonic.Unmarshal(body, &errorResp); err != nil {
 			return nil, latency, &schemas.BifrostError{
 				IsBifrostError: true,
@@ -172,6 +177,9 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 					Message: schemas.ErrProviderResponseUnmarshal,
 					Error:   err,
 				},
+				ExtraFields: schemas.BifrostErrorExtraFields{
+					RawResponse: rawErrorResponse,
+				},
 			}
 		}
 
@@ -179,6 +187,9 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 			StatusCode: &resp.StatusCode,
 			Error: &schemas.ErrorField{
 				Message: errorResp.Message,
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RawResponse: rawErrorResponse,
 			},
 		}
 	}
@@ -523,7 +534,7 @@ func (provider *BedrockProvider) TextCompletion(ctx *schemas.BifrostContext, key
 	path, deployment := provider.getModelPath("invoke", request.Model, key)
 	body, latency, err := provider.completeRequest(ctx, jsonData, path, key)
 	if err != nil {
-		return nil, err
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Handle model-specific response conversion
@@ -596,7 +607,7 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 
 	resp, deployment, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model, "invoke-with-response-stream")
 	if bifrostErr != nil {
-		return nil, bifrostErr
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Create response channel
@@ -726,7 +737,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	// Create the signed request
 	responseBody, latency, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
 	if bifrostErr != nil {
-		return nil, bifrostErr
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// pool the response
@@ -735,13 +746,13 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 
 	// Parse the response using the new Bedrock type
 	if err := sonic.Unmarshal(responseBody, bedrockResponse); err != nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Convert using the new response converter
 	bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
 	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Set ExtraFields
@@ -788,7 +799,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 
 	resp, deployment, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model, "converse-stream")
 	if bifrostErr != nil {
-		return nil, bifrostErr
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Create response channel
@@ -984,7 +995,7 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 	// Create the signed request
 	responseBody, latency, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
 	if bifrostErr != nil {
-		return nil, bifrostErr
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// pool the response
@@ -993,13 +1004,13 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 
 	// Parse the response using the new Bedrock type
 	if err := sonic.Unmarshal(responseBody, bedrockResponse); err != nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Convert using the new response converter
 	bifrostResponse, err := bedrockResponse.ToBifrostResponsesResponse(ctx)
 	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	bifrostResponse.Model = deployment
@@ -1048,7 +1059,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 
 	resp, deployment, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model, "converse-stream")
 	if bifrostErr != nil {
-		return nil, bifrostErr
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Create response channel
@@ -1128,7 +1139,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, finalResponse, nil, nil), responseChan)
 					}
 					break
-				}				
+				}
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				provider.logger.Warn(fmt.Sprintf("Error decoding %s EventStream message: %v", providerName, err))
 				providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.ResponsesStreamRequest, providerName, request.Model, provider.logger)
@@ -1252,28 +1263,29 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	var latency time.Duration
 	var path string
 	var deployment string
+	var jsonData []byte
 
 	switch modelType {
 	case "titan":
-		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
 			func() (any, error) { return ToBedrockTitanEmbeddingRequest(request) },
 			provider.GetProviderKey())
-		if bifrostErr != nil {
-			return nil, bifrostErr
+		if bifrostError != nil {
+			return nil, bifrostError
 		}
 		path, deployment = provider.getModelPath("invoke", request.Model, key)
 		rawResponse, latency, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
 
 	case "cohere":
-		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
 			func() (any, error) { return ToBedrockCohereEmbeddingRequest(request) },
 			provider.GetProviderKey())
-		if bifrostErr != nil {
-			return nil, bifrostErr
+		if bifrostError != nil {
+			return nil, bifrostError
 		}
 		path, deployment = provider.getModelPath("invoke", request.Model, key)
 		rawResponse, latency, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
@@ -1283,7 +1295,7 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	}
 
 	if bifrostError != nil {
-		return nil, bifrostError
+		return nil, providerUtils.EnrichError(ctx, bifrostError, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	// Parse response based on model type
@@ -1292,7 +1304,7 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	case "titan":
 		var titanResp BedrockTitanEmbeddingResponse
 		if err := sonic.Unmarshal(rawResponse, &titanResp); err != nil {
-			return nil, providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err, providerName)
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Titan embedding response", err, providerName), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
 		bifrostResponse = titanResp.ToBifrostEmbeddingResponse()
 		bifrostResponse.Model = request.Model
@@ -1300,7 +1312,7 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	case "cohere":
 		var cohereResp cohere.CohereEmbeddingResponse
 		if err := sonic.Unmarshal(rawResponse, &cohereResp); err != nil {
-			return nil, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", err, providerName)
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", err, providerName), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
 		bifrostResponse = cohereResp.ToBifrostEmbeddingResponse()
 		bifrostResponse.Model = request.Model
@@ -2088,6 +2100,9 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}
 
+	sendBackRawRequest := provider.sendBackRawRequest
+	sendBackRawResponse := provider.sendBackRawResponse
+
 	region := DefaultBedrockRegion
 	if key.BedrockKeyConfig.Region != nil {
 		region = *key.BedrockKeyConfig.Region
@@ -2097,12 +2112,12 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	reqURL := fmt.Sprintf("https://bedrock.%s.amazonaws.com/model-invocation-job", region)
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("error creating request", err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error creating request", err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	// Sign request
 	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, region, "bedrock", providerName); err != nil {
-		return nil, err
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	// Execute request
@@ -2111,35 +2126,35 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	latency := time.Since(startTime)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			return nil, &schemas.BifrostError{
+			return nil, providerUtils.EnrichError(ctx, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: &schemas.ErrorField{
 					Type:    schemas.Ptr(schemas.RequestCancelled),
 					Message: schemas.ErrRequestCancelled,
 					Error:   err,
 				},
-			}
+			}, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 		}
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("error reading response", err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error reading response", err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		var errorResp BedrockError
 		if err := sonic.Unmarshal(body, &errorResp); err == nil && errorResp.Message != "" {
-			return nil, providerUtils.NewProviderAPIError(errorResp.Message, nil, resp.StatusCode, providerName, nil, nil)
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(errorResp.Message, nil, resp.StatusCode, providerName, nil, nil), jsonData, body, sendBackRawRequest, sendBackRawResponse)
 		}
-		return nil, providerUtils.NewProviderAPIError(string(body), nil, resp.StatusCode, providerName, nil, nil)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewProviderAPIError(string(body), nil, resp.StatusCode, providerName, nil, nil), jsonData, body, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	var bedrockResp BedrockBatchJobResponse
 	if err := sonic.Unmarshal(body, &bedrockResp); err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, providerName)
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err, providerName), jsonData, body, sendBackRawRequest, sendBackRawResponse)
 	}
 
 	// AWS CreateModelInvocationJob only returns jobArn, not status or other details.

--- a/core/providers/cohere/errors.go
+++ b/core/providers/cohere/errors.go
@@ -18,11 +18,9 @@ func parseCohereError(resp *fasthttp.Response, meta *providerUtils.RequestMetada
 		bifrostErr.Error.Code = errorResp.Code
 	}
 	if meta != nil {
-		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-			Provider:       meta.Provider,
-			ModelRequested: meta.Model,
-			RequestType:    meta.RequestType,
-		}
+		bifrostErr.ExtraFields.Provider = meta.Provider
+		bifrostErr.ExtraFields.ModelRequested = meta.Model
+		bifrostErr.ExtraFields.RequestType = meta.RequestType
 	}
 	return bifrostErr
 }

--- a/core/providers/elevenlabs/errors.go
+++ b/core/providers/elevenlabs/errors.go
@@ -65,11 +65,9 @@ func parseElevenlabsError(resp *fasthttp.Response, meta *providerUtils.RequestMe
 					},
 				}
 				if meta != nil {
-					result.ExtraFields = schemas.BifrostErrorExtraFields{
-						Provider:       meta.Provider,
-						ModelRequested: meta.Model,
-						RequestType:    meta.RequestType,
-					}
+					result.ExtraFields.Provider = meta.Provider
+					result.ExtraFields.ModelRequested = meta.Model
+					result.ExtraFields.RequestType = meta.RequestType
 				}
 				return result
 			}
@@ -94,11 +92,9 @@ func parseElevenlabsError(resp *fasthttp.Response, meta *providerUtils.RequestMe
 		}
 	}
 	if meta != nil {
-		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-			Provider:       meta.Provider,
-			ModelRequested: meta.Model,
-			RequestType:    meta.RequestType,
-		}
+		bifrostErr.ExtraFields.Provider = meta.Provider
+		bifrostErr.ExtraFields.ModelRequested = meta.Model
+		bifrostErr.ExtraFields.RequestType = meta.RequestType
 	}
 	return bifrostErr
 }

--- a/core/providers/gemini/errors.go
+++ b/core/providers/gemini/errors.go
@@ -63,11 +63,9 @@ func parseGeminiError(resp *fasthttp.Response, meta *providerUtils.RequestMetada
 		// Set Message to trimmed concatenated message
 		bifrostErr.Error.Message = message
 		if meta != nil {
-			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-				Provider:       meta.Provider,
-				ModelRequested: meta.Model,
-				RequestType:    meta.RequestType,
-			}
+			bifrostErr.ExtraFields.Provider = meta.Provider
+			bifrostErr.ExtraFields.ModelRequested = meta.Model
+			bifrostErr.ExtraFields.RequestType = meta.RequestType
 		}
 		return bifrostErr
 	}
@@ -83,11 +81,9 @@ func parseGeminiError(resp *fasthttp.Response, meta *providerUtils.RequestMetada
 		bifrostErr.Error.Message = errorResp.Error.Message
 	}
 	if meta != nil {
-		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-			Provider:       meta.Provider,
-			ModelRequested: meta.Model,
-			RequestType:    meta.RequestType,
-		}
+		bifrostErr.ExtraFields.Provider = meta.Provider
+		bifrostErr.ExtraFields.ModelRequested = meta.Model
+		bifrostErr.ExtraFields.RequestType = meta.RequestType
 	}
 	return bifrostErr
 }

--- a/core/providers/openai/errors.go
+++ b/core/providers/openai/errors.go
@@ -34,11 +34,9 @@ func ParseOpenAIError(resp *fasthttp.Response, requestType schemas.RequestType, 
 
 	// Set ExtraFields unconditionally so provider/model/request metadata is always attached
 	if bifrostErr != nil {
-		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-			Provider:       providerName,
-			ModelRequested: model,
-			RequestType:    requestType,
-		}
+		bifrostErr.ExtraFields.Provider = providerName
+		bifrostErr.ExtraFields.ModelRequested = model
+		bifrostErr.ExtraFields.RequestType = requestType
 	}
 
 	return bifrostErr

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -137,13 +137,13 @@ func (provider *PerplexityProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 
 	responseBody, latency, err := provider.completeRequest(ctx, jsonBody, provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"), key.Value, request.Model)
 	if err != nil {
-		return nil, err
+		return nil, providerUtils.EnrichError(ctx, err, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	var response PerplexityChatResponse
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
-		return nil, bifrostErr
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	bifrostResponse := response.ToBifrostChatResponse(request.Model)

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1,0 +1,374 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// TestHandleProviderAPIError_RawResponseIncluded verifies that HandleProviderAPIError
+// always includes the raw response body in BifrostError.ExtraFields.RawResponse
+func TestHandleProviderAPIError_RawResponseIncluded(t *testing.T) {
+	tests := []struct {
+		name        string
+		statusCode  int
+		body        []byte
+		contentType string
+		description string
+	}{
+		{
+			name:        "Decode failure",
+			statusCode:  500,
+			body:        []byte{0xFF, 0xFE}, // Invalid gzip-compressed data
+			contentType: "application/json",
+			description: "Should include raw response when decode fails",
+		},
+		{
+			name:        "Empty response",
+			statusCode:  502,
+			body:        []byte(""),
+			contentType: "application/json",
+			description: "Should include empty raw response",
+		},
+		{
+			name:        "Valid JSON error",
+			statusCode:  400,
+			body:        []byte(`{"error": {"message": "Invalid API key"}}`),
+			contentType: "application/json",
+			description: "Should include raw response for valid JSON",
+		},
+		{
+			name:        "HTML error response",
+			statusCode:  503,
+			body:        []byte(`<html><body><h1>Service Unavailable</h1></body></html>`),
+			contentType: "text/html",
+			description: "Should include raw response for HTML errors",
+		},
+		{
+			name:        "Unparseable non-HTML response",
+			statusCode:  400,
+			body:        []byte(`This is not JSON or HTML`),
+			contentType: "text/plain",
+			description: "Should include raw response for unparseable content",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &fasthttp.Response{}
+			resp.SetStatusCode(tt.statusCode)
+			resp.Header.Set("Content-Type", tt.contentType)
+			// Set Content-Encoding: gzip for decode failure test to trigger BodyGunzip() error
+			if tt.name == "Decode failure" {
+				resp.Header.Set("Content-Encoding", "gzip")
+			}
+			resp.SetBody(tt.body)
+
+			var errorResp map[string]interface{}
+			bifrostErr := HandleProviderAPIError(resp, &errorResp)
+
+			if bifrostErr == nil {
+				t.Fatal("HandleProviderAPIError() returned nil")
+			}
+
+			if bifrostErr.ExtraFields.RawResponse == nil {
+				t.Errorf("%s: RawResponse is nil, expected it to be set", tt.description)
+			}
+
+			// Verify the raw response matches the body (for non-decode-failure cases)
+			if tt.name != "Decode failure" {
+				rawResponseBytes, err := sonic.Marshal(bifrostErr.ExtraFields.RawResponse)
+				if err != nil {
+					t.Errorf("Failed to marshal RawResponse: %v", err)
+				}
+
+				// The RawResponse should contain the body content
+				if len(rawResponseBytes) == 0 {
+					t.Errorf("%s: RawResponse is empty", tt.description)
+				}
+			}
+
+			t.Logf("✓ %s: RawResponse is set", tt.name)
+		})
+	}
+}
+
+// TestEnrichError_PreservesExistingRawResponse verifies that EnrichError preserves
+// existing RawResponse from the error's ExtraFields when responseBody parameter is nil
+func TestEnrichError_PreservesExistingRawResponse(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	existingRawResponse := map[string]interface{}{
+		"error": map[string]interface{}{
+			"message": "Original error from provider",
+			"code":    "invalid_api_key",
+		},
+	}
+
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: false,
+		StatusCode:     schemas.Ptr(401),
+		Error: &schemas.ErrorField{
+			Message: "Authentication failed",
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RawResponse: existingRawResponse,
+		},
+	}
+
+	requestBody := []byte(`{"model": "gpt-4", "messages": []}`)
+
+	// Call EnrichError with nil responseBody - should preserve existing RawResponse
+	enrichedErr := EnrichError(ctx, bifrostErr, requestBody, nil, true, true)
+
+	if enrichedErr == nil {
+		t.Fatal("EnrichError() returned nil")
+	}
+
+	if enrichedErr.ExtraFields.RawResponse == nil {
+		t.Error("RawResponse was cleared when it should have been preserved")
+	} else {
+		// Verify it's still the original
+		if rawMap, ok := enrichedErr.ExtraFields.RawResponse.(map[string]interface{}); ok {
+			if errorMap, ok := rawMap["error"].(map[string]interface{}); ok {
+				if errorMap["code"] != "invalid_api_key" {
+					t.Error("RawResponse was modified, expected it to be preserved")
+				}
+			}
+		}
+	}
+
+	t.Log("✓ EnrichError preserves existing RawResponse when responseBody is nil")
+}
+
+// TestEnrichError_OverwritesWithProvidedResponse verifies that EnrichError sets
+// RawResponse when a responseBody is provided
+func TestEnrichError_OverwritesWithProvidedResponse(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: false,
+		StatusCode:     schemas.Ptr(400),
+		Error: &schemas.ErrorField{
+			Message: "Bad request",
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{},
+	}
+
+	requestBody := []byte(`{"model": "gpt-4"}`)
+	responseBody := []byte(`{"error": {"message": "Model not found"}}`)
+
+	enrichedErr := EnrichError(ctx, bifrostErr, requestBody, responseBody, true, true)
+
+	if enrichedErr == nil {
+		t.Fatal("EnrichError() returned nil")
+	}
+
+	if enrichedErr.ExtraFields.RawResponse == nil {
+		t.Error("RawResponse should be set from responseBody parameter")
+	}
+
+	if enrichedErr.ExtraFields.RawRequest == nil {
+		t.Error("RawRequest should be set from requestBody parameter")
+	}
+
+	t.Log("✓ EnrichError sets RawRequest and RawResponse from provided bodies")
+}
+
+// TestEnrichError_RespectsFlags verifies that EnrichError respects
+// sendBackRawRequest and sendBackRawResponse flags
+func TestEnrichError_RespectsFlags(t *testing.T) {
+	tests := []struct {
+		name                string
+		sendBackRawRequest  bool
+		sendBackRawResponse bool
+		expectRequest       bool
+		expectResponse      bool
+	}{
+		{
+			name:                "Both enabled",
+			sendBackRawRequest:  true,
+			sendBackRawResponse: true,
+			expectRequest:       true,
+			expectResponse:      true,
+		},
+		{
+			name:                "Only request enabled",
+			sendBackRawRequest:  true,
+			sendBackRawResponse: false,
+			expectRequest:       true,
+			expectResponse:      false,
+		},
+		{
+			name:                "Only response enabled",
+			sendBackRawRequest:  false,
+			sendBackRawResponse: true,
+			expectRequest:       false,
+			expectResponse:      true,
+		},
+		{
+			name:                "Both disabled",
+			sendBackRawRequest:  false,
+			sendBackRawResponse: false,
+			expectRequest:       false,
+			expectResponse:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+			bifrostErr := &schemas.BifrostError{
+				IsBifrostError: false,
+				StatusCode:     schemas.Ptr(500),
+				Error:          &schemas.ErrorField{Message: "Error"},
+				ExtraFields:    schemas.BifrostErrorExtraFields{},
+			}
+
+			requestBody := []byte(`{"model": "test"}`)
+			responseBody := []byte(`{"error": "test error"}`)
+
+			enrichedErr := EnrichError(ctx, bifrostErr, requestBody, responseBody, tt.sendBackRawRequest, tt.sendBackRawResponse)
+
+			hasRequest := enrichedErr.ExtraFields.RawRequest != nil
+			hasResponse := enrichedErr.ExtraFields.RawResponse != nil
+
+			if hasRequest != tt.expectRequest {
+				t.Errorf("RawRequest: got %v, want %v", hasRequest, tt.expectRequest)
+			}
+
+			if hasResponse != tt.expectResponse {
+				t.Errorf("RawResponse: got %v, want %v", hasResponse, tt.expectResponse)
+			}
+		})
+	}
+}
+
+// TestProviderErrorFlow_EndToEnd simulates the full flow of a provider error
+// being captured and enriched with raw request/response
+func TestProviderErrorFlow_EndToEnd(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	// Simulate provider error response
+	errorBody := []byte(`{"error": {"message": "Rate limit exceeded", "type": "rate_limit_error", "code": "rate_limit"}}`)
+
+	resp := &fasthttp.Response{}
+	resp.SetStatusCode(429)
+	resp.Header.Set("Content-Type", "application/json")
+	resp.SetBody(errorBody)
+
+	// Step 1: Parse the error (like ParseOpenAIError does)
+	var errorResp map[string]interface{}
+	bifrostErr := HandleProviderAPIError(resp, &errorResp)
+
+	if bifrostErr == nil {
+		t.Fatal("HandleProviderAPIError returned nil")
+	}
+
+	// Verify raw response is captured by HandleProviderAPIError
+	if bifrostErr.ExtraFields.RawResponse == nil {
+		t.Error("HandleProviderAPIError should have set RawResponse")
+	}
+
+	// Step 2: Enrich with request (like providers do)
+	requestBody := []byte(`{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}`)
+
+	enrichedErr := EnrichError(ctx, bifrostErr, requestBody, nil, true, true)
+
+	// Verify both raw request and raw response are present
+	if enrichedErr.ExtraFields.RawRequest == nil {
+		t.Error("EnrichError should have set RawRequest")
+	}
+
+	if enrichedErr.ExtraFields.RawResponse == nil {
+		t.Error("EnrichError should have preserved RawResponse from HandleProviderAPIError")
+	}
+
+	t.Log("✓ End-to-end: Raw request and error response captured successfully")
+}
+
+// TestHandleProviderAPIError_AllPathsSetRawResponse verifies that all error return
+// paths in HandleProviderAPIError include RawResponse
+func TestHandleProviderAPIError_AllPathsSetRawResponse(t *testing.T) {
+	testCases := []struct {
+		name       string
+		statusCode int
+		body       []byte
+		setupResp  func(*fasthttp.Response)
+		errorType  string
+	}{
+		{
+			name:       "Path 1: Decode error",
+			statusCode: 500,
+			body:       []byte{0xFF, 0xFE, 0xFD}, // Invalid gzip-compressed data
+			setupResp: func(r *fasthttp.Response) {
+				r.Header.Set("Content-Type", "application/json")
+				// Set Content-Encoding: gzip to trigger BodyGunzip() error on invalid gzip data
+				r.Header.Set("Content-Encoding", "gzip")
+			},
+			errorType: "decode_failure",
+		},
+		{
+			name:       "Path 2: Empty response",
+			statusCode: 502,
+			body:       []byte("   "), // Only whitespace
+			setupResp: func(r *fasthttp.Response) {
+				r.Header.Set("Content-Type", "application/json")
+			},
+			errorType: "empty_response",
+		},
+		{
+			name:       "Path 3: Valid JSON",
+			statusCode: 400,
+			body:       []byte(`{"error": {"message": "Bad request"}}`),
+			setupResp: func(r *fasthttp.Response) {
+				r.Header.Set("Content-Type", "application/json")
+			},
+			errorType: "valid_json",
+		},
+		{
+			name:       "Path 4: HTML response",
+			statusCode: 503,
+			body:       []byte(`<!DOCTYPE html><html><head><title>Error</title></head><body><h1>Service Error</h1></body></html>`),
+			setupResp: func(r *fasthttp.Response) {
+				r.Header.Set("Content-Type", "text/html")
+			},
+			errorType: "html",
+		},
+		{
+			name:       "Path 5: Unparseable non-HTML",
+			statusCode: 500,
+			body:       []byte(`This is plain text that's not JSON`),
+			setupResp: func(r *fasthttp.Response) {
+				r.Header.Set("Content-Type", "text/plain")
+			},
+			errorType: "unparseable",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &fasthttp.Response{}
+			resp.SetStatusCode(tc.statusCode)
+			resp.SetBody(tc.body)
+			tc.setupResp(resp)
+
+			var errorResp map[string]interface{}
+			bifrostErr := HandleProviderAPIError(resp, &errorResp)
+
+			if bifrostErr == nil {
+				t.Fatalf("%s: HandleProviderAPIError returned nil", tc.name)
+			}
+
+			if bifrostErr.ExtraFields.RawResponse == nil {
+				t.Errorf("%s [%s]: RawResponse is nil - MISSING raw error body!", tc.name, tc.errorType)
+			} else {
+				t.Logf("✓ %s [%s]: RawResponse is set", tc.name, tc.errorType)
+			}
+		})
+	}
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -559,4 +559,6 @@ type BifrostErrorExtraFields struct {
 	Provider       ModelProvider `json:"provider"`
 	ModelRequested string        `json:"model_requested"`
 	RequestType    RequestType   `json:"request_type"`
+	RawRequest     interface{}   `json:"raw_request,omitempty"`
+	RawResponse    interface{}   `json:"raw_response,omitempty"`
 }


### PR DESCRIPTION
## Summary

Add raw request data to error responses to improve debugging capabilities. This enhancement attaches the original request payload to error responses, making it easier to diagnose issues when API calls fail.

## Changes

- Added `RawRequest` field to `BifrostErrorExtraFields` struct to store the original request data
- Modified error handling in provider implementations to include raw request data when errors occur
- Updated the logging plugin to capture and store raw request data from errors
- Implemented `WithRawRequest` utility function to consistently attach request data to errors

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] Plugins

## How to test

Test error scenarios with various providers to verify raw request data is included in error responses:

```sh
# Core/Transports
go version
go test ./...

# Test with invalid API key or malformed request
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4","messages":[{"role":"user","content":"Invalid request"}]}'
```

## Breaking changes

- [x] No

## Related issues

Improves error debugging capabilities

## Security considerations

The implementation respects the `sendBackRawRequest` configuration flag to ensure sensitive data is only included when explicitly enabled.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)