### PR TITLE
test fixes

### DIFF
--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1234,10 +1234,15 @@ func (provider *AzureProvider) ImageGeneration(ctx *schemas.BifrostContext, key 
 		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
 	}
 
+	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set", provider.GetProviderKey())
+	}
+
 	response, err := openai.HandleOpenAIImageGenerationRequest(
 		ctx,
 		provider.client,
-		fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", key.AzureKeyConfig.Endpoint, deployment, *apiVersion),
+		fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", endpoint, deployment, apiVersion.GetValue()),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -1245,7 +1250,7 @@ func (provider *AzureProvider) ImageGeneration(ctx *schemas.BifrostContext, key 
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
-	)
+	)	
 	if err != nil {
 		return nil, err
 	}
@@ -1282,6 +1287,11 @@ func (provider *AzureProvider) ImageGenerationStream(
 		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
 	}
 
+	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+	if endpoint == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set", provider.GetProviderKey())
+	}
+
 	postResponseConverter := func(resp *schemas.BifrostImageGenerationStreamResponse) *schemas.BifrostImageGenerationStreamResponse {
 		if resp != nil {
 			resp.ExtraFields.ModelDeployment = deployment
@@ -1289,7 +1299,7 @@ func (provider *AzureProvider) ImageGenerationStream(
 		return resp
 	}
 
-	url := fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", key.AzureKeyConfig.Endpoint, deployment, *apiVersion)
+	url := fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", endpoint, deployment, apiVersion.GetValue())
 
 	authHeader, err := provider.getAzureAuthHeaders(ctx, key, false)
 	if err != nil {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -805,7 +805,6 @@ func HandleOpenAIChatCompletionStreaming(
 		if ok && isResponsesToChatCompletionsFallbackValue {
 			isResponsesToChatCompletionsFallback = true
 			responsesStreamState = schemas.AcquireChatToResponsesStreamState()
-			defer schemas.ReleaseChatToResponsesStreamState(responsesStreamState)
 		}
 	}
 
@@ -911,6 +910,8 @@ func HandleOpenAIChatCompletionStreaming(
 			} else if ctx.Err() == context.DeadlineExceeded {
 				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, streamRequestType, logger)
 			}
+			// Release the responses stream state if it was acquired (for ResponsesToChatCompletions fallback)
+			schemas.ReleaseChatToResponsesStreamState(responsesStreamState)
 			close(responseChan)
 		}()
 		defer providerUtils.ReleaseStreamingResponse(resp)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1297,7 +1297,7 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 
 	// Build the native Vertex embedding API endpoint
 	url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
-		key.VertexKeyConfig.Region, key.VertexKeyConfig.ProjectID, key.VertexKeyConfig.Region, deployment)
+		region, projectID, region, deployment)
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()


### PR DESCRIPTION
## Summary

Fixed race conditions in MockAccount and improved error handling in Azure and Vertex providers.

## Changes

- Added mutex protection to MockAccount methods to prevent race conditions during concurrent testing
- Added null checks for Azure provider's endpoint configuration before using it
- Fixed memory leak in OpenAI provider by properly releasing ResponsesToChatCompletions stream state
- Fixed Vertex provider to use local variables instead of potentially nil key config values

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Improves stability by preventing race conditions and null pointer exceptions.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)