### PR TITLE
fix: structured output handling for anthropic via vertex

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -6,3 +6,5 @@
   - inputExamples
   - add IsError to tool_result content
   - add "none" option to ToolChoice.Type
+  
+- fix: implement structured output handling for Anthropic models on Vertex where the beta structured-output header is unsupported

--- a/core/internal/testutil/structured_outputs.go
+++ b/core/internal/testutil/structured_outputs.go
@@ -103,7 +103,7 @@ func testStructuredOutputChatWithValue(t *testing.T, client *bifrost.Bifrost, ct
 	chatOperation := func() (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 		// Add Anthropic beta header for structured outputs if model contains "claude"
 		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
+		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") && testConfig.Provider != schemas.Vertex {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
 			}
@@ -236,7 +236,7 @@ func RunStructuredOutputChatStreamTest(t *testing.T, client *bifrost.Bifrost, ct
 
 		// Add Anthropic beta header for structured outputs if model contains "claude"
 		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
+		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") && testConfig.Provider != schemas.Vertex {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
 			}
@@ -410,7 +410,7 @@ func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx
 
 		// Add Anthropic beta header for structured outputs if model contains "claude"
 		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
+		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") && testConfig.Provider != schemas.Vertex {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
 			}
@@ -564,7 +564,7 @@ func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifros
 
 		// Add Anthropic beta header for structured outputs if model contains "claude"
 		reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") {
+		if strings.Contains(strings.ToLower(testConfig.ChatModel), "claude") && testConfig.Provider != schemas.Vertex {
 			extraHeaders := map[string][]string{
 				"anthropic-beta": {"structured-outputs-2025-11-13"},
 			}
@@ -665,7 +665,15 @@ func RunStructuredOutputResponsesStreamTest(t *testing.T, client *bifrost.Bifros
 
 							case schemas.ResponsesStreamResponseTypeOutputItemAdded:
 								if streamResp.Item != nil && streamResp.Item.Content != nil {
-									if streamResp.Item.Content.ContentStr != nil {
+									// Check ContentBlocks first
+									if len(streamResp.Item.Content.ContentBlocks) > 0 {
+										for _, block := range streamResp.Item.Content.ContentBlocks {
+											if block.Type == schemas.ResponsesOutputMessageContentTypeText && block.Text != nil {
+												fullContent.WriteString(*block.Text)
+											}
+										}
+									} else if streamResp.Item.Content.ContentStr != nil {
+										// Fallback to ContentStr
 										fullContent.WriteString(*streamResp.Item.Content.ContentStr)
 									}
 								}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -43,6 +43,8 @@ type AnthropicResponsesStreamState struct {
 	CreatedAt                 int                               // Timestamp for created_at consistency
 	HasEmittedCreated         bool                              // Whether we've emitted response.created
 	HasEmittedInProgress      bool                              // Whether we've emitted response.in_progress
+	StructuredOutputToolName  string                            // Name of the structured output tool (if using tool-based SO for Vertex)
+	StructuredOutputIndex     *int                              // Output index of the structured output tool call
 }
 
 // anthropicResponsesStreamStatePool provides a pool for Anthropic responses stream state objects.
@@ -127,6 +129,8 @@ func acquireAnthropicResponsesStreamState() *AnthropicResponsesStreamState {
 	state.CreatedAt = int(time.Now().Unix())
 	state.HasEmittedCreated = false
 	state.HasEmittedInProgress = false
+	state.StructuredOutputToolName = ""
+	state.StructuredOutputIndex = nil
 	return state
 }
 
@@ -161,6 +165,8 @@ func (state *AnthropicResponsesStreamState) flush() {
 	state.CreatedAt = int(time.Now().Unix())
 	state.HasEmittedCreated = false
 	state.HasEmittedInProgress = false
+	state.StructuredOutputToolName = ""
+	state.StructuredOutputIndex = nil
 }
 
 // getOrCreateOutputIndex returns the output index for a given content index, creating a new one if needed
@@ -424,6 +430,27 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 
 				return responses, nil, false
 			case AnthropicContentBlockTypeToolUse:
+				// Check if this is the structured output tool - if so, skip emitting tool call
+				if state.StructuredOutputToolName != "" && chunk.ContentBlock.Name != nil && *chunk.ContentBlock.Name == state.StructuredOutputToolName {
+					// Mark this output index for structured output handling
+					state.StructuredOutputIndex = &outputIndex
+
+					// Initialize argument buffer for accumulating the JSON
+					state.ToolArgumentBuffers[outputIndex] = ""
+
+					// Mark tool use blocks to prevent synthetic content_part.added events
+					if chunk.Index != nil {
+						state.TextContentIndices[*chunk.Index] = false
+					}
+
+					// Store item ID for this structured output
+					if chunk.ContentBlock.ID != nil {
+						state.ItemIDs[outputIndex] = *chunk.ContentBlock.ID
+					}
+
+					return nil, nil, false
+				}
+
 				// Function call starting - emit output_item.added with type "function_call" and status "in_progress"
 				statusInProgress := "in_progress"
 				itemID := ""
@@ -608,6 +635,12 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 						state.ToolArgumentBuffers[outputIndex] = ""
 					}
 					state.ToolArgumentBuffers[outputIndex] += *chunk.Delta.PartialJSON
+
+					// Check if this is the structured output tool - if so, just accumulate without emitting
+					if state.StructuredOutputIndex != nil && *state.StructuredOutputIndex == outputIndex {
+						// This is the structured output tool - accumulate without emitting delta events
+						return nil, nil, false
+					}
 
 					// Emit appropriate delta type based on whether this is an MCP call
 					var deltaType schemas.ResponsesStreamResponseType
@@ -920,6 +953,61 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 					// Clear the reasoning content index tracking
 					delete(state.ReasoningContentIndices, *chunk.Index)
 				}
+			}
+
+			// Check if this is a structured output tool call
+			if accumulatedArgs, hasArgs := state.ToolArgumentBuffers[outputIndex]; hasArgs && state.StructuredOutputIndex != nil && *state.StructuredOutputIndex == outputIndex {
+				// This was a structured output tool - emit as text message instead
+				textContent := accumulatedArgs
+				if textContent == "" {
+					textContent = "{}"
+				}
+
+				// Create ContentBlocks with output_text type instead of ContentStr
+				contentBlock := schemas.ResponsesMessageContentBlock{
+					Type: schemas.ResponsesOutputMessageContentTypeText,
+					Text: &textContent,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+					},
+				}
+
+				item := &schemas.ResponsesMessage{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+					Status: schemas.Ptr("completed"),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{contentBlock},
+					},
+				}
+				if itemID != "" {
+					item.ID = &itemID
+				}
+
+				// Emit output_item.added for the text message
+				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+					Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+					SequenceNumber: sequenceNumber + len(responses),
+					OutputIndex:    schemas.Ptr(outputIndex),
+					ContentIndex:   chunk.Index,
+					Item:           item,
+				})
+
+				// Emit output_item.done
+				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+					Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+					SequenceNumber: sequenceNumber + len(responses),
+					OutputIndex:    schemas.Ptr(outputIndex),
+					ContentIndex:   chunk.Index,
+					Item:           item,
+				})
+
+				// Clear the buffer and tracking
+				delete(state.ToolArgumentBuffers, outputIndex)
+				state.StructuredOutputIndex = nil
+
+				return responses, nil, false
 			}
 
 			// Check if this is a tool call (function_call or MCP call)
@@ -1846,7 +1934,7 @@ func (request *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.B
 	var bifrostMessages []schemas.ResponsesMessage
 
 	// Convert regular messages using the new conversion method
-	convertedMessages := ConvertAnthropicMessagesToBifrostMessages(request.Messages, request.System, false, provider == schemas.Bedrock)
+	convertedMessages := ConvertAnthropicMessagesToBifrostMessages(ctx, request.Messages, request.System, false, provider == schemas.Bedrock)
 	bifrostMessages = append(bifrostMessages, convertedMessages...)
 
 	// Convert tools if present
@@ -1920,30 +2008,48 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			}
 		}
 		if bifrostReq.Params.Text != nil {
-			// Citations cannot be used together with Structured Outputs in anthropic.
-			hasCitationsEnabled := false
-			// loop over input messages and check if any message has citations enabled
-			for _, message := range bifrostReq.Input {
-				if message.Content == nil || message.Content.ContentBlocks == nil {
-					continue
-				}
-				if message.Content.ContentBlocks != nil {
-					for _, block := range message.Content.ContentBlocks {
-						if block.Type == schemas.ResponsesInputMessageContentBlockTypeFile &&
-							block.Citations != nil &&
-							block.Citations.Enabled != nil &&
-							*block.Citations.Enabled {
-							hasCitationsEnabled = true
-							break
+			// Vertex doesn't support native structured outputs, so convert to tool
+			if bifrostReq.Provider == schemas.Vertex {
+				if bifrostReq.Params.Text.Format != nil {
+					responseFormatTool := convertResponsesTextFormatToTool(ctx, bifrostReq.Params.Text)
+					if responseFormatTool != nil {
+						if anthropicReq.Tools == nil {
+							anthropicReq.Tools = []AnthropicTool{}
+						}
+						anthropicReq.Tools = append(anthropicReq.Tools, *responseFormatTool)
+						// Force the model to use this specific tool
+						anthropicReq.ToolChoice = &AnthropicToolChoice{
+							Type: "tool",
+							Name: responseFormatTool.Name,
 						}
 					}
 				}
-				if hasCitationsEnabled {
-					break
+			} else {
+				// Citations cannot be used together with Structured Outputs in anthropic.
+				hasCitationsEnabled := false
+				// loop over input messages and check if any message has citations enabled
+				for _, message := range bifrostReq.Input {
+					if message.Content == nil || message.Content.ContentBlocks == nil {
+						continue
+					}
+					if message.Content.ContentBlocks != nil {
+						for _, block := range message.Content.ContentBlocks {
+							if block.Type == schemas.ResponsesInputMessageContentBlockTypeFile &&
+								block.Citations != nil &&
+								block.Citations.Enabled != nil &&
+								*block.Citations.Enabled {
+								hasCitationsEnabled = true
+								break
+							}
+						}
+					}
+					if hasCitationsEnabled {
+						break
+					}
 				}
-			}
-			if !hasCitationsEnabled {
-				anthropicReq.OutputFormat = convertResponsesTextConfigToAnthropicOutputFormat(bifrostReq.Params.Text)
+				if !hasCitationsEnabled {
+					anthropicReq.OutputFormat = convertResponsesTextConfigToAnthropicOutputFormat(bifrostReq.Params.Text)
+				}
 			}
 		}
 		if bifrostReq.Params.Reasoning != nil {
@@ -2009,7 +2115,11 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				}
 			}
 			if len(anthropicTools) > 0 {
-				anthropicReq.Tools = anthropicTools
+				if anthropicReq.Tools == nil {
+					anthropicReq.Tools = anthropicTools
+				} else {
+					anthropicReq.Tools = append(anthropicReq.Tools, anthropicTools...)
+				}
 			}
 			if len(mcpServers) > 0 {
 				anthropicReq.MCPServers = mcpServers
@@ -2052,7 +2162,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 }
 
 // ToBifrostResponsesResponse converts an Anthropic response to BifrostResponse with Responses structure
-func (response *AnthropicMessageResponse) ToBifrostResponsesResponse() *schemas.BifrostResponsesResponse {
+func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schemas.BifrostContext) *schemas.BifrostResponsesResponse {
 	if response == nil {
 		return nil
 	}
@@ -2095,7 +2205,7 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse() *schemas.
 				ContentBlocks: response.Content,
 			},
 		}
-		outputMessages := ConvertAnthropicMessagesToBifrostMessages([]AnthropicMessage{tempMsg}, nil, true, false)
+		outputMessages := ConvertAnthropicMessagesToBifrostMessages(ctx, []AnthropicMessage{tempMsg}, nil, true, false)
 		if len(outputMessages) > 0 {
 			bifrostResp.Output = outputMessages
 		}
@@ -2171,8 +2281,16 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 }
 
 // ConvertAnthropicMessagesToBifrostMessages converts an array of Anthropic messages to Bifrost ResponsesMessage format
-func ConvertAnthropicMessagesToBifrostMessages(anthropicMessages []AnthropicMessage, systemContent *AnthropicContent, isOutputMessage bool, keepToolsGrouped bool) []schemas.ResponsesMessage {
+func ConvertAnthropicMessagesToBifrostMessages(ctx *schemas.BifrostContext, anthropicMessages []AnthropicMessage, systemContent *AnthropicContent, isOutputMessage bool, keepToolsGrouped bool) []schemas.ResponsesMessage {
 	var bifrostMessages []schemas.ResponsesMessage
+
+	// Get structured output tool name from context if present
+	var structuredOutputToolName string
+	if ctx != nil {
+		if toolName, ok := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string); ok {
+			structuredOutputToolName = toolName
+		}
+	}
 
 	// Handle system message first if present
 	if systemContent != nil {
@@ -2184,9 +2302,9 @@ func ConvertAnthropicMessagesToBifrostMessages(anthropicMessages []AnthropicMess
 	for _, msg := range anthropicMessages {
 		var convertedMessages []schemas.ResponsesMessage
 		if keepToolsGrouped {
-			convertedMessages = convertSingleAnthropicMessageToBifrostMessagesGrouped(&msg, isOutputMessage)
+			convertedMessages = convertSingleAnthropicMessageToBifrostMessagesGrouped(&msg, isOutputMessage, structuredOutputToolName)
 		} else {
-			convertedMessages = convertSingleAnthropicMessageToBifrostMessages(&msg, isOutputMessage)
+			convertedMessages = convertSingleAnthropicMessageToBifrostMessages(ctx, &msg, isOutputMessage, structuredOutputToolName)
 		}
 		bifrostMessages = append(bifrostMessages, convertedMessages...)
 	}
@@ -2677,7 +2795,7 @@ func convertAnthropicSystemToBifrostMessages(systemContent *AnthropicContent) []
 }
 
 // Helper function to convert a single Anthropic message to Bifrost messages
-func convertSingleAnthropicMessageToBifrostMessages(msg *AnthropicMessage, isOutputMessage bool) []schemas.ResponsesMessage {
+func convertSingleAnthropicMessageToBifrostMessages(ctx *schemas.BifrostContext, msg *AnthropicMessage, isOutputMessage bool, structuredOutputToolName string) []schemas.ResponsesMessage {
 	// Determine if this message should use output types based on role
 	// Assistant messages in conversation history should use output_text
 	isOutput := isOutputMessage || msg.Role == AnthropicMessageRoleAssistant
@@ -2699,7 +2817,7 @@ func convertSingleAnthropicMessageToBifrostMessages(msg *AnthropicMessage, isOut
 	// Handle content blocks
 	if msg.Content.ContentBlocks != nil {
 		roleVal := schemas.ResponsesMessageRoleType(msg.Role)
-		return convertAnthropicContentBlocksToResponsesMessages(msg.Content.ContentBlocks, &roleVal, isOutput)
+		return convertAnthropicContentBlocksToResponsesMessages(ctx, msg.Content.ContentBlocks, &roleVal, isOutput, structuredOutputToolName)
 	}
 
 	return []schemas.ResponsesMessage{}
@@ -2707,7 +2825,7 @@ func convertSingleAnthropicMessageToBifrostMessages(msg *AnthropicMessage, isOut
 
 // Helper function to convert a single Anthropic message to Bifrost messages, grouping text and tool calls
 // This keeps assistant messages with mixed text and tool_use blocks together
-func convertSingleAnthropicMessageToBifrostMessagesGrouped(msg *AnthropicMessage, isOutputMessage bool) []schemas.ResponsesMessage {
+func convertSingleAnthropicMessageToBifrostMessagesGrouped(msg *AnthropicMessage, isOutputMessage bool, structuredOutputToolName string) []schemas.ResponsesMessage {
 	// Determine if this message should use output types based on role
 	// Assistant messages in conversation history should use output_text
 	isOutput := isOutputMessage || msg.Role == AnthropicMessageRoleAssistant
@@ -2995,7 +3113,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 }
 
 // Helper function to convert Anthropic content blocks to Bifrost ResponsesMessages
-func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicContentBlock, role *schemas.ResponsesMessageRoleType, isOutputMessage bool) []schemas.ResponsesMessage {
+func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContext, contentBlocks []AnthropicContentBlock, role *schemas.ResponsesMessageRoleType, isOutputMessage bool, structuredOutputToolName string) []schemas.ResponsesMessage {
 	var bifrostMessages []schemas.ResponsesMessage
 	var reasoningContentBlocks []schemas.ResponsesMessageContentBlock
 
@@ -3110,33 +3228,66 @@ func convertAnthropicContentBlocksToResponsesMessages(contentBlocks []AnthropicC
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
 		case AnthropicContentBlockTypeToolUse:
-			// Convert tool use to function call message
-			if block.ID != nil && block.Name != nil {
+			// Check if this is the structured output tool - if so, convert to text content
+			if structuredOutputToolName != "" && block.Name != nil && *block.Name == structuredOutputToolName {
+				// This is a structured output tool - convert to text message
+				var jsonStr string
+				if block.Input != nil {
+					jsonStr = schemas.JsonifyInput(block.Input)
+				} else {
+					jsonStr = "{}"
+				}
+
+				contentBlock := schemas.ResponsesMessageContentBlock{
+					Type: schemas.ResponsesOutputMessageContentTypeText,
+					Text: &jsonStr,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+					},
+				}
+
 				bifrostMsg := schemas.ResponsesMessage{
-					Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role:   role,
 					Status: schemas.Ptr("completed"),
-					ResponsesToolMessage: &schemas.ResponsesToolMessage{
-						CallID: block.ID,
-						Name:   block.Name,
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{contentBlock},
 					},
 				}
 				if isOutputMessage {
-					bifrostMsg.ID = schemas.Ptr("fc_" + providerUtils.GetRandomString(50))
-				}
-
-				// here need to check for computer tool use
-				if block.Name != nil && *block.Name == string(AnthropicToolNameComputer) {
-					bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeComputerCall)
-					bifrostMsg.ResponsesToolMessage.Name = nil
-					if inputMap, ok := block.Input.(map[string]interface{}); ok {
-						bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
-							ResponsesComputerToolCallAction: convertAnthropicToResponsesComputerAction(inputMap),
-						}
-					}
-				} else {
-					bifrostMsg.ResponsesToolMessage.Arguments = schemas.Ptr(schemas.JsonifyInput(block.Input))
+					bifrostMsg.ID = schemas.Ptr("msg_" + providerUtils.GetRandomString(50))
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
+			} else {
+				// Convert tool use to function call message
+				if block.ID != nil && block.Name != nil {
+					bifrostMsg := schemas.ResponsesMessage{
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+						Status: schemas.Ptr("completed"),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID: block.ID,
+							Name:   block.Name,
+						},
+					}
+					if isOutputMessage {
+						bifrostMsg.ID = schemas.Ptr("fc_" + providerUtils.GetRandomString(50))
+					}
+
+					// here need to check for computer tool use
+					if block.Name != nil && *block.Name == string(AnthropicToolNameComputer) {
+						bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeComputerCall)
+						bifrostMsg.ResponsesToolMessage.Name = nil
+						if inputMap, ok := block.Input.(map[string]interface{}); ok {
+							bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+								ResponsesComputerToolCallAction: convertAnthropicToResponsesComputerAction(inputMap),
+							}
+						}
+					} else {
+						bifrostMsg.ResponsesToolMessage.Arguments = schemas.Ptr(schemas.JsonifyInput(block.Input))
+					}
+					bifrostMessages = append(bifrostMessages, bifrostMsg)
+				}
 			}
 		case AnthropicContentBlockTypeToolResult:
 			// Convert tool result to function call output message

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -139,6 +139,330 @@ func appendUniqueHeader(slice []string, item string) []string {
 	return append(slice, item)
 }
 
+// convertChatResponseFormatToTool converts a response_format config to an Anthropic tool for structured output
+// This is used when the provider is Vertex, which doesn't support native structured outputs
+func convertChatResponseFormatToTool(ctx *schemas.BifrostContext, params *schemas.ChatParameters) *AnthropicTool {
+	if params == nil || params.ResponseFormat == nil {
+		return nil
+	}
+
+	// ResponseFormat is stored as interface{}, need to parse it
+	responseFormatMap, ok := (*params.ResponseFormat).(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Check if type is "json_schema"
+	formatType, ok := responseFormatMap["type"].(string)
+	if !ok || formatType != "json_schema" {
+		return nil
+	}
+
+	// Extract json_schema object
+	jsonSchemaObj, ok := responseFormatMap["json_schema"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Extract name and schema
+	toolName, ok := jsonSchemaObj["name"].(string)
+	if !ok || toolName == "" {
+		toolName = "json_response"
+	}
+
+	schemaObj, ok := jsonSchemaObj["schema"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Extract description from schema if available
+	description := "Returns structured JSON output"
+	if desc, ok := schemaObj["description"].(string); ok && desc != "" {
+		description = desc
+	}
+
+	// Set bifrost context key structured output tool name
+	toolName = fmt.Sprintf("bf_so_%s", toolName)
+	ctx.SetValue(schemas.BifrostContextKeyStructuredOutputToolName, toolName)
+
+	// Create the Anthropic tool
+	normalizedSchema := normalizeSchemaForAnthropic(schemaObj)
+	schemaParams := convertMapToToolFunctionParameters(normalizedSchema)
+
+	return &AnthropicTool{
+		Name:        toolName,
+		Description: schemas.Ptr(description),
+		InputSchema: schemaParams,
+	}
+}
+
+// convertResponsesTextFormatToTool converts a text config to an Anthropic tool for structured output
+// This is used when the provider is Vertex, which doesn't support native structured outputs
+func convertResponsesTextFormatToTool(ctx *schemas.BifrostContext, textConfig *schemas.ResponsesTextConfig) *AnthropicTool {
+	if textConfig == nil || textConfig.Format == nil {
+		return nil
+	}
+
+	format := textConfig.Format
+	if format.Type != "json_schema" {
+		return nil
+	}
+
+	toolName := "json_response"
+	if format.Name != nil && strings.TrimSpace(*format.Name) != "" {
+		toolName = strings.TrimSpace(*format.Name)
+	}
+
+	description := "Returns structured JSON output"
+	if format.JSONSchema != nil && format.JSONSchema.Description != nil {
+		description = *format.JSONSchema.Description
+	}
+
+	toolName = fmt.Sprintf("bf_so_%s", toolName)
+	ctx.SetValue(schemas.BifrostContextKeyStructuredOutputToolName, toolName)
+
+	var schemaParams *schemas.ToolFunctionParameters
+	if format.JSONSchema != nil {
+		schemaParams = convertJSONSchemaToToolParameters(format.JSONSchema)
+	} else {
+		return nil // Schema is required for tooling
+	}
+
+	return &AnthropicTool{
+		Name:        toolName,
+		Description: schemas.Ptr(description),
+		InputSchema: schemaParams,
+	}
+}
+
+// convertJSONSchemaToToolParameters directly converts ResponsesTextConfigFormatJSONSchema to ToolFunctionParameters
+func convertJSONSchemaToToolParameters(schema *schemas.ResponsesTextConfigFormatJSONSchema) *schemas.ToolFunctionParameters {
+	if schema == nil {
+		return nil
+	}
+
+	// Default type to "object" if not specified
+	schemaType := "object"
+	if schema.Type != nil {
+		schemaType = *schema.Type
+	}
+
+	params := &schemas.ToolFunctionParameters{
+		Type:                 schemaType,
+		Description:          schema.Description,
+		Required:             schema.Required,
+		Enum:                 schema.Enum,
+		Ref:                  schema.Ref,
+		MinItems:             schema.MinItems,
+		MaxItems:             schema.MaxItems,
+		Format:               schema.Format,
+		Pattern:              schema.Pattern,
+		MinLength:            schema.MinLength,
+		MaxLength:            schema.MaxLength,
+		Minimum:              schema.Minimum,
+		Maximum:              schema.Maximum,
+		Title:                schema.Title,
+		Default:              schema.Default,
+		Nullable:             schema.Nullable,
+		AdditionalProperties: schema.AdditionalProperties,
+	}
+
+	// Convert map[string]any to OrderedMap for Properties
+	if schema.Properties != nil {
+		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Properties); ok {
+			params.Properties = &orderedMap
+		}
+	}
+
+	// Convert map[string]any to OrderedMap for Defs
+	if schema.Defs != nil {
+		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Defs); ok {
+			params.Defs = &orderedMap
+		}
+	}
+
+	// Convert map[string]any to OrderedMap for Definitions
+	if schema.Definitions != nil {
+		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Definitions); ok {
+			params.Definitions = &orderedMap
+		}
+	}
+
+	// Convert map[string]any to OrderedMap for Items
+	if schema.Items != nil {
+		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Items); ok {
+			params.Items = &orderedMap
+		}
+	}
+
+	// Convert []map[string]any to []OrderedMap for composition fields
+	if len(schema.AnyOf) > 0 {
+		params.AnyOf = make([]schemas.OrderedMap, 0, len(schema.AnyOf))
+		for _, item := range schema.AnyOf {
+			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
+				params.AnyOf = append(params.AnyOf, orderedMap)
+			}
+		}
+	}
+
+	if len(schema.OneOf) > 0 {
+		params.OneOf = make([]schemas.OrderedMap, 0, len(schema.OneOf))
+		for _, item := range schema.OneOf {
+			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
+				params.OneOf = append(params.OneOf, orderedMap)
+			}
+		}
+	}
+
+	if len(schema.AllOf) > 0 {
+		params.AllOf = make([]schemas.OrderedMap, 0, len(schema.AllOf))
+		for _, item := range schema.AllOf {
+			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
+				params.AllOf = append(params.AllOf, orderedMap)
+			}
+		}
+	}
+
+	return params
+}
+
+// convertMapToToolFunctionParameters converts a map to ToolFunctionParameters
+func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolFunctionParameters {
+	params := &schemas.ToolFunctionParameters{}
+
+	if typeVal, ok := m["type"].(string); ok {
+		params.Type = typeVal
+	}
+	if desc, ok := m["description"].(string); ok {
+		params.Description = &desc
+	}
+	if props, ok := schemas.SafeExtractOrderedMap(m["properties"]); ok {
+		params.Properties = &props
+	}
+	if req, ok := m["required"].([]interface{}); ok {
+		required := make([]string, 0, len(req))
+		for _, r := range req {
+			if str, ok := r.(string); ok {
+				required = append(required, str)
+			}
+		}
+		params.Required = required
+	}
+	if addProps, ok := m["additionalProperties"]; ok {
+		if addPropsBool, ok := addProps.(bool); ok {
+			params.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
+				AdditionalPropertiesBool: &addPropsBool,
+			}
+		} else if addPropsMap, ok := schemas.SafeExtractOrderedMap(addProps); ok {
+			params.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
+				AdditionalPropertiesMap: &addPropsMap,
+			}
+		}
+	}
+	if defs, ok := schemas.SafeExtractOrderedMap(m["$defs"]); ok {
+		params.Defs = &defs
+	}
+	if definitions, ok := schemas.SafeExtractOrderedMap(m["definitions"]); ok {
+		params.Definitions = &definitions
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		params.Ref = &ref
+	}
+	if items, ok := schemas.SafeExtractOrderedMap(m["items"]); ok {
+		params.Items = &items
+	}
+	if minItems, ok := anthropicExtractInt64(m["minItems"]); ok {
+		params.MinItems = schemas.Ptr(minItems)
+	}
+	if maxItems, ok := anthropicExtractInt64(m["maxItems"]); ok {
+		params.MaxItems = schemas.Ptr(maxItems)
+	}
+	if anyOf, ok := m["anyOf"].([]interface{}); ok {
+		anyOfMaps := make([]schemas.OrderedMap, 0, len(anyOf))
+		for _, item := range anyOf {
+			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
+				anyOfMaps = append(anyOfMaps, orderedMap)
+			}
+		}
+		if len(anyOfMaps) > 0 {
+			params.AnyOf = anyOfMaps
+		}
+	}
+	if oneOf, ok := m["oneOf"].([]interface{}); ok {
+		oneOfMaps := make([]schemas.OrderedMap, 0, len(oneOf))
+		for _, item := range oneOf {
+			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
+				oneOfMaps = append(oneOfMaps, orderedMap)
+			}
+		}
+		if len(oneOfMaps) > 0 {
+			params.OneOf = oneOfMaps
+		}
+	}
+	if allOf, ok := m["allOf"].([]interface{}); ok {
+		allOfMaps := make([]schemas.OrderedMap, 0, len(allOf))
+		for _, item := range allOf {
+			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
+				allOfMaps = append(allOfMaps, orderedMap)
+			}
+		}
+		if len(allOfMaps) > 0 {
+			params.AllOf = allOfMaps
+		}
+	}
+	if format, ok := m["format"].(string); ok {
+		params.Format = &format
+	}
+	if pattern, ok := m["pattern"].(string); ok {
+		params.Pattern = &pattern
+	}
+	if minLength, ok := anthropicExtractInt64(m["minLength"]); ok {
+		params.MinLength = schemas.Ptr(minLength)
+	}
+	if maxLength, ok := anthropicExtractInt64(m["maxLength"]); ok {
+		params.MaxLength = schemas.Ptr(maxLength)
+	}
+	if minimum, ok := anthropicExtractFloat64(m["minimum"]); ok {
+		params.Minimum = &minimum
+	}
+	if maximum, ok := anthropicExtractFloat64(m["maximum"]); ok {
+		params.Maximum = &maximum
+	}
+	if title, ok := m["title"].(string); ok {
+		params.Title = &title
+	}
+	if enumVal, ok := m["enum"]; ok {
+		switch e := enumVal.(type) {
+		case []interface{}:
+			enumStrs := make([]string, 0, len(e))
+			for _, v := range e {
+				if s, ok := v.(string); ok {
+					enumStrs = append(enumStrs, s)
+				}
+			}
+			if len(enumStrs) > 0 {
+				params.Enum = enumStrs
+			}
+		case []string:
+			if len(e) > 0 {
+				params.Enum = e
+			}
+		}
+	}
+	if def, ok := m["default"]; ok {
+		params.Default = def
+	}
+	if nullable, ok := m["nullable"].(bool); ok {
+		params.Nullable = &nullable
+	}
+
+	if params.Type == "" {
+		params.Type = "object"
+	}
+
+	return params
+}
+
 // ConvertAnthropicFinishReasonToBifrost converts provider finish reasons to Bifrost format
 func ConvertAnthropicFinishReasonToBifrost(providerReason AnthropicStopReason) string {
 	if bifrostReason, ok := anthropicFinishReasonToBifrost[providerReason]; ok {

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -461,7 +461,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 		request,
 		func() (any, error) {
 			if schemas.IsAnthropicModel(deployment) {
-				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -509,7 +509,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
-		response = anthropicResponse.ToBifrostChatResponse()
+		response = anthropicResponse.ToBifrostChatResponse(ctx)
 	} else {
 		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
@@ -568,7 +568,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 			ctx,
 			request,
 			func() (any, error) {
-				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -700,7 +700,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 		if bifrostErr != nil {
 			return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
-		response = anthropicResponse.ToBifrostResponsesResponse()
+		response = anthropicResponse.ToBifrostResponsesResponse(ctx)
 	} else {
 		rawRequest, rawResponse, bifrostErr = providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 		if bifrostErr != nil {
@@ -1261,7 +1261,7 @@ func (provider *AzureProvider) ImageGeneration(ctx *schemas.BifrostContext, key 
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.logger,
-	)	
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -295,7 +295,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 			if schemas.IsAnthropicModel(deployment) {
 				// Use centralized Anthropic converter
-				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -477,7 +477,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		}
 
 		// Create final response
-		response := anthropicResponse.ToBifrostChatResponse()
+		response := anthropicResponse.ToBifrostChatResponse(ctx)
 
 		response.ExtraFields = schemas.BifrostResponseExtraFields{
 			RequestType:    schemas.ChatCompletionRequest,
@@ -598,7 +598,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			ctx,
 			request,
 			func() (any, error) {
-				reqBody, err := anthropic.ToAnthropicChatRequest(request)
+				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
 					return nil, err
 				}
@@ -910,7 +910,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		}
 
 		// Create final response
-		response := anthropicResponse.ToBifrostResponsesResponse()
+		response := anthropicResponse.ToBifrostResponsesResponse(ctx)
 
 		response.ExtraFields = schemas.BifrostResponseExtraFields{
 			RequestType:    schemas.ResponsesRequest,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: implement structured output handling for Anthropic models on Vertex where the beta structured-output header is unsupported


### PR DESCRIPTION
## Summary

Fix structured output handling for Anthropic models on Vertex AI where the beta structured-output header is unsupported.

## Changes

- Implemented a workaround for Vertex AI by converting structured output requests to tool calls
- Added detection of structured output tool calls and conversion back to content in responses
- Modified request/response handling to check provider type before applying Anthropic beta headers
- Added context tracking for structured output tool names to maintain consistency

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test structured output with Anthropic models on Vertex AI:

```sh
# Core/Transports
go test ./core/providers/anthropic/...
go test ./core/providers/vertex/...
go test ./core/internal/testutil/...

# Test with a request that uses structured output format
curl -X POST "http://localhost:8000/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude-3-opus-20240229",
    "provider": "vertex",
    "messages": [{"role": "user", "content": "List 3 planets in JSON"}],
    "response_format": {"type": "json_schema"}
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issue with structured output not working for Anthropic models on Vertex AI.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable