### PR TITLE
adds retry framework to batch and file APIs

### DIFF
--- a/core/internal/testutil/batch.go
+++ b/core/internal/testutil/batch.go
@@ -19,48 +19,75 @@ func RunBatchCreateTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 	t.Run("BatchCreate", func(t *testing.T) {
 		t.Logf("[RUNNING] Batch Create test for provider: %s", testConfig.Provider)
 
-		// Create a batch request with a simple chat completion
-		request := &schemas.BifrostBatchCreateRequest{
-			Provider: testConfig.Provider,
-			Model:    schemas.Ptr(testConfig.ChatModel),
-			Endpoint: schemas.BatchEndpointChatCompletions,
-			Requests: []schemas.BatchRequestItem{
-				{
-					CustomID: "test-request-1",
-					Body: map[string]interface{}{
-						"model": testConfig.ChatModel,
-						"messages": []map[string]string{
-							{"role": "user", "content": "Say hello"},
+		// Use retry framework
+		retryConfig := GetTestRetryConfigForScenario("BatchCreate", testConfig)
+		retryContext := TestRetryContext{
+			ScenarioName: "BatchCreate",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_batch_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
+		}
+
+		batchCreateRetryConfig := BatchCreateRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchCreateRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		expectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithBatchCreateTestRetry(t, batchCreateRetryConfig, retryContext, expectations, "BatchCreate", func() (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+			request := &schemas.BifrostBatchCreateRequest{
+				Provider: testConfig.Provider,
+				Model:    schemas.Ptr(testConfig.ChatModel),
+				Endpoint: schemas.BatchEndpointChatCompletions,
+				Requests: []schemas.BatchRequestItem{
+					{
+						CustomID: "test-request-1",
+						Body: map[string]interface{}{
+							"model": testConfig.ChatModel,
+							"messages": []map[string]string{
+								{"role": "user", "content": "Say hello"},
+							},
 						},
 					},
 				},
-			},
-			CompletionWindow: "24h",
-			ExtraParams:      testConfig.BatchExtraParams,
-		}
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.BatchCreateRequest(bfCtx, request)
+				CompletionWindow: "24h",
+				ExtraParams:      testConfig.BatchExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchCreateRequest(bfCtx, request)
+		})
+
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
 				return
 			}
-			t.Errorf("BatchCreate failed: %v", err)
-			return
+			t.Fatalf("❌ BatchCreate failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("BatchCreate returned nil response")
-			return
+			t.Fatal("❌ BatchCreate returned nil response after retries")
 		}
 
 		if response.ID == "" {
-			t.Error("BatchCreate returned empty batch ID")
-			return
+			t.Fatal("❌ BatchCreate returned empty batch ID after retries")
 		}
 
-		t.Logf("[SUCCESS] Batch Create test passed for provider: %s, batch ID: %s", testConfig.Provider, response.ID)
+		t.Logf("✅ Batch Create test passed for provider: %s, batch ID: %s", testConfig.Provider, response.ID)
 	})
 }
 
@@ -74,29 +101,57 @@ func RunBatchListTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 	t.Run("BatchList", func(t *testing.T) {
 		t.Logf("[RUNNING] Batch List test for provider: %s", testConfig.Provider)
 
-		request := &schemas.BifrostBatchListRequest{
-			Provider: testConfig.Provider,
-			Limit:    10,
+		// Use retry framework
+		retryConfig := GetTestRetryConfigForScenario("BatchList", testConfig)
+		retryContext := TestRetryContext{
+			ScenarioName: "BatchList",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_list": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.BatchListRequest(bfCtx, request)
+		batchListRetryConfig := BatchListRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchListRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		expectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithBatchListTestRetry(t, batchListRetryConfig, retryContext, expectations, "BatchList", func() (*schemas.BifrostBatchListResponse, *schemas.BifrostError) {
+			request := &schemas.BifrostBatchListRequest{
+				Provider: testConfig.Provider,
+				Limit:    10,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchListRequest(bfCtx, request)
+		})
+
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
 				return
 			}
-			t.Errorf("BatchList failed: %v", err)
-			return
+			t.Fatalf("❌ BatchList failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("BatchList returned nil response")
-			return
+			t.Fatal("❌ BatchList returned nil response after retries")
 		}
 
-		t.Logf("[SUCCESS] Batch List test passed for provider: %s, found %d batches", testConfig.Provider, len(response.Data))
+		t.Logf("✅ Batch List test passed for provider: %s, found %d batches", testConfig.Provider, len(response.Data))
 	})
 }
 
@@ -110,68 +165,120 @@ func RunBatchRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 	t.Run("BatchRetrieve", func(t *testing.T) {
 		t.Logf("[RUNNING] Batch Retrieve test for provider: %s", testConfig.Provider)
 
-		// First, we need to create a batch to retrieve
-		// Note: In real tests, you might want to use an existing batch ID
-		createRequest := &schemas.BifrostBatchCreateRequest{
-			Provider: testConfig.Provider,
-			Model:    schemas.Ptr(testConfig.ChatModel),
-			Endpoint: schemas.BatchEndpointChatCompletions,
-			Requests: []schemas.BatchRequestItem{
-				{
-					CustomID: "test-retrieve-1",
-					Body: map[string]interface{}{
-						"model": testConfig.ChatModel,
-						"messages": []map[string]string{
-							{"role": "user", "content": "Say hello"},
+		// First, we need to create a batch to retrieve using retry framework
+		retryConfig := GetTestRetryConfigForScenario("BatchRetrieve", testConfig)
+
+		createRetryContext := TestRetryContext{
+			ScenarioName: "BatchRetrieve_Create",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_batch_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
+		}
+
+		batchCreateRetryConfig := BatchCreateRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchCreateRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		createExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		createResponse, createErr := WithBatchCreateTestRetry(t, batchCreateRetryConfig, createRetryContext, createExpectations, "BatchRetrieve_Create", func() (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+			createRequest := &schemas.BifrostBatchCreateRequest{
+				Provider: testConfig.Provider,
+				Model:    schemas.Ptr(testConfig.ChatModel),
+				Endpoint: schemas.BatchEndpointChatCompletions,
+				Requests: []schemas.BatchRequestItem{
+					{
+						CustomID: "test-retrieve-1",
+						Body: map[string]interface{}{
+							"model": testConfig.ChatModel,
+							"messages": []map[string]string{
+								{"role": "user", "content": "Say hello"},
+							},
 						},
 					},
 				},
-			},
-			CompletionWindow: "24h",
-			ExtraParams:      testConfig.BatchExtraParams,
-		}
+				CompletionWindow: "24h",
+				ExtraParams:      testConfig.BatchExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchCreateRequest(bfCtx, createRequest)
+		})
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		createResponse, createErr := client.BatchCreateRequest(bfCtx, createRequest)
 		if createErr != nil {
-			// Check if this is an unsupported operation error
 			if createErr.Error != nil && (createErr.Error.Code != nil && *createErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for create", testConfig.Provider)
 				return
 			}
-			t.Errorf("BatchCreate (for retrieve test) failed: %v", createErr)
-			return
+			t.Fatalf("❌ BatchCreate (for retrieve test) failed after retries: %v", GetErrorMessage(createErr))
 		}
 
 		if createResponse == nil || createResponse.ID == "" {
-			t.Error("BatchCreate returned invalid response for retrieve test")
-			return
+			t.Fatal("❌ BatchCreate returned invalid response for retrieve test after retries")
 		}
 
-		// Now retrieve the batch
-		retrieveRequest := &schemas.BifrostBatchRetrieveRequest{
-			Provider: testConfig.Provider,
-			BatchID:  createResponse.ID,
+		// Now retrieve the batch using retry framework
+		retrieveRetryContext := TestRetryContext{
+			ScenarioName: "BatchRetrieve",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_batch": true,
+				"expected_batch_id":   createResponse.ID,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.BatchRetrieveRequest(bfCtx2, retrieveRequest)
+		batchRetrieveRetryConfig := BatchRetrieveRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchRetrieveRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		retrieveExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithBatchRetrieveTestRetry(t, batchRetrieveRetryConfig, retrieveRetryContext, retrieveExpectations, "BatchRetrieve", func() (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError) {
+			retrieveRequest := &schemas.BifrostBatchRetrieveRequest{
+				Provider: testConfig.Provider,
+				BatchID:  createResponse.ID,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchRetrieveRequest(bfCtx, retrieveRequest)
+		})
+
 		if err != nil {
-			t.Errorf("BatchRetrieve failed: %v", err)
-			return
+			t.Fatalf("❌ BatchRetrieve failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("BatchRetrieve returned nil response")
-			return
+			t.Fatal("❌ BatchRetrieve returned nil response after retries")
 		}
 
 		if response.ID != createResponse.ID {
-			t.Errorf("BatchRetrieve returned wrong batch ID: got %s, expected %s", response.ID, createResponse.ID)
-			return
+			t.Fatalf("❌ BatchRetrieve returned wrong batch ID: got %s, expected %s", response.ID, createResponse.ID)
 		}
 
-		t.Logf("[SUCCESS] Batch Retrieve test passed for provider: %s, batch ID: %s, status: %s", testConfig.Provider, response.ID, response.Status)
+		t.Logf("✅ Batch Retrieve test passed for provider: %s, batch ID: %s, status: %s", testConfig.Provider, response.ID, response.Status)
 	})
 }
 
@@ -185,63 +292,118 @@ func RunBatchCancelTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 	t.Run("BatchCancel", func(t *testing.T) {
 		t.Logf("[RUNNING] Batch Cancel test for provider: %s", testConfig.Provider)
 
-		// First, create a batch to cancel
-		createRequest := &schemas.BifrostBatchCreateRequest{
-			Provider: testConfig.Provider,
-			Model:    schemas.Ptr(testConfig.ChatModel),
-			Endpoint: schemas.BatchEndpointChatCompletions,
-			Requests: []schemas.BatchRequestItem{
-				{
-					CustomID: "test-cancel-1",
-					Body: map[string]interface{}{
-						"model": testConfig.ChatModel,
-						"messages": []map[string]string{
-							{"role": "user", "content": "Say hello"},
+		// First, create a batch to cancel using retry framework
+		retryConfig := GetTestRetryConfigForScenario("BatchCancel", testConfig)
+
+		createRetryContext := TestRetryContext{
+			ScenarioName: "BatchCancel_Create",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_batch_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
+		}
+
+		batchCreateRetryConfig := BatchCreateRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchCreateRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		createExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		createResponse, createErr := WithBatchCreateTestRetry(t, batchCreateRetryConfig, createRetryContext, createExpectations, "BatchCancel_Create", func() (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+			createRequest := &schemas.BifrostBatchCreateRequest{
+				Provider: testConfig.Provider,
+				Model:    schemas.Ptr(testConfig.ChatModel),
+				Endpoint: schemas.BatchEndpointChatCompletions,
+				Requests: []schemas.BatchRequestItem{
+					{
+						CustomID: "test-cancel-1",
+						Body: map[string]interface{}{
+							"model": testConfig.ChatModel,
+							"messages": []map[string]string{
+								{"role": "user", "content": "Say hello"},
+							},
 						},
 					},
 				},
-			},
-			CompletionWindow: "24h",
-			ExtraParams:      testConfig.BatchExtraParams,
-		}
+				CompletionWindow: "24h",
+				ExtraParams:      testConfig.BatchExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchCreateRequest(bfCtx, createRequest)
+		})
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		createResponse, createErr := client.BatchCreateRequest(bfCtx, createRequest)
 		if createErr != nil {
-			// Check if this is an unsupported operation error
 			if createErr.Error != nil && (createErr.Error.Code != nil && *createErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for create", testConfig.Provider)
 				return
 			}
-			t.Errorf("BatchCreate (for cancel test) failed: %v", createErr)
-			return
+			t.Fatalf("❌ BatchCreate (for cancel test) failed after retries: %v", GetErrorMessage(createErr))
 		}
 
 		if createResponse == nil || createResponse.ID == "" {
-			t.Error("BatchCreate returned invalid response for cancel test")
-			return
+			t.Fatal("❌ BatchCreate returned invalid response for cancel test after retries")
 		}
 
-		// Now cancel the batch
-		cancelRequest := &schemas.BifrostBatchCancelRequest{
-			Provider: testConfig.Provider,
-			BatchID:  createResponse.ID,
+		// Now cancel the batch using retry framework
+		cancelRetryContext := TestRetryContext{
+			ScenarioName: "BatchCancel",
+			ExpectedBehavior: map[string]interface{}{
+				"should_cancel_batch": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+				"batch_id": createResponse.ID,
+			},
 		}
 
-		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.BatchCancelRequest(bfCtx2, cancelRequest)
+		batchCancelRetryConfig := BatchCancelRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchCancelRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		cancelExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithBatchCancelTestRetry(t, batchCancelRetryConfig, cancelRetryContext, cancelExpectations, "BatchCancel", func() (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError) {
+			cancelRequest := &schemas.BifrostBatchCancelRequest{
+				Provider: testConfig.Provider,
+				BatchID:  createResponse.ID,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchCancelRequest(bfCtx, cancelRequest)
+		})
+
 		if err != nil {
 			// Note: Cancel might fail if batch has already completed
-			t.Logf("[WARNING] BatchCancel failed (batch may have already completed): %v", err)
+			t.Logf("[WARNING] BatchCancel failed after retries (batch may have already completed): %v", GetErrorMessage(err))
 			return
 		}
 
 		if response == nil {
-			t.Error("BatchCancel returned nil response")
-			return
+			t.Fatal("❌ BatchCancel returned nil response after retries")
 		}
 
-		t.Logf("[SUCCESS] Batch Cancel test passed for provider: %s, batch ID: %s", testConfig.Provider, response.ID)
+		t.Logf("✅ Batch Cancel test passed for provider: %s, batch ID: %s", testConfig.Provider, response.ID)
 	})
 }
 
@@ -259,23 +421,53 @@ func RunBatchResultsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Cont
 		// This test assumes there might be an existing completed batch
 		// In practice, you might want to poll for completion or use a pre-existing batch ID
 
-		// For now, we'll just verify the API call works
-		// A full test would involve creating a batch, waiting for completion, then getting results
-		request := &schemas.BifrostBatchResultsRequest{
-			Provider: testConfig.Provider,
-			BatchID:  "test-batch-id", // This would be a real batch ID in practice
+		// Use retry framework
+		retryConfig := GetTestRetryConfigForScenario("BatchResults", testConfig)
+		retryContext := TestRetryContext{
+			ScenarioName: "BatchResults",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_results": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		_, err := client.BatchResultsRequest(bfCtx, request)
+		batchResultsRetryConfig := BatchResultsRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []BatchResultsRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		expectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		// For now, we'll just verify the API call works
+		// A full test would involve creating a batch, waiting for completion, then getting results
+		_, err := WithBatchResultsTestRetry(t, batchResultsRetryConfig, retryContext, expectations, "BatchResults", func() (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
+			request := &schemas.BifrostBatchResultsRequest{
+				Provider: testConfig.Provider,
+				BatchID:  "test-batch-id", // This would be a real batch ID in practice
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.BatchResultsRequest(bfCtx, request)
+		})
+
 		if err != nil {
 			// This is expected to fail with a "batch not found" error since we're using a fake ID
 			// In a real test, you would use an actual completed batch ID
-			t.Logf("[INFO] BatchResults test completed (expected error with test ID): %v", err)
+			t.Logf("[INFO] BatchResults test completed (expected error with test ID): %v", GetErrorMessage(err))
 			return
 		}
 
-		t.Logf("[SUCCESS] Batch Results test passed for provider: %s", testConfig.Provider)
+		t.Logf("✅ Batch Results test passed for provider: %s", testConfig.Provider)
 	})
 }
 
@@ -347,41 +539,67 @@ func RunFileUploadTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 	t.Run("FileUpload", func(t *testing.T) {
 		t.Logf("[RUNNING] File Upload test for provider: %s", testConfig.Provider)
 
-		// Create a simple JSONL file content for batch processing
-		fileContent := []byte(`{"custom_id": "test-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
-`)
-
-		request := &schemas.BifrostFileUploadRequest{
-			Provider:    testConfig.Provider,
-			File:        fileContent,
-			Filename:    "test_batch.jsonl",
-			Purpose:     "batch",
-			ExtraParams: testConfig.FileExtraParams,
+		// Use retry framework
+		retryConfig := GetTestRetryConfigForScenario("FileUpload", testConfig)
+		retryContext := TestRetryContext{
+			ScenarioName: "FileUpload",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_file_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.FileUploadRequest(bfCtx, request)
+		fileUploadRetryConfig := FileUploadRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileUploadRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		expectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithFileUploadTestRetry(t, fileUploadRetryConfig, retryContext, expectations, "FileUpload", func() (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+			// Create a simple JSONL file content for batch processing
+			fileContent := []byte(`{"custom_id": "test-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
+`)
+			request := &schemas.BifrostFileUploadRequest{
+				Provider:    testConfig.Provider,
+				File:        fileContent,
+				Filename:    "test_batch.jsonl",
+				Purpose:     "batch",
+				ExtraParams: testConfig.FileExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileUploadRequest(bfCtx, request)
+		})
+
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
 				return
 			}
-			t.Errorf("FileUpload failed: %v", err)
-			return
+			t.Fatalf("❌ FileUpload failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("FileUpload returned nil response")
-			return
+			t.Fatal("❌ FileUpload returned nil response after retries")
 		}
 
 		if response.ID == "" {
-			t.Error("FileUpload returned empty file ID")
-			return
+			t.Fatal("❌ FileUpload returned empty file ID after retries")
 		}
 
-		t.Logf("[SUCCESS] File Upload test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
+		t.Logf("✅ File Upload test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
 	})
 }
 
@@ -395,30 +613,58 @@ func RunFileListTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context,
 	t.Run("FileList", func(t *testing.T) {
 		t.Logf("[RUNNING] File List test for provider: %s", testConfig.Provider)
 
-		request := &schemas.BifrostFileListRequest{
-			Provider:    testConfig.Provider,
-			Limit:       10,
-			ExtraParams: testConfig.FileExtraParams,
+		// Use retry framework
+		retryConfig := GetTestRetryConfigForScenario("FileList", testConfig)
+		retryContext := TestRetryContext{
+			ScenarioName: "FileList",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_list": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.FileListRequest(bfCtx, request)
+		fileListRetryConfig := FileListRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileListRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		expectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithFileListTestRetry(t, fileListRetryConfig, retryContext, expectations, "FileList", func() (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+			request := &schemas.BifrostFileListRequest{
+				Provider:    testConfig.Provider,
+				Limit:       10,
+				ExtraParams: testConfig.FileExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileListRequest(bfCtx, request)
+		})
+
 		if err != nil {
 			// Check if this is an unsupported operation error
 			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
 				return
 			}
-			t.Errorf("FileList failed: %v", err)
-			return
+			t.Fatalf("❌ FileList failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("FileList returned nil response")
-			return
+			t.Fatal("❌ FileList returned nil response after retries")
 		}
 
-		t.Logf("[SUCCESS] File List test passed for provider: %s, found %d files", testConfig.Provider, len(response.Data))
+		t.Logf("✅ File List test passed for provider: %s, found %d files", testConfig.Provider, len(response.Data))
 	})
 }
 
@@ -432,58 +678,111 @@ func RunFileRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Cont
 	t.Run("FileRetrieve", func(t *testing.T) {
 		t.Logf("[RUNNING] File Retrieve test for provider: %s", testConfig.Provider)
 
-		// First upload a file to retrieve
-		fileContent := []byte(`{"custom_id": "test-retrieve-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
-`)
+		// First upload a file to retrieve using retry framework
+		retryConfig := GetTestRetryConfigForScenario("FileRetrieve", testConfig)
 
-		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider:    testConfig.Provider,
-			File:        fileContent,
-			Filename:    "test_retrieve.jsonl",
-			Purpose:     "batch",
-			ExtraParams: testConfig.FileExtraParams,
+		uploadRetryContext := TestRetryContext{
+			ScenarioName: "FileRetrieve_Upload",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_file_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
+		fileUploadRetryConfig := FileUploadRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileUploadRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		uploadExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		uploadResponse, uploadErr := WithFileUploadTestRetry(t, fileUploadRetryConfig, uploadRetryContext, uploadExpectations, "FileRetrieve_Upload", func() (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+			fileContent := []byte(`{"custom_id": "test-retrieve-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
+`)
+			uploadRequest := &schemas.BifrostFileUploadRequest{
+				Provider:    testConfig.Provider,
+				File:        fileContent,
+				Filename:    "test_retrieve.jsonl",
+				Purpose:     "batch",
+				ExtraParams: testConfig.FileExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileUploadRequest(bfCtx, uploadRequest)
+		})
+
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
 				return
 			}
-			t.Errorf("FileUpload (for retrieve test) failed: %v", uploadErr)
-			return
+			t.Fatalf("❌ FileUpload (for retrieve test) failed after retries: %v", GetErrorMessage(uploadErr))
 		}
 
 		if uploadResponse == nil || uploadResponse.ID == "" {
-			t.Error("FileUpload returned invalid response for retrieve test")
-			return
+			t.Fatal("❌ FileUpload returned invalid response for retrieve test after retries")
 		}
 
-		// Now retrieve the file
-		retrieveRequest := &schemas.BifrostFileRetrieveRequest{
-			Provider: testConfig.Provider,
-			FileID:   uploadResponse.ID,
+		// Now retrieve the file using retry framework
+		retrieveRetryContext := TestRetryContext{
+			ScenarioName: "FileRetrieve",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_file": true,
+				"expected_file_id":   uploadResponse.ID,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.FileRetrieveRequest(bfCtx2, retrieveRequest)
+		fileRetrieveRetryConfig := FileRetrieveRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileRetrieveRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		retrieveExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithFileRetrieveTestRetry(t, fileRetrieveRetryConfig, retrieveRetryContext, retrieveExpectations, "FileRetrieve", func() (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+			retrieveRequest := &schemas.BifrostFileRetrieveRequest{
+				Provider: testConfig.Provider,
+				FileID:   uploadResponse.ID,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileRetrieveRequest(bfCtx, retrieveRequest)
+		})
+
 		if err != nil {
-			t.Errorf("FileRetrieve failed: %v", err)
-			return
+			t.Fatalf("❌ FileRetrieve failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("FileRetrieve returned nil response")
-			return
+			t.Fatal("❌ FileRetrieve returned nil response after retries")
 		}
 
 		if response.ID != uploadResponse.ID {
-			t.Errorf("FileRetrieve returned wrong file ID: got %s, expected %s", response.ID, uploadResponse.ID)
-			return
+			t.Fatalf("❌ FileRetrieve returned wrong file ID: got %s, expected %s", response.ID, uploadResponse.ID)
 		}
 
-		t.Logf("[SUCCESS] File Retrieve test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
+		t.Logf("✅ File Retrieve test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
 	})
 }
 
@@ -497,58 +796,111 @@ func RunFileDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 	t.Run("FileDelete", func(t *testing.T) {
 		t.Logf("[RUNNING] File Delete test for provider: %s", testConfig.Provider)
 
-		// First upload a file to delete
-		fileContent := []byte(`{"custom_id": "test-delete-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
-`)
+		// First upload a file to delete using retry framework
+		retryConfig := GetTestRetryConfigForScenario("FileDelete", testConfig)
 
-		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider:    testConfig.Provider,
-			File:        fileContent,
-			Filename:    "test_delete.jsonl",
-			Purpose:     "batch",
-			ExtraParams: testConfig.FileExtraParams,
+		uploadRetryContext := TestRetryContext{
+			ScenarioName: "FileDelete_Upload",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_file_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
+		fileUploadRetryConfig := FileUploadRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileUploadRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		uploadExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		uploadResponse, uploadErr := WithFileUploadTestRetry(t, fileUploadRetryConfig, uploadRetryContext, uploadExpectations, "FileDelete_Upload", func() (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+			fileContent := []byte(`{"custom_id": "test-delete-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
+`)
+			uploadRequest := &schemas.BifrostFileUploadRequest{
+				Provider:    testConfig.Provider,
+				File:        fileContent,
+				Filename:    "test_delete.jsonl",
+				Purpose:     "batch",
+				ExtraParams: testConfig.FileExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileUploadRequest(bfCtx, uploadRequest)
+		})
+
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
 				return
 			}
-			t.Errorf("FileUpload (for delete test) failed: %v", uploadErr)
-			return
+			t.Fatalf("❌ FileUpload (for delete test) failed after retries: %v", GetErrorMessage(uploadErr))
 		}
 
 		if uploadResponse == nil || uploadResponse.ID == "" {
-			t.Error("FileUpload returned invalid response for delete test")
-			return
+			t.Fatal("❌ FileUpload returned invalid response for delete test after retries")
 		}
 
-		// Now delete the file
-		deleteRequest := &schemas.BifrostFileDeleteRequest{
-			Provider: testConfig.Provider,
-			FileID:   uploadResponse.ID,
+		// Now delete the file using retry framework
+		deleteRetryContext := TestRetryContext{
+			ScenarioName: "FileDelete",
+			ExpectedBehavior: map[string]interface{}{
+				"should_delete_file": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+				"file_id":  uploadResponse.ID,
+			},
 		}
 
-		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.FileDeleteRequest(bfCtx2, deleteRequest)
+		fileDeleteRetryConfig := FileDeleteRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileDeleteRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		deleteExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithFileDeleteTestRetry(t, fileDeleteRetryConfig, deleteRetryContext, deleteExpectations, "FileDelete", func() (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+			deleteRequest := &schemas.BifrostFileDeleteRequest{
+				Provider: testConfig.Provider,
+				FileID:   uploadResponse.ID,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileDeleteRequest(bfCtx, deleteRequest)
+		})
+
 		if err != nil {
-			t.Errorf("FileDelete failed: %v", err)
-			return
+			t.Fatalf("❌ FileDelete failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("FileDelete returned nil response")
-			return
+			t.Fatal("❌ FileDelete returned nil response after retries")
 		}
 
 		if !response.Deleted {
-			t.Error("FileDelete did not mark file as deleted")
-			return
+			t.Fatal("❌ FileDelete did not mark file as deleted after retries")
 		}
 
-		t.Logf("[SUCCESS] File Delete test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
+		t.Logf("✅ File Delete test passed for provider: %s, file ID: %s", testConfig.Provider, response.ID)
 	})
 }
 
@@ -562,59 +914,112 @@ func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 	t.Run("FileContent", func(t *testing.T) {
 		t.Logf("[RUNNING] File Content test for provider: %s", testConfig.Provider)
 
-		// First upload a file to download
-		originalContent := []byte(`{"custom_id": "test-content-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
-`)
+		// First upload a file to download using retry framework
+		retryConfig := GetTestRetryConfigForScenario("FileContent", testConfig)
 
-		uploadRequest := &schemas.BifrostFileUploadRequest{
-			Provider:    testConfig.Provider,
-			File:        originalContent,
-			Filename:    "test_content.jsonl",
-			Purpose:     "batch",
-			ExtraParams: testConfig.FileExtraParams,
+		uploadRetryContext := TestRetryContext{
+			ScenarioName: "FileContent_Upload",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_file_id": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+			},
 		}
 
-		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		uploadResponse, uploadErr := client.FileUploadRequest(bfCtx, uploadRequest)
+		fileUploadRetryConfig := FileUploadRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileUploadRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		uploadExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		uploadResponse, uploadErr := WithFileUploadTestRetry(t, fileUploadRetryConfig, uploadRetryContext, uploadExpectations, "FileContent_Upload", func() (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+			originalContent := []byte(`{"custom_id": "test-content-1", "method": "POST", "url": "/v1/chat/completions", "body": {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello"}]}}
+`)
+			uploadRequest := &schemas.BifrostFileUploadRequest{
+				Provider:    testConfig.Provider,
+				File:        originalContent,
+				Filename:    "test_content.jsonl",
+				Purpose:     "batch",
+				ExtraParams: testConfig.FileExtraParams,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileUploadRequest(bfCtx, uploadRequest)
+		})
+
 		if uploadErr != nil {
 			if uploadErr.Error != nil && (uploadErr.Error.Code != nil && *uploadErr.Error.Code == "unsupported_operation") {
 				t.Logf("[EXPECTED] Provider %s returned unsupported operation error for upload", testConfig.Provider)
 				return
 			}
-			t.Errorf("FileUpload (for content test) failed: %v", uploadErr)
-			return
+			t.Fatalf("❌ FileUpload (for content test) failed after retries: %v", GetErrorMessage(uploadErr))
 		}
 
 		if uploadResponse == nil || uploadResponse.ID == "" {
-			t.Error("FileUpload returned invalid response for content test")
-			return
+			t.Fatal("❌ FileUpload returned invalid response for content test after retries")
 		}
 
-		// Now download the file content
-		contentRequest := &schemas.BifrostFileContentRequest{
-			Provider: testConfig.Provider,
-			FileID:   uploadResponse.ID,
+		// Now download the file content using retry framework
+		contentRetryContext := TestRetryContext{
+			ScenarioName: "FileContent",
+			ExpectedBehavior: map[string]interface{}{
+				"should_return_content": true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+				"file_id":  uploadResponse.ID,
+			},
 		}
 
-		bfCtx2 := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		response, err := client.FileContentRequest(bfCtx2, contentRequest)
+		fileContentRetryConfig := FileContentRetryConfig{
+			MaxAttempts: retryConfig.MaxAttempts,
+			BaseDelay:   retryConfig.BaseDelay,
+			MaxDelay:    retryConfig.MaxDelay,
+			Conditions:  []FileContentRetryCondition{},
+			OnRetry:     retryConfig.OnRetry,
+			OnFinalFail: retryConfig.OnFinalFail,
+		}
+
+		contentExpectations := ResponseExpectations{
+			ShouldHaveLatency: true,
+			ProviderSpecific: map[string]interface{}{
+				"expected_provider": string(testConfig.Provider),
+			},
+		}
+
+		response, err := WithFileContentTestRetry(t, fileContentRetryConfig, contentRetryContext, contentExpectations, "FileContent", func() (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+			contentRequest := &schemas.BifrostFileContentRequest{
+				Provider: testConfig.Provider,
+				FileID:   uploadResponse.ID,
+			}
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.FileContentRequest(bfCtx, contentRequest)
+		})
+
 		if err != nil {
-			t.Errorf("FileContent failed: %v", err)
-			return
+			t.Fatalf("❌ FileContent failed after retries: %v", GetErrorMessage(err))
 		}
 
 		if response == nil {
-			t.Error("FileContent returned nil response")
-			return
+			t.Fatal("❌ FileContent returned nil response after retries")
 		}
 
 		if len(response.Content) == 0 {
-			t.Error("FileContent returned empty content")
-			return
+			t.Fatal("❌ FileContent returned empty content after retries")
 		}
 
 		// Verify content matches (optional, as some providers may modify content)
-		t.Logf("[SUCCESS] File Content test passed for provider: %s, file ID: %s, content length: %d bytes", testConfig.Provider, response.FileID, len(response.Content))
+		t.Logf("✅ File Content test passed for provider: %s, file ID: %s, content length: %d bytes", testConfig.Provider, response.FileID, len(response.Content))
 	})
 }
 

--- a/core/internal/testutil/response_validation.go
+++ b/core/internal/testutil/response_validation.go
@@ -1399,6 +1399,492 @@ func collectCountTokensResponseMetrics(response *schemas.BifrostCountTokensRespo
 	result.MetricsCollected["request_type"] = response.ExtraFields.RequestType
 }
 
+// =============================================================================
+// BATCH API VALIDATION FUNCTIONS
+// =============================================================================
+
+// ValidateBatchCreateResponse performs comprehensive validation for batch create responses
+func ValidateBatchCreateResponse(t *testing.T, response *schemas.BifrostBatchCreateResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate batch ID is present
+	if response.ID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Batch ID is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["batch_id"] = response.ID
+	result.MetricsCollected["status"] = response.Status
+	result.MetricsCollected["has_endpoint"] = response.Endpoint != ""
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateBatchListResponse performs comprehensive validation for batch list responses
+func ValidateBatchListResponse(t *testing.T, response *schemas.BifrostBatchListResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["batch_count"] = len(response.Data)
+	result.MetricsCollected["has_more"] = response.HasMore
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateBatchRetrieveResponse performs comprehensive validation for batch retrieve responses
+func ValidateBatchRetrieveResponse(t *testing.T, response *schemas.BifrostBatchRetrieveResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate batch ID is present
+	if response.ID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Batch ID is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["batch_id"] = response.ID
+	result.MetricsCollected["status"] = response.Status
+	result.MetricsCollected["has_request_counts"] = response.RequestCounts.Total > 0
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateBatchCancelResponse performs comprehensive validation for batch cancel responses
+func ValidateBatchCancelResponse(t *testing.T, response *schemas.BifrostBatchCancelResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate batch ID is present
+	if response.ID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Batch ID is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["batch_id"] = response.ID
+	result.MetricsCollected["status"] = response.Status
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateBatchResultsResponse performs comprehensive validation for batch results responses
+func ValidateBatchResultsResponse(t *testing.T, response *schemas.BifrostBatchResultsResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate batch ID is present
+	if response.BatchID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Batch ID is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["batch_id"] = response.BatchID
+	result.MetricsCollected["results_count"] = len(response.Results)
+	result.MetricsCollected["has_more"] = response.HasMore
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// =============================================================================
+// FILE API VALIDATION FUNCTIONS
+// =============================================================================
+
+// ValidateFileUploadResponse performs comprehensive validation for file upload responses
+func ValidateFileUploadResponse(t *testing.T, response *schemas.BifrostFileUploadResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate file ID is present
+	if response.ID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "File ID is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["file_id"] = response.ID
+	result.MetricsCollected["filename"] = response.Filename
+	result.MetricsCollected["bytes"] = response.Bytes
+	result.MetricsCollected["purpose"] = response.Purpose
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateFileListResponse performs comprehensive validation for file list responses
+func ValidateFileListResponse(t *testing.T, response *schemas.BifrostFileListResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["file_count"] = len(response.Data)
+	result.MetricsCollected["has_more"] = response.HasMore
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateFileRetrieveResponse performs comprehensive validation for file retrieve responses
+func ValidateFileRetrieveResponse(t *testing.T, response *schemas.BifrostFileRetrieveResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate file ID is present
+	if response.ID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "File ID is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["file_id"] = response.ID
+	result.MetricsCollected["filename"] = response.Filename
+	result.MetricsCollected["bytes"] = response.Bytes
+	result.MetricsCollected["status"] = response.Status
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateFileDeleteResponse performs comprehensive validation for file delete responses
+func ValidateFileDeleteResponse(t *testing.T, response *schemas.BifrostFileDeleteResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate file ID is present
+	if response.ID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "File ID is empty")
+	}
+
+	// Validate deleted flag
+	if !response.Deleted {
+		result.Passed = false
+		result.Errors = append(result.Errors, "File was not marked as deleted")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["file_id"] = response.ID
+	result.MetricsCollected["deleted"] = response.Deleted
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
+// ValidateFileContentResponse performs comprehensive validation for file content responses
+func ValidateFileContentResponse(t *testing.T, response *schemas.BifrostFileContentResponse, err *schemas.BifrostError, expectations ResponseExpectations, scenarioName string) ValidationResult {
+	result := ValidationResult{
+		Passed:           true,
+		Errors:           make([]string, 0),
+		Warnings:         make([]string, 0),
+		MetricsCollected: make(map[string]interface{}),
+	}
+
+	if err != nil {
+		result.Passed = false
+		parsed := ParseBifrostError(err)
+		result.Errors = append(result.Errors, fmt.Sprintf("Got error when expecting success: %s", FormatErrorConcise(parsed)))
+		LogError(t, err, scenarioName)
+		return result
+	}
+
+	if response == nil {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Response is nil")
+		return result
+	}
+
+	// Validate file ID is present
+	if response.FileID == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "File ID is empty")
+	}
+
+	// Validate content is present
+	if len(response.Content) == 0 {
+		result.Passed = false
+		result.Errors = append(result.Errors, "File content is empty")
+	}
+
+	// Validate latency if expected
+	if expectations.ShouldHaveLatency {
+		if response.ExtraFields.Latency <= 0 {
+			result.Passed = false
+			result.Errors = append(result.Errors, "Expected latency information but not present or invalid")
+		} else {
+			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
+		}
+	}
+
+	// Collect metrics
+	result.MetricsCollected["file_id"] = response.FileID
+	result.MetricsCollected["content_length"] = len(response.Content)
+	result.MetricsCollected["content_type"] = response.ContentType
+
+	logValidationResults(t, result, scenarioName)
+	return result
+}
+
 // extractChatToolCallNames extracts tool call function names from chat response for error messages
 func extractChatToolCallNames(response *schemas.BifrostChatResponse) []string {
 	var toolNames []string

--- a/core/internal/testutil/test_retry_framework.go
+++ b/core/internal/testutil/test_retry_framework.go
@@ -176,6 +176,66 @@ type ListModelsRetryCondition interface {
 	GetConditionName() string
 }
 
+// BatchCreateRetryCondition defines an interface for checking if a batch create test operation should be retried
+type BatchCreateRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostBatchCreateResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// BatchListRetryCondition defines an interface for checking if a batch list test operation should be retried
+type BatchListRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostBatchListResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// BatchRetrieveRetryCondition defines an interface for checking if a batch retrieve test operation should be retried
+type BatchRetrieveRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostBatchRetrieveResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// BatchCancelRetryCondition defines an interface for checking if a batch cancel test operation should be retried
+type BatchCancelRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostBatchCancelResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// BatchResultsRetryCondition defines an interface for checking if a batch results test operation should be retried
+type BatchResultsRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostBatchResultsResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// FileUploadRetryCondition defines an interface for checking if a file upload test operation should be retried
+type FileUploadRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostFileUploadResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// FileListRetryCondition defines an interface for checking if a file list test operation should be retried
+type FileListRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostFileListResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// FileRetrieveRetryCondition defines an interface for checking if a file retrieve test operation should be retried
+type FileRetrieveRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostFileRetrieveResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// FileDeleteRetryCondition defines an interface for checking if a file delete test operation should be retried
+type FileDeleteRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostFileDeleteResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
+// FileContentRetryCondition defines an interface for checking if a file content test operation should be retried
+type FileContentRetryCondition interface {
+	ShouldRetry(response *schemas.BifrostFileContentResponse, err *schemas.BifrostError, context TestRetryContext) (bool, string)
+	GetConditionName() string
+}
+
 // TestRetryContext provides context information for retry decisions
 type TestRetryContext struct {
 	ScenarioName     string                 // Name of the test scenario
@@ -280,6 +340,106 @@ type ListModelsRetryConfig struct {
 	BaseDelay   time.Duration                                    // Base delay between retries
 	MaxDelay    time.Duration                                    // Maximum delay between retries
 	Conditions  []ListModelsRetryCondition                       // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// BatchCreateRetryConfig configures retry behavior for batch create test scenarios
+type BatchCreateRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []BatchCreateRetryCondition                      // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// BatchListRetryConfig configures retry behavior for batch list test scenarios
+type BatchListRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []BatchListRetryCondition                        // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// BatchRetrieveRetryConfig configures retry behavior for batch retrieve test scenarios
+type BatchRetrieveRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []BatchRetrieveRetryCondition                    // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// BatchCancelRetryConfig configures retry behavior for batch cancel test scenarios
+type BatchCancelRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []BatchCancelRetryCondition                      // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// BatchResultsRetryConfig configures retry behavior for batch results test scenarios
+type BatchResultsRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []BatchResultsRetryCondition                     // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// FileUploadRetryConfig configures retry behavior for file upload test scenarios
+type FileUploadRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []FileUploadRetryCondition                       // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// FileListRetryConfig configures retry behavior for file list test scenarios
+type FileListRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []FileListRetryCondition                         // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// FileRetrieveRetryConfig configures retry behavior for file retrieve test scenarios
+type FileRetrieveRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []FileRetrieveRetryCondition                     // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// FileDeleteRetryConfig configures retry behavior for file delete test scenarios
+type FileDeleteRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []FileDeleteRetryCondition                       // Conditions that trigger retries
+	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
+	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
+}
+
+// FileContentRetryConfig configures retry behavior for file content test scenarios
+type FileContentRetryConfig struct {
+	MaxAttempts int                                              // Maximum retry attempts (including initial attempt)
+	BaseDelay   time.Duration                                    // Base delay between retries
+	MaxDelay    time.Duration                                    // Maximum delay between retries
+	Conditions  []FileContentRetryCondition                      // Conditions that trigger retries
 	OnRetry     func(attempt int, reason string, t *testing.T)   // Called before each retry
 	OnFinalFail func(attempts int, finalErr error, t *testing.T) // Called on final failure
 }
@@ -2404,6 +2564,982 @@ func checkListModelsRetryConditions(response *schemas.BifrostListModelsResponse,
 	}
 
 	return false, ""
+}
+
+// =============================================================================
+// BATCH API RETRY FUNCTIONS
+// =============================================================================
+
+// WithBatchCreateTestRetry wraps a batch create test operation with retry logic
+func WithBatchCreateTestRetry(
+	t *testing.T,
+	config BatchCreateRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError),
+) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostBatchCreateResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		// Execute the operation
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		// ALWAYS retry on ANY error condition
+		shouldRetry := false
+		var retryReason string
+
+		// Check for errors first
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		// Check for nil response
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		// If we have a response, validate it
+		if response != nil {
+			validationResult := ValidateBatchCreateResponse(t, response, err, expectations, scenarioName)
+
+			// If validation passes and no errors, we're done!
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			// ALWAYS retry on validation failures
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		// Retry if needed and attempts remaining
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateBatchCreateResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithBatchListTestRetry wraps a batch list test operation with retry logic
+func WithBatchListTestRetry(
+	t *testing.T,
+	config BatchListRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostBatchListResponse, *schemas.BifrostError),
+) (*schemas.BifrostBatchListResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostBatchListResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateBatchListResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateBatchListResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithBatchRetrieveTestRetry wraps a batch retrieve test operation with retry logic
+func WithBatchRetrieveTestRetry(
+	t *testing.T,
+	config BatchRetrieveRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError),
+) (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostBatchRetrieveResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateBatchRetrieveResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateBatchRetrieveResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithBatchCancelTestRetry wraps a batch cancel test operation with retry logic
+func WithBatchCancelTestRetry(
+	t *testing.T,
+	config BatchCancelRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError),
+) (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostBatchCancelResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateBatchCancelResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateBatchCancelResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithBatchResultsTestRetry wraps a batch results test operation with retry logic
+func WithBatchResultsTestRetry(
+	t *testing.T,
+	config BatchResultsRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError),
+) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostBatchResultsResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateBatchResultsResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateBatchResultsResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// =============================================================================
+// FILE API RETRY FUNCTIONS
+// =============================================================================
+
+// WithFileUploadTestRetry wraps a file upload test operation with retry logic
+func WithFileUploadTestRetry(
+	t *testing.T,
+	config FileUploadRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostFileUploadResponse, *schemas.BifrostError),
+) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostFileUploadResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateFileUploadResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateFileUploadResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithFileListTestRetry wraps a file list test operation with retry logic
+func WithFileListTestRetry(
+	t *testing.T,
+	config FileListRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostFileListResponse, *schemas.BifrostError),
+) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostFileListResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateFileListResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateFileListResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithFileRetrieveTestRetry wraps a file retrieve test operation with retry logic
+func WithFileRetrieveTestRetry(
+	t *testing.T,
+	config FileRetrieveRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError),
+) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostFileRetrieveResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateFileRetrieveResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateFileRetrieveResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithFileDeleteTestRetry wraps a file delete test operation with retry logic
+func WithFileDeleteTestRetry(
+	t *testing.T,
+	config FileDeleteRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError),
+) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostFileDeleteResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateFileDeleteResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateFileDeleteResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
+}
+
+// WithFileContentTestRetry wraps a file content test operation with retry logic
+func WithFileContentTestRetry(
+	t *testing.T,
+	config FileContentRetryConfig,
+	context TestRetryContext,
+	expectations ResponseExpectations,
+	scenarioName string,
+	operation func() (*schemas.BifrostFileContentResponse, *schemas.BifrostError),
+) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+
+	var lastResponse *schemas.BifrostFileContentResponse
+	var lastError *schemas.BifrostError
+
+	for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+		context.AttemptNumber = attempt
+
+		response, err := operation()
+		lastResponse = response
+		lastError = err
+
+		shouldRetry := false
+		var retryReason string
+
+		if err != nil {
+			shouldRetry = true
+			if isTimeoutError(err) {
+				retryReason = fmt.Sprintf("timeout error detected: %s", GetErrorMessage(err))
+			} else {
+				parsed := ParseBifrostError(err)
+				retryReason = fmt.Sprintf("❌ error occurred: %s", FormatErrorConcise(parsed))
+			}
+		}
+
+		if response == nil {
+			shouldRetry = true
+			if retryReason != "" {
+				retryReason += " and ❌ response is nil"
+			} else {
+				retryReason = "❌ response is nil"
+			}
+		}
+
+		if response != nil {
+			validationResult := ValidateFileContentResponse(t, response, err, expectations, scenarioName)
+
+			if validationResult.Passed && err == nil {
+				return response, err
+			}
+
+			if !validationResult.Passed {
+				shouldRetry = true
+				if retryReason != "" {
+					retryReason += fmt.Sprintf(" | ❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				} else {
+					retryReason = fmt.Sprintf("❌ validation failure: %s", strings.Join(validationResult.Errors, "; "))
+				}
+			}
+		}
+
+		if shouldRetry && attempt < config.MaxAttempts {
+			if config.OnRetry != nil {
+				config.OnRetry(attempt, retryReason, t)
+			}
+
+			delay := calculateRetryDelay(attempt-1, config.BaseDelay, config.MaxDelay)
+			time.Sleep(delay)
+			continue
+		}
+
+		if !shouldRetry {
+			return response, err
+		}
+
+		break
+	}
+
+	if config.OnFinalFail != nil {
+		var errorMsg string
+		if lastError != nil {
+			if lastError.Error != nil {
+				errorMsg = lastError.Error.Message
+			} else {
+				errorMsg = "unknown error"
+			}
+		} else if lastResponse == nil {
+			errorMsg = "response is nil"
+		} else {
+			validationResult := ValidateFileContentResponse(t, lastResponse, nil, expectations, scenarioName)
+			errorMsg = strings.Join(validationResult.Errors, "; ")
+		}
+		config.OnFinalFail(config.MaxAttempts, fmt.Errorf("final error: %s", errorMsg), t)
+	}
+
+	return lastResponse, lastError
 }
 
 // SpeechStreamValidationResult represents the result of speech streaming validation

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -513,6 +513,10 @@
     {
       "source": "/features/mcp/filtering",
       "destination": "/mcp/filtering"
+    },
+    {
+      "source": "/features/enterprise/governance",
+      "destination": "https://docs.getbifrost.ai/enterprise/setting-up-okta"
     }
   ],
   "footer": {

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -263,7 +263,7 @@ export default function ClientSettingsView() {
 						<label htmlFor="enable-litellm-fallbacks" className="text-sm font-medium">
 							Enable LiteLLM Fallbacks
 						</label>
-						<p className="text-muted-foreground text-sm">Enable litellm-specific fallbacks. <a className="text-primary underline cursor-pointer" href="https://docs.getbifrost.ai/features/litellm-compatibility" target="_blank" rel="noopener noreferrer">Learn more</a></p>
+						<p className="text-muted-foreground text-sm">Enable litellm-specific fallbacks. <a className="text-primary underline cursor-pointer" href="https://docs.getbifrost.ai/features/litellm-compat" target="_blank" rel="noopener noreferrer">Learn more</a></p>
 					</div>
 					<Switch
 						id="enable-litellm-fallbacks"


### PR DESCRIPTION
## Summary

Implemented retry framework for batch and file API tests to improve test reliability and consistency.

## Changes

- Added retry logic to all batch API test functions (Create, List, Retrieve, Cancel, Results)
- Added retry logic to all file API test functions (Upload, List, Retrieve, Delete, Content)
- Implemented validation functions for batch and file API responses
- Updated test output formatting with clearer success/failure indicators (✅/❌)
- Enhanced error handling and reporting in test functions

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)

## How to test

Run the batch and file API tests to verify they now use the retry framework:

```sh
# Run batch API tests
go test -v ./core/internal/testutil -run TestBatch

# Run file API tests
go test -v ./core/internal/testutil -run TestFile
```

## Breaking changes

- [x] No

## Related issues

Improves test reliability for batch and file API operations.

## Security considerations

No security implications as this only affects test code.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally