### PR TITLE
anthropic beta features

### DIFF
--- a/.github/workflows/openapi-bundle.yml
+++ b/.github/workflows/openapi-bundle.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -43,13 +43,14 @@ jobs:
         run: python bundle.py
 
       - name: Commit and push changes
+        if: github.event_name == 'push'
         run: |
-          CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-          if [ "$CURRENT_BRANCH" = "HEAD" ]; then
-            # In detached HEAD state (common in CI), use GITHUB_REF_NAME or default to main
-            CURRENT_BRANCH="${GITHUB_REF_NAME:-main}"
-          fi
+          CURRENT_BRANCH="${GITHUB_REF_NAME:-main}"
 
           git add docs/openapi/openapi.json
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
           git commit -m "chore: regenerate openapi.json --skip-pipeline"
           git push origin "$CURRENT_BRANCH"

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,8 @@
 - fix: allow flat $defs and propertyOrdering in jsonschema and forward it to Gemini
+- feat: adds beta feature for Anthropic
+  - deferLoading
+  - strict
+  - allowedCallers
+  - inputExamples
+  - add IsError to tool_result content
+  - add "none" option to ToolChoice.Type

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -251,7 +251,6 @@ func SetExtraHeaders(ctx context.Context, req *fasthttp.Request, extraHeaders ma
 			req.Header.Set(canonicalKey, value)
 		}
 	}
-
 	// Give priority to extra headers in the context
 	if extraHeaders, ok := (ctx).Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
 		for k, values := range filterHeaders(extraHeaders) {

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -19,7 +19,7 @@ import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Check, ChevronsUpDown, Gauge, X } from "lucide-react";
+import { Check, ChevronsUpDown, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -194,12 +194,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				onEscapeKeyDown={(e) => e.preventDefault()}
 			>
 				<SheetHeader className="flex flex-col items-start p-0">
-					<SheetTitle className="flex items-center gap-2">
-						<div className="bg-muted rounded-lg p-2 dark:bg-zinc-800">
-							<Gauge className="text-muted-foreground h-5 w-5 dark:text-zinc-300" />
-						</div>
-						{isEditing ? "Edit Model Limit" : "Create Model Limit"}
-					</SheetTitle>
+					<SheetTitle className="flex items-center gap-2">{isEditing ? "Edit Model Limit" : "Create Model Limit"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update budget and rate limit configuration." : "Set up budget and rate limits for a model."}
 					</SheetDescription>
@@ -237,7 +232,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 														variant="outline"
 														role="combobox"
 														aria-expanded={providerOpen}
-														className={cn("h-10 w-full justify-between font-normal", !field.value && "text-muted-foreground")}
+														className={cn("h-8 w-full justify-between font-normal", !field.value && "text-muted-foreground")}
 													>
 														{field.value ? (
 															<div className="flex items-center gap-2">

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -16,9 +16,9 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { resetDurationLabels } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
-import { resetDurationLabels } from "@/lib/constants/governance";
 import { getErrorMessage, useDeleteModelConfigMutation } from "@/lib/store";
 import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
@@ -86,6 +86,7 @@ export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimit
 				{/* Header */}
 				<div className="flex items-start justify-between gap-4">
 					<div className="space-y-1">
+						<h1 className="text-lg font-semibold">Model limits </h1>
 						<p className="text-muted-foreground text-sm">
 							Configure budgets and rate limits at the model level. For provider-specific limits, visit each provider&apos;s settings.
 						</p>
@@ -98,7 +99,7 @@ export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimit
 
 				{/* Table or Empty State */}
 				{modelConfigs?.length === 0 ? (
-					<div className="border-border/60 from-muted/30 to-muted/10 relative overflow-hidden rounded-xl border border-dashed bg-gradient-to-br px-8 py-12">
+					<div className="border-border/60 from-muted/30 to-muted/10 relative overflow-hidden rounded-sm border px-8 py-12">
 						<div className="relative flex flex-col items-center text-center">
 							{/* Icon */}
 							<div className="bg-muted mb-4 rounded-full p-4">
@@ -111,14 +112,8 @@ export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimit
 								Add model-level limits to control spending and request rates across your infrastructure.
 							</p>
 
-							{/* CTA */}
-							<Button onClick={handleAddModelLimit} disabled={!hasCreateAccess} size="lg" className="gap-2">
-								<Plus className="h-4 w-4" />
-								Add Your First Model Limit
-							</Button>
-
 							{/* Feature hints */}
-							<div className="text-muted-foreground mt-8 flex items-center justify-center gap-2 text-xs">
+							<div className="text-muted-foreground flex items-center justify-center gap-2 text-xs">
 								<span>Budget Controls</span>
 								<span>•</span>
 								<span>Token Limits</span>

--- a/ui/app/workspace/providers/views/modelProviderConfig.tsx
+++ b/ui/app/workspace/providers/views/modelProviderConfig.tsx
@@ -1,5 +1,4 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { isKnownProvider, ModelProvider } from "@/lib/types/config";
 import { useEffect, useMemo, useState } from "react";
@@ -118,7 +117,6 @@ export default function ModelProviderConfig({ provider }: Props) {
 					<ModelProviderKeysTableView className="mt-4" provider={provider} />
 				</>
 			)}
-			{provider.config_hash && <ConfigSyncAlert className="my-2" />}
 			<ProviderGovernanceTable className="mt-4" provider={provider} />
 		</div>
 	);

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -430,7 +430,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 				onInteractOutside={(e) => e.preventDefault()}
 				onEscapeKeyDown={(e) => e.preventDefault()}
 			>
-				<SheetHeader className="flex flex-col items-start pt-8">
+				<SheetHeader className="flex flex-col items-start px-3 pt-8">
 					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Create Virtual Key"}</SheetTitle>
 					<SheetDescription>
 						{isEditing

--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -136,13 +136,13 @@ export function ModelMultiselect({
 			isCreatable={true}
 			dynamicOptionCreation={true}
 			createOptionText="Press enter to add new model"
-			defaultOptions={defaultOptions.length > 0 ? defaultOptions : [] as Option<ModelOption>[]}
+			defaultOptions={defaultOptions.length > 0 ? defaultOptions : ([] as Option<ModelOption>[])}
 			isLoading={isLoading}
 			placeholder={placeholder}
 			disabled={disabled || !provider}
-			className={cn("!min-h-10 w-full", className)}
-			triggerClassName="!shadow-none !border-border !min-h-10 px-1"
-			menuClassName="!z-[100] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
+			className={cn("!min-h-8.7 w-full", className)}
+			triggerClassName="!shadow-none !border-border !min-h-8.7 px-1"
+			menuClassName="!z-[100] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar py-1.5"
 			isClearable={false}
 			closeMenuOnSelect={false}
 			menuPlacement="auto"


### PR DESCRIPTION
## Summary

Enhance Anthropic provider with improved error handling for tool calls and update GitHub workflow for OpenAPI bundle generation.

## Issue
Closes #1421

## Changes

- Added support for handling `is_error` flag in Anthropic tool results
- Implemented bidirectional conversion of error states between Bifrost and Anthropic formats
- Added support for the `strict` parameter in tool function definitions
- Updated GitHub workflow to use `GH_TOKEN` instead of `GITHUB_TOKEN`
- Improved OpenAPI bundle workflow to skip commits when no changes are detected
- Added conditional execution for the commit step to only run on push events

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Anthropic provider with tool calls that result in errors:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The PR updates the GitHub workflow to use `GH_TOKEN` instead of `GITHUB_TOKEN`, which may require updating repository secrets.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable