### PR TITLE
fix: remove mutex locks in getLastChunk methods to prevent deadlocks

### DIFF
--- a/framework/streaming/accumulator_test.go
+++ b/framework/streaming/accumulator_test.go
@@ -1,0 +1,478 @@
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestChatStreamingFinalChunkNoDeadlock tests that processing the final chunk doesn't deadlock
+// This is a regression test for the issue where getLastChatChunk() was trying to acquire
+// a lock that was already held by processAccumulatedChatStreamingChunks()
+func TestChatStreamingFinalChunkNoDeadlock(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-request-123"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+
+	// Create accumulator with some chunks
+	for i := 0; i < 10; i++ {
+		chunk := &ChatStreamChunk{
+			ChunkIndex: i,
+			Timestamp:  time.Now(),
+			Delta: &schemas.ChatStreamResponseChoiceDelta{
+				Content: bifrost.Ptr(fmt.Sprintf("chunk %d", i)),
+			},
+		}
+		if i == 9 {
+			// Last chunk has usage
+			chunk.TokenUsage = &schemas.BifrostLLMUsage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			}
+		}
+		err := accumulator.addChatStreamChunk(requestID, chunk, i == 9)
+		if err != nil {
+			t.Fatalf("Failed to add chunk %d: %v", i, err)
+		}
+	}
+
+	// Create a mock response for the final chunk
+	response := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ID:     "msg_123",
+			Object: "chat.completion.chunk",
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+						Delta: &schemas.ChatStreamResponseChoiceDelta{},
+					},
+					FinishReason: bifrost.Ptr("stop"),
+				},
+			},
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ChatCompletionStreamRequest,
+				Provider:       schemas.Anthropic,
+				ModelRequested: "claude-opus-4",
+				ChunkIndex:     9,
+			},
+		},
+	}
+
+	// Set final chunk indicator
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	// Use a timeout to detect deadlock
+	done := make(chan struct{})
+	var processErr error
+
+	go func() {
+		defer close(done)
+		_, processErr = accumulator.processChatStreamingResponse(ctx, response, nil)
+	}()
+
+	select {
+	case <-done:
+		if processErr != nil {
+			t.Fatalf("Failed to process final chunk: %v", processErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Deadlock detected: processChatStreamingResponse took too long (>5s)")
+	}
+}
+
+// TestResponsesStreamingFinalChunkNoDeadlock tests Responses streaming doesn't deadlock
+func TestResponsesStreamingFinalChunkNoDeadlock(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-responses-request"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+
+	// Add some chunks
+	for i := 0; i < 5; i++ {
+		chunk := &ResponsesStreamChunk{
+			ChunkIndex: i,
+			Timestamp:  time.Now(),
+			StreamResponse: &schemas.BifrostResponsesStreamResponse{
+				Type: "message_delta",
+				Response: &schemas.BifrostResponsesResponse{
+					Usage: &schemas.ResponsesResponseUsage{
+						InputTokens:  100,
+						OutputTokens: 50,
+					},
+				},
+			},
+		}
+		if i == 4 {
+			chunk.TokenUsage = &schemas.BifrostLLMUsage{
+				PromptTokens:     100,
+				CompletionTokens: 50,
+				TotalTokens:      150,
+			}
+		}
+		err := accumulator.addResponsesStreamChunk(requestID, chunk, i == 4)
+		if err != nil {
+			t.Fatalf("Failed to add chunk: %v", err)
+		}
+	}
+
+	// Create final chunk response
+	response := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			ID: bifrost.Ptr("msg_456"),
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  100,
+				OutputTokens: 50,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ResponsesStreamRequest,
+				Provider:       schemas.Anthropic,
+				ModelRequested: "claude-opus-4",
+				ChunkIndex:     4,
+			},
+		},
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	done := make(chan struct{})
+	var processErr error
+
+	go func() {
+		defer close(done)
+		_, processErr = accumulator.processResponsesStreamingResponse(ctx, response, nil)
+	}()
+
+	select {
+	case <-done:
+		if processErr != nil {
+			t.Fatalf("Failed to process final chunk: %v", processErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Deadlock detected: processResponsesStreamingResponse took too long (>5s)")
+	}
+}
+
+// TestConcurrentChunkAddition tests that adding chunks concurrently is safe
+func TestConcurrentChunkAddition(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-concurrent-add"
+	const numGoroutines = 10
+	const chunksPerGoroutine = 10
+
+	var wg sync.WaitGroup
+	errors := make(chan error, numGoroutines)
+
+	for g := 0; g < numGoroutines; g++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+			for i := 0; i < chunksPerGoroutine; i++ {
+				chunk := &ChatStreamChunk{
+					ChunkIndex: goroutineID*chunksPerGoroutine + i,
+					Timestamp:  time.Now(),
+					Delta: &schemas.ChatStreamResponseChoiceDelta{
+						Content: bifrost.Ptr(fmt.Sprintf("g%d-c%d", goroutineID, i)),
+					},
+				}
+				err := accumulator.addChatStreamChunk(requestID, chunk, false)
+				if err != nil {
+					errors <- err
+					return
+				}
+			}
+		}(g)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		close(errors)
+		for err := range errors {
+			t.Errorf("Concurrent add error: %v", err)
+		}
+
+		// Verify all chunks were added
+		acc := accumulator.getOrCreateStreamAccumulator(requestID)
+		acc.mu.Lock()
+		chunkCount := len(acc.ChatStreamChunks)
+		acc.mu.Unlock()
+
+		if chunkCount != numGoroutines*chunksPerGoroutine {
+			t.Errorf("Expected %d chunks, got %d", numGoroutines*chunksPerGoroutine, chunkCount)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Deadlock detected: concurrent chunk addition took too long (>10s)")
+	}
+}
+
+// TestGetLastChunkMethodsSafe tests that the getLast*Chunk methods don't cause deadlock
+func TestGetLastChunkMethodsSafe(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-last-chunk"
+
+	// Add a chat chunk
+	chunk := &ChatStreamChunk{
+		ChunkIndex: 0,
+		Timestamp:  time.Now(),
+		TokenUsage: &schemas.BifrostLLMUsage{
+			PromptTokens:     100,
+			CompletionTokens: 50,
+			TotalTokens:      150,
+		},
+	}
+	err := accumulator.addChatStreamChunk(requestID, chunk, false)
+	if err != nil {
+		t.Fatalf("Failed to add chunk: %v", err)
+	}
+
+	// Get the accumulator
+	acc := accumulator.getOrCreateStreamAccumulator(requestID)
+
+	// This should not deadlock - getLastChatChunk doesn't acquire locks anymore
+	lastChunk := acc.getLastChatChunk()
+	if lastChunk == nil {
+		t.Error("Expected to get last chunk, got nil")
+	}
+	if lastChunk.ChunkIndex != 0 {
+		t.Errorf("Expected chunk index 0, got %d", lastChunk.ChunkIndex)
+	}
+}
+
+// TestAudioStreamingFinalChunkNoDeadlock tests that audio streaming doesn't deadlock on final chunk
+func TestAudioStreamingFinalChunkNoDeadlock(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-audio-request"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+
+	// Add some audio chunks
+	for i := 0; i < 8; i++ {
+		chunk := &AudioStreamChunk{
+			ChunkIndex: i,
+			Timestamp:  time.Now(),
+			Delta: &schemas.BifrostSpeechStreamResponse{
+				Type:  schemas.SpeechStreamResponseTypeDelta,
+				Audio: []byte(fmt.Sprintf("audio-data-%d", i)),
+			},
+		}
+		if i == 7 {
+			chunk.TokenUsage = &schemas.SpeechUsage{
+				InputTokens:  100,
+				OutputTokens: 50,
+				TotalTokens:  150,
+			}
+		}
+		err := accumulator.addAudioStreamChunk(requestID, chunk, i == 7)
+		if err != nil {
+			t.Fatalf("Failed to add audio chunk: %v", err)
+		}
+	}
+
+	// Create final chunk response
+	response := &schemas.BifrostResponse{
+		SpeechResponse: &schemas.BifrostSpeechResponse{
+			Audio: []byte("final-audio-data"),
+			Usage: &schemas.SpeechUsage{
+				InputTokens:  100,
+				OutputTokens: 50,
+				TotalTokens:  150,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.SpeechStreamRequest,
+				Provider:       schemas.OpenAI,
+				ModelRequested: "tts-1",
+				ChunkIndex:     7,
+			},
+		},
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	done := make(chan struct{})
+	var processErr error
+
+	go func() {
+		defer close(done)
+		_, processErr = accumulator.processAudioStreamingResponse(ctx, response, nil)
+	}()
+
+	select {
+	case <-done:
+		if processErr != nil {
+			t.Fatalf("Failed to process final audio chunk: %v", processErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Deadlock detected: processAudioStreamingResponse took too long (>5s)")
+	}
+}
+
+// TestTranscriptionStreamingFinalChunkNoDeadlock tests that transcription streaming doesn't deadlock on final chunk
+func TestTranscriptionStreamingFinalChunkNoDeadlock(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-transcription-request"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+
+	// Add some transcription chunks
+	for i := 0; i < 6; i++ {
+		delta := fmt.Sprintf("transcribed text %d ", i)
+		chunk := &TranscriptionStreamChunk{
+			ChunkIndex: i,
+			Timestamp:  time.Now(),
+			Delta: &schemas.BifrostTranscriptionStreamResponse{
+				Type:  schemas.TranscriptionStreamResponseTypeDelta,
+				Delta: &delta,
+				Text:  delta,
+			},
+		}
+		if i == 5 {
+			inputTokens := 100
+			outputTokens := 50
+			totalTokens := 150
+			chunk.TokenUsage = &schemas.TranscriptionUsage{
+				Type:         "tokens",
+				InputTokens:  &inputTokens,
+				OutputTokens: &outputTokens,
+				TotalTokens:  &totalTokens,
+			}
+		}
+		err := accumulator.addTranscriptionStreamChunk(requestID, chunk, i == 5)
+		if err != nil {
+			t.Fatalf("Failed to add transcription chunk: %v", err)
+		}
+	}
+
+	// Create final chunk response
+	response := &schemas.BifrostResponse{
+		TranscriptionResponse: &schemas.BifrostTranscriptionResponse{
+			Text: "Complete transcription",
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.TranscriptionStreamRequest,
+				Provider:       schemas.OpenAI,
+				ModelRequested: "whisper-1",
+				ChunkIndex:     5,
+			},
+		},
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	done := make(chan struct{})
+	var processErr error
+
+	go func() {
+		defer close(done)
+		_, processErr = accumulator.processTranscriptionStreamingResponse(ctx, response, nil)
+	}()
+
+	select {
+	case <-done:
+		if processErr != nil {
+			t.Fatalf("Failed to process final transcription chunk: %v", processErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Deadlock detected: processTranscriptionStreamingResponse took too long (>5s)")
+	}
+}
+
+// TestGetLastAudioAndTranscriptionChunksSafe tests that getLastAudioChunk and getLastTranscriptionChunk are safe
+func TestGetLastAudioAndTranscriptionChunksSafe(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-last-audio-transcription"
+
+	// Add audio chunk
+	audioChunk := &AudioStreamChunk{
+		ChunkIndex: 5,
+		Timestamp:  time.Now(),
+		Delta: &schemas.BifrostSpeechStreamResponse{
+			Type:  schemas.SpeechStreamResponseTypeDelta,
+			Audio: []byte("audio-data"),
+		},
+		TokenUsage: &schemas.SpeechUsage{
+			InputTokens:  100,
+			OutputTokens: 50,
+			TotalTokens:  150,
+		},
+	}
+	err := accumulator.addAudioStreamChunk(requestID, audioChunk, false)
+	if err != nil {
+		t.Fatalf("Failed to add audio chunk: %v", err)
+	}
+
+	// Add transcription chunk
+	delta := "transcribed text"
+	inputTokens := 100
+	outputTokens := 50
+	totalTokens := 150
+	transcriptionChunk := &TranscriptionStreamChunk{
+		ChunkIndex: 3,
+		Timestamp:  time.Now(),
+		Delta: &schemas.BifrostTranscriptionStreamResponse{
+			Type:  schemas.TranscriptionStreamResponseTypeDelta,
+			Delta: &delta,
+			Text:  delta,
+		},
+		TokenUsage: &schemas.TranscriptionUsage{
+			Type:         "tokens",
+			InputTokens:  &inputTokens,
+			OutputTokens: &outputTokens,
+			TotalTokens:  &totalTokens,
+		},
+	}
+	err = accumulator.addTranscriptionStreamChunk(requestID, transcriptionChunk, false)
+	if err != nil {
+		t.Fatalf("Failed to add transcription chunk: %v", err)
+	}
+
+	// Get the accumulator
+	acc := accumulator.getOrCreateStreamAccumulator(requestID)
+
+	// Test getLastAudioChunk - should not deadlock
+	lastAudio := acc.getLastAudioChunk()
+	if lastAudio == nil {
+		t.Error("Expected to get last audio chunk, got nil")
+	}
+	if lastAudio != nil && lastAudio.ChunkIndex != 5 {
+		t.Errorf("Expected audio chunk index 5, got %d", lastAudio.ChunkIndex)
+	}
+
+	// Test getLastTranscriptionChunk - should not deadlock
+	lastTranscription := acc.getLastTranscriptionChunk()
+	if lastTranscription == nil {
+		t.Error("Expected to get last transcription chunk, got nil")
+	}
+	if lastTranscription != nil && lastTranscription.ChunkIndex != 3 {
+		t.Errorf("Expected transcription chunk index 3, got %d", lastTranscription.ChunkIndex)
+	}
+}

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -124,8 +124,6 @@ type StreamAccumulator struct {
 
 // getLastChatChunk returns the chunk with the highest ChunkIndex (contains metadata like TokenUsage, Cost)
 func (sa *StreamAccumulator) getLastChatChunk() *ChatStreamChunk {
-	sa.mu.Lock()
-	defer sa.mu.Unlock()
 	if sa.MaxChatChunkIndex < 0 {
 		return nil
 	}
@@ -139,8 +137,6 @@ func (sa *StreamAccumulator) getLastChatChunk() *ChatStreamChunk {
 
 // getLastResponsesChunk returns the chunk with the highest ChunkIndex (contains metadata like TokenUsage, Cost)
 func (sa *StreamAccumulator) getLastResponsesChunk() *ResponsesStreamChunk {
-	sa.mu.Lock()
-	defer sa.mu.Unlock()
 	if sa.MaxResponsesChunkIndex < 0 {
 		return nil
 	}
@@ -154,8 +150,6 @@ func (sa *StreamAccumulator) getLastResponsesChunk() *ResponsesStreamChunk {
 
 // getLastTranscriptionChunk returns the chunk with the highest ChunkIndex (contains metadata like TokenUsage, Cost)
 func (sa *StreamAccumulator) getLastTranscriptionChunk() *TranscriptionStreamChunk {
-	sa.mu.Lock()
-	defer sa.mu.Unlock()
 	if sa.MaxTranscriptionChunkIndex < 0 {
 		return nil
 	}
@@ -169,8 +163,6 @@ func (sa *StreamAccumulator) getLastTranscriptionChunk() *TranscriptionStreamChu
 
 // getLastAudioChunk returns the chunk with the highest ChunkIndex (contains metadata like TokenUsage, Cost)
 func (sa *StreamAccumulator) getLastAudioChunk() *AudioStreamChunk {
-	sa.mu.Lock()
-	defer sa.mu.Unlock()
 	if sa.MaxAudioChunkIndex < 0 {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Fixed a deadlock issue in the streaming accumulator when processing final chunks by removing unnecessary mutex locks in the `getLast*Chunk` methods.

## Changes

- Removed mutex locks in `getLastChatChunk`, `getLastResponsesChunk`, `getLastTranscriptionChunk`, and `getLastAudioChunk` methods
- Added comprehensive test suite to verify the fix works across all streaming types (chat, responses, audio, transcription)
- Added tests for concurrent chunk addition to ensure thread safety

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the new tests to verify the fix
go test ./framework/streaming -v
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes a regression where `getLastChatChunk()` was trying to acquire a lock that was already held by `processAccumulatedChatStreamingChunks()`, causing deadlocks when processing final chunks in streaming responses.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable