### PR TITLE
adds volume graph to logs page & dashboard tab

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -18,6 +18,28 @@ type RDBLogStore struct {
 	logger schemas.Logger
 }
 
+// generateBucketTimestamps generates all bucket timestamps for a time range.
+// It aligns the start time to bucket boundaries and generates timestamps up to (but not exceeding) the end time.
+func generateBucketTimestamps(startTime, endTime *time.Time, bucketSizeSeconds int64) []int64 {
+	if startTime == nil || endTime == nil || bucketSizeSeconds <= 0 {
+		return nil
+	}
+
+	startUnix := startTime.Unix()
+	endUnix := endTime.Unix()
+
+	// Align start time to bucket boundary
+	alignedStart := (startUnix / bucketSizeSeconds) * bucketSizeSeconds
+
+	// Generate all bucket timestamps
+	var timestamps []int64
+	for ts := alignedStart; ts <= endUnix; ts += bucketSizeSeconds {
+		timestamps = append(timestamps, ts)
+	}
+
+	return timestamps
+}
+
 // applyFilters applies search filters to a GORM query
 func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *gorm.DB {
 	if len(filters.Providers) > 0 {
@@ -387,6 +409,382 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 	return &HistogramResult{
 		Buckets:           buckets,
 		BucketSizeSeconds: bucketSizeSeconds,
+	}, nil
+}
+
+// GetTokenHistogram returns time-bucketed token usage for the given filters.
+func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*TokenHistogramResult, error) {
+	if bucketSizeSeconds <= 0 {
+		bucketSizeSeconds = 3600 // Default to 1 hour
+	}
+
+	dialect := s.db.Dialector.Name()
+
+	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery = s.applyFilters(baseQuery, filters)
+	// Only count completed requests for token stats
+	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+
+	var results []struct {
+		BucketTimestamp  int64 `gorm:"column:bucket_timestamp"`
+		PromptTokens     int64 `gorm:"column:prompt_tokens"`
+		CompletionTokens int64 `gorm:"column:completion_tokens"`
+		TotalTokens      int64 `gorm:"column:total_tokens"`
+	}
+
+	var selectClause string
+	switch dialect {
+	case "sqlite":
+		selectClause = fmt.Sprintf(`
+			(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp,
+			COALESCE(SUM(prompt_tokens), 0) as prompt_tokens,
+			COALESCE(SUM(completion_tokens), 0) as completion_tokens,
+			COALESCE(SUM(total_tokens), 0) as total_tokens
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	case "mysql":
+		selectClause = fmt.Sprintf(`
+			(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp,
+			COALESCE(SUM(prompt_tokens), 0) as prompt_tokens,
+			COALESCE(SUM(completion_tokens), 0) as completion_tokens,
+			COALESCE(SUM(total_tokens), 0) as total_tokens
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	default:
+		selectClause = fmt.Sprintf(`
+			CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) / %d) * %d AS BIGINT) as bucket_timestamp,
+			COALESCE(SUM(prompt_tokens), 0) as prompt_tokens,
+			COALESCE(SUM(completion_tokens), 0) as completion_tokens,
+			COALESCE(SUM(total_tokens), 0) as total_tokens
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	}
+
+	if err := baseQuery.
+		Select(selectClause).
+		Group("bucket_timestamp").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get token histogram: %w", err)
+	}
+
+	// Create a map of bucket timestamp -> result for quick lookup
+	resultMap := make(map[int64]struct {
+		PromptTokens     int64
+		CompletionTokens int64
+		TotalTokens      int64
+	})
+	for _, r := range results {
+		resultMap[r.BucketTimestamp] = struct {
+			PromptTokens     int64
+			CompletionTokens int64
+			TotalTokens      int64
+		}{
+			PromptTokens:     r.PromptTokens,
+			CompletionTokens: r.CompletionTokens,
+			TotalTokens:      r.TotalTokens,
+		}
+	}
+
+	// Generate all bucket timestamps for the time range
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+
+	// If no time range specified, just return what we have from the query
+	if len(allTimestamps) == 0 {
+		buckets := make([]TokenHistogramBucket, len(results))
+		for i, r := range results {
+			buckets[i] = TokenHistogramBucket{
+				Timestamp:        time.Unix(r.BucketTimestamp, 0).UTC(),
+				PromptTokens:     r.PromptTokens,
+				CompletionTokens: r.CompletionTokens,
+				TotalTokens:      r.TotalTokens,
+			}
+		}
+		return &TokenHistogramResult{
+			Buckets:           buckets,
+			BucketSizeSeconds: bucketSizeSeconds,
+		}, nil
+	}
+
+	// Fill in all buckets, using zeros for missing timestamps
+	buckets := make([]TokenHistogramBucket, len(allTimestamps))
+	for i, ts := range allTimestamps {
+		if data, exists := resultMap[ts]; exists {
+			buckets[i] = TokenHistogramBucket{
+				Timestamp:        time.Unix(ts, 0).UTC(),
+				PromptTokens:     data.PromptTokens,
+				CompletionTokens: data.CompletionTokens,
+				TotalTokens:      data.TotalTokens,
+			}
+		} else {
+			buckets[i] = TokenHistogramBucket{
+				Timestamp:        time.Unix(ts, 0).UTC(),
+				PromptTokens:     0,
+				CompletionTokens: 0,
+				TotalTokens:      0,
+			}
+		}
+	}
+
+	return &TokenHistogramResult{
+		Buckets:           buckets,
+		BucketSizeSeconds: bucketSizeSeconds,
+	}, nil
+}
+
+// GetCostHistogram returns time-bucketed cost data with model breakdown for the given filters.
+func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*CostHistogramResult, error) {
+	if bucketSizeSeconds <= 0 {
+		bucketSizeSeconds = 3600 // Default to 1 hour
+	}
+
+	dialect := s.db.Dialector.Name()
+
+	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery = s.applyFilters(baseQuery, filters)
+	// Only count completed requests with cost
+	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
+
+	// Query grouped by bucket and model
+	var results []struct {
+		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
+		Model           string  `gorm:"column:model"`
+		TotalCost       float64 `gorm:"column:total_cost"`
+	}
+
+	var selectClause string
+	switch dialect {
+	case "sqlite":
+		selectClause = fmt.Sprintf(`
+			(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp,
+			model,
+			COALESCE(SUM(cost), 0) as total_cost
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	case "mysql":
+		selectClause = fmt.Sprintf(`
+			(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp,
+			model,
+			COALESCE(SUM(cost), 0) as total_cost
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	default:
+		selectClause = fmt.Sprintf(`
+			CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) / %d) * %d AS BIGINT) as bucket_timestamp,
+			model,
+			COALESCE(SUM(cost), 0) as total_cost
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	}
+
+	if err := baseQuery.
+		Select(selectClause).
+		Group("bucket_timestamp, model").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get cost histogram: %w", err)
+	}
+
+	// Aggregate results into buckets with model breakdown
+	bucketMap := make(map[int64]*CostHistogramBucket)
+	modelsSet := make(map[string]bool)
+
+	for _, r := range results {
+		modelsSet[r.Model] = true
+		if bucket, exists := bucketMap[r.BucketTimestamp]; exists {
+			bucket.TotalCost += r.TotalCost
+			bucket.ByModel[r.Model] = r.TotalCost
+		} else {
+			bucketMap[r.BucketTimestamp] = &CostHistogramBucket{
+				Timestamp: time.Unix(r.BucketTimestamp, 0).UTC(),
+				TotalCost: r.TotalCost,
+				ByModel:   map[string]float64{r.Model: r.TotalCost},
+			}
+		}
+	}
+
+	// Extract unique models
+	models := make([]string, 0, len(modelsSet))
+	for model := range modelsSet {
+		models = append(models, model)
+	}
+
+	// Generate all bucket timestamps for the time range
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+
+	// If no time range specified, just return what we have from the query
+	if len(allTimestamps) == 0 {
+		// Convert map to sorted slice
+		buckets := make([]CostHistogramBucket, 0, len(bucketMap))
+		for _, bucket := range bucketMap {
+			buckets = append(buckets, *bucket)
+		}
+
+		// Sort by timestamp
+		for i := 0; i < len(buckets)-1; i++ {
+			for j := i + 1; j < len(buckets); j++ {
+				if buckets[i].Timestamp.After(buckets[j].Timestamp) {
+					buckets[i], buckets[j] = buckets[j], buckets[i]
+				}
+			}
+		}
+
+		return &CostHistogramResult{
+			Buckets:           buckets,
+			BucketSizeSeconds: bucketSizeSeconds,
+			Models:            models,
+		}, nil
+	}
+
+	// Fill in all buckets, using zeros for missing timestamps
+	buckets := make([]CostHistogramBucket, len(allTimestamps))
+	for i, ts := range allTimestamps {
+		if bucket, exists := bucketMap[ts]; exists {
+			buckets[i] = *bucket
+		} else {
+			buckets[i] = CostHistogramBucket{
+				Timestamp: time.Unix(ts, 0).UTC(),
+				TotalCost: 0,
+				ByModel:   make(map[string]float64),
+			}
+		}
+	}
+
+	return &CostHistogramResult{
+		Buckets:           buckets,
+		BucketSizeSeconds: bucketSizeSeconds,
+		Models:            models,
+	}, nil
+}
+
+// GetModelHistogram returns time-bucketed model usage with success/error breakdown for the given filters.
+func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ModelHistogramResult, error) {
+	if bucketSizeSeconds <= 0 {
+		bucketSizeSeconds = 3600 // Default to 1 hour
+	}
+
+	dialect := s.db.Dialector.Name()
+
+	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery = s.applyFilters(baseQuery, filters)
+	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+
+	// Query grouped by bucket and model with status counts
+	var results []struct {
+		BucketTimestamp int64  `gorm:"column:bucket_timestamp"`
+		Model           string `gorm:"column:model"`
+		Total           int64  `gorm:"column:total"`
+		Success         int64  `gorm:"column:success"`
+		Error           int64  `gorm:"column:error_count"`
+	}
+
+	var selectClause string
+	switch dialect {
+	case "sqlite":
+		selectClause = fmt.Sprintf(`
+			(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp,
+			model,
+			COUNT(*) as total,
+			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	case "mysql":
+		selectClause = fmt.Sprintf(`
+			(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp,
+			model,
+			COUNT(*) as total,
+			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	default:
+		selectClause = fmt.Sprintf(`
+			CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) / %d) * %d AS BIGINT) as bucket_timestamp,
+			model,
+			COUNT(*) as total,
+			SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) as success,
+			SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) as error_count
+		`, bucketSizeSeconds, bucketSizeSeconds)
+	}
+
+	if err := baseQuery.
+		Select(selectClause).
+		Group("bucket_timestamp, model").
+		Order("bucket_timestamp ASC").
+		Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get model histogram: %w", err)
+	}
+
+	// Aggregate results into buckets with model breakdown
+	bucketMap := make(map[int64]*ModelHistogramBucket)
+	modelsSet := make(map[string]bool)
+
+	for _, r := range results {
+		modelsSet[r.Model] = true
+		if bucket, exists := bucketMap[r.BucketTimestamp]; exists {
+			bucket.ByModel[r.Model] = ModelUsageStats{
+				Total:   r.Total,
+				Success: r.Success,
+				Error:   r.Error,
+			}
+		} else {
+			bucketMap[r.BucketTimestamp] = &ModelHistogramBucket{
+				Timestamp: time.Unix(r.BucketTimestamp, 0).UTC(),
+				ByModel: map[string]ModelUsageStats{
+					r.Model: {
+						Total:   r.Total,
+						Success: r.Success,
+						Error:   r.Error,
+					},
+				},
+			}
+		}
+	}
+
+	// Extract unique models
+	models := make([]string, 0, len(modelsSet))
+	for model := range modelsSet {
+		models = append(models, model)
+	}
+
+	// Generate all bucket timestamps for the time range
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+
+	// If no time range specified, just return what we have from the query
+	if len(allTimestamps) == 0 {
+		// Convert map to sorted slice
+		buckets := make([]ModelHistogramBucket, 0, len(bucketMap))
+		for _, bucket := range bucketMap {
+			buckets = append(buckets, *bucket)
+		}
+
+		// Sort by timestamp
+		for i := 0; i < len(buckets)-1; i++ {
+			for j := i + 1; j < len(buckets); j++ {
+				if buckets[i].Timestamp.After(buckets[j].Timestamp) {
+					buckets[i], buckets[j] = buckets[j], buckets[i]
+				}
+			}
+		}
+
+		return &ModelHistogramResult{
+			Buckets:           buckets,
+			BucketSizeSeconds: bucketSizeSeconds,
+			Models:            models,
+		}, nil
+	}
+
+	// Fill in all buckets, using empty maps for missing timestamps
+	buckets := make([]ModelHistogramBucket, len(allTimestamps))
+	for i, ts := range allTimestamps {
+		if bucket, exists := bucketMap[ts]; exists {
+			buckets[i] = *bucket
+		} else {
+			buckets[i] = ModelHistogramBucket{
+				Timestamp: time.Unix(ts, 0).UTC(),
+				ByModel:   make(map[string]ModelUsageStats),
+			}
+		}
+	}
+
+	return &ModelHistogramResult{
+		Buckets:           buckets,
+		BucketSizeSeconds: bucketSizeSeconds,
+		Models:            models,
 	}, nil
 }
 

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -28,6 +28,7 @@ type LogStore interface {
 	HasLogs(ctx context.Context) (bool, error)
 	SearchLogs(ctx context.Context, filters SearchFilters, pagination PaginationOptions) (*SearchResult, error)
 	GetStats(ctx context.Context, filters SearchFilters) (*SearchStats, error)
+	GetHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*HistogramResult, error)
 	Update(ctx context.Context, id string, entry any) error
 	BulkUpdateCost(ctx context.Context, updates map[string]float64) error
 	Flush(ctx context.Context, since time.Time) error

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -29,6 +29,9 @@ type LogStore interface {
 	SearchLogs(ctx context.Context, filters SearchFilters, pagination PaginationOptions) (*SearchResult, error)
 	GetStats(ctx context.Context, filters SearchFilters) (*SearchStats, error)
 	GetHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*HistogramResult, error)
+	GetTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*TokenHistogramResult, error)
+	GetCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*CostHistogramResult, error)
+	GetModelHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ModelHistogramResult, error)
 	Update(ctx context.Context, id string, entry any) error
 	BulkUpdateCost(ctx context.Context, updates map[string]float64) error
 	Flush(ctx context.Context, since time.Time) error

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -575,3 +575,51 @@ type HistogramResult struct {
 	Buckets           []HistogramBucket `json:"buckets"`
 	BucketSizeSeconds int64             `json:"bucket_size_seconds"`
 }
+
+// TokenHistogramBucket represents a single time bucket for token usage
+type TokenHistogramBucket struct {
+	Timestamp        time.Time `json:"timestamp"`
+	PromptTokens     int64     `json:"prompt_tokens"`
+	CompletionTokens int64     `json:"completion_tokens"`
+	TotalTokens      int64     `json:"total_tokens"`
+}
+
+// TokenHistogramResult represents the token histogram query result
+type TokenHistogramResult struct {
+	Buckets           []TokenHistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64                  `json:"bucket_size_seconds"`
+}
+
+// CostHistogramBucket represents a single time bucket for cost data
+type CostHistogramBucket struct {
+	Timestamp time.Time          `json:"timestamp"`
+	TotalCost float64            `json:"total_cost"`
+	ByModel   map[string]float64 `json:"by_model"`
+}
+
+// CostHistogramResult represents the cost histogram query result
+type CostHistogramResult struct {
+	Buckets           []CostHistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64                 `json:"bucket_size_seconds"`
+	Models            []string              `json:"models"`
+}
+
+// ModelUsageStats represents usage statistics for a single model
+type ModelUsageStats struct {
+	Total   int64 `json:"total"`
+	Success int64 `json:"success"`
+	Error   int64 `json:"error"`
+}
+
+// ModelHistogramBucket represents a single time bucket for model usage
+type ModelHistogramBucket struct {
+	Timestamp time.Time                  `json:"timestamp"`
+	ByModel   map[string]ModelUsageStats `json:"by_model"`
+}
+
+// ModelHistogramResult represents the model histogram query result
+type ModelHistogramResult struct {
+	Buckets           []ModelHistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64                  `json:"bucket_size_seconds"`
+	Models            []string               `json:"models"`
+}

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -561,3 +561,17 @@ func (l *Log) BuildContentSummary() string {
 
 	return strings.Join(parts, " ")
 }
+
+// HistogramBucket represents a single time bucket in the histogram
+type HistogramBucket struct {
+	Timestamp time.Time `json:"timestamp"`
+	Count     int64     `json:"count"`
+	Success   int64     `json:"success"`
+	Error     int64     `json:"error"`
+}
+
+// HistogramResult represents the histogram query result
+type HistogramResult struct {
+	Buckets           []HistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64             `json:"bucket_size_seconds"`
+}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -377,6 +377,21 @@ func (p *LoggerPlugin) GetHistogram(ctx context.Context, filters logstore.Search
 	return p.store.GetHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetTokenHistogram returns time-bucketed token usage for the given filters
+func (p *LoggerPlugin) GetTokenHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.TokenHistogramResult, error) {
+	return p.store.GetTokenHistogram(ctx, filters, bucketSizeSeconds)
+}
+
+// GetCostHistogram returns time-bucketed cost data with model breakdown for the given filters
+func (p *LoggerPlugin) GetCostHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.CostHistogramResult, error) {
+	return p.store.GetCostHistogram(ctx, filters, bucketSizeSeconds)
+}
+
+// GetModelHistogram returns time-bucketed model usage with success/error breakdown for the given filters
+func (p *LoggerPlugin) GetModelHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ModelHistogramResult, error) {
+	return p.store.GetModelHistogram(ctx, filters, bucketSizeSeconds)
+}
+
 // GetAvailableModels returns all unique models from logs
 func (p *LoggerPlugin) GetAvailableModels(ctx context.Context) []string {
 	result, err := p.store.FindAll(ctx, "model IS NOT NULL AND model != ''", "model")

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -372,6 +372,11 @@ func (p *LoggerPlugin) GetStats(ctx context.Context, filters logstore.SearchFilt
 	return p.store.GetStats(ctx, filters)
 }
 
+// GetHistogram returns time-bucketed request counts for the given filters
+func (p *LoggerPlugin) GetHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.HistogramResult, error) {
+	return p.store.GetHistogram(ctx, filters, bucketSizeSeconds)
+}
+
 // GetAvailableModels returns all unique models from logs
 func (p *LoggerPlugin) GetAvailableModels(ctx context.Context) []string {
 	result, err := p.store.FindAll(ctx, "model IS NOT NULL AND model != ''", "model")

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -30,6 +30,15 @@ type LogManager interface {
 	// GetHistogram returns time-bucketed request counts for the given filters
 	GetHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.HistogramResult, error)
 
+	// GetTokenHistogram returns time-bucketed token usage for the given filters
+	GetTokenHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.TokenHistogramResult, error)
+
+	// GetCostHistogram returns time-bucketed cost data with model breakdown for the given filters
+	GetCostHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.CostHistogramResult, error)
+
+	// GetModelHistogram returns time-bucketed model usage with success/error breakdown for the given filters
+	GetModelHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ModelHistogramResult, error)
+
 	// Get the number of dropped requests
 	GetDroppedRequests(ctx context.Context) int64
 
@@ -76,6 +85,27 @@ func (p *PluginLogManager) GetHistogram(ctx context.Context, filters *logstore.S
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.GetHistogram(ctx, *filters, bucketSizeSeconds)
+}
+
+func (p *PluginLogManager) GetTokenHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.TokenHistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetTokenHistogram(ctx, *filters, bucketSizeSeconds)
+}
+
+func (p *PluginLogManager) GetCostHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.CostHistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetCostHistogram(ctx, *filters, bucketSizeSeconds)
+}
+
+func (p *PluginLogManager) GetModelHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ModelHistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetModelHistogram(ctx, *filters, bucketSizeSeconds)
 }
 
 func (p *PluginLogManager) GetDroppedRequests(ctx context.Context) int64 {

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -27,6 +27,9 @@ type LogManager interface {
 	// GetStats calculates statistics for logs matching the given filters
 	GetStats(ctx context.Context, filters *logstore.SearchFilters) (*logstore.SearchStats, error)
 
+	// GetHistogram returns time-bucketed request counts for the given filters
+	GetHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.HistogramResult, error)
+
 	// Get the number of dropped requests
 	GetDroppedRequests(ctx context.Context) int64
 
@@ -66,6 +69,13 @@ func (p *PluginLogManager) GetStats(ctx context.Context, filters *logstore.Searc
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.GetStats(ctx, *filters)
+}
+
+func (p *PluginLogManager) GetHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.HistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetHistogram(ctx, *filters, bucketSizeSeconds)
 }
 
 func (p *PluginLogManager) GetDroppedRequests(ctx context.Context) int64 {

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -43,6 +43,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	// Log retrieval with filtering, search, and pagination
 	r.GET("/api/logs", lib.ChainMiddlewares(h.getLogs, middlewares...))
 	r.GET("/api/logs/stats", lib.ChainMiddlewares(h.getLogsStats, middlewares...))
+	r.GET("/api/logs/histogram", lib.ChainMiddlewares(h.getLogsHistogram, middlewares...))
 	r.GET("/api/logs/dropped", lib.ChainMiddlewares(h.getDroppedRequests, middlewares...))
 	r.GET("/api/logs/filterdata", lib.ChainMiddlewares(h.getAvailableFilterData, middlewares...))
 	r.DELETE("/api/logs", lib.ChainMiddlewares(h.deleteLogs, middlewares...))
@@ -291,6 +292,118 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, stats)
+}
+
+// getLogsHistogram handles GET /api/logs/histogram - Get time-bucketed request counts
+func (h *LoggingHandler) getLogsHistogram(ctx *fasthttp.RequestCtx) {
+	// Parse query parameters into filters (same as getLogsStats)
+	filters := &logstore.SearchFilters{}
+
+	// Extract filters from query parameters
+	if providers := string(ctx.QueryArgs().Peek("providers")); providers != "" {
+		filters.Providers = parseCommaSeparated(providers)
+	}
+	if models := string(ctx.QueryArgs().Peek("models")); models != "" {
+		filters.Models = parseCommaSeparated(models)
+	}
+	if statuses := string(ctx.QueryArgs().Peek("status")); statuses != "" {
+		filters.Status = parseCommaSeparated(statuses)
+	}
+	if objects := string(ctx.QueryArgs().Peek("objects")); objects != "" {
+		filters.Objects = parseCommaSeparated(objects)
+	}
+	if selectedKeyIDs := string(ctx.QueryArgs().Peek("selected_key_ids")); selectedKeyIDs != "" {
+		filters.SelectedKeyIDs = parseCommaSeparated(selectedKeyIDs)
+	}
+	if virtualKeyIDs := string(ctx.QueryArgs().Peek("virtual_key_ids")); virtualKeyIDs != "" {
+		filters.VirtualKeyIDs = parseCommaSeparated(virtualKeyIDs)
+	}
+	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
+		if t, err := time.Parse(time.RFC3339, startTime); err == nil {
+			filters.StartTime = &t
+		}
+	}
+	if endTime := string(ctx.QueryArgs().Peek("end_time")); endTime != "" {
+		if t, err := time.Parse(time.RFC3339, endTime); err == nil {
+			filters.EndTime = &t
+		}
+	}
+	if minLatency := string(ctx.QueryArgs().Peek("min_latency")); minLatency != "" {
+		if f, err := strconv.ParseFloat(minLatency, 64); err == nil {
+			filters.MinLatency = &f
+		}
+	}
+	if maxLatency := string(ctx.QueryArgs().Peek("max_latency")); maxLatency != "" {
+		if val, err := strconv.ParseFloat(maxLatency, 64); err == nil {
+			filters.MaxLatency = &val
+		}
+	}
+	if minTokens := string(ctx.QueryArgs().Peek("min_tokens")); minTokens != "" {
+		if val, err := strconv.Atoi(minTokens); err == nil {
+			filters.MinTokens = &val
+		}
+	}
+	if maxTokens := string(ctx.QueryArgs().Peek("max_tokens")); maxTokens != "" {
+		if val, err := strconv.Atoi(maxTokens); err == nil {
+			filters.MaxTokens = &val
+		}
+	}
+	if cost := string(ctx.QueryArgs().Peek("min_cost")); cost != "" {
+		if val, err := strconv.ParseFloat(cost, 64); err == nil {
+			filters.MinCost = &val
+		}
+	}
+	if maxCost := string(ctx.QueryArgs().Peek("max_cost")); maxCost != "" {
+		if val, err := strconv.ParseFloat(maxCost, 64); err == nil {
+			filters.MaxCost = &val
+		}
+	}
+	if missingCost := string(ctx.QueryArgs().Peek("missing_cost_only")); missingCost != "" {
+		if val, err := strconv.ParseBool(missingCost); err == nil {
+			filters.MissingCostOnly = val
+		}
+	}
+	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
+		filters.ContentSearch = contentSearch
+	}
+
+	// Calculate bucket size based on time range
+	bucketSizeSeconds := calculateBucketSize(filters.StartTime, filters.EndTime)
+
+	result, err := h.logManager.GetHistogram(ctx, filters, bucketSizeSeconds)
+	if err != nil {
+		logger.Error("failed to get log histogram: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Histogram calculation failed: %v", err))
+		return
+	}
+
+	SendJSON(ctx, result)
+}
+
+// calculateBucketSize determines appropriate bucket size based on time range
+func calculateBucketSize(start, end *time.Time) int64 {
+	if start == nil || end == nil {
+		return 3600 // Default 1 hour
+	}
+	duration := end.Sub(*start)
+	switch {
+	case duration >= 365*24*time.Hour: // >= 12 months
+		return 30 * 24 * 3600 // Monthly (30 days)
+	case duration >= 90*24*time.Hour: // >= 3 months
+		return 7 * 24 * 3600 // Weekly (7 days)
+	case duration >= 30*24*time.Hour: // >= 1 month
+		return 3 * 24 * 3600 // 3 days
+	case duration >= 7*24*time.Hour: // >= 7 days
+		return 24 * 3600 // Daily
+	case duration >= 3*24*time.Hour: // >= 3 days
+		return 8 * 3600 // 8 hours
+	case duration >= 24*time.Hour: // >= 24 hours
+		return 3600 // Hourly
+	case duration >= 2*time.Hour: // >= 2 hours
+		return 600 // 10 minutes
+	default:
+		return 60 // 1 minute buckets for < 2 hours
+	}
 }
 
 // getDroppedRequests handles GET /api/logs/dropped - Get the number of dropped requests

--- a/ui/app/workspace/dashboard/components/chartCard.tsx
+++ b/ui/app/workspace/dashboard/components/chartCard.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { ReactNode } from "react";
+
+interface ChartCardProps {
+	title: string;
+	children: ReactNode;
+	headerActions?: ReactNode;
+	loading?: boolean;
+}
+
+export function ChartCard({ title, children, headerActions, loading }: ChartCardProps) {
+	if (loading) {
+		return (
+			<Card className="rounded-sm px-2 py-1 shadow-none">
+				<div className="mb-3 flex items-center justify-between">
+					<span className="text-primary pl-2 text-sm font-medium">{title}</span>
+					{headerActions && <div className="flex items-center gap-2">{headerActions}</div>}
+				</div>
+				<div style={{ height: "200px" }}>
+					<Skeleton className="h-full w-full" />
+				</div>
+			</Card>
+		);
+	}
+
+	return (
+		<Card className="rounded-sm px-2 py-1 shadow-none">
+			<div className="mb-3 flex items-center justify-between">
+				<span className="text-primary pl-2 text-sm font-medium">{title}</span>
+				{headerActions && <div className="flex items-center gap-2">{headerActions}</div>}
+			</div>
+			<div style={{ height: "200px" }}>{children}</div>
+		</Card>
+	);
+}

--- a/ui/app/workspace/dashboard/components/chartErrorBoundary.tsx
+++ b/ui/app/workspace/dashboard/components/chartErrorBoundary.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { BarChart, CartesianGrid, ResponsiveContainer, XAxis, YAxis } from "recharts";
+
+// Empty chart placeholder when data fails to render
+function EmptyChart() {
+	return (
+		<ResponsiveContainer width="100%" height="100%">
+			<BarChart data={[{ name: "", value: 0 }, { name: " ", value: 0 }]}>
+				<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+				<XAxis dataKey="name" tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }} tickLine={false} axisLine={false} />
+				<YAxis tick={{ fontSize: 13, className: "fill-zinc-500" }} tickLine={false} axisLine={false} width={40} domain={[0, 1]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
+}
+
+interface ChartErrorBoundaryProps {
+	children: ReactNode;
+	resetKey?: string;
+}
+
+interface ChartErrorBoundaryState {
+	hasError: boolean;
+	prevResetKey?: string;
+}
+
+export class ChartErrorBoundary extends Component<ChartErrorBoundaryProps, ChartErrorBoundaryState> {
+	constructor(props: ChartErrorBoundaryProps) {
+		super(props);
+		this.state = { hasError: false };
+	}
+
+	static getDerivedStateFromError(_: Error) {
+		return { hasError: true };
+	}
+
+	static getDerivedStateFromProps(props: ChartErrorBoundaryProps, state: ChartErrorBoundaryState) {
+		// Reset error state when resetKey changes
+		if (props.resetKey !== state.prevResetKey) {
+			return { hasError: false, prevResetKey: props.resetKey };
+		}
+		return null;
+	}
+
+	componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+		console.warn("Chart rendering error:", error.message);
+	}
+
+	render() {
+		if (this.state.hasError) {
+			return <EmptyChart />;
+		}
+		return this.props.children;
+	}
+}

--- a/ui/app/workspace/dashboard/components/chartTypeToggle.tsx
+++ b/ui/app/workspace/dashboard/components/chartTypeToggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { BarChart3, LineChart } from "lucide-react";
+
+export type ChartType = "bar" | "line";
+
+interface ChartTypeToggleProps {
+	chartType: ChartType;
+	onToggle: (type: ChartType) => void;
+}
+
+export function ChartTypeToggle({ chartType, onToggle }: ChartTypeToggleProps) {
+	return (
+		<div className="flex items-center gap-1">
+			<Button
+				variant={chartType === "bar" ? "secondary" : "ghost"}
+				size="sm"
+				className="h-7 w-7 p-0"
+				onClick={() => onToggle("bar")}
+			>
+				<BarChart3 className="h-3.5 w-3.5" />
+			</Button>
+			<Button
+				variant={chartType === "line" ? "secondary" : "ghost"}
+				size="sm"
+				className="h-7 w-7 p-0"
+				onClick={() => onToggle("line")}
+			>
+				<LineChart className="h-3.5 w-3.5" />
+			</Button>
+		</div>
+	);
+}

--- a/ui/app/workspace/dashboard/components/costChart.tsx
+++ b/ui/app/workspace/dashboard/components/costChart.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import type { CostHistogramResponse } from "@/lib/types/logs";
+import { useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { formatCost, formatFullTimestamp, formatTimestamp, getModelColor } from "../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface CostChartProps {
+	data: CostHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+	selectedModel: string;
+}
+
+function CustomTooltip({ active, payload, selectedModel, models }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				{selectedModel === "all" ? (
+					<>
+						{models.map((model: string, idx: number) => {
+							const cost = data.by_model?.[model] || 0;
+							if (cost === 0) return null;
+							return (
+								<div key={model} className="flex items-center justify-between gap-4">
+									<span className="flex items-center gap-1.5">
+										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(idx) }} />
+										<span className="max-w-[120px] truncate text-zinc-600 dark:text-zinc-400">{model}</span>
+									</span>
+									<span className="font-medium">{formatCost(cost)}</span>
+								</div>
+							);
+						})}
+						<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
+							<span className="text-zinc-600 dark:text-zinc-400">Total</span>
+							<span className="font-medium">{formatCost(data.total_cost)}</span>
+						</div>
+					</>
+				) : (
+					<div className="flex items-center justify-between gap-4">
+						<span className="flex items-center gap-1.5">
+							<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+							<span className="text-zinc-600 dark:text-zinc-400">{selectedModel}</span>
+						</span>
+						<span className="font-medium">{formatCost(data.by_model?.[selectedModel] || 0)}</span>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export function CostChart({ data, chartType, startTime, endTime, selectedModel }: CostChartProps) {
+	const { chartData, displayModels } = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return { chartData: [], displayModels: [] };
+		}
+
+		const models = selectedModel === "all" ? data.models : [selectedModel];
+
+		const processed = data.buckets.map((bucket, index) => {
+			const item: any = {
+				...bucket,
+				index,
+				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+			};
+			// Flatten by_model for easier chart access
+			models.forEach((model) => {
+				item[`model_${model}`] = bucket.by_model?.[model] || 0;
+			});
+			return item;
+		});
+
+		return { chartData: processed, displayModels: models };
+	}, [data, selectedModel]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}-${selectedModel}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={50}
+							tickFormatter={(v) => formatCost(v)}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip
+							content={<CustomTooltip selectedModel={selectedModel} models={data.models} />}
+							cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
+						/>
+						{displayModels.map((model, idx) => (
+							<Bar
+								key={model}
+								dataKey={`model_${model}`}
+								stackId="cost"
+								fill={getModelColor(idx)}
+								fillOpacity={0.9}
+								barSize={30}
+								radius={idx === displayModels.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
+							/>
+						))}
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={50}
+							tickFormatter={(v) => formatCost(v)}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip selectedModel={selectedModel} models={data.models} />} />
+						{displayModels.map((model, idx) => (
+							<Area
+								key={model}
+								type="monotone"
+								dataKey={`model_${model}`}
+								stackId="1"
+								stroke={getModelColor(idx)}
+								fill={getModelColor(idx)}
+								fillOpacity={0.7}
+							/>
+						))}
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}

--- a/ui/app/workspace/dashboard/components/logVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/logVolumeChart.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import type { LogsHistogramResponse } from "@/lib/types/logs";
+import { useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface LogVolumeChartProps {
+	data: LogsHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+}
+
+function CustomTooltip({ active, payload }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Success</span>
+					</span>
+					<span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-red-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Error</span>
+					</span>
+					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function LogVolumeChart({ data, chartType, startTime, endTime }: LogVolumeChartProps) {
+	const chartData = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return [];
+		}
+
+		return data.buckets.map((bucket, index) => ({
+			...bucket,
+			index,
+			formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+		}));
+	}, [data]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={40}
+							tickFormatter={(v) => v.toLocaleString()}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						<Bar dataKey="success" stackId="requests" fill={CHART_COLORS.success} fillOpacity={0.9} radius={[0, 0, 0, 0]} barSize={30} />
+						<Bar dataKey="error" stackId="requests" fill={CHART_COLORS.error} fillOpacity={0.9} radius={[2, 2, 0, 0]} barSize={30} />
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={40}
+							tickFormatter={(v) => v.toLocaleString()}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} />
+						<Area
+							type="monotone"
+							dataKey="success"
+							stackId="1"
+							stroke={CHART_COLORS.success}
+							fill={CHART_COLORS.success}
+							fillOpacity={0.7}
+						/>
+						<Area type="monotone" dataKey="error" stackId="1" stroke={CHART_COLORS.error} fill={CHART_COLORS.error} fillOpacity={0.7} />
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}

--- a/ui/app/workspace/dashboard/components/modelFilterSelect.tsx
+++ b/ui/app/workspace/dashboard/components/modelFilterSelect.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+interface ModelFilterSelectProps {
+	models: string[];
+	selectedModel: string;
+	onModelChange: (model: string) => void;
+}
+
+export function ModelFilterSelect({ models, selectedModel, onModelChange }: ModelFilterSelectProps) {
+	return (
+		<Select value={selectedModel} onValueChange={onModelChange}>
+			<SelectTrigger className="h-5 w-[130px] text-xs">
+				<SelectValue placeholder="All Models" />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="all">All Models</SelectItem>
+				{models.map((model) => (
+					<SelectItem key={model} value={model} className="text-xs">
+						{model}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/ui/app/workspace/dashboard/components/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/modelUsageChart.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import type { ModelHistogramResponse } from "@/lib/types/logs";
+import { useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp, getModelColor } from "../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+// Sanitize model names to avoid Recharts interpreting dots/brackets as path separators
+function sanitizeModelKey(model: string): string {
+	return model.replace(/[.\[\]]/g, "_");
+}
+
+interface ModelUsageChartProps {
+	data: ModelHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+	selectedModel: string;
+}
+
+function CustomTooltip({ active, payload, selectedModel, models }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				{selectedModel === "all" ? (
+					<>
+						{models.map((model: string, idx: number) => {
+							const stats = data.by_model?.[model];
+							if (!stats || stats.total === 0) return null;
+							return (
+								<div key={model} className="flex items-center justify-between gap-4">
+									<span className="flex items-center gap-1.5">
+										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(idx) }} />
+										<span className="max-w-[120px] truncate text-zinc-600 dark:text-zinc-400">{model}</span>
+									</span>
+									<span className="font-medium">{stats.total.toLocaleString()}</span>
+								</div>
+							);
+						})}
+					</>
+				) : (
+					<>
+						<div className="flex items-center justify-between gap-4">
+							<span className="flex items-center gap-1.5">
+								<span className="h-2 w-2 rounded-full bg-emerald-500" />
+								<span className="text-zinc-600 dark:text-zinc-400">Success</span>
+							</span>
+							<span className="font-medium text-emerald-600 dark:text-emerald-400">
+								{(data.by_model?.[selectedModel]?.success || 0).toLocaleString()}
+							</span>
+						</div>
+						<div className="flex items-center justify-between gap-4">
+							<span className="flex items-center gap-1.5">
+								<span className="h-2 w-2 rounded-full bg-red-500" />
+								<span className="text-zinc-600 dark:text-zinc-400">Error</span>
+							</span>
+							<span className="font-medium text-red-600 dark:text-red-400">
+								{(data.by_model?.[selectedModel]?.error || 0).toLocaleString()}
+							</span>
+						</div>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export function ModelUsageChart({ data, chartType, startTime, endTime, selectedModel }: ModelUsageChartProps) {
+	const { chartData, displayModels } = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return { chartData: [], displayModels: [] };
+		}
+
+		const models = data.models;
+
+		const processed = data.buckets.map((bucket, index) => {
+			const item: any = {
+				...bucket,
+				index,
+				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+			};
+
+			if (selectedModel === "all") {
+				// For "all", show total per model
+				models.forEach((model) => {
+					const safeKey = sanitizeModelKey(model);
+					item[`model_${safeKey}`] = bucket.by_model?.[model]?.total || 0;
+				});
+			} else {
+				// For specific model, show success/error breakdown
+				const stats = bucket.by_model?.[selectedModel];
+				item.success = stats?.success || 0;
+				item.error = stats?.error || 0;
+			}
+			return item;
+		});
+
+		return { chartData: processed, displayModels: models };
+	}, [data, selectedModel]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}-${selectedModel}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={40}
+							tickFormatter={(v) => v.toLocaleString()}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip
+							content={<CustomTooltip selectedModel={selectedModel} models={displayModels} />}
+							cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
+						/>
+						{selectedModel === "all" ? (
+							displayModels.map((model, idx) => (
+								<Bar
+									key={model}
+									dataKey={`model_${sanitizeModelKey(model)}`}
+									stackId="models"
+									fill={getModelColor(idx)}
+									fillOpacity={0.9}
+									barSize={30}
+									radius={idx === displayModels.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
+								/>
+							))
+						) : (
+							<>
+								<Bar dataKey="success" stackId="status" fill={CHART_COLORS.success} fillOpacity={0.9} radius={[0, 0, 0, 0]} barSize={30} />
+								<Bar dataKey="error" stackId="status" fill={CHART_COLORS.error} fillOpacity={0.9} radius={[2, 2, 0, 0]} barSize={30} />
+							</>
+						)}
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={40}
+							tickFormatter={(v) => v.toLocaleString()}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip selectedModel={selectedModel} models={displayModels} />} />
+						{selectedModel === "all" ? (
+							displayModels.map((model, idx) => (
+								<Area
+									key={model}
+									type="monotone"
+									dataKey={`model_${sanitizeModelKey(model)}`}
+									stackId="1"
+									stroke={getModelColor(idx)}
+									fill={getModelColor(idx)}
+									fillOpacity={0.7}
+								/>
+							))
+						) : (
+							<>
+								<Area
+									type="monotone"
+									dataKey="success"
+									stackId="1"
+									stroke={CHART_COLORS.success}
+									fill={CHART_COLORS.success}
+									fillOpacity={0.7}
+								/>
+								<Area type="monotone" dataKey="error" stackId="1" stroke={CHART_COLORS.error} fill={CHART_COLORS.error} fillOpacity={0.7} />
+							</>
+						)}
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}

--- a/ui/app/workspace/dashboard/components/tokenUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/tokenUsageChart.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import type { TokenHistogramResponse } from "@/lib/types/logs";
+import { useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp, formatTokens } from "../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface TokenUsageChartProps {
+	data: TokenHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+}
+
+function CustomTooltip({ active, payload }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-blue-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Input</span>
+					</span>
+					<span className="font-medium">{data.prompt_tokens.toLocaleString()}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Output</span>
+					</span>
+					<span className="font-medium">{data.completion_tokens.toLocaleString()}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
+					<span className="text-zinc-600 dark:text-zinc-400">Total</span>
+					<span className="font-medium">{data.total_tokens.toLocaleString()}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function TokenUsageChart({ data, chartType, startTime, endTime }: TokenUsageChartProps) {
+	const chartData = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return [];
+		}
+
+		return data.buckets.map((bucket, index) => ({
+			...bucket,
+			index,
+			formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+		}));
+	}, [data]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={50}
+							tickFormatter={formatTokens}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						<Bar
+							dataKey="prompt_tokens"
+							stackId="tokens"
+							fill={CHART_COLORS.promptTokens}
+							fillOpacity={0.9}
+							radius={[0, 0, 0, 0]}
+							barSize={30}
+						/>
+						<Bar
+							dataKey="completion_tokens"
+							stackId="tokens"
+							fill={CHART_COLORS.completionTokens}
+							fillOpacity={0.9}
+							radius={[2, 2, 0, 0]}
+							barSize={30}
+						/>
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={50}
+							tickFormatter={formatTokens}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} />
+						<Area
+							type="monotone"
+							dataKey="prompt_tokens"
+							stackId="1"
+							stroke={CHART_COLORS.promptTokens}
+							fill={CHART_COLORS.promptTokens}
+							fillOpacity={0.7}
+						/>
+						<Area
+							type="monotone"
+							dataKey="completion_tokens"
+							stackId="1"
+							stroke={CHART_COLORS.completionTokens}
+							fill={CHART_COLORS.completionTokens}
+							fillOpacity={0.7}
+						/>
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}

--- a/ui/app/workspace/dashboard/layout.tsx
+++ b/ui/app/workspace/dashboard/layout.tsx
@@ -1,0 +1,12 @@
+"use client"
+
+import { NoPermissionView } from "@/components/noPermissionView"
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View)
+  if (!hasObservabilityAccess) {
+    return <NoPermissionView entity="dashboard" />;
+  }
+  return <div>{children}</div>
+}

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
+import {
+	useLazyGetLogsCostHistogramQuery,
+	useLazyGetLogsHistogramQuery,
+	useLazyGetLogsModelHistogramQuery,
+	useLazyGetLogsTokenHistogramQuery,
+} from "@/lib/store";
+import type {
+	CostHistogramResponse,
+	LogFilters,
+	LogsHistogramResponse,
+	ModelHistogramResponse,
+	TokenHistogramResponse,
+} from "@/lib/types/logs";
+import { dateUtils } from "@/lib/types/logs";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChartCard } from "./components/chartCard";
+import { type ChartType, ChartTypeToggle } from "./components/chartTypeToggle";
+import { CostChart } from "./components/costChart";
+import { LogVolumeChart } from "./components/logVolumeChart";
+import { ModelFilterSelect } from "./components/modelFilterSelect";
+import { ModelUsageChart } from "./components/modelUsageChart";
+import { TokenUsageChart } from "./components/tokenUsageChart";
+import { CHART_COLORS, getModelColor } from "./utils/chartUtils";
+
+// Type-safe parser for chart type URL state
+const toChartType = (value: string): ChartType => (value === 'line' ? 'line' : 'bar')
+
+// Calculate default timestamps once at module level
+const DEFAULT_END_TIME = Math.floor(Date.now() / 1000);
+const DEFAULT_START_TIME = (() => {
+	const date = new Date();
+	date.setHours(date.getHours() - 24);
+	return Math.floor(date.getTime() / 1000);
+})();
+
+// Predefined time periods
+const TIME_PERIODS = [
+	{ label: "Last hour", value: "1h" },
+	{ label: "Last 6 hours", value: "6h" },
+	{ label: "Last 24 hours", value: "24h" },
+	{ label: "Last 7 days", value: "7d" },
+	{ label: "Last 30 days", value: "30d" },
+];
+
+function getTimeRangeFromPeriod(period: string): { start: number; end: number } {
+	const now = Math.floor(Date.now() / 1000);
+	switch (period) {
+		case "1h":
+			return { start: now - 3600, end: now };
+		case "6h":
+			return { start: now - 6 * 3600, end: now };
+		case "24h":
+			return { start: now - 24 * 3600, end: now };
+		case "7d":
+			return { start: now - 7 * 24 * 3600, end: now };
+		case "30d":
+			return { start: now - 30 * 24 * 3600, end: now };
+		default:
+			return { start: now - 24 * 3600, end: now };
+	}
+}
+
+export default function DashboardPage() {
+	// Data states
+	const [histogramData, setHistogramData] = useState<LogsHistogramResponse | null>(null);
+	const [tokenData, setTokenData] = useState<TokenHistogramResponse | null>(null);
+	const [costData, setCostData] = useState<CostHistogramResponse | null>(null);
+	const [modelData, setModelData] = useState<ModelHistogramResponse | null>(null);
+
+	// Loading states
+	const [loadingHistogram, setLoadingHistogram] = useState(true);
+	const [loadingTokens, setLoadingTokens] = useState(true);
+	const [loadingCost, setLoadingCost] = useState(true);
+	const [loadingModels, setLoadingModels] = useState(true);
+
+	// RTK Query lazy hooks
+	const [triggerHistogram] = useLazyGetLogsHistogramQuery();
+	const [triggerTokens] = useLazyGetLogsTokenHistogramQuery();
+	const [triggerCost] = useLazyGetLogsCostHistogramQuery();
+	const [triggerModels] = useLazyGetLogsModelHistogramQuery();
+
+	// URL state management
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			start_time: parseAsInteger.withDefault(DEFAULT_START_TIME),
+			end_time: parseAsInteger.withDefault(DEFAULT_END_TIME),
+			period: parseAsString.withDefault("24h"),
+			volume_chart: parseAsString.withDefault("bar"),
+			token_chart: parseAsString.withDefault("bar"),
+			cost_chart: parseAsString.withDefault("bar"),
+			model_chart: parseAsString.withDefault("bar"),
+			cost_model: parseAsString.withDefault("all"),
+			usage_model: parseAsString.withDefault("all"),
+		},
+		{
+			history: "push",
+			shallow: false,
+		},
+	);
+
+	// Derived filter for API calls
+	const filters: LogFilters = useMemo(
+		() => ({
+			start_time: dateUtils.toISOString(urlState.start_time),
+			end_time: dateUtils.toISOString(urlState.end_time),
+		}),
+		[urlState.start_time, urlState.end_time],
+	);
+
+	// Date range for picker
+	const dateRange = useMemo(
+		() => ({
+			from: dateUtils.fromUnixTimestamp(urlState.start_time),
+			to: dateUtils.fromUnixTimestamp(urlState.end_time),
+		}),
+		[urlState.start_time, urlState.end_time],
+	);
+
+	// Available models for dropdowns
+	const availableModels = useMemo(() => {
+		return costData?.models || modelData?.models || [];
+	}, [costData?.models, modelData?.models]);
+
+	// Fetch all data
+	const fetchAllData = useCallback(async () => {
+		setLoadingHistogram(true);
+		setLoadingTokens(true);
+		setLoadingCost(true);
+		setLoadingModels(true);
+
+		const fetchFilters = { filters };
+
+		// Fetch all in parallel
+		const [histogramResult, tokenResult, costResult, modelResult] = await Promise.all([
+			triggerHistogram(fetchFilters),
+			triggerTokens(fetchFilters),
+			triggerCost(fetchFilters),
+			triggerModels(fetchFilters),
+		]);
+
+		if (histogramResult.data) {
+			setHistogramData(histogramResult.data);
+		}
+		setLoadingHistogram(false);
+
+		if (tokenResult.data) {
+			setTokenData(tokenResult.data);
+		}
+		setLoadingTokens(false);
+
+		if (costResult.data) {
+			setCostData(costResult.data);
+		}
+		setLoadingCost(false);
+
+		if (modelResult.data) {
+			setModelData(modelResult.data);
+		}
+		setLoadingModels(false);
+	}, [filters, triggerHistogram, triggerTokens, triggerCost, triggerModels]);
+
+	// Fetch data on mount and when filters change
+	useEffect(() => {
+		fetchAllData();
+	}, [fetchAllData]);
+
+	// Handle time period change
+	const handlePeriodChange = useCallback(
+		(period: string | undefined) => {
+			if (!period) return;
+			const { start, end } = getTimeRangeFromPeriod(period);
+			setUrlState({
+				start_time: start,
+				end_time: end,
+				period,
+			});
+		},
+		[setUrlState],
+	);
+
+	// Handle custom date range change
+	const handleDateRangeChange = useCallback(
+		(range: { from?: Date; to?: Date }) => {
+			if (!range.from || !range.to) return;
+			setUrlState({
+				start_time: dateUtils.toUnixTimestamp(range.from),
+				end_time: dateUtils.toUnixTimestamp(range.to),
+				period: "", // Clear period when custom range is selected
+			});
+		},
+		[setUrlState],
+	);
+
+	// Chart type toggles
+	const handleVolumeChartToggle = useCallback((type: ChartType) => setUrlState({ volume_chart: type }), [setUrlState]);
+	const handleTokenChartToggle = useCallback((type: ChartType) => setUrlState({ token_chart: type }), [setUrlState]);
+	const handleCostChartToggle = useCallback((type: ChartType) => setUrlState({ cost_chart: type }), [setUrlState]);
+	const handleModelChartToggle = useCallback((type: ChartType) => setUrlState({ model_chart: type }), [setUrlState]);
+
+	// Model filter changes
+	const handleCostModelChange = useCallback((model: string) => setUrlState({ cost_model: model }), [setUrlState]);
+	const handleUsageModelChange = useCallback((model: string) => setUrlState({ usage_model: model }), [setUrlState]);
+
+	return (
+		<div className="mx-auto flex h-full max-w-7xl flex-col gap-4">
+			{/* Header with time filter */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<h1 className="text-lg font-semibold">Dashboard </h1>
+					<Badge variant="secondary" className="text-xs">
+						BETA
+					</Badge>
+				</div>
+				<DateTimePickerWithRange
+					dateTime={dateRange}
+					onDateTimeUpdate={handleDateRangeChange}
+					preDefinedPeriods={TIME_PERIODS}
+					predefinedPeriod={urlState.period || undefined}
+					onPredefinedPeriodChange={handlePeriodChange}
+					popupAlignment="end"
+				/>
+			</div>
+
+			{/* Charts Grid */}
+			<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+				{/* Log Volume Chart */}
+				<ChartCard
+					title="Request Volume"
+					loading={loadingHistogram}
+					headerActions={
+						<div className="flex items-center gap-3">
+							<div className="flex items-center gap-2 text-xs">
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
+									<span className="text-muted-foreground">Success</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
+									<span className="text-muted-foreground">Error</span>
+								</span>
+							</div>
+							<ChartTypeToggle chartType={toChartType(urlState.volume_chart)} onToggle={handleVolumeChartToggle} />
+						</div>
+					}
+				>
+					<LogVolumeChart
+						data={histogramData}
+						chartType={toChartType(urlState.volume_chart)}
+						startTime={urlState.start_time}
+						endTime={urlState.end_time}
+					/>
+				</ChartCard>
+
+				{/* Token Usage Chart */}
+				<ChartCard
+					title="Token Usage"
+					loading={loadingTokens}
+					headerActions={
+						<div className="flex items-center gap-3">
+							<div className="flex items-center gap-2 text-xs">
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
+									<span className="text-muted-foreground">Input</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
+									<span className="text-muted-foreground">Output</span>
+								</span>
+							</div>
+							<ChartTypeToggle chartType={toChartType(urlState.token_chart)} onToggle={handleTokenChartToggle} />
+						</div>
+					}
+				>
+					<TokenUsageChart
+						data={tokenData}
+						chartType={toChartType(urlState.token_chart)}
+						startTime={urlState.start_time}
+						endTime={urlState.end_time}
+					/>
+				</ChartCard>
+
+				{/* Cost Chart */}
+				<ChartCard
+					title="Cost"
+					loading={loadingCost}
+					headerActions={
+						<div className="flex items-center gap-3">
+							<div className="flex items-center gap-2 text-xs">
+								{urlState.cost_model === "all" ? (
+									<>
+										{availableModels.slice(0, 3).map((model, idx) => (
+											<span key={model} className="flex items-center gap-1">
+												<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(idx) }} />
+												<span className="text-muted-foreground">{model}</span>
+											</span>
+										))}
+										{availableModels.length > 3 && <span className="text-muted-foreground">+{availableModels.length - 3} more</span>}
+									</>
+								) : (
+									<span className="flex items-center gap-1">
+										<span
+											className="h-2 w-2 rounded-full"
+											style={{ backgroundColor: getModelColor(availableModels.indexOf(urlState.cost_model)) }}
+										/>
+										<span className="text-muted-foreground">{urlState.cost_model}</span>
+									</span>
+								)}
+							</div>
+							<ModelFilterSelect models={availableModels} selectedModel={urlState.cost_model} onModelChange={handleCostModelChange} />
+							<ChartTypeToggle chartType={toChartType(urlState.cost_chart)} onToggle={handleCostChartToggle} />
+						</div>
+					}
+				>
+					<CostChart
+						data={costData}
+						chartType={toChartType(urlState.cost_chart)}
+						startTime={urlState.start_time}
+						endTime={urlState.end_time}
+						selectedModel={urlState.cost_model}
+					/>
+				</ChartCard>
+
+				{/* Model Usage Chart */}
+				<ChartCard
+					title="Model Usage"
+					loading={loadingModels}
+					headerActions={
+						<div className="flex items-center gap-3">
+							<div className="flex items-center gap-2 text-xs">
+								{urlState.usage_model === "all" ? (
+									<>
+										{availableModels.slice(0, 3).map((model, idx) => (
+											<span key={model} className="flex items-center gap-1">
+												<span className="h-2 w-2 rounded-full" style={{ backgroundColor: getModelColor(idx) }} />
+												<span className="text-muted-foreground">{model}</span>
+											</span>
+										))}
+										{availableModels.length > 3 && <span className="text-muted-foreground">+{availableModels.length - 3} more</span>}
+									</>
+								) : (
+									<>
+										<span className="flex items-center gap-1">
+											<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
+											<span className="text-muted-foreground">Success</span>
+										</span>
+										<span className="flex items-center gap-1">
+											<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
+											<span className="text-muted-foreground">Error</span>
+										</span>
+									</>
+								)}
+							</div>
+							<ModelFilterSelect models={availableModels} selectedModel={urlState.usage_model} onModelChange={handleUsageModelChange} />
+							<ChartTypeToggle chartType={toChartType(urlState.model_chart)} onToggle={handleModelChartToggle} />
+						</div>
+					}
+				>
+					<ModelUsageChart
+						data={modelData}
+						chartType={toChartType(urlState.model_chart)}
+						startTime={urlState.start_time}
+						endTime={urlState.end_time}
+						selectedModel={urlState.usage_model}
+					/>
+				</ChartCard>
+			</div>
+		</div>
+	);
+}

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -1,0 +1,75 @@
+// Chart utility functions for the dashboard
+
+// Format timestamp based on bucket size
+export function formatTimestamp(timestamp: string, bucketSizeSeconds: number): string {
+	const date = new Date(timestamp);
+
+	if (bucketSizeSeconds >= 86400) {
+		// Daily buckets: "Jan 20"
+		return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+	} else if (bucketSizeSeconds >= 3600) {
+		// Hourly buckets: "10:00"
+		return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+	} else {
+		// Sub-hourly: "10:15"
+		return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+	}
+}
+
+// Format full timestamp for tooltip
+export function formatFullTimestamp(timestamp: string): string {
+	const date = new Date(timestamp);
+	return date.toLocaleString("en-US", {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
+}
+
+// Format cost values
+export function formatCost(cost: number): string {
+	if (cost < 0.01) {
+		return `$${cost.toFixed(4)}`;
+	}
+	return `$${cost.toFixed(2)}`;
+}
+
+// Format token values
+export function formatTokens(tokens: number): string {
+	if (tokens >= 1000000) {
+		return `${(tokens / 1000000).toFixed(1)}M`;
+	}
+	if (tokens >= 1000) {
+		return `${(tokens / 1000).toFixed(1)}K`;
+	}
+	return tokens.toLocaleString();
+}
+
+// Color palette for models
+export const MODEL_COLORS = [
+	"#10b981", // emerald-500
+	"#3b82f6", // blue-500
+	"#f59e0b", // amber-500
+	"#ef4444", // red-500
+	"#8b5cf6", // violet-500
+	"#ec4899", // pink-500
+	"#06b6d4", // cyan-500
+	"#84cc16", // lime-500
+];
+
+// Get color for a model by index
+export function getModelColor(index: number): string {
+	return MODEL_COLORS[index % MODEL_COLORS.length];
+}
+
+// Chart colors
+export const CHART_COLORS = {
+	success: "#10b981", // emerald-500
+	error: "#ef4444", // red-500
+	promptTokens: "#3b82f6", // blue-500
+	completionTokens: "#10b981", // emerald-500
+	totalTokens: "#8b5cf6", // violet-500
+	cost: "#f59e0b", // amber-500
+};

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -15,7 +15,7 @@ import {
 	useDeleteLogsMutation,
 	useLazyGetLogsHistogramQuery,
 	useLazyGetLogsQuery,
-	useLazyGetLogsStatsQuery
+	useLazyGetLogsStatsQuery,
 } from "@/lib/store";
 import type {
 	ChatMessage,
@@ -25,7 +25,7 @@ import type {
 	LogFilters,
 	LogsHistogramResponse,
 	LogStats,
-	Pagination
+	Pagination,
 } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -63,7 +63,7 @@ export default function LogsPage() {
 
 	const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
 	const [isChartOpen, setIsChartOpen] = useState(true);
-	
+
 	// Debouncing for streaming updates (client-side)
 	const streamingUpdateTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
@@ -323,7 +323,13 @@ export default function LogsPage() {
 
 					// Update histogram for completed requests
 					setHistogram((prevHistogram) => {
-						if (!prevHistogram || !prevHistogram.bucket_size_seconds) return prevHistogram;
+						if (
+							!prevHistogram ||
+							typeof prevHistogram.bucket_size_seconds !== 'number' ||
+							prevHistogram.bucket_size_seconds <= 0
+						) {
+							return prevHistogram
+						}
 
 						const logTime = new Date(log.timestamp).getTime();
 						const bucketSizeMs = prevHistogram.bucket_size_seconds * 1000;

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -4,6 +4,7 @@ import { createColumns } from "@/app/workspace/logs/views/columns";
 import { EmptyState } from "@/app/workspace/logs/views/emptyState";
 import { LogDetailSheet } from "@/app/workspace/logs/views/logDetailsSheet";
 import { LogsDataTable } from "@/app/workspace/logs/views/logsTable";
+import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
 import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
@@ -12,6 +13,7 @@ import { useWebSocket } from "@/hooks/useWebSocket";
 import {
 	getErrorMessage,
 	useDeleteLogsMutation,
+	useLazyGetLogsHistogramQuery,
 	useLazyGetLogsQuery,
 	useLazyGetLogsStatsQuery
 } from "@/lib/store";
@@ -21,6 +23,7 @@ import type {
 	ContentBlock,
 	LogEntry,
 	LogFilters,
+	LogsHistogramResponse,
 	LogStats,
 	Pagination
 } from "@/lib/types/logs";
@@ -42,9 +45,11 @@ export default function LogsPage() {
 	const [logs, setLogs] = useState<LogEntry[]>([]);
 	const [totalItems, setTotalItems] = useState(0); // changes with filters
 	const [stats, setStats] = useState<LogStats | null>(null);
+	const [histogram, setHistogram] = useState<LogsHistogramResponse | null>(null);
 	const [initialLoading, setInitialLoading] = useState(true); // on initial load
 	const [fetchingLogs, setFetchingLogs] = useState(false); // on pagination/filters change
 	const [fetchingStats, setFetchingStats] = useState(false); // on stats fetch
+	const [fetchingHistogram, setFetchingHistogram] = useState(false); // on histogram fetch
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
 
@@ -53,9 +58,11 @@ export default function LogsPage() {
 	// RTK Query lazy hooks for manual triggering
 	const [triggerGetLogs] = useLazyGetLogsQuery();
 	const [triggerGetStats] = useLazyGetLogsStatsQuery();
+	const [triggerGetHistogram] = useLazyGetLogsHistogramQuery();
 	const [deleteLogs] = useDeleteLogsMutation();
 
 	const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
+	const [isChartOpen, setIsChartOpen] = useState(true);
 	
 	// Debouncing for streaming updates (client-side)
 	const streamingUpdateTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -146,6 +153,37 @@ export default function LogsPage() {
 		},
 		[setUrlState],
 	);
+
+	// Handler for time range changes from the volume chart
+	const handleTimeRangeChange = useCallback(
+		(startTime: number, endTime: number) => {
+			setUrlState({
+				start_time: startTime,
+				end_time: endTime,
+				offset: 0,
+			});
+		},
+		[setUrlState],
+	);
+
+	// Handler for resetting zoom to default 24h view
+	const handleResetZoom = useCallback(() => {
+		const now = Math.floor(Date.now() / 1000);
+		const twentyFourHoursAgo = now - 24 * 60 * 60;
+		setUrlState({
+			start_time: twentyFourHoursAgo,
+			end_time: now,
+			offset: 0,
+		});
+	}, [setUrlState]);
+
+	// Check if user has zoomed (time range is different from default 24h)
+	const isZoomed = useMemo(() => {
+		const currentRange = urlState.end_time - urlState.start_time;
+		const defaultRange = 24 * 60 * 60; // 24 hours in seconds
+		// Consider zoomed if range is less than 90% of default (to account for minor differences)
+		return currentRange < defaultRange * 0.9;
+	}, [urlState.start_time, urlState.end_time]);
 
 	const latest = useRef({ logs, filters, pagination, showEmptyState, liveEnabled });
 	useEffect(() => {
@@ -282,6 +320,48 @@ export default function LogsPage() {
 
 						return newStats;
 					});
+
+					// Update histogram for completed requests
+					setHistogram((prevHistogram) => {
+						if (!prevHistogram || !prevHistogram.bucket_size_seconds) return prevHistogram;
+
+						const logTime = new Date(log.timestamp).getTime();
+						const bucketSizeMs = prevHistogram.bucket_size_seconds * 1000;
+						const bucketTime = Math.floor(logTime / bucketSizeMs) * bucketSizeMs;
+
+						const updatedBuckets = [...prevHistogram.buckets];
+						const bucketIndex = updatedBuckets.findIndex((b) => {
+							const bTime = new Date(b.timestamp).getTime();
+							return Math.floor(bTime / bucketSizeMs) * bucketSizeMs === bucketTime;
+						});
+
+						if (bucketIndex >= 0) {
+							// Update existing bucket
+							updatedBuckets[bucketIndex] = {
+								...updatedBuckets[bucketIndex],
+								count: updatedBuckets[bucketIndex].count + 1,
+								success: updatedBuckets[bucketIndex].success + (log.status === "success" ? 1 : 0),
+								error: updatedBuckets[bucketIndex].error + (log.status === "error" ? 1 : 0),
+							};
+						} else {
+							// Create new bucket for this timestamp
+							const newBucket = {
+								timestamp: new Date(bucketTime).toISOString(),
+								count: 1,
+								success: log.status === "success" ? 1 : 0,
+								error: log.status === "error" ? 1 : 0,
+							};
+							// Insert in sorted order
+							const insertIndex = updatedBuckets.findIndex((b) => new Date(b.timestamp).getTime() > bucketTime);
+							if (insertIndex === -1) {
+								updatedBuckets.push(newBucket);
+							} else {
+								updatedBuckets.splice(insertIndex, 0, newBucket);
+							}
+						}
+
+						return { ...prevHistogram, buckets: updatedBuckets };
+					});
 				}
 			}
 		}
@@ -378,6 +458,25 @@ export default function LogsPage() {
 		}
 	}, [filters, triggerGetStats]);
 
+	const fetchHistogram = useCallback(async () => {
+		setFetchingHistogram(true);
+
+		try {
+			const result = await triggerGetHistogram({ filters });
+
+			if (result.error) {
+				// Don't show error for histogram failure, just log it
+				console.error("Failed to fetch histogram:", result.error);
+			} else if (result.data) {
+				setHistogram(result.data);
+			}
+		} catch (error) {
+			console.error("Failed to fetch histogram:", error);
+		} finally {
+			setFetchingHistogram(false);
+		}
+	}, [filters, triggerGetHistogram]);
+
 	// Helper to toggle live updates
 	const handleLiveToggle = useCallback(
 		(enabled: boolean) => {
@@ -398,10 +497,11 @@ export default function LogsPage() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [filters, pagination, initialLoading]);
 
-	// Fetch stats when filters change (but not pagination)
+	// Fetch stats and histogram when filters change (but not pagination)
 	useEffect(() => {
 		if (!initialLoading) {
 			fetchStats();
+			fetchHistogram();
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [filters, initialLoading]);
@@ -412,6 +512,7 @@ export default function LogsPage() {
 			// Load logs and stats in parallel, don't wait for stats to show the page
 			await fetchLogs();
 			fetchStats(); // Don't await - let it load in background
+			fetchHistogram(); // Don't await - let it load in background
 			setInitialLoading(false);
 		};
 		initialLoad();
@@ -524,16 +625,16 @@ export default function LogsPage() {
 	const columns = useMemo(() => createColumns(handleDelete, hasDeleteAccess), [handleDelete, hasDeleteAccess]);
 
 	return (
-		<div className="dark:bg-card bg-white">
+		<div className="dark:bg-card h-[calc(100dvh-3.3rem)] max-h-[calc(100dvh-1.5rem)] bg-white">
 			{initialLoading ? (
 				<FullPageLoader />
 			) : showEmptyState ? (
 				<EmptyState isSocketConnected={isSocketConnected} error={error} />
 			) : (
-				<div className="mx-auto max-w-7xl space-y-6">
-					<div className="space-y-6">
+				<div className="mx-auto flex h-full max-w-7xl flex-col">
+					<div className="flex flex-1 flex-col gap-2 overflow-hidden">
 						{/* Quick Stats */}
-						<div className="grid grid-cols-1 gap-4 md:grid-cols-5">
+						<div className="grid shrink-0 grid-cols-1 gap-4 md:grid-cols-5">
 							{statCards.map((card) => (
 								<Card key={card.title} className="py-4 shadow-none">
 									<CardContent className="flex items-center justify-between px-4">
@@ -546,33 +647,50 @@ export default function LogsPage() {
 							))}
 						</div>
 
+						{/* Volume Chart */}
+						<div className="shrink-0">
+							<LogsVolumeChart
+								data={histogram}
+								loading={fetchingHistogram}
+								onTimeRangeChange={handleTimeRangeChange}
+								onResetZoom={handleResetZoom}
+								isZoomed={isZoomed}
+								startTime={urlState.start_time}
+								endTime={urlState.end_time}
+								isOpen={isChartOpen}
+								onOpenChange={setIsChartOpen}
+							/>
+						</div>
+
 						{/* Error Alert */}
 						{error && (
-							<Alert variant="destructive">
+							<Alert variant="destructive" className="shrink-0">
 								<AlertCircle className="h-4 w-4" />
 								<AlertDescription>{error}</AlertDescription>
 							</Alert>
 						)}
 
-						<LogsDataTable
-							columns={columns}
-							data={logs}
-							totalItems={totalItems}
-							loading={fetchingLogs}
-							filters={filters}
-							pagination={pagination}
-							onFiltersChange={setFilters}
-							onPaginationChange={setPagination}
-							onRowClick={(row, columnId) => {
-								if (columnId === "actions") return;
-								setSelectedLog(row);
-							}}
-							isSocketConnected={isSocketConnected}
-							liveEnabled={liveEnabled}
-							onLiveToggle={handleLiveToggle}
-							fetchLogs={fetchLogs}
-							fetchStats={fetchStats}
-						/>
+						<div className="min-h-0 flex-1">
+							<LogsDataTable
+								columns={columns}
+								data={logs}
+								totalItems={totalItems}
+								loading={fetchingLogs}
+								filters={filters}
+								pagination={pagination}
+								onFiltersChange={setFilters}
+								onPaginationChange={setPagination}
+								onRowClick={(row, columnId) => {
+									if (columnId === "actions") return;
+									setSelectedLog(row);
+								}}
+								isSocketConnected={isSocketConnected}
+								liveEnabled={liveEnabled}
+								onLiveToggle={handleLiveToggle}
+								fetchLogs={fetchLogs}
+								fetchStats={fetchStats}
+							/>
+						</div>
 					</div>
 
 					{/* Log Detail Sheet */}

--- a/ui/app/workspace/logs/views/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/views/logDetailsSheet.tsx
@@ -315,8 +315,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							<div className="space-y-4">
 								<BlockHeader title="Tokens" icon={<DollarSign className="h-5 w-5 text-gray-600" />} />
 								<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
-									<LogEntryDetailsView className="w-full" label="Prompt Tokens" value={log.token_usage?.prompt_tokens || "-"} />
-									<LogEntryDetailsView className="w-full" label="Completion Tokens" value={log.token_usage?.completion_tokens || "-"} />
+									<LogEntryDetailsView className="w-full" label="Input Tokens" value={log.token_usage?.prompt_tokens || "-"} />
+									<LogEntryDetailsView className="w-full" label="Output Tokens" value={log.token_usage?.completion_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Total Tokens" value={log.token_usage?.total_tokens || "-"} />
 									{log.token_usage?.prompt_tokens_details && (
 										<>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -104,17 +104,20 @@ export function LogsDataTable({
 	};
 
 	return (
-		<div className="space-y-2">
-			<LogFiltersComponent
-				filters={filters}
-				onFiltersChange={onFiltersChange}
-				liveEnabled={liveEnabled}
-				onLiveToggle={onLiveToggle}
-				fetchLogs={fetchLogs}
-				fetchStats={fetchStats}
-			/>
-			<div ref={tableContainerRef} className="h-[calc(100vh-16.5rem)] rounded-sm border">
-				<Table containerClassName="max-h-[calc(100vh-16.5rem)]">
+		<div className="flex h-full flex-col gap-2">
+			<div className="shrink-0">
+				<LogFiltersComponent
+					filters={filters}
+					onFiltersChange={onFiltersChange}
+					liveEnabled={liveEnabled}
+					onLiveToggle={onLiveToggle}
+					fetchLogs={fetchLogs}
+					fetchStats={fetchStats}
+				/>
+			</div>
+			
+			<div ref={tableContainerRef} className="min-h-0 flex-1 overflow-hidden rounded-sm border">
+				<Table containerClassName="h-full overflow-auto">
 					<TableHeader className="px-2">
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>
@@ -184,7 +187,7 @@ export function LogsDataTable({
 			</div>
 
 			{/* Pagination Footer */}
-			<div className="flex items-center justify-between text-xs">
+			<div className="flex shrink-0 items-center justify-between text-xs">
 				<div className="text-muted-foreground flex items-center gap-2">
 					{startItem.toLocaleString()}-{endItem.toLocaleString()} of {totalItems.toLocaleString()} entries
 				</div>

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -1,0 +1,432 @@
+'use client'
+
+import { Card } from '@/components/ui/card'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
+import { Skeleton } from '@/components/ui/skeleton'
+import type { HistogramBucket, LogsHistogramResponse } from '@/lib/types/logs'
+import { ChevronDown, RotateCcw } from 'lucide-react'
+import { Component, type ErrorInfo, type ReactNode, useCallback, useMemo, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceArea,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+// Empty chart placeholder when data fails to render
+function EmptyChart() {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={[{ name: '', value: 0 }, { name: ' ', value: 0 }]}>
+        <CartesianGrid strokeDasharray="3 3" className="stroke-zinc-200 dark:stroke-zinc-700" />
+        <XAxis dataKey="name" tick={{ fontSize: 13, className: 'fill-zinc-500', dy: 5 }} tickLine={false} axisLine={false} />
+        <YAxis tick={{ fontSize: 13, className: 'fill-zinc-500' }} tickLine={false} axisLine={false} width={40} domain={[0, 1]} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+// Error boundary to catch Recharts rendering errors
+class ChartErrorBoundary extends Component<{ children: ReactNode; resetKey?: string }, { hasError: boolean }> {
+  constructor(props: { children: ReactNode; resetKey?: string }) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(_: Error) {
+    return { hasError: true }
+  }
+
+  static getDerivedStateFromProps(props: { resetKey?: string }, state: { hasError: boolean; prevResetKey?: string }) {
+    // Reset error state when resetKey changes
+    if (props.resetKey !== state.prevResetKey) {
+      return { hasError: false, prevResetKey: props.resetKey }
+    }
+    return null
+  }
+
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    console.warn('Chart rendering error:', error.message)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <EmptyChart />
+    }
+    return this.props.children
+  }
+}
+
+interface LogsVolumeChartProps {
+  data: LogsHistogramResponse | null
+  loading?: boolean
+  onTimeRangeChange: (startTime: number, endTime: number) => void
+  onResetZoom?: () => void
+  isZoomed?: boolean
+  startTime: number // Unix timestamp in seconds
+  endTime: number // Unix timestamp in seconds
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+// Format timestamp based on bucket size
+function formatTimestamp(timestamp: string, bucketSizeSeconds: number): string {
+  const date = new Date(timestamp)
+
+  if (bucketSizeSeconds >= 86400) {
+    // Daily buckets: "Jan 20"
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+  } else if (bucketSizeSeconds >= 3600) {
+    // Hourly buckets: "10:00"
+    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+  } else {
+    // Sub-hourly: "10:15"
+    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
+  }
+}
+
+// Format full timestamp for tooltip
+function formatFullTimestamp(timestamp: string): string {
+  const date = new Date(timestamp)
+  return date.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+// Custom tooltip component
+function CustomTooltip({ active, payload, label }: any) {
+  if (!active || !payload || !payload.length) return null
+
+  const data = payload[0]?.payload as HistogramBucket & { formattedTime: string }
+  if (!data) return null
+
+  return (
+    <div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+      <div className="space-y-1 text-sm">
+        <div className="flex items-center justify-between gap-4 mt-2">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-blue-500" />
+            <span className="text-zinc-600 dark:text-zinc-400">Total</span>
+          </span>
+          <span className="font-medium">{data.count.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            <span className="text-zinc-600 dark:text-zinc-400">Success</span>
+          </span>
+          <span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            <span className="text-zinc-600 dark:text-zinc-400">Error</span>
+          </span>
+          <span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function LogsVolumeChart({
+  data,
+  loading,
+  onTimeRangeChange,
+  onResetZoom,
+  isZoomed,
+  startTime,
+  endTime,
+  isOpen,
+  onOpenChange,
+}: LogsVolumeChartProps) {
+
+  // State for drag selection
+  const [refAreaLeft, setRefAreaLeft] = useState<number | null>(null)
+  const [refAreaRight, setRefAreaRight] = useState<number | null>(null)
+  const [isSelecting, setIsSelecting] = useState(false)
+
+  // Transform data for chart, filling in empty buckets for the full time range
+  const chartData = useMemo(() => {
+    // Need bucket_size_seconds and valid time range
+    if (!data?.bucket_size_seconds || !startTime || !endTime || startTime >= endTime) {
+      return []
+    }
+
+    const bucketSizeMs = data.bucket_size_seconds * 1000
+
+    // Align start time to bucket boundary
+    const minTime = Math.floor((startTime * 1000) / bucketSizeMs) * bucketSizeMs
+    const maxTime = endTime * 1000
+
+    // Safety: limit maximum number of buckets to prevent performance issues
+    const maxBuckets = 500
+    const estimatedBuckets = Math.ceil((maxTime - minTime) / bucketSizeMs)
+
+    if (estimatedBuckets > maxBuckets) {
+      // If too many buckets, just return the original data without filling
+      const result = (data.buckets || []).map((bucket, index) => ({
+        ...bucket,
+        index,
+        formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+      }))
+      // Ensure at least 2 data points for Recharts
+      if (result.length === 1) {
+        const nextTimestamp = new Date(new Date(result[0].timestamp).getTime() + bucketSizeMs).toISOString()
+        result.push({
+          timestamp: nextTimestamp,
+          count: 0,
+          success: 0,
+          error: 0,
+          index: 1,
+          formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
+        })
+      }
+      return result
+    }
+
+    // First, create all empty buckets for the time range
+    const filledBuckets: Array<HistogramBucket & { formattedTime: string; index: number }> = []
+    for (let time = minTime, idx = 0; time <= maxTime; time += bucketSizeMs, idx++) {
+      const timestamp = new Date(time).toISOString()
+      filledBuckets.push({
+        timestamp,
+        count: 0,
+        success: 0,
+        error: 0,
+        index: idx,
+        formattedTime: formatTimestamp(timestamp, data.bucket_size_seconds),
+      })
+    }
+
+    // Then, place API buckets at their correct positions using index calculation
+    // This is more robust than exact timestamp matching
+    for (const bucket of (data.buckets || [])) {
+      const bucketTime = new Date(bucket.timestamp).getTime()
+      // Calculate the index for this bucket based on its offset from minTime
+      const bucketIndex = Math.round((bucketTime - minTime) / bucketSizeMs)
+
+      if (bucketIndex >= 0 && bucketIndex < filledBuckets.length) {
+        filledBuckets[bucketIndex] = {
+          ...bucket,
+          index: bucketIndex,
+          formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+        }
+      }
+    }
+
+    // Ensure at least 2 data points for Recharts
+    if (filledBuckets.length === 1) {
+      const nextTimestamp = new Date(new Date(filledBuckets[0].timestamp).getTime() + bucketSizeMs).toISOString()
+      filledBuckets.push({
+        timestamp: nextTimestamp,
+        count: 0,
+        success: 0,
+        error: 0,
+        index: 1,
+        formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
+      })
+    }
+
+    return filledBuckets
+  }, [data, startTime, endTime])
+
+  // Handle mouse down on chart (start selection)
+  const handleMouseDown = useCallback((e: any) => {
+    if (e?.activeTooltipIndex !== undefined) {
+      setRefAreaLeft(e.activeTooltipIndex)
+      setIsSelecting(true)
+    }
+  }, [])
+
+  // Handle mouse move on chart (during selection)
+  const handleMouseMove = useCallback((e: any) => {
+    if (isSelecting && e?.activeTooltipIndex !== undefined) {
+      setRefAreaRight(e.activeTooltipIndex)
+    }
+  }, [isSelecting])
+
+  // Handle mouse up on chart (end selection)
+  const handleMouseUp = useCallback(() => {
+    if (refAreaLeft === null || refAreaRight === null || !data?.bucket_size_seconds || chartData.length === 0) {
+      setRefAreaLeft(null)
+      setRefAreaRight(null)
+      setIsSelecting(false)
+      return
+    }
+
+    // Get the buckets by index
+    const leftBucket = chartData[refAreaLeft]
+    const rightBucket = chartData[refAreaRight]
+
+    if (leftBucket && rightBucket) {
+      const leftTime = new Date(leftBucket.timestamp).getTime() / 1000
+      const rightTime = new Date(rightBucket.timestamp).getTime() / 1000 + data.bucket_size_seconds
+
+      // Ensure left < right
+      const selectionStart = Math.min(leftTime, rightTime)
+      const selectionEnd = Math.max(leftTime, rightTime)
+
+      // Only trigger if selection spans at least one bucket
+      if (selectionEnd - selectionStart >= data.bucket_size_seconds) {
+        onTimeRangeChange(selectionStart, selectionEnd)
+      }
+    }
+
+    setRefAreaLeft(null)
+    setRefAreaRight(null)
+    setIsSelecting(false)
+  }, [refAreaLeft, refAreaRight, data, chartData, onTimeRangeChange])
+
+  // Handle click on a bar (zoom into that bucket)
+  const handleBarClick = useCallback((barData: any) => {
+    if (!data || !barData?.timestamp) return
+
+    const bucket = barData as HistogramBucket
+    const startTime = new Date(bucket.timestamp).getTime() / 1000
+    const endTime = startTime + data.bucket_size_seconds
+
+    onTimeRangeChange(startTime, endTime)
+  }, [data, onTimeRangeChange])
+
+  if (loading) {
+    return (
+      <Card className="shadow-none px-2 py-2 rounded-sm gap-0">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ChevronDown className="text-muted-foreground h-4 w-4" />
+            <span className="text-muted-foreground text-sm font-medium">Request Volume</span>
+          </div>
+          <div className="flex items-center gap-4 mr-2">
+            <div className="flex items-center gap-3 text-xs">
+              <span className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                <span className="text-muted-foreground">Success</span>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-red-500" />
+                <span className="text-muted-foreground">Error</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="" style={{ height: '131px', marginTop: 4 }}>
+          <Skeleton className="h-full w-full" />
+        </div>
+      </Card>
+    )
+  }
+
+  // Check if we have valid data for the chart
+  const hasValidData = data && startTime && endTime && chartData.length >= 2
+
+  return (
+		<Card className="rounded-sm px-2 py-2 shadow-none">
+			<Collapsible open={isOpen} onOpenChange={onOpenChange}>
+				<div className="flex items-center justify-between">
+					<CollapsibleTrigger className="flex items-center gap-2 hover:opacity-80">
+						<ChevronDown className={`text-muted-foreground h-4 w-4 transition-transform duration-200 ${isOpen ? "" : "-rotate-90"}`} />
+						<span className="text-muted-foreground text-sm font-medium">Request Volume</span>
+					</CollapsibleTrigger>
+					<div className="mr-2 flex items-center gap-4">
+						{isOpen && (
+							<div className="flex items-center gap-3 text-xs">
+								<span className="flex items-center gap-1.5">
+									<span className="h-2 w-2 rounded-full bg-emerald-500" />
+									<span className="text-muted-foreground">Success</span>
+								</span>
+								<span className="flex items-center gap-1.5">
+									<span className="h-2 w-2 rounded-full bg-red-500" />
+									<span className="text-muted-foreground">Error</span>
+								</span>
+							</div>
+						)}
+						{isZoomed && onResetZoom && (
+							<button
+								onClick={onResetZoom}
+								className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
+							>
+								<RotateCcw className="h-3 w-3" />
+								Reset zoom
+							</button>
+						)}
+					</div>
+				</div>
+				<CollapsibleContent className="data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down overflow-hidden">
+					<div className="mt-2 h-32 select-none">
+						{hasValidData ? (
+							<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+								<ResponsiveContainer width="100%" height="100%">
+									<BarChart
+										data={chartData}
+										onMouseDown={handleMouseDown}
+										onMouseMove={handleMouseMove}
+										onMouseUp={handleMouseUp}
+										onMouseLeave={handleMouseUp}
+										barCategoryGap={1}
+									>
+										<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+										<XAxis
+											dataKey="index"
+											type="number"
+											domain={[-0.5, chartData.length - 0.5]}
+											tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }}
+											tickLine={true}
+											axisLine={false}
+											tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+											interval="preserveStartEnd"
+										/>
+										<YAxis
+											tick={{ fontSize: 13, className: "fill-zinc-500" }}
+											tickLine={false}
+											axisLine={false}
+											width={40}
+											tickFormatter={(v) => v.toLocaleString()}
+											domain={[0, (dataMax: number) => Math.max(dataMax, 5)]}
+											allowDataOverflow={false}
+										/>
+										<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+										<Bar
+											dataKey="success"
+											stackId="requests"
+											barSize={30}
+											fill="#10b981"
+											fillOpacity={0.7}
+											radius={[0, 0, 0, 0]}
+											cursor="pointer"
+											onClick={(data: any) => handleBarClick(data)}
+										/>
+										<Bar
+											dataKey="error"
+											stackId="requests"
+											fill="#ef4444"
+											barSize={30}
+											fillOpacity={0.7}
+											radius={[2, 2, 0, 0]}
+											cursor="pointer"
+											onClick={(data: any) => handleBarClick(data)}
+										/>
+										{refAreaLeft !== null && refAreaRight !== null && chartData[refAreaLeft] && chartData[refAreaRight] && (
+											<ReferenceArea x1={refAreaLeft} x2={refAreaRight} strokeOpacity={0.3} fill="#6366f1" fillOpacity={0.2} />
+										)}
+									</BarChart>
+								</ResponsiveContainer>
+							</ChartErrorBoundary>
+						) : (
+							<EmptyChart />
+						)}
+					</div>
+				</CollapsibleContent>
+			</Collapsible>
+		</Card>
+	);
+}

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -1,341 +1,346 @@
-'use client'
+"use client";
 
-import { Card } from '@/components/ui/card'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
-import { Skeleton } from '@/components/ui/skeleton'
-import type { HistogramBucket, LogsHistogramResponse } from '@/lib/types/logs'
-import { ChevronDown, RotateCcw } from 'lucide-react'
-import { Component, type ErrorInfo, type ReactNode, useCallback, useMemo, useState } from 'react'
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ReferenceArea,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { HistogramBucket, LogsHistogramResponse } from "@/lib/types/logs";
+import { ChevronDown, RotateCcw } from "lucide-react";
+import { Component, type ErrorInfo, type ReactNode, useCallback, useMemo, useState } from "react";
+import { Bar, BarChart, CartesianGrid, ReferenceArea, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 // Empty chart placeholder when data fails to render
 function EmptyChart() {
-  return (
-    <ResponsiveContainer width="100%" height="100%">
-      <BarChart data={[{ name: '', value: 0 }, { name: ' ', value: 0 }]}>
-        <CartesianGrid strokeDasharray="3 3" className="stroke-zinc-200 dark:stroke-zinc-700" />
-        <XAxis dataKey="name" tick={{ fontSize: 13, className: 'fill-zinc-500', dy: 5 }} tickLine={false} axisLine={false} />
-        <YAxis tick={{ fontSize: 13, className: 'fill-zinc-500' }} tickLine={false} axisLine={false} width={40} domain={[0, 1]} />
-      </BarChart>
-    </ResponsiveContainer>
-  )
+	return (
+		<ResponsiveContainer width="100%" height="100%">
+			<BarChart
+				data={[
+					{ name: "", value: 0 },
+					{ name: " ", value: 0 },
+				]}
+			>
+				<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+				<XAxis dataKey="name" tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }} tickLine={false} axisLine={false} />
+				<YAxis tick={{ fontSize: 13, className: "fill-zinc-500" }} tickLine={false} axisLine={false} width={40} domain={[0, 1]} />
+			</BarChart>
+		</ResponsiveContainer>
+	);
 }
 
 // Error boundary to catch Recharts rendering errors
 class ChartErrorBoundary extends Component<{ children: ReactNode; resetKey?: string }, { hasError: boolean }> {
-  constructor(props: { children: ReactNode; resetKey?: string }) {
-    super(props)
-    this.state = { hasError: false }
-  }
+	constructor(props: { children: ReactNode; resetKey?: string }) {
+		super(props);
+		this.state = { hasError: false };
+	}
 
-  static getDerivedStateFromError(_: Error) {
-    return { hasError: true }
-  }
+	static getDerivedStateFromError(_: Error) {
+		return { hasError: true };
+	}
 
-  static getDerivedStateFromProps(props: { resetKey?: string }, state: { hasError: boolean; prevResetKey?: string }) {
-    // Reset error state when resetKey changes
-    if (props.resetKey !== state.prevResetKey) {
-      return { hasError: false, prevResetKey: props.resetKey }
-    }
-    return null
-  }
+	static getDerivedStateFromProps(props: { resetKey?: string }, state: { hasError: boolean; prevResetKey?: string }) {
+		// Reset error state when resetKey changes
+		if (props.resetKey !== state.prevResetKey) {
+			return { hasError: false, prevResetKey: props.resetKey };
+		}
+		return null;
+	}
 
-  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
-    console.warn('Chart rendering error:', error.message)
-  }
+	componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+		console.warn("Chart rendering error:", error.message);
+	}
 
-  render() {
-    if (this.state.hasError) {
-      return <EmptyChart />
-    }
-    return this.props.children
-  }
+	render() {
+		if (this.state.hasError) {
+			return <EmptyChart />;
+		}
+		return this.props.children;
+	}
 }
 
 interface LogsVolumeChartProps {
-  data: LogsHistogramResponse | null
-  loading?: boolean
-  onTimeRangeChange: (startTime: number, endTime: number) => void
-  onResetZoom?: () => void
-  isZoomed?: boolean
-  startTime: number // Unix timestamp in seconds
-  endTime: number // Unix timestamp in seconds
-  isOpen: boolean
-  onOpenChange: (open: boolean) => void
+	data: LogsHistogramResponse | null;
+	loading?: boolean;
+	onTimeRangeChange: (startTime: number, endTime: number) => void;
+	onResetZoom?: () => void;
+	isZoomed?: boolean;
+	startTime: number; // Unix timestamp in seconds
+	endTime: number; // Unix timestamp in seconds
+	isOpen: boolean;
+	onOpenChange: (open: boolean) => void;
 }
 
 // Format timestamp based on bucket size
 function formatTimestamp(timestamp: string, bucketSizeSeconds: number): string {
-  const date = new Date(timestamp)
+	const date = new Date(timestamp);
 
-  if (bucketSizeSeconds >= 86400) {
-    // Daily buckets: "Jan 20"
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-  } else if (bucketSizeSeconds >= 3600) {
-    // Hourly buckets: "10:00"
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
-  } else {
-    // Sub-hourly: "10:15"
-    return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false })
-  }
+	if (bucketSizeSeconds >= 86400) {
+		// Daily buckets: "Jan 20"
+		return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+	} else if (bucketSizeSeconds >= 3600) {
+		// Hourly buckets: "10:00"
+		return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+	} else {
+		// Sub-hourly: "10:15"
+		return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+	}
 }
 
 // Format full timestamp for tooltip
 function formatFullTimestamp(timestamp: string): string {
-  const date = new Date(timestamp)
-  return date.toLocaleString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
+	const date = new Date(timestamp);
+	return date.toLocaleString("en-US", {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
 }
 
 // Custom tooltip component
 function CustomTooltip({ active, payload, label }: any) {
-  if (!active || !payload || !payload.length) return null
+	if (!active || !payload || !payload.length) return null;
 
-  const data = payload[0]?.payload as HistogramBucket & { formattedTime: string }
-  if (!data) return null
+	const data = payload[0]?.payload as HistogramBucket & { formattedTime: string };
+	if (!data) return null;
 
-  return (
-    <div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
-      <div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
-      <div className="space-y-1 text-sm">
-        <div className="flex items-center justify-between gap-4 mt-2">
-          <span className="flex items-center gap-1.5">
-            <span className="h-2 w-2 rounded-full bg-blue-500" />
-            <span className="text-zinc-600 dark:text-zinc-400">Total</span>
-          </span>
-          <span className="font-medium">{data.count.toLocaleString()}</span>
-        </div>
-        <div className="flex items-center justify-between gap-4">
-          <span className="flex items-center gap-1.5">
-            <span className="h-2 w-2 rounded-full bg-emerald-500" />
-            <span className="text-zinc-600 dark:text-zinc-400">Success</span>
-          </span>
-          <span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
-        </div>
-        <div className="flex items-center justify-between gap-4">
-          <span className="flex items-center gap-1.5">
-            <span className="h-2 w-2 rounded-full bg-red-500" />
-            <span className="text-zinc-600 dark:text-zinc-400">Error</span>
-          </span>
-          <span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
-        </div>
-      </div>
-    </div>
-  )
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="mt-2 flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-blue-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Total</span>
+					</span>
+					<span className="font-medium">{data.count.toLocaleString()}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Success</span>
+					</span>
+					<span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full bg-red-500" />
+						<span className="text-zinc-600 dark:text-zinc-400">Error</span>
+					</span>
+					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
+				</div>
+			</div>
+		</div>
+	);
 }
 
 export function LogsVolumeChart({
-  data,
-  loading,
-  onTimeRangeChange,
-  onResetZoom,
-  isZoomed,
-  startTime,
-  endTime,
-  isOpen,
-  onOpenChange,
+	data,
+	loading,
+	onTimeRangeChange,
+	onResetZoom,
+	isZoomed,
+	startTime,
+	endTime,
+	isOpen,
+	onOpenChange,
 }: LogsVolumeChartProps) {
+	// State for drag selection
+	const [refAreaLeft, setRefAreaLeft] = useState<number | null>(null);
+	const [refAreaRight, setRefAreaRight] = useState<number | null>(null);
+	const [isSelecting, setIsSelecting] = useState(false);
 
-  // State for drag selection
-  const [refAreaLeft, setRefAreaLeft] = useState<number | null>(null)
-  const [refAreaRight, setRefAreaRight] = useState<number | null>(null)
-  const [isSelecting, setIsSelecting] = useState(false)
+	// Transform data for chart, filling in empty buckets for the full time range
+	const chartData = useMemo(() => {
+		// Need bucket_size_seconds and valid time range
+		if (!data?.bucket_size_seconds || !startTime || !endTime || startTime >= endTime) {
+			return [];
+		}
 
-  // Transform data for chart, filling in empty buckets for the full time range
-  const chartData = useMemo(() => {
-    // Need bucket_size_seconds and valid time range
-    if (!data?.bucket_size_seconds || !startTime || !endTime || startTime >= endTime) {
-      return []
-    }
+		const bucketSizeMs = data.bucket_size_seconds * 1000;
 
-    const bucketSizeMs = data.bucket_size_seconds * 1000
+		// Align start time to bucket boundary
+		const minTime = Math.floor((startTime * 1000) / bucketSizeMs) * bucketSizeMs;
+		const maxTime = endTime * 1000;
 
-    // Align start time to bucket boundary
-    const minTime = Math.floor((startTime * 1000) / bucketSizeMs) * bucketSizeMs
-    const maxTime = endTime * 1000
+		// Safety: limit maximum number of buckets to prevent performance issues
+		const maxBuckets = 500;
+		const estimatedBuckets = Math.ceil((maxTime - minTime) / bucketSizeMs);
 
-    // Safety: limit maximum number of buckets to prevent performance issues
-    const maxBuckets = 500
-    const estimatedBuckets = Math.ceil((maxTime - minTime) / bucketSizeMs)
+		if (estimatedBuckets > maxBuckets) {
+			// If too many buckets, just return the original data without filling
+			const result = (data.buckets || []).map((bucket, index) => ({
+				...bucket,
+				index,
+				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+			}));
+			// Ensure at least 2 data points for Recharts
+			if (result.length === 1) {
+				const nextTimestamp = new Date(new Date(result[0].timestamp).getTime() + bucketSizeMs).toISOString();
+				result.push({
+					timestamp: nextTimestamp,
+					count: 0,
+					success: 0,
+					error: 0,
+					index: 1,
+					formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
+				});
+			}
+			return result;
+		}
 
-    if (estimatedBuckets > maxBuckets) {
-      // If too many buckets, just return the original data without filling
-      const result = (data.buckets || []).map((bucket, index) => ({
-        ...bucket,
-        index,
-        formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
-      }))
-      // Ensure at least 2 data points for Recharts
-      if (result.length === 1) {
-        const nextTimestamp = new Date(new Date(result[0].timestamp).getTime() + bucketSizeMs).toISOString()
-        result.push({
-          timestamp: nextTimestamp,
-          count: 0,
-          success: 0,
-          error: 0,
-          index: 1,
-          formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
-        })
-      }
-      return result
-    }
+		// First, create all empty buckets for the time range
+		const filledBuckets: Array<HistogramBucket & { formattedTime: string; index: number }> = [];
+		for (let time = minTime, idx = 0; time <= maxTime; time += bucketSizeMs, idx++) {
+			const timestamp = new Date(time).toISOString();
+			filledBuckets.push({
+				timestamp,
+				count: 0,
+				success: 0,
+				error: 0,
+				index: idx,
+				formattedTime: formatTimestamp(timestamp, data.bucket_size_seconds),
+			});
+		}
 
-    // First, create all empty buckets for the time range
-    const filledBuckets: Array<HistogramBucket & { formattedTime: string; index: number }> = []
-    for (let time = minTime, idx = 0; time <= maxTime; time += bucketSizeMs, idx++) {
-      const timestamp = new Date(time).toISOString()
-      filledBuckets.push({
-        timestamp,
-        count: 0,
-        success: 0,
-        error: 0,
-        index: idx,
-        formattedTime: formatTimestamp(timestamp, data.bucket_size_seconds),
-      })
-    }
+		// Then, place API buckets at their correct positions using index calculation
+		// This is more robust than exact timestamp matching
+		for (const bucket of data.buckets || []) {
+			const bucketTime = new Date(bucket.timestamp).getTime();
+			// Calculate the index for this bucket based on its offset from minTime
+			const bucketIndex = Math.round((bucketTime - minTime) / bucketSizeMs);
 
-    // Then, place API buckets at their correct positions using index calculation
-    // This is more robust than exact timestamp matching
-    for (const bucket of (data.buckets || [])) {
-      const bucketTime = new Date(bucket.timestamp).getTime()
-      // Calculate the index for this bucket based on its offset from minTime
-      const bucketIndex = Math.round((bucketTime - minTime) / bucketSizeMs)
+			if (bucketIndex >= 0 && bucketIndex < filledBuckets.length) {
+				filledBuckets[bucketIndex] = {
+					...bucket,
+					index: bucketIndex,
+					formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+				};
+			}
+		}
 
-      if (bucketIndex >= 0 && bucketIndex < filledBuckets.length) {
-        filledBuckets[bucketIndex] = {
-          ...bucket,
-          index: bucketIndex,
-          formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
-        }
-      }
-    }
+		// Ensure at least 2 data points for Recharts
+		if (filledBuckets.length === 1) {
+			const nextTimestamp = new Date(new Date(filledBuckets[0].timestamp).getTime() + bucketSizeMs).toISOString();
+			filledBuckets.push({
+				timestamp: nextTimestamp,
+				count: 0,
+				success: 0,
+				error: 0,
+				index: 1,
+				formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
+			});
+		}
 
-    // Ensure at least 2 data points for Recharts
-    if (filledBuckets.length === 1) {
-      const nextTimestamp = new Date(new Date(filledBuckets[0].timestamp).getTime() + bucketSizeMs).toISOString()
-      filledBuckets.push({
-        timestamp: nextTimestamp,
-        count: 0,
-        success: 0,
-        error: 0,
-        index: 1,
-        formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
-      })
-    }
+		return filledBuckets;
+	}, [data, startTime, endTime]);
 
-    return filledBuckets
-  }, [data, startTime, endTime])
+	// Handle mouse down on chart (start selection)
+	const handleMouseDown = useCallback((e: any) => {
+		if (e?.activeTooltipIndex !== undefined) {
+			setRefAreaLeft(e.activeTooltipIndex);
+			setIsSelecting(true);
+		}
+	}, []);
 
-  // Handle mouse down on chart (start selection)
-  const handleMouseDown = useCallback((e: any) => {
-    if (e?.activeTooltipIndex !== undefined) {
-      setRefAreaLeft(e.activeTooltipIndex)
-      setIsSelecting(true)
-    }
-  }, [])
+	// Handle mouse move on chart (during selection)
+	const handleMouseMove = useCallback(
+		(e: any) => {
+			if (isSelecting && e?.activeTooltipIndex !== undefined) {
+				setRefAreaRight(e.activeTooltipIndex);
+			}
+		},
+		[isSelecting],
+	);
 
-  // Handle mouse move on chart (during selection)
-  const handleMouseMove = useCallback((e: any) => {
-    if (isSelecting && e?.activeTooltipIndex !== undefined) {
-      setRefAreaRight(e.activeTooltipIndex)
-    }
-  }, [isSelecting])
+	// Handle mouse up on chart (end selection)
+	const handleMouseUp = useCallback(() => {
+		if (refAreaLeft === null || refAreaRight === null || !data?.bucket_size_seconds || chartData.length === 0) {
+			setRefAreaLeft(null);
+			setRefAreaRight(null);
+			setIsSelecting(false);
+			return;
+		}
 
-  // Handle mouse up on chart (end selection)
-  const handleMouseUp = useCallback(() => {
-    if (refAreaLeft === null || refAreaRight === null || !data?.bucket_size_seconds || chartData.length === 0) {
-      setRefAreaLeft(null)
-      setRefAreaRight(null)
-      setIsSelecting(false)
-      return
-    }
+		// Get the buckets by index
+		const leftBucket = chartData[refAreaLeft];
+		const rightBucket = chartData[refAreaRight];
 
-    // Get the buckets by index
-    const leftBucket = chartData[refAreaLeft]
-    const rightBucket = chartData[refAreaRight]
+		if (leftBucket && rightBucket) {
+			const leftTime = new Date(leftBucket.timestamp).getTime() / 1000;
+			const rightTime = new Date(rightBucket.timestamp).getTime() / 1000 + data.bucket_size_seconds;
 
-    if (leftBucket && rightBucket) {
-      const leftTime = new Date(leftBucket.timestamp).getTime() / 1000
-      const rightTime = new Date(rightBucket.timestamp).getTime() / 1000 + data.bucket_size_seconds
+			// Ensure left < right
+			const selectionStart = Math.min(leftTime, rightTime);
+			const selectionEnd = Math.max(leftTime, rightTime);
 
-      // Ensure left < right
-      const selectionStart = Math.min(leftTime, rightTime)
-      const selectionEnd = Math.max(leftTime, rightTime)
+			// Only trigger if selection spans at least one bucket
+			if (selectionEnd - selectionStart >= data.bucket_size_seconds) {
+				onTimeRangeChange(selectionStart, selectionEnd);
+			}
+		}
 
-      // Only trigger if selection spans at least one bucket
-      if (selectionEnd - selectionStart >= data.bucket_size_seconds) {
-        onTimeRangeChange(selectionStart, selectionEnd)
-      }
-    }
+		setRefAreaLeft(null);
+		setRefAreaRight(null);
+		setIsSelecting(false);
+	}, [refAreaLeft, refAreaRight, data, chartData, onTimeRangeChange]);
 
-    setRefAreaLeft(null)
-    setRefAreaRight(null)
-    setIsSelecting(false)
-  }, [refAreaLeft, refAreaRight, data, chartData, onTimeRangeChange])
+	// Handle click on a bar (zoom into that bucket)
+	const handleBarClick = useCallback(
+		(barData: any) => {
+			if (!data || !barData?.timestamp) return;
 
-  // Handle click on a bar (zoom into that bucket)
-  const handleBarClick = useCallback((barData: any) => {
-    if (!data || !barData?.timestamp) return
+			const bucket = barData as HistogramBucket;
+			const startTime = new Date(bucket.timestamp).getTime() / 1000;
+			const endTime = startTime + data.bucket_size_seconds;
 
-    const bucket = barData as HistogramBucket
-    const startTime = new Date(bucket.timestamp).getTime() / 1000
-    const endTime = startTime + data.bucket_size_seconds
+			onTimeRangeChange(startTime, endTime);
+		},
+		[data, onTimeRangeChange],
+	);
 
-    onTimeRangeChange(startTime, endTime)
-  }, [data, onTimeRangeChange])
+	if (loading) {
+		return (
+			<Card className="gap-0 rounded-sm px-2 py-2 shadow-none">
+				<div className="flex items-center justify-between">
+					<div className="flex items-center gap-2">
+						<ChevronDown className="text-muted-foreground h-4 w-4" />
+						<span className="text-muted-foreground text-sm font-medium">Request Volume</span>
+					</div>
+					<div className="mr-2 flex items-center gap-4">
+						<div className="flex items-center gap-3 text-xs">
+							<span className="flex items-center gap-1.5">
+								<span className="h-2 w-2 rounded-full bg-emerald-500" />
+								<span className="text-muted-foreground">Success</span>
+							</span>
+							<span className="flex items-center gap-1.5">
+								<span className="h-2 w-2 rounded-full bg-red-500" />
+								<span className="text-muted-foreground">Error</span>
+							</span>
+						</div>
+					</div>
+				</div>
+				<div className="" style={{ height: "131px", marginTop: 4 }}>
+					<Skeleton className="h-full w-full" />
+				</div>
+			</Card>
+		);
+	}
 
-  if (loading) {
-    return (
-      <Card className="shadow-none px-2 py-2 rounded-sm gap-0">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <ChevronDown className="text-muted-foreground h-4 w-4" />
-            <span className="text-muted-foreground text-sm font-medium">Request Volume</span>
-          </div>
-          <div className="flex items-center gap-4 mr-2">
-            <div className="flex items-center gap-3 text-xs">
-              <span className="flex items-center gap-1.5">
-                <span className="h-2 w-2 rounded-full bg-emerald-500" />
-                <span className="text-muted-foreground">Success</span>
-              </span>
-              <span className="flex items-center gap-1.5">
-                <span className="h-2 w-2 rounded-full bg-red-500" />
-                <span className="text-muted-foreground">Error</span>
-              </span>
-            </div>
-          </div>
-        </div>
-        <div className="" style={{ height: '131px', marginTop: 4 }}>
-          <Skeleton className="h-full w-full" />
-        </div>
-      </Card>
-    )
-  }
+	// Check if we have valid data for the chart
+	const hasValidData = data && startTime && endTime && chartData.length >= 2;
 
-  // Check if we have valid data for the chart
-  const hasValidData = data && startTime && endTime && chartData.length >= 2
-
-  return (
+	return (
 		<Card className="rounded-sm px-2 py-2 shadow-none">
 			<Collapsible open={isOpen} onOpenChange={onOpenChange}>
 				<div className="flex items-center justify-between">
 					<CollapsibleTrigger className="flex items-center gap-2 hover:opacity-80">
 						<ChevronDown className={`text-muted-foreground h-4 w-4 transition-transform duration-200 ${isOpen ? "" : "-rotate-90"}`} />
 						<span className="text-muted-foreground text-sm font-medium">Request Volume</span>
+						<Badge variant="secondary" className="text-xs">
+							BETA
+						</Badge>
 					</CollapsibleTrigger>
 					<div className="mr-2 flex items-center gap-4">
 						{isOpen && (

--- a/ui/app/workspace/page.tsx
+++ b/ui/app/workspace/page.tsx
@@ -3,5 +3,5 @@
 import { redirect } from "next/navigation";
 
 export default function WorkspacePage() {
-	redirect("/workspace/logs");
+	redirect("/workspace/dashboard");
 }

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -6,6 +6,7 @@ import {
 	Boxes,
 	BoxIcon,
 	BugIcon,
+	ChartColumnBig,
 	ChevronsLeftRightEllipsis,
 	CircleDollarSign,
 	Cog,
@@ -221,13 +222,12 @@ const SidebarItemView = ({
 		<SidebarMenuItem key={item.title}>
 			<SidebarMenuButton
 				tooltip={item.title}
-				className={`relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
-					isActive || isAnySubItemActive
+				className={`relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isActive || isAnySubItemActive
 						? "bg-sidebar-accent text-primary border-primary/20"
 						: isAllowed && item.hasAccess
 							? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
 							: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-				} `}
+					} `}
 				onClick={hasSubItems ? handleClick : () => handleNavigation(item.url)}
 			>
 				<div className="flex w-full items-center justify-between">
@@ -264,13 +264,12 @@ const SidebarItemView = ({
 						return (
 							<SidebarMenuSubItem key={subItem.title}>
 								<SidebarMenuSubButton
-									className={`h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
-										isSubItemActive
+									className={`h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemActive
 											? "bg-sidebar-accent text-primary font-medium"
 											: subItem.hasAccess === false
 												? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
 												: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-									}`}
+										}`}
 									onClick={() => (subItem.hasAccess === false ? undefined : handleSubItemClick(subItem))}
 								>
 									<div className="flex items-center gap-2">
@@ -362,6 +361,13 @@ export default function AppSidebar() {
 			description: "Request logs & monitoring",
 			hasAccess: hasLogsAccess,
 			subItems: [
+				{
+					title: "Dashboard",
+					url: "/workspace/dashboard",
+					icon: ChartColumnBig,
+					description: "Dashboard",
+					hasAccess: hasObservabilityAccess,
+				},
 				{
 					title: "Logs",
 					url: "/workspace/logs",
@@ -561,14 +567,14 @@ export default function AppSidebar() {
 				},
 				...(IS_ENTERPRISE
 					? [
-							{
-								title: "Proxy",
-								url: "/workspace/config/proxy",
-								icon: Globe,
-								description: "Proxy configuration",
-								hasAccess: hasSettingsAccess,
-							},
-						]
+						{
+							title: "Proxy",
+							url: "/workspace/config/proxy",
+							icon: Globe,
+							description: "Proxy configuration",
+							hasAccess: hasSettingsAccess,
+						},
+					]
 					: []),
 				{
 					title: "API Keys",

--- a/ui/components/ui/datePickerWithRange.tsx
+++ b/ui/components/ui/datePickerWithRange.tsx
@@ -186,7 +186,7 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 										className=""
 										value={timeValue?.from}
 										onChange={(v) => {
-											if (!date || !date.from) return
+											if (!date || !date.from) return;
 											if (v) setTimeValue({ from: v, to: timeValue.to });
 											const from = new Date(date.from);
 											if (v) from.setHours(v.hour, v.minute);
@@ -209,7 +209,7 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 										className=""
 										value={timeValue?.to}
 										onChange={(v) => {
-											if (!date || !date.to) return
+											if (!date || !date.to) return;
 											if (v) setTimeValue({ ...timeValue, to: v });
 											const to = new Date(date.to);
 											if (v) to.setHours(v.hour, v.minute);
@@ -230,7 +230,7 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 							<div className="flex w-[150px] flex-col gap-1 border-l py-2 pr-3 pl-2">
 								{props.preDefinedPeriods.map((period) => (
 									<Button
-										className={cn("text-md w-full", predefinedPeriod === period.value && "bg-background-brand-dark text-white")}
+										className={cn("w-full text-start text-sm", predefinedPeriod === period.value && "bg-primary text-primary-foreground")}
 										variant="ghost"
 										key={period.value}
 										onClick={(e) => {
@@ -251,11 +251,11 @@ export function DateTimePickerWithRange(props: DateTimePickerWithRangeProps) {
 							<Button
 								className="ml-auto"
 								onClick={(e) => {
-									if (!date || !date.from || !date.to) return
+									if (!date || !date.from || !date.to) return;
 									onTrigger(e, {
 										from: { date: date.from, time: timeValue.from },
 										to: { date: date.to, time: timeValue.to },
-									})
+									});
 								}}
 							>
 								{triggerLabel}

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -12,6 +12,40 @@ import {
 } from "@/lib/types/logs";
 import { baseApi } from "./baseApi";
 
+// Helper function to build filter params
+function buildFilterParams(filters: LogFilters): Record<string, string | number> {
+	const params: Record<string, string | number> = {};
+
+	if (filters.providers && filters.providers.length > 0) {
+		params.providers = filters.providers.join(",");
+	}
+	if (filters.models && filters.models.length > 0) {
+		params.models = filters.models.join(",");
+	}
+	if (filters.status && filters.status.length > 0) {
+		params.status = filters.status.join(",");
+	}
+	if (filters.objects && filters.objects.length > 0) {
+		params.objects = filters.objects.join(",");
+	}
+	if (filters.selected_key_ids && filters.selected_key_ids.length > 0) {
+		params.selected_key_ids = filters.selected_key_ids.join(",");
+	}
+	if (filters.virtual_key_ids && filters.virtual_key_ids.length > 0) {
+		params.virtual_key_ids = filters.virtual_key_ids.join(",");
+	}
+	if (filters.start_time) params.start_time = filters.start_time;
+	if (filters.end_time) params.end_time = filters.end_time;
+	if (filters.min_latency) params.min_latency = filters.min_latency;
+	if (filters.max_latency) params.max_latency = filters.max_latency;
+	if (filters.min_tokens) params.min_tokens = filters.min_tokens;
+	if (filters.max_tokens) params.max_tokens = filters.max_tokens;
+	if (filters.missing_cost_only) params.missing_cost_only = "true";
+	if (filters.content_search) params.content_search = filters.content_search;
+
+	return params;
+}
+
 export const logsApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Get logs with filters and pagination
@@ -210,11 +244,17 @@ export const {
 	useGetLogsQuery,
 	useGetLogsStatsQuery,
 	useGetLogsHistogramQuery,
+	useGetLogsTokenHistogramQuery,
+	useGetLogsCostHistogramQuery,
+	useGetLogsModelHistogramQuery,
 	useGetDroppedRequestsQuery,
 	useGetAvailableFilterDataQuery,
 	useLazyGetLogsQuery,
 	useLazyGetLogsStatsQuery,
 	useLazyGetLogsHistogramQuery,
+	useLazyGetLogsTokenHistogramQuery,
+	useLazyGetLogsCostHistogramQuery,
+	useLazyGetLogsModelHistogramQuery,
 	useLazyGetDroppedRequestsQuery,
 	useLazyGetAvailableFilterDataQuery,
 	useDeleteLogsMutation,

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -1,5 +1,15 @@
 import { RedactedDBKey, VirtualKey } from "@/lib/types/governance";
-import { LogEntry, LogFilters, LogStats, Pagination, RecalculateCostResponse } from "@/lib/types/logs";
+import {
+	CostHistogramResponse,
+	LogEntry,
+	LogFilters,
+	LogsHistogramResponse,
+	LogStats,
+	ModelHistogramResponse,
+	Pagination,
+	RecalculateCostResponse,
+	TokenHistogramResponse,
+} from "@/lib/types/logs";
 import { baseApi } from "./baseApi";
 
 export const logsApi = baseApi.injectEndpoints({
@@ -107,6 +117,62 @@ export const logsApi = baseApi.injectEndpoints({
 			providesTags: ["Logs"],
 		}),
 
+		// Get logs histogram with filters
+		getLogsHistogram: builder.query<
+			LogsHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
+		// Get token usage histogram with filters
+		getLogsTokenHistogram: builder.query<
+			TokenHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram/tokens",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
+		// Get cost histogram with filters and model breakdown
+		getLogsCostHistogram: builder.query<
+			CostHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram/cost",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
+		// Get model usage histogram with filters
+		getLogsModelHistogram: builder.query<
+			ModelHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram/models",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
 		// Get dropped requests count
 		getDroppedRequests: builder.query<{ dropped_requests: number }, void>({
 			query: () => "/logs/dropped",
@@ -143,10 +209,12 @@ export const logsApi = baseApi.injectEndpoints({
 export const {
 	useGetLogsQuery,
 	useGetLogsStatsQuery,
+	useGetLogsHistogramQuery,
 	useGetDroppedRequestsQuery,
 	useGetAvailableFilterDataQuery,
 	useLazyGetLogsQuery,
 	useLazyGetLogsStatsQuery,
+	useLazyGetLogsHistogramQuery,
 	useLazyGetDroppedRequestsQuery,
 	useLazyGetAvailableFilterDataQuery,
 	useDeleteLogsMutation,

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -369,6 +369,50 @@ export interface LogsHistogramResponse {
 	bucket_size_seconds: number;
 }
 
+// Token histogram types
+export interface TokenHistogramBucket {
+	timestamp: string;
+	prompt_tokens: number;
+	completion_tokens: number;
+	total_tokens: number;
+}
+
+export interface TokenHistogramResponse {
+	buckets: TokenHistogramBucket[];
+	bucket_size_seconds: number;
+}
+
+// Cost histogram types
+export interface CostHistogramBucket {
+	timestamp: string;
+	total_cost: number;
+	by_model: Record<string, number>;
+}
+
+export interface CostHistogramResponse {
+	buckets: CostHistogramBucket[];
+	bucket_size_seconds: number;
+	models: string[];
+}
+
+// Model usage histogram types
+export interface ModelUsageStats {
+	total: number;
+	success: number;
+	error: number;
+}
+
+export interface ModelHistogramBucket {
+	timestamp: string;
+	by_model: Record<string, ModelUsageStats>;
+}
+
+export interface ModelHistogramResponse {
+	buckets: ModelHistogramBucket[];
+	bucket_size_seconds: number;
+	models: string[];
+}
+
 export interface LogsResponse {
 	logs: LogEntry[];
 	pagination: Pagination;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -357,6 +357,18 @@ export interface LogStats {
 	total_cost: number;
 }
 
+export interface HistogramBucket {
+	timestamp: string;
+	count: number;
+	success: number;
+	error: number;
+}
+
+export interface LogsHistogramResponse {
+	buckets: HistogramBucket[];
+	bucket_size_seconds: number;
+}
+
 export interface LogsResponse {
 	logs: LogEntry[];
 	pagination: Pagination;


### PR DESCRIPTION
## Summary

Added dashboard functionality with time-series charts for visualizing request volume, token usage, cost, and model usage over time. This provides users with better insights into their API usage patterns and trends.

## Changes

- Added four new histogram endpoints to the LogStore interface:
  - `GetHistogram`: Returns time-bucketed request counts with success/error breakdown
  - `GetTokenHistogram`: Returns time-bucketed token usage (prompt/completion)
  - `GetCostHistogram`: Returns time-bucketed cost data with model breakdown
  - `GetModelHistogram`: Returns time-bucketed model usage with success/error breakdown

- Implemented SQL queries for each histogram type with database-specific syntax for SQLite, MySQL, and PostgreSQL

- Added helper function `generateBucketTimestamps` to ensure consistent time buckets across all charts

- Created new data structures for histogram results with appropriate JSON serialization

- Added new HTTP endpoints in the API:
  - `/api/logs/histogram`: Basic request volume histogram
  - `/api/logs/histogram/tokens`: Token usage histogram
  - `/api/logs/histogram/cost`: Cost breakdown histogram
  - `/api/logs/histogram/models`: Model usage histogram

- Built a new dashboard UI with:
  - Interactive charts using Recharts
  - Time period selection with predefined ranges
  - Chart type toggles (bar/line)
  - Model filtering for cost and usage charts
  - Error boundaries to handle chart rendering issues

- Added volume chart to logs page for interactive time filtering

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Generate log data by making API requests with different models
2. Navigate to `/workspace/dashboard` to view the charts
3. Test different time ranges using the date picker
4. Toggle between bar and line chart views
5. Filter cost and model usage by specific models
6. On the logs page, use the volume chart to zoom into specific time periods

```sh
# Core/Transports
go test ./framework/logstore/...
go test ./plugins/logging/...
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm dev
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The dashboard uses the same authentication and authorization mechanisms as existing log endpoints. Added RBAC check to ensure only users with observability access can view the dashboard.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable