### PR TITLE
fix: parse model provider when sending raw request to anthropic

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -39,6 +39,13 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		if err := sonic.Unmarshal(jsonBody, &requestBody); err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, fmt.Errorf("failed to unmarshal request body: %w", err), providerName)
 		}
+		// update model with provider model
+		if modelVal, exists := requestBody["model"]; exists {
+			if modelStr, ok := modelVal.(string); ok {
+				_, model := schemas.ParseModelString(modelStr, schemas.Anthropic)
+				requestBody["model"] = model
+			}
+		}
 		// Add max_tokens if not present
 		if _, exists := requestBody["max_tokens"]; !exists {
 			requestBody["max_tokens"] = AnthropicDefaultMaxTokens


### PR DESCRIPTION
## Summary

Update the Anthropic provider to use the correct model name from the provider when making requests.

## Changes

- Added logic to update the model parameter in the request body with the provider-specific model name
- Uses `schemas.ParseModelString` to extract the provider model from the model string
- Only applies this change when the "model" field exists in the request body

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test that Anthropic requests use the correct model name:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

You can also test by making a request to the Anthropic provider and verifying that the model name is correctly transformed.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses issues with model name handling in Anthropic provider requests.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable