### PR TITLE
feat: add initContainers to helm chart

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 1.5.3
+version: 1.6.0
 appVersion: "1.5.2"
 keywords:
   - ai

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -598,3 +598,7 @@ envFrom: []
   # - configMapRef:
   #     name: my-configmap
 
+
+# Init containers to run before the main application container.
+# Provide a list of init containers using standard Kubernetes container spec.
+initContainers: []

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 entries:
   bifrost:
   - apiVersion: v2
-    appVersion: 1.5.2
+    appVersion: 1.4.2
     created: "2026-01-23T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,28 @@ apiVersion: v1
 entries:
   bifrost:
   - apiVersion: v2
+    appVersion: 1.5.2
+    created: "2026-01-23T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.6.0.tgz
+    version: 1.6.0
+  - apiVersion: v2
     appVersion: 1.5.3
     created: "2026-01-16T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface


### PR DESCRIPTION
## Summary

Adds `initContainers` option to Helm chart. This allows using custom init containers.

This allows using a custom script to add a custom CA to the system certificate store.

## Changes

- add `initContainers` to values.yaml and deployment.yaml

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs
- [x] CI/CD

## Related issues

Link related issues and discussions. Example: Closes #1383 

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


