### PR TITLE
fixes deadlog bugs

### DIFF
--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -119,7 +119,7 @@ func TestUpdateProvidersConfig_UpdateExistingByKeyID(t *testing.T) {
 	result, err := store.GetProvidersConfig(ctx)
 	require.NoError(t, err)
 	assert.Len(t, result["openai"].Keys, 1)
-	assert.Equal(t, "sk-test-key-v2", result["openai"].Keys[0].Value)
+	assert.Equal(t, "sk-test-key-v2", result["openai"].Keys[0].Value.Val)
 }
 
 func TestUpdateProvidersConfig_UpdateExistingByName_FallbackFix(t *testing.T) {
@@ -162,7 +162,7 @@ func TestUpdateProvidersConfig_UpdateExistingByName_FallbackFix(t *testing.T) {
 	result, err := store.GetProvidersConfig(ctx)
 	require.NoError(t, err)
 	assert.Len(t, result["openai"].Keys, 1, "Should have exactly one key, not duplicated")
-	assert.Equal(t, "sk-test-key-v2", result["openai"].Keys[0].Value, "Value should be updated")
+	assert.Equal(t, "sk-test-key-v2", result["openai"].Keys[0].Value.Val, "Value should be updated")
 	assert.Equal(t, "original-uuid", result["openai"].Keys[0].ID, "Original KeyID should be preserved")
 }
 

--- a/framework/docker-compose.yml
+++ b/framework/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: bifrost-postgres
+    container_name: bifrost-postgres-fw
     environment:
       POSTGRES_USER: bifrost
       POSTGRES_PASSWORD: bifrost_password

--- a/framework/streaming/audio.go
+++ b/framework/streaming/audio.go
@@ -71,7 +71,7 @@ func (a *Accumulator) processAccumulatedAudioStreamingChunks(requestID string, b
 	data.AudioOutput = completeMessage
 	data.ErrorDetails = bifrostErr
 	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, CacheDebug)
-	if lastChunk := accumulator.getLastAudioChunk(); lastChunk != nil {
+	if lastChunk := accumulator.getLastAudioChunkLocked(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = &schemas.BifrostLLMUsage{
 				PromptTokens:     lastChunk.TokenUsage.InputTokens,

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -337,7 +337,7 @@ func (a *Accumulator) processAccumulatedChatStreamingChunks(requestID string, re
 	}
 	data.ErrorDetails = respErr
 	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, FinishReason)
-	if lastChunk := accumulator.getLastChatChunk(); lastChunk != nil {
+	if lastChunk := accumulator.getLastChatChunkLocked(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = lastChunk.TokenUsage
 		}

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -815,7 +815,7 @@ func (a *Accumulator) processAccumulatedResponsesStreamingChunks(requestID strin
 	data.ErrorDetails = respErr
 
 	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, FinishReason)
-	if lastChunk := accumulator.getLastResponsesChunk(); lastChunk != nil {
+	if lastChunk := accumulator.getLastResponsesChunkLocked(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = lastChunk.TokenUsage
 		}

--- a/framework/streaming/transcription.go
+++ b/framework/streaming/transcription.go
@@ -78,7 +78,7 @@ func (a *Accumulator) processAccumulatedTranscriptionStreamingChunks(requestID s
 	data.TranscriptionOutput = completeMessage
 	data.ErrorDetails = bifrostErr
 	// Update metadata from the chunk with highest index (contains TokenUsage, Cost, CacheDebug)
-	if lastChunk := accumulator.getLastTranscriptionChunk(); lastChunk != nil {
+	if lastChunk := accumulator.getLastTranscriptionChunkLocked(); lastChunk != nil {
 		if lastChunk.TokenUsage != nil {
 			data.TokenUsage = &schemas.BifrostLLMUsage{}
 			if lastChunk.TokenUsage.InputTokens != nil {

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -144,6 +144,12 @@ type StreamAccumulator struct {
 func (sa *StreamAccumulator) getLastChatChunk() *ChatStreamChunk {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
+	return sa.getLastChatChunkLocked()
+}
+
+// getLastChatChunkLocked returns the chunk with the highest ChunkIndex.
+// MUST be called with sa.mu already held.
+func (sa *StreamAccumulator) getLastChatChunkLocked() *ChatStreamChunk {
 	if sa.MaxChatChunkIndex < 0 {
 		return nil
 	}
@@ -159,6 +165,12 @@ func (sa *StreamAccumulator) getLastChatChunk() *ChatStreamChunk {
 func (sa *StreamAccumulator) getLastResponsesChunk() *ResponsesStreamChunk {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
+	return sa.getLastResponsesChunkLocked()
+}
+
+// getLastResponsesChunkLocked returns the chunk with the highest ChunkIndex.
+// MUST be called with sa.mu already held.
+func (sa *StreamAccumulator) getLastResponsesChunkLocked() *ResponsesStreamChunk {
 	if sa.MaxResponsesChunkIndex < 0 {
 		return nil
 	}
@@ -174,6 +186,12 @@ func (sa *StreamAccumulator) getLastResponsesChunk() *ResponsesStreamChunk {
 func (sa *StreamAccumulator) getLastTranscriptionChunk() *TranscriptionStreamChunk {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
+	return sa.getLastTranscriptionChunkLocked()
+}
+
+// getLastTranscriptionChunkLocked returns the chunk with the highest ChunkIndex.
+// MUST be called with sa.mu already held.
+func (sa *StreamAccumulator) getLastTranscriptionChunkLocked() *TranscriptionStreamChunk {
 	if sa.MaxTranscriptionChunkIndex < 0 {
 		return nil
 	}
@@ -189,6 +207,12 @@ func (sa *StreamAccumulator) getLastTranscriptionChunk() *TranscriptionStreamChu
 func (sa *StreamAccumulator) getLastAudioChunk() *AudioStreamChunk {
 	sa.mu.Lock()
 	defer sa.mu.Unlock()
+	return sa.getLastAudioChunkLocked()
+}
+
+// getLastAudioChunkLocked returns the chunk with the highest ChunkIndex.
+// MUST be called with sa.mu already held.
+func (sa *StreamAccumulator) getLastAudioChunkLocked() *AudioStreamChunk {
 	if sa.MaxAudioChunkIndex < 0 {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Fixed potential race conditions in streaming accumulator methods by introducing locked variants that can be safely called when a mutex is already held.

## Changes

- Added new `*Locked` methods for all streaming chunk getters that can be called when the mutex is already held
- Updated existing code to use these locked variants when appropriate
- Fixed test assertions to use the correct path to access key values
- Updated container name in docker-compose to avoid conflicts with other services

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./framework/streaming/...
go test ./framework/configstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change addresses potential race conditions that could lead to unpredictable behavior in streaming operations.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)