### PR TITLE
feat: add path parameter support in HTTPRequest to fix VK level provider routing GenAI integrations

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,3 @@
 - chore: added case-insensitive helper methods for header and query parameter lookups in HTTPRequest
+- feat: added support for path parameter lookups in HTTPRequest
+- fix: missing request type in error response for anthropic SDK integration

--- a/core/providers/anthropic/errors.go
+++ b/core/providers/anthropic/errors.go
@@ -1,9 +1,9 @@
 package anthropic
 
 import (
-	"encoding/json"
 	"fmt"
 
+	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
@@ -15,15 +15,13 @@ func ToAnthropicChatCompletionError(bifrostErr *schemas.BifrostError) *Anthropic
 		return nil
 	}
 
-	// Provide blank strings for nil pointer fields
+	// Safely extract type and message from nested error
 	errorType := ""
-	if bifrostErr.Type != nil {
-		errorType = *bifrostErr.Type
-	}
-
-	// Safely extract message from nested error
 	message := ""
 	if bifrostErr.Error != nil {
+		if bifrostErr.Error.Type != nil {
+			errorType = *bifrostErr.Error.Type
+		}
 		message = bifrostErr.Error.Message
 	}
 
@@ -48,7 +46,7 @@ func ToAnthropicResponsesStreamError(bifrostErr *schemas.BifrostError) string {
 	anthropicErr := ToAnthropicChatCompletionError(bifrostErr)
 
 	// Marshal to JSON
-	jsonData, err := json.Marshal(anthropicErr)
+	jsonData, err := sonic.Marshal(anthropicErr)
 	if err != nil {
 		return ""
 	}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1747,3 +1747,12 @@ type GeminiCountTokensResponse struct {
 	// Output only. List of modalities that were processed in the cached content.
 	CacheTokensDetails []*ModalityTokenCount `json:"cacheTokensDetails,omitempty"`
 }
+
+var GeminiRequestSuffixPaths = []string{
+	":streamGenerateContent",
+	":generateContent",
+	":countTokens",
+	":embedContent",
+	":batchEmbedContents",
+	":predict",
+}

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,1 +1,2 @@
-- feat: Fixed weighted provider routing to correctly match provider-prefixed models in allowed lists
+- feat: fixed weighted provider routing to correctly match provider-prefixed models in allowed lists
+- fix: added support for model lookup in Google GenAI integration by path parameter

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -288,7 +289,7 @@ func (p *GovernancePlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, r
 		p.logger.Error("failed to unmarshal request body to check for virtual key: %v", err)
 		return nil, nil
 	}
-	payload, err = p.loadBalanceProvider(payload, virtualKey)
+	payload, err = p.loadBalanceProvider(ctx, req, payload, virtualKey)
 	if err != nil {
 		p.logger.Error("failed to load balance provider: %v", err)
 		return nil, nil
@@ -304,23 +305,39 @@ func (p *GovernancePlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, r
 
 // loadBalanceProvider loads balances the provider for the request
 // Parameters:
+//   - req: The HTTP request
 //   - body: The request body
 //   - virtualKey: The virtual key configuration
 //
 // Returns:
 //   - map[string]any: The updated request body
 //   - error: Any error that occurred during processing
-func (p *GovernancePlugin) loadBalanceProvider(body map[string]any, virtualKey *configstoreTables.TableVirtualKey) (map[string]any, error) {
+func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, body map[string]any, virtualKey *configstoreTables.TableVirtualKey) (map[string]any, error) {
 	// Check if the request has a model field
 	modelValue, hasModel := body["model"]
 	if !hasModel {
-		return body, nil
+		// For genai integration, model is present in URL path instead of the request body
+		if strings.Contains(req.Path, "/genai") {
+			modelValue = req.CaseInsensitivePathParamLookup("model")
+		} else {
+			return body, nil
+		}
 	}
 	modelStr, ok := modelValue.(string)
 	if !ok || modelStr == "" {
 		return body, nil
 	}
-
+	var genaiRequestSuffix string
+	// Remove Google GenAI API endpoint suffixes if present
+	if strings.Contains(req.Path, "/genai") {
+		for _, sfx := range gemini.GeminiRequestSuffixPaths {
+			if before, ok := strings.CutSuffix(modelStr, sfx); ok {
+				modelStr = before
+				genaiRequestSuffix = sfx
+				break
+			}
+		}
+	}
 	// Check if model already has provider prefix (contains "/")
 	if strings.Contains(modelStr, "/") {
 		provider, _ := schemas.ParseModelString(modelStr, "")
@@ -393,8 +410,14 @@ func (p *GovernancePlugin) loadBalanceProvider(body map[string]any, virtualKey *
 	if selectedProvider == "" && len(allowedProviderConfigs) > 0 {
 		selectedProvider = schemas.ModelProvider(allowedProviderConfigs[0].Provider)
 	}
-	// Update the model field in the request body
-	body["model"] = string(selectedProvider) + "/" + modelStr
+	// For genai integration, model is present in URL path instead of the request body
+	if strings.Contains(req.Path, "/genai") {
+		newModelWithRequestSuffix := string(selectedProvider) + "/" + modelStr + genaiRequestSuffix
+		ctx.SetValue("model", newModelWithRequestSuffix)
+	} else {
+		// Update the model field in the request body
+		body["model"] = string(selectedProvider) + "/" + modelStr
+	}
 
 	// Check if fallbacks field is already present
 	_, hasFallbacks := body["fallbacks"]

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -108,7 +108,7 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			}
 			return nil, errors.New("invalid request type")
 		},
-			ListModelsResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostListModelsResponse) (interface{}, error) {
+		ListModelsResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostListModelsResponse) (interface{}, error) {
 			return gemini.ToGeminiListModelsResponse(resp), nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
@@ -377,14 +377,7 @@ func extractAndSetModelFromURL(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 	isCountTokens := strings.HasSuffix(modelStr, ":countTokens")
 
 	// Remove Google GenAI API endpoint suffixes if present
-	for _, sfx := range []string{
-		":streamGenerateContent",
-		":generateContent",
-		":countTokens",
-		":embedContent",
-		":batchEmbedContents",
-		":predict",
-	} {
+	for _, sfx := range gemini.GeminiRequestSuffixPaths {
 		modelStr = strings.TrimSuffix(modelStr, sfx)
 	}
 

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -854,7 +854,6 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 
 // handleFileRequest handles file API requests (upload, list, retrieve, delete, content)
 func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, fileReq *FileRequest, bifrostCtx *schemas.BifrostContext) {
-	
 
 	var response interface{}
 	var err error

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,3 @@
-- feat: Improved model validation for provider-prefixed model configurations
+- feat: improved model validation for provider-prefixed model configurations
+- fix: added support for model lookup in Google GenAI integration by path parameter (fixes using VK provider routing for GenAI integration)
+- fix: missing request type in error response for anthropic SDK integration


### PR DESCRIPTION
## Summary

Added support for path parameter lookups in HTTP requests, fixed error handling in the Anthropic SDK integration, and enhanced the Google GenAI integration to properly handle model routing through path parameters.

## Changes

- Added path parameter extraction and lookup functionality to HTTPRequest, including case-insensitive helper methods
- Fixed error response handling in Anthropic SDK integration by properly including request type information
- Enhanced the governance plugin to support model lookup via path parameters for Google GenAI integration
- Added constants for Gemini request suffix paths to improve maintainability
- Updated the HTTP transport to extract path parameters from fasthttp user values

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test path parameter extraction and lookup:
```sh
go test ./transports/bifrost-http/handlers/...
```

Test Google GenAI integration with virtual key routing:
1. Configure a virtual key with provider routing
2. Send a request to the GenAI endpoint with a model in the path
3. Verify the model is correctly routed to the specified provider

Test Anthropic error responses:
1. Configure an invalid Anthropic request
2. Verify the error response includes the correct type information

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with virtual key provider routing for Google GenAI integration and improves error handling for Anthropic SDK.

## Security considerations

No security implications as this is enhancing existing functionality.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable