### PR TITLE
docs: openrouter with claude code issue documentation

### DIFF
--- a/docs/quickstart/gateway/cli-agents.mdx
+++ b/docs/quickstart/gateway/cli-agents.mdx
@@ -143,13 +143,17 @@ Run `/model` without arguments to check your current model. The switch is instan
 If you use Claude-specific features like **web search**, **computer use**, or **citations**, ensure the model you switch to also supports these capabilities. Non-Claude models or Claude models on certain providers may not support all features.
 </Warning>
 
-#### Model Selection Guide
+#### Provider Compatibility
 
-| Model | Best For | Cost |
-|-------|----------|------|
-| **Sonnet 4.5** | Daily development, general coding tasks | Medium |
-| **Opus 4.5** | Complex reasoning, architectural decisions, state-of-the-art engineering | High |
-| **Haiku 4.5** | Lightweight agents, high-frequency tasks, quick iterations | Low |
+<Warning>
+**Not all providers work well with Claude Code**. Since Claude Code heavily relies on tool calling for file operations, terminal commands, and code editing, providers must properly support and stream tool call arguments.
+
+**Known Issues:**
+- **OpenRouter**: Does not stream function call arguments properly. Tool calls return with empty `arguments` fields, causing Claude Code to fail when attempting file operations or other tool-based actions.
+- **Some proxy providers**: May not fully implement the Anthropic API streaming specification for tool calls.
+
+If you experience issues with tool calls not executing properly, try switching to a different provider in your Bifrost configuration.
+</Warning>
 
 #### Example: Full Bifrost Setup
 


### PR DESCRIPTION
## Summary

Updated the CLI Agents documentation to include provider compatibility warnings for Claude Code, replacing the previous model selection guide.

## Changes

- Replaced the "Model Selection Guide" table with a new "Provider Compatibility" section
- Added a warning about compatibility issues when using Claude Code with certain providers
- Specifically noted that OpenRouter doesn't stream function call arguments properly
- Mentioned that some proxy providers may not fully implement the Anthropic API streaming specification
- Added guidance to try switching providers if users experience tool call execution issues

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. View the updated documentation page at `docs/quickstart/gateway/cli-agents.mdx`
2. Verify the "Provider Compatibility" section appears correctly
3. Ensure the warning formatting is properly displayed

## Breaking changes

- [x] No

## Related issues

Documents known issues with certain providers when using Claude Code's tool calling capabilities.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)