### PR TITLE
adds race flag for compiling plugin

### DIFF
--- a/examples/plugins/hello-world/go.mod
+++ b/examples/plugins/hello-world/go.mod
@@ -2,7 +2,7 @@ module github.com/maximhq/bifrost/examples/plugins/hello-world
 
 go 1.25.5
 
-require github.com/maximhq/bifrost/core v1.3.8
+require github.com/maximhq/bifrost/core v1.3.9
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/examples/plugins/hello-world/go.sum
+++ b/examples/plugins/hello-world/go.sum
@@ -39,8 +39,8 @@ github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
 github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy/I=
 github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
-github.com/maximhq/bifrost/core v1.3.8 h1:xtwB9+HeTzYz5IKHkpUtupzBd0A5yl1avdLJGjsOKPI=
-github.com/maximhq/bifrost/core v1.3.8/go.mod h1:abKQRnJQPZz8/UMxCcbuNHEyq19Db+IX4KlGJdlLY8E=
+github.com/maximhq/bifrost/core v1.3.9 h1:mlJBEn9fsrJTcEjb88oDTAuAjtlPojALOOFnkrfcC4A=
+github.com/maximhq/bifrost/core v1.3.9/go.mod h1:abKQRnJQPZz8/UMxCcbuNHEyq19Db+IX4KlGJdlLY8E=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/framework/plugins/race_disabled.go
+++ b/framework/plugins/race_disabled.go
@@ -1,0 +1,6 @@
+//go:build !race
+
+package plugins
+
+// raceEnabled indicates if the binary was built with race detection
+const raceEnabled = false

--- a/framework/plugins/race_enabled.go
+++ b/framework/plugins/race_enabled.go
@@ -1,0 +1,6 @@
+//go:build race
+
+package plugins
+
+// raceEnabled indicates if the binary was built with race detection
+const raceEnabled = true

--- a/framework/plugins/soplugin_test.go
+++ b/framework/plugins/soplugin_test.go
@@ -390,7 +390,12 @@ func buildHelloWorldPlugin(t *testing.T) string {
 
 	// Build the plugin directly with go build
 	pluginPath := filepath.Join(buildDir, "hello-world"+pluginExt)
-	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", pluginPath, "main.go")
+	args := []string{"build", "-buildmode=plugin", "-o", pluginPath}
+	if raceEnabled {
+		args = append(args, "-race")
+	}
+	args = append(args, "main.go")
+	cmd := exec.Command("go", args...)
 	cmd.Dir = absPluginDir
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
 	output, err := cmd.CombinedOutput()
@@ -567,7 +572,12 @@ func buildHelloWorldPluginForBenchmark(b *testing.B) string {
 	require.NoError(b, err, "Failed to create build directory")
 
 	// Build the plugin directly with go build
-	cmd := exec.Command("go", "build", "-buildmode=plugin", "-o", pluginPath, "main.go")
+	args := []string{"build", "-buildmode=plugin", "-o", pluginPath}
+	if raceEnabled {
+		args = append(args, "-race")
+	}
+	args = append(args, "main.go")
+	cmd := exec.Command("go", args...)
 	cmd.Dir = absPluginDir
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
 	output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

Add race detection support for plugin tests and update the hello-world plugin dependency.

## Changes

- Added race detection capability to plugin tests by conditionally including the `-race` flag when building test plugins
- Created two build-tag specific files (`race_enabled.go` and `race_disabled.go`) to detect if the binary was built with race detection
- Updated the hello-world plugin dependency from `github.com/maximhq/bifrost/core v1.3.8` to `v1.3.9`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the plugin tests with race detection enabled:

```sh
go test -race ./framework/plugins/...
```

Verify that the tests pass both with and without the race flag.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves test reliability by enabling race detection in plugin tests.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable