### PR TITLE
feat: added support for `addWatermark` parameter in Gemini Image Gen

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- feat: added support for addWatermark parameter in Gemini Image Gen
 - fix: allow setting authorization header through extra headers and in allow list and deny list
 - feat: added support for gemini google search tool
 - fix: function response part handling in gemini

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -66,6 +66,9 @@ func (request *GeminiGenerationRequest) ToBifrostImageGenerationRequest() *schem
 			if request.Parameters.EnhancePrompt != nil {
 				bifrostReq.Params.ExtraParams["enhancePrompt"] = *request.Parameters.EnhancePrompt
 			}
+			if request.Parameters.AddWatermark != nil {
+				bifrostReq.Params.ExtraParams["addWatermark"] = *request.Parameters.AddWatermark
+			}
 			if len(request.Parameters.SafetySettings) > 0 {
 				bifrostReq.Params.ExtraParams["safetySettings"] = request.Parameters.SafetySettings
 			}
@@ -334,6 +337,9 @@ func ToImagenImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 
 		// Handle extra parameters for Imagen-specific fields
 		if bifrostReq.Params.ExtraParams != nil {
+			if addWatermark, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["addWatermark"]); ok {
+				req.Parameters.AddWatermark = addWatermark
+			}
 			if sampleImageSize, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["sampleImageSize"]); ok {
 				req.Parameters.SampleImageSize = &sampleImageSize
 			}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -2122,6 +2122,7 @@ type GeminiImagenRequest struct {
 }
 
 type GeminiImagenParameters struct {
+	AddWatermark     *bool                `json:"addWatermark,omitempty"`     // Whether to add a watermark to the image
 	SampleCount      *int                 `json:"sampleCount,omitempty"`      // 1 - 4
 	SampleImageSize  *string              `json:"sampleImageSize,omitempty"`  // "1K", "2K", "4K"
 	AspectRatio      *string              `json:"aspectRatio,omitempty"`      // "1:1", "3:4", "4:3", "9:16", "16:9"

--- a/core/providers/openai/images.go
+++ b/core/providers/openai/images.go
@@ -22,6 +22,8 @@ func ToOpenAIImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 	switch bifrostReq.Provider {
 	case schemas.XAI:
 		filterXAISpecificParameters(req)
+	case schemas.OpenAI, schemas.Azure:
+		filterOpenAISpecificParameters(req)
 	}
 	return req
 }
@@ -31,6 +33,12 @@ func filterXAISpecificParameters(req *OpenAIImageGenerationRequest) {
 	req.ImageGenerationParameters.Style = nil
 	req.ImageGenerationParameters.Size = nil
 	req.ImageGenerationParameters.OutputCompression = nil
+}
+
+func filterOpenAISpecificParameters(req *OpenAIImageGenerationRequest) {
+	req.ImageGenerationParameters.Seed = nil
+	req.NumInferenceSteps = nil
+	req.NegativePrompt = nil
 }
 
 // ToBifrostImageGenerationRequest converts an OpenAI image generation request to Bifrost format


### PR DESCRIPTION
## Summary

Added support for the `addWatermark` parameter in Gemini's Imagen image generation API, allowing users to control whether watermarks are added to generated images. Added filtering for OpenAI-specific parameters to prevent sending unsupported parameters

## Changes

- Added the `AddWatermark` field to the `GeminiImagenParameters` struct with appropriate JSON tags and documentation
- Implemented extraction of the `addWatermark` parameter from the Bifrost request's extra parameters
- Properly passes the watermark preference to the Gemini API
- Added filtering for OpenAI-specific parameters to prevent sending unsupported parameters

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Make an image generation request to the Gemini provider with the `addWatermark` parameter:

```sh
curl -X POST http://localhost:8080/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "vertex/imagen-4.0-generate-001",
    "prompt": "a beautiful sunset over mountains",
    "addWatermark": false
  }'
```

2. Verify that the generated image respects the watermark preference

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

No security implications as this only exposes an existing API parameter.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable