### PR TITLE
adds prehook posthook for http

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -148,7 +148,7 @@ const (
 	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func() (callback to complete trace after streaming - set by tracing middleware)
 	BifrostContextKeyPostHookSpanFinalizer               BifrostContextKey = "bifrost-posthook-span-finalizer"                  // func(context.Context) (callback to finalize post-hook spans after streaming - set by bifrost)
 	BifrostContextKeyAccumulatorID                       BifrostContextKey = "bifrost-accumulator-id"                           // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)
-	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))	
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -78,6 +78,7 @@ func caseInsensitiveLookup(data map[string]string, key string) string {
 
 // HTTPResponse is a serializable representation of an HTTP response.
 // Used for short-circuit responses in plugin HTTP transport interception.
+// This type is pooled for allocation control - use AcquireHTTPResponse and ReleaseHTTPResponse.
 type HTTPResponse struct {
 	StatusCode int               `json:"status_code"`
 	Headers    map[string]string `json:"headers"`
@@ -120,6 +121,37 @@ func ReleaseHTTPRequest(req *HTTPRequest) {
 	httpRequestPool.Put(req)
 }
 
+// httpResponsePool is the pool for HTTPResponse objects to reduce allocations.
+var httpResponsePool = sync.Pool{
+	New: func() any {
+		return &HTTPResponse{
+			Headers: make(map[string]string, 8),
+		}
+	},
+}
+
+// AcquireHTTPResponse gets an HTTPResponse from the pool.
+// The returned HTTPResponse is ready to use with a pre-allocated Headers map.
+// Call ReleaseHTTPResponse when done to return it to the pool.
+func AcquireHTTPResponse() *HTTPResponse {
+	return httpResponsePool.Get().(*HTTPResponse)
+}
+
+// ReleaseHTTPResponse returns an HTTPResponse to the pool.
+// The HTTPResponse is reset before being returned to the pool.
+// Do not use the HTTPResponse after calling this function.
+func ReleaseHTTPResponse(resp *HTTPResponse) {
+	if resp == nil {
+		return
+	}
+	// Clear the map
+	clear(resp.Headers)
+	// Reset fields
+	resp.StatusCode = 0
+	resp.Body = nil
+	httpResponsePool.Put(resp)
+}
+
 // Plugin defines the interface for Bifrost plugins.
 // Plugins can intercept and modify requests and responses at different stages
 // of the processing pipeline.
@@ -155,7 +187,7 @@ type Plugin interface {
 	// GetName returns the name of the plugin.
 	GetName() string
 
-	// HTTPTransportIntercept is called at the HTTP transport layer before requests enter Bifrost core.
+	// HTTPTransportPreHook is called at the HTTP transport layer before requests enter Bifrost core.
 	// It receives a serializable HTTPRequest and allows plugins to modify it in-place.
 	// Only invoked when using HTTP transport (bifrost-http), not when using Bifrost as a Go SDK directly.
 	// Works with both native .so plugins and WASM plugins due to serializable types.
@@ -166,7 +198,19 @@ type Plugin interface {
 	// - (nil, error): Short-circuit with error response
 	//
 	// Return nil for both values if the plugin doesn't need HTTP transport interception.
-	HTTPTransportIntercept(ctx *BifrostContext, req *HTTPRequest) (*HTTPResponse, error)
+	HTTPTransportPreHook(ctx *BifrostContext, req *HTTPRequest) (*HTTPResponse, error)
+
+	// HTTPTransportPostHook is called at the HTTP transport layer after requests exit Bifrost core.
+	// It receives a serializable HTTPRequest and HTTPResponse and allows plugins to modify it in-place.
+	// Only invoked when using HTTP transport (bifrost-http), not when using Bifrost as a Go SDK directly.
+	// Works with both native .so plugins and WASM plugins due to serializable types.
+	//
+	// Return values:
+	// - nil: Continue to next plugin/handler, response modifications are applied
+	// - error: Short-circuit with error response and skip remaining plugins
+	//
+	// Return nil if the plugin doesn't need HTTP transport interception.
+	HTTPTransportPostHook(ctx *BifrostContext, req *HTTPRequest, resp *HTTPResponse) error
 
 	// PreHook is called before a request is processed by a provider.
 	// It allows plugins to modify the request before it is sent to the provider.

--- a/docs/plugins/getting-started.mdx
+++ b/docs/plugins/getting-started.mdx
@@ -52,17 +52,18 @@ This generates a `.so` file that exports specific functions matching Bifrost's p
   <Tab title="v1.4.x+">
     - `Init(config any) error` - Initialize the plugin with configuration
     - `GetName() string` - Return the plugin name
+    - `HTTPTransportPreHook()` - Intercept HTTP requests before they enter Bifrost core (HTTP transport only)
+    - `HTTPTransportPostHook()` - Intercept HTTP responses after they exit Bifrost core (HTTP transport only)
     - `PreHook()` - Intercept requests before they reach providers
     - `PostHook()` - Process responses after provider calls
-    - `HTTPTransportMiddleware()` - Middleware for HTTP transport layer (HTTP transport only)
     - `Cleanup() error` - Clean up resources on shutdown
   </Tab>
   <Tab title="v1.3.x">
     - `Init(config any) error` - Initialize the plugin with configuration
     - `GetName() string` - Return the plugin name
+    - `TransportInterceptor()` - Modify raw HTTP headers/body (HTTP transport only)
     - `PreHook()` - Intercept requests before they reach providers
     - `PostHook()` - Process responses after provider calls
-    - `TransportInterceptor()` - Modify raw HTTP headers/body (HTTP transport only)
     - `Cleanup() error` - Clean up resources on shutdown
   </Tab>
 </Tabs>
@@ -89,10 +90,11 @@ Plugins execute in a specific order:
 
 <Tabs>
   <Tab title="v1.4.x+">
-    1. `HTTPTransportMiddleware` - HTTP transport middleware (HTTP transport only)
+    1. `HTTPTransportPreHook` - Intercept HTTP requests (HTTP transport only)
     2. `PreHook` - Executes in registration order, can short-circuit requests
     3. Provider call (if not short-circuited)
     4. `PostHook` - Executes in reverse order of PreHooks
+    5. `HTTPTransportPostHook` - Intercept HTTP responses (HTTP transport only, reverse order)
   </Tab>
   <Tab title="v1.3.x">
     1. `TransportInterceptor` - Modifies raw HTTP requests (HTTP transport only)

--- a/docs/plugins/migration-guide.mdx
+++ b/docs/plugins/migration-guide.mdx
@@ -6,7 +6,7 @@ icon: "arrow-up-right-dots"
 
 ## Overview
 
-Bifrost v1.4.x introduces a new plugin interface for HTTP transport layer interception. This guide helps you migrate existing plugins from the v1.3.x `TransportInterceptor` pattern to the v1.4.x `HTTPTransportIntercept` pattern.
+Bifrost v1.4.x introduces a new plugin interface for HTTP transport layer interception. This guide helps you migrate existing plugins from the v1.3.x `TransportInterceptor` pattern to the v1.4.x `HTTPTransportPreHook` and `HTTPTransportPostHook` pattern.
 
 <Note>
 If your plugin doesn't use `TransportInterceptor`, no migration is needed. The `PreHook`, `PostHook`, `Init`, `GetName`, and `Cleanup` functions remain unchanged.
@@ -14,29 +14,31 @@ If your plugin doesn't use `TransportInterceptor`, no migration is needed. The `
 
 ## What Changed?
 
-The HTTP transport interception mechanism changed from a simple function that receives and returns headers/body to a serializable intercept pattern that works with both native `.so` plugins and WASM plugins.
+The HTTP transport interception mechanism changed from a simple function that receives and returns headers/body to a dual-hook pattern that works with both native `.so` plugins and WASM plugins.
 
 ### Key Differences
 
-| Aspect | v1.3.x (TransportInterceptor) | v1.4.x+ (HTTPTransportIntercept) |
-|--------|-------------------------------|----------------------------------|
-| Signature | `TransportInterceptor(ctx, url, headers, body)` | `HTTPTransportIntercept(ctx, req)` |
-| Return type | `(headers, body, error)` | `(*HTTPResponse, error)` |
+| Aspect | v1.3.x (TransportInterceptor) | v1.4.x+ (Pre/Post Hooks) |
+|--------|-------------------------------|--------------------------|
+| Signature | `TransportInterceptor(ctx, url, headers, body)` | `HTTPTransportPreHook(ctx, req)` + `HTTPTransportPostHook(ctx, req, resp)` |
+| Return type | `(headers, body, error)` | Pre: `(*HTTPResponse, error)`, Post: `error` |
 | Request type | Separate `headers map`, `body map` | Unified `*HTTPRequest` struct |
-| Modification | Return modified maps | Modify `req` in-place |
+| Response access | Not available | Post-hook receives `*HTTPResponse` |
+| Modification | Return modified maps | Modify `req`/`resp` in-place |
 | Short-circuit | Return error | Return `*HTTPResponse` |
 | WASM support | No | Yes |
-| Context | Limited `BifrostContext` | Full `*BifrostContext` |
+| Context | Limited `BifrostContext` | Full `*BifrostContext` with `SetValue`/`Value` |
 
 ### Why the Change?
 
-The new intercept pattern provides:
+The new dual-hook pattern provides:
 
 1. **WASM plugin support** - Serializable types work across WASM boundary
-2. **Simpler API** - No middleware wrapper, direct function call
-3. **Better testability** - No fasthttp dependency in plugin tests
-4. **Full context access** - BifrostContext available for request metadata
-5. **Custom response short-circuits** - Return a full response to short-circuit
+2. **Response interception** - Post-hook can modify responses before returning to client
+3. **Simpler API** - No middleware wrapper, direct function call
+4. **Better testability** - No fasthttp dependency in plugin tests
+5. **Full context access** - BifrostContext available for sharing data between hooks
+6. **Custom response short-circuits** - Return a full response to short-circuit
 
 ## Migration Steps
 
@@ -73,9 +75,9 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 **After (v1.4.x+):**
 
 ```go
-// HTTPTransportIntercept intercepts requests at the transport layer
+// HTTPTransportPreHook intercepts requests BEFORE they enter Bifrost core
 // Modify req in-place. Return (*HTTPResponse, nil) to short-circuit.
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	// Add custom header (in-place modification)
 	req.Headers["x-custom-header"] = "value"
 	
@@ -85,8 +87,26 @@ func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPReques
 	body["custom_field"] = "custom_value"
 	req.Body, _ = sonic.Marshal(body)
 	
+	// Store values in context for use in post-hook
+	ctx.SetValue(schemas.BifrostContextKey("my-plugin-key"), "my-value")
+	
 	// Return nil to continue, or return &HTTPResponse{} to short-circuit
 	return nil, nil
+}
+
+// HTTPTransportPostHook intercepts responses AFTER they exit Bifrost core
+// Modify resp in-place. Called in reverse order of pre-hooks.
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	// Add response header
+	resp.Headers["x-processed-by"] = "my-plugin"
+	
+	// Read values set in pre-hook
+	if val := ctx.Value(schemas.BifrostContextKey("my-plugin-key")); val != nil {
+		fmt.Println("Context value:", val)
+	}
+	
+	// Return nil to continue, or return error to short-circuit
+	return nil
 }
 ```
 
@@ -109,7 +129,7 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 ```go
 import "github.com/bytedance/sonic"
 
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	// Parse body
 	var body map[string]any
 	if err := sonic.Unmarshal(req.Body, &body); err == nil {
@@ -119,6 +139,16 @@ func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPReques
 		req.Body, _ = sonic.Marshal(body)
 	}
 	return nil, nil
+}
+
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	// Modify response body if needed
+	var respBody map[string]any
+	if err := sonic.Unmarshal(resp.Body, &respBody); err == nil {
+		respBody["plugin_processed"] = true
+		resp.Body, _ = sonic.Marshal(respBody)
+	}
+	return nil
 }
 ```
 
@@ -134,8 +164,13 @@ return headers, body, nil
 
 **v1.4.x+:**
 ```go
+// In HTTPTransportPreHook - modify request headers
 req.Headers["authorization"] = "Bearer " + token
 return nil, nil
+
+// In HTTPTransportPostHook - modify response headers
+resp.Headers["x-request-id"] = requestID
+return nil
 ```
 
 ### Reading Headers
@@ -147,6 +182,10 @@ apiKey := headers["X-API-Key"]
 
 **v1.4.x+:**
 ```go
+// Use case-insensitive helper for reading (recommended)
+apiKey := req.CaseInsensitiveHeaderLookup("X-API-Key")
+
+// Or direct map access (case-sensitive)
 apiKey := req.Headers["x-api-key"]
 ```
 
@@ -165,12 +204,17 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 
 **v1.4.x+:**
 ```go
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
-	if req.Headers["x-skip-processing"] == "true" {
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if req.CaseInsensitiveHeaderLookup("x-skip-processing") == "true" {
 		return nil, nil // Continue without modification
 	}
 	// Process...
 	return nil, nil
+}
+
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	// Post-hook always runs unless pre-hook short-circuited
+	return nil
 }
 ```
 
@@ -188,8 +232,8 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 
 **v1.4.x+:**
 ```go
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
-	if req.Headers["x-api-key"] == "" {
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	if req.CaseInsensitiveHeaderLookup("x-api-key") == "" {
 		// Return a custom response to short-circuit
 		return &schemas.HTTPResponse{
 			StatusCode: 401,
@@ -198,6 +242,11 @@ func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPReques
 		}, nil
 	}
 	return nil, nil
+}
+
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	// Not called if pre-hook short-circuited
+	return nil
 }
 ```
 
@@ -214,12 +263,24 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 
 **v1.4.x+:**
 ```go
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	// Full access to request properties
-	method := req.Method      // "GET", "POST", etc.
-	path := req.Path          // "/v1/chat/completions"
-	query := req.Query        // map[string]string of query params
+	method := req.Method        // "GET", "POST", etc.
+	path := req.Path            // "/v1/chat/completions"
+	query := req.Query          // map[string]string of query params
+	pathParams := req.PathParams // map[string]string of path variables (e.g., {model})
 	return nil, nil
+}
+
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	// Access both request and response
+	statusCode := resp.StatusCode
+	responseHeaders := resp.Headers
+	responseBody := resp.Body
+	_ = statusCode      // Use variables...
+	_ = responseHeaders
+	_ = responseBody
+	return nil
 }
 ```
 
@@ -242,11 +303,12 @@ func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPReques
      -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}'
    ```
 
-4. **Verify logs show the new intercept being called:**
+4. **Verify logs show both hooks being called:**
    ```
-   HTTPTransportIntercept called
+   HTTPTransportPreHook called
    PreHook called
    PostHook called
+   HTTPTransportPostHook called
    ```
 
 ## Troubleshooting
@@ -256,13 +318,15 @@ func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPReques
 **Error:** `plugin: symbol TransportInterceptor not found`
 
 This error occurs if Bifrost v1.4.x is looking for the old function. Make sure:
-1. You've updated to `HTTPTransportIntercept`
-2. The function signature matches exactly: `func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)`
+1. You've updated to `HTTPTransportPreHook` and `HTTPTransportPostHook`
+2. The function signatures match exactly:
+   - `func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)`
+   - `func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error`
 3. You've rebuilt the plugin with the correct core version
 
 ### Body modification not working
 
-Make sure you're assigning back to `req.Body`:
+Make sure you're assigning back to `req.Body` in the pre-hook:
 
 ```go
 // Wrong - body changes lost
@@ -278,16 +342,52 @@ body["model"] = "gpt-4"
 req.Body, _ = sonic.Marshal(body)  // Assign back!
 ```
 
-### Headers not being set
+### Response modification not working
 
-Make sure you're modifying `req.Headers` directly:
+Make sure you're modifying `resp` in the post-hook:
 
 ```go
-// Set header (case-sensitive keys)
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	// Modify response headers
+	resp.Headers["x-custom-header"] = "value"
+	
+	// Modify response body
+	var body map[string]any
+	sonic.Unmarshal(resp.Body, &body)
+	body["extra_field"] = "value"
+	resp.Body, _ = sonic.Marshal(body)
+	
+	return nil
+}
+```
+
+### Headers not being set
+
+Make sure you're modifying `req.Headers` or `resp.Headers` directly:
+
+```go
+// Set request header in pre-hook
 req.Headers["x-custom-header"] = "value"
 
-// Read header
-value := req.Headers["x-custom-header"]
+// Set response header in post-hook
+resp.Headers["x-custom-header"] = "value"
+
+// Read headers using case-insensitive helper
+value := req.CaseInsensitiveHeaderLookup("X-Custom-Header")
+```
+
+### Context values not available in post-hook
+
+Make sure you're using the correct context key type:
+
+```go
+// In pre-hook - set value
+ctx.SetValue(schemas.BifrostContextKey("my-key"), "my-value")
+
+// In post-hook - read value
+if val := ctx.Value(schemas.BifrostContextKey("my-key")); val != nil {
+	// Use val
+}
 ```
 
 ## Need Help?

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -86,21 +86,42 @@ func GetName() string {
 	return "Hello World Plugin"
 }
 
-// HTTPTransportIntercept intercepts requests at the HTTP transport layer
+// HTTPTransportPreHook intercepts requests BEFORE they enter Bifrost core
 // Modify req in-place. Return (*HTTPResponse, nil) to short-circuit.
 // Only called when using HTTP transport (bifrost-http)
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
-	fmt.Println("HTTPTransportIntercept called")
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	fmt.Println("HTTPTransportPreHook called")
 
 	// Read headers using case-insensitive helper (recommended)
 	contentType := req.CaseInsensitiveHeaderLookup("Content-Type")
 	fmt.Printf("Content-Type: %s\n", contentType)
 
-	// Modify request in-place (use lowercase for direct map access)
+	// Modify request in-place
 	req.Headers["x-custom-header"] = "custom-value"
+
+	// Store values in context for use in other hooks
+	ctx.SetValue(schemas.BifrostContextKey("my-plugin-key"), "pre-hook-value")
 
 	// Return nil to continue, or return &schemas.HTTPResponse{} to short-circuit
 	return nil, nil
+}
+
+// HTTPTransportPostHook intercepts responses AFTER they exit Bifrost core
+// Modify resp in-place. Called in reverse order of pre-hooks.
+// Only called when using HTTP transport (bifrost-http)
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	fmt.Println("HTTPTransportPostHook called")
+
+	// Modify response headers
+	resp.Headers["x-processed-by"] = "my-plugin"
+
+	// Read context values set in pre-hook
+	if val := ctx.Value(schemas.BifrostContextKey("my-plugin-key")); val != nil {
+		fmt.Printf("Context value: %v\n", val)
+	}
+
+	// Return nil to continue, or return error to short-circuit
+	return nil
 }
 
 // PreHook is called before the request is sent to the provider
@@ -214,12 +235,12 @@ Returns a unique identifier for your plugin. This name appears in logs and statu
 
 <Tabs>
   <Tab title="v1.4.x+">
-#### `HTTPTransportIntercept(ctx, req)`
+#### `HTTPTransportPreHook(ctx, req)`
 
-**HTTP transport only.** Intercepts requests at the transport layer. Use this to:
+**HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core. Use this to:
 - Modify request headers, body, or query params in-place
 - Short-circuit with a custom response
-- Access `BifrostContext` for request metadata
+- Store values in `BifrostContext` for use in other hooks
 - Works with both native .so and WASM plugins
 
 Key points:
@@ -228,6 +249,20 @@ Key points:
 - Return `(nil, nil)` to continue to next plugin/handler
 - Return `(*HTTPResponse, nil)` to short-circuit with response
 - Return `(nil, error)` to short-circuit with error
+
+#### `HTTPTransportPostHook(ctx, req, resp)`
+
+**HTTP transport only.** Intercepts responses AFTER they exit Bifrost core. Use this to:
+- Modify response headers or body in-place
+- Log or monitor response data
+- Access context values set in pre-hook
+- Called in **reverse order** of pre-hooks
+
+Key points:
+- Receives both `*HTTPRequest` and `*HTTPResponse`
+- Modify `resp.Headers`, `resp.Body`, `resp.StatusCode` directly
+- Return `nil` to continue to next plugin/handler
+- Return `error` to short-circuit with error and skip remaining post-hooks
 
 <Note>
 **Header and Query Parameter Lookups**: Use the case-insensitive helper methods for reading headers and query parameters:
@@ -249,7 +284,7 @@ The helper methods (`CaseInsensitiveHeaderLookup` and `CaseInsensitiveQueryLooku
 </Note>
 
 <Warning>
-This function is **only called** when using `bifrost-http`. It's **not invoked** when using Bifrost as a Go SDK.
+These functions are **only called** when using `bifrost-http`. They are **not invoked** when using Bifrost as a Go SDK.
 </Warning>
   </Tab>
   <Tab title="v1.3.x">
@@ -455,9 +490,10 @@ Check the logs for plugin hook calls:
 <Tabs>
   <Tab title="v1.4.x+">
 ```
-HTTPTransportIntercept called
+HTTPTransportPreHook called
 PreHook called
 PostHook called
+HTTPTransportPostHook called
 ```
   </Tab>
   <Tab title="v1.3.x">

--- a/docs/plugins/writing-wasm-plugin.mdx
+++ b/docs/plugins/writing-wasm-plugin.mdx
@@ -29,7 +29,8 @@ All WASM plugins must export these functions:
 | `free` | `(ptr: u32)` or `(ptr: u32, size: u32)` | Free allocated memory (Rust requires size for dealloc) |
 | `get_name` | `() -> u64` | Returns packed ptr+len of plugin name |
 | `init` | `(config_ptr, config_len: u32) -> i32` | Initialize with config (0 = success) |
-| `http_intercept` | `(input_ptr, input_len: u32) -> u64` | HTTP transport intercept |
+| `http_pre_hook` | `(input_ptr, input_len: u32) -> u64` | HTTP transport pre-hook (request interception) |
+| `http_post_hook` | `(input_ptr, input_len: u32) -> u64` | HTTP transport post-hook (response interception) |
 | `pre_hook` | `(input_ptr, input_len: u32) -> u64` | Pre-request hook |
 | `post_hook` | `(input_ptr, input_len: u32) -> u64` | Post-response hook |
 | `cleanup` | `() -> i32` | Cleanup resources (0 = success) |
@@ -140,12 +141,22 @@ export function init(configPtr: u32, configLen: u32): i32 {
   return 0 // Success
 }
 
-export function http_intercept(inputPtr: u32, inputLen: u32): u64 {
+export function http_pre_hook(inputPtr: u32, inputLen: u32): u64 {
   const input = readString(inputPtr, inputLen)
   
   // Parse and modify as needed
   // For pass-through, return the input with has_response: false
   const output = '{"context":{},"request":null,"response":null,"has_response":false,"error":""}'
+  
+  return writeString(output)
+}
+
+export function http_post_hook(inputPtr: u32, inputLen: u32): u64 {
+  const input = readString(inputPtr, inputLen)
+  
+  // Parse input which includes both request and response
+  // For pass-through, just return context and empty error
+  const output = '{"context":{},"error":""}'
   
   return writeString(output)
 }
@@ -303,14 +314,14 @@ func init_plugin(configPtr, configLen uint32) int32 {
 	return 0 // Success
 }
 
-// HTTPInterceptInput represents the input to http_intercept
-type HTTPInterceptInput struct {
+// HTTPPreHookInput represents the input to http_pre_hook
+type HTTPPreHookInput struct {
 	Context map[string]interface{} `json:"context"`
 	Request json.RawMessage        `json:"request"`
 }
 
-// HTTPInterceptOutput represents the output from http_intercept
-type HTTPInterceptOutput struct {
+// HTTPPreHookOutput represents the output from http_pre_hook
+type HTTPPreHookOutput struct {
 	Context     map[string]interface{} `json:"context"`
 	Request     json.RawMessage        `json:"request,omitempty"`
 	Response    json.RawMessage        `json:"response,omitempty"`
@@ -318,25 +329,61 @@ type HTTPInterceptOutput struct {
 	Error       string                 `json:"error"`
 }
 
-//export http_intercept
-func http_intercept(inputPtr, inputLen uint32) uint64 {
+//export http_pre_hook
+func http_pre_hook(inputPtr, inputLen uint32) uint64 {
 	inputData := readInput(inputPtr, inputLen)
 	
-	var input HTTPInterceptInput
+	var input HTTPPreHookInput
 	if err := json.Unmarshal(inputData, &input); err != nil {
-		output := HTTPInterceptOutput{Error: err.Error()}
+		output := HTTPPreHookOutput{Error: err.Error()}
 		data, _ := json.Marshal(output)
 		return writeBytes(data)
 	}
 	
 	// Add custom context value
-	input.Context["from-http"] = "wasm-plugin"
+	input.Context["from-http-pre"] = "wasm-plugin"
 	
 	// Pass through
-	output := HTTPInterceptOutput{
+	output := HTTPPreHookOutput{
 		Context:     input.Context,
 		Request:     input.Request,
 		HasResponse: false,
+	}
+	
+	data, _ := json.Marshal(output)
+	return writeBytes(data)
+}
+
+// HTTPPostHookInput represents the input to http_post_hook
+type HTTPPostHookInput struct {
+	Context  map[string]interface{} `json:"context"`
+	Request  json.RawMessage        `json:"request"`
+	Response json.RawMessage        `json:"response"`
+}
+
+// HTTPPostHookOutput represents the output from http_post_hook
+type HTTPPostHookOutput struct {
+	Context map[string]interface{} `json:"context"`
+	Error   string                 `json:"error"`
+}
+
+//export http_post_hook
+func http_post_hook(inputPtr, inputLen uint32) uint64 {
+	inputData := readInput(inputPtr, inputLen)
+	
+	var input HTTPPostHookInput
+	if err := json.Unmarshal(inputData, &input); err != nil {
+		output := HTTPPostHookOutput{Error: err.Error()}
+		data, _ := json.Marshal(output)
+		return writeBytes(data)
+	}
+	
+	// Add custom context value
+	input.Context["from-http-post"] = "wasm-plugin"
+	
+	// Pass through
+	output := HTTPPostHookOutput{
+		Context: input.Context,
 	}
 	
 	data, _ := json.Marshal(output)
@@ -585,13 +632,13 @@ pub extern "C" fn init(config_ptr: u32, config_len: u32) -> i32 {
 }
 
 #[derive(Deserialize)]
-struct HTTPInterceptInput {
+struct HTTPPreHookInput {
     context: HashMap<String, serde_json::Value>,
     request: serde_json::Value,
 }
 
 #[derive(Serialize, Default)]
-struct HTTPInterceptOutput {
+struct HTTPPreHookOutput {
     context: HashMap<String, serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     request: Option<serde_json::Value>,
@@ -602,13 +649,13 @@ struct HTTPInterceptOutput {
 }
 
 #[no_mangle]
-pub extern "C" fn http_intercept(input_ptr: u32, input_len: u32) -> u64 {
+pub extern "C" fn http_pre_hook(input_ptr: u32, input_len: u32) -> u64 {
     let input_str = read_string(input_ptr, input_len);
     
-    let input: HTTPInterceptInput = match serde_json::from_str(&input_str) {
+    let input: HTTPPreHookInput = match serde_json::from_str(&input_str) {
         Ok(i) => i,
         Err(e) => {
-            let output = HTTPInterceptOutput {
+            let output = HTTPPreHookOutput {
                 error: format!("Parse error: {}", e),
                 ..Default::default()
             };
@@ -617,13 +664,52 @@ pub extern "C" fn http_intercept(input_ptr: u32, input_len: u32) -> u64 {
     };
     
     let mut context = input.context;
-    context.insert("from-http".to_string(), serde_json::json!("rust-wasm"));
+    context.insert("from-http-pre".to_string(), serde_json::json!("rust-wasm"));
     
-    let output = HTTPInterceptOutput {
+    let output = HTTPPreHookOutput {
         context,
         request: Some(input.request),
         has_response: false,
         ..Default::default()
+    };
+    
+    write_string(&serde_json::to_string(&output).unwrap())
+}
+
+#[derive(Deserialize)]
+struct HTTPPostHookInput {
+    context: HashMap<String, serde_json::Value>,
+    request: serde_json::Value,
+    response: serde_json::Value,
+}
+
+#[derive(Serialize, Default)]
+struct HTTPPostHookOutput {
+    context: HashMap<String, serde_json::Value>,
+    error: String,
+}
+
+#[no_mangle]
+pub extern "C" fn http_post_hook(input_ptr: u32, input_len: u32) -> u64 {
+    let input_str = read_string(input_ptr, input_len);
+    
+    let input: HTTPPostHookInput = match serde_json::from_str(&input_str) {
+        Ok(i) => i,
+        Err(e) => {
+            let output = HTTPPostHookOutput {
+                error: format!("Parse error: {}", e),
+                ..Default::default()
+            };
+            return write_string(&serde_json::to_string(&output).unwrap());
+        }
+    };
+    
+    let mut context = input.context;
+    context.insert("from-http-post".to_string(), serde_json::json!("rust-wasm"));
+    
+    let output = HTTPPostHookOutput {
+        context,
+        error: String::new(),
     };
     
     write_string(&serde_json::to_string(&output).unwrap())
@@ -749,7 +835,7 @@ Output: `build/plugin.wasm`
 
 ## Hook Input/Output Structures
 
-### http_intercept
+### http_pre_hook
 
 <Note>
 **Header and Query Parameter Handling**: Headers and query parameters in `request.headers` and `request.query` preserve the original casing sent by the client. When looking up headers/query params, you should perform case-insensitive comparisons in your WASM plugin code to handle various casing (e.g., `Content-Type`, `content-type`, `CONTENT-TYPE`).
@@ -798,6 +884,44 @@ To short-circuit with a response:
   "error": ""
 }
 ```
+
+### http_post_hook
+
+Called after the response is received from the LLM provider. Receives both the original request and the response.
+
+**Input:**
+```json
+{
+  "context": {
+    "request_id": "abc-123",
+    "custom_key": "value"
+  },
+  "request": {
+    "method": "POST",
+    "path": "/v1/chat/completions",
+    "headers": { "content-type": "application/json" },
+    "query": {},
+    "body": "<base64-encoded>"
+  },
+  "response": {
+    "status_code": 200,
+    "headers": { "content-type": "application/json" },
+    "body": "<base64-encoded>"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "context": { "request_id": "abc-123", "custom_key": "value", "post_processed": true },
+  "error": ""
+}
+```
+
+<Note>
+The `http_post_hook` is called in **reverse order** of `http_pre_hook`. Context values set in `http_pre_hook` are available in `http_post_hook`.
+</Note>
 
 ### pre_hook
 

--- a/examples/plugins/hello-world/main.go
+++ b/examples/plugins/hello-world/main.go
@@ -15,18 +15,28 @@ func GetName() string {
 	return "Hello World Plugin"
 }
 
-func HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
-	fmt.Println("HTTPTransportIntercept called")
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	fmt.Println("HTTPTransportPreHook called")
 	// Modify request in-place
-	req.Headers["x-hello-world-plugin"] = "transport-interceptor-value"
+	req.Headers["x-hello-world-plugin"] = "transport-pre-hook-value"
 	// Store value in context for PreHook/PostHook
-	ctx.SetValue(schemas.BifrostContextKey("hello-world-plugin-transport-interceptor"), "transport-interceptor-value")
+	ctx.SetValue(schemas.BifrostContextKey("hello-world-plugin-transport-pre-hook"), "transport-pre-hook-value")
 	// Return nil to continue processing, or return &schemas.HTTPResponse{} to short-circuit
 	return nil, nil
 }
 
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	fmt.Println("HTTPTransportPostHook called")
+	// Modify response in-place
+	resp.Headers["x-hello-world-plugin"] = "transport-post-hook-value"
+	// Store value in context
+	ctx.SetValue(schemas.BifrostContextKey("hello-world-plugin-transport-post-hook"), "transport-post-hook-value")
+	// Return nil to continue processing
+	return nil
+}
+
 func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
-	value1 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-transport-interceptor"))
+	value1 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-transport-pre-hook"))
 	fmt.Println("value1:", value1)
 	ctx.SetValue(schemas.BifrostContextKey("hello-world-plugin-pre-hook"), "pre-hook-value")
 	fmt.Println("PreHook called")
@@ -35,7 +45,7 @@ func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas
 
 func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	fmt.Println("PostHook called")
-	value1 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-transport-interceptor"))
+	value1 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-transport-pre-hook"))
 	fmt.Println("value1:", value1)
 	value2 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-pre-hook"))
 	fmt.Println("value2:", value2)

--- a/framework/configstore/dlock.go
+++ b/framework/configstore/dlock.go
@@ -146,7 +146,7 @@ type DistributedLock struct {
 }
 
 // Lock acquires the lock, blocking until it's available or the context is cancelled.
-// It will retry up to maxRetries times with retryInterval between attempts.
+// It will make up to (maxRetries + 1) attempts, sleeping retryInterval between failed attempts.
 func (l *DistributedLock) Lock(ctx context.Context) error {
 	for i := 0; i <= l.maxRetries; i++ {
 		select {

--- a/framework/configstore/dlock_test.go
+++ b/framework/configstore/dlock_test.go
@@ -1,0 +1,1147 @@
+package configstore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// mockLogger implements schemas.Logger for testing
+type mockLogger struct {
+	debugMessages []string
+	infoMessages  []string
+	warnMessages  []string
+	errorMessages []string
+	mu            sync.Mutex
+}
+
+func newMockLogger() *mockLogger {
+	return &mockLogger{
+		debugMessages: make([]string, 0),
+		infoMessages:  make([]string, 0),
+		warnMessages:  make([]string, 0),
+		errorMessages: make([]string, 0),
+	}
+}
+
+func (l *mockLogger) Debug(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.debugMessages = append(l.debugMessages, msg)
+}
+
+func (l *mockLogger) Info(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infoMessages = append(l.infoMessages, msg)
+}
+
+func (l *mockLogger) Warn(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.warnMessages = append(l.warnMessages, msg)
+}
+
+func (l *mockLogger) Error(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errorMessages = append(l.errorMessages, msg)
+}
+
+func (l *mockLogger) Fatal(msg string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errorMessages = append(l.errorMessages, msg)
+}
+
+func (l *mockLogger) SetLevel(level schemas.LogLevel) {}
+
+func (l *mockLogger) SetOutputType(outputType schemas.LoggerOutputType) {}
+
+// setupLockTestStore creates a test RDBConfigStore with SQLite in-memory database
+func setupLockTestStore(t *testing.T) *RDBConfigStore {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "Failed to create test database")
+
+	err = db.AutoMigrate(&tables.TableDistributedLock{})
+	require.NoError(t, err, "Failed to migrate test database")
+
+	return &RDBConfigStore{
+		db:     db,
+		logger: newMockLogger(),
+	}
+}
+
+// =============================================================================
+// LockStore Interface Tests (RDBConfigStore implementation)
+// =============================================================================
+
+func TestTryAcquireLock_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	lock := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+
+	acquired, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+	assert.True(t, acquired, "Lock should be acquired")
+
+	// Verify lock exists in database
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.NotNil(t, storedLock)
+	assert.Equal(t, "holder-1", storedLock.HolderID)
+}
+
+func TestTryAcquireLock_AlreadyHeld(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// First holder acquires the lock
+	lock1 := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	acquired, err := store.TryAcquireLock(ctx, lock1)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Second holder tries to acquire the same lock
+	lock2 := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-2",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	acquired, err = store.TryAcquireLock(ctx, lock2)
+	require.NoError(t, err)
+	assert.False(t, acquired, "Lock should not be acquired by second holder")
+
+	// Verify original holder still owns the lock
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.Equal(t, "holder-1", storedLock.HolderID)
+}
+
+func TestTryAcquireLock_MultipleLocks(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	locks := []string{"lock-a", "lock-b", "lock-c"}
+
+	for _, lockKey := range locks {
+		lock := &tables.TableDistributedLock{
+			LockKey:   lockKey,
+			HolderID:  "holder-1",
+			ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+		}
+		acquired, err := store.TryAcquireLock(ctx, lock)
+		require.NoError(t, err)
+		assert.True(t, acquired, "Lock %s should be acquired", lockKey)
+	}
+
+	// Verify all locks exist
+	for _, lockKey := range locks {
+		storedLock, err := store.GetLock(ctx, lockKey)
+		require.NoError(t, err)
+		assert.NotNil(t, storedLock)
+	}
+}
+
+func TestGetLock_NotFound(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	lock, err := store.GetLock(ctx, "non-existent-lock")
+	require.NoError(t, err)
+	assert.Nil(t, lock, "Should return nil for non-existent lock")
+}
+
+func TestUpdateLockExpiry_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create initial lock
+	lock := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	acquired, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// Extend expiry
+	newExpiry := time.Now().UTC().Add(60 * time.Second)
+	err = store.UpdateLockExpiry(ctx, "test-lock", "holder-1", newExpiry)
+	require.NoError(t, err)
+
+	// Verify expiry was updated
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.WithinDuration(t, newExpiry, storedLock.ExpiresAt, time.Second)
+}
+
+func TestUpdateLockExpiry_WrongHolder(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create lock with holder-1
+	lock := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	acquired, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// Try to extend with wrong holder
+	newExpiry := time.Now().UTC().Add(60 * time.Second)
+	err = store.UpdateLockExpiry(ctx, "test-lock", "holder-2", newExpiry)
+	assert.ErrorIs(t, err, ErrLockNotHeld)
+}
+
+func TestUpdateLockExpiry_ExpiredLock(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create lock that's already expired
+	lock := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(-1 * time.Second),
+	}
+	// Directly insert the expired lock
+	err := store.db.Create(lock).Error
+	require.NoError(t, err)
+
+	// Try to extend expired lock
+	newExpiry := time.Now().UTC().Add(60 * time.Second)
+	err = store.UpdateLockExpiry(ctx, "test-lock", "holder-1", newExpiry)
+	assert.ErrorIs(t, err, ErrLockNotHeld)
+}
+
+func TestReleaseLock_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create lock
+	lock := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	acquired, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// Release lock
+	released, err := store.ReleaseLock(ctx, "test-lock", "holder-1")
+	require.NoError(t, err)
+	assert.True(t, released)
+
+	// Verify lock is gone
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.Nil(t, storedLock)
+}
+
+func TestReleaseLock_WrongHolder(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create lock with holder-1
+	lock := &tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	acquired, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	// Try to release with wrong holder
+	released, err := store.ReleaseLock(ctx, "test-lock", "holder-2")
+	require.NoError(t, err)
+	assert.False(t, released, "Should not release lock with wrong holder")
+
+	// Verify lock still exists
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.NotNil(t, storedLock)
+	assert.Equal(t, "holder-1", storedLock.HolderID)
+}
+
+func TestReleaseLock_NotExists(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	released, err := store.ReleaseLock(ctx, "non-existent-lock", "holder-1")
+	require.NoError(t, err)
+	assert.False(t, released)
+}
+
+func TestCleanupExpiredLocks_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create some expired locks
+	expiredLocks := []tables.TableDistributedLock{
+		{LockKey: "expired-1", HolderID: "h1", ExpiresAt: time.Now().UTC().Add(-1 * time.Minute)},
+		{LockKey: "expired-2", HolderID: "h2", ExpiresAt: time.Now().UTC().Add(-2 * time.Minute)},
+	}
+
+	// Create some valid locks
+	validLocks := []tables.TableDistributedLock{
+		{LockKey: "valid-1", HolderID: "h3", ExpiresAt: time.Now().UTC().Add(30 * time.Second)},
+		{LockKey: "valid-2", HolderID: "h4", ExpiresAt: time.Now().UTC().Add(60 * time.Second)},
+	}
+
+	for _, l := range expiredLocks {
+		err := store.db.Create(&l).Error
+		require.NoError(t, err)
+	}
+	for _, l := range validLocks {
+		err := store.db.Create(&l).Error
+		require.NoError(t, err)
+	}
+
+	// Cleanup expired locks
+	count, err := store.CleanupExpiredLocks(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count, "Should cleanup 2 expired locks")
+
+	// Verify expired locks are gone
+	for _, l := range expiredLocks {
+		lock, err := store.GetLock(ctx, l.LockKey)
+		require.NoError(t, err)
+		assert.Nil(t, lock)
+	}
+
+	// Verify valid locks still exist
+	for _, l := range validLocks {
+		lock, err := store.GetLock(ctx, l.LockKey)
+		require.NoError(t, err)
+		assert.NotNil(t, lock)
+	}
+}
+
+func TestCleanupExpiredLocks_NoExpired(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create only valid locks
+	lock := &tables.TableDistributedLock{
+		LockKey:   "valid-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	_, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+
+	count, err := store.CleanupExpiredLocks(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestCleanupExpiredLockByKey_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create expired lock
+	lock := tables.TableDistributedLock{
+		LockKey:   "expired-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(-1 * time.Minute),
+	}
+	err := store.db.Create(&lock).Error
+	require.NoError(t, err)
+
+	// Cleanup specific expired lock
+	cleaned, err := store.CleanupExpiredLockByKey(ctx, "expired-lock")
+	require.NoError(t, err)
+	assert.True(t, cleaned)
+
+	// Verify lock is gone
+	storedLock, err := store.GetLock(ctx, "expired-lock")
+	require.NoError(t, err)
+	assert.Nil(t, storedLock)
+}
+
+func TestCleanupExpiredLockByKey_NotExpired(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	// Create valid lock
+	lock := &tables.TableDistributedLock{
+		LockKey:   "valid-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(30 * time.Second),
+	}
+	_, err := store.TryAcquireLock(ctx, lock)
+	require.NoError(t, err)
+
+	// Try to cleanup non-expired lock
+	cleaned, err := store.CleanupExpiredLockByKey(ctx, "valid-lock")
+	require.NoError(t, err)
+	assert.False(t, cleaned, "Should not cleanup non-expired lock")
+
+	// Verify lock still exists
+	storedLock, err := store.GetLock(ctx, "valid-lock")
+	require.NoError(t, err)
+	assert.NotNil(t, storedLock)
+}
+
+func TestCleanupExpiredLockByKey_NotExists(t *testing.T) {
+	store := setupLockTestStore(t)
+	ctx := context.Background()
+
+	cleaned, err := store.CleanupExpiredLockByKey(ctx, "non-existent")
+	require.NoError(t, err)
+	assert.False(t, cleaned)
+}
+
+// =============================================================================
+// DistributedLockManager Tests
+// =============================================================================
+
+func TestNewDistributedLockManager_DefaultOptions(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+
+	manager := NewDistributedLockManager(store, logger)
+
+	assert.NotNil(t, manager)
+	assert.Equal(t, DefaultLockTTL, manager.defaultTTL)
+	assert.Equal(t, DefaultRetryInterval, manager.retryInterval)
+	assert.Equal(t, DefaultMaxRetries, manager.maxRetries)
+}
+
+func TestNewDistributedLockManager_CustomOptions(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+
+	customTTL := 60 * time.Second
+	customRetryInterval := 200 * time.Millisecond
+	customMaxRetries := 50
+
+	manager := NewDistributedLockManager(
+		store,
+		logger,
+		WithDefaultTTL(customTTL),
+		WithRetryInterval(customRetryInterval),
+		WithMaxRetries(customMaxRetries),
+	)
+
+	assert.Equal(t, customTTL, manager.defaultTTL)
+	assert.Equal(t, customRetryInterval, manager.retryInterval)
+	assert.Equal(t, customMaxRetries, manager.maxRetries)
+}
+
+func TestDistributedLockManager_NewLock(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+
+	lock := manager.NewLock("my-lock")
+
+	assert.NotNil(t, lock)
+	assert.Equal(t, "my-lock", lock.Key())
+	assert.NotEmpty(t, lock.HolderID())
+	assert.Equal(t, DefaultLockTTL, lock.ttl)
+}
+
+func TestDistributedLockManager_NewLockWithTTL(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+
+	customTTL := 5 * time.Minute
+	lock := manager.NewLockWithTTL("my-lock", customTTL)
+
+	assert.Equal(t, customTTL, lock.ttl)
+}
+
+func TestDistributedLockManager_CleanupExpiredLocks(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	// Create expired lock directly
+	lock := tables.TableDistributedLock{
+		LockKey:   "expired-lock",
+		HolderID:  "holder-1",
+		ExpiresAt: time.Now().UTC().Add(-1 * time.Minute),
+	}
+	err := store.db.Create(&lock).Error
+	require.NoError(t, err)
+
+	count, err := manager.CleanupExpiredLocks(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+// =============================================================================
+// DistributedLock Tests
+// =============================================================================
+
+func TestDistributedLock_TryLock_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+}
+
+func TestDistributedLock_TryLock_AlreadyHeld(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock1 := manager.NewLock("test-lock")
+	lock2 := manager.NewLock("test-lock")
+
+	// First lock succeeds
+	acquired, err := lock1.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Second lock fails
+	acquired, err = lock2.TryLock(ctx)
+	require.NoError(t, err)
+	assert.False(t, acquired)
+}
+
+func TestDistributedLock_TryLock_CleansUpExpired(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	// Create expired lock directly in database
+	expiredLock := tables.TableDistributedLock{
+		LockKey:   "test-lock",
+		HolderID:  "old-holder",
+		ExpiresAt: time.Now().UTC().Add(-1 * time.Minute),
+	}
+	err := store.db.Create(&expiredLock).Error
+	require.NoError(t, err)
+
+	// New lock should be able to acquire after cleanup
+	lock := manager.NewLock("test-lock")
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired, "Should acquire lock after expired cleanup")
+}
+
+func TestDistributedLock_Lock_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger,
+		WithRetryInterval(10*time.Millisecond),
+		WithMaxRetries(3),
+	)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+
+	err := lock.Lock(ctx)
+	require.NoError(t, err)
+
+	// Verify lock is held
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+func TestDistributedLock_Lock_ContextCancelled(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+
+	// First acquire the lock
+	lock1 := manager.NewLock("test-lock")
+	ctx := context.Background()
+	_, err := lock1.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Try to acquire with cancelled context
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	lock2 := manager.NewLock("test-lock")
+	err = lock2.Lock(cancelCtx)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDistributedLock_Lock_Timeout(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger,
+		WithRetryInterval(10*time.Millisecond),
+		WithMaxRetries(3),
+	)
+	ctx := context.Background()
+
+	// First lock holds
+	lock1 := manager.NewLock("test-lock")
+	_, err := lock1.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Second lock should fail after retries
+	lock2 := manager.NewLock("test-lock")
+	err = lock2.Lock(ctx)
+	assert.ErrorIs(t, err, ErrLockNotAcquired)
+}
+
+func TestDistributedLock_LockWithRetry_ExponentialBackoff(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	// First lock holds
+	lock1 := manager.NewLock("test-lock")
+	_, err := lock1.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Second lock with limited retries
+	lock2 := manager.NewLock("test-lock")
+	start := time.Now()
+	err = lock2.LockWithRetry(ctx, 2)
+	elapsed := time.Since(start)
+
+	assert.ErrorIs(t, err, ErrLockNotAcquired)
+	// With exponential backoff: 1s + 2s = 3s minimum
+	assert.True(t, elapsed >= 3*time.Second, "Expected at least 3s delay, got %v", elapsed)
+}
+
+func TestDistributedLock_Unlock_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	err = lock.Unlock(ctx)
+	require.NoError(t, err)
+
+	// Verify lock is released
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.Nil(t, storedLock)
+}
+
+func TestDistributedLock_Unlock_NotHeld(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	// Never acquired
+
+	err := lock.Unlock(ctx)
+	assert.ErrorIs(t, err, ErrLockNotHeld)
+}
+
+func TestDistributedLock_Unlock_AlreadyReleased(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// First unlock succeeds
+	err = lock.Unlock(ctx)
+	require.NoError(t, err)
+
+	// Second unlock fails
+	err = lock.Unlock(ctx)
+	assert.ErrorIs(t, err, ErrLockNotHeld)
+}
+
+func TestDistributedLock_Extend_Success(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger, WithDefaultTTL(10*time.Second))
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Get original expiry
+	storedLock, err := store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	originalExpiry := storedLock.ExpiresAt
+
+	// Wait a bit and extend
+	time.Sleep(100 * time.Millisecond)
+	err = lock.Extend(ctx)
+	require.NoError(t, err)
+
+	// Verify expiry was extended
+	storedLock, err = store.GetLock(ctx, "test-lock")
+	require.NoError(t, err)
+	assert.True(t, storedLock.ExpiresAt.After(originalExpiry))
+}
+
+func TestDistributedLock_Extend_NotHeld(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	// Never acquired
+
+	err := lock.Extend(ctx)
+	assert.ErrorIs(t, err, ErrLockNotHeld)
+}
+
+func TestDistributedLock_Extend_StolenLock(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Simulate lock being stolen by another process
+	err = store.db.Model(&tables.TableDistributedLock{}).
+		Where("lock_key = ?", "test-lock").
+		Update("holder_id", "another-holder").Error
+	require.NoError(t, err)
+
+	// Extend should fail
+	err = lock.Extend(ctx)
+	assert.Error(t, err)
+}
+
+func TestDistributedLock_IsHeld_True(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+func TestDistributedLock_IsHeld_NotAcquired(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	// Never acquired
+
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.False(t, held)
+}
+
+func TestDistributedLock_IsHeld_Expired(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger, WithDefaultTTL(50*time.Millisecond))
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Wait for lock to expire
+	time.Sleep(100 * time.Millisecond)
+
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.False(t, held, "Lock should not be held after expiry")
+}
+
+func TestDistributedLock_IsHeld_StolenByAnotherHolder(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Simulate lock being stolen by another process
+	err = store.db.Model(&tables.TableDistributedLock{}).
+		Where("lock_key = ?", "test-lock").
+		Update("holder_id", "another-holder").Error
+	require.NoError(t, err)
+
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.False(t, held)
+}
+
+func TestDistributedLock_IsHeld_DeletedFromDB(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Delete lock directly from database
+	err = store.db.Where("lock_key = ?", "test-lock").Delete(&tables.TableDistributedLock{}).Error
+	require.NoError(t, err)
+
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.False(t, held)
+}
+
+// =============================================================================
+// Concurrent Access Tests
+// =============================================================================
+
+func TestDistributedLock_ConcurrentAcquire(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger,
+		WithRetryInterval(10*time.Millisecond),
+		WithMaxRetries(5),
+	)
+	ctx := context.Background()
+
+	const numGoroutines = 10
+	successCount := 0
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lock := manager.NewLock("contended-lock")
+			acquired, err := lock.TryLock(ctx)
+			if err == nil && acquired {
+				mu.Lock()
+				successCount++
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Only one goroutine should have acquired the lock
+	assert.Equal(t, 1, successCount, "Exactly one goroutine should acquire the lock")
+}
+
+func TestDistributedLock_ConcurrentLockUnlock(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger,
+		WithRetryInterval(50*time.Millisecond),
+		WithMaxRetries(100),
+		WithDefaultTTL(5*time.Second),
+	)
+	ctx := context.Background()
+
+	const numGoroutines = 5
+	counter := 0
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			lock := manager.NewLock("counter-lock")
+
+			// Each goroutine tries to increment the counter with lock protection
+			err := lock.Lock(ctx)
+			if err != nil {
+				return
+			}
+
+			mu.Lock()
+			counter++
+			mu.Unlock()
+
+			// Simulate some work
+			time.Sleep(10 * time.Millisecond)
+
+			_ = lock.Unlock(ctx)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All goroutines should have incremented the counter
+	assert.Equal(t, numGoroutines, counter, "All goroutines should complete")
+}
+
+func TestDistributedLock_MultipleLocksPerManager(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	const numLocks = 10
+	var wg sync.WaitGroup
+
+	for i := 0; i < numLocks; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			lockKey := "lock-" + string(rune('a'+id))
+			lock := manager.NewLock(lockKey)
+
+			acquired, err := lock.TryLock(ctx)
+			require.NoError(t, err)
+			assert.True(t, acquired, "Lock %s should be acquired", lockKey)
+
+			time.Sleep(10 * time.Millisecond)
+
+			err = lock.Unlock(ctx)
+			require.NoError(t, err)
+		}(i)
+	}
+
+	wg.Wait()
+}
+
+// =============================================================================
+// Edge Case Tests
+// =============================================================================
+
+func TestDistributedLock_EmptyLockKey(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("")
+
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired, "Empty lock key should be allowed")
+}
+
+func TestDistributedLock_LongLockKey(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	// Create a 255 character lock key (max size per schema)
+	longKey := ""
+	for i := 0; i < 255; i++ {
+		longKey += "a"
+	}
+
+	lock := manager.NewLock(longKey)
+
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+}
+
+func TestDistributedLock_SpecialCharactersInKey(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	specialKeys := []string{
+		"lock:with:colons",
+		"lock/with/slashes",
+		"lock-with-dashes",
+		"lock_with_underscores",
+		"lock.with.dots",
+		"lock with spaces",
+		"lock\twith\ttabs",
+	}
+
+	for _, key := range specialKeys {
+		lock := manager.NewLock(key)
+		acquired, err := lock.TryLock(ctx)
+		require.NoError(t, err, "Key: %s", key)
+		assert.True(t, acquired, "Lock with key %s should be acquired", key)
+
+		err = lock.Unlock(ctx)
+		require.NoError(t, err)
+	}
+}
+
+func TestDistributedLock_ZeroTTL(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger, WithDefaultTTL(0))
+	ctx := context.Background()
+
+	lock := manager.NewLock("zero-ttl-lock")
+
+	// Zero TTL should still work but lock will be immediately expired
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Lock should immediately appear not held due to zero TTL
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.False(t, held, "Zero TTL lock should not be held")
+}
+
+func TestDistributedLock_VeryShortTTL(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger, WithDefaultTTL(1*time.Millisecond))
+	ctx := context.Background()
+
+	lock := manager.NewLock("short-ttl-lock")
+
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Wait for TTL to expire
+	time.Sleep(10 * time.Millisecond)
+
+	// Another lock should be able to acquire
+	lock2 := manager.NewLock("short-ttl-lock")
+	acquired, err = lock2.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired, "Should acquire lock after TTL expires")
+}
+
+func TestDistributedLock_ReacquireAfterUnlock(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+
+	// First acquire
+	acquired, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Release
+	err = lock.Unlock(ctx)
+	require.NoError(t, err)
+
+	// Same lock instance should NOT be able to reacquire (new holder ID needed)
+	// But a new lock should work
+	lock2 := manager.NewLock("test-lock")
+	acquired, err = lock2.TryLock(ctx)
+	require.NoError(t, err)
+	assert.True(t, acquired, "New lock instance should acquire after release")
+}
+
+func TestDistributedLock_ExtendMultipleTimes(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger, WithDefaultTTL(100*time.Millisecond))
+	ctx := context.Background()
+
+	lock := manager.NewLock("test-lock")
+	_, err := lock.TryLock(ctx)
+	require.NoError(t, err)
+
+	// Extend multiple times
+	for i := 0; i < 5; i++ {
+		time.Sleep(20 * time.Millisecond)
+		err = lock.Extend(ctx)
+		require.NoError(t, err, "Extension %d failed", i+1)
+	}
+
+	// Lock should still be held
+	held, err := lock.IsHeld(ctx)
+	require.NoError(t, err)
+	assert.True(t, held)
+}
+
+// =============================================================================
+// Constants and Defaults Tests
+// =============================================================================
+
+func TestConstants(t *testing.T) {
+	assert.Equal(t, 30*time.Second, DefaultLockTTL)
+	assert.Equal(t, 100*time.Millisecond, DefaultRetryInterval)
+	assert.Equal(t, 100, DefaultMaxRetries)
+	assert.Equal(t, 5*time.Minute, DefaultCleanupInterval)
+}
+
+func TestErrors(t *testing.T) {
+	assert.Equal(t, "failed to acquire lock", ErrLockNotAcquired.Error())
+	assert.Equal(t, "lock not held by this holder", ErrLockNotHeld.Error())
+	assert.Equal(t, "lock has expired", ErrLockExpired.Error())
+}
+
+// =============================================================================
+// Key and HolderID Accessor Tests
+// =============================================================================
+
+func TestDistributedLock_Key(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+
+	lock := manager.NewLock("my-unique-lock")
+	assert.Equal(t, "my-unique-lock", lock.Key())
+}
+
+func TestDistributedLock_HolderID(t *testing.T) {
+	store := setupLockTestStore(t)
+	logger := newMockLogger()
+	manager := NewDistributedLockManager(store, logger)
+
+	lock1 := manager.NewLock("lock-1")
+	lock2 := manager.NewLock("lock-2")
+
+	// Each lock should have a unique holder ID
+	assert.NotEmpty(t, lock1.HolderID())
+	assert.NotEmpty(t, lock2.HolderID())
+	assert.NotEqual(t, lock1.HolderID(), lock2.HolderID())
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -161,6 +161,10 @@ type ConfigStore interface {
 	// Returns true if the lock was released, false if it wasn't held by the given holder.
 	ReleaseLock(ctx context.Context, lockKey, holderID string) (bool, error)
 
+	// CleanupExpiredLockByKey atomically deletes a specific lock only if it has expired.
+	// Returns true if an expired lock was deleted, false if the lock doesn't exist or hasn't expired.
+	CleanupExpiredLockByKey(ctx context.Context, lockKey string) (bool, error)
+
 	// CleanupExpiredLocks removes all locks that have expired.
 	// Returns the number of locks cleaned up.
 	CleanupExpiredLocks(ctx context.Context) (int64, error)

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -221,20 +221,6 @@ func (mc *ModelCatalog) startSyncWorker(ctx context.Context) {
 // syncTick performs a single sync tick with proper lock management
 func (mc *ModelCatalog) syncTick(ctx context.Context) {
 	// Guard against nil distributedLockManager
-	if mc.distributedLockManager == nil {
-		if err := mc.checkAndSyncPricing(ctx); err != nil {
-			mc.logger.Error("background pricing sync failed: %v", err)
-		}
-		return
-	}
-	// Acquire the distributed lock
-	lock := mc.distributedLockManager.NewLock("modelcatalog_sync")
-	if err := lock.LockWithRetry(ctx, 10); err != nil {
-		mc.logger.Error("failed to acquire pricing sync lock: %v", err)
-		return
-	}
-	defer lock.Unlock(ctx) // Now correctly scoped to this function
-	// Check and sync pricing data
 	if err := mc.checkAndSyncPricing(ctx); err != nil {
 		mc.logger.Error("background pricing sync failed: %v", err)
 	}

--- a/framework/plugins/soloader.go
+++ b/framework/plugins/soloader.go
@@ -57,13 +57,21 @@ func (l *SharedObjectPluginLoader) LoadDynamicPlugin(path string, config any) (s
 	if dp.getName, ok = getNameSym.(func() string); !ok {
 		return nil, fmt.Errorf("failed to cast GetName to func() string")
 	}
-	// Looking up for HTTPTransportIntercept method
-	httpTransportInterceptSym, err := plugin.Lookup("HTTPTransportIntercept")
+	// Looking up for HTTPTransportPreHook method
+	httpTransportPreHookSym, err := plugin.Lookup("HTTPTransportPreHook")
 	if err != nil {
 		return nil, err
 	}
-	if dp.httpTransportIntercept, ok = httpTransportInterceptSym.(func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)); !ok {
-		return nil, fmt.Errorf("failed to cast HTTPTransportIntercept to func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)")
+	if dp.httpTransportPreHook, ok = httpTransportPreHookSym.(func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)); !ok {
+		return nil, fmt.Errorf("failed to cast HTTPTransportPreHook to func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)")
+	}
+	// Looking up for HTTPTransportPostHook method
+	httpTransportPostHookSym, err := plugin.Lookup("HTTPTransportPostHook")
+	if err != nil {
+		return nil, err
+	}
+	if dp.httpTransportPostHook, ok = httpTransportPostHookSym.(func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error); !ok {
+		return nil, fmt.Errorf("failed to cast HTTPTransportPostHook to func(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error")
 	}
 	// Looking up for PreHook method
 	preHookSym, err := plugin.Lookup("PreHook")

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -44,7 +44,8 @@ type InMemoryStore interface {
 
 type BaseGovernancePlugin interface {
 	GetName() string
-	HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)
+	HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error)
+	HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error
 	PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error)
 	PostHook(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error)
 	Cleanup() error
@@ -288,9 +289,9 @@ func parseVirtualKeyFromHTTPRequest(req *schemas.HTTPRequest) *string {
 	return nil
 }
 
-// HTTPTransportIntercept intercepts requests before they are processed (governance decision point)
+// HTTPTransportPreHook intercepts requests before they are processed (governance decision point)
 // It modifies the request in-place and returns nil to continue, or an HTTPResponse to short-circuit.
-func (p *GovernancePlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	virtualKeyValue := parseVirtualKeyFromHTTPRequest(req)
 	if virtualKeyValue == nil {
 		return nil, nil
@@ -329,6 +330,12 @@ func (p *GovernancePlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, r
 	}
 	req.Body = body
 	return nil, nil
+}
+
+// HTTPTransportPostHook intercepts requests after they are processed (governance decision point)
+// It modifies the response in-place and returns nil to continue
+func (p *GovernancePlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // loadBalanceProvider loads balances the provider for the request

--- a/plugins/jsonparser/main.go
+++ b/plugins/jsonparser/main.go
@@ -83,9 +83,14 @@ func (p *JsonParserPlugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (p *JsonParserPlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (p *JsonParserPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (p *JsonParserPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // PreHook is not used for this plugin as we only process responses

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -191,9 +191,14 @@ func (p *LoggerPlugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (p *LoggerPlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (p *LoggerPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (p *LoggerPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // PreHook is called before a request is processed - FULLY ASYNC, NO DATABASE I/O
@@ -287,7 +292,7 @@ func (p *LoggerPlugin) PreHook(ctx *schemas.BifrostContext, req *schemas.Bifrost
 	logMsg.InitialData = initialData
 	logMsg.FallbackIndex = fallbackIndex
 
-	go func(msg *LogMessage) {		
+	go func(msg *LogMessage) {
 		defer p.putLogMessage(msg) // Return to pool when done
 		if err := p.insertInitialLogEntry(
 			p.ctx,

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -156,9 +156,14 @@ func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (plugin *Plugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (plugin *Plugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (plugin *Plugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // getEffectiveLogRepoID determines which single log repo ID to use based on priority:

--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -478,9 +478,14 @@ func (p *MockerPlugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (p *MockerPlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (p *MockerPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (p *MockerPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // PreHook intercepts requests and applies mocking rules based on configuration

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -145,9 +145,14 @@ func (p *OtelPlugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (p *OtelPlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (p *OtelPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (p *OtelPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // ValidateConfig function for the OTEL plugin

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -335,9 +335,14 @@ func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (plugin *Plugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (plugin *Plugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (plugin *Plugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // PreHook is called before a request is processed by Bifrost.

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -281,9 +281,14 @@ func (p *PrometheusPlugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportIntercept is not used for this plugin
-func (p *PrometheusPlugin) HTTPTransportIntercept(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+// HTTPTransportPreHook is not used for this plugin
+func (p *PrometheusPlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
+}
+
+// HTTPTransportPostHook is not used for this plugin
+func (p *PrometheusPlugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	return nil
 }
 
 // PreHook records the start time of the request in the context.
@@ -320,7 +325,7 @@ func (p *PrometheusPlugin) PostHook(ctx *schemas.BifrostContext, result *schemas
 	customerID := getStringFromContext(ctx, schemas.BifrostContextKey("bf-governance-customer-id"))
 	customerName := getStringFromContext(ctx, schemas.BifrostContextKey("bf-governance-customer-name"))
 
-	// Extract ALL context values BEFORE spawning the goroutine.		
+	// Extract ALL context values BEFORE spawning the goroutine.
 	labelValues := map[string]string{
 		"provider":          string(provider),
 		"model":             model,

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -379,7 +379,7 @@ func LoadPlugins(ctx context.Context, config *lib.Config) ([]schemas.Plugin, []s
 		})
 	}
 	// Initializing governance plugin
-	if config.ClientConfig.EnableGovernance {
+	if config.ClientConfig.EnableGovernance && ctx.Value("isEnterprise") == nil {
 		// Initialize governance plugin
 		governancePlugin, err := LoadPlugin[*governance.GovernancePlugin](ctx, governance.PluginName, nil, &governance.Config{
 			IsVkMandatory: &config.ClientConfig.EnforceGovernanceHeader,


### PR DESCRIPTION
## Add HTTP Transport Post-Hook for Plugins

Adds a new `HTTPTransportPostHook` method to the Plugin interface, allowing plugins to modify HTTP responses after they exit Bifrost core. This complements the existing pre-hook functionality and renames the previous `HTTPTransportIntercept` method to `HTTPTransportPreHook` for clarity and consistency.

## Changes

- Renamed `HTTPTransportIntercept` to `HTTPTransportPreHook` for better naming clarity
- Added new `HTTPTransportPostHook` method to the Plugin interface to intercept and modify responses
- Updated the shared object plugin loader to support the new hook
- Updated the example hello-world plugin to demonstrate both pre and post hooks
- Added `CleanupExpiredLockByKey` method to ConfigStore interface for targeted lock cleanup

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins

## How to test

```sh
# Build and test the updated plugin system
go test ./framework/plugins/...

# Test the hello-world plugin example
cd examples/plugins/hello-world
go build -buildmode=plugin -o hello-world.so main.go
```

## Breaking changes

- [x] Yes
- [ ] No

Existing plugins will need to be updated to implement the renamed `HTTPTransportPreHook` method (previously `HTTPTransportIntercept`) and add the new `HTTPTransportPostHook` method.

## Security considerations

The new post-hook functionality allows plugins to modify HTTP responses, which could potentially expose sensitive information if not properly implemented. Plugin developers should be careful not to expose internal details in modified responses.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed