### PR TITLE
adds structured output to responses

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1652,6 +1652,12 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 						bedrockReq.ToolConfig = &BedrockToolConfig{}
 					}
 					bedrockReq.ToolConfig.Tools = append(bedrockReq.ToolConfig.Tools, *responseFormatTool)
+					// Force the model to use this specific tool (same as ChatCompletion)
+					bedrockReq.ToolConfig.ToolChoice = &BedrockToolChoice{
+						Tool: &BedrockToolChoiceTool{
+							Name: responseFormatTool.ToolSpec.Name,
+						},
+					}
 				}
 			}
 		}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,2 @@
-- fix: fixes tool call-based structured output flow for Bedrock streaming requests
+- fix: fixes tool call-based structured output flow for Bedrock streaming requests (Chat and Responses API)
 - chore: updates test cases to assert content and tool_calls validations


### PR DESCRIPTION
## Summary

Fixes the structured output flow for Bedrock streaming requests by properly handling tool calls in both Chat and Responses API.

## Changes

- Added support for intercepting tool calls for structured output in Bedrock's ResponsesStream method
- Implemented conversion of tool use events to text output when using structured output mode
- Added tool choice configuration to force the model to use the specified response format tool
- Updated streaming logic to properly accumulate and forward structured output as text content

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test structured output with Bedrock models using both Chat and Responses API:

```sh
# Core/Transports
go version
go test ./...

# Test with a request that includes response_format with type: json_object
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
    "messages": [{"role": "user", "content": "Return a JSON object with name and age"}],
    "response_format": {"type": "json_object"}
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes structured output handling in Bedrock streaming requests

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable