### PR TITLE
fix: resolve duplicate error when adding first MCP server

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2404,8 +2404,9 @@ func (bifrost *Bifrost) AddMCPClient(config schemas.MCPClientConfig) error {
 	if bifrost.mcpManager == nil {
 		// Use sync.Once to ensure thread-safe initialization
 		bifrost.mcpInitOnce.Do(func() {
+			// Initialize with empty config - client will be added via AddClient below
 			bifrost.mcpManager = mcp.NewMCPManager(bifrost.ctx, schemas.MCPConfig{
-				ClientConfigs: []schemas.MCPClientConfig{config},
+				ClientConfigs: []schemas.MCPClientConfig{},
 			}, bifrost.logger)
 		})
 	}

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -8,3 +8,4 @@
   - add "none" option to ToolChoice.Type
   
 - fix: implement structured output handling for Anthropic models on Vertex where the beta structured-output header is unsupported
+- fix: duplicate error when adding first MCP server

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
 - fix: implement structured output handling for Anthropic models on Vertex where the beta structured-output header is unsupported
+- fix: duplicate error when adding first MCP server


### PR DESCRIPTION
## Summary

Fix a bug that caused duplicate error messages when adding the first MCP server to Bifrost.

## Changes

- Modified the MCP manager initialization in `AddMCPClient` to start with an empty client config list
- The client is now properly added via the `AddClient` method that's called after initialization
- This prevents duplicate client registration that was causing errors

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Configure a Bifrost instance with MCP
2. Add the first MCP server
3. Verify no duplicate error messages appear in logs

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issue with duplicate error messages when adding the first MCP server.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable