### PR TITLE
fix: call enrich error in vertex provider for raw request and response

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
 - fix: allow setting authorization header through extra headers and in allow list and deny list
 - feat: added support for gemini google search tool
 - fix: function response part handling in gemini
+- fix: call enrich error in vertex to return raw request and response in bifrost errors

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -3,3 +3,4 @@
 - feat: support for listing models from specific provider or all providers via a header flag x-bf-list-models-provider from integrations.
 - feat: added support for gemini google search tool
 - fix: function response part handling in gemini
+- fix: call enrich error in vertex to return raw request and response in bifrost errors


### PR DESCRIPTION
## Summary

Enhanced error handling in the Vertex provider by implementing `EnrichError` to include request and response data in error objects.

## Changes

- Replaced direct error returns with `EnrichError` calls throughout the Vertex provider
- Added request body (jsonBody) and response body data to error objects
- Maintained configuration for raw request/response inclusion based on provider settings
- Improved error context for better debugging and troubleshooting

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test error scenarios with the Vertex provider to verify that errors contain the expected context:

```sh
# Core/Transports
go version
go test ./core/providers/vertex/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves error handling and debugging capabilities for the Vertex provider.

## Security considerations

The enriched errors may contain sensitive information from requests/responses, but this follows the existing pattern of including raw requests/responses when configured.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable