### PR TITLE
fix: function response part handling in gemini

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - fix: allow setting authorization header through extra headers and in allow list and deny list
 - feat: added support for gemini google search tool
+- fix: function response part handling in gemini

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,3 +2,4 @@
 - feat: configure custom CORS headers, allowing clients to specify additional headers that should be allowed in cross-origin requests.
 - feat: support for listing models from specific provider or all providers via a header flag x-bf-list-models-provider from integrations.
 - feat: added support for gemini google search tool
+- fix: function response part handling in gemini


### PR DESCRIPTION
## Summary

Fix function response handling in Gemini to properly support parallel function calling according to Gemini API requirements.

## Changes

- Modified the Gemini provider to group consecutive function response parts into a single message
- Ensured function responses are sent with the correct "model" role
- Separated function response handling from regular content handling
- Updated the handling of tool response messages to follow Gemini's parallel function calling requirements

## Fixes
#1387 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test parallel function calling with Gemini:

```sh
# Core/Transports
go version
go test ./...

# Test with multiple function calls in a single turn
# Verify that function responses are properly grouped and the model can process them correctly
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with Gemini's function response handling requirements.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)