### PR TITLE
fix: openai responses compliance

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -865,13 +865,18 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 				Model:    "claude-3-sonnet",
 				Input: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello, world!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -917,13 +922,18 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 						},
 					},
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -957,13 +967,18 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 				Model:    "claude-3-sonnet",
 				Input: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -1002,13 +1017,18 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 				Model:    "claude-3-sonnet",
 				Input: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -1066,13 +1086,18 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 				Model:    "claude-3-sonnet",
 				Input: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("What's the weather?"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -1136,13 +1161,18 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 				Model:    "claude-3-sonnet",
 				Input: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -1933,13 +1963,18 @@ func TestBedrockToBifrostResponseConversion(t *testing.T) {
 			expected: &schemas.BifrostResponsesResponse{
 				Output: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesOutputMessageContentTypeText,
 									Text: schemas.Ptr("Hello, world!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},
@@ -1970,13 +2005,18 @@ func TestBedrockToBifrostResponseConversion(t *testing.T) {
 			expected: &schemas.BifrostResponsesResponse{
 				Output: []schemas.ResponsesMessage{
 					{
-						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Status: schemas.Ptr("completed"),
 						Content: &schemas.ResponsesMessageContent{
 							ContentBlocks: []schemas.ResponsesMessageContentBlock{
 								{
 									Type: schemas.ResponsesOutputMessageContentTypeText,
 									Text: schemas.Ptr("Hello!"),
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
 								},
 							},
 						},

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -254,11 +254,16 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 				responses = append(responses, reasoningDoneResponse)
 
 				// Emit content_part.done for reasoning
+				part := &schemas.ResponsesMessageContentBlock{
+					Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+					Text: &emptyText,
+				}
 				partDoneResponse := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 					SequenceNumber: sequenceNumber + len(responses),
 					OutputIndex:    schemas.Ptr(prevOutputIndex),
 					ContentIndex:   &reasoningContentIndex,
+					Part:           part,
 				}
 				if itemID != "" {
 					partDoneResponse.ItemID = &itemID
@@ -267,8 +272,15 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 
 				// Emit output_item.done for reasoning
 				statusCompleted := "completed"
+				messageType := schemas.ResponsesMessageTypeReasoning
+				role := schemas.ResponsesInputMessageRoleAssistant
 				doneItem := &schemas.ResponsesMessage{
+					Type:   &messageType,
+					Role:   &role,
 					Status: &statusCompleted,
+					ResponsesReasoning: &schemas.ResponsesReasoning{
+						Summary: []schemas.ResponsesReasoningSummary{},
+					},
 				}
 				if itemID != "" {
 					doneItem.ID = &itemID
@@ -310,12 +322,22 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 				accumulatedArgs := state.ToolArgumentBuffers[prevOutputIndex]
 
 				// Emit content_part.done for tool call
+				emptyText := ""
+				part := &schemas.ResponsesMessageContentBlock{
+					Type: schemas.ResponsesOutputMessageContentTypeText,
+					Text: &emptyText,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+					},
+				}
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 					SequenceNumber: sequenceNumber + len(responses),
 					OutputIndex:    schemas.Ptr(prevOutputIndex),
 					ContentIndex:   schemas.Ptr(prevContentIndex),
 					ItemID:         &prevItemID,
+					Part:           part,
 				})
 
 				// Emit function_call_arguments.done with full arguments
@@ -450,11 +472,16 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 						responses = append(responses, reasoningDoneResponse)
 
 						// Emit content_part.done for reasoning
+						part := &schemas.ResponsesMessageContentBlock{
+							Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+							Text: &emptyText,
+						}
 						partDoneResponse := &schemas.BifrostResponsesStreamResponse{
 							Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 							SequenceNumber: sequenceNumber + len(responses),
 							OutputIndex:    schemas.Ptr(prevOutputIndex),
 							ContentIndex:   &reasoningContentIndex,
+							Part:           part,
 						}
 						if itemID != "" {
 							partDoneResponse.ItemID = &itemID
@@ -463,8 +490,15 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 
 						// Emit output_item.done for reasoning
 						statusCompleted := "completed"
+						messageType := schemas.ResponsesMessageTypeReasoning
+						role := schemas.ResponsesInputMessageRoleAssistant
 						doneItem := &schemas.ResponsesMessage{
+							Type:   &messageType,
+							Role:   &role,
 							Status: &statusCompleted,
+							ResponsesReasoning: &schemas.ResponsesReasoning{
+								Summary: []schemas.ResponsesReasoningSummary{},
+							},
 						}
 						if itemID != "" {
 							doneItem.ID = &itemID
@@ -528,6 +562,10 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 				part := &schemas.ResponsesMessageContentBlock{
 					Type: schemas.ResponsesOutputMessageContentTypeText,
 					Text: &emptyText,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+					},
 				}
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeContentPartAdded,
@@ -549,6 +587,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 					OutputIndex:    schemas.Ptr(outputIndex),
 					ContentIndex:   &contentBlockIndex,
 					Delta:          &text,
+					LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 				}
 				if itemID != "" {
 					textDeltaResponse.ItemID = &itemID
@@ -574,6 +613,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 					OutputIndex:    schemas.Ptr(outputIndex),
 					ContentIndex:   &contentBlockIndex,
 					Delta:          &text,
+					LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 				}
 				if itemID != "" {
 					response.ItemID = &itemID
@@ -768,12 +808,22 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 			// This is a tool call that needs to be closed
 
 			// Emit content_part.done for tool call
+			emptyText := ""
+			part := &schemas.ResponsesMessageContentBlock{
+				Type: schemas.ResponsesOutputMessageContentTypeText,
+				Text: &emptyText,
+				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+				},
+			}
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 				SequenceNumber: sequenceNumber + len(responses),
 				OutputIndex:    schemas.Ptr(outputIndex),
 				ContentIndex:   &contentIndex,
 				ItemID:         &itemID,
+				Part:           part,
 			})
 
 			// Emit function_call_arguments.done with full arguments
@@ -841,21 +891,38 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 				ContentIndex:   &contentIndex,
 				ItemID:         &itemID,
 				Text:           &emptyText,
+				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 			})
 
 			// Emit content_part.done for text
+			part := &schemas.ResponsesMessageContentBlock{
+				Type: schemas.ResponsesOutputMessageContentTypeText,
+				Text: &emptyText,
+				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+				},
+			}
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 				SequenceNumber: sequenceNumber + len(responses),
 				OutputIndex:    schemas.Ptr(outputIndex),
 				ContentIndex:   &contentIndex,
 				ItemID:         &itemID,
+				Part:           part,
 			})
 
 			// Emit output_item.done for text
 			statusCompleted := "completed"
+			messageType := schemas.ResponsesMessageTypeMessage
+			role := schemas.ResponsesInputMessageRoleAssistant
 			doneItem := &schemas.ResponsesMessage{
+				Type:   &messageType,
+				Role:   &role,
 				Status: &statusCompleted,
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+				},
 			}
 			if itemID != "" {
 				doneItem.ID = &itemID
@@ -905,11 +972,16 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 		responses = append(responses, reasoningDoneResponse)
 
 		// Emit content_part.done for reasoning
+		part := &schemas.ResponsesMessageContentBlock{
+			Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+			Text: &emptyText,
+		}
 		partDoneResponse := &schemas.BifrostResponsesStreamResponse{
 			Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 			SequenceNumber: sequenceNumber + len(responses),
 			OutputIndex:    schemas.Ptr(outputIndex),
 			ContentIndex:   &reasoningContentIndex,
+			Part:           part,
 		}
 		if itemID != "" {
 			partDoneResponse.ItemID = &itemID
@@ -918,8 +990,15 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 
 		// Emit output_item.done for reasoning
 		statusCompleted := "completed"
+		messageType := schemas.ResponsesMessageTypeReasoning
+		role := schemas.ResponsesInputMessageRoleAssistant
 		doneItem := &schemas.ResponsesMessage{
+			Type:   &messageType,
+			Role:   &role,
 			Status: &statusCompleted,
+			ResponsesReasoning: &schemas.ResponsesReasoning{
+				Summary: []schemas.ResponsesReasoningSummary{},
+			},
 		}
 		if itemID != "" {
 			doneItem.ID = &itemID
@@ -2601,16 +2680,22 @@ func createTextMessage(
 	textBlockType schemas.ResponsesMessageContentBlockType,
 	isOutputMessage bool,
 ) schemas.ResponsesMessage {
+	contentBlock := schemas.ResponsesMessageContentBlock{
+		Type: textBlockType,
+		Text: text,
+	}
+	if textBlockType == schemas.ResponsesOutputMessageContentTypeText {
+		contentBlock.ResponsesOutputMessageContentText = &schemas.ResponsesOutputMessageContentText{
+			Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+			LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+		}
+	}
 	bifrostMsg := schemas.ResponsesMessage{
-		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-		Role: &role,
+		Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Status: schemas.Ptr("completed"),
+		Role:   &role,
 		Content: &schemas.ResponsesMessageContent{
-			ContentBlocks: []schemas.ResponsesMessageContentBlock{
-				{
-					Type: textBlockType,
-					Text: text,
-				},
-			},
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{contentBlock},
 		},
 	}
 	if isOutputMessage {

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -143,7 +143,9 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 
 	// Create the BifrostResponse with Responses structure
 	bifrostResp := &schemas.BifrostResponsesResponse{
-		Model: response.ModelVersion,
+		ID:        schemas.Ptr("resp_" + providerUtils.GetRandomString(50)),
+		CreatedAt: int(time.Now().Unix()),
+		Model:     response.ModelVersion,
 	}
 
 	// Convert usage information
@@ -838,9 +840,10 @@ func processGeminiTextPart(part *Part, state *GeminiResponsesStreamState, sequen
 			OutputIndex:    &outputIndex,
 			ItemID:         &itemID,
 			Item: &schemas.ResponsesMessage{
-				ID:   &itemID,
-				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+				ID:     &itemID,
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Status: schemas.Ptr("in_progress"),
+				Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 				Content: &schemas.ResponsesMessageContent{
 					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
 				},
@@ -858,6 +861,10 @@ func processGeminiTextPart(part *Part, state *GeminiResponsesStreamState, sequen
 			Part: &schemas.ResponsesMessageContentBlock{
 				Type: schemas.ResponsesOutputMessageContentTypeText,
 				Text: schemas.Ptr(""),
+				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+				},
 			},
 		})
 
@@ -883,6 +890,7 @@ func processGeminiTextPart(part *Part, state *GeminiResponsesStreamState, sequen
 			ContentIndex:   &contentIndex,
 			ItemID:         &itemID,
 			Delta:          &text,
+			LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 		}
 		if len(part.ThoughtSignature) > 0 {
 			thoughtSig := base64.StdEncoding.EncodeToString(part.ThoughtSignature)
@@ -967,7 +975,12 @@ func processGeminiThoughtPart(part *Part, state *GeminiResponsesStreamState, seq
 		ItemID:         &itemID,
 		Item: &schemas.ResponsesMessage{
 			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 			Status: &statusCompleted,
+			ResponsesReasoning: &schemas.ResponsesReasoning{
+				Summary: []schemas.ResponsesReasoningSummary{},
+			},
 		},
 	})
 
@@ -1017,7 +1030,13 @@ func processGeminiThoughtSignaturePart(part *Part, state *GeminiResponsesStreamS
 		ItemID:         &itemID,
 		Item: &schemas.ResponsesMessage{
 			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 			Status: &statusCompleted,
+			ResponsesReasoning: &schemas.ResponsesReasoning{
+				Summary:          []schemas.ResponsesReasoningSummary{},
+				EncryptedContent: &thoughtSig,
+			},
 		},
 	})
 
@@ -1162,9 +1181,24 @@ func processGeminiFunctionResponsePart(part *Part, state *GeminiResponsesStreamS
 		ItemID:         &itemID,
 		Item: &schemas.ResponsesMessage{
 			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 			Status: &status,
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID: &responseID,
+				Output: &schemas.ResponsesToolMessageOutputStruct{
+					ResponsesToolCallOutputStr: &output,
+				},
+			},
 		},
 	})
+	// Add tool name if present
+	if name := strings.TrimSpace(part.FunctionResponse.Name); name != "" {
+		last := responses[len(responses)-1]
+		if last.Item != nil && last.Item.ResponsesToolMessage != nil {
+			last.Item.ResponsesToolMessage.Name = schemas.Ptr(name)
+		}
+	}
 
 	return responses
 }
@@ -1235,7 +1269,12 @@ func processGeminiInlineDataPart(part *Part, state *GeminiResponsesStreamState, 
 		ItemID:         &itemID,
 		Item: &schemas.ResponsesMessage{
 			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 			Status: &statusCompleted,
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+			},
 		},
 	})
 
@@ -1308,7 +1347,12 @@ func processGeminiFileDataPart(part *Part, state *GeminiResponsesStreamState, se
 		ItemID:         &itemID,
 		Item: &schemas.ResponsesMessage{
 			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 			Status: &statusCompleted,
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+			},
 		},
 	})
 
@@ -1332,20 +1376,35 @@ func closeGeminiTextItem(state *GeminiResponsesStreamState, sequenceNumber int) 
 		ContentIndex:   &contentIndex,
 		ItemID:         &itemID,
 		Text:           &fullText,
+		LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 	})
 
 	// Emit content_part.done
+	part := &schemas.ResponsesMessageContentBlock{
+		Type: schemas.ResponsesOutputMessageContentTypeText,
+		Text: schemas.Ptr(""),
+		ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+			LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+			Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+		},
+	}
 	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 		Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
 		SequenceNumber: sequenceNumber + len(responses),
 		OutputIndex:    &outputIndex,
 		ContentIndex:   &contentIndex,
 		ItemID:         &itemID,
+		Part:           part,
 	})
 
 	// Emit output_item.done
 	doneItem := &schemas.ResponsesMessage{
+		Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 		Status: schemas.Ptr("completed"),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+		},
 	}
 	if itemID != "" {
 		doneItem.ID = &itemID
@@ -1379,6 +1438,12 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, usage *GenerateCont
 	// Close any open tool calls
 	for outputIndex := range state.ToolArgumentBuffers {
 		itemID := state.ItemIDs[outputIndex]
+		toolCallID := state.ToolCallIDs[outputIndex]
+		toolName := state.ToolCallNames[outputIndex]
+		toolArgs := state.ToolArgumentBuffers[outputIndex]
+		if strings.TrimSpace(toolName) == "" {
+			toolName = toolCallID
+		}
 
 		// Emit output_item.done for tool call
 		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
@@ -1388,7 +1453,13 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, usage *GenerateCont
 			ItemID:         &itemID,
 			Item: &schemas.ResponsesMessage{
 				ID:     &itemID,
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
 				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &toolCallID,
+					Name:      &toolName,
+					Arguments: &toolArgs,
+				},
 			},
 		})
 	}
@@ -1830,12 +1901,18 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 			case part.Text != "":
 				// Regular text message
 				msg := schemas.ResponsesMessage{
-					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+					ID:     schemas.Ptr("msg_" + providerUtils.GetRandomString(50)),
+					Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+					Status: schemas.Ptr("completed"),
 					Content: &schemas.ResponsesMessageContent{
 						ContentBlocks: []schemas.ResponsesMessageContentBlock{
 							{
 								Type: schemas.ResponsesOutputMessageContentTypeText,
 								Text: &part.Text,
+								ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+									LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+								},
 							},
 						},
 					},
@@ -1876,8 +1953,10 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 					Arguments: &argumentsStr,
 				}
 				msg := schemas.ResponsesMessage{
+					ID:                   schemas.Ptr("fc_" + providerUtils.GetRandomString(50)),
 					Role:                 schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
 					Type:                 schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+					Status:               schemas.Ptr("completed"),
 					ResponsesToolMessage: toolMsg,
 				}
 				messages = append(messages, msg)
@@ -2523,8 +2602,8 @@ func convertContentBlockToGeminiPart(block schemas.ResponsesMessageContentBlock)
 					data = *urlInfo.DataURLWithoutPrefix
 				}
 
-				// Decode base64 data
-				decodedData, err := base64.StdEncoding.DecodeString(data)
+				// Decode base64 data (handles both standard and URL-safe base64)
+				decodedData, err := decodeBase64StringToBytes(data)
 				if err != nil {
 					return nil, fmt.Errorf("failed to decode base64 image data: %w", err)
 				}
@@ -2547,8 +2626,8 @@ func convertContentBlockToGeminiPart(block schemas.ResponsesMessageContentBlock)
 
 	case schemas.ResponsesInputMessageContentBlockTypeAudio:
 		if block.Audio != nil {
-			// Decode base64 audio data
-			decodedData, err := base64.StdEncoding.DecodeString(block.Audio.Data)
+			// Decode base64 audio data (handles both standard and URL-safe base64)
+			decodedData, err := decodeBase64StringToBytes(block.Audio.Data)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode base64 audio data: %w", err)
 			}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1214,8 +1214,8 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, 
 							})
 						}
 					} else if block.InputAudio != nil {
-						// Decode the audio data (already base64 encoded in the schema)
-						decodedData, err := base64.StdEncoding.DecodeString(block.InputAudio.Data)
+						// Decode the audio data (handles both standard and URL-safe base64)
+						decodedData, err := decodeBase64StringToBytes(block.InputAudio.Data)
 						if err != nil || len(decodedData) == 0 {
 							continue
 						}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -3,16 +3,32 @@ package schemas
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Ptr creates a pointer to any value.
 // This is a helper function for creating pointers to values.
 func Ptr[T any](v T) *T {
 	return &v
+}
+
+// GetRandomString generates a random alphanumeric string of the given length.
+func GetRandomString(length int) string {
+	if length <= 0 {
+		return ""
+	}
+	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
+	letters := []rune("abcdef0123456789")
+	b := make([]rune, length)
+	for i := range b {
+		b[i] = letters[randomSource.Intn(len(letters))]
+	}
+	return string(b)
 }
 
 // ParseModelString extracts provider and model from a model string.

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -228,7 +228,7 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 						return resp.ExtraFields.RawResponse, nil
 					}
 				}
-				return resp, nil
+				return resp.WithDefaults(), nil
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return err
@@ -240,7 +240,11 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 							return string(resp.Type), resp.ExtraFields.RawResponse, nil
 						}
 					}
-					return string(resp.Type), resp, nil
+					converted := resp.WithDefaults()
+					if converted == nil {
+						return "", nil, nil
+					}
+					return string(resp.Type), converted, nil
 				},
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 					return err


### PR DESCRIPTION
## Summary

Add default values to OpenAI Responses API to ensure compatibility with OpenAI's expected response format.

## Changes

- Added `ToOpenAIResponsesResponse` function in both `core/providers/openai` and `transports/bifrost-http/integrations` to convert Bifrost responses to OpenAI format
- Set default values for all required fields in the response structure
- Updated the schema in `core/schemas/responses.go` to include additional fields needed for OpenAI compatibility
- Modified the HTTP transport to use the conversion function when returning responses

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the OpenAI Responses API endpoint to ensure it returns properly formatted responses with all required fields:

```sh
# Core/Transports
go version
go test ./...

# Make a request to the responses endpoint and verify the response format
curl -X POST http://localhost:8080/v1/responses \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes compatibility issues with OpenAI client libraries expecting specific response formats.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable