### PR TITLE
fix: allow setting auth headers through extra headers

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: allow setting authorization header through extra headers and in allow list and deny list

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -236,16 +236,11 @@ func filterHeaders(headers map[string][]string) map[string][]string {
 // SetExtraHeaders sets additional headers from NetworkConfig to the fasthttp request.
 // This allows users to configure custom headers for their provider requests.
 // Header keys are canonicalized using textproto.CanonicalMIMEHeaderKey to avoid duplicates.
-// The Authorization header is excluded for security reasons.
 // It accepts a list of headers (all canonicalized) to skip for security reasons.
 // Headers are only set if they don't already exist on the request to avoid overwriting important headers.
 func SetExtraHeaders(ctx context.Context, req *fasthttp.Request, extraHeaders map[string]string, skipHeaders []string) {
 	for key, value := range extraHeaders {
 		canonicalKey := textproto.CanonicalMIMEHeaderKey(key)
-		// Skip Authorization header for security reasons
-		if key == "Authorization" {
-			continue
-		}
 		if skipHeaders != nil {
 			if slices.Contains(skipHeaders, key) {
 				continue
@@ -345,10 +340,6 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 func SetExtraHeadersHTTP(ctx context.Context, req *http.Request, extraHeaders map[string]string, skipHeaders []string) {
 	for key, value := range extraHeaders {
 		canonicalKey := textproto.CanonicalMIMEHeaderKey(key)
-		// Skip Authorization header for security reasons
-		if key == "Authorization" {
-			continue
-		}
 		if skipHeaders != nil {
 			if slices.Contains(skipHeaders, key) {
 				continue

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -673,7 +673,6 @@ Bifrost maintains a security denylist of headers that are never forwarded to pro
 
 ```go
 denylist := map[string]bool{
-    "authorization":       true,
     "proxy-authorization": true,
     "cookie":              true,
     "host":                true,

--- a/docs/quickstart/go-sdk/provider-configuration.mdx
+++ b/docs/quickstart/go-sdk/provider-configuration.mdx
@@ -275,7 +275,6 @@ Bifrost maintains a security denylist of headers that are never forwarded to pro
 
 ```go
 denylist := map[string]bool{
-    "authorization":       true,
     "proxy-authorization": true,
     "cookie":              true,
     "host":                true,

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -100,7 +100,6 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, hea
 	// Security denylist of header names that should never be accepted (case-insensitive)
 	// This denylist is always enforced regardless of user configuration
 	securityDenylist := map[string]bool{
-		"authorization":       true,
 		"proxy-authorization": true,
 		"cookie":              true,
 		"host":                true,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,3 @@
+- fix: allow setting authorization header through extra headers and in allow list and deny list
+- feat: configure custom CORS headers, allowing clients to specify additional headers that should be allowed in cross-origin requests.
+- feat: support for listing models from specific provider or all providers via a header flag x-bf-list-models-provider from integrations.

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -35,7 +35,6 @@ const defaultConfig: CoreConfig = {
 // Security headers that cannot be configured in allowlist/denylist
 // These headers are always blocked for security reasons regardless of configuration
 const SECURITY_HEADERS = [
-	"authorization",
 	"proxy-authorization",
 	"cookie",
 	"host",
@@ -347,7 +346,7 @@ export default function ClientSettingsView() {
 						<AccordionContent>
 							<p className="text-sm">Some headers are always blocked for security reasons regardless of configuration. These headers cannot be added to the allowlist or denylist:</p>
 							<p className="text-muted-foreground mt-1 font-mono text-xs">
-								authorization, proxy-authorization, cookie, host, content-length, connection, transfer-encoding, x-api-key, x-goog-api-key,
+								proxy-authorization, cookie, host, content-length, connection, transfer-encoding, x-api-key, x-goog-api-key,
 								x-bf-api-key, x-bf-vk
 							</p>
 						</AccordionContent>


### PR DESCRIPTION
## Summary

This PR removes the `authorization` header from the security denylist, allowing it to be forwarded to providers when configured in extra headers.

## Changes

- Removed explicit checks that blocked the `authorization` header in `SetExtraHeaders` and `SetExtraHeadersHTTP` functions
- Removed `authorization` from the security denylist in the Bifrost HTTP transport
- Updated documentation and UI to reflect that the `authorization` header is no longer in the security denylist

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)
- [x] Docs

## How to test

Test that authorization headers can now be forwarded to providers:

```sh
# Core/Transports
go test ./core/providers/utils/...
go test ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

Configure a provider with an authorization header in the extra headers and verify it's properly forwarded in the request.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change allows the `authorization` header to be forwarded to providers when explicitly configured. This is a deliberate security decision to enable authentication with provider APIs that require authorization headers.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)