### PR TITLE
containers api

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1523,6 +1523,162 @@ func (bifrost *Bifrost) FileContentRequest(ctx *schemas.BifrostContext, req *sch
 	return response.FileContentResponse, nil
 }
 
+// ContainerCreateRequest creates a new container.
+func (bifrost *Bifrost) ContainerCreateRequest(ctx *schemas.BifrostContext, req *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	if req == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "container create request is nil",
+			},
+		}
+	}
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "provider is required for container create request",
+			},
+		}
+	}
+	if req.Name == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "name is required for container create request",
+			},
+		}
+	}
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.ContainerCreateRequest
+	bifrostReq.ContainerCreateRequest = req
+
+	response, err := bifrost.handleRequest(ctx, bifrostReq)
+	if err != nil {
+		return nil, err
+	}
+	return response.ContainerCreateResponse, nil
+}
+
+// ContainerListRequest lists containers.
+func (bifrost *Bifrost) ContainerListRequest(ctx *schemas.BifrostContext, req *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	if req == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "container list request is nil",
+			},
+		}
+	}
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "provider is required for container list request",
+			},
+		}
+	}
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.ContainerListRequest
+	bifrostReq.ContainerListRequest = req
+
+	response, err := bifrost.handleRequest(ctx, bifrostReq)
+	if err != nil {
+		return nil, err
+	}
+	return response.ContainerListResponse, nil
+}
+
+// ContainerRetrieveRequest retrieves a specific container.
+func (bifrost *Bifrost) ContainerRetrieveRequest(ctx *schemas.BifrostContext, req *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	if req == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "container retrieve request is nil",
+			},
+		}
+	}
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "provider is required for container retrieve request",
+			},
+		}
+	}
+	if req.ContainerID == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "container_id is required for container retrieve request",
+			},
+		}
+	}
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.ContainerRetrieveRequest
+	bifrostReq.ContainerRetrieveRequest = req
+
+	response, err := bifrost.handleRequest(ctx, bifrostReq)
+	if err != nil {
+		return nil, err
+	}
+	return response.ContainerRetrieveResponse, nil
+}
+
+// ContainerDeleteRequest deletes a container.
+func (bifrost *Bifrost) ContainerDeleteRequest(ctx *schemas.BifrostContext, req *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	if req == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "container delete request is nil",
+			},
+		}
+	}
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "provider is required for container delete request",
+			},
+		}
+	}
+	if req.ContainerID == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "container_id is required for container delete request",
+			},
+		}
+	}
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.ContainerDeleteRequest
+	bifrostReq.ContainerDeleteRequest = req
+
+	response, err := bifrost.handleRequest(ctx, bifrostReq)
+	if err != nil {
+		return nil, err
+	}
+	return response.ContainerDeleteResponse, nil
+}
+
 // RemovePlugin removes a plugin from the server.
 func (bifrost *Bifrost) RemovePlugin(name string) error {
 
@@ -3423,6 +3579,30 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, req *Ch
 			return nil, bifrostError
 		}
 		response.BatchResultsResponse = batchResultsResponse
+	case schemas.ContainerCreateRequest:
+		containerCreateResponse, bifrostError := provider.ContainerCreate(req.Context, key, req.BifrostRequest.ContainerCreateRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.ContainerCreateResponse = containerCreateResponse
+	case schemas.ContainerListRequest:
+		containerListResponse, bifrostError := provider.ContainerList(req.Context, keys, req.BifrostRequest.ContainerListRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.ContainerListResponse = containerListResponse
+	case schemas.ContainerRetrieveRequest:
+		containerRetrieveResponse, bifrostError := provider.ContainerRetrieve(req.Context, keys, req.BifrostRequest.ContainerRetrieveRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.ContainerRetrieveResponse = containerRetrieveResponse
+	case schemas.ContainerDeleteRequest:
+		containerDeleteResponse, bifrostError := provider.ContainerDelete(req.Context, keys, req.BifrostRequest.ContainerDeleteRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.ContainerDeleteResponse = containerDeleteResponse
 	default:
 		_, model, _ := req.BifrostRequest.GetRequestFields()
 		return nil, &schemas.BifrostError{
@@ -3779,6 +3959,10 @@ func resetBifrostRequest(req *schemas.BifrostRequest) {
 	req.BatchRetrieveRequest = nil
 	req.BatchCancelRequest = nil
 	req.BatchResultsRequest = nil
+	req.ContainerCreateRequest = nil
+	req.ContainerListRequest = nil
+	req.ContainerRetrieveRequest = nil
+	req.ContainerDeleteRequest = nil
 }
 
 // getBifrostRequest gets a BifrostRequest from the pool

--- a/core/internal/testutil/account.go
+++ b/core/internal/testutil/account.go
@@ -61,6 +61,10 @@ type TestScenarios struct {
 	ChatAudio             bool // Chat completion with audio input/output functionality
 	StructuredOutputs     bool // Structured outputs (JSON schema) functionality
 	WebSearchTool         bool // Web search tool functionality
+	ContainerCreate       bool // Container API create functionality
+	ContainerList         bool // Container API list functionality
+	ContainerRetrieve     bool // Container API retrieve functionality
+	ContainerDelete       bool // Container API delete functionality
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios
@@ -710,8 +714,12 @@ var AllProviderConfigs = []ComprehensiveTestConfig{
 			FileList:              true, // OpenAI supports file API
 			FileRetrieve:          true, // OpenAI supports file API
 			FileDelete:            true, // OpenAI supports file API
-			FileContent:           true, // OpenAI supports file API
-			ChatAudio:             true, // OpenAI supports chat audio
+			FileContent:           true,  // OpenAI supports file API
+			ChatAudio:             true,  // OpenAI supports chat audio
+			ContainerCreate:       true,  // OpenAI supports container API
+			ContainerList:         true,  // OpenAI supports container API
+			ContainerRetrieve:     true,  // OpenAI supports container API
+			ContainerDelete:       true,  // OpenAI supports container API
 		},
 		Fallbacks: []schemas.Fallback{
 			{Provider: schemas.Anthropic, Model: "claude-3-7-sonnet-20250219"},

--- a/core/internal/testutil/containers.go
+++ b/core/internal/testutil/containers.go
@@ -1,0 +1,249 @@
+// Package testutil provides container API test utilities for the Bifrost system.
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunContainerCreateTest tests the container create functionality
+func RunContainerCreateTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.ContainerCreate {
+		t.Logf("[SKIPPED] Container Create: Not supported by provider %s", testConfig.Provider)
+		return
+	}
+
+	t.Run("ContainerCreate", func(t *testing.T) {
+		t.Logf("[RUNNING] Container Create test for provider: %s", testConfig.Provider)
+
+		request := &schemas.BifrostContainerCreateRequest{
+			Provider: testConfig.Provider,
+			Name:     "bifrost-test-container",
+		}
+
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.ContainerCreateRequest(bfCtx, request)
+
+		if err != nil {
+			// Check if this is an unsupported operation error
+			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
+				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
+				return
+			}
+			t.Fatalf("❌ ContainerCreate failed: %v", GetErrorMessage(err))
+		}
+
+		if response == nil {
+			t.Fatal("❌ ContainerCreate returned nil response")
+		}
+
+		if response.ID == "" {
+			t.Fatal("❌ ContainerCreate returned empty container ID")
+		}
+
+		t.Logf("✅ Container Create test passed for provider: %s, container ID: %s", testConfig.Provider, response.ID)
+
+		// Clean up: delete the created container
+		deleteRequest := &schemas.BifrostContainerDeleteRequest{
+			Provider:    testConfig.Provider,
+			ContainerID: response.ID,
+		}
+		_, deleteErr := client.ContainerDeleteRequest(bfCtx, deleteRequest)
+		if deleteErr != nil {
+			t.Logf("[WARNING] Failed to clean up container %s: %v", response.ID, GetErrorMessage(deleteErr))
+		}
+	})
+}
+
+// RunContainerListTest tests the container list functionality
+func RunContainerListTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.ContainerList {
+		t.Logf("[SKIPPED] Container List: Not supported by provider %s", testConfig.Provider)
+		return
+	}
+
+	t.Run("ContainerList", func(t *testing.T) {
+		t.Logf("[RUNNING] Container List test for provider: %s", testConfig.Provider)
+
+		request := &schemas.BifrostContainerListRequest{
+			Provider: testConfig.Provider,
+			Limit:    10,
+		}
+
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		response, err := client.ContainerListRequest(bfCtx, request)
+
+		if err != nil {
+			// Check if this is an unsupported operation error
+			if err.Error != nil && (err.Error.Code != nil && *err.Error.Code == "unsupported_operation") {
+				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
+				return
+			}
+			t.Fatalf("❌ ContainerList failed: %v", GetErrorMessage(err))
+		}
+
+		if response == nil {
+			t.Fatal("❌ ContainerList returned nil response")
+		}
+
+		t.Logf("✅ Container List test passed for provider: %s, found %d containers", testConfig.Provider, len(response.Data))
+	})
+}
+
+// RunContainerRetrieveTest tests the container retrieve functionality
+func RunContainerRetrieveTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.ContainerRetrieve {
+		t.Logf("[SKIPPED] Container Retrieve: Not supported by provider %s", testConfig.Provider)
+		return
+	}
+
+	t.Run("ContainerRetrieve", func(t *testing.T) {
+		t.Logf("[RUNNING] Container Retrieve test for provider: %s", testConfig.Provider)
+
+		// First, create a container to retrieve
+		createRequest := &schemas.BifrostContainerCreateRequest{
+			Provider: testConfig.Provider,
+			Name:     "bifrost-test-container-retrieve",
+		}
+
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		createResponse, createErr := client.ContainerCreateRequest(bfCtx, createRequest)
+
+		if createErr != nil {
+			if createErr.Error != nil && (createErr.Error.Code != nil && *createErr.Error.Code == "unsupported_operation") {
+				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
+				return
+			}
+			t.Fatalf("❌ ContainerCreate (setup) failed: %v", GetErrorMessage(createErr))
+		}
+
+		if createResponse == nil || createResponse.ID == "" {
+			t.Fatal("❌ ContainerCreate (setup) returned nil or empty response")
+		}
+
+		containerID := createResponse.ID
+		defer func() {
+			// Clean up
+			deleteRequest := &schemas.BifrostContainerDeleteRequest{
+				Provider:    testConfig.Provider,
+				ContainerID: containerID,
+			}
+			_, _ = client.ContainerDeleteRequest(bfCtx, deleteRequest)
+		}()
+
+		// Now retrieve the container
+		retrieveRequest := &schemas.BifrostContainerRetrieveRequest{
+			Provider:    testConfig.Provider,
+			ContainerID: containerID,
+		}
+
+		response, err := client.ContainerRetrieveRequest(bfCtx, retrieveRequest)
+
+		if err != nil {
+			t.Fatalf("❌ ContainerRetrieve failed: %v", GetErrorMessage(err))
+		}
+
+		if response == nil {
+			t.Fatal("❌ ContainerRetrieve returned nil response")
+		}
+
+		if response.ID != containerID {
+			t.Fatalf("❌ ContainerRetrieve returned wrong container ID: expected %s, got %s", containerID, response.ID)
+		}
+
+		t.Logf("✅ Container Retrieve test passed for provider: %s, container ID: %s", testConfig.Provider, response.ID)
+	})
+}
+
+// RunContainerDeleteTest tests the container delete functionality
+func RunContainerDeleteTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.ContainerDelete {
+		t.Logf("[SKIPPED] Container Delete: Not supported by provider %s", testConfig.Provider)
+		return
+	}
+
+	t.Run("ContainerDelete", func(t *testing.T) {
+		t.Logf("[RUNNING] Container Delete test for provider: %s", testConfig.Provider)
+
+		// First, create a container to delete
+		createRequest := &schemas.BifrostContainerCreateRequest{
+			Provider: testConfig.Provider,
+			Name:     "bifrost-test-container-delete",
+		}
+
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		createResponse, createErr := client.ContainerCreateRequest(bfCtx, createRequest)
+
+		if createErr != nil {
+			if createErr.Error != nil && (createErr.Error.Code != nil && *createErr.Error.Code == "unsupported_operation") {
+				t.Logf("[EXPECTED] Provider %s returned unsupported operation error", testConfig.Provider)
+				return
+			}
+			t.Fatalf("❌ ContainerCreate (setup) failed: %v", GetErrorMessage(createErr))
+		}
+
+		if createResponse == nil || createResponse.ID == "" {
+			t.Fatal("❌ ContainerCreate (setup) returned nil or empty response")
+		}
+
+		containerID := createResponse.ID
+
+		// Now delete the container
+		deleteRequest := &schemas.BifrostContainerDeleteRequest{
+			Provider:    testConfig.Provider,
+			ContainerID: containerID,
+		}
+
+		response, err := client.ContainerDeleteRequest(bfCtx, deleteRequest)
+
+		if err != nil {
+			t.Fatalf("❌ ContainerDelete failed: %v", GetErrorMessage(err))
+		}
+
+		if response == nil {
+			t.Fatal("❌ ContainerDelete returned nil response")
+		}
+
+		if !response.Deleted {
+			t.Fatal("❌ ContainerDelete returned deleted=false")
+		}
+
+		t.Logf("✅ Container Delete test passed for provider: %s, container ID: %s", testConfig.Provider, containerID)
+	})
+}
+
+// RunContainerUnsupportedTest tests that providers correctly return unsupported operation errors
+func RunContainerUnsupportedTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	// Only run this test if none of the container operations are supported
+	if testConfig.Scenarios.ContainerCreate || testConfig.Scenarios.ContainerList ||
+		testConfig.Scenarios.ContainerRetrieve || testConfig.Scenarios.ContainerDelete {
+		t.Logf("[SKIPPED] Container Unsupported: Provider %s supports container operations", testConfig.Provider)
+		return
+	}
+
+	t.Run("ContainerUnsupported", func(t *testing.T) {
+		t.Logf("[RUNNING] Container Unsupported test for provider: %s", testConfig.Provider)
+
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+		// Test ContainerCreate returns unsupported
+		createRequest := &schemas.BifrostContainerCreateRequest{
+			Provider: testConfig.Provider,
+			Name:     "test-container",
+		}
+		_, createErr := client.ContainerCreateRequest(bfCtx, createRequest)
+
+		if createErr == nil {
+			t.Fatal("❌ Expected unsupported operation error for ContainerCreate, got nil")
+		}
+
+		if createErr.Error == nil || createErr.Error.Code == nil || *createErr.Error.Code != "unsupported_operation" {
+			t.Fatalf("❌ Expected unsupported_operation error code, got: %v", createErr)
+		}
+
+		t.Logf("✅ Container Unsupported test passed for provider: %s", testConfig.Provider)
+	})
+}

--- a/core/internal/testutil/tests.go
+++ b/core/internal/testutil/tests.go
@@ -81,6 +81,11 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunStructuredOutputChatStreamTest,
 		RunStructuredOutputResponsesTest,
 		RunStructuredOutputResponsesStreamTest,
+		RunContainerCreateTest,
+		RunContainerListTest,
+		RunContainerRetrieveTest,
+		RunContainerDeleteTest,
+		RunContainerUnsupportedTest,
 	}
 
 	// Execute all test scenarios
@@ -145,6 +150,11 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"StructuredOutputChatStream", testConfig.Scenarios.StructuredOutputs && testConfig.Scenarios.CompletionStream},
 		{"StructuredOutputResponses", testConfig.Scenarios.StructuredOutputs},
 		{"StructuredOutputResponsesStream", testConfig.Scenarios.StructuredOutputs && testConfig.Scenarios.CompletionStream},
+		{"ContainerCreate", testConfig.Scenarios.ContainerCreate},
+		{"ContainerList", testConfig.Scenarios.ContainerList},
+		{"ContainerRetrieve", testConfig.Scenarios.ContainerRetrieve},
+		{"ContainerDelete", testConfig.Scenarios.ContainerDelete},
+		{"ContainerUnsupported", !testConfig.Scenarios.ContainerCreate && !testConfig.Scenarios.ContainerList && !testConfig.Scenarios.ContainerRetrieve && !testConfig.Scenarios.ContainerDelete},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -2161,3 +2161,23 @@ func (provider *AnthropicProvider) CountTokens(ctx *schemas.BifrostContext, key 
 
 	return response, nil
 }
+
+// ContainerCreate is not supported by the Anthropic provider.
+func (provider *AnthropicProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Anthropic provider.
+func (provider *AnthropicProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Anthropic provider.
+func (provider *AnthropicProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Anthropic provider.
+func (provider *AnthropicProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2466,3 +2466,23 @@ func (provider *AzureProvider) BatchResults(ctx *schemas.BifrostContext, keys []
 func (provider *AzureProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Azure provider.
+func (provider *AzureProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Azure provider.
+func (provider *AzureProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Azure provider.
+func (provider *AzureProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Azure provider.
+func (provider *AzureProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -3011,3 +3011,23 @@ func (provider *BedrockProvider) getModelPath(basePath string, model string, key
 func (provider *BedrockProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Bedrock provider.
+func (provider *BedrockProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Bedrock provider.
+func (provider *BedrockProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Bedrock provider.
+func (provider *BedrockProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Bedrock provider.
+func (provider *BedrockProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -278,3 +278,23 @@ func (provider *CerebrasProvider) BatchResults(_ *schemas.BifrostContext, _ []sc
 func (provider *CerebrasProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Cerebras provider.
+func (provider *CerebrasProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Cerebras provider.
+func (provider *CerebrasProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Cerebras provider.
+func (provider *CerebrasProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Cerebras provider.
+func (provider *CerebrasProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -1010,3 +1010,23 @@ func (provider *CohereProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 
 	return bifrostResponse, nil
 }
+
+// ContainerCreate is not supported by the Cohere provider.
+func (provider *CohereProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Cohere provider.
+func (provider *CohereProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Cohere provider.
+func (provider *CohereProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Cohere provider.
+func (provider *CohereProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -799,3 +799,23 @@ func (provider *ElevenlabsProvider) FileContent(_ *schemas.BifrostContext, _ []s
 func (provider *ElevenlabsProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Elevenlabs provider.
+func (provider *ElevenlabsProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Elevenlabs provider.
+func (provider *ElevenlabsProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Elevenlabs provider.
+func (provider *ElevenlabsProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Elevenlabs provider.
+func (provider *ElevenlabsProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -3180,3 +3180,23 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 
 	return response, nil
 }
+
+// ContainerCreate is not supported by the Gemini provider.
+func (provider *GeminiProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Gemini provider.
+func (provider *GeminiProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Gemini provider.
+func (provider *GeminiProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Gemini provider.
+func (provider *GeminiProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -251,3 +251,23 @@ func (provider *GroqProvider) FileContent(_ *schemas.BifrostContext, _ []schemas
 func (provider *GroqProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Groq provider.
+func (provider *GroqProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Groq provider.
+func (provider *GroqProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Groq provider.
+func (provider *GroqProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Groq provider.
+func (provider *GroqProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -1369,3 +1369,23 @@ func (provider *HuggingFaceProvider) FileContent(_ *schemas.BifrostContext, _ []
 func (provider *HuggingFaceProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -660,3 +660,23 @@ func (provider *MistralProvider) ImageGeneration(ctx *schemas.BifrostContext, ke
 func (provider *MistralProvider) ImageGenerationStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (chan *schemas.BifrostStream, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageGenerationStreamRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Mistral provider.
+func (provider *MistralProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Mistral provider.
+func (provider *MistralProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Mistral provider.
+func (provider *MistralProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Mistral provider.
+func (provider *MistralProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -411,3 +411,23 @@ func (provider *NebiusProvider) FileContent(_ *schemas.BifrostContext, _ []schem
 func (provider *NebiusProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Nebius provider.
+func (provider *NebiusProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Nebius provider.
+func (provider *NebiusProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Nebius provider.
+func (provider *NebiusProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Nebius provider.
+func (provider *NebiusProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -289,3 +289,23 @@ func (provider *OllamaProvider) FileContent(_ *schemas.BifrostContext, _ []schem
 func (provider *OllamaProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Ollama provider.
+func (provider *OllamaProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Ollama provider.
+func (provider *OllamaProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Ollama provider.
+func (provider *OllamaProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Ollama provider.
+func (provider *OllamaProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -355,3 +355,23 @@ func (provider *OpenRouterProvider) FileContent(_ *schemas.BifrostContext, _ []s
 func (provider *OpenRouterProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the OpenRouter provider.
+func (provider *OpenRouterProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the OpenRouter provider.
+func (provider *OpenRouterProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the OpenRouter provider.
+func (provider *OpenRouterProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the OpenRouter provider.
+func (provider *OpenRouterProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -247,3 +247,23 @@ func (provider *ParasailProvider) BatchResults(_ *schemas.BifrostContext, _ []sc
 func (provider *ParasailProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Parasail provider.
+func (provider *ParasailProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Parasail provider.
+func (provider *ParasailProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Parasail provider.
+func (provider *ParasailProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Parasail provider.
+func (provider *ParasailProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -316,3 +316,23 @@ func (provider *PerplexityProvider) FileContent(_ *schemas.BifrostContext, _ []s
 func (provider *PerplexityProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -287,3 +287,23 @@ func (provider *SGLProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas
 func (provider *SGLProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the SGL provider.
+func (provider *SGLProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the SGL provider.
+func (provider *SGLProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the SGL provider.
+func (provider *SGLProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the SGL provider.
+func (provider *SGLProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1930,3 +1930,23 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 
 	return response, nil
 }
+
+// ContainerCreate is not supported by the Vertex provider.
+func (provider *VertexProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the Vertex provider.
+func (provider *VertexProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the Vertex provider.
+func (provider *VertexProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the Vertex provider.
+func (provider *VertexProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/xai/xai.go
+++ b/core/providers/xai/xai.go
@@ -301,3 +301,23 @@ func (provider *XAIProvider) FileContent(_ *schemas.BifrostContext, _ []schemas.
 func (provider *XAIProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
 }
+
+// ContainerCreate is not supported by the xAI provider.
+func (provider *XAIProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by the xAI provider.
+func (provider *XAIProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by the xAI provider.
+func (provider *XAIProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by the xAI provider.
+func (provider *XAIProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -111,6 +111,10 @@ const (
 	FileRetrieveRequest          RequestType = "file_retrieve"
 	FileDeleteRequest            RequestType = "file_delete"
 	FileContentRequest           RequestType = "file_content"
+	ContainerCreateRequest       RequestType = "container_create"
+	ContainerListRequest         RequestType = "container_list"
+	ContainerRetrieveRequest     RequestType = "container_retrieve"
+	ContainerDeleteRequest       RequestType = "container_delete"
 	CountTokensRequest           RequestType = "count_tokens"
 	UnknownRequest               RequestType = "unknown"
 )
@@ -195,11 +199,15 @@ type BifrostRequest struct {
 	FileRetrieveRequest    *BifrostFileRetrieveRequest
 	FileDeleteRequest      *BifrostFileDeleteRequest
 	FileContentRequest     *BifrostFileContentRequest
-	BatchCreateRequest     *BifrostBatchCreateRequest
-	BatchListRequest       *BifrostBatchListRequest
-	BatchRetrieveRequest   *BifrostBatchRetrieveRequest
-	BatchCancelRequest     *BifrostBatchCancelRequest
-	BatchResultsRequest    *BifrostBatchResultsRequest
+	BatchCreateRequest        *BifrostBatchCreateRequest
+	BatchListRequest          *BifrostBatchListRequest
+	BatchRetrieveRequest      *BifrostBatchRetrieveRequest
+	BatchCancelRequest        *BifrostBatchCancelRequest
+	BatchResultsRequest       *BifrostBatchResultsRequest
+	ContainerCreateRequest    *BifrostContainerCreateRequest
+	ContainerListRequest      *BifrostContainerListRequest
+	ContainerRetrieveRequest  *BifrostContainerRetrieveRequest
+	ContainerDeleteRequest    *BifrostContainerDeleteRequest
 }
 
 // GetRequestFields returns the provider, model, and fallbacks from the request.
@@ -271,6 +279,14 @@ func (br *BifrostRequest) GetRequestFields() (provider ModelProvider, model stri
 			return br.BatchResultsRequest.Provider, *br.BatchResultsRequest.Model, nil
 		}
 		return br.BatchResultsRequest.Provider, "", nil
+	case br.ContainerCreateRequest != nil:
+		return br.ContainerCreateRequest.Provider, "", nil
+	case br.ContainerListRequest != nil:
+		return br.ContainerListRequest.Provider, "", nil
+	case br.ContainerRetrieveRequest != nil:
+		return br.ContainerRetrieveRequest.Provider, "", nil
+	case br.ContainerDeleteRequest != nil:
+		return br.ContainerDeleteRequest.Provider, "", nil
 	}
 	return "", "", nil
 }
@@ -385,6 +401,10 @@ type BifrostResponse struct {
 	BatchRetrieveResponse         *BifrostBatchRetrieveResponse
 	BatchCancelResponse           *BifrostBatchCancelResponse
 	BatchResultsResponse          *BifrostBatchResultsResponse
+	ContainerCreateResponse       *BifrostContainerCreateResponse
+	ContainerListResponse         *BifrostContainerListResponse
+	ContainerRetrieveResponse     *BifrostContainerRetrieveResponse
+	ContainerDeleteResponse       *BifrostContainerDeleteResponse
 }
 
 func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
@@ -433,6 +453,14 @@ func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 		return &r.BatchCancelResponse.ExtraFields
 	case r.BatchResultsResponse != nil:
 		return &r.BatchResultsResponse.ExtraFields
+	case r.ContainerCreateResponse != nil:
+		return &r.ContainerCreateResponse.ExtraFields
+	case r.ContainerListResponse != nil:
+		return &r.ContainerListResponse.ExtraFields
+	case r.ContainerRetrieveResponse != nil:
+		return &r.ContainerRetrieveResponse.ExtraFields
+	case r.ContainerDeleteResponse != nil:
+		return &r.ContainerDeleteResponse.ExtraFields
 	}
 
 	return &BifrostResponseExtraFields{}

--- a/core/schemas/containers.go
+++ b/core/schemas/containers.go
@@ -1,0 +1,126 @@
+// Package schemas defines the core schemas and types used by the Bifrost system.
+package schemas
+
+// ContainerStatus represents the status of a container.
+type ContainerStatus string
+
+const (
+	ContainerStatusRunning ContainerStatus = "running"
+)
+
+// ContainerExpiresAfter represents the expiration configuration for a container.
+type ContainerExpiresAfter struct {
+	Anchor  string `json:"anchor"`  // The anchor point for expiration (e.g., "last_active_at")
+	Minutes int    `json:"minutes"` // Number of minutes after anchor point
+}
+
+// ContainerObject represents a container object returned by the API.
+type ContainerObject struct {
+	ID           string                 `json:"id"`
+	Object       string                 `json:"object,omitempty"` // "container"
+	Name         string                 `json:"name"`
+	CreatedAt    int64                  `json:"created_at"`
+	Status       ContainerStatus        `json:"status,omitempty"`
+	ExpiresAfter *ContainerExpiresAfter `json:"expires_after,omitempty"`
+	LastActiveAt *int64                 `json:"last_active_at,omitempty"`
+	MemoryLimit  string                 `json:"memory_limit,omitempty"` // e.g., "1g", "4g"
+	Metadata     map[string]string      `json:"metadata,omitempty"`
+}
+
+// BifrostContainerCreateRequest represents a request to create a container.
+type BifrostContainerCreateRequest struct {
+	Provider ModelProvider `json:"provider"`
+
+	// Required fields
+	Name string `json:"name"` // Name of the container
+
+	// Optional fields
+	ExpiresAfter *ContainerExpiresAfter `json:"expires_after,omitempty"` // Expiration configuration
+	FileIDs      []string               `json:"file_ids,omitempty"`      // IDs of existing files to copy into this container
+	MemoryLimit  string                 `json:"memory_limit,omitempty"`  // Memory limit (e.g., "1g", "4g")
+	Metadata     map[string]string      `json:"metadata,omitempty"`      // User-provided metadata
+
+	// Extra parameters for provider-specific features
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// BifrostContainerCreateResponse represents the response from creating a container.
+type BifrostContainerCreateResponse struct {
+	ID           string                 `json:"id"`
+	Object       string                 `json:"object,omitempty"` // "container"
+	Name         string                 `json:"name"`
+	CreatedAt    int64                  `json:"created_at"`
+	Status       ContainerStatus        `json:"status,omitempty"`
+	ExpiresAfter *ContainerExpiresAfter `json:"expires_after,omitempty"`
+	LastActiveAt *int64                 `json:"last_active_at,omitempty"`
+	MemoryLimit  string                 `json:"memory_limit,omitempty"`
+	Metadata     map[string]string      `json:"metadata,omitempty"`
+
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+}
+
+// BifrostContainerListRequest represents a request to list containers.
+type BifrostContainerListRequest struct {
+	Provider ModelProvider `json:"provider"`
+
+	// Pagination
+	Limit int     `json:"limit,omitempty"` // Max results to return (1-100, default 20)
+	After *string `json:"after,omitempty"` // Cursor for pagination
+	Order *string `json:"order,omitempty"` // Sort order (asc/desc), default desc
+
+	// Extra parameters for provider-specific features
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// BifrostContainerListResponse represents the response from listing containers.
+type BifrostContainerListResponse struct {
+	Object  string            `json:"object,omitempty"` // "list"
+	Data    []ContainerObject `json:"data"`
+	FirstID *string           `json:"first_id,omitempty"`
+	LastID  *string           `json:"last_id,omitempty"`
+	HasMore bool              `json:"has_more,omitempty"`
+
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+}
+
+// BifrostContainerRetrieveRequest represents a request to retrieve a container.
+type BifrostContainerRetrieveRequest struct {
+	Provider    ModelProvider `json:"provider"`
+	ContainerID string        `json:"container_id"` // ID of the container to retrieve
+
+	// Extra parameters for provider-specific features
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// BifrostContainerRetrieveResponse represents the response from retrieving a container.
+type BifrostContainerRetrieveResponse struct {
+	ID           string                 `json:"id"`
+	Object       string                 `json:"object,omitempty"` // "container"
+	Name         string                 `json:"name"`
+	CreatedAt    int64                  `json:"created_at"`
+	Status       ContainerStatus        `json:"status,omitempty"`
+	ExpiresAfter *ContainerExpiresAfter `json:"expires_after,omitempty"`
+	LastActiveAt *int64                 `json:"last_active_at,omitempty"`
+	MemoryLimit  string                 `json:"memory_limit,omitempty"`
+	Metadata     map[string]string      `json:"metadata,omitempty"`
+
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+}
+
+// BifrostContainerDeleteRequest represents a request to delete a container.
+type BifrostContainerDeleteRequest struct {
+	Provider    ModelProvider `json:"provider"`
+	ContainerID string        `json:"container_id"` // ID of the container to delete
+
+	// Extra parameters for provider-specific features
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// BifrostContainerDeleteResponse represents the response from deleting a container.
+type BifrostContainerDeleteResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object,omitempty"` // "container.deleted"
+	Deleted bool   `json:"deleted"`
+
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -191,6 +191,10 @@ type AllowedRequests struct {
 	FileRetrieve          bool `json:"file_retrieve"`
 	FileDelete            bool `json:"file_delete"`
 	FileContent           bool `json:"file_content"`
+	ContainerCreate       bool `json:"container_create"`
+	ContainerList         bool `json:"container_list"`
+	ContainerRetrieve     bool `json:"container_retrieve"`
+	ContainerDelete       bool `json:"container_delete"`
 }
 
 // IsOperationAllowed checks if a specific operation is allowed
@@ -250,6 +254,14 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 		return ar.FileDelete
 	case FileContentRequest:
 		return ar.FileContent
+	case ContainerCreateRequest:
+		return ar.ContainerCreate
+	case ContainerListRequest:
+		return ar.ContainerList
+	case ContainerRetrieveRequest:
+		return ar.ContainerRetrieve
+	case ContainerDeleteRequest:
+		return ar.ContainerDelete
 	default:
 		return false // Default to not allowed for unknown operations
 	}
@@ -376,4 +388,12 @@ type Provider interface {
 	FileDelete(ctx *BifrostContext, keys []Key, request *BifrostFileDeleteRequest) (*BifrostFileDeleteResponse, *BifrostError)
 	// FileContent downloads file content from the provider
 	FileContent(ctx *BifrostContext, keys []Key, request *BifrostFileContentRequest) (*BifrostFileContentResponse, *BifrostError)
+	// ContainerCreate creates a new container
+	ContainerCreate(ctx *BifrostContext, key Key, request *BifrostContainerCreateRequest) (*BifrostContainerCreateResponse, *BifrostError)
+	// ContainerList lists containers
+	ContainerList(ctx *BifrostContext, keys []Key, request *BifrostContainerListRequest) (*BifrostContainerListResponse, *BifrostError)
+	// ContainerRetrieve retrieves a specific container
+	ContainerRetrieve(ctx *BifrostContext, keys []Key, request *BifrostContainerRetrieveRequest) (*BifrostContainerRetrieveResponse, *BifrostError)
+	// ContainerDelete deletes a container
+	ContainerDelete(ctx *BifrostContext, keys []Key, request *BifrostContainerDeleteRequest) (*BifrostContainerDeleteResponse, *BifrostError)
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -220,6 +220,11 @@ func isFileRequestType(reqType schemas.RequestType) bool {
 	return reqType == schemas.FileUploadRequest || reqType == schemas.FileListRequest || reqType == schemas.FileRetrieveRequest || reqType == schemas.FileDeleteRequest || reqType == schemas.FileContentRequest
 }
 
+// isContainerRequestType returns true if the given request type is a container API operation.
+func isContainerRequestType(reqType schemas.RequestType) bool {
+	return reqType == schemas.ContainerCreateRequest || reqType == schemas.ContainerListRequest || reqType == schemas.ContainerRetrieveRequest || reqType == schemas.ContainerDeleteRequest
+}
+
 // IsFinalChunk returns true if the given context is a final chunk.
 func IsFinalChunk(ctx *schemas.BifrostContext) bool {
 	if ctx == nil {

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -76,6 +76,8 @@ tags:
     description: Batch processing operations
   - name: Files
     description: File management operations
+  - name: Containers
+    description: Container management operations
   # Provider Integrations
   - name: OpenAI Integration
     description: OpenAI-compatible API endpoints (/openai/*)
@@ -149,6 +151,10 @@ paths:
     $ref: './paths/inference/files.yaml#/files-by-id'
   /v1/files/{file_id}/content:
     $ref: './paths/inference/files.yaml#/files-content'
+  /v1/containers:
+    $ref: './paths/inference/containers.yaml#/containers'
+  /v1/containers/{container_id}:
+    $ref: './paths/inference/containers.yaml#/containers-by-id'
 
   # ==================== OpenAI Integration ====================
   # Chat Completions

--- a/docs/openapi/paths/inference/containers.yaml
+++ b/docs/openapi/paths/inference/containers.yaml
@@ -1,0 +1,133 @@
+containers:
+  post:
+    operationId: createContainer
+    summary: Create a container
+    description: |
+      Creates a new container for storing files and data.
+    tags:
+      - Containers
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/containers.yaml#/ContainerCreateRequest'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/containers.yaml#/ContainerCreateResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+  get:
+    operationId: listContainers
+    summary: List containers
+    description: |
+      Lists containers for a provider.
+    tags:
+      - Containers
+    parameters:
+      - name: provider
+        in: query
+        required: true
+        description: Provider to list containers for
+        schema:
+          $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+      - name: limit
+        in: query
+        description: Maximum number of containers to return (1-100, default 20)
+        schema:
+          type: integer
+          minimum: 1
+          limit: 200
+          maximum: 100
+      - name: after
+        in: query
+        description: Cursor for pagination
+        schema:
+          type: string
+      - name: order
+        in: query
+        description: Sort order (asc/desc)
+        schema:
+          type: string
+          enum: [asc, desc]
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/containers.yaml#/ContainerListResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+containers-by-id:
+  get:
+    operationId: retrieveContainer
+    summary: Retrieve a container
+    description: |
+      Retrieves a specific container by ID.
+    tags:
+      - Containers
+    parameters:
+      - name: container_id
+        in: path
+        required: true
+        description: The ID of the container to retrieve
+        schema:
+          type: string
+      - name: provider
+        in: query
+        required: true
+        description: The provider of the container
+        schema:
+          $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/containers.yaml#/ContainerRetrieveResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+  delete:
+    operationId: deleteContainer
+    summary: Delete a container
+    description: |
+      Deletes a container.
+    tags:
+      - Containers
+    parameters:
+      - name: container_id
+        in: path
+        required: true
+        description: The ID of the container to delete
+        schema:
+          type: string
+      - name: provider
+        in: query
+        required: true
+        description: The provider of the container
+        schema:
+          $ref: '../../schemas/inference/common.yaml#/ModelProvider'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/containers.yaml#/ContainerDeleteResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/schemas/inference/containers.yaml
+++ b/docs/openapi/schemas/inference/containers.yaml
@@ -1,0 +1,187 @@
+# Containers API schemas
+
+ContainerStatus:
+  type: string
+  enum:
+    - running
+  description: The status of a container
+
+ContainerExpiresAfter:
+  type: object
+  description: Expiration configuration for a container
+  properties:
+    anchor:
+      type: string
+      description: The anchor point for expiration (e.g., "last_active_at")
+    minutes:
+      type: integer
+      description: Number of minutes after anchor point
+
+ContainerObject:
+  type: object
+  description: A container object
+  properties:
+    id:
+      type: string
+      description: The unique identifier for the container
+    object:
+      type: string
+      description: The object type (always "container")
+    name:
+      type: string
+      description: The name of the container
+    created_at:
+      type: integer
+      format: int64
+      description: Unix timestamp of when the container was created
+    status:
+      $ref: '#/ContainerStatus'
+    expires_after:
+      $ref: '#/ContainerExpiresAfter'
+    last_active_at:
+      type: integer
+      format: int64
+      description: Unix timestamp of last activity
+    memory_limit:
+      type: string
+      description: Memory limit for the container (e.g., "1g", "4g")
+    metadata:
+      type: object
+      additionalProperties:
+        type: string
+      description: User-provided metadata
+
+ContainerCreateRequest:
+  type: object
+  required:
+    - provider
+    - name
+  properties:
+    provider:
+      $ref: './common.yaml#/ModelProvider'
+    name:
+      type: string
+      description: Name of the container
+    expires_after:
+      $ref: '#/ContainerExpiresAfter'
+    file_ids:
+      type: array
+      items:
+        type: string
+      description: IDs of existing files to copy into this container
+    memory_limit:
+      type: string
+      description: Memory limit for the container (e.g., "1g", "4g")
+    metadata:
+      type: object
+      additionalProperties:
+        type: string
+      description: User-provided metadata
+
+ContainerCreateResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: The unique identifier for the created container
+    object:
+      type: string
+      description: The object type (always "container")
+    name:
+      type: string
+      description: The name of the container
+    created_at:
+      type: integer
+      format: int64
+      description: Unix timestamp of when the container was created
+    status:
+      $ref: '#/ContainerStatus'
+    expires_after:
+      $ref: '#/ContainerExpiresAfter'
+    last_active_at:
+      type: integer
+      format: int64
+      description: Unix timestamp of last activity
+    memory_limit:
+      type: string
+      description: Memory limit for the container
+    metadata:
+      type: object
+      additionalProperties:
+        type: string
+      description: User-provided metadata
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+ContainerListResponse:
+  type: object
+  properties:
+    object:
+      type: string
+      description: The object type (always "list")
+    data:
+      type: array
+      items:
+        $ref: '#/ContainerObject'
+      description: List of container objects
+    first_id:
+      type: string
+      description: ID of the first container in the list
+    last_id:
+      type: string
+      description: ID of the last container in the list
+    has_more:
+      type: boolean
+      description: Whether there are more containers to fetch
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+ContainerRetrieveResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: The unique identifier for the container
+    object:
+      type: string
+      description: The object type (always "container")
+    name:
+      type: string
+      description: The name of the container
+    created_at:
+      type: integer
+      format: int64
+      description: Unix timestamp of when the container was created
+    status:
+      $ref: '#/ContainerStatus'
+    expires_after:
+      $ref: '#/ContainerExpiresAfter'
+    last_active_at:
+      type: integer
+      format: int64
+      description: Unix timestamp of last activity
+    memory_limit:
+      type: string
+      description: Memory limit for the container
+    metadata:
+      type: object
+      additionalProperties:
+        type: string
+      description: User-provided metadata
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+ContainerDeleteResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: The ID of the deleted container
+    object:
+      type: string
+      description: The object type (always "container.deleted")
+    deleted:
+      type: boolean
+      description: Whether the container was successfully deleted
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -97,11 +97,23 @@ type FileRequest struct {
 	ContentRequest  *schemas.BifrostFileContentRequest
 }
 
+// ContainerRequest wraps a Bifrost container request with its type information.
+type ContainerRequest struct {
+	Type            schemas.RequestType
+	CreateRequest   *schemas.BifrostContainerCreateRequest
+	ListRequest     *schemas.BifrostContainerListRequest
+	RetrieveRequest *schemas.BifrostContainerRetrieveRequest
+	DeleteRequest   *schemas.BifrostContainerDeleteRequest
+}
+
 // BatchRequestConverter is a function that converts integration-specific batch requests to Bifrost format.
 type BatchRequestConverter func(ctx *schemas.BifrostContext, req interface{}) (*BatchRequest, error)
 
 // FileRequestConverter is a function that converts integration-specific file requests to Bifrost format.
 type FileRequestConverter func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error)
+
+// ContainerRequestConverter is a function that converts integration-specific container requests to Bifrost format.
+type ContainerRequestConverter func(ctx *schemas.BifrostContext, req interface{}) (*ContainerRequest, error)
 
 // RequestConverter is a function that converts integration-specific requests to Bifrost format.
 // It takes the parsed request object and returns a BifrostRequest ready for processing.
@@ -175,6 +187,22 @@ type FileDeleteResponseConverter func(ctx *schemas.BifrostContext, resp *schemas
 // It takes a BifrostFileContentResponse and returns the format expected by the specific integration.
 // Note: This may return binary data or a wrapper object depending on the integration.
 type FileContentResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostFileContentResponse) (interface{}, error)
+
+// ContainerCreateResponseConverter is a function that converts BifrostContainerCreateResponse to integration-specific format.
+// It takes a BifrostContainerCreateResponse and returns the format expected by the specific integration.
+type ContainerCreateResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostContainerCreateResponse) (interface{}, error)
+
+// ContainerListResponseConverter is a function that converts BifrostContainerListResponse to integration-specific format.
+// It takes a BifrostContainerListResponse and returns the format expected by the specific integration.
+type ContainerListResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostContainerListResponse) (interface{}, error)
+
+// ContainerRetrieveResponseConverter is a function that converts BifrostContainerRetrieveResponse to integration-specific format.
+// It takes a BifrostContainerRetrieveResponse and returns the format expected by the specific integration.
+type ContainerRetrieveResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostContainerRetrieveResponse) (interface{}, error)
+
+// ContainerDeleteResponseConverter is a function that converts BifrostContainerDeleteResponse to integration-specific format.
+// It takes a BifrostContainerDeleteResponse and returns the format expected by the specific integration.
+type ContainerDeleteResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostContainerDeleteResponse) (interface{}, error)
 
 // CountTokensResponseConverter is a function that converts BifrostCountTokensResponse to integration-specific format.
 // It takes a BifrostCountTokensResponse and returns the format expected by the specific integration.
@@ -275,37 +303,42 @@ const (
 // RouteConfig defines the configuration for a single route in an integration.
 // It specifies the path, method, and handlers for request/response conversion.
 type RouteConfig struct {
-	Type                             RouteConfigType                  // Type of the route
-	Path                             string                           // HTTP path pattern (e.g., "/openai/v1/chat/completions")
-	Method                           string                           // HTTP method (POST, GET, PUT, DELETE)
-	GetRequestTypeInstance           func() interface{}               // Factory function to create request instance (SHOULD NOT BE NIL)
-	RequestParser                    RequestParser                    // Optional: custom request parsing (e.g., multipart/form-data)
-	RequestConverter                 RequestConverter                 // Function to convert request to BifrostRequest (for inference requests)
-	BatchRequestConverter            BatchRequestConverter            // Function to convert request to BatchRequest (for batch operations)
-	FileRequestConverter             FileRequestConverter             // Function to convert request to FileRequest (for file operations)
-	ListModelsResponseConverter      ListModelsResponseConverter      // Function to convert BifrostListModelsResponse to integration format (SHOULD NOT BE NIL)
-	TextResponseConverter            TextResponseConverter            // Function to convert BifrostTextCompletionResponse to integration format (SHOULD NOT BE NIL)
-	ChatResponseConverter            ChatResponseConverter            // Function to convert BifrostChatResponse to integration format (SHOULD NOT BE NIL)
-	ResponsesResponseConverter       ResponsesResponseConverter       // Function to convert BifrostResponsesResponse to integration format (SHOULD NOT BE NIL)
-	EmbeddingResponseConverter       EmbeddingResponseConverter       // Function to convert BifrostEmbeddingResponse to integration format (SHOULD NOT BE NIL)
-	SpeechResponseConverter          SpeechResponseConverter          // Function to convert BifrostSpeechResponse to integration format (SHOULD NOT BE NIL)
-	TranscriptionResponseConverter   TranscriptionResponseConverter   // Function to convert BifrostTranscriptionResponse to integration format (SHOULD NOT BE NIL)
-	ImageGenerationResponseConverter ImageGenerationResponseConverter // Function to convert BifrostImageGenerationResponse to integration format (SHOULD NOT BE NIL)
-	BatchCreateResponseConverter     BatchCreateResponseConverter     // Function to convert BifrostBatchCreateResponse to integration format
-	BatchListResponseConverter       BatchListResponseConverter       // Function to convert BifrostBatchListResponse to integration format
-	BatchRetrieveResponseConverter   BatchRetrieveResponseConverter   // Function to convert BifrostBatchRetrieveResponse to integration format
-	BatchCancelResponseConverter     BatchCancelResponseConverter     // Function to convert BifrostBatchCancelResponse to integration format
-	BatchResultsResponseConverter    BatchResultsResponseConverter    // Function to convert BifrostBatchResultsResponse to integration format
-	FileUploadResponseConverter      FileUploadResponseConverter      // Function to convert BifrostFileUploadResponse to integration format
-	FileListResponseConverter        FileListResponseConverter        // Function to convert BifrostFileListResponse to integration format
-	FileRetrieveResponseConverter    FileRetrieveResponseConverter    // Function to convert BifrostFileRetrieveResponse to integration format
-	FileDeleteResponseConverter      FileDeleteResponseConverter      // Function to convert BifrostFileDeleteResponse to integration format
-	FileContentResponseConverter     FileContentResponseConverter     // Function to convert BifrostFileContentResponse to integration format
-	CountTokensResponseConverter     CountTokensResponseConverter     // Function to convert BifrostCountTokensResponse to integration format
-	ErrorConverter                   ErrorConverter                   // Function to convert BifrostError to integration format (SHOULD NOT BE NIL)
-	StreamConfig                     *StreamConfig                    // Optional: Streaming configuration (if nil, streaming not supported)
-	PreCallback                      PreRequestCallback               // Optional: called after parsing but before Bifrost processing
-	PostCallback                     PostRequestCallback              // Optional: called after request processing
+	Type                               RouteConfigType                    // Type of the route
+	Path                               string                             // HTTP path pattern (e.g., "/openai/v1/chat/completions")
+	Method                             string                             // HTTP method (POST, GET, PUT, DELETE)
+	GetRequestTypeInstance             func() interface{}                 // Factory function to create request instance (SHOULD NOT BE NIL)
+	RequestParser                      RequestParser                      // Optional: custom request parsing (e.g., multipart/form-data)
+	RequestConverter                   RequestConverter                   // Function to convert request to BifrostRequest (for inference requests)
+	BatchRequestConverter              BatchRequestConverter              // Function to convert request to BatchRequest (for batch operations)
+	FileRequestConverter               FileRequestConverter               // Function to convert request to FileRequest (for file operations)
+	ContainerRequestConverter          ContainerRequestConverter          // Function to convert request to ContainerRequest (for container operations)
+	ListModelsResponseConverter        ListModelsResponseConverter        // Function to convert BifrostListModelsResponse to integration format (SHOULD NOT BE NIL)
+	TextResponseConverter              TextResponseConverter              // Function to convert BifrostTextCompletionResponse to integration format (SHOULD NOT BE NIL)
+	ChatResponseConverter              ChatResponseConverter              // Function to convert BifrostChatResponse to integration format (SHOULD NOT BE NIL)
+	ResponsesResponseConverter         ResponsesResponseConverter         // Function to convert BifrostResponsesResponse to integration format (SHOULD NOT BE NIL)
+	EmbeddingResponseConverter         EmbeddingResponseConverter         // Function to convert BifrostEmbeddingResponse to integration format (SHOULD NOT BE NIL)
+	SpeechResponseConverter            SpeechResponseConverter            // Function to convert BifrostSpeechResponse to integration format (SHOULD NOT BE NIL)
+	TranscriptionResponseConverter     TranscriptionResponseConverter     // Function to convert BifrostTranscriptionResponse to integration format (SHOULD NOT BE NIL)
+	ImageGenerationResponseConverter   ImageGenerationResponseConverter   // Function to convert BifrostImageGenerationResponse to integration format (SHOULD NOT BE NIL)
+	BatchCreateResponseConverter       BatchCreateResponseConverter       // Function to convert BifrostBatchCreateResponse to integration format
+	BatchListResponseConverter         BatchListResponseConverter         // Function to convert BifrostBatchListResponse to integration format
+	BatchRetrieveResponseConverter     BatchRetrieveResponseConverter     // Function to convert BifrostBatchRetrieveResponse to integration format
+	BatchCancelResponseConverter       BatchCancelResponseConverter       // Function to convert BifrostBatchCancelResponse to integration format
+	BatchResultsResponseConverter      BatchResultsResponseConverter      // Function to convert BifrostBatchResultsResponse to integration format
+	FileUploadResponseConverter        FileUploadResponseConverter        // Function to convert BifrostFileUploadResponse to integration format
+	FileListResponseConverter          FileListResponseConverter          // Function to convert BifrostFileListResponse to integration format
+	FileRetrieveResponseConverter      FileRetrieveResponseConverter      // Function to convert BifrostFileRetrieveResponse to integration format
+	FileDeleteResponseConverter        FileDeleteResponseConverter        // Function to convert BifrostFileDeleteResponse to integration format
+	FileContentResponseConverter       FileContentResponseConverter       // Function to convert BifrostFileContentResponse to integration format
+	ContainerCreateResponseConverter   ContainerCreateResponseConverter   // Function to convert BifrostContainerCreateResponse to integration format
+	ContainerListResponseConverter     ContainerListResponseConverter     // Function to convert BifrostContainerListResponse to integration format
+	ContainerRetrieveResponseConverter ContainerRetrieveResponseConverter // Function to convert BifrostContainerRetrieveResponse to integration format
+	ContainerDeleteResponseConverter   ContainerDeleteResponseConverter   // Function to convert BifrostContainerDeleteResponse to integration format
+	CountTokensResponseConverter       CountTokensResponseConverter       // Function to convert BifrostCountTokensResponse to integration format
+	ErrorConverter                     ErrorConverter                     // Function to convert BifrostError to integration format (SHOULD NOT BE NIL)
+	StreamConfig                       *StreamConfig                      // Optional: Streaming configuration (if nil, streaming not supported)
+	PreCallback                        PreRequestCallback                 // Optional: called after parsing but before Bifrost processing
+	PostCallback                       PostRequestCallback                // Optional: called after request processing
 }
 
 // GenericRouter provides a reusable router implementation for all integrations.
@@ -347,10 +380,11 @@ func (g *GenericRouter) RegisterRoutes(r *router.Router, middlewares ...schemas.
 			continue
 		}
 
-		// Determine route type: inference, batch, or file
+		// Determine route type: inference, batch, file, or container
 		isBatchRoute := route.BatchRequestConverter != nil
 		isFileRoute := route.FileRequestConverter != nil
-		isInferenceRoute := !isBatchRoute && !isFileRoute
+		isContainerRoute := route.ContainerRequestConverter != nil
+		isInferenceRoute := !isBatchRoute && !isFileRoute && !isContainerRoute
 
 		// For inference routes, require RequestConverter
 		if isInferenceRoute && route.RequestConverter == nil {
@@ -471,6 +505,22 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				return
 			}
 			g.handleFileRequest(ctx, config, req, fileReq, bifrostCtx)
+			return
+		}
+
+		// Handle container requests if ContainerRequestConverter is set
+		if config.ContainerRequestConverter != nil {
+			defer cancel()
+			containerReq, err := config.ContainerRequestConverter(bifrostCtx, req)
+			if err != nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to convert container request"))
+				return
+			}
+			if containerReq == nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container request"))
+				return
+			}
+			g.handleContainerRequest(ctx, config, req, containerReq, bifrostCtx)
 			return
 		}
 
@@ -1042,6 +1092,113 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 
 	// If response is nil, PostCallback has set headers/status - return without body
 	if response == nil {
+		return
+	}
+
+	g.sendSuccess(ctx, bifrostCtx, config.ErrorConverter, response)
+}
+
+// handleContainerRequest handles container API requests (create, list, retrieve, delete)
+func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config RouteConfig, req interface{}, containerReq *ContainerRequest, bifrostCtx *schemas.BifrostContext) {
+	var response interface{}
+	var err error
+
+	switch containerReq.Type {
+	case schemas.ContainerCreateRequest:
+		if containerReq.CreateRequest == nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container create request"))
+			return
+		}
+		containerResponse, bifrostErr := g.client.ContainerCreateRequest(bifrostCtx, containerReq.CreateRequest)
+		if bifrostErr != nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, bifrostErr)
+			return
+		}
+		if config.PostCallback != nil {
+			if err := config.PostCallback(ctx, req, containerResponse); err != nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to execute post-request callback"))
+				return
+			}
+		}
+		if config.ContainerCreateResponseConverter != nil {
+			response, err = config.ContainerCreateResponseConverter(bifrostCtx, containerResponse)
+		} else {
+			response = containerResponse
+		}
+
+	case schemas.ContainerListRequest:
+		if containerReq.ListRequest == nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container list request"))
+			return
+		}
+		containerResponse, bifrostErr := g.client.ContainerListRequest(bifrostCtx, containerReq.ListRequest)
+		if bifrostErr != nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, bifrostErr)
+			return
+		}
+		if config.PostCallback != nil {
+			if err := config.PostCallback(ctx, req, containerResponse); err != nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to execute post-request callback"))
+				return
+			}
+		}
+		if config.ContainerListResponseConverter != nil {
+			response, err = config.ContainerListResponseConverter(bifrostCtx, containerResponse)
+		} else {
+			response = containerResponse
+		}
+
+	case schemas.ContainerRetrieveRequest:
+		if containerReq.RetrieveRequest == nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container retrieve request"))
+			return
+		}
+		containerResponse, bifrostErr := g.client.ContainerRetrieveRequest(bifrostCtx, containerReq.RetrieveRequest)
+		if bifrostErr != nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, bifrostErr)
+			return
+		}
+		if config.PostCallback != nil {
+			if err := config.PostCallback(ctx, req, containerResponse); err != nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to execute post-request callback"))
+				return
+			}
+		}
+		if config.ContainerRetrieveResponseConverter != nil {
+			response, err = config.ContainerRetrieveResponseConverter(bifrostCtx, containerResponse)
+		} else {
+			response = containerResponse
+		}
+
+	case schemas.ContainerDeleteRequest:
+		if containerReq.DeleteRequest == nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container delete request"))
+			return
+		}
+		containerResponse, bifrostErr := g.client.ContainerDeleteRequest(bifrostCtx, containerReq.DeleteRequest)
+		if bifrostErr != nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, bifrostErr)
+			return
+		}
+		if config.PostCallback != nil {
+			if err := config.PostCallback(ctx, req, containerResponse); err != nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to execute post-request callback"))
+				return
+			}
+		}
+		if config.ContainerDeleteResponseConverter != nil {
+			response, err = config.ContainerDeleteResponseConverter(bifrostCtx, containerResponse)
+		} else {
+			response = containerResponse
+		}
+
+	default:
+		g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Unknown container request type"))
+		return
+	}
+
+	if err != nil {
+		g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to convert container response"))
 		return
 	}
 

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -172,7 +172,11 @@ export type RequestType =
 	| "file_list"
 	| "file_retrieve"
 	| "file_delete"
-	| "file_content";
+	| "file_content"
+	| "container_create"
+	| "container_list"
+	| "container_retrieve"
+	| "container_delete";
 
 // AllowedRequests matching Go's schemas.AllowedRequests
 export interface AllowedRequests {


### PR DESCRIPTION
## Summary

This PR adds support for OpenAI's Container API, allowing users to create, list, retrieve, and delete containers through Bifrost.

## Changes

- Added Container API schemas and request/response types
- Implemented Container API methods in the Bifrost core
- Added OpenAI provider implementation for Container API operations
- Added "unsupported operation" implementations for all other providers
- Created HTTP transport routes for Container API endpoints
- Added comprehensive test utilities for Container API operations

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Test the Container API functionality with the OpenAI provider:

```sh
# Run core tests
go test ./core/internal/testutil -run TestContainerCreate
go test ./core/internal/testutil -run TestContainerList
go test ./core/internal/testutil -run TestContainerRetrieve
go test ./core/internal/testutil -run TestContainerDelete

# Test via HTTP API
curl -X POST http://localhost:8080/v1/containers \
  -H "Content-Type: application/json" \
  -d '{"provider":"openai", "name":"test-container"}'

curl -X GET http://localhost:8080/v1/containers?provider=openai

curl -X GET http://localhost:8080/v1/containers/{container_id}?provider=openai

curl -X DELETE http://localhost:8080/v1/containers/{container_id}?provider=openai
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Implements Container API support as part of the OpenAI provider integration.

## Security considerations

Container API operations require valid API keys with appropriate permissions.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable