### PR TITLE
fixes html cases

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -411,16 +411,9 @@ func HandleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.Bif
 	// Try to unmarshal decoded body for RawResponse
 	var rawErrorResponse interface{}
 	if err := sonic.Unmarshal(decodedBody, &rawErrorResponse); err != nil {
-		return &schemas.BifrostError{
-			IsBifrostError: false,
-			StatusCode:     &statusCode,
-			Error: &schemas.ErrorField{
-				Message: string(decodedBody),
-			},
-			ExtraFields: schemas.BifrostErrorExtraFields{
-				RawResponse: string(decodedBody),
-			},
-		}
+		// Store raw body as string for RawResponse when JSON parsing fails
+		// Continue to HTML detection and proper error handling below
+		rawErrorResponse = string(decodedBody)
 	}
 
 	// Check for empty response


### PR DESCRIPTION
## Summary

Improve error handling in the provider API error processing by preserving raw response data even when JSON parsing fails.

## Changes

- Modified the error handling flow in `HandleProviderAPIError` to continue processing after a JSON unmarshal failure
- Instead of immediately returning a BifrostError when JSON parsing fails, the code now stores the raw response as a string and continues with HTML detection and proper error handling
- This ensures consistent error handling regardless of whether the response is valid JSON or not

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with a provider that returns non-JSON error responses:

```sh
# Core/Transports
go version
go test ./core/providers/utils/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves error handling for provider API responses

## Security considerations

No security implications as this only affects error handling of responses.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable