### PR TITLE
increased timeout for core tests to 20m

### DIFF
--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -38,7 +38,7 @@ echo "✅ Core build validation successful"
 # Run core tests with coverage
 echo "🔧 Running core tests with coverage..."
 cd core
-go test -v -race -coverprofile=coverage.txt -coverpkg=./... ./...
+go test -v -race -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
 
 # Upload coverage to Codecov
 if [ -n "${CODECOV_TOKEN:-}" ]; then


### PR DESCRIPTION
## Summary

Increase the timeout for core tests in the release workflow to prevent test failures in CI.

## Changes

- Modified the core test command in `release-core.sh` to include a 20-minute timeout parameter (`-timeout 20m`)
- This prevents long-running tests from being terminated prematurely during the release process

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that core tests complete successfully with the new timeout parameter:

```sh
cd core
go test -v -race -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only affects test execution duration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable