### PR TITLE
soplugin test fixes

### DIFF
--- a/framework/plugins/soplugin_test.go
+++ b/framework/plugins/soplugin_test.go
@@ -382,8 +382,9 @@ func buildHelloWorldPlugin(t *testing.T) string {
 		pluginExt = ".dll"
 	}
 
-	// Create build directory
+	// Clean and create build directory to ensure fresh build with current Go version
 	buildDir := filepath.Join(absPluginDir, "build")
+	os.RemoveAll(buildDir)
 	err = os.MkdirAll(buildDir, 0755)
 	require.NoError(t, err, "Failed to create build directory")
 
@@ -558,14 +559,10 @@ func buildHelloWorldPluginForBenchmark(b *testing.B) string {
 		pluginExt = ".dll"
 	}
 
-	// Check if plugin already exists
-	pluginPath := filepath.Join(absPluginDir, "build", "hello-world"+pluginExt)
-	if _, err := os.Stat(pluginPath); err == nil {
-		return pluginPath
-	}
-
-	// Create build directory
+	// Clean and create build directory to ensure fresh build with current Go version
 	buildDir := filepath.Join(absPluginDir, "build")
+	pluginPath := filepath.Join(buildDir, "hello-world"+pluginExt)
+	os.RemoveAll(buildDir)
 	err = os.MkdirAll(buildDir, 0755)
 	require.NoError(b, err, "Failed to create build directory")
 

--- a/framework/vectorstore/qdrant_test.go
+++ b/framework/vectorstore/qdrant_test.go
@@ -166,12 +166,11 @@ func TestQdrantConfig_Validation(t *testing.T) {
 			errorMsg:    "qdrant host is required",
 		},
 		{
-			name: "missing port",
+			name: "missing port uses default",
 			config: QdrantConfig{
 				Host: *schemas.NewEnvVar("localhost"),
 			},
-			expectError: true,
-			errorMsg:    "qdrant port is required",
+			expectError: false, // Port defaults to 6334 via CoerceInt fallback
 		},
 		{
 			name: "with api key",


### PR DESCRIPTION
## Summary

Improve plugin test reliability by ensuring fresh builds with the current Go version and fix Qdrant port validation to use default value when not specified.

## Changes

- Modified `buildHelloWorldPlugin` and `buildHelloWorldPluginForBenchmark` to clean the build directory before each test run, ensuring plugins are always built with the current Go version
- Removed caching logic in `buildHelloWorldPluginForBenchmark` that could lead to stale plugin builds
- Fixed Qdrant config validation test to correctly reflect that missing port uses the default value (6334) rather than returning an error

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Test plugin functionality
go test ./framework/plugins -v

# Test Qdrant configuration
go test ./framework/vectorstore -v -run=TestQdrantConfig_Validation
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes potential test failures when running with different Go versions.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable