### PR TITLE
feat: gemini web search tool

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 - fix: allow setting authorization header through extra headers and in allow list and deny list
+- feat: added support for gemini google search tool

--- a/core/go.mod
+++ b/core/go.mod
@@ -3,6 +3,7 @@ module github.com/maximhq/bifrost/core
 go 1.25.5
 
 require (
+	cloud.google.com/go v0.123.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/aws/aws-sdk-go-v2 v1.41.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
+cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7bImXLTAZU=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 h1:JXg2dwJUmPB9JmtVmdEB16APJ7jurfbY5jnfXpJoRMc=

--- a/core/internal/testutil/web_search_tool.go
+++ b/core/internal/testutil/web_search_tool.go
@@ -339,6 +339,12 @@ func RunWebSearchToolWithDomainsTest(t *testing.T, client *bifrost.Bifrost, ctx 
 		return
 	}
 
+	if testConfig.Provider == "gemini" {
+		// skip because gemini google search tool does not support domain filtering
+		t.Logf("Skipping WebSearchToolWithDomains test for provider %s because gemini google search tool does not support domain filtering", testConfig.Provider)
+		return
+	}
+
 	t.Run("WebSearchToolWithDomains", func(t *testing.T) {
 		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
 			t.Parallel()
@@ -431,6 +437,12 @@ func RunWebSearchToolWithDomainsTest(t *testing.T, client *bifrost.Bifrost, ctx 
 func RunWebSearchToolContextSizesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
 	if !testConfig.Scenarios.WebSearchTool {
 		t.Logf("Web search tool not supported for provider %s", testConfig.Provider)
+		return
+	}
+
+	if testConfig.Provider == "gemini" {
+		// skip because gemini google search tool does not support context size
+		t.Logf("Skipping WebSearchToolContextSizes test for provider %s because gemini google search tool does not support context size", testConfig.Provider)
 		return
 	}
 

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -50,6 +50,7 @@ func TestGemini(t *testing.T) {
 			MultipleToolCalls:     true,
 			End2EndToolCalling:    true,
 			AutomaticFunctionCall: true,
+			WebSearchTool:         true,
 			ImageURL:              false,
 			ImageBase64:           true,
 			MultipleImages:        false,

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -192,7 +192,39 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 		// Track which message indices have been consumed as thought signatures
 		consumedIndices := make(map[int]bool)
 
+		// Find last web_search_call and collect annotations and rendered_content for grounding metadata
+		var lastWebSearchCall *schemas.ResponsesMessage
+		var webSearchAnnotations []schemas.ResponsesOutputMessageContentTextAnnotation
+		var lastRenderedContent *string
+		for i := range bifrostResp.Output {
+			msg := &bifrostResp.Output[i]
+			if msg.Type != nil && *msg.Type == schemas.ResponsesMessageTypeWebSearchCall {
+				lastWebSearchCall = msg
+				consumedIndices[i] = true
+			}
+			// Collect annotations (typically in message after web search)
+			if msg.Content != nil && msg.Content.ContentBlocks != nil {
+				for _, block := range msg.Content.ContentBlocks {
+					if block.ResponsesOutputMessageContentText != nil && len(block.ResponsesOutputMessageContentText.Annotations) > 0 {
+						webSearchAnnotations = append(webSearchAnnotations, block.ResponsesOutputMessageContentText.Annotations...)
+					}
+					// Collect rendered_content
+					if block.Type == schemas.ResponsesOutputMessageContentTypeRenderedContent &&
+						block.ResponsesOutputMessageContentRenderedContent != nil &&
+						block.ResponsesOutputMessageContentRenderedContent.RenderedContent != "" {
+						lastRenderedContent = &block.ResponsesOutputMessageContentRenderedContent.RenderedContent
+						consumedIndices[i] = true // Mark this message as consumed
+					}
+				}
+			}
+		}
+
 		for i, msg := range bifrostResp.Output {
+			// Skip web_search_call messages as they're converted to grounding metadata
+			if consumedIndices[i] {
+				continue
+			}
+
 			// Determine the role
 			role := "model" // default
 			if msg.Role != nil {
@@ -372,6 +404,11 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 				candidate.FinishReason = FinishReasonStop
 			}
 
+			// Attach grounding metadata if web search was used
+			if lastWebSearchCall != nil {
+				candidate.GroundingMetadata = buildGroundingMetadataFromWebSearch(lastWebSearchCall, webSearchAnnotations, lastRenderedContent)
+			}
+
 			candidates = append(candidates, candidate)
 		}
 
@@ -393,9 +430,62 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 	return geminiResp
 }
 
-func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStreamResponse) *GenerateContentResponse {
+// BifrostToGeminiStreamState tracks state when converting Bifrost streams to Gemini format
+type BifrostToGeminiStreamState struct {
+	// Web search buffering
+	WebSearchCall   *schemas.ResponsesMessage                             // Buffered web_search_call
+	Annotations     []schemas.ResponsesOutputMessageContentTextAnnotation // Buffered annotations
+	RenderedContent *string                                               // Buffered rendered content from search entry point
+	HasWebSearch    bool                                                  // Whether we've seen web search
+}
+
+// NewBifrostToGeminiStreamState creates a new state for Bifrost→Gemini streaming
+func NewBifrostToGeminiStreamState() *BifrostToGeminiStreamState {
+	return &BifrostToGeminiStreamState{
+		Annotations: make([]schemas.ResponsesOutputMessageContentTextAnnotation, 0),
+	}
+}
+
+func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStreamResponse, state *BifrostToGeminiStreamState) *GenerateContentResponse {
 	if bifrostResp == nil {
 		return nil
+	}
+
+	// Initialize state if not provided (backward compatibility)
+	if state == nil {
+		state = NewBifrostToGeminiStreamState()
+	}
+
+	// Buffer web search call
+	if bifrostResp.Type == schemas.ResponsesStreamResponseTypeOutputItemDone &&
+		bifrostResp.Item != nil &&
+		bifrostResp.Item.Type != nil &&
+		*bifrostResp.Item.Type == schemas.ResponsesMessageTypeWebSearchCall {
+		state.WebSearchCall = bifrostResp.Item
+		state.HasWebSearch = true
+		return nil // Don't emit yet, wait for completion
+	}
+
+	// Buffer annotations
+	if bifrostResp.Type == schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded &&
+		bifrostResp.Annotation != nil {
+		state.Annotations = append(state.Annotations, *bifrostResp.Annotation)
+		return nil // Don't emit yet, wait for completion
+	}
+
+	// Buffer rendered_content messages
+	if bifrostResp.Type == schemas.ResponsesStreamResponseTypeOutputItemDone &&
+		bifrostResp.Item != nil &&
+		bifrostResp.Item.Content != nil &&
+		bifrostResp.Item.Content.ContentBlocks != nil {
+		for _, block := range bifrostResp.Item.Content.ContentBlocks {
+			if block.Type == schemas.ResponsesOutputMessageContentTypeRenderedContent &&
+				block.ResponsesOutputMessageContentRenderedContent != nil &&
+				block.ResponsesOutputMessageContentRenderedContent.RenderedContent != "" {
+				state.RenderedContent = &block.ResponsesOutputMessageContentRenderedContent.RenderedContent
+				return nil // Don't emit yet, wait for completion
+			}
+		}
 	}
 
 	// Skip lifecycle events that don't have corresponding Gemini equivalents
@@ -404,8 +494,14 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 		schemas.ResponsesStreamResponseTypeCreated,
 		schemas.ResponsesStreamResponseTypeInProgress,
 		schemas.ResponsesStreamResponseTypeReasoningSummaryPartAdded,
-		schemas.ResponsesStreamResponseTypeQueued:
-		// These are lifecycle events with no Gemini equivalent
+		schemas.ResponsesStreamResponseTypeQueued,
+		// Skip web search lifecycle events - buffered above
+		schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
+		schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
+		schemas.ResponsesStreamResponseTypeWebSearchCallCompleted,
+		schemas.ResponsesStreamResponseTypeWebSearchCallResultsAdded,
+		schemas.ResponsesStreamResponseTypeWebSearchCallResultsCompleted:
+		// These are lifecycle events with no Gemini equivalent or are buffered
 		return nil
 	}
 
@@ -546,6 +642,11 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 
 			// Set finish reason
 			candidate.FinishReason = FinishReasonStop
+
+			// Attach grounding metadata if we buffered web search data
+			if state.HasWebSearch && state.WebSearchCall != nil {
+				candidate.GroundingMetadata = buildGroundingMetadataFromWebSearch(state.WebSearchCall, state.Annotations, state.RenderedContent)
+			}
 		}
 
 	// Response failed
@@ -613,6 +714,9 @@ type GeminiResponsesStreamState struct {
 	HasStartedText     bool            // Whether we've started text content
 	HasStartedToolCall bool            // Whether we've started a tool call
 	TextBuffer         strings.Builder // Accumulates text deltas for output_text.done
+
+	// Web search tracking
+	HasEmittedWebSearch bool // Whether web_search_call events have been emitted
 }
 
 // geminiResponsesStreamStatePool provides a pool for Gemini responses stream state objects.
@@ -632,6 +736,7 @@ var geminiResponsesStreamStatePool = sync.Pool{
 			TextItemClosed:       false,
 			HasStartedText:       false,
 			HasStartedToolCall:   false,
+			HasEmittedWebSearch:  false,
 		}
 	},
 }
@@ -778,8 +883,19 @@ func (response *GenerateContentResponse) ToBifrostResponsesStream(sequenceNumber
 		// Only close if we've actually started emitting content (text, tool calls, etc.)
 		// This prevents emitting response.completed for empty chunks with just finishReason
 		if candidate.FinishReason != "" && len(state.ItemIDs) > 0 {
+			// Check for grounding metadata (web search results)
+			if candidate.GroundingMetadata != nil && !state.HasEmittedWebSearch {
+				// Emit web search events before closing
+				webSearchResponses := emitWebSearchFromGroundingMetadata(
+					candidate.GroundingMetadata,
+					state,
+					sequenceNumber+len(responses),
+				)
+				responses = append(responses, webSearchResponses...)
+			}
+
 			// Close any open items
-			closeResponses := closeGeminiOpenItems(state, response.UsageMetadata, sequenceNumber+len(responses))
+			closeResponses := closeGeminiOpenItems(state, candidate.GroundingMetadata, response.UsageMetadata, sequenceNumber+len(responses))
 			responses = append(responses, closeResponses...)
 		}
 	}
@@ -1423,7 +1539,7 @@ func closeGeminiTextItem(state *GeminiResponsesStreamState, sequenceNumber int) 
 }
 
 // closeGeminiOpenItems closes any open items and emits the final completed event
-func closeGeminiOpenItems(state *GeminiResponsesStreamState, usage *GenerateContentResponseUsageMetadata, sequenceNumber int) []*schemas.BifrostResponsesStreamResponse {
+func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *GroundingMetadata, usage *GenerateContentResponseUsageMetadata, sequenceNumber int) []*schemas.BifrostResponsesStreamResponse {
 	if state.HasEmittedCompleted {
 		return nil
 	}
@@ -1433,6 +1549,16 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, usage *GenerateCont
 	// Close text item if still open
 	if closeResponses := state.closeTextItemIfOpen(sequenceNumber); closeResponses != nil {
 		responses = append(responses, closeResponses...)
+	}
+
+	// Emit annotations from grounding supports if present
+	if groundingMetadata != nil && len(groundingMetadata.GroundingSupports) > 0 && state.TextOutputIndex >= 0 {
+		annotationResponses := emitAnnotationsFromGroundingSupports(
+			groundingMetadata,
+			state,
+			sequenceNumber+len(responses),
+		)
+		responses = append(responses, annotationResponses...)
 	}
 
 	// Close any open tool calls
@@ -1489,7 +1615,7 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, usage *GenerateCont
 
 // FinalizeGeminiResponsesStream finalizes the stream by closing any open items and emitting completed event
 func FinalizeGeminiResponsesStream(state *GeminiResponsesStreamState, usage *GenerateContentResponseUsageMetadata, sequenceNumber int) []*schemas.BifrostResponsesStreamResponse {
-	return closeGeminiOpenItems(state, usage, sequenceNumber)
+	return closeGeminiOpenItems(state, nil, usage, sequenceNumber)
 }
 
 // convertGeminiSystemInstructionToResponsesMessage converts Gemini SystemInstruction to a system role message
@@ -1814,7 +1940,26 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 	var responsesTools []schemas.ResponsesTool
 
 	for _, tool := range tools {
-		if len(tool.FunctionDeclarations) > 0 {
+		// you cant use function declarations and google search together
+		if tool.GoogleSearch != nil {
+			responsesTool := schemas.ResponsesTool{
+				Type: schemas.ResponsesToolTypeWebSearch,
+			}
+			responsesTool.ResponsesToolWebSearch = &schemas.ResponsesToolWebSearch{}
+			if tool.GoogleSearch.TimeRangeFilter != nil || len(tool.GoogleSearch.ExcludeDomains) > 0 {
+				filters := &schemas.ResponsesToolWebSearchFilters{
+					BlockedDomains: tool.GoogleSearch.ExcludeDomains,
+				}
+				if tool.GoogleSearch.TimeRangeFilter != nil {
+					filters.TimeRangeFilter = &schemas.Interval{
+						StartTime: tool.GoogleSearch.TimeRangeFilter.StartTime,
+						EndTime:   tool.GoogleSearch.TimeRangeFilter.EndTime,
+					}
+				}
+				responsesTool.ResponsesToolWebSearch.Filters = filters
+			}
+			responsesTools = append(responsesTools, responsesTool)
+		} else if len(tool.FunctionDeclarations) > 0 {
 			for _, fn := range tool.FunctionDeclarations {
 				responsesTool := schemas.ResponsesTool{
 					Type:                  schemas.ResponsesToolTypeFunction,
@@ -2114,6 +2259,112 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 				messages = append(messages, msg)
 			}
 		}
+
+		// check if gemini used google search tool
+		if candidate.GroundingMetadata != nil {
+			webSearchmessage := schemas.ResponsesMessage{
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					Action: &schemas.ResponsesToolMessageActionStruct{
+						ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+							Type:    "search",
+							Queries: candidate.GroundingMetadata.WebSearchQueries,
+						},
+					},
+				},
+			}
+			if len(candidate.GroundingMetadata.WebSearchQueries) > 0 {
+				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Query =
+					schemas.Ptr(candidate.GroundingMetadata.WebSearchQueries[0])
+			}
+
+			sources := []schemas.ResponsesWebSearchToolCallActionSearchSource{}
+			for _, source := range candidate.GroundingMetadata.GroundingChunks {
+				if source.Web != nil {
+					sources = append(sources, schemas.ResponsesWebSearchToolCallActionSearchSource{
+						Type:  "url",
+						Title: schemas.Ptr(source.Web.Title),
+						URL:   source.Web.URI,
+					})
+				}
+			}
+
+			if len(sources) > 0 {
+				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Sources = sources
+			}
+
+			messages = append(messages, webSearchmessage)
+
+			// create a annotations message for grounding supports
+			if len(candidate.GroundingMetadata.GroundingSupports) > 0 {
+				annotations := []schemas.ResponsesOutputMessageContentTextAnnotation{}
+				for _, support := range candidate.GroundingMetadata.GroundingSupports {
+					if support.Segment != nil {
+						annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
+							Type:       "url_citation",
+							Text:       schemas.Ptr(support.Segment.Text),
+							StartIndex: schemas.Ptr(int(support.Segment.StartIndex)),
+							EndIndex:   schemas.Ptr(int(support.Segment.EndIndex)),
+						}
+
+						// Look up URL from grounding chunks
+						if len(support.GroundingChunkIndices) > 0 {
+							chunkIdx := support.GroundingChunkIndices[0]
+							if chunkIdx >= 0 && int(chunkIdx) < len(candidate.GroundingMetadata.GroundingChunks) {
+								chunk := candidate.GroundingMetadata.GroundingChunks[chunkIdx]
+								if chunk.Web != nil {
+									annotation.URL = schemas.Ptr(chunk.Web.URI)
+									if chunk.Web.Title != "" {
+										annotation.Title = schemas.Ptr(chunk.Web.Title)
+									}
+								}
+							}
+						}
+
+						if annotation.URL != nil {
+							annotations = append(annotations, annotation)
+						}
+					}
+				}
+				annotationsMessage := schemas.ResponsesMessage{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Status: schemas.Ptr("completed"),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesOutputMessageContentTypeText,
+								Text: schemas.Ptr(""),
+								ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+									Annotations: annotations,
+								},
+							},
+						},
+					},
+				}
+				messages = append(messages, annotationsMessage)
+			}
+
+			// Emit rendered content if present
+			if candidate.GroundingMetadata.SearchEntryPoint != nil &&
+				candidate.GroundingMetadata.SearchEntryPoint.RenderedContent != "" {
+				renderedContentMessage := schemas.ResponsesMessage{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Status: schemas.Ptr("completed"),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesOutputMessageContentTypeRenderedContent,
+								ResponsesOutputMessageContentRenderedContent: &schemas.ResponsesOutputMessageContentRenderedContent{
+									RenderedContent: candidate.GroundingMetadata.SearchEntryPoint.RenderedContent,
+								},
+							},
+						},
+					},
+				}
+				messages = append(messages, renderedContentMessage)
+			}
+		}
 	}
 
 	return messages
@@ -2298,8 +2549,18 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 	geminiTool := Tool{}
 
+	hasWebSearchTool := false
+
 	for _, tool := range tools {
-		if tool.Type == "function" {
+		if tool.Type == schemas.ResponsesToolTypeWebSearch {
+			hasWebSearchTool = true
+			break
+		}
+	}
+
+	for _, tool := range tools {
+		// you cant use function declarations and google search together
+		if tool.Type == schemas.ResponsesToolTypeFunction && !hasWebSearchTool {
 			// Extract function information from ResponsesExtendedTool
 			if tool.ResponsesToolFunction != nil {
 				if tool.Name != nil && tool.ResponsesToolFunction != nil {
@@ -2322,9 +2583,23 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 				}
 			}
 		}
+		if tool.Type == schemas.ResponsesToolTypeWebSearch {
+			geminiTool.GoogleSearch = &GoogleSearch{}
+			if tool.ResponsesToolWebSearch != nil && tool.ResponsesToolWebSearch.Filters != nil {
+				if tool.ResponsesToolWebSearch.Filters.TimeRangeFilter != nil {
+					geminiTool.GoogleSearch.TimeRangeFilter = &Interval{
+						StartTime: tool.ResponsesToolWebSearch.Filters.TimeRangeFilter.StartTime,
+						EndTime:   tool.ResponsesToolWebSearch.Filters.TimeRangeFilter.EndTime,
+					}
+				}
+				if len(tool.ResponsesToolWebSearch.Filters.BlockedDomains) > 0 {
+					geminiTool.GoogleSearch.ExcludeDomains = tool.ResponsesToolWebSearch.Filters.BlockedDomains
+				}
+			}
+		}
 	}
 
-	if len(geminiTool.FunctionDeclarations) > 0 {
+	if len(geminiTool.FunctionDeclarations) > 0 || geminiTool.GoogleSearch != nil {
 		return []Tool{geminiTool}
 	}
 	return []Tool{}
@@ -2698,4 +2973,320 @@ func convertContentBlockToGeminiPart(block schemas.ResponsesMessageContentBlock)
 	}
 
 	return nil, nil
+}
+
+// buildGroundingMetadataFromWebSearch converts a Bifrost web_search_call message to Gemini GroundingMetadata
+func buildGroundingMetadataFromWebSearch(webSearchCall *schemas.ResponsesMessage, annotations []schemas.ResponsesOutputMessageContentTextAnnotation, renderedContent *string) *GroundingMetadata {
+	if webSearchCall == nil || webSearchCall.ResponsesToolMessage == nil || webSearchCall.ResponsesToolMessage.Action == nil {
+		return nil
+	}
+
+	action := webSearchCall.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction
+	if action == nil {
+		return nil
+	}
+
+	groundingMetadata := &GroundingMetadata{}
+
+	// Add SearchEntryPoint with rendered content if provided
+	if renderedContent != nil && *renderedContent != "" {
+		groundingMetadata.SearchEntryPoint = &SearchEntryPoint{
+			RenderedContent: *renderedContent,
+		}
+	}
+
+	// Extract web search queries
+	if len(action.Queries) > 0 {
+		groundingMetadata.WebSearchQueries = action.Queries
+	} else if action.Query != nil {
+		groundingMetadata.WebSearchQueries = []string{*action.Query}
+	}
+
+	// Extract grounding chunks from sources
+	var groundingChunks []*GroundingChunk
+	urlToIndexMap := make(map[string]int32) // Map URL to chunk index for annotation processing
+
+	for _, source := range action.Sources {
+		if source.URL == "" {
+			continue
+		}
+
+		title := source.URL // Use URL as fallback
+		if source.Title != nil && *source.Title != "" {
+			title = *source.Title
+		}
+
+		chunk := &GroundingChunk{
+			Web: &GroundingChunkWeb{
+				URI:   source.URL,
+				Title: title,
+			},
+		}
+		groundingChunks = append(groundingChunks, chunk)
+		urlToIndexMap[source.URL] = int32(len(groundingChunks) - 1)
+	}
+
+	if len(groundingChunks) > 0 {
+		groundingMetadata.GroundingChunks = groundingChunks
+	}
+
+	// Convert annotations to grounding supports
+	var groundingSupports []*GroundingSupport
+	for _, annotation := range annotations {
+		if annotation.Type != "url_citation" {
+			continue
+		}
+
+		support := &GroundingSupport{
+			Segment: &Segment{},
+		}
+
+		// Set segment text
+		if annotation.Text != nil {
+			support.Segment.Text = *annotation.Text
+		}
+
+		// Set segment indices
+		if annotation.StartIndex != nil {
+			support.Segment.StartIndex = int32(*annotation.StartIndex)
+		}
+		if annotation.EndIndex != nil {
+			support.Segment.EndIndex = int32(*annotation.EndIndex)
+		}
+
+		// Map annotation URL to chunk indices
+		if annotation.URL != nil {
+			if chunkIdx, exists := urlToIndexMap[*annotation.URL]; exists {
+				support.GroundingChunkIndices = []int32{chunkIdx}
+			}
+		}
+
+		// Only add support if we have valid segment or chunk indices
+		if support.Segment.Text != "" || len(support.GroundingChunkIndices) > 0 {
+			groundingSupports = append(groundingSupports, support)
+		}
+	}
+
+	if len(groundingSupports) > 0 {
+		groundingMetadata.GroundingSupports = groundingSupports
+	}
+
+	// Return nil if no meaningful data was extracted
+	if len(groundingMetadata.WebSearchQueries) == 0 && len(groundingMetadata.GroundingChunks) == 0 {
+		return nil
+	}
+
+	return groundingMetadata
+}
+
+// emitWebSearchFromGroundingMetadata converts grounding metadata to web search event stream
+func emitWebSearchFromGroundingMetadata(
+	metadata *GroundingMetadata,
+	state *GeminiResponsesStreamState,
+	sequenceNumber int,
+) []*schemas.BifrostResponsesStreamResponse {
+	var responses []*schemas.BifrostResponsesStreamResponse
+
+	if metadata == nil || len(metadata.WebSearchQueries) == 0 {
+		return responses
+	}
+
+	outputIndex := state.nextOutputIndex()
+	itemID := state.generateItemID("ws", outputIndex)
+	state.ItemIDs[outputIndex] = itemID
+
+	// Build web search action
+	action := &schemas.ResponsesWebSearchToolCallAction{
+		Type:    "search",
+		Queries: metadata.WebSearchQueries,
+	}
+	if len(metadata.WebSearchQueries) > 0 {
+		action.Query = &metadata.WebSearchQueries[0]
+	}
+
+	// Convert groundingChunks to sources
+	var sources []schemas.ResponsesWebSearchToolCallActionSearchSource
+	for _, chunk := range metadata.GroundingChunks {
+		if chunk.Web != nil && chunk.Web.URI != "" {
+			source := schemas.ResponsesWebSearchToolCallActionSearchSource{
+				Type: "url",
+				URL:  chunk.Web.URI,
+			}
+			if chunk.Web.Title != "" {
+				source.Title = &chunk.Web.Title
+			} else {
+				source.Title = &chunk.Web.URI // Fallback to URI
+			}
+			sources = append(sources, source)
+		}
+	}
+	action.Sources = sources
+
+	// 1. output_item.added (web_search_call, in_progress)
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    &outputIndex,
+		Item: &schemas.ResponsesMessage{
+			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+			Status: schemas.Ptr("in_progress"),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				Action: &schemas.ResponsesToolMessageActionStruct{
+					ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
+						Type: "search",
+					},
+				},
+			},
+		},
+	})
+
+	// 2. web_search_call.in_progress
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    &outputIndex,
+		ItemID:         &itemID,
+	})
+
+	// 3. web_search_call.searching
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    &outputIndex,
+		ItemID:         &itemID,
+	})
+
+	// 4. web_search_call.completed
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeWebSearchCallCompleted,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    &outputIndex,
+		ItemID:         &itemID,
+	})
+
+	// 5. output_item.done (with full action including sources)
+	responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    &outputIndex,
+		ItemID:         &itemID,
+		Item: &schemas.ResponsesMessage{
+			ID:     &itemID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall),
+			Status: schemas.Ptr("completed"),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				Action: &schemas.ResponsesToolMessageActionStruct{
+					ResponsesWebSearchToolCallAction: action,
+				},
+			},
+		},
+	})
+
+	state.HasEmittedWebSearch = true
+
+	// Emit rendered content if present
+	if metadata.SearchEntryPoint != nil && metadata.SearchEntryPoint.RenderedContent != "" {
+		renderedIndex := state.nextOutputIndex()
+		renderedItemID := state.generateItemID("rc", renderedIndex)
+		state.ItemIDs[renderedIndex] = renderedItemID
+
+		// output_item.added with rendered_content
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &renderedIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:     &renderedItemID,
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Status: schemas.Ptr("completed"),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeRenderedContent,
+							ResponsesOutputMessageContentRenderedContent: &schemas.ResponsesOutputMessageContentRenderedContent{
+								RenderedContent: metadata.SearchEntryPoint.RenderedContent,
+							},
+						},
+					},
+				},
+			},
+		})
+
+		// output_item.done for rendered content
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+			SequenceNumber: sequenceNumber + len(responses),
+			OutputIndex:    &renderedIndex,
+			ItemID:         &renderedItemID,
+		})
+	}
+
+	return responses
+}
+
+// emitAnnotationsFromGroundingSupports converts grounding supports to annotation events
+func emitAnnotationsFromGroundingSupports(
+	metadata *GroundingMetadata,
+	state *GeminiResponsesStreamState,
+	sequenceNumber int,
+) []*schemas.BifrostResponsesStreamResponse {
+	var responses []*schemas.BifrostResponsesStreamResponse
+
+	if metadata == nil || len(metadata.GroundingSupports) == 0 || state.TextOutputIndex < 0 {
+		return responses
+	}
+
+	itemID := state.ItemIDs[state.TextOutputIndex]
+
+	emmitedIndex := 0
+	// Convert each grounding support to an annotation event
+	for _, support := range metadata.GroundingSupports {
+		if support.Segment == nil {
+			continue
+		}
+
+		annotation := schemas.ResponsesOutputMessageContentTextAnnotation{
+			Type: "url_citation",
+		}
+
+		// Set text and indices
+		if support.Segment.Text != "" {
+			annotation.Text = &support.Segment.Text
+		}
+		annotation.StartIndex = schemas.Ptr(int(support.Segment.StartIndex))
+		annotation.EndIndex = schemas.Ptr(int(support.Segment.EndIndex))
+
+		// Find URL and title from chunk indices
+		if len(support.GroundingChunkIndices) > 0 {
+			chunkIdx := support.GroundingChunkIndices[0]
+			if int(chunkIdx) < len(metadata.GroundingChunks) {
+				chunk := metadata.GroundingChunks[chunkIdx]
+				if chunk.Web != nil {
+					annotation.URL = &chunk.Web.URI
+					if chunk.Web.Title != "" {
+						annotation.Title = &chunk.Web.Title
+					}
+				}
+			}
+		}
+
+		if annotation.URL == nil {
+			continue
+		}
+
+		// Emit annotation.added event
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:            schemas.ResponsesStreamResponseTypeOutputTextAnnotationAdded,
+			SequenceNumber:  sequenceNumber + len(responses),
+			OutputIndex:     &state.TextOutputIndex,
+			ItemID:          &itemID,
+			ContentIndex:    schemas.Ptr(0),
+			Annotation:      &annotation,
+			AnnotationIndex: &emmitedIndex,
+		})
+		emmitedIndex++
+	}
+
+	return responses
 }

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/civil"
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -274,10 +275,14 @@ type Interval struct {
 }
 
 func (i *Interval) UnmarshalJSON(data []byte) error {
+	// Try both camelCase and snake_case
 	type Alias Interval
 	aux := &struct {
 		StartTime *time.Time `json:"startTime,omitempty"`
 		EndTime   *time.Time `json:"endTime,omitempty"`
+		// snake_case alternatives
+		StartTimeSnake *time.Time `json:"start_time,omitempty"`
+		EndTimeSnake   *time.Time `json:"end_time,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(i),
@@ -287,12 +292,17 @@ func (i *Interval) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	// Prefer camelCase, fallback to snake_case
 	if !reflect.ValueOf(aux.StartTime).IsZero() {
 		i.StartTime = time.Time(*aux.StartTime)
+	} else if !reflect.ValueOf(aux.StartTimeSnake).IsZero() {
+		i.StartTime = time.Time(*aux.StartTimeSnake)
 	}
 
 	if !reflect.ValueOf(aux.EndTime).IsZero() {
 		i.EndTime = time.Time(*aux.EndTime)
+	} else if !reflect.ValueOf(aux.EndTimeSnake).IsZero() {
+		i.EndTime = time.Time(*aux.EndTimeSnake)
 	}
 
 	return nil
@@ -327,6 +337,33 @@ type GoogleSearch struct {
 	// Optional. List of domains to be excluded from the search results.
 	// The default limit is 2000 domains.
 	ExcludeDomains []string `json:"excludeDomains,omitempty"`
+}
+
+// UnmarshalJSON handles both camelCase and snake_case
+func (g *GoogleSearch) UnmarshalJSON(data []byte) error {
+	type Alias GoogleSearch
+	aux := &struct {
+		*Alias
+		// snake_case alternatives
+		TimeRangeFilterSnake *Interval `json:"time_range_filter,omitempty"`
+		ExcludeDomainsSnake  []string  `json:"exclude_domains,omitempty"`
+	}{
+		Alias: (*Alias)(g),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Use snake_case if camelCase wasn't provided
+	if g.TimeRangeFilter == nil && aux.TimeRangeFilterSnake != nil {
+		g.TimeRangeFilter = aux.TimeRangeFilterSnake
+	}
+	if len(g.ExcludeDomains) == 0 && len(aux.ExcludeDomainsSnake) > 0 {
+		g.ExcludeDomains = aux.ExcludeDomainsSnake
+	}
+
+	return nil
 }
 
 // DynamicRetrievalConfig describes the options to customize dynamic retrieval.
@@ -681,6 +718,57 @@ type Tool struct {
 	ComputerUse *ToolComputerUse `json:"computerUse,omitempty"`
 	// Optional. CodeExecution tool type. Enables the model to execute code as part of generation.
 	CodeExecution *ToolCodeExecution `json:"codeExecution,omitempty"`
+}
+
+// UnmarshalJSON handles both camelCase and snake_case
+func (t *Tool) UnmarshalJSON(data []byte) error {
+	type Alias Tool
+	aux := &struct {
+		*Alias
+		// snake_case alternatives for the most commonly used fields
+		FunctionDeclarationsSnake  []*FunctionDeclaration `json:"function_declarations,omitempty"`
+		GoogleSearchSnake          *GoogleSearch          `json:"google_search,omitempty"`
+		GoogleSearchRetrievalSnake *GoogleSearchRetrieval `json:"google_search_retrieval,omitempty"`
+		EnterpriseWebSearchSnake   *EnterpriseWebSearch   `json:"enterprise_web_search,omitempty"`
+		GoogleMapsSnake            *GoogleMaps            `json:"google_maps,omitempty"`
+		URLContextSnake            *URLContext            `json:"url_context,omitempty"`
+		ComputerUseSnake           *ToolComputerUse       `json:"computer_use,omitempty"`
+		CodeExecutionSnake         *ToolCodeExecution     `json:"code_execution,omitempty"`
+	}{
+		Alias: (*Alias)(t),
+	}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Use snake_case if camelCase wasn't provided
+	if t.FunctionDeclarations == nil && aux.FunctionDeclarationsSnake != nil {
+		t.FunctionDeclarations = aux.FunctionDeclarationsSnake
+	}
+	if t.GoogleSearch == nil && aux.GoogleSearchSnake != nil {
+		t.GoogleSearch = aux.GoogleSearchSnake
+	}
+	if t.GoogleSearchRetrieval == nil && aux.GoogleSearchRetrievalSnake != nil {
+		t.GoogleSearchRetrieval = aux.GoogleSearchRetrievalSnake
+	}
+	if t.EnterpriseWebSearch == nil && aux.EnterpriseWebSearchSnake != nil {
+		t.EnterpriseWebSearch = aux.EnterpriseWebSearchSnake
+	}
+	if t.GoogleMaps == nil && aux.GoogleMapsSnake != nil {
+		t.GoogleMaps = aux.GoogleMapsSnake
+	}
+	if t.URLContext == nil && aux.URLContextSnake != nil {
+		t.URLContext = aux.URLContextSnake
+	}
+	if t.ComputerUse == nil && aux.ComputerUseSnake != nil {
+		t.ComputerUse = aux.ComputerUseSnake
+	}
+	if t.CodeExecution == nil && aux.CodeExecutionSnake != nil {
+		t.CodeExecution = aux.CodeExecutionSnake
+	}
+
+	return nil
 }
 
 // GenerationConfig represents generation configuration. You can find API default values and more details at https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig
@@ -1338,12 +1426,304 @@ type URLContextMetadata struct {
 	URLMetadata []*URLMetadata `json:"urlMetadata,omitempty"`
 }
 
+// Source attributions for content. This data type is not supported in Gemini API.
+type Citation struct {
+	// Output only. End index into the content.
+	EndIndex int32 `json:"endIndex,omitempty"`
+	// Output only. License of the attribution.
+	License string `json:"license,omitempty"`
+	// Output only. Publication date of the attribution.
+	PublicationDate civil.Date `json:"publicationDate,omitempty"`
+	// Output only. Start index into the content.
+	StartIndex int32 `json:"startIndex,omitempty"`
+	// Output only. Title of the attribution.
+	Title string `json:"title,omitempty"`
+	// Output only. URL reference of the attribution.
+	URI string `json:"uri,omitempty"`
+}
+
+type dateJSON civil.Date
+
+func (d *dateJSON) UnmarshalJSON(data []byte) error {
+	m := make(map[string]int)
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("failed to unmarshal date from map: %w", err)
+	}
+
+	if len(m) == 0 {
+		return nil
+	}
+	if _, ok := m["year"]; !ok {
+		return fmt.Errorf("key %q not found", "year")
+	}
+	d.Year = m["year"]
+
+	if month, ok := m["month"]; ok {
+		d.Month = time.Month(month)
+	}
+	if day, ok := m["day"]; ok {
+		d.Day = day
+	}
+	return nil
+}
+
+func (d *dateJSON) MarshalJSON() ([]byte, error) {
+	m := make(map[string]int)
+	if d == nil || (civil.Date)(*d).IsZero() {
+		return json.Marshal(nil)
+	}
+	if d.Year != 0 {
+		m["year"] = d.Year
+	}
+	if d.Month != 0 {
+		m["month"] = int(d.Month)
+	}
+	if d.Day != 0 {
+		m["day"] = d.Day
+	}
+	return json.Marshal(m)
+}
+
+func (c *Citation) UnmarshalJSON(data []byte) error {
+	type Alias Citation
+	aux := &struct {
+		PublicationDate *dateJSON `json:"publicationDate,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if !reflect.ValueOf(aux.PublicationDate).IsZero() {
+		c.PublicationDate = civil.Date(*aux.PublicationDate)
+	}
+
+	return nil
+}
+
+func (c *Citation) MarshalJSON() ([]byte, error) {
+	type Alias Citation
+	aux := &struct {
+		PublicationDate *dateJSON `json:"publicationDate,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(c),
+	}
+
+	if !reflect.ValueOf(c.PublicationDate).IsZero() {
+		aux.PublicationDate = (*dateJSON)(&c.PublicationDate)
+	}
+
+	return json.Marshal(aux)
+}
+
+// Citation information when the model quotes another source.
+type CitationMetadata struct {
+	// Optional. Contains citation information when the model directly quotes, at
+	// length, from another source. Can include traditional websites and code
+	// repositories.
+	Citations []*Citation `json:"citations,omitempty"`
+}
+
+// Author attribution for a photo or review. This data type is not supported in Gemini
+// API.
+type GroundingChunkMapsPlaceAnswerSourcesAuthorAttribution struct {
+	// Name of the author of the Photo or Review.
+	DisplayName string `json:"displayName,omitempty"`
+	// Profile photo URI of the author of the Photo or Review.
+	PhotoURI string `json:"photoUri,omitempty"`
+	// URI of the author of the Photo or Review.
+	URI string `json:"uri,omitempty"`
+}
+
+// Encapsulates a review snippet. This data type is not supported in Gemini API.
+type GroundingChunkMapsPlaceAnswerSourcesReviewSnippet struct {
+	// This review's author.
+	AuthorAttribution *GroundingChunkMapsPlaceAnswerSourcesAuthorAttribution `json:"authorAttribution,omitempty"`
+	// A link where users can flag a problem with the review.
+	FlagContentURI string `json:"flagContentUri,omitempty"`
+	// A link to show the review on Google Maps.
+	GoogleMapsURI string `json:"googleMapsUri,omitempty"`
+	// A string of formatted recent time, expressing the review time relative to the current
+	// time in a form appropriate for the language and country.
+	RelativePublishTimeDescription string `json:"relativePublishTimeDescription,omitempty"`
+	// A reference representing this place review which may be used to look up this place
+	// review again.
+	Review string `json:"review,omitempty"`
+	// ID of the review referencing the place.
+	ReviewID string `json:"reviewId,omitempty"`
+	// Title of the review.
+	Title string `json:"title,omitempty"`
+}
+
+// Sources used to generate the place answer. This data type is not supported in Gemini
+// API.
+type GroundingChunkMapsPlaceAnswerSources struct {
+	// A link where users can flag a problem with the generated answer.
+	FlagContentURI string `json:"flagContentUri,omitempty"`
+	// Snippets of reviews that are used to generate the answer.
+	ReviewSnippets []*GroundingChunkMapsPlaceAnswerSourcesReviewSnippet `json:"reviewSnippets,omitempty"`
+}
+
+// Chunk from Google Maps. This data type is not supported in Gemini API.
+type GroundingChunkMaps struct {
+	// Sources used to generate the place answer. This includes review snippets and photos
+	// that were used to generate the answer, as well as uris to flag content.
+	PlaceAnswerSources *GroundingChunkMapsPlaceAnswerSources `json:"placeAnswerSources,omitempty"`
+	// This Place's resource name, in `places/{place_id}` format. Can be used to look up
+	// the Place.
+	PlaceID string `json:"placeId,omitempty"`
+	// Text of the place answer.
+	Text string `json:"text,omitempty"`
+	// Title of the place.
+	Title string `json:"title,omitempty"`
+	// URI reference of the place.
+	URI string `json:"uri,omitempty"`
+}
+
+// Represents where the chunk starts and ends in the document. This data type is not
+// supported in Gemini API.
+type RAGChunkPageSpan struct {
+	// Page where chunk starts in the document. Inclusive. 1-indexed.
+	FirstPage int32 `json:"firstPage,omitempty"`
+	// Page where chunk ends in the document. Inclusive. 1-indexed.
+	LastPage int32 `json:"lastPage,omitempty"`
+}
+
+// A RAGChunk includes the content of a chunk of a RAGFile, and associated metadata.
+// This data type is not supported in Gemini API.
+type RAGChunk struct {
+	// If populated, represents where the chunk starts and ends in the document.
+	PageSpan *RAGChunkPageSpan `json:"pageSpan,omitempty"`
+	// The content of the chunk.
+	Text string `json:"text,omitempty"`
+}
+
+// Chunk from context retrieved by the retrieval tools. This data type is not supported
+// in Gemini API.
+type GroundingChunkRetrievedContext struct {
+	// Output only. The full document name for the referenced Vertex AI Search document.
+	DocumentName string `json:"documentName,omitempty"`
+	// Additional context for the RAG retrieval result. This is only populated when using
+	// the RAG retrieval tool.
+	RAGChunk *RAGChunk `json:"ragChunk,omitempty"`
+	// Text of the attribution.
+	Text string `json:"text,omitempty"`
+	// Title of the attribution.
+	Title string `json:"title,omitempty"`
+	// URI reference of the attribution.
+	URI string `json:"uri,omitempty"`
+}
+
+// Chunk from the web.
+type GroundingChunkWeb struct {
+	// Domain of the (original) URI. This field is not supported in Gemini API.
+	Domain string `json:"domain,omitempty"`
+	// Title of the chunk.
+	Title string `json:"title,omitempty"`
+	// URI reference of the chunk.
+	URI string `json:"uri,omitempty"`
+}
+
+// Grounding chunk.
+type GroundingChunk struct {
+	// Grounding chunk from Google Maps. This field is not supported in Gemini API.
+	Maps *GroundingChunkMaps `json:"maps,omitempty"`
+	// Grounding chunk from context retrieved by the retrieval tools. This field is not
+	// supported in Gemini API.
+	RetrievedContext *GroundingChunkRetrievedContext `json:"retrievedContext,omitempty"`
+	// Grounding chunk from the web.
+	Web *GroundingChunkWeb `json:"web,omitempty"`
+}
+
+// Segment of the content.
+type Segment struct {
+	// Output only. End index in the given Part, measured in bytes. Offset from the start
+	// of the Part, exclusive, starting at zero.
+	EndIndex int32 `json:"endIndex,omitempty"`
+	// Output only. The index of a Part object within its parent Content object.
+	PartIndex int32 `json:"partIndex,omitempty"`
+	// Output only. Start index in the given Part, measured in bytes. Offset from the start
+	// of the Part, inclusive, starting at zero.
+	StartIndex int32 `json:"startIndex,omitempty"`
+	// Output only. The text corresponding to the segment from the response.
+	Text string `json:"text,omitempty"`
+}
+
+// Grounding support.
+type GroundingSupport struct {
+	// Confidence score of the support references. Ranges from 0 to 1. 1 is the most confident.
+	// For Gemini 2.0 and before, this list must have the same size as the grounding_chunk_indices.
+	// For Gemini 2.5 and after, this list will be empty and should be ignored.
+	ConfidenceScores []float32 `json:"confidenceScores,omitempty"`
+	// A list of indices (into 'grounding_chunk') specifying the citations associated with
+	// the claim. For instance [1,3,4] means that grounding_chunk[1], grounding_chunk[3],
+	// grounding_chunk[4] are the retrieved content attributed to the claim.
+	GroundingChunkIndices []int32 `json:"groundingChunkIndices,omitempty"`
+	// Segment of the content this support belongs to.
+	Segment *Segment `json:"segment,omitempty"`
+}
+
+// Metadata related to retrieval in the grounding flow.
+type RetrievalMetadata struct {
+	// Optional. Score indicating how likely information from Google Search could help answer
+	// the prompt. The score is in the range `[0, 1]`, where 0 is the least likely and 1
+	// is the most likely. This score is only populated when Google Search grounding and
+	// dynamic retrieval is enabled. It will be compared to the threshold to determine whether
+	// to trigger Google Search.
+	GoogleSearchDynamicRetrievalScore float32 `json:"googleSearchDynamicRetrievalScore,omitempty"`
+}
+
+// Google search entry point.
+type SearchEntryPoint struct {
+	// Optional. Web content snippet that can be embedded in a web page or an app webview.
+	RenderedContent string `json:"renderedContent,omitempty"`
+	// Optional. Base64 encoded JSON representing array of tuple.
+	SDKBlob []byte `json:"sdkBlob,omitempty"`
+}
+
+// Source content flagging URI for a place or review. This is currently populated only
+// for Google Maps grounding. This data type is not supported in Gemini API.
+type GroundingMetadataSourceFlaggingURI struct {
+	// A link where users can flag a problem with the source (place or review).
+	FlagContentURI string `json:"flagContentUri,omitempty"`
+	// ID of the place or review.
+	SourceID string `json:"sourceId,omitempty"`
+}
+
+// Metadata returned to client when grounding is enabled.
+type GroundingMetadata struct {
+	// Optional. Output only. Resource name of the Google Maps widget context token to be
+	// used with the PlacesContextElement widget to render contextual data. This is populated
+	// only for Google Maps grounding. This field is not supported in Gemini API.
+	GoogleMapsWidgetContextToken string `json:"googleMapsWidgetContextToken,omitempty"`
+	// List of supporting references retrieved from specified grounding source.
+	GroundingChunks []*GroundingChunk `json:"groundingChunks,omitempty"`
+	// Optional. List of grounding support.
+	GroundingSupports []*GroundingSupport `json:"groundingSupports,omitempty"`
+	// Optional. Output only. Retrieval metadata.
+	RetrievalMetadata *RetrievalMetadata `json:"retrievalMetadata,omitempty"`
+	// Optional. Queries executed by the retrieval tools. This field is not supported in
+	// Gemini API.
+	RetrievalQueries []string `json:"retrievalQueries,omitempty"`
+	// Optional. Google search entry for the following-up web searches.
+	SearchEntryPoint *SearchEntryPoint `json:"searchEntryPoint,omitempty"`
+	// Optional. Output only. List of source flagging uris. This is currently populated
+	// only for Google Maps grounding. This field is not supported in Gemini API.
+	SourceFlaggingUris []*GroundingMetadataSourceFlaggingURI `json:"sourceFlaggingUris,omitempty"`
+	// Optional. Web search queries for the following-up web search.
+	WebSearchQueries []string `json:"webSearchQueries,omitempty"`
+}
+
 // Candidate represents a response candidate generated from the model.
 type Candidate struct {
 	// Optional. Contains the multi-part content of the response.
 	Content *Content `json:"content,omitempty"`
 	// Optional. Source attribution of the generated content.
-	CitationMetadata *map[string]any `json:"citationMetadata,omitempty"`
+	CitationMetadata *CitationMetadata `json:"citationMetadata,omitempty"`
 	// Optional. Describes the reason the model stopped generating tokens.
 	FinishMessage string `json:"finishMessage,omitempty"`
 	// Optional. Number of tokens for this candidate.
@@ -1357,7 +1737,7 @@ type Candidate struct {
 	// Output only. Average log probability score of the candidate.
 	AvgLogprobs float64 `json:"avgLogprobs,omitempty"`
 	// Output only. Metadata specifies sources used to ground generated content.
-	GroundingMetadata *map[string]any `json:"groundingMetadata,omitempty"`
+	GroundingMetadata *GroundingMetadata `json:"groundingMetadata,omitempty"`
 	// Output only. Index of the candidate.
 	Index int32 `json:"index,omitempty"`
 	// Output only. Log-likelihood scores for the response tokens and top tokens

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -212,7 +212,7 @@ func (req *OpenAIResponsesRequest) filterUnsupportedTools() {
 
 				// MaxUses is intentionally omitted (nil) - OpenAI doesn't support it
 
-				// Handle Filters: OpenAI doesn't support BlockedDomains
+				// Handle Filters: OpenAI doesn't support BlockedDomains or TimeRangeFilter
 				if tool.ResponsesToolWebSearch.Filters != nil {
 					hasAllowedDomains := len(tool.ResponsesToolWebSearch.Filters.AllowedDomains) > 0
 
@@ -220,7 +220,7 @@ func (req *OpenAIResponsesRequest) filterUnsupportedTools() {
 						// Keep only AllowedDomains (copy the slice to avoid sharing)
 						newWebSearch.Filters = &schemas.ResponsesToolWebSearchFilters{
 							AllowedDomains: append([]string(nil), tool.ResponsesToolWebSearch.Filters.AllowedDomains...),
-							// BlockedDomains is intentionally omitted - OpenAI doesn't support it
+							// BlockedDomains and TimeRangeFilter are intentionally omitted - OpenAI doesn't support it
 						}
 					}
 					// If only blocked domains or both empty, Filters stays nil

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
 - fix: allow setting authorization header through extra headers and in allow list and deny list
 - feat: configure custom CORS headers, allowing clients to specify additional headers that should be allowed in cross-origin requests.
 - feat: support for listing models from specific provider or all providers via a header flag x-bf-list-models-provider from integrations.
+- feat: added support for gemini google search tool


### PR DESCRIPTION
## Summary

Add support for Google Search grounding in Gemini provider, enabling web search capabilities and citation of sources in responses.

## Changes

- Added Google Cloud dependency to support Gemini's web search functionality
- Implemented web search tool support in Gemini provider
- Added conversion logic for web search queries, results, and citations between Bifrost and Gemini formats
- Enhanced streaming response handling to properly process web search events and annotations
- Added support for grounding metadata to track search results and citations

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Gemini provider with web search enabled:

```sh
# Run Bifrost with Gemini provider
export BIFROST_GEMINI_API_KEY=your_api_key
go run ./cmd/bifrost

# Make a request with web search enabled
curl -X POST http://localhost:8000/v1/genai/models/gemini-1.5-pro/generateContent \
  -H "Content-Type: application/json" \
  -d '{
    "contents": [{"parts":[{"text":"What are the latest developments in quantum computing?"}]}],
    "tools": [{"googleSearch": {}}]
  }'
```

Verify that responses include web search results with citations and source URLs.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Implements web search functionality for Gemini provider

## Security considerations

Web search functionality requires proper API key permissions for Google Search API access.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable