### PR TITLE
fix: turn JSON array tool result into JSON object for Bedrock Converse API

### DIFF
--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -430,9 +430,16 @@ func convertToolMessages(msgs []schemas.ChatMessage) (BedrockMessage, error) {
 				})
 			} else {
 				// Use the parsed JSON object
-				toolResultContent = append(toolResultContent, BedrockContentBlock{
-					JSON: parsedOutput,
-				})
+				// Bedrock does not consider a json array valid for this field, so we wrap it first.
+				if _, isArray := parsedOutput.([]any); isArray {
+					toolResultContent = append(toolResultContent, BedrockContentBlock{
+						JSON: map[string]any{"results": parsedOutput},
+					})
+				} else {
+					toolResultContent = append(toolResultContent, BedrockContentBlock{
+						JSON: parsedOutput,
+					})
+				}
 			}
 		} else if msg.Content.ContentBlocks != nil {
 			for _, block := range msg.Content.ContentBlocks {


### PR DESCRIPTION
## Summary

Convert tool result content that is a JSON array to a JSON object to conform with Bedrock Converse API.

## Changes

In the documentation, Converse API ToolResultContent specifies that it accepts JSON value ([documentation](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ToolResultContentBlock.html)), but it does not accept a JSON array of JSON objects, which I think is valid JSON value.

This PR converts valid JSON array to JSON object by putting the array in a simple object under a single key "results":
```
{"results": [the original JSON array]}
```
This is to help MCP and Tools that returns a valid JSON array to work with models on Bedrock. 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


