### PR TITLE
fix: Add allowed model filtering for openrouter, huggingface

### DIFF
--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -378,7 +378,7 @@ func (provider *HuggingFaceProvider) listModelsByKey(ctx *schemas.BifrostContext
 		}
 
 		if result.response != nil {
-			providerResponse := result.response.ToBifrostListModelsResponse(providerName, result.provider)
+			providerResponse := result.response.ToBifrostListModelsResponse(providerName, result.provider, key.Models)
 			if providerResponse != nil {
 				aggregatedResponse.Data = append(aggregatedResponse.Data, providerResponse.Data...)
 				totalLatency += result.latency

--- a/core/providers/huggingface/models.go
+++ b/core/providers/huggingface/models.go
@@ -13,7 +13,7 @@ const (
 	maxModelFetchLimit     = 1000
 )
 
-func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, inferenceProvider inferenceProvider) *schemas.BifrostListModelsResponse {
+func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, inferenceProvider inferenceProvider, allowedModels []string) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -23,6 +23,11 @@ func (response *HuggingFaceListModelsResponse) ToBifrostListModelsResponse(provi
 	}
 	for _, model := range response.Models {
 		if model.ModelID == "" {
+			continue
+		}
+
+		key := fmt.Sprintf("%s/%s", inferenceProvider, model.ModelID)
+		if len(allowedModels) > 0 && !slices.Contains(allowedModels, key) {
 			continue
 		}
 

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -104,20 +104,16 @@ func (provider *OpenRouterProvider) listModelsByKey(ctx *schemas.BifrostContext,
 		return nil, bifrostErr
 	}
 
-	for i := range openrouterResponse.Data {
-		openrouterResponse.Data[i].ID = string(schemas.OpenRouter) + "/" + openrouterResponse.Data[i].ID
-	}
+	prefix := string(schemas.OpenRouter) + "/"
+	filteredData := make([]schemas.Model, 0, len(openrouterResponse.Data))
 
-	if len(key.Models) > 0 {
-		filteredData := make([]schemas.Model, 0, len(openrouterResponse.Data))
-		for _, model := range openrouterResponse.Data {
-			modelID := strings.TrimPrefix(model.ID, string(schemas.OpenRouter)+"/")
-			if slices.Contains(key.Models, modelID) {
-				filteredData = append(filteredData, model)
-			}
+	for i := range openrouterResponse.Data {
+		if len(key.Models) == 0 || slices.Contains(key.Models, openrouterResponse.Data[i].ID) {
+			openrouterResponse.Data[i].ID = prefix + openrouterResponse.Data[i].ID
+			filteredData = append(filteredData, openrouterResponse.Data[i])
 		}
-		openrouterResponse.Data = filteredData
 	}
+	openrouterResponse.Data = filteredData
 
 	openrouterResponse.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -4,6 +4,7 @@ package openrouter
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -105,6 +106,17 @@ func (provider *OpenRouterProvider) listModelsByKey(ctx *schemas.BifrostContext,
 
 	for i := range openrouterResponse.Data {
 		openrouterResponse.Data[i].ID = string(schemas.OpenRouter) + "/" + openrouterResponse.Data[i].ID
+	}
+
+	if len(key.Models) > 0 {
+		filteredData := make([]schemas.Model, 0, len(openrouterResponse.Data))
+		for _, model := range openrouterResponse.Data {
+			modelID := strings.TrimPrefix(model.ID, string(schemas.OpenRouter)+"/")
+			if slices.Contains(key.Models, modelID) {
+				filteredData = append(filteredData, model)
+			}
+		}
+		openrouterResponse.Data = filteredData
 	}
 
 	openrouterResponse.ExtraFields.Latency = latency.Milliseconds()


### PR DESCRIPTION
## Summary

When a model provider API key is configured with allowed models, the list models API filters out and returns only allowed models, but I noticed that this wasn't implemented for openrouter and huggingface.

## Changes

Added filtering for openrouter and huggingface API keys if allowed models is configured.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


