### PR TITLE
fix: check bedrock provider alias for name matches

### DIFF
--- a/core/providers/bedrock/models.go
+++ b/core/providers/bedrock/models.go
@@ -103,31 +103,32 @@ func findDeploymentMatch(deployments map[string]string, modelID string) (deploym
 	// Check if any deployment value matches the modelID (with or without prefix)
 	for aliasKey, deploymentValue := range deployments {
 		// Exact match
-		if deploymentValue == modelID {
+		if deploymentValue == modelID || aliasKey == modelID {
 			return deploymentValue, aliasKey
 		}
 
 		// Check prefix variations
 		deploymentPrefix := extractPrefix(deploymentValue)
 		modelIDPrefix := extractPrefix(modelID)
+		aliasKeyPrefix := extractPrefix(aliasKey)
 
-		// Case 1: deploymentValue has prefix, modelID doesn't
-		if deploymentPrefix != "" && modelIDPrefix == "" {
-			if removePrefix(deploymentValue) == modelID {
+		// Case 1: deploymentValue or aliasKey has prefix, modelID doesn't
+		if (deploymentPrefix != "" && modelIDPrefix == "") || (aliasKeyPrefix != "" && modelIDPrefix == "") {
+			if removePrefix(deploymentValue) == modelID || removePrefix(aliasKey) == modelID {
 				return deploymentValue, aliasKey
 			}
 		}
 
-		// Case 2: modelID has prefix, deploymentValue doesn't
-		if modelIDPrefix != "" && deploymentPrefix == "" {
-			if removePrefix(modelID) == deploymentValue {
+		// Case 2: modelID or aliasKey has prefix, deploymentValue doesn't
+		if (modelIDPrefix != "" && deploymentPrefix == "") || (aliasKeyPrefix != "" && deploymentPrefix == "") {
+			if removePrefix(modelID) == deploymentValue || removePrefix(modelID) == aliasKey {
 				return deploymentValue, aliasKey
 			}
 		}
 
 		// Case 3: Both have prefixes but different prefixes
-		if deploymentPrefix != "" && modelIDPrefix != "" && deploymentPrefix != modelIDPrefix {
-			if removePrefix(deploymentValue) == removePrefix(modelID) {
+		if (deploymentPrefix != "" && modelIDPrefix != "" && deploymentPrefix != modelIDPrefix) || (aliasKeyPrefix != "" && modelIDPrefix != "" && aliasKeyPrefix != modelIDPrefix) {
+			if removePrefix(deploymentValue) == removePrefix(modelID) || removePrefix(aliasKey) == removePrefix(modelID) {
 				return deploymentValue, aliasKey
 			}
 		}


### PR DESCRIPTION
## Summary

Bifrost's Bedrock provider cannot list models when configured with AWS Inference Profiles using custom deployment IDs. This causes `/v1/models?provider=bedrock` to return empty results, thus disabling cost tracking and budgets.

This PR changes the `findDeploymentMatch` function to also check for matching deployment aliases.

Raised in https://github.com/maximhq/bifrost/issues/1412

## Changes

- Changes the `findDeploymentMatch` function to also check for matching deployment aliases.
- Follows existing logic of checking for exact match first, then checking combinations of prefix removals.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


