### PR TITLE
improves key selection speed

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4513,9 +4513,8 @@ func WeightedRandomKeySelector(ctx *schemas.BifrostContext, keys []schemas.Key, 
 		totalWeight += int(key.Weight * 100) // Convert float to int for better performance
 	}
 
-	// Use a fast random number generator
-	randomSource := rand.New(rand.NewSource(time.Now().UnixNano()))
-	randomValue := randomSource.Intn(totalWeight)
+	// Use global thread-safe random (Go 1.20+) - no allocation, no syscall
+	randomValue := rand.Intn(totalWeight)
 
 	// Select key based on weight
 	currentWeight := 0


### PR DESCRIPTION
## Summary

Optimize random key selection in the Bifrost service by replacing a custom random number generator with Go's built-in thread-safe global random generator.

## Changes

- Replaced the custom random number generator in `WeightedRandomKeySelector` that used `rand.New(rand.NewSource())` with Go's global thread-safe `rand.Intn()` function
- This change eliminates memory allocations and system calls during random key selection
- Fixed a minor whitespace issue in the Vertex deployment check condition

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that random key selection still works correctly:

```sh
# Core/Transports
go version
go test ./core/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The change maintains the same level of randomness while improving performance. The global random generator in Go 1.20+ is thread-safe and suitable for this use case.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable