### PR TITLE
fixes bedrock cases

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -873,10 +873,6 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello, world!"),
-									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-									},
 								},
 							},
 						},
@@ -930,10 +926,6 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
-									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-									},
 								},
 							},
 						},
@@ -975,10 +967,6 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
-									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-									},
 								},
 							},
 						},
@@ -1025,10 +1013,6 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
-									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-									},
 								},
 							},
 						},
@@ -1094,10 +1078,6 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("What's the weather?"),
-									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-									},
 								},
 							},
 						},
@@ -1169,10 +1149,6 @@ func TestBedrockToBifrostRequestConversion(t *testing.T) {
 								{
 									Type: schemas.ResponsesInputMessageContentBlockTypeText,
 									Text: schemas.Ptr("Hello!"),
-									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
-										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
-										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
-									},
 								},
 							},
 						},


### PR DESCRIPTION
## Summary

Removed unnecessary empty `ResponsesOutputMessageContentText` fields from Bedrock test cases to simplify test data structures.

## Changes

- Removed redundant `ResponsesOutputMessageContentText` fields with empty annotation and logProb arrays from multiple test cases in the Bedrock provider tests
- This cleanup makes the test data more concise and easier to maintain

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Bedrock provider tests to ensure they still pass after removing the redundant fields:

```sh
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects test code.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable