### PR TITLE
fix(helm): add top-level auth_config support for Bifrost authentication

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 1.5.2
+version: 1.5.3
 appVersion: "1.5.2"
 keywords:
   - ai

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -313,6 +313,27 @@ false
 {{- $_ := set $config "governance" $governance }}
 {{- end }}
 {{- end }}
+{{- /* Top-level Auth Config - for main Bifrost authentication */ -}}
+{{- if .Values.bifrost.authConfig }}
+{{- $authConfig := dict }}
+{{- /* Only use env var reference if governance auth secret is NOT already configured (to avoid referencing uninjected env vars) */ -}}
+{{- if and .Values.bifrost.authConfig.existingSecret .Values.bifrost.authConfig.usernameKey (not (and .Values.bifrost.governance .Values.bifrost.governance.authConfig .Values.bifrost.governance.authConfig.existingSecret)) }}
+{{- $_ := set $authConfig "admin_username" "env.BIFROST_ADMIN_USERNAME" }}
+{{- else if .Values.bifrost.authConfig.adminUsername }}
+{{- $_ := set $authConfig "admin_username" .Values.bifrost.authConfig.adminUsername }}
+{{- end }}
+{{- if and .Values.bifrost.authConfig.existingSecret .Values.bifrost.authConfig.passwordKey (not (and .Values.bifrost.governance .Values.bifrost.governance.authConfig .Values.bifrost.governance.authConfig.existingSecret)) }}
+{{- $_ := set $authConfig "admin_password" "env.BIFROST_ADMIN_PASSWORD" }}
+{{- else if .Values.bifrost.authConfig.adminPassword }}
+{{- $_ := set $authConfig "admin_password" .Values.bifrost.authConfig.adminPassword }}
+{{- end }}
+{{- if hasKey .Values.bifrost.authConfig "isEnabled" }}
+{{- $_ := set $authConfig "is_enabled" .Values.bifrost.authConfig.isEnabled }}
+{{- end }}
+{{- if or $authConfig.admin_username $authConfig.admin_password $authConfig.is_enabled }}
+{{- $_ := set $config "auth_config" $authConfig }}
+{{- end }}
+{{- end }}
 {{- /* Cluster Config */ -}}
 {{- if and .Values.bifrost.cluster .Values.bifrost.cluster.enabled }}
 {{- $cluster := dict "enabled" true }}

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -131,6 +131,19 @@ spec:
                   name: {{ .Values.bifrost.governance.authConfig.existingSecret }}
                   key: {{ .Values.bifrost.governance.authConfig.passwordKey | default "password" }}
             {{- end }}
+            {{- /* Top-level auth credentials from existing secret (reuses same env vars as governance) */ -}}
+            {{- if and .Values.bifrost.authConfig .Values.bifrost.authConfig.existingSecret (not (and .Values.bifrost.governance .Values.bifrost.governance.authConfig .Values.bifrost.governance.authConfig.existingSecret)) }}
+            - name: BIFROST_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bifrost.authConfig.existingSecret }}
+                  key: {{ .Values.bifrost.authConfig.usernameKey | default "username" }}
+            - name: BIFROST_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bifrost.authConfig.existingSecret }}
+                  key: {{ .Values.bifrost.authConfig.passwordKey | default "password" }}
+            {{- end }}
             {{- /* Provider secrets */ -}}
             {{- range $provider, $secret := .Values.bifrost.providerSecrets }}
             {{- if and $secret.existingSecret $secret.envVar }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -58,7 +58,7 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}    
+  annotations: {}
   hosts:
     - host: bifrost.local
       paths:
@@ -114,17 +114,28 @@ affinity: {}
 # Bifrost specific configuration
 # You can find entire schema at https://getbifrost.ai/schema
 bifrost:
-  # Application settings    
+  # Application settings
   appDir: /app/data
   port: 8080
   host: 0.0.0.0
   logLevel: info
   logStyle: json
-  
+
   # Encryption key for sensitive data
   # Can be set as a secret or environment variable
   encryptionKey: ""
-  
+
+  # Authentication configuration (top-level)
+  # This controls authentication for Bifrost API and dashboard
+  authConfig:
+    adminUsername: ""
+    adminPassword: ""
+    isEnabled: false
+    # Use existing Kubernetes secret for admin credentials
+    existingSecret: ""
+    usernameKey: "username"
+    passwordKey: "password"
+
   # Client configuration
   client:
     dropExcessRequests: false
@@ -140,7 +151,7 @@ bifrost:
     maxRequestBodySizeMb: 100
     enableLitellmFallbacks: false
     prometheusLabels: []
-  
+
   # Framework configuration
   framework:
     pricing:
@@ -148,7 +159,7 @@ bifrost:
       pricingUrl: ""
       # Sync interval in seconds (default: 86400 = 24 hours, minimum: 3600)
       pricingSyncInterval: 86400
-  
+
   # Provider configurations (add your provider keys here)
   # You can specify API keys directly or use env.VAR_NAME syntax to reference environment variables
   # When using existingSecret in providerSecrets, the keys will be injected as env vars and
@@ -164,7 +175,7 @@ bifrost:
     #   keys:
     #     - value: "sk-ant-..."
     #       weight: 1
-  
+
   # Provider secrets - use existing Kubernetes secrets for provider API keys
   # These will be injected as environment variables that can be referenced in providers config
   providerSecrets: {}
@@ -176,7 +187,7 @@ bifrost:
     #   existingSecret: "my-anthropic-secret"
     #   key: "api-key"
     #   envVar: "ANTHROPIC_API_KEY"
-  
+
   # MCP (Model Context Protocol) configuration
   mcp:
     enabled: false
@@ -187,22 +198,22 @@ bifrost:
       #     command: "/path/to/mcp/server"
       #     args: []
       #     envs: []
-  
+
   # Plugins configuration
   plugins:
     telemetry:
       enabled: false
       config: {}
-    
+
     logging:
       enabled: false
       config: {}
-    
+
     governance:
       enabled: false
       config:
         is_vk_mandatory: false
-    
+
     maxim:
       enabled: false
       config:
@@ -212,7 +223,7 @@ bifrost:
       secretRef:
         name: ""
         key: "api-key"
-    
+
     semanticCache:
       enabled: false
       config:
@@ -226,7 +237,7 @@ bifrost:
         cache_by_model: true
         cache_by_provider: true
         exclude_system_prompt: false
-    
+
     otel:
       enabled: false
       config:
@@ -234,7 +245,7 @@ bifrost:
         collector_url: ""
         trace_type: "otel"
         protocol: "grpc"
-    
+
     datadog:
       enabled: false
       config:
@@ -244,7 +255,7 @@ bifrost:
         version: ""
         custom_tags: {}
         enable_traces: true
-  
+
   # Governance configuration for budgets, rate limits, customers, teams, and virtual keys
   governance:
     budgets: []
@@ -283,7 +294,7 @@ bifrost:
       existingSecret: ""
       usernameKey: "username"
       passwordKey: "password"
-  
+
   # Cluster mode configuration for distributed deployments
   cluster:
     enabled: false
@@ -314,7 +325,7 @@ bifrost:
       etcdEndpoints: []
       # mDNS discovery
       mdnsService: ""
-  
+
   # SAML/SCIM configuration for enterprise SSO
   saml:
     enabled: false
@@ -339,13 +350,13 @@ bifrost:
       # userIdField: "oid"
       # teamIdsField: "groups"
       # rolesField: "roles"
-  
+
   # Load balancer configuration for intelligent request routing
   loadBalancer:
     enabled: false
     trackerConfig: {}
     bootstrap: {}
-  
+
   # Guardrails configuration for content moderation and policy enforcement
   guardrails:
     rules: []
@@ -369,7 +380,7 @@ storage:
   # Default storage mode: sqlite or postgres
   # Used as fallback when per-store type is not specified
   mode: sqlite  # Options: sqlite, postgres
-  
+
   # Persistent volume for SQLite databases (when using sqlite for any store)
   persistence:
     enabled: true
@@ -377,13 +388,13 @@ storage:
     accessMode: ReadWriteOnce
     size: 10Gi
     # existingClaim: ""  # Use an existing PVC
-  
+
   # Configuration store settings
   configStore:
     enabled: true
     # Backend type for config store. Empty string uses storage.mode as default
     type: ""  # Options: sqlite, postgres, or "" (uses storage.mode)
-  
+
   # Logs store settings
   logsStore:
     enabled: true
@@ -394,7 +405,7 @@ storage:
 postgresql:
   # Deploy PostgreSQL as part of this chart
   enabled: false
-  
+
   # Use external PostgreSQL instance
   external:
     enabled: false
@@ -407,24 +418,24 @@ postgresql:
     # Use existing Kubernetes secret for password (takes precedence over password field)
     existingSecret: ""
     passwordKey: "password"
-  
+
   # PostgreSQL image configuration
   image:
     repository: postgres
     tag: "16-alpine"
     pullPolicy: IfNotPresent
-  
+
   # PostgreSQL subchart configuration (when postgresql.enabled is true)
   auth:
     username: bifrost
     password: bifrost_password
     database: bifrost
-  
+
   primary:
     persistence:
       enabled: true
       size: 8Gi
-    
+
     resources:
       limits:
         cpu: 1000m
@@ -432,7 +443,7 @@ postgresql:
       requests:
         cpu: 250m
         memory: 256Mi
-  
+
   metrics:
     enabled: false
 
@@ -441,12 +452,12 @@ vectorStore:
   # Enable vector store for semantic caching
   enabled: false
   type: none  # Options: none, weaviate, redis, qdrant
-  
+
   # Weaviate configuration
   weaviate:
     # Deploy Weaviate as part of this chart
     enabled: false
-    
+
     # Use external Weaviate instance
     external:
       enabled: false
@@ -458,18 +469,18 @@ vectorStore:
       # Use existing Kubernetes secret for API key (takes precedence over apiKey field)
       existingSecret: ""
       apiKeyKey: "api-key"
-    
+
     # Weaviate subchart configuration (when weaviate.enabled is true)
     replicas: 1
-    
+
     image:
       repository: semitechnologies/weaviate
       tag: "1.24.1"
-    
+
     persistence:
       enabled: true
       size: 10Gi
-    
+
     resources:
       limits:
         cpu: 1000m
@@ -477,7 +488,7 @@ vectorStore:
       requests:
         cpu: 500m
         memory: 1Gi
-    
+
     env:
       QUERY_DEFAULTS_LIMIT: "25"
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
@@ -485,12 +496,12 @@ vectorStore:
       DEFAULT_VECTORIZER_MODULE: "none"
       ENABLE_MODULES: ""
       CLUSTER_HOSTNAME: "node1"
-  
+
   # Redis configuration
   redis:
     # Deploy Redis as part of this chart
     enabled: false
-    
+
     # Use external Redis instance
     external:
       enabled: false
@@ -501,23 +512,23 @@ vectorStore:
       # Use existing Kubernetes secret for password (takes precedence over password field)
       existingSecret: ""
       passwordKey: "password"
-    
+
     # Redis image configuration
     image:
       repository: redis
       tag: "7-alpine"
       pullPolicy: IfNotPresent
-    
+
     # Redis subchart configuration (when redis.enabled is true)
     auth:
       enabled: true
       password: "redis_password"
-    
+
     master:
       persistence:
         enabled: true
         size: 8Gi
-      
+
       resources:
         limits:
           cpu: 500m
@@ -525,7 +536,7 @@ vectorStore:
         requests:
           cpu: 250m
           memory: 256Mi
-    
+
     metrics:
       enabled: false
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,28 @@ apiVersion: v1
 entries:
   bifrost:
   - apiVersion: v2
+    appVersion: 1.5.3
+    created: "2026-01-16T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.5.3.tgz
+    version: 1.5.3
+  - apiVersion: v2
     appVersion: 1.5.2
     created: "2026-01-05T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
@@ -122,7 +144,7 @@ entries:
     keywords:
     - ai
     - gateway
-    - llm    
+    - llm
     maintainers:
     - email: akshay@getmaxim.ai
       name: Bifrost Team
@@ -157,4 +179,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-01-05T12:00:00.000000+00:00"
+generated: "2026-01-16T12:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Adds support for top-level `auth_config` in the Helm chart configuration. The existing `governance.authConfig` was placing `auth_config` inside the `governance` object, but the Bifrost code expects it at the **top level** of `config.json` for authentication to work.

## Changes

- **values.yaml**: Added new `bifrost.authConfig` section with `adminUsername`, `adminPassword`, `isEnabled`, and secret reference support
- **_helpers.tpl**: Added template logic to output `auth_config` at the config root level
- **deployment.yaml**: Reuses existing `BIFROST_ADMIN_USERNAME` and `BIFROST_ADMIN_PASSWORD` env vars when using existing secrets
- **Chart.yaml**: Bumped version from 1.5.2 → 1.5.3

The existing `bifrost.governance.authConfig` is preserved for backward compatibility.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Render the Helm template and verify auth_config is at top level
cd helm-charts/bifrost
helm template test . \
  --set image.tag=v1.5.0 \
  --set bifrost.authConfig.adminUsername=admin \
  --set bifrost.authConfig.adminPassword=secret123 \
  --set bifrost.authConfig.isEnabled=true \
  | grep -A 20 "config.json"
```

Expected: `auth_config` should appear at the root level of the JSON config, not nested inside `governance`:

```json
{
  "auth_config": {
    "admin_username": "admin",
    "admin_password": "secret123",
    "is_enabled": true
  },
  ...
}
```

## Screenshots/Recordings

N/A - Helm chart changes only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- Auth credentials can be provided via `existingSecret` to avoid storing passwords in values
- Reuses existing `BIFROST_ADMIN_USERNAME` and `BIFROST_ADMIN_PASSWORD` env vars

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
