### PR TITLE
fix: provider key enabled/disabled state now persists across restarts

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- fix: provider key enabled/disabled state now persists across restarts

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -470,7 +470,6 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			// ConfigHash should only be set during initial sync from config.json,
 			// not when updating via UI (so DB updates aren't overwritten on restart)
 			dbKey.ID = existingKey.ID
-			dbKey.Enabled = existingKey.Enabled
 			dbKey.ConfigHash = existingKey.ConfigHash
 			if err := txDB.WithContext(ctx).Save(&dbKey).Error; err != nil {
 				return s.parseGormError(err)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -8,3 +8,4 @@
 - fix: append valid/non-empty content blocks to form bedrock requests
 - fix: handle multiple data types in bedrock tool result
 - fix: anthropic and gemini responses stream event cycle
+- fix: provider key enabled/disabled state now persists across restarts


### PR DESCRIPTION
## Summary

Fix a bug where provider key enabled/disabled state was not persisting across application restarts.

## Changes

- Modified `RDBConfigStore.UpdateProvider` to preserve the `Enabled` state of provider keys when updating them
- Previously, the `Enabled` field was being reset to the value from the existing key in the database, which meant that changes to this state were lost on restart

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Add a provider key through the UI
2. Toggle the enabled/disabled state of the key
3. Restart the application
4. Verify that the enabled/disabled state is preserved after restart

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where provider key enabled/disabled state was not persisting across restarts.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)