### PR TITLE
fix: append bedrock content block only when required fields are present

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -5,3 +5,6 @@
 - feat: added support for gemini google search tool
 - fix: function response part handling in gemini
 - fix: call enrich error in vertex to return raw request and response in bifrost errors
+- fix: append valid/non-empty content blocks to form bedrock requests
+- fix: handle multiple data types in bedrock tool result
+- fix: anthropic and gemini responses stream event cycle

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -1610,6 +1610,18 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			}
 
 			return events
+		} else if bifrostResp.Item != nil &&
+			bifrostResp.Item.Type != nil &&
+			(*bifrostResp.Item.Type == schemas.ResponsesMessageTypeFunctionCall ||
+				*bifrostResp.Item.Type == schemas.ResponsesMessageTypeMCPCall) {
+
+			// Function call or MCP call complete - just emit content_block_stop
+			streamResp.Type = AnthropicStreamEventTypeContentBlockStop
+			if bifrostResp.ContentIndex != nil {
+				streamResp.Index = bifrostResp.ContentIndex
+			} else if bifrostResp.OutputIndex != nil {
+				streamResp.Index = bifrostResp.OutputIndex
+			}
 		} else {
 			// For text blocks and other content blocks, emit content_block_stop
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStop

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -27,6 +27,7 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		}
 		// Replace model with deployment
 		requestBody["model"] = deployment
+		delete(requestBody, "fallbacks")
 		// Add stream if not present
 		if isStreaming {
 			requestBody["stream"] = true

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -2169,3 +2169,293 @@ func TestToBedrockResponsesRequest_AdditionalFields_InterfaceSlice(t *testing.T)
 
 	assert.Equal(t, []string{"/amazon-bedrock-invocationMetrics/inputTokenCount"}, bedrockReq.AdditionalModelResponseFieldPaths)
 }
+
+// TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_EmptyBlocks tests that
+// empty ContentBlocks are not created when required fields are missing, preventing the Bedrock API error:
+// "ContentBlock object at messages.1.content.0 must set one of the following keys: text, image, toolUse, toolResult, document, video, cachePoint, reasoningContent, citationsContent, searchResult."
+func TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_EmptyBlocks(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          *schemas.BifrostResponsesResponse
+		expectedBlocks int // Expected number of ContentBlocks in the output
+		description    string
+	}{
+		{
+			name: "ImageBlockWithNilImageURL_ShouldNotCreateEmptyBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+									ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+										ImageURL: nil, // Missing ImageURL - should not create empty block
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 0,
+			description:    "Image block with nil ImageURL should not create an empty ContentBlock",
+		},
+		{
+			name: "ImageBlockWithNilImageBlock_ShouldNotCreateEmptyBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type:                                   schemas.ResponsesInputMessageContentBlockTypeImage,
+									ResponsesInputMessageContentBlockImage: nil, // Missing image block - should not create empty block
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 0,
+			description:    "Image block with nil ResponsesInputMessageContentBlockImage should not create an empty ContentBlock",
+		},
+		{
+			name: "ReasoningBlockWithNilText_ShouldNotCreateEmptyBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+									Text: nil, // Missing Text - should not create empty block
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 0,
+			description:    "Reasoning block with nil Text should not create an empty ContentBlock",
+		},
+		{
+			name: "FileBlockWithNilFileData_ShouldNotCreateEmptyBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+									ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+										FileData: nil, // Missing FileData - should not create empty block
+										Filename: schemas.Ptr("test.pdf"),
+										FileType: schemas.Ptr("application/pdf"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 0,
+			description:    "File block with nil FileData should not create an empty ContentBlock",
+		},
+		{
+			name: "FileBlockWithNilFileBlock_ShouldNotCreateEmptyBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type:                                  schemas.ResponsesInputMessageContentBlockTypeFile,
+									ResponsesInputMessageContentBlockFile: nil, // Missing file block - should not create empty block
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 0,
+			description:    "File block with nil ResponsesInputMessageContentBlockFile should not create an empty ContentBlock",
+		},
+		{
+			name: "ValidTextBlock_ShouldCreateBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeText,
+									Text: schemas.Ptr("Valid text content"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 1,
+			description:    "Valid text block should create a ContentBlock",
+		},
+		{
+			name: "ValidReasoningBlock_ShouldCreateBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+									Text: schemas.Ptr("Valid reasoning content"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 1,
+			description:    "Valid reasoning block should create a ContentBlock",
+		},
+		{
+			name: "ValidFileBlock_ShouldCreateBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+									ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+										FileData: schemas.Ptr("dGVzdCBmaWxlIGRhdGE="), // base64 encoded "test file data"
+										Filename: schemas.Ptr("test.pdf"),
+										FileType: schemas.Ptr("application/pdf"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 1,
+			description:    "Valid file block should create a ContentBlock",
+		},
+		{
+			name: "MixedValidAndInvalidBlocks_ShouldOnlyCreateValidBlocks",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeText,
+									Text: schemas.Ptr("Valid text"),
+								},
+								{
+									Type:                                   schemas.ResponsesInputMessageContentBlockTypeImage,
+									ResponsesInputMessageContentBlockImage: nil, // Invalid - should be skipped
+								},
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeReasoning,
+									Text: schemas.Ptr("Valid reasoning"),
+								},
+								{
+									Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+									ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+										FileData: nil, // Invalid - should be skipped
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 2, // Only valid text and reasoning blocks
+			description:    "Mixed valid and invalid blocks should only create valid ContentBlocks",
+		},
+		{
+			name: "CacheControlBlock_ShouldCreateCachePointBlock",
+			input: &schemas.BifrostResponsesResponse{
+				CreatedAt: 1234567890,
+				Output: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Type: schemas.ResponsesOutputMessageContentTypeText,
+									Text: schemas.Ptr("Text with cache control"),
+									CacheControl: &schemas.CacheControl{
+										Type: schemas.CacheControlTypeEphemeral,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedBlocks: 2, // Text block + CachePoint block
+			description:    "ContentBlock with CacheControl should create both content and CachePoint blocks",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := bedrock.ToBedrockConverseResponse(tt.input)
+			require.NoError(t, err, "Conversion should not error")
+			require.NotNil(t, actual, "Response should not be nil")
+			require.NotNil(t, actual.Output, "Output should not be nil")
+			require.NotNil(t, actual.Output.Message, "Message should not be nil")
+
+			actualBlocks := len(actual.Output.Message.Content)
+			assert.Equal(t, tt.expectedBlocks, actualBlocks, tt.description)
+
+			// Verify that all created blocks have at least one required field set
+			for i, block := range actual.Output.Message.Content {
+				hasRequiredField := block.Text != nil ||
+					block.Image != nil ||
+					block.Document != nil ||
+					block.ToolUse != nil ||
+					block.ToolResult != nil ||
+					block.ReasoningContent != nil ||
+					block.CachePoint != nil ||
+					block.JSON != nil ||
+					block.GuardContent != nil
+
+				assert.True(t, hasRequiredField,
+					"ContentBlock at index %d must have at least one required field set (text, image, toolUse, toolResult, document, video, cachePoint, reasoningContent, citationsContent, searchResult)",
+					i)
+			}
+		})
+	}
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -1209,14 +1209,25 @@ func processGeminiFunctionCallPart(part *Part, state *GeminiResponsesStreamState
 			ResponsesToolMessage: &schemas.ResponsesToolMessage{
 				CallID:    &toolUseID,
 				Name:      &part.FunctionCall.Name,
-				Arguments: &argsJSON,
+				Arguments: schemas.Ptr(""),
 			},
 		},
 	}
 
 	responses = append(responses, addedEvent)
 
-	// Gemini sends complete function calls, so immediately emit done event
+	// Generate synthetic argument deltas to simulate streaming behavior
+	if argsJSON != "" {
+		deltaEvents := generateSyntheticFunctionCallArgumentDeltas(
+			argsJSON,
+			&outputIndex,
+			&toolUseID,
+			sequenceNumber+len(responses),
+		)
+		responses = append(responses, deltaEvents...)
+	}
+
+	// Gemini sends complete function calls, so emit done event after synthetic deltas
 	doneEvent := &schemas.BifrostResponsesStreamResponse{
 		Type:           schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDone,
 		SequenceNumber: sequenceNumber + len(responses),
@@ -1232,6 +1243,27 @@ func processGeminiFunctionCallPart(part *Part, state *GeminiResponsesStreamState
 	}
 
 	responses = append(responses, doneEvent)
+
+	outputItemDone := &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+		SequenceNumber: sequenceNumber + len(responses),
+		OutputIndex:    &outputIndex,
+		ItemID:         &toolUseID,
+		Item: &schemas.ResponsesMessage{
+			ID:     &toolUseID,
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+			Status: schemas.Ptr("completed"),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID:    &toolUseID,
+				Name:      &part.FunctionCall.Name,
+				Arguments: &argsJSON,
+			},
+		},
+	}
+
+	responses = append(responses, outputItemDone)
+
+	delete(state.ToolArgumentBuffers, outputIndex)
 
 	state.HasStartedToolCall = true
 
@@ -3324,4 +3356,31 @@ func emitAnnotationsFromGroundingSupports(
 	}
 
 	return responses
+}
+
+// generateSyntheticFunctionCallArgumentDeltas creates synthetic FunctionCallArgumentsDelta events
+// from complete JSON arguments to simulate streaming behavior for providers that don't natively stream
+func generateSyntheticFunctionCallArgumentDeltas(argumentsJSON string, outputIndex *int, itemID *string, baseSequenceNumber int) []*schemas.BifrostResponsesStreamResponse {
+	var events []*schemas.BifrostResponsesStreamResponse
+
+	// Chunk size for synthetic streaming (matching realistic streaming patterns)
+	chunkSize := 8 // Small chunks to simulate realistic streaming
+
+	// Break the JSON into chunks
+	runes := []rune(argumentsJSON)
+	for i := 0; i < len(runes); i += chunkSize {
+		end := min(i+chunkSize, len(runes))
+
+		chunk := string(runes[i:end])
+		deltaEvent := &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			SequenceNumber: baseSequenceNumber + len(events),
+			OutputIndex:    outputIndex,
+			ItemID:         itemID,
+			Delta:          &chunk,
+		}
+		events = append(events, deltaEvent)
+	}
+
+	return events
 }

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -27,6 +27,7 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		}
 		delete(requestBody, "model")
 		delete(requestBody, "region")
+		delete(requestBody, "fallbacks")
 		// Add anthropic_version if not present
 		if _, exists := requestBody["anthropic_version"]; !exists {
 			requestBody["anthropic_version"] = DefaultVertexAnthropicVersion

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -5,3 +5,6 @@
 - feat: added support for gemini google search tool
 - fix: function response part handling in gemini
 - fix: call enrich error in vertex to return raw request and response in bifrost errors
+- fix: append valid/non-empty content blocks to form bedrock requests
+- fix: handle multiple data types in bedrock tool result
+- fix: anthropic and gemini responses stream event cycle


### PR DESCRIPTION
## Summary

Fix Bedrock API error by preventing empty ContentBlocks in responses when required fields are missing.

## Changes

- Modified `convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks` to only append blocks that have at least one required field set
- Added validation to ensure blocks have required fields before adding them to the response
- Added comprehensive test cases to verify empty blocks are not created when required fields are missing
- Fixed document block creation to only set the Document field when file data is available

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the new test cases
go test ./core/providers/bedrock -run TestConvertBifrostResponsesMessageContentBlocksToBedrockContentBlocks_EmptyBlocks

# Run all bedrock provider tests
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the Bedrock API would return an error when empty ContentBlocks were created without required fields: "ContentBlock object at messages.1.content.0 must set one of the following keys: text, image, toolUse, toolResult, document, video, cachePoint, reasoningContent, citationsContent, searchResult."

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable