### PR TITLE
init migration fix

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -166,6 +166,18 @@ func migrationInit(ctx context.Context, db *gorm.DB) error {
 					return err
 				}
 			}
+			// TableBudget and TableRateLimit must be created before TableProvider
+			// because TableProvider has FK references to them
+			if !migrator.HasTable(&tables.TableBudget{}) {
+				if err := migrator.CreateTable(&tables.TableBudget{}); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasTable(&tables.TableRateLimit{}) {
+				if err := migrator.CreateTable(&tables.TableRateLimit{}); err != nil {
+					return err
+				}
+			}
 			if !migrator.HasTable(&tables.TableProvider{}) {
 				if err := migrator.CreateTable(&tables.TableProvider{}); err != nil {
 					return err
@@ -207,16 +219,6 @@ func migrationInit(ctx context.Context, db *gorm.DB) error {
 			}
 			if !migrator.HasTable(&tables.TableLogStoreConfig{}) {
 				if err := migrator.CreateTable(&tables.TableLogStoreConfig{}); err != nil {
-					return err
-				}
-			}
-			if !migrator.HasTable(&tables.TableBudget{}) {
-				if err := migrator.CreateTable(&tables.TableBudget{}); err != nil {
-					return err
-				}
-			}
-			if !migrator.HasTable(&tables.TableRateLimit{}) {
-				if err := migrator.CreateTable(&tables.TableRateLimit{}); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
## Summary

Reordered table creation in migrations to ensure proper foreign key relationships are respected.

## Changes

- Moved the creation of `TableBudget` and `TableRateLimit` tables before `TableProvider` table
- Added a comment explaining that `TableBudget` and `TableRateLimit` must be created before `TableProvider` because `TableProvider` has foreign key references to them

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./framework/configstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes database migration errors when foreign key constraints are enforced.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable