### PR TITLE
fixes mintlify

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -360,6 +360,8 @@
         "tab": "Changelogs",
         "icon": "bolt",
         "pages": [
+          "changelogs/v1.4.0",
+          "changelogs/v1.4.0-prerelease10",
           "changelogs/v1.4.0-prerelease9",
           "changelogs/v1.4.0-prerelease8",
           "changelogs/v1.4.0-prerelease7",
@@ -367,8 +369,6 @@
           "changelogs/v1.4.0-prerelease5",
           "changelogs/v1.4.0-prerelease4",
           "changelogs/v1.4.0-prerelease3",
-          "changelogs/v1.4.0-prerelease10",
-          "changelogs/v1.4.0",
           "changelogs/v1.3.63",
           "changelogs/v1.3.62",
           "changelogs/v1.3.61",


### PR DESCRIPTION
## Summary

Fix version sorting in the Mintlify changelog to properly handle prerelease versions and ensure correct ordering of v1.4.0 and v1.4.0-prerelease10 in the documentation.

## Changes

- Enhanced version comparison logic to properly handle release vs prerelease versions (releases should come before prereleases in descending order)
- Added special handling for prerelease versions with numeric suffixes (e.g., 'prerelease10') to ensure correct numeric sorting
- Reordered the changelog entries in docs.json to show v1.4.0 before v1.4.0-prerelease10

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Run the changelog generation script to verify the sorting logic:

```sh
.github/workflows/scripts/push-mintlify-changelog.sh
```

2. Check that v1.4.0 appears before v1.4.0-prerelease10 in the generated documentation

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes incorrect sorting of version numbers in the documentation sidebar

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed