### PR TITLE
1.4.2-test-fixes

### DIFF
--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -81,6 +81,15 @@ func TestOpenAI(t *testing.T) {
 			CountTokens:           true,
 			ChatAudio:             true,
 			StructuredOutputs:     true, // Structured outputs with nullable enum support
+			ContainerCreate:       true,
+			ContainerList:         true,
+			ContainerRetrieve:     true,
+			ContainerDelete:       true,
+			ContainerFileCreate:   true,
+			ContainerFileList:     true,
+			ContainerFileRetrieve: true,
+			ContainerFileContent:  true,
+			ContainerFileDelete:   true,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Added support for container operations in OpenAI provider and enhanced the mock account functionality to support custom base URLs for providers.

## Changes

- Added a new `AddProviderWithBaseURL` method to `MockAccount` to allow specifying a custom base URL when adding a provider
- Modified the `TestUpdateProvider` test to use Ollama instead of Anthropic as a test provider, since Ollama requires a base URL
- Added container-related capabilities to the OpenAI provider feature flags, including:
  - Container creation, listing, retrieval, and deletion
  - Container file operations (create, list, retrieve, content, delete)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./core/bifrost_test.go
go test ./core/providers/openai/openai_test.go
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

No significant security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)