### PR TITLE
feat: replicate provider

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -122,6 +122,8 @@ jobs:
           VERTEX_CREDENTIALS: ${{ secrets.VERTEX_CREDENTIALS }}
           VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
           HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          REPLICATE_OWNER : ${{ secrets.REPLICATE_OWNER }}
         run: |
           echo "Running tests for PR #${{ github.event.pull_request.number || 'manual run' }}"
           ./.github/workflows/scripts/run-tests.sh

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -464,6 +464,8 @@ jobs:
           HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_BEDROCK_ROLE_ARN: ${{ secrets.AWS_BEDROCK_ROLE_ARN }}
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
         run: ./.github/workflows/scripts/release-core.sh "${{ needs.detect-changes.outputs.core-version }}"
 
   framework-release:
@@ -551,6 +553,8 @@ jobs:
           VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
         run: ./.github/workflows/scripts/release-framework.sh "${{ needs.detect-changes.outputs.framework-version }}"
 
   plugins-release:
@@ -648,6 +652,8 @@ jobs:
           VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
         run: ./.github/workflows/scripts/release-all-plugins.sh '${{ needs.detect-changes.outputs.changed-plugins }}'
 
   bifrost-http-release:
@@ -746,6 +752,8 @@ jobs:
           VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
+          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+          REPLICATE_OWNER: ${{ secrets.REPLICATE_OWNER }}
         run: ./.github/workflows/scripts/release-bifrost-http.sh "${{ needs.detect-changes.outputs.transport-version }}"
 
   # Docker build amd64

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -34,6 +34,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/openrouter"
 	"github.com/maximhq/bifrost/core/providers/parasail"
 	"github.com/maximhq/bifrost/core/providers/perplexity"
+	"github.com/maximhq/bifrost/core/providers/replicate"
 	"github.com/maximhq/bifrost/core/providers/sgl"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/providers/vertex"
@@ -3088,6 +3089,8 @@ func (bifrost *Bifrost) createBaseProvider(providerKey schemas.ModelProvider, co
 		return huggingface.NewHuggingFaceProvider(config, bifrost.logger), nil
 	case schemas.XAI:
 		return xai.NewXAIProvider(config, bifrost.logger)
+	case schemas.Replicate:
+		return replicate.NewReplicateProvider(config, bifrost.logger)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", targetProviderKey)
 	}
@@ -5374,6 +5377,11 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 				if len(key.VertexKeyConfig.Deployments) > 0 {
 					_, deploymentSupported = key.VertexKeyConfig.Deployments[model]
 				}
+			} else if baseProviderType == schemas.Replicate && key.ReplicateKeyConfig != nil {
+				// For Replicate, check if deployment exists for this model
+				if len(key.ReplicateKeyConfig.Deployments) > 0 {
+					_, deploymentSupported = key.ReplicateKeyConfig.Deployments[model]
+				}
 			}
 
 			if modelSupported && deploymentSupported {
@@ -5382,7 +5390,7 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 		}
 	}
 	if len(supportedKeys) == 0 {
-		if baseProviderType == schemas.Azure || baseProviderType == schemas.Bedrock || baseProviderType == schemas.Vertex {
+		if baseProviderType == schemas.Azure || baseProviderType == schemas.Bedrock || baseProviderType == schemas.Vertex || baseProviderType == schemas.Replicate {
 			return schemas.Key{}, fmt.Errorf("no keys found that support model/deployment: %s", model)
 		}
 		return schemas.Key{}, fmt.Errorf("no keys found that support model: %s", model)

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -8,3 +8,4 @@
 - fix: **Bedrock: Stop reason conversion** - Created dedicated Bedrock stop reason converter instead of reusing Anthropic's, properly handling Bedrock-specific reasons like `guardrail_intervened` and `content_filtered`
 - fix: **Bedrock: ToolChoice auto handling** - Return `nil` for `auto` tool choice (Bedrock's default) instead of failing
 - fix: **Bedrock: Stop reason mapping** - Now uses own `bedrockFinishReasonToBifrost` map with Bedrock-specific stop reasons (`guardrail_intervened` -> `content_filter`, `content_filtered` -> `content_filter`)
+feat: added support for replicate provider

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -142,6 +142,7 @@ func (account *ComprehensiveTestAccount) GetConfiguredProviders() ([]schemas.Mod
 		schemas.HuggingFace,
 		schemas.Nebius,
 		schemas.XAI,
+		schemas.Replicate,
 		ProviderOpenAICustom,
 	}, nil
 }
@@ -396,6 +397,15 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.XAI_API_KEY"),
+				Models:         []string{},
+				Weight:         1.0,
+				UseForBatchAPI: bifrost.Ptr(true),
+			},
+		}, nil
+	case schemas.Replicate:
+		return []schemas.Key{
+			{
+				Value:          *schemas.NewEnvVar("env.REPLICATE_API_KEY"),
 				Models:         []string{},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
@@ -676,6 +686,19 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
 				DefaultRequestTimeoutInSeconds: 120,
+				MaxRetries:                     10,
+				RetryBackoffInitial:            1 * time.Second,
+				RetryBackoffMax:                12 * time.Second,
+			},
+			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+				Concurrency: Concurrency,
+				BufferSize:  10,
+			},
+		}, nil
+	case schemas.Replicate:
+		return &schemas.ProviderConfig{
+			NetworkConfig: schemas.NetworkConfig{
+				DefaultRequestTimeoutInSeconds: 300,
 				MaxRetries:                     10,
 				RetryBackoffInitial:            1 * time.Second,
 				RetryBackoffMax:                12 * time.Second,
@@ -1255,6 +1278,34 @@ var AllProviderConfigs = []ComprehensiveTestConfig{
 			ImageVariation:        false, // XAI does not support image variation
 			ImageVariationStream:  false, // XAI does not support streaming image variation
 			ListModels:            true,
+		},
+	},
+	{
+		Provider:             schemas.Replicate,
+		ChatModel:            "openai/gpt-4.1-mini",
+		TextModel:            "openai/gpt-4.1-mini",
+		ImageGenerationModel: "black-forest-labs/flux-dev",
+		Scenarios: TestScenarios{
+			TextCompletion:        false, // Not typical
+			SimpleChat:            true,
+			CompletionStream:      true,
+			MultiTurnConversation: true,
+			ToolCalls:             true,
+			MultipleToolCalls:     true,
+			End2EndToolCalling:    true,
+			AutomaticFunctionCall: true,
+			ImageURL:              true,
+			ImageBase64:           true,
+			MultipleImages:        true,
+			CompleteEnd2End:       true,
+			SpeechSynthesis:       false, // Not supported
+			SpeechSynthesisStream: false, // Not supported
+			Transcription:         false, // Not supported
+			TranscriptionStream:   false, // Not supported
+			Embedding:             false, // Not supported
+			ListModels:            true,
+			ImageGeneration:       true,
+			ImageGenerationStream: false,
 		},
 	},
 }

--- a/core/internal/llmtests/batch.go
+++ b/core/internal/llmtests/batch.go
@@ -1028,8 +1028,9 @@ func RunFileContentTest(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 
 		response, err := WithFileContentTestRetry(t, fileContentRetryConfig, contentRetryContext, contentExpectations, "FileContent", func() (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
 			contentRequest := &schemas.BifrostFileContentRequest{
-				Provider: testConfig.Provider,
-				FileID:   uploadResponse.ID,
+				Provider:    testConfig.Provider,
+				FileID:      uploadResponse.ID,
+				ExtraParams: testConfig.FileExtraParams,
 			}
 			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 			return client.FileContentRequest(bfCtx, contentRequest)

--- a/core/providers/replicate/chat.go
+++ b/core/providers/replicate/chat.go
@@ -1,0 +1,315 @@
+package replicate
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// unsupportedSystemPromptModels is a set of models that don't support the system_prompt field.
+var unsupportedSystemPromptModels = []string{
+	"meta/meta-llama-3-8b",
+	"meta/llama-2-70b",
+	"openai/gpt-oss-20b",
+	"openai/o1-mini",
+	"xai/grok-4",
+}
+
+func ToReplicateChatRequest(bifrostReq *schemas.BifrostChatRequest) (*ReplicatePredictionRequest, error) {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil, fmt.Errorf("bifrost request is nil or input is nil")
+	}
+
+	// Build the input from messages
+	input := &ReplicatePredictionRequestInput{}
+
+	isGPT5Structured := strings.HasPrefix(bifrostReq.Model, string(schemas.OpenAI)) && strings.Contains(bifrostReq.Model, "gpt-5-structured")
+
+	// openai models support messages
+	if len(bifrostReq.Input) > 0 && strings.HasPrefix(bifrostReq.Model, string(schemas.OpenAI)) {
+		if isGPT5Structured {
+			responsesMessages := []schemas.ResponsesMessage{}
+			for _, msg := range bifrostReq.Input {
+				responsesMessages = append(responsesMessages, msg.ToResponsesMessages()...)
+			}
+			if len(responsesMessages) > 0 {
+				input.InputItemList = responsesMessages
+			}
+		} else {
+			input.Messages = bifrostReq.Input
+		}
+	} else {
+		// Extract system prompt and build conversation prompt
+		var systemPrompt string
+		var conversationParts []string
+		var imageInput []string
+
+		for _, msg := range bifrostReq.Input {
+			if msg.Content == nil {
+				continue
+			}
+
+			// Get message content as string
+			var contentStr string
+			if msg.Content.ContentStr != nil {
+				contentStr = *msg.Content.ContentStr
+			} else if msg.Content.ContentBlocks != nil {
+				// Concatenate text blocks only
+				var textParts []string
+				for _, block := range msg.Content.ContentBlocks {
+					if block.Text != nil && *block.Text != "" {
+						textParts = append(textParts, *block.Text)
+					}
+					if block.ImageURLStruct != nil && block.ImageURLStruct.URL != "" {
+						imageInput = append(imageInput, block.ImageURLStruct.URL)
+					}
+				}
+				contentStr = strings.Join(textParts, "\n")
+			}
+
+			if contentStr == "" {
+				continue
+			}
+
+			// Handle different roles
+			switch msg.Role {
+			case schemas.ChatMessageRoleSystem:
+				if systemPrompt == "" {
+					systemPrompt = contentStr
+				} else {
+					systemPrompt += "\n" + contentStr
+				}
+			case schemas.ChatMessageRoleUser:
+				conversationParts = append(conversationParts, contentStr)
+			case schemas.ChatMessageRoleAssistant:
+				// For assistant messages, we can include them in the conversation context
+				conversationParts = append(conversationParts, contentStr)
+			}
+		}
+
+		// Set system prompt if present and model supports it
+		modelSupportsSystemPrompt := supportsSystemPrompt(bifrostReq.Model)
+
+		if systemPrompt != "" {
+			if modelSupportsSystemPrompt {
+				// Model supports system_prompt field
+				input.SystemPrompt = &systemPrompt
+			} else {
+				// Model doesn't support system_prompt - prepend to prompt
+				if len(conversationParts) > 0 {
+					// Prepend system prompt to conversation
+					conversationParts = append([]string{systemPrompt}, conversationParts...)
+				} else {
+					// No conversation parts, use system prompt as the prompt
+					conversationParts = []string{systemPrompt}
+				}
+			}
+		}
+
+		// Build the final prompt from conversation parts
+		if len(conversationParts) > 0 {
+			prompt := strings.Join(conversationParts, "\n\n")
+			input.Prompt = &prompt
+		}
+
+		// Ensure we have at least some content (prompt or system prompt)
+		if input.Prompt == nil && input.SystemPrompt == nil {
+			return nil, fmt.Errorf("no content found in chat messages - need at least one user or system message")
+		}
+
+		if len(imageInput) > 0 {
+			input.ImageInput = imageInput
+		}
+	}
+
+	// Map parameters if present
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		// Temperature
+		if params.Temperature != nil {
+			input.Temperature = params.Temperature
+		}
+
+		// Top P
+		if params.TopP != nil {
+			input.TopP = params.TopP
+		}
+
+		// Max tokens - use max_completion_tokens if available
+		if params.MaxCompletionTokens != nil {
+			if isGPT5Structured {
+				input.MaxOutputTokens = params.MaxCompletionTokens
+			} else if strings.HasPrefix(bifrostReq.Model, string(schemas.OpenAI)) {
+				input.MaxCompletionTokens = params.MaxCompletionTokens
+			} else {
+				input.MaxTokens = params.MaxCompletionTokens
+			}
+		}
+
+		// Presence penalty
+		if params.PresencePenalty != nil {
+			input.PresencePenalty = params.PresencePenalty
+		}
+
+		// Frequency penalty
+		if params.FrequencyPenalty != nil {
+			input.FrequencyPenalty = params.FrequencyPenalty
+		}
+
+		// Seed
+		if params.Seed != nil {
+			input.Seed = params.Seed
+		}
+
+		if params.Reasoning != nil {
+			if params.Reasoning.Effort != nil {
+				input.ReasoningEffort = params.Reasoning.Effort
+			}
+		}
+
+		if isGPT5Structured {
+			if len(params.Tools) > 0 {
+				responsesTools := []schemas.ResponsesTool{}
+				for _, tool := range params.Tools {
+					responsesTools = append(responsesTools, *tool.ToResponsesTool())
+				}
+				if len(responsesTools) > 0 {
+					input.Tools = responsesTools
+				}
+			}
+		}
+
+		if params.ExtraParams != nil {
+			input.ExtraParams = params.ExtraParams
+		}
+	}
+
+	// Check if model is a version ID and set version field accordingly
+	req := &ReplicatePredictionRequest{
+		Input: input,
+	}
+
+	if isVersionID(bifrostReq.Model) {
+		req.Version = &bifrostReq.Model
+	}
+
+	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
+		if webhook, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["webhook"]); ok {
+			req.Webhook = webhook
+		}
+		if webhookEventsFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["webhook_events_filter"]); ok {
+			req.WebhookEventsFilter = webhookEventsFilter
+		}
+	}
+
+	return req, nil
+}
+
+// ToBifrostChatResponse converts a Replicate prediction response to Bifrost format
+func (response *ReplicatePredictionResponse) ToBifrostChatResponse() *schemas.BifrostChatResponse {
+	if response == nil {
+		return nil
+	}
+
+	// Parse timestamps
+	createdAt := ParseReplicateTimestamp(response.CreatedAt)
+	if createdAt == 0 {
+		createdAt = time.Now().Unix()
+	}
+
+	// Initialize Bifrost response
+	bifrostResponse := &schemas.BifrostChatResponse{
+		ID:      response.ID,
+		Model:   response.Model,
+		Object:  "chat.completion",
+		Created: int(createdAt),
+	}
+
+	// Convert output to content
+	var contentStr *string
+	if response.Output != nil {
+		if response.Output.OutputStr != nil {
+			contentStr = response.Output.OutputStr
+		} else if response.Output.OutputArray != nil {
+			// Join array of strings into a single string
+			joined := strings.Join(response.Output.OutputArray, "")
+			contentStr = &joined
+		} else if response.Output.OutputObject != nil && response.Output.OutputObject.Text != nil {
+			contentStr = response.Output.OutputObject.Text
+		}
+	}
+
+	// Create message content
+	messageContent := schemas.ChatMessageContent{
+		ContentStr: contentStr,
+	}
+
+	// Create the assistant message
+	message := schemas.ChatMessage{
+		Role:    schemas.ChatMessageRoleAssistant,
+		Content: &messageContent,
+	}
+
+	// Determine finish reason based on status
+	var finishReason *string
+	switch response.Status {
+	case ReplicatePredictionStatusSucceeded:
+		reason := "stop"
+		finishReason = &reason
+	case ReplicatePredictionStatusFailed:
+		reason := "error"
+		finishReason = &reason
+	case ReplicatePredictionStatusCanceled:
+		reason := "stop"
+		finishReason = &reason
+	}
+
+	// Create choice
+	choice := schemas.BifrostResponseChoice{
+		Index: 0,
+		ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+			Message: &message,
+		},
+		FinishReason: finishReason,
+	}
+
+	bifrostResponse.Choices = []schemas.BifrostResponseChoice{choice}
+
+	// Extract usage information from logs
+	if response.Logs != nil {
+		inputTokens, outputTokens, totalTokens, found := parseTokenUsageFromLogs(response.Logs, schemas.ChatCompletionRequest)
+		if found {
+			bifrostResponse.Usage = &schemas.BifrostLLMUsage{
+				PromptTokens:     inputTokens,
+				CompletionTokens: outputTokens,
+				TotalTokens:      totalTokens,
+			}
+		}
+	}
+
+	return bifrostResponse
+}
+
+// supportsSystemPrompt checks if a model supports the system_prompt field.
+func supportsSystemPrompt(model string) bool {
+	// Normalize model name to lowercase for comparison
+	modelLower := strings.ToLower(model)
+
+	// Extract model identifier (handle both "owner/name" and "owner/name:version" formats)
+	modelIdentifier := modelLower
+	if idx := strings.Index(modelLower, ":"); idx != -1 {
+		modelIdentifier = modelLower[:idx]
+	}
+
+	// All deepseek models don't support system prompt
+	if strings.HasPrefix(modelIdentifier, "deepseek-ai/deepseek") {
+		return false
+	}
+
+	isUnsupported := slices.Contains(unsupportedSystemPromptModels, modelIdentifier)
+	return !isUnsupported
+}

--- a/core/providers/replicate/errors.go
+++ b/core/providers/replicate/errors.go
@@ -1,0 +1,35 @@
+package replicate
+
+import (
+	"github.com/bytedance/sonic"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// parseReplicateError parses Replicate API error response
+func parseReplicateError(body []byte, statusCode int) *schemas.BifrostError {
+	var replicateErr ReplicateError
+	if err := sonic.Unmarshal(body, &replicateErr); err == nil && replicateErr.Detail != "" {
+		return &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &statusCode,
+			Error: &schemas.ErrorField{
+				Message: replicateErr.Detail,
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				Provider: schemas.Replicate,
+			},
+		}
+	}
+
+	// Fallback to generic error
+	return &schemas.BifrostError{
+		IsBifrostError: false,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Message: string(body),
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			Provider: schemas.Replicate,
+		},
+	}
+}

--- a/core/providers/replicate/files.go
+++ b/core/providers/replicate/files.go
@@ -1,0 +1,93 @@
+package replicate
+
+import (
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Replicate File API Converters
+
+// ToBifrostFileStatus converts Replicate file status to Bifrost file status.
+// Replicate doesn't explicitly provide status, so we infer from the response.
+func ToBifrostFileStatus(fileResp *ReplicateFileResponse) schemas.FileStatus {
+	// If file has all required fields and is accessible, it's processed
+	if fileResp.ID != "" && fileResp.Size > 0 {
+		return schemas.FileStatusProcessed
+	}
+	return schemas.FileStatusUploaded
+}
+
+// ToBifrostFileUploadResponse converts Replicate file response to Bifrost file upload response.
+func (r *ReplicateFileResponse) ToBifrostFileUploadResponse(providerName schemas.ModelProvider, latency time.Duration, sendBackRawRequest bool, sendBackRawResponse bool, rawRequest interface{}, rawResponse interface{}) *schemas.BifrostFileUploadResponse {
+	resp := &schemas.BifrostFileUploadResponse{
+		ID:             r.ID,
+		Object:         "file",
+		Bytes:          r.Size,
+		CreatedAt:      ParseReplicateTimestamp(r.CreatedAt),
+		Filename:       r.Name,
+		Purpose:        schemas.FilePurposeBatch, // Replicate uses files primarily for batch/general purposes
+		Status:         ToBifrostFileStatus(r),
+		StorageBackend: schemas.FileStorageAPI,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.FileUploadRequest,
+			Provider:    providerName,
+			Latency:     latency.Milliseconds(),
+		},
+	}
+
+	// Add ExpiresAt if present
+	if r.ExpiresAt != "" {
+		expiresAt := ParseReplicateTimestamp(r.ExpiresAt)
+		if expiresAt > 0 {
+			resp.ExpiresAt = &expiresAt
+		}
+	}
+
+	if sendBackRawRequest {
+		resp.ExtraFields.RawRequest = rawRequest
+	}
+
+	if sendBackRawResponse {
+		resp.ExtraFields.RawResponse = rawResponse
+	}
+
+	return resp
+}
+
+// ToBifrostFileRetrieveResponse converts Replicate file response to Bifrost file retrieve response.
+func (r *ReplicateFileResponse) ToBifrostFileRetrieveResponse(providerName schemas.ModelProvider, latency time.Duration, sendBackRawRequest bool, sendBackRawResponse bool, rawRequest interface{}, rawResponse interface{}) *schemas.BifrostFileRetrieveResponse {
+	resp := &schemas.BifrostFileRetrieveResponse{
+		ID:             r.ID,
+		Object:         "file",
+		Bytes:          r.Size,
+		CreatedAt:      ParseReplicateTimestamp(r.CreatedAt),
+		Filename:       r.Name,
+		Purpose:        schemas.FilePurposeBatch,
+		Status:         ToBifrostFileStatus(r),
+		StorageBackend: schemas.FileStorageAPI,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.FileRetrieveRequest,
+			Provider:    providerName,
+			Latency:     latency.Milliseconds(),
+		},
+	}
+
+	// Add ExpiresAt if present
+	if r.ExpiresAt != "" {
+		expiresAt := ParseReplicateTimestamp(r.ExpiresAt)
+		if expiresAt > 0 {
+			resp.ExpiresAt = &expiresAt
+		}
+	}
+
+	if sendBackRawRequest {
+		resp.ExtraFields.RawRequest = rawRequest
+	}
+
+	if sendBackRawResponse {
+		resp.ExtraFields.RawResponse = rawResponse
+	}
+
+	return resp
+}

--- a/core/providers/replicate/images.go
+++ b/core/providers/replicate/images.go
@@ -1,0 +1,299 @@
+package replicate
+
+import (
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// modelInputImageFieldMap maps model identifiers to their input image field names.
+var modelInputImageFieldMap = map[string]string{
+	// image_prompt models
+	"black-forest-labs/flux-1.1-pro":                 "image_prompt",
+	"black-forest-labs/flux-1.1-pro-ultra":           "image_prompt",
+	"black-forest-labs/flux-pro":                     "image_prompt",
+	"black-forest-labs/flux-1.1-pro-ultra-finetuned": "image_prompt",
+
+	// input_image models (kontext variants)
+	"black-forest-labs/flux-kontext-pro": "input_image",
+	"black-forest-labs/flux-kontext-max": "input_image",
+	"black-forest-labs/flux-kontext-dev": "input_image",
+
+	// image models
+	"black-forest-labs/flux-dev":      "image",
+	"black-forest-labs/flux-fill-pro": "image",
+	"black-forest-labs/flux-dev-lora": "image",
+	"black-forest-labs/flux-krea-dev": "image",
+}
+
+// ToReplicateImageGenerationInput converts a Bifrost image generation request to Replicate prediction input
+func ToReplicateImageGenerationInput(bifrostReq *schemas.BifrostImageGenerationRequest) *ReplicatePredictionRequest {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil
+	}
+
+	input := &ReplicatePredictionRequestInput{
+		Prompt: &bifrostReq.Input.Prompt,
+	}
+
+	// Map parameters if available
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		// Map InputImages to the appropriate field based on model
+		if len(params.InputImages) > 0 {
+			fieldName := getInputImageFieldName(bifrostReq.Model)
+
+			switch fieldName {
+			case "image_prompt":
+				// For flux-1.1-pro variants: use first image as image_prompt
+				input.ImagePrompt = &params.InputImages[0]
+
+			case "input_image":
+				// For flux-kontext variants: add to ExtraParams as input_image
+				input.InputImage = &params.InputImages[0]
+
+			case "image":
+				// For flux-dev variants: use first image as image field
+				input.Image = &params.InputImages[0]
+
+			case "input_images":
+				// For all other models: use input_images array
+				input.InputImages = params.InputImages
+			}
+		}
+
+		if bifrostReq.Params.N != nil {
+			input.NumberOfImages = bifrostReq.Params.N
+		}
+
+		if params.AspectRatio != nil {
+			input.AspectRatio = params.AspectRatio
+		}
+
+		if params.Resolution != nil {
+			input.Resolution = params.Resolution
+		}
+
+		// Map OutputFormat
+		if params.OutputFormat != nil {
+			input.OutputFormat = params.OutputFormat
+		}
+
+		if params.Quality != nil {
+			input.Quality = params.Quality
+		}
+
+		if params.Background != nil {
+			input.Background = params.Background
+		}
+
+		// Map Seed
+		if params.Seed != nil {
+			input.Seed = params.Seed
+		}
+
+		// Map NegativePrompt
+		if params.NegativePrompt != nil {
+			input.NegativePrompt = params.NegativePrompt
+		}
+
+		// Map NumInferenceSteps
+		if params.NumInferenceSteps != nil {
+			input.NumInferenceStep = params.NumInferenceSteps
+		}
+
+		if params.ExtraParams != nil {
+			input.ExtraParams = params.ExtraParams
+		}
+	}
+
+	request := &ReplicatePredictionRequest{
+		Input: input,
+	}
+
+	// Check if model is a version ID and set version field accordingly
+	if isVersionID(bifrostReq.Model) {
+		request.Version = &bifrostReq.Model
+	}
+
+	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
+		if webhook, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["webhook"]); ok {
+			request.Webhook = webhook
+		}
+		if webhookEventsFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["webhook_events_filter"]); ok {
+			request.WebhookEventsFilter = webhookEventsFilter
+		}
+	}
+
+	return request
+}
+
+// ToBifrostImageGenerationResponse converts a Replicate prediction response to Bifrost format
+func ToBifrostImageGenerationResponse(
+	prediction *ReplicatePredictionResponse,
+) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	if prediction == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: "prediction response is nil",
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				Provider: schemas.Replicate,
+			},
+		}
+	}
+
+	response := &schemas.BifrostImageGenerationResponse{
+		ID:      prediction.ID,
+		Created: ParseReplicateTimestamp(prediction.CreatedAt),
+		Model:   prediction.Model,
+		Data:    []schemas.ImageData{},
+	}
+
+	// Convert output to ImageData
+	// Replicate output can be either a string (single URL) or array of strings
+	if prediction.Output != nil {
+		if prediction.Output.OutputStr != nil && *prediction.Output.OutputStr != "" {
+			response.Data = append(response.Data, schemas.ImageData{
+				URL:   *prediction.Output.OutputStr,
+				Index: 0,
+			})
+		} else if len(prediction.Output.OutputArray) > 0 {
+			for i, url := range prediction.Output.OutputArray {
+				response.Data = append(response.Data, schemas.ImageData{
+					URL:   url,
+					Index: i,
+				})
+			}
+		}
+	}
+
+	// Extract usage information from logs
+	if prediction.Logs != nil {
+		inputTokens, outputTokens, totalTokens, found := parseTokenUsageFromLogs(prediction.Logs, schemas.ImageGenerationRequest)
+		if found {
+			response.Usage = &schemas.ImageUsage{
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
+				TotalTokens:  totalTokens,
+			}
+		}
+	}
+
+	return response, nil
+}
+
+// getInputImageFieldName returns the appropriate input image field name based on the model.
+// Uses O(1) map lookup for high RPS performance.
+func getInputImageFieldName(model string) string {
+	// Normalize model name to lowercase for comparison
+	modelLower := strings.ToLower(model)
+
+	// Extract model identifier (handle both "owner/name" and "owner/name:version" formats)
+	modelIdentifier := modelLower
+	if before, _, ok := strings.Cut(modelLower, ":"); ok {
+		modelIdentifier = before
+	}
+
+	if fieldName, exists := modelInputImageFieldMap[modelIdentifier]; exists {
+		return fieldName
+	}
+
+	// Default to input_images for all other models
+	return "input_images"
+}
+
+// ToReplicateImageEditInput converts a Bifrost image edit request to Replicate prediction input
+func ToReplicateImageEditInput(bifrostReq *schemas.BifrostImageEditRequest) *ReplicatePredictionRequest {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil
+	}
+
+	input := &ReplicatePredictionRequestInput{
+		Prompt: &bifrostReq.Input.Prompt,
+	}
+
+	// Map image URLs - Replicate requires image URLs, not file bytes
+	if len(bifrostReq.Input.Images) > 0 {
+		images := make([]string, 0, len(bifrostReq.Input.Images))
+		for _, img := range bifrostReq.Input.Images {
+			if len(img.Image) > 0 {
+				images = append(images, providerUtils.FileBytesToBase64DataURL(img.Image))
+			}
+		}
+
+		if len(images) > 0 {
+			// Determine the appropriate field based on model
+			fieldName := getInputImageFieldName(bifrostReq.Model)
+
+			switch fieldName {
+			case "image_prompt":
+				// For flux-1.1-pro variants: use first image as image_prompt
+				input.ImagePrompt = &images[0]
+
+			case "input_image":
+				// For flux-kontext variants: use first image as input_image
+				input.InputImage = &images[0]
+
+			case "image":
+				// For flux-dev variants: use first image as image field
+				input.Image = &images[0]
+
+			case "input_images":
+				// For all other models: use input_images array
+				input.InputImages = images
+			}
+		}
+	}
+
+	// Map parameters if available
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		if params.N != nil {
+			input.NumberOfImages = params.N
+		}
+
+		if params.OutputFormat != nil {
+			input.OutputFormat = params.OutputFormat
+		}
+
+		if params.Quality != nil {
+			input.Quality = params.Quality
+		}
+
+		if params.Background != nil {
+			input.Background = params.Background
+		}
+
+		if params.Seed != nil {
+			input.Seed = params.Seed
+		}
+
+		if params.NegativePrompt != nil {
+			input.NegativePrompt = params.NegativePrompt
+		}
+
+		if params.NumInferenceSteps != nil {
+			input.NumInferenceStep = params.NumInferenceSteps
+		}
+
+		if params.ExtraParams != nil {
+			input.ExtraParams = params.ExtraParams
+		}
+	}
+
+	request := &ReplicatePredictionRequest{
+		Input: input,
+	}
+
+	// Check if model is a version ID and set version field accordingly
+	if isVersionID(bifrostReq.Model) {
+		request.Version = &bifrostReq.Model
+	}
+
+	return request
+}

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -1,0 +1,3171 @@
+// Package providers implements various LLM providers and their utility functions.
+// This file contains the replicate provider implementation.
+package replicate
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// ReplicateProvider implements the Provider interface for Replicate's API.
+type ReplicateProvider struct {
+	logger               schemas.Logger        // Logger for provider operations
+	client               *fasthttp.Client      // HTTP client for API requests
+	networkConfig        schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest   bool                  // Whether to include raw request in BifrostResponse
+	sendBackRawResponse  bool                  // Whether to include raw response in BifrostResponse
+	customProviderConfig *schemas.CustomProviderConfig
+}
+
+// NewReplicateProvider creates a new Replicate provider instance.
+// It initializes the HTTP client with the provided configuration and sets up response pools.
+// The client is configured with timeouts, concurrency limits, and optional proxy settings.
+func NewReplicateProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*ReplicateProvider, error) {
+	config.CheckAndSetDefaults()
+
+	client := &fasthttp.Client{
+		ReadTimeout:         time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
+		WriteTimeout:        time.Second * time.Duration(config.NetworkConfig.DefaultRequestTimeoutInSeconds),
+		MaxConnsPerHost:     5000,
+		MaxIdleConnDuration: 60 * time.Second,
+		MaxConnWaitTimeout:  10 * time.Second,
+	}
+
+	// Configure proxy if provided
+	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
+
+	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+
+	if config.NetworkConfig.BaseURL == "" {
+		config.NetworkConfig.BaseURL = replicateAPIBaseURL
+	}
+
+	return &ReplicateProvider{
+		logger:               logger,
+		client:               client,
+		networkConfig:        config.NetworkConfig,
+		sendBackRawRequest:   config.SendBackRawRequest,
+		sendBackRawResponse:  config.SendBackRawResponse,
+		customProviderConfig: config.CustomProviderConfig,
+	}, nil
+}
+
+// GetProviderKey returns the provider identifier for Replicate.
+func (provider *ReplicateProvider) GetProviderKey() schemas.ModelProvider {
+	return schemas.Replicate
+}
+
+// buildRequestURL builds the request URL with custom provider config support
+func (provider *ReplicateProvider) buildRequestURL(ctx *schemas.BifrostContext, defaultPath string, requestType schemas.RequestType) string {
+	path, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	if isCompleteURL {
+		return path
+	}
+	return provider.networkConfig.BaseURL + path
+}
+
+const (
+	replicateAPIBaseURL = "https://api.replicate.com"
+	pollingInterval     = 2 * time.Second
+)
+
+// createPrediction creates a new prediction on Replicate API
+// Supports both sync (with Prefer: wait header) and async modes
+// stripPrefer should be true for streaming requests to exclude the Prefer header
+func createPrediction(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	jsonBody []byte,
+	key schemas.Key,
+	url string,
+	extraHeaders map[string]string,
+	stripPrefer bool,
+	logger schemas.Logger,
+	sendBackRawRequest bool,
+	sendBackRawResponse bool,
+) (*ReplicatePredictionResponse, interface{}, time.Duration, *schemas.BifrostError) {
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set URL
+	req.SetRequestURI(url)
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+
+	// Set authorization header
+	if value := key.Value.GetValue(); value != "" {
+		req.Header.Set("Authorization", "Bearer "+value)
+	}
+
+	// Set any extra headers from network config
+	// Strip Prefer header for streaming requests to ensure async mode
+	headersToUse := extraHeaders
+	if stripPrefer {
+		headersToUse = stripPreferHeader(extraHeaders)
+	}
+	providerUtils.SetExtraHeaders(ctx, req, headersToUse, nil)
+
+	req.SetBody(jsonBody)
+
+	// Make request
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
+	if bifrostErr != nil {
+		return nil, nil, latency, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK && resp.StatusCode() != fasthttp.StatusCreated {
+		logger.Debug(fmt.Sprintf("error from replicate provider: %s", string(resp.Body())))
+		return nil, nil, latency, parseReplicateError(resp.Body(), resp.StatusCode())
+	}
+
+	// Parse response
+	body, decodeErr := providerUtils.CheckAndDecodeBody(resp)
+	if decodeErr != nil {
+		return nil, nil, latency, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, decodeErr, schemas.Replicate)
+	}
+
+	var prediction ReplicatePredictionResponse
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &prediction, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, sendBackRawResponse))
+	if bifrostErr != nil {
+		return nil, nil, latency, bifrostErr
+	}
+
+	return &prediction, rawResponse, latency, nil
+}
+
+// getPrediction retrieves the current state of a prediction
+func getPrediction(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	predictionURL string,
+	key schemas.Key,
+	logger schemas.Logger,
+	sendBackRawResponse bool,
+) (*ReplicatePredictionResponse, interface{}, *schemas.BifrostError) {
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set URL
+	req.SetRequestURI(predictionURL)
+	req.Header.SetMethod(http.MethodGet)
+
+	// Set authorization header
+	if value := key.Value.GetValue(); value != "" {
+		req.Header.Set("Authorization", "Bearer "+value)
+	}
+
+	// Make request
+	_, bifrostErr := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
+	if bifrostErr != nil {
+		return nil, nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		logger.Debug(fmt.Sprintf("error from replicate provider: %s", string(resp.Body())))
+		return nil, nil, parseReplicateError(resp.Body(), resp.StatusCode())
+	}
+
+	// Parse response
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, schemas.Replicate)
+	}
+
+	prediction := &ReplicatePredictionResponse{}
+	_, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, prediction, nil, false, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, nil, bifrostErr
+	}
+
+	return prediction, rawResponse, nil
+}
+
+// pollPrediction polls a prediction URL until it reaches a terminal state or timeout
+func pollPrediction(
+	ctx *schemas.BifrostContext,
+	client *fasthttp.Client,
+	predictionURL string,
+	key schemas.Key,
+	timeoutSeconds int,
+	logger schemas.Logger,
+	sendBackRawResponse bool,
+) (*ReplicatePredictionResponse, interface{}, *schemas.BifrostError) {
+	// Create context with timeout
+	pollCtx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSeconds)*time.Second)
+	defer cancel()
+
+	ticker := time.NewTicker(pollingInterval)
+	defer ticker.Stop()
+
+	// Poll immediately first time
+	prediction, rawResponse, err := getPrediction(ctx, client, predictionURL, key, logger, sendBackRawResponse)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// If already in terminal state, return immediately
+	if isTerminalStatus(prediction.Status) {
+		return prediction, rawResponse, checkForErrorStatus(prediction)
+	}
+
+	logger.Debug(fmt.Sprintf("polling replicate prediction %s, status: %s", prediction.ID, prediction.Status))
+
+	// Continue polling until terminal state or timeout
+	for {
+		select {
+		case <-pollCtx.Done():
+			return nil, nil, providerUtils.NewBifrostOperationError(
+				schemas.ErrProviderRequestTimedOut,
+				fmt.Errorf("prediction polling timed out after %d seconds", timeoutSeconds),
+				schemas.Replicate,
+			)
+		case <-ticker.C:
+			prediction, rawResponse, err = getPrediction(ctx, client, predictionURL, key, logger, sendBackRawResponse)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			logger.Debug(fmt.Sprintf("prediction %s status: %s", prediction.ID, prediction.Status))
+
+			if isTerminalStatus(prediction.Status) {
+				return prediction, rawResponse, checkForErrorStatus(prediction)
+			}
+		}
+	}
+}
+
+// listDeploymentsByKey performs a list deployments request for a single key.
+// Deployments are account-specific, so this needs to be called per key.
+func (provider *ReplicateProvider) listDeploymentsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	providerName := provider.GetProviderKey()
+	client := provider.client
+	extraHeaders := provider.networkConfig.ExtraHeaders
+
+	// Build deployments URL
+	deploymentsURL := provider.buildRequestURL(ctx, "/v1/deployments", schemas.ListModelsRequest)
+
+	// Initialize pagination variables
+	currentURL := deploymentsURL
+	allDeployments := []ReplicateDeployment{}
+
+	// Follow pagination until there are no more pages
+	for currentURL != "" {
+		// Create request
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+
+		// Set up request
+		req.SetRequestURI(currentURL)
+		req.Header.SetMethod(http.MethodGet)
+		req.Header.SetContentType("application/json")
+
+		// Set authorization header if key is provided
+		if key.Value.GetValue() != "" {
+			req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+		}
+
+		// Set extra headers from network config
+		providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
+
+		// Make request
+		_, bifrostErr := providerUtils.MakeRequestWithContext(ctx, client, req, resp)
+
+		// Release resources
+		fasthttp.ReleaseRequest(req)
+
+		if bifrostErr != nil {
+			fasthttp.ReleaseResponse(resp)
+			return nil, bifrostErr
+		}
+
+		// Handle error response
+		if resp.StatusCode() != fasthttp.StatusOK {
+			errorResponse := parseReplicateError(resp.Body(), resp.StatusCode())
+			fasthttp.ReleaseResponse(resp)
+			return nil, errorResponse
+		}
+
+		// Make a copy of the response body before releasing
+		bodyCopy := make([]byte, len(resp.Body()))
+		copy(bodyCopy, resp.Body())
+
+		fasthttp.ReleaseResponse(resp)
+
+		// Parse response from the copy
+		var pageResponse ReplicateDeploymentListResponse
+		if err := sonic.Unmarshal(bodyCopy, &pageResponse); err != nil {
+			return nil, providerUtils.NewBifrostOperationError(
+				"failed to parse deployments response",
+				err,
+				schemas.Replicate,
+			)
+		}
+
+		// Append results from this page
+		allDeployments = append(allDeployments, pageResponse.Results...)
+
+		// Check if there's a next page
+		if pageResponse.Next != nil && *pageResponse.Next != "" {
+			currentURL = *pageResponse.Next
+		} else {
+			currentURL = ""
+		}
+	}
+
+	// Wrap deployments in response structure
+	deploymentsResponse := &ReplicateDeploymentListResponse{
+		Results: allDeployments,
+	}
+
+	// Convert deployments to Bifrost response (no public models here)
+	response := ToBifrostListModelsResponse(
+		deploymentsResponse,
+		providerName,
+	)
+
+	return response, nil
+}
+
+// ListModels performs a list models request to Replicate's API.
+func (provider *ReplicateProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ListModelsRequest); err != nil {
+		return nil, err
+	}
+
+	if provider.networkConfig.BaseURL == "" {
+		return nil, providerUtils.NewConfigurationError("base_url is not set", provider.GetProviderKey())
+	}
+
+	startTime := time.Now()
+	providerName := provider.GetProviderKey()
+
+	deploymentsResponse, err := providerUtils.HandleMultipleListModelsRequests(
+		ctx,
+		keys,
+		request,
+		provider.listDeploymentsByKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply pagination to the combined results
+	response := &schemas.BifrostListModelsResponse{
+		Data: deploymentsResponse.Data,
+	}
+
+	response = response.ApplyPagination(request.PageSize, request.PageToken)
+
+	// Set metadata
+	latency := time.Since(startTime)
+	response.ExtraFields.Provider = providerName
+	response.ExtraFields.RequestType = schemas.ListModelsRequest
+	response.ExtraFields.Latency = latency.Milliseconds()
+
+	return response, nil
+}
+
+// TextCompletion performs a text completion request to the replicate API.
+func (provider *ReplicateProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.TextCompletionRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// build replicate request
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) { return ToReplicateTextRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Check for Prefer: wait header from context for sync mode
+	isSync := parsePreferHeader(provider.networkConfig.ExtraHeaders)
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.TextCompletionRequest,
+		isDeployment,
+	)
+
+	// create prediction
+	prediction, rawResponse, latency, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		false,
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// if not sync, poll until done
+	if !isSync && !isTerminalStatus(prediction.Status) {
+		prediction, rawResponse, err = pollPrediction(
+			ctx,
+			provider.client,
+			prediction.URLs.Get,
+			key,
+			provider.networkConfig.DefaultRequestTimeoutInSeconds,
+			provider.logger,
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		)
+		if err != nil {
+			return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+	}
+
+	// Check for terminal error status (failed/canceled) after sync mode or polling
+	if err := checkForErrorStatus(prediction); err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response
+	bifrostResponse := prediction.ToBifrostTextCompletionResponse()
+
+	// Set extra fields
+	bifrostResponse.ExtraFields.Provider = schemas.Replicate
+	bifrostResponse.ExtraFields.RequestType = schemas.TextCompletionRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
+// TextCompletionStream performs a streaming text completion request to replicate's API.
+// It formats the request, sends it to replicate, and processes the response.
+// Returns a channel of BifrostStream objects or an error if the request fails.
+func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.TextCompletionStreamRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Convert Bifrost request to Replicate format with streaming enabled
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			replicateReq, err := ToReplicateTextRequest(request)
+			if err != nil {
+				return nil, err
+			}
+			replicateReq.Stream = schemas.Ptr(true)
+			return replicateReq, nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.TextCompletionStreamRequest,
+		isDeployment,
+	)
+
+	// Create prediction
+	prediction, _, _, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		true, // Streaming request, strip Prefer header for async mode
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Verify stream URL is available
+	if prediction.URLs == nil || prediction.URLs.Stream == nil || *prediction.URLs.Stream == "" {
+		bifrostErr := providerUtils.NewBifrostOperationError(
+			"stream URL not available in prediction response",
+			fmt.Errorf("prediction response missing stream URL"),
+			provider.GetProviderKey(),
+		)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	streamURL := *prediction.URLs.Stream
+
+	// Connect to stream URL
+	bodyStream, resp, bifrostErr := listenToReplicateStreamURL(provider.client, streamURL, key)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.TextCompletionStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.TextCompletionStreamRequest, provider.logger)
+			}
+			close(responseChan)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+
+		// Setup cancellation handler
+		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+		defer stopCancellation()
+
+		startTime := time.Now()
+		lastChunkTime := startTime
+		chunkIndex := 0
+
+		// Setup scanner to read SSE stream
+		scanner := bufio.NewScanner(bodyStream)
+		buf := make([]byte, 0, 1024*1024)
+		scanner.Buffer(buf, 10*1024*1024)
+
+		var currentEvent ReplicateSSEEvent
+		messageID := prediction.ID
+
+		for scanner.Scan() {
+			// Check for context cancellation
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line := scanner.Text()
+
+			// Skip comment lines
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+
+			// Empty line indicates end of event
+			if line == "" {
+				if currentEvent.Event == "" && currentEvent.Data == "" {
+					continue
+				}
+
+				// Process the complete event
+				switch currentEvent.Event {
+				case "output":
+					// Accumulate content from data field
+					if currentEvent.Data != "" {
+						// Create a streaming chunk with text completion response
+						text := currentEvent.Data
+						response := &schemas.BifrostTextCompletionResponse{
+							ID:     messageID,
+							Model:  request.Model,
+							Object: "text_completion",
+							Choices: []schemas.BifrostResponseChoice{
+								{
+									Index: 0,
+									TextCompletionResponseChoice: &schemas.TextCompletionResponseChoice{
+										Text: &text,
+									},
+								},
+							},
+							ExtraFields: schemas.BifrostResponseExtraFields{
+								RequestType:    schemas.TextCompletionStreamRequest,
+								Provider:       provider.GetProviderKey(),
+								ModelRequested: request.Model,
+								ChunkIndex:     chunkIndex,
+								Latency:        time.Since(lastChunkTime).Milliseconds(),
+							},
+						}
+
+						// Set raw response if enabled (per-chunk event as JSON string)
+						if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+							if eventJSON, err := sonic.Marshal(currentEvent); err == nil {
+								response.ExtraFields.RawResponse = string(eventJSON)
+							}
+						}
+
+						lastChunkTime = time.Now()
+						chunkIndex++
+
+						providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+							providerUtils.GetBifrostResponseForStreamResponse(response, nil, nil, nil, nil, nil),
+							responseChan)
+					}
+
+				case "done":
+					// Parse done event data
+					var doneData ReplicateDoneEvent
+					if currentEvent.Data != "" && currentEvent.Data != "{}" {
+						if err := sonic.Unmarshal([]byte(currentEvent.Data), &doneData); err != nil {
+							provider.logger.Warn(fmt.Sprintf("Failed to parse done event data: %v", err))
+						}
+					}
+
+					// Check for cancellation or error
+					switch doneData.Reason {
+					case "canceled":
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							"prediction was canceled",
+							fmt.Errorf("stream ended: prediction canceled"),
+							provider.GetProviderKey(),
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       provider.GetProviderKey(),
+							ModelRequested: request.Model,
+							RequestType:    schemas.TextCompletionStreamRequest,
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						enrichedErr := providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+						// Explicitly close the body stream to terminate connection to Replicate
+						resp.CloseBodyStream()
+						return
+
+					case "error":
+						errorMsg := "prediction failed"
+						if doneData.Output != nil {
+							errorMsg = fmt.Sprintf("prediction failed: %v", doneData.Output)
+						}
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							errorMsg,
+							fmt.Errorf("stream ended with error"),
+							provider.GetProviderKey(),
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       provider.GetProviderKey(),
+							ModelRequested: request.Model,
+							RequestType:    schemas.TextCompletionStreamRequest,
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						enrichedErr := providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+						// Explicitly close the body stream to terminate connection to Replicate
+						resp.CloseBodyStream()
+						return
+					}
+
+					// Send final chunk with finish reason
+					finishReason := schemas.Ptr("stop")
+					finalResponse := providerUtils.CreateBifrostTextCompletionChunkResponse(
+						messageID,
+						nil, // usage - not available in done event
+						finishReason,
+						chunkIndex,
+						schemas.TextCompletionStreamRequest,
+						provider.GetProviderKey(),
+						request.Model,
+					)
+
+					// Set raw request if enabled
+					if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+						providerUtils.ParseAndSetRawRequest(&finalResponse.ExtraFields, jsonData)
+					}
+
+					finalResponse.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+						providerUtils.GetBifrostResponseForStreamResponse(finalResponse, nil, nil, nil, nil, nil),
+						responseChan)
+					resp.CloseBodyStream()
+					return
+				}
+
+				// Reset event for next one
+				currentEvent = ReplicateSSEEvent{}
+				continue
+			}
+
+			// Parse SSE fields
+			if after, ok := strings.CutPrefix(line, "event: "); ok {
+				currentEvent.Event = strings.TrimSpace(after)
+			} else if after, ok := strings.CutPrefix(line, "data: "); ok {
+				// For multiline data, append with newline
+				if currentEvent.Data != "" {
+					currentEvent.Data += "\n"
+				}
+				currentEvent.Data += after
+			} else if after, ok := strings.CutPrefix(line, "id: "); ok {
+				currentEvent.ID = strings.TrimSpace(after)
+			}
+		}
+
+		// Handle scanner errors
+		if err := scanner.Err(); err != nil {
+			// If context was cancelled/timed out, let defer handle it
+			if ctx.Err() != nil {
+				return
+			}
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			provider.logger.Warn("Error reading stream: %v", err)
+			enrichedErr := providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey()), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+			return
+		}
+	}()
+
+	return responseChan, nil
+}
+
+// ChatCompletion performs a chat completion request to the replicate API.
+func (provider *ReplicateProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// build replicate request
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) { return ToReplicateChatRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Check for Prefer: wait header from context for sync mode
+	isSync := parsePreferHeader(provider.networkConfig.ExtraHeaders)
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ChatCompletionRequest,
+		isDeployment,
+	)
+
+	// create prediction
+	prediction, rawResponse, latency, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		false,
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// if not sync, poll until done
+	if !isSync && !isTerminalStatus(prediction.Status) {
+		prediction, rawResponse, err = pollPrediction(
+			ctx,
+			provider.client,
+			prediction.URLs.Get,
+			key,
+			provider.networkConfig.DefaultRequestTimeoutInSeconds,
+			provider.logger,
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		)
+		if err != nil {
+			return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+	}
+
+	// Check for terminal error status (failed/canceled) after sync mode or polling
+	if err := checkForErrorStatus(prediction); err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response
+	bifrostResponse := prediction.ToBifrostChatResponse()
+
+	// Set extra fields
+	bifrostResponse.ExtraFields.Provider = schemas.Replicate
+	bifrostResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
+// ChatCompletionStream performs a streaming chat completion request to the replicate API.
+// It supports real-time streaming of responses using Server-Sent Events (SSE).
+// Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
+func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Convert Bifrost request to Replicate format with streaming enabled
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			replicateReq, err := ToReplicateChatRequest(request)
+			if err != nil {
+				return nil, err
+			}
+			replicateReq.Stream = schemas.Ptr(true)
+			return replicateReq, nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ChatCompletionStreamRequest,
+		isDeployment,
+	)
+
+	// Create prediction
+	prediction, _, _, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		true,
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Verify stream URL is available
+	if prediction.URLs == nil || prediction.URLs.Stream == nil || *prediction.URLs.Stream == "" {
+		bifrostErr := providerUtils.NewBifrostOperationError(
+			"stream URL not available in prediction response",
+			fmt.Errorf("prediction response missing stream URL"),
+			provider.GetProviderKey(),
+		)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	streamURL := *prediction.URLs.Stream
+
+	// Connect to stream URL
+	bodyStream, resp, bifrostErr := listenToReplicateStreamURL(provider.client, streamURL, key)
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ChatCompletionStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ChatCompletionStreamRequest, provider.logger)
+			}
+			close(responseChan)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+
+		// Setup cancellation handler
+		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+		defer stopCancellation()
+
+		startTime := time.Now()
+		lastChunkTime := startTime
+		chunkIndex := 0
+
+		// Setup scanner to read SSE stream
+		scanner := bufio.NewScanner(bodyStream)
+		buf := make([]byte, 0, 1024*1024)
+		scanner.Buffer(buf, 10*1024*1024)
+
+		var currentEvent ReplicateSSEEvent
+		messageID := prediction.ID
+
+		for scanner.Scan() {
+			// Check for context cancellation
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line := scanner.Text()
+
+			// Skip comment lines
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+
+			// Empty line indicates end of event
+			if line == "" {
+				if currentEvent.Event == "" && currentEvent.Data == "" {
+					continue
+				}
+
+				// Process the complete event
+				switch currentEvent.Event {
+				case "output":
+					// Accumulate content from data field
+					if currentEvent.Data != "" {
+						// Create a streaming chunk
+						content := currentEvent.Data
+						role := string(schemas.ChatMessageRoleAssistant)
+						delta := &schemas.ChatStreamResponseChoiceDelta{
+							Content: &content,
+							Role:    &role,
+						}
+
+						response := &schemas.BifrostChatResponse{
+							ID:      messageID,
+							Model:   request.Model,
+							Object:  "chat.completion.chunk",
+							Created: int(time.Now().Unix()),
+							Choices: []schemas.BifrostResponseChoice{
+								{
+									Index: 0,
+									ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+										Delta: delta,
+									},
+								},
+							},
+							ExtraFields: schemas.BifrostResponseExtraFields{
+								RequestType:    schemas.ChatCompletionStreamRequest,
+								Provider:       provider.GetProviderKey(),
+								ModelRequested: request.Model,
+								ChunkIndex:     chunkIndex,
+								Latency:        time.Since(lastChunkTime).Milliseconds(),
+							},
+						}
+
+						// Set raw response if enabled (per-chunk event as JSON string)
+						if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+							if eventJSON, err := sonic.Marshal(currentEvent); err == nil {
+								response.ExtraFields.RawResponse = string(eventJSON)
+							}
+						}
+
+						lastChunkTime = time.Now()
+						chunkIndex++
+
+						providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+							providerUtils.GetBifrostResponseForStreamResponse(nil, response, nil, nil, nil, nil),
+							responseChan)
+					}
+
+				case "done":
+					// Parse done event data
+					var doneData ReplicateDoneEvent
+					if currentEvent.Data != "" && currentEvent.Data != "{}" {
+						if err := sonic.Unmarshal([]byte(currentEvent.Data), &doneData); err != nil {
+							provider.logger.Warn(fmt.Sprintf("Failed to parse done event data: %v", err))
+						}
+					}
+
+					// Check for cancellation or error
+					switch doneData.Reason {
+					case "canceled":
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							"prediction was canceled",
+							fmt.Errorf("stream ended: prediction canceled"),
+							provider.GetProviderKey(),
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       provider.GetProviderKey(),
+							ModelRequested: request.Model,
+							RequestType:    schemas.ChatCompletionStreamRequest,
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						enrichedErr := providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+						// Explicitly close the body stream to terminate connection to Replicate
+						resp.CloseBodyStream()
+						return
+
+					case "error":
+						errorMsg := "prediction failed"
+						if doneData.Output != nil {
+							errorMsg = fmt.Sprintf("prediction failed: %v", doneData.Output)
+						}
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							errorMsg,
+							fmt.Errorf("stream ended with error"),
+							provider.GetProviderKey(),
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       provider.GetProviderKey(),
+							ModelRequested: request.Model,
+							RequestType:    schemas.ChatCompletionStreamRequest,
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						enrichedErr := providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+						// Explicitly close the body stream to terminate connection to Replicate
+						resp.CloseBodyStream()
+						return
+					}
+
+					// Send final chunk with finish reason
+					finishReason := "stop"
+					finalResponse := &schemas.BifrostChatResponse{
+						ID:      messageID,
+						Model:   request.Model,
+						Object:  "chat.completion.chunk",
+						Created: int(time.Now().Unix()),
+						Choices: []schemas.BifrostResponseChoice{
+							{
+								Index:        0,
+								FinishReason: &finishReason,
+								ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+									Delta: &schemas.ChatStreamResponseChoiceDelta{},
+								},
+							},
+						},
+						ExtraFields: schemas.BifrostResponseExtraFields{
+							RequestType:    schemas.ChatCompletionStreamRequest,
+							Provider:       provider.GetProviderKey(),
+							ModelRequested: request.Model,
+							ChunkIndex:     chunkIndex,
+							Latency:        time.Since(startTime).Milliseconds(),
+						},
+					}
+
+					// Set raw request if enabled
+					if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+						providerUtils.ParseAndSetRawRequest(&finalResponse.ExtraFields, jsonData)
+					}
+
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+						providerUtils.GetBifrostResponseForStreamResponse(nil, finalResponse, nil, nil, nil, nil),
+						responseChan)
+					resp.CloseBodyStream()
+					return
+				}
+
+				// Reset event for next one
+				currentEvent = ReplicateSSEEvent{}
+				continue
+			}
+
+			// Parse SSE fields
+			if after, ok := strings.CutPrefix(line, "event: "); ok {
+				currentEvent.Event = strings.TrimSpace(after)
+			} else if after, ok := strings.CutPrefix(line, "data: "); ok {
+				// For multiline data, append with newline
+				if currentEvent.Data != "" {
+					currentEvent.Data += "\n"
+				}
+				currentEvent.Data += after
+			} else if after, ok := strings.CutPrefix(line, "id: "); ok {
+				currentEvent.ID = strings.TrimSpace(after)
+			}
+		}
+
+		// Handle scanner errors
+		if err := scanner.Err(); err != nil {
+			// If context was cancelled/timed out, let defer handle it
+			if ctx.Err() != nil {
+				return
+			}
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			provider.logger.Warn("Error reading stream: %v", err)
+			enrichedErr := providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey()), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+			return
+		}
+	}()
+
+	return responseChan, nil
+}
+
+// Responses performs a responses request to the replicate API.
+func (provider *ReplicateProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// build replicate request
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) { return ToReplicateResponsesRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Check for Prefer: wait header from context for sync mode
+	isSync := parsePreferHeader(provider.networkConfig.ExtraHeaders)
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ResponsesRequest,
+		isDeployment,
+	)
+
+	// create prediction
+	prediction, rawResponse, latency, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		false,
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// if not sync, poll until done
+	if !isSync && !isTerminalStatus(prediction.Status) {
+		prediction, rawResponse, err = pollPrediction(
+			ctx,
+			provider.client,
+			prediction.URLs.Get,
+			key,
+			provider.networkConfig.DefaultRequestTimeoutInSeconds,
+			provider.logger,
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		)
+		if err != nil {
+			return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+	}
+
+	// Check for terminal error status (failed/canceled) after sync mode or polling
+	if err := checkForErrorStatus(prediction); err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response
+	response := prediction.ToBifrostResponsesResponse()
+	response.ExtraFields.RequestType = schemas.ResponsesRequest
+	response.ExtraFields.Provider = provider.GetProviderKey()
+	response.ExtraFields.ModelRequested = request.Model
+	response.ExtraFields.Latency = latency.Milliseconds()
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonData)
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		response.ExtraFields.RawResponse = rawResponse
+	}
+	return response, nil
+}
+
+// ResponsesStream performs a streaming responses request to the replicate API.
+func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Build replicate request
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) { return ToReplicateResponsesRequest(request) },
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Enable streaming
+	var replicateReq ReplicatePredictionRequest
+	if err := sonic.Unmarshal(jsonData, &replicateReq); err == nil {
+		replicateReq.Stream = schemas.Ptr(true)
+		var streamErr error
+		jsonData, streamErr = sonic.Marshal(replicateReq)
+		if streamErr != nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to marshal request", streamErr, provider.GetProviderKey())
+		}
+	}
+
+	// Build prediction URL
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ResponsesStreamRequest,
+		isDeployment,
+	)
+
+	// Create prediction
+	prediction, _, _, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		true, // Streaming request, strip Prefer header for async mode
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Verify stream URL is available
+	if prediction.URLs == nil || prediction.URLs.Stream == nil || *prediction.URLs.Stream == "" {
+		bifrostErr := providerUtils.NewBifrostOperationError(
+			"stream URL not available in prediction response",
+			fmt.Errorf("prediction response missing stream URL"),
+			provider.GetProviderKey(),
+		)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	streamURL := *prediction.URLs.Stream
+
+	// Setup request for streaming
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+	defer fasthttp.ReleaseRequest(req)
+
+	req.Header.SetMethod(http.MethodGet)
+	req.SetRequestURI(streamURL)
+	req.Header.Set("Accept", "text/event-stream")
+
+	// Set authorization
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	// Set extra headers
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	// Make the streaming request
+	streamErr := provider.client.Do(req, resp)
+	if streamErr != nil {
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(streamErr, context.Canceled) {
+			return nil, providerUtils.EnrichError(ctx, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   streamErr,
+				},
+			}, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		if errors.Is(streamErr, fasthttp.ErrTimeout) || errors.Is(streamErr, context.DeadlineExceeded) {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, streamErr, provider.GetProviderKey()), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, streamErr, provider.GetProviderKey()), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode() != fasthttp.StatusOK {
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		body := resp.Body()
+		return nil, providerUtils.EnrichError(ctx, parseReplicateError(body, resp.StatusCode()), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ResponsesStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ResponsesStreamRequest, provider.logger)
+			}
+			close(responseChan)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+
+		// Setup cancellation handler
+		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), provider.logger)
+		defer stopCancellation()
+
+		if resp.BodyStream() == nil {
+			bifrostErr := providerUtils.NewBifrostOperationError(
+				"Provider returned an empty response",
+				fmt.Errorf("provider returned an empty response"),
+				provider.GetProviderKey(),
+			)
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse), responseChan, provider.logger)
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.BodyStream())
+		startTime := time.Now()
+		sequenceNumber := 0
+		messageID := prediction.ID
+		// Generate a unique item ID for the message (needed for accumulator to track deltas)
+		itemID := "msg_" + messageID
+
+		// Track lifecycle state
+		var hasEmittedCreated, hasEmittedInProgress bool
+		var hasEmittedOutputItemAdded, hasEmittedContentPartAdded bool
+		var hasReceivedContent bool
+		outputIndex := 0
+		contentIndex := 0
+
+		// Accumulate raw responses for debugging
+		var rawResponseChunks []interface{}
+		sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+		sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+
+		// Parse SSE events
+		currentEvent := ReplicateSSEEvent{}
+
+		for scanner.Scan() {
+			if ctx.Err() != nil {
+				return
+			}
+
+			line := scanner.Text()
+
+			// Empty line indicates end of event
+			if line == "" {
+				if currentEvent.Event != "" {
+					// Process the event
+					switch currentEvent.Event {
+					case "output":
+						// Text chunk received
+						if currentEvent.Data != "" {
+							// Accumulate raw response if enabled
+							if sendBackRawResponse {
+								rawResponseChunks = append(rawResponseChunks, currentEvent)
+							}
+
+							// Emit lifecycle events on first content
+							if !hasEmittedCreated {
+								// response.created
+								createdResp := &schemas.BifrostResponsesStreamResponse{
+									Type:           schemas.ResponsesStreamResponseTypeCreated,
+									SequenceNumber: sequenceNumber,
+									Response: &schemas.BifrostResponsesResponse{
+										ID:        schemas.Ptr(messageID),
+										Model:     request.Model,
+										CreatedAt: int(startTime.Unix()),
+									},
+									ExtraFields: schemas.BifrostResponseExtraFields{
+										RequestType:    schemas.ResponsesStreamRequest,
+										Provider:       provider.GetProviderKey(),
+										ModelRequested: request.Model,
+										Latency:        time.Since(startTime).Milliseconds(),
+										ChunkIndex:     sequenceNumber,
+									},
+								}
+								if sendBackRawRequest {
+									providerUtils.ParseAndSetRawRequest(&createdResp.ExtraFields, jsonData)
+								}
+								providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+									providerUtils.GetBifrostResponseForStreamResponse(nil, nil, createdResp, nil, nil, nil),
+									responseChan)
+								sequenceNumber++
+								hasEmittedCreated = true
+							}
+
+							if !hasEmittedInProgress {
+								// response.in_progress
+								inProgressResp := &schemas.BifrostResponsesStreamResponse{
+									Type:           schemas.ResponsesStreamResponseTypeInProgress,
+									SequenceNumber: sequenceNumber,
+									Response: &schemas.BifrostResponsesResponse{
+										ID:        schemas.Ptr(messageID),
+										CreatedAt: int(startTime.Unix()),
+									},
+									ExtraFields: schemas.BifrostResponseExtraFields{
+										RequestType:    schemas.ResponsesStreamRequest,
+										Provider:       provider.GetProviderKey(),
+										ModelRequested: request.Model,
+										ChunkIndex:     sequenceNumber,
+									},
+								}
+								providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+									providerUtils.GetBifrostResponseForStreamResponse(nil, nil, inProgressResp, nil, nil, nil),
+									responseChan)
+								sequenceNumber++
+								hasEmittedInProgress = true
+							}
+
+							if !hasEmittedOutputItemAdded {
+								// response.output_item.added
+								messageType := schemas.ResponsesMessageTypeMessage
+								role := schemas.ResponsesInputMessageRoleAssistant
+								status := "in_progress"
+								itemAddedResp := &schemas.BifrostResponsesStreamResponse{
+									Type:           schemas.ResponsesStreamResponseTypeOutputItemAdded,
+									SequenceNumber: sequenceNumber,
+									OutputIndex:    schemas.Ptr(outputIndex),
+									Item: &schemas.ResponsesMessage{
+										ID:     schemas.Ptr(itemID),
+										Type:   &messageType,
+										Role:   &role,
+										Status: &status,
+										Content: &schemas.ResponsesMessageContent{
+											ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+										},
+									},
+									ExtraFields: schemas.BifrostResponseExtraFields{
+										RequestType:    schemas.ResponsesStreamRequest,
+										Provider:       provider.GetProviderKey(),
+										ModelRequested: request.Model,
+										ChunkIndex:     sequenceNumber,
+									},
+								}
+								providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+									providerUtils.GetBifrostResponseForStreamResponse(nil, nil, itemAddedResp, nil, nil, nil),
+									responseChan)
+								sequenceNumber++
+								hasEmittedOutputItemAdded = true
+							}
+
+							if !hasEmittedContentPartAdded {
+								// response.content_part.added
+								emptyText := ""
+								partAddedResp := &schemas.BifrostResponsesStreamResponse{
+									Type:           schemas.ResponsesStreamResponseTypeContentPartAdded,
+									SequenceNumber: sequenceNumber,
+									OutputIndex:    schemas.Ptr(outputIndex),
+									ContentIndex:   schemas.Ptr(contentIndex),
+									ItemID:         schemas.Ptr(itemID),
+									Part: &schemas.ResponsesMessageContentBlock{
+										Type: schemas.ResponsesOutputMessageContentTypeText,
+										Text: &emptyText,
+										ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+											Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+											LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+										},
+									},
+									ExtraFields: schemas.BifrostResponseExtraFields{
+										RequestType:    schemas.ResponsesStreamRequest,
+										Provider:       provider.GetProviderKey(),
+										ModelRequested: request.Model,
+										ChunkIndex:     sequenceNumber,
+									},
+								}
+								providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+									providerUtils.GetBifrostResponseForStreamResponse(nil, nil, partAddedResp, nil, nil, nil),
+									responseChan)
+								sequenceNumber++
+								hasEmittedContentPartAdded = true
+							}
+
+							// response.output_text.delta
+							deltaResp := &schemas.BifrostResponsesStreamResponse{
+								Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
+								SequenceNumber: sequenceNumber,
+								OutputIndex:    schemas.Ptr(outputIndex),
+								ContentIndex:   schemas.Ptr(contentIndex),
+								ItemID:         schemas.Ptr(itemID),
+								Delta:          schemas.Ptr(currentEvent.Data),
+								LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
+								ExtraFields: schemas.BifrostResponseExtraFields{
+									RequestType:    schemas.ResponsesStreamRequest,
+									Provider:       provider.GetProviderKey(),
+									ModelRequested: request.Model,
+									ChunkIndex:     sequenceNumber,
+								},
+							}
+							providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+								providerUtils.GetBifrostResponseForStreamResponse(nil, nil, deltaResp, nil, nil, nil),
+								responseChan)
+							sequenceNumber++
+							hasReceivedContent = true
+						}
+					case "done":
+						// Accumulate done event in raw responses if enabled
+						if sendBackRawResponse {
+							rawResponseChunks = append(rawResponseChunks, currentEvent)
+						}
+
+						// Stream completed
+						if hasReceivedContent {
+							// response.output_text.done
+							textDoneResp := &schemas.BifrostResponsesStreamResponse{
+								Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
+								SequenceNumber: sequenceNumber,
+								OutputIndex:    schemas.Ptr(outputIndex),
+								ContentIndex:   schemas.Ptr(contentIndex),
+								ItemID:         schemas.Ptr(itemID),
+								LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
+								ExtraFields: schemas.BifrostResponseExtraFields{
+									RequestType:    schemas.ResponsesStreamRequest,
+									Provider:       provider.GetProviderKey(),
+									ModelRequested: request.Model,
+									ChunkIndex:     sequenceNumber,
+								},
+							}
+							providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+								providerUtils.GetBifrostResponseForStreamResponse(nil, nil, textDoneResp, nil, nil, nil),
+								responseChan)
+							sequenceNumber++
+
+							// response.content_part.done
+							partDoneResp := &schemas.BifrostResponsesStreamResponse{
+								Type:           schemas.ResponsesStreamResponseTypeContentPartDone,
+								SequenceNumber: sequenceNumber,
+								OutputIndex:    schemas.Ptr(outputIndex),
+								ContentIndex:   schemas.Ptr(contentIndex),
+								ItemID:         schemas.Ptr(itemID),
+								Part: &schemas.ResponsesMessageContentBlock{
+									Type: schemas.ResponsesOutputMessageContentTypeText,
+									ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+										Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+										LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+									},
+								},
+								ExtraFields: schemas.BifrostResponseExtraFields{
+									RequestType:    schemas.ResponsesStreamRequest,
+									Provider:       provider.GetProviderKey(),
+									ModelRequested: request.Model,
+									ChunkIndex:     sequenceNumber,
+								},
+							}
+							providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+								providerUtils.GetBifrostResponseForStreamResponse(nil, nil, partDoneResp, nil, nil, nil),
+								responseChan)
+							sequenceNumber++
+
+							// response.output_item.done
+							messageType := schemas.ResponsesMessageTypeMessage
+							role := schemas.ResponsesInputMessageRoleAssistant
+							status := "completed"
+							itemDoneResp := &schemas.BifrostResponsesStreamResponse{
+								Type:           schemas.ResponsesStreamResponseTypeOutputItemDone,
+								SequenceNumber: sequenceNumber,
+								OutputIndex:    schemas.Ptr(outputIndex),
+								Item: &schemas.ResponsesMessage{
+									ID:     schemas.Ptr(itemID),
+									Type:   &messageType,
+									Role:   &role,
+									Status: &status,
+									Content: &schemas.ResponsesMessageContent{
+										ContentBlocks: []schemas.ResponsesMessageContentBlock{
+											{
+												Type: schemas.ResponsesOutputMessageContentTypeText,
+												ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+													Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+													LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+												},
+											},
+										},
+									},
+								},
+								ExtraFields: schemas.BifrostResponseExtraFields{
+									RequestType:    schemas.ResponsesStreamRequest,
+									Provider:       provider.GetProviderKey(),
+									ModelRequested: request.Model,
+									ChunkIndex:     sequenceNumber,
+								},
+							}
+							providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+								providerUtils.GetBifrostResponseForStreamResponse(nil, nil, itemDoneResp, nil, nil, nil),
+								responseChan)
+							sequenceNumber++
+						}
+
+						// response.completed
+						completedResp := &schemas.BifrostResponsesStreamResponse{
+							Type:           schemas.ResponsesStreamResponseTypeCompleted,
+							SequenceNumber: sequenceNumber,
+							Response: &schemas.BifrostResponsesResponse{
+								ID:          schemas.Ptr(messageID),
+								Model:       request.Model,
+								CreatedAt:   int(startTime.Unix()),
+								CompletedAt: schemas.Ptr(int(time.Now().Unix())),
+							},
+							ExtraFields: schemas.BifrostResponseExtraFields{
+								RequestType:    schemas.ResponsesStreamRequest,
+								Provider:       provider.GetProviderKey(),
+								ModelRequested: request.Model,
+								Latency:        time.Since(startTime).Milliseconds(),
+								ChunkIndex:     sequenceNumber,
+							},
+						}
+
+						// Set raw request if enabled (on final chunk only)
+						if sendBackRawRequest {
+							providerUtils.ParseAndSetRawRequest(&completedResp.ExtraFields, jsonData)
+						}
+
+						// Set raw response if enabled
+						if sendBackRawResponse && len(rawResponseChunks) > 0 {
+							completedResp.ExtraFields.RawResponse = rawResponseChunks
+						}
+
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+							providerUtils.GetBifrostResponseForStreamResponse(nil, nil, completedResp, nil, nil, nil),
+							responseChan)
+						resp.CloseBodyStream()
+						return
+					case "error":
+						// Accumulate error event in raw responses if enabled
+						if sendBackRawResponse {
+							rawResponseChunks = append(rawResponseChunks, currentEvent)
+						}
+
+						// Handle error
+						errorMsg := "stream error"
+						if currentEvent.Data != "" {
+							errorMsg = currentEvent.Data
+						}
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							errorMsg,
+							fmt.Errorf("stream error: %s", errorMsg),
+							provider.GetProviderKey(),
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       provider.GetProviderKey(),
+							ModelRequested: request.Model,
+							RequestType:    schemas.ResponsesStreamRequest,
+						}
+
+						// Include accumulated raw responses in error
+						if sendBackRawResponse && len(rawResponseChunks) > 0 {
+							bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+						}
+
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						enrichedErr := providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+						resp.CloseBodyStream()
+						return
+					}
+				}
+
+				// Reset event for next one
+				currentEvent = ReplicateSSEEvent{}
+				continue
+			}
+
+			// Parse SSE fields
+			if after, ok := strings.CutPrefix(line, "event: "); ok {
+				currentEvent.Event = strings.TrimSpace(after)
+			} else if after, ok := strings.CutPrefix(line, "data: "); ok {
+				// For multiline data, append with newline
+				if currentEvent.Data != "" {
+					currentEvent.Data += "\n"
+				}
+				currentEvent.Data += after
+			}
+		}
+
+		// Handle scanner errors
+		if err := scanner.Err(); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			provider.logger.Warn("Error reading stream: %v", err)
+			bifrostErr := providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey())
+
+			// Include accumulated raw responses in error
+			if sendBackRawResponse && len(rawResponseChunks) > 0 {
+				bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+			}
+
+			enrichedErr := providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, enrichedErr, responseChan, provider.logger)
+			return
+		}
+	}()
+
+	return responseChan, nil
+}
+
+// Embedding is not supported by the replicate provider.
+func (provider *ReplicateProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
+}
+
+// Speech is not supported by the replicate provider.
+func (provider *ReplicateProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+}
+
+// SpeechStream is not supported by the replicate provider.
+func (provider *ReplicateProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
+}
+
+// Transcription is not supported by the replicate provider.
+func (provider *ReplicateProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+}
+
+// TranscriptionStream is not supported by the replicate provider.
+func (provider *ReplicateProvider) TranscriptionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionStreamRequest, provider.GetProviderKey())
+}
+
+// ImageGeneration performs an image generation request to the replicate API using predictions.
+func (provider *ReplicateProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ImageGenerationRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Convert Bifrost request to Replicate format
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToReplicateImageGenerationInput(request), nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Check for Prefer: wait header from context for sync mode
+	isSync := parsePreferHeader(provider.networkConfig.ExtraHeaders)
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ImageGenerationRequest,
+		isDeployment,
+	)
+
+	// Create prediction with appropriate mode
+	prediction, rawResponse, latency, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		false,
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// If async mode and not complete, poll until done
+	if !isSync && !isTerminalStatus(prediction.Status) {
+		prediction, rawResponse, err = pollPrediction(
+			ctx,
+			provider.client,
+			prediction.URLs.Get,
+			key,
+			provider.networkConfig.DefaultRequestTimeoutInSeconds,
+			provider.logger,
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		)
+		if err != nil {
+			return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+	}
+
+	// Check for terminal error status (failed/canceled) after sync mode or polling
+	if err := checkForErrorStatus(prediction); err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response
+	bifrostResponse, err := ToBifrostImageGenerationResponse(prediction)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Set extra fields
+	bifrostResponse.ExtraFields.Provider = schemas.Replicate
+	bifrostResponse.ExtraFields.RequestType = schemas.ImageGenerationRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
+// ImageGenerationStream performs a streaming image generation request to the replicate API.
+// It creates a prediction with streaming enabled and listens to the stream URL for progressive updates.
+func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostImageGenerationRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ImageGenerationStreamRequest); err != nil {
+		return nil, err
+	}
+
+	providerName := provider.GetProviderKey()
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Convert Bifrost request to Replicate format with streaming enabled
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			replicateReq := ToReplicateImageGenerationInput(request)
+			replicateReq.Stream = schemas.Ptr(true)
+			return replicateReq, nil
+		},
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ImageGenerationStreamRequest,
+		isDeployment,
+	)
+	// Create prediction
+	prediction, _, _, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		true, // Streaming request, strip Prefer header for async mode
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Verify stream URL is available
+	if prediction.URLs == nil || prediction.URLs.Stream == nil || *prediction.URLs.Stream == "" {
+		return nil, providerUtils.NewBifrostOperationError(
+			"stream URL not available in prediction response",
+			fmt.Errorf("prediction response missing stream URL"),
+			providerName,
+		)
+	}
+
+	streamURL := *prediction.URLs.Stream
+
+	// Connect to stream URL
+	bodyStream, resp, bifrostErr := listenToReplicateStreamURL(provider.client, streamURL, key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageGenerationStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageGenerationStreamRequest, provider.logger)
+			}
+			close(responseChan)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+
+		// Setup cancellation handler
+		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+		defer stopCancellation()
+
+		startTime := time.Now()
+		lastChunkTime := startTime
+		chunkIndex := 0
+
+		// Setup scanner to read SSE stream
+		scanner := bufio.NewScanner(bodyStream)
+		buf := make([]byte, 0, 1024*1024)
+		scanner.Buffer(buf, 10*1024*1024)
+
+		var currentEvent ReplicateSSEEvent
+		// Track last image data for final chunk
+		var lastB64Data string
+		var lastOutputFormat string
+		// Accumulate all raw response chunks for complete stream history
+		var rawResponseChunks []interface{}
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line := scanner.Text()
+
+			// Skip comment lines
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+
+			// Empty line indicates end of event
+			if line == "" {
+				if currentEvent.Event == "" && currentEvent.Data == "" {
+					continue
+				}
+
+				// Process the complete event
+				switch currentEvent.Event {
+				case "output":
+					// Check if data is a data URI (image) or plain text
+					var b64Data, outputFormat string
+					if strings.HasPrefix(currentEvent.Data, "data:") {
+						// Parse image data from data URI
+						var mimeType string
+						b64Data, mimeType = parseDataURIImage(currentEvent.Data)
+
+						// Extract output format from MIME type
+						if mimeType != "" {
+							// Convert "image/webp" to "webp"
+							parts := strings.Split(mimeType, "/")
+							if len(parts) == 2 {
+								outputFormat = parts[1]
+							}
+						}
+					} else {
+						// For non-data-URI output (e.g., text), store as-is
+						// This shouldn't happen for image generation but handle it gracefully
+						provider.logger.Debug(fmt.Sprintf("Received non-data-URI output: %s", currentEvent.Data[:min(100, len(currentEvent.Data))]))
+						// Skip non-image output for image generation
+						currentEvent = ReplicateSSEEvent{}
+						continue
+					}
+
+					// Create chunk
+					chunk := &schemas.BifrostImageGenerationStreamResponse{
+						Type:         schemas.ImageGenerationEventTypePartial,
+						Index:        0, // Single image for now
+						ChunkIndex:   chunkIndex,
+						B64JSON:      b64Data,
+						CreatedAt:    time.Now().Unix(),
+						OutputFormat: outputFormat,
+						ExtraFields: schemas.BifrostResponseExtraFields{
+							RequestType:    schemas.ImageGenerationStreamRequest,
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							ChunkIndex:     chunkIndex,
+							Latency:        time.Since(lastChunkTime).Milliseconds(),
+						},
+					}
+
+					// Accumulate raw response chunks if enabled
+					if sendBackRawResponse {
+						rawResponseChunks = append(rawResponseChunks, currentEvent)
+					}
+
+					// Track last image data for final chunk
+					lastB64Data = b64Data
+					lastOutputFormat = outputFormat
+
+					lastChunkTime = time.Now()
+					chunkIndex++
+
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+						providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, nil, chunk),
+						responseChan)
+
+				case "done":
+					// Parse done event data
+					var doneData ReplicateDoneEvent
+					if currentEvent.Data != "" && currentEvent.Data != "{}" {
+						if err := sonic.Unmarshal([]byte(currentEvent.Data), &doneData); err != nil {
+							provider.logger.Warn(fmt.Sprintf("Failed to parse done event data: %v", err))
+						}
+					}
+
+					// Check for cancellation or error
+					switch doneData.Reason {
+					case "canceled":
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							"prediction was canceled",
+							fmt.Errorf("stream ended: prediction canceled"),
+							providerName,
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							RequestType:    schemas.ImageGenerationStreamRequest,
+						}
+						// Include accumulated raw responses in error
+						if sendBackRawResponse && len(rawResponseChunks) > 0 {
+							bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+						return
+					case "error":
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							"prediction failed",
+							fmt.Errorf("stream ended with error"),
+							providerName,
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							RequestType:    schemas.ImageGenerationStreamRequest,
+						}
+						// Include accumulated raw responses in error
+						if sendBackRawResponse && len(rawResponseChunks) > 0 {
+							bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+						return
+					}
+
+					// Send completion chunk (success case when reason is empty or not present)
+					finalChunk := &schemas.BifrostImageGenerationStreamResponse{
+						Type:         schemas.ImageGenerationEventTypeCompleted,
+						Index:        0,
+						ChunkIndex:   chunkIndex,
+						B64JSON:      lastB64Data,      // Include last image data
+						OutputFormat: lastOutputFormat, // Include output format
+						CreatedAt:    time.Now().Unix(),
+						ExtraFields: schemas.BifrostResponseExtraFields{
+							RequestType:    schemas.ImageGenerationStreamRequest,
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							ChunkIndex:     chunkIndex,
+							Latency:        time.Since(startTime).Milliseconds(),
+						},
+					}
+
+					// Set raw request only on final chunk if enabled
+					if sendBackRawRequest {
+						providerUtils.ParseAndSetRawRequest(&finalChunk.ExtraFields, jsonData)
+					}
+
+					// Set accumulated raw responses on final chunk if enabled
+					if sendBackRawResponse {
+						// Append the final done event to the accumulated chunks
+						rawResponseChunks = append(rawResponseChunks, currentEvent)
+						finalChunk.ExtraFields.RawResponse = rawResponseChunks
+					}
+
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+						providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, nil, finalChunk),
+						responseChan)
+					return
+
+				case "error":
+					// Parse error event data
+					var errorData ReplicateErrorEvent
+					errorMsg := "stream error"
+
+					if currentEvent.Data != "" {
+						if err := sonic.Unmarshal([]byte(currentEvent.Data), &errorData); err != nil {
+							provider.logger.Warn(fmt.Sprintf("Failed to parse error event data: %v", err))
+							// Fallback to raw data
+							errorMsg = currentEvent.Data
+						} else if errorData.Detail != "" {
+							errorMsg = errorData.Detail
+						}
+					}
+
+					bifrostErr := &schemas.BifrostError{
+						IsBifrostError: false,
+						Error: &schemas.ErrorField{
+							Message: errorMsg,
+						},
+						ExtraFields: schemas.BifrostErrorExtraFields{
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							RequestType:    schemas.ImageGenerationStreamRequest,
+						},
+					}
+					// Include accumulated raw responses in error
+					if sendBackRawResponse {
+						rawResponseChunks = append(rawResponseChunks, currentEvent)
+						bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+					}
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+					return
+				}
+
+				// Reset current event after processing
+				currentEvent = ReplicateSSEEvent{}
+				continue
+			}
+
+			// Parse SSE field
+			if strings.HasPrefix(line, "event: ") {
+				currentEvent.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			} else if strings.HasPrefix(line, "data:") {
+				currentEvent.Data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			} else if strings.HasPrefix(line, "id:") {
+				currentEvent.ID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+			}
+		}
+
+		// Check for scanner errors
+		if err := scanner.Err(); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			provider.logger.Warn(fmt.Sprintf("Error reading SSE stream: %v", err))
+			providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.ImageGenerationStreamRequest, providerName, request.Model, provider.logger)
+		}
+	}()
+
+	return responseChan, nil
+}
+
+// ImageEdit is not supported by the Replicate provider.
+func (provider *ReplicateProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ImageEditRequest); err != nil {
+		return nil, err
+	}
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Convert Bifrost request to Replicate format
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToReplicateImageEditInput(request), nil
+		},
+		provider.GetProviderKey())
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Check for Prefer: wait header from context for sync mode
+	isSync := parsePreferHeader(provider.networkConfig.ExtraHeaders)
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ImageEditRequest,
+		isDeployment,
+	)
+
+	// Create prediction with appropriate mode
+	prediction, rawResponse, latency, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		false,
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// If async mode and not complete, poll until done
+	if !isSync && !isTerminalStatus(prediction.Status) {
+		prediction, rawResponse, err = pollPrediction(
+			ctx,
+			provider.client,
+			prediction.URLs.Get,
+			key,
+			provider.networkConfig.DefaultRequestTimeoutInSeconds,
+			provider.logger,
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		)
+		if err != nil {
+			return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+	}
+
+	// Check for terminal error status (failed/canceled) after sync mode or polling
+	if err := checkForErrorStatus(prediction); err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Convert to Bifrost response (reuse image generation response format)
+	bifrostResponse, err := ToBifrostImageGenerationResponse(prediction)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Set extra fields
+	bifrostResponse.ExtraFields.Provider = schemas.Replicate
+	bifrostResponse.ExtraFields.RequestType = schemas.ImageEditRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequest(&bifrostResponse.ExtraFields, jsonData)
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
+}
+
+// ImageEditStream performs a streaming image edit request to the replicate API.
+// It creates a prediction with streaming enabled and listens to the stream URL for progressive updates.
+func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostImageEditRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Replicate, provider.customProviderConfig, schemas.ImageEditStreamRequest); err != nil {
+		return nil, err
+	}
+
+	providerName := provider.GetProviderKey()
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+
+	deployment, isDeployment := resolveDeploymentModel(request.Model, key)
+	if isDeployment {
+		request.Model = deployment
+	}
+
+	// Convert Bifrost request to Replicate format with streaming enabled
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			replicateReq := ToReplicateImageEditInput(request)
+			replicateReq.Stream = schemas.Ptr(true)
+			return replicateReq, nil
+		},
+		providerName)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Build prediction URL based on model type (version ID or model name)
+	predictionURL := buildPredictionURL(
+		ctx,
+		provider.networkConfig.BaseURL,
+		request.Model,
+		provider.customProviderConfig,
+		schemas.ImageEditStreamRequest,
+		isDeployment,
+	)
+
+	// Create prediction
+	prediction, _, _, err := createPrediction(
+		ctx,
+		provider.client,
+		jsonData,
+		key,
+		providerUtils.GetPathFromContext(ctx, predictionURL),
+		provider.networkConfig.ExtraHeaders,
+		true, // Streaming request, strip Prefer header for async mode
+		provider.logger,
+		provider.sendBackRawRequest,
+		provider.sendBackRawResponse,
+	)
+	if err != nil {
+		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	// Verify stream URL is available
+	if prediction.URLs == nil || prediction.URLs.Stream == nil || *prediction.URLs.Stream == "" {
+		return nil, providerUtils.NewBifrostOperationError(
+			"stream URL not available in prediction response",
+			fmt.Errorf("prediction response missing stream URL"),
+			providerName,
+		)
+	}
+
+	streamURL := *prediction.URLs.Stream
+
+	// Connect to stream URL
+	bodyStream, resp, bifrostErr := listenToReplicateStreamURL(provider.client, streamURL, key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Create response channel
+	responseChan := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+
+	// Start streaming in a goroutine
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageEditStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageEditStreamRequest, provider.logger)
+			}
+			close(responseChan)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+
+		// Setup cancellation handler
+		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+		defer stopCancellation()
+
+		startTime := time.Now()
+		lastChunkTime := startTime
+		chunkIndex := 0
+
+		// Setup scanner to read SSE stream
+		scanner := bufio.NewScanner(bodyStream)
+		buf := make([]byte, 0, 1024*1024)
+		scanner.Buffer(buf, 10*1024*1024)
+
+		var currentEvent ReplicateSSEEvent
+		// Track last image data for final chunk
+		var lastB64Data string
+		var lastOutputFormat string
+		// Accumulate all raw response chunks for complete stream history
+		var rawResponseChunks []interface{}
+
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			line := scanner.Text()
+
+			// Skip comment lines
+			if strings.HasPrefix(line, ":") {
+				continue
+			}
+
+			// Empty line indicates end of event
+			if line == "" {
+				if currentEvent.Event == "" && currentEvent.Data == "" {
+					continue
+				}
+
+				// Process the complete event
+				switch currentEvent.Event {
+				case "output":
+					// Check if data is a data URI (image) or plain text
+					var b64Data, outputFormat string
+					if strings.HasPrefix(currentEvent.Data, "data:") {
+						// Parse image data from data URI
+						var mimeType string
+						b64Data, mimeType = parseDataURIImage(currentEvent.Data)
+
+						// Extract output format from MIME type
+						if mimeType != "" {
+							// Convert "image/webp" to "webp"
+							parts := strings.Split(mimeType, "/")
+							if len(parts) == 2 {
+								outputFormat = parts[1]
+							}
+						}
+					} else {
+						// For non-data-URI output, skip for image edit
+						provider.logger.Debug(fmt.Sprintf("Received non-data-URI output: %s", currentEvent.Data[:min(100, len(currentEvent.Data))]))
+						currentEvent = ReplicateSSEEvent{}
+						continue
+					}
+
+					// Create chunk (use ImageEditEventTypePartial)
+					chunk := &schemas.BifrostImageGenerationStreamResponse{
+						Type:         schemas.ImageEditEventTypePartial,
+						Index:        0,
+						ChunkIndex:   chunkIndex,
+						B64JSON:      b64Data,
+						CreatedAt:    time.Now().Unix(),
+						OutputFormat: outputFormat,
+						ExtraFields: schemas.BifrostResponseExtraFields{
+							RequestType:    schemas.ImageEditStreamRequest,
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							ChunkIndex:     chunkIndex,
+							Latency:        time.Since(lastChunkTime).Milliseconds(),
+						},
+					}
+
+					// Accumulate raw response chunks if enabled
+					if sendBackRawResponse {
+						rawResponseChunks = append(rawResponseChunks, currentEvent)
+					}
+
+					// Track last image data for final chunk
+					lastB64Data = b64Data
+					lastOutputFormat = outputFormat
+
+					lastChunkTime = time.Now()
+					chunkIndex++
+
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+						providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, nil, chunk),
+						responseChan)
+
+				case "done":
+					// Parse done event data
+					var doneData ReplicateDoneEvent
+					if currentEvent.Data != "" && currentEvent.Data != "{}" {
+						if err := sonic.Unmarshal([]byte(currentEvent.Data), &doneData); err != nil {
+							provider.logger.Warn(fmt.Sprintf("Failed to parse done event data: %v", err))
+						}
+					}
+
+					// Check for cancellation or error
+					switch doneData.Reason {
+					case "canceled":
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							"prediction was canceled",
+							fmt.Errorf("stream ended: prediction canceled"),
+							providerName,
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							RequestType:    schemas.ImageEditStreamRequest,
+						}
+						if sendBackRawResponse && len(rawResponseChunks) > 0 {
+							bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+						return
+					case "error":
+						bifrostErr := providerUtils.NewBifrostOperationError(
+							"prediction failed",
+							fmt.Errorf("stream ended with error"),
+							providerName,
+						)
+						bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							RequestType:    schemas.ImageEditStreamRequest,
+						}
+						if sendBackRawResponse && len(rawResponseChunks) > 0 {
+							bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+						}
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+						providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+						return
+					}
+
+					// Send completion chunk (success case)
+					finalChunk := &schemas.BifrostImageGenerationStreamResponse{
+						Type:         schemas.ImageEditEventTypeCompleted,
+						Index:        0,
+						ChunkIndex:   chunkIndex,
+						B64JSON:      lastB64Data,
+						CreatedAt:    time.Now().Unix(),
+						OutputFormat: lastOutputFormat,
+						ExtraFields: schemas.BifrostResponseExtraFields{
+							RequestType:    schemas.ImageEditStreamRequest,
+							Provider:       providerName,
+							ModelRequested: request.Model,
+							ChunkIndex:     chunkIndex,
+							Latency:        time.Since(startTime).Milliseconds(),
+						},
+					}
+
+					if sendBackRawRequest {
+						providerUtils.ParseAndSetRawRequest(&finalChunk.ExtraFields, jsonData)
+					}
+					if sendBackRawResponse {
+						rawResponseChunks = append(rawResponseChunks, currentEvent)
+						finalChunk.ExtraFields.RawResponse = rawResponseChunks
+					}
+
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+						providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, nil, finalChunk),
+						responseChan)
+					return
+
+				case "error":
+					// Parse error event
+					var errorData ReplicateErrorEvent
+					if err := sonic.Unmarshal([]byte(currentEvent.Data), &errorData); err != nil {
+						provider.logger.Warn(fmt.Sprintf("Failed to parse error event: %v", err))
+						errorData.Detail = currentEvent.Data
+					}
+
+					bifrostErr := providerUtils.NewBifrostOperationError(
+						"stream error",
+						fmt.Errorf("%s", errorData.Detail),
+						providerName,
+					)
+					bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+						Provider:       providerName,
+						ModelRequested: request.Model,
+						RequestType:    schemas.ImageEditStreamRequest,
+					}
+					if sendBackRawResponse && len(rawResponseChunks) > 0 {
+						bifrostErr.ExtraFields.RawResponse = rawResponseChunks
+					}
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+					return
+				}
+
+				// Reset for next event
+				currentEvent = ReplicateSSEEvent{}
+				continue
+			}
+
+			// Parse SSE field
+			if strings.HasPrefix(line, "event:") {
+				currentEvent.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			} else if strings.HasPrefix(line, "data:") {
+				currentEvent.Data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			} else if strings.HasPrefix(line, "id:") {
+				currentEvent.ID = strings.TrimSpace(strings.TrimPrefix(line, "id:"))
+			}
+		}
+
+		// Check for scanner errors
+		if err := scanner.Err(); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+			bifrostErr := providerUtils.NewBifrostOperationError(
+				"stream read error",
+				err,
+				providerName,
+			)
+			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+				Provider:       providerName,
+				ModelRequested: request.Model,
+				RequestType:    schemas.ImageEditStreamRequest,
+			}
+			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, provider.logger)
+		}
+	}()
+
+	return responseChan, nil
+}
+
+// ImageVariation is not supported by the Replicate provider.
+func (provider *ReplicateProvider) ImageVariation(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageVariationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ImageVariationRequest, provider.GetProviderKey())
+}
+
+// BatchCreate is not supported by replicate provider.
+func (provider *ReplicateProvider) BatchCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostBatchCreateRequest) (*schemas.BifrostBatchCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCreateRequest, provider.GetProviderKey())
+}
+
+// BatchList is not supported by replicate provider.
+func (provider *ReplicateProvider) BatchList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchListRequest) (*schemas.BifrostBatchListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchListRequest, provider.GetProviderKey())
+}
+
+// BatchRetrieve is not supported by replicate provider.
+func (provider *ReplicateProvider) BatchRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchRetrieveRequest) (*schemas.BifrostBatchRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchRetrieveRequest, provider.GetProviderKey())
+}
+
+// BatchCancel is not supported by replicate provider.
+func (provider *ReplicateProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchCancelRequest) (*schemas.BifrostBatchCancelResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
+}
+
+// BatchResults is not supported by replicate provider.
+func (provider *ReplicateProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
+}
+
+// FileUpload uploads a file to Replicate's Files API.
+func (provider *ReplicateProvider) FileUpload(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostFileUploadRequest) (*schemas.BifrostFileUploadResponse, *schemas.BifrostError) {
+	providerName := provider.GetProviderKey()
+
+	if len(request.File) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("file content is required", nil, providerName)
+	}
+
+	// Create multipart form data
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Add file field (content)
+	filename := request.Filename
+	if filename == "" {
+		filename = "file"
+	}
+
+	// Determine content type - use from request or infer from filename
+	contentType := "application/octet-stream"
+	if request.ContentType != nil && *request.ContentType != "" {
+		contentType = *request.ContentType
+	} else {
+		// Try to infer from filename extension
+		if strings.HasSuffix(filename, ".json") {
+			contentType = "application/json"
+		} else if strings.HasSuffix(filename, ".jsonl") {
+			contentType = "application/x-ndjson"
+		} else if strings.HasSuffix(filename, ".txt") {
+			contentType = "text/plain"
+		} else if strings.HasSuffix(filename, ".zip") {
+			contentType = "application/zip"
+		}
+	}
+
+	// Create form file with proper headers
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="content"; filename="%s"`, filename))
+	h.Set("Content-Type", contentType)
+
+	part, err := writer.CreatePart(h)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to create form file", err, providerName)
+	}
+	if _, err := part.Write(request.File); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to write file content", err, providerName)
+	}
+
+	// Add filename field if provided
+	if filename != "" {
+		if err := writer.WriteField("filename", filename); err != nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to write filename field", err, providerName)
+		}
+	}
+
+	// Add type field (content type)
+	if err := writer.WriteField("type", contentType); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to write type field", err, providerName)
+	}
+
+	// Add metadata field if provided
+	if request.ExtraParams != nil {
+		if metadata, ok := request.ExtraParams["metadata"].(map[string]interface{}); ok {
+			if len(metadata) > 0 {
+				metadataJSON, err := sonic.Marshal(metadata)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError("failed to marshal metadata", err, providerName)
+				}
+				h := make(textproto.MIMEHeader)
+				h.Set("Content-Disposition", `form-data; name="metadata"`)
+				h.Set("Content-Type", "application/json")
+				metadataPart, err := writer.CreatePart(h)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError("failed to create metadata part", err, providerName)
+				}
+				if _, err := metadataPart.Write(metadataJSON); err != nil {
+					return nil, providerUtils.NewBifrostOperationError("failed to write metadata", err, providerName)
+				}
+			}
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to close multipart writer", err, providerName)
+	}
+
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set headers
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files")
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType(writer.FormDataContentType())
+
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	req.SetBody(buf.Bytes())
+
+	// Make request
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK && resp.StatusCode() != fasthttp.StatusCreated {
+		provider.logger.Debug("error from %s provider: %s", providerName, string(resp.Body()))
+		return nil, parseReplicateError(resp.Body(), resp.StatusCode())
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+	}
+
+	var replicateResp ReplicateFileResponse
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &replicateResp, nil, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return replicateResp.ToBifrostFileUploadResponse(providerName, latency, sendBackRawRequest, sendBackRawResponse, rawRequest, rawResponse), nil
+}
+
+// FileList lists files using serial pagination across keys.
+// Exhausts all pages from one key before moving to the next.
+func (provider *ReplicateProvider) FileList(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileListRequest) (*schemas.BifrostFileListResponse, *schemas.BifrostError) {
+	providerName := provider.GetProviderKey()
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+
+	// Initialize serial pagination helper (Replicate uses cursor-based pagination)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err, providerName)
+	}
+
+	// Get current key to query
+	key, nativeCursor, ok := helper.GetCurrentKey()
+	if !ok {
+		// All keys exhausted
+		return &schemas.BifrostFileListResponse{
+			Object:  "list",
+			Data:    []schemas.FileObject{},
+			HasMore: false,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.FileListRequest,
+				Provider:    providerName,
+			},
+		}, nil
+	}
+
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Build URL with query params
+	requestURL := provider.networkConfig.BaseURL + "/v1/files"
+	values := url.Values{}
+	if request.Limit > 0 {
+		values.Set("limit", fmt.Sprintf("%d", request.Limit))
+	}
+	// Use native cursor from serial helper (Replicate pagination URL)
+	if nativeCursor != "" {
+		// For Replicate, the cursor is actually the full next URL
+		requestURL = nativeCursor
+	} else if encodedValues := values.Encode(); encodedValues != "" {
+		requestURL += "?" + encodedValues
+	}
+
+	// Set headers
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.SetRequestURI(requestURL)
+	req.Header.SetMethod(http.MethodGet)
+	req.Header.SetContentType("application/json")
+
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	// Make request
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		provider.logger.Debug("error from %s provider: %s", providerName, string(resp.Body()))
+		return nil, parseReplicateError(resp.Body(), resp.StatusCode())
+	}
+
+	body, decodeErr := providerUtils.CheckAndDecodeBody(resp)
+	if decodeErr != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, decodeErr, providerName)
+	}
+
+	var replicateResp ReplicateFileListResponse
+	_, _, bifrostErr = providerUtils.HandleProviderResponse(body, &replicateResp, nil, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Convert files to Bifrost format
+	files := make([]schemas.FileObject, 0, len(replicateResp.Results))
+	for _, file := range replicateResp.Results {
+		files = append(files, schemas.FileObject{
+			ID:        file.ID,
+			Object:    "file",
+			Bytes:     file.Size,
+			CreatedAt: ParseReplicateTimestamp(file.CreatedAt),
+			Filename:  file.Name,
+			Purpose:   schemas.FilePurposeBatch,
+			Status:    ToBifrostFileStatus(&file),
+		})
+	}
+
+	// Build cursor for next request
+	// Replicate uses full URL for pagination
+	var nextCursor string
+	hasMore := false
+	if replicateResp.Next != nil && *replicateResp.Next != "" {
+		nextCursor = *replicateResp.Next
+		hasMore = true
+	}
+
+	// Use helper to build proper cursor with key index
+	finalCursor, finalHasMore := helper.BuildNextCursor(hasMore, nextCursor)
+
+	// Convert to Bifrost response
+	bifrostResp := &schemas.BifrostFileListResponse{
+		Object:  "list",
+		Data:    files,
+		HasMore: finalHasMore,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.FileListRequest,
+			Provider:    providerName,
+			Latency:     latency.Milliseconds(),
+		},
+	}
+	if finalCursor != "" {
+		bifrostResp.After = &finalCursor
+	}
+
+	return bifrostResp, nil
+}
+
+// FileRetrieve retrieves file metadata from Replicate's Files API by trying each key until found.
+func (provider *ReplicateProvider) FileRetrieve(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileRetrieveRequest) (*schemas.BifrostFileRetrieveResponse, *schemas.BifrostError) {
+	providerName := provider.GetProviderKey()
+
+	if request.FileID == "" {
+		return nil, providerUtils.NewBifrostOperationError("file_id is required", nil, providerName)
+	}
+
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+
+	var lastErr *schemas.BifrostError
+	for _, key := range keys {
+		// Create request
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+
+		// Set headers
+		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + url.PathEscape(request.FileID))
+		req.Header.SetMethod(http.MethodGet)
+		req.Header.SetContentType("application/json")
+
+		if key.Value.GetValue() != "" {
+			req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+		}
+
+		// Make request
+		latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+		if bifrostErr != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			lastErr = bifrostErr
+			continue
+		}
+
+		// Handle error response
+		if resp.StatusCode() != fasthttp.StatusOK {
+			provider.logger.Debug("error from %s provider: %s", providerName, string(resp.Body()))
+			lastErr = parseReplicateError(resp.Body(), resp.StatusCode())
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			continue
+		}
+
+		body, err := providerUtils.CheckAndDecodeBody(resp)
+		if err != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			lastErr = providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+			continue
+		}
+
+		var replicateResp ReplicateFileResponse
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &replicateResp, nil, sendBackRawRequest, sendBackRawResponse)
+		if bifrostErr != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			lastErr = bifrostErr
+			continue
+		}
+
+		fasthttp.ReleaseRequest(req)
+		fasthttp.ReleaseResponse(resp)
+
+		return replicateResp.ToBifrostFileRetrieveResponse(providerName, latency, sendBackRawRequest, sendBackRawResponse, rawRequest, rawResponse), nil
+	}
+
+	return nil, lastErr
+}
+
+// FileDelete deletes a file from Replicate's Files API by trying each key until successful.
+func (provider *ReplicateProvider) FileDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileDeleteRequest) (*schemas.BifrostFileDeleteResponse, *schemas.BifrostError) {
+	providerName := provider.GetProviderKey()
+
+	if request.FileID == "" {
+		return nil, providerUtils.NewBifrostOperationError("file_id is required", nil, providerName)
+	}
+
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+
+	var lastErr *schemas.BifrostError
+	for _, key := range keys {
+		// Create request
+		req := fasthttp.AcquireRequest()
+		resp := fasthttp.AcquireResponse()
+
+		// Set headers
+		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + url.PathEscape(request.FileID))
+		req.Header.SetMethod(http.MethodDelete)
+		req.Header.SetContentType("application/json")
+
+		if key.Value.GetValue() != "" {
+			req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+		}
+
+		// Make request
+		latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+		if bifrostErr != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			lastErr = bifrostErr
+			continue
+		}
+
+		// Handle success response (204 No Content is expected for DELETE)
+		if resp.StatusCode() == fasthttp.StatusNoContent {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			return &schemas.BifrostFileDeleteResponse{
+				ID:      request.FileID,
+				Object:  "file",
+				Deleted: true,
+				ExtraFields: schemas.BifrostResponseExtraFields{
+					RequestType: schemas.FileDeleteRequest,
+					Provider:    providerName,
+					Latency:     latency.Milliseconds(),
+				},
+			}, nil
+		}
+
+		// Handle error response
+		if resp.StatusCode() != fasthttp.StatusOK {
+			provider.logger.Debug("error from %s provider: %s", providerName, string(resp.Body()))
+			lastErr = parseReplicateError(resp.Body(), resp.StatusCode())
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			continue
+		}
+
+		// Some APIs return 200 with body, parse it
+		body, err := providerUtils.CheckAndDecodeBody(resp)
+		if err != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			lastErr = providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+			continue
+		}
+
+		// Try to parse response body if present
+		var deleteResp map[string]interface{}
+		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, &deleteResp, nil, sendBackRawRequest, sendBackRawResponse)
+		if bifrostErr != nil {
+			fasthttp.ReleaseRequest(req)
+			fasthttp.ReleaseResponse(resp)
+			lastErr = bifrostErr
+			continue
+		}
+
+		fasthttp.ReleaseRequest(req)
+		fasthttp.ReleaseResponse(resp)
+
+		result := &schemas.BifrostFileDeleteResponse{
+			ID:      request.FileID,
+			Object:  "file",
+			Deleted: true,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.FileDeleteRequest,
+				Provider:    providerName,
+				Latency:     latency.Milliseconds(),
+			},
+		}
+
+		if sendBackRawRequest {
+			result.ExtraFields.RawRequest = rawRequest
+		}
+
+		if sendBackRawResponse {
+			result.ExtraFields.RawResponse = rawResponse
+		}
+
+		return result, nil
+	}
+
+	return nil, lastErr
+}
+
+// FileContent is not supported by replicate provider.
+func (provider *ReplicateProvider) FileContent(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostFileContentRequest) (*schemas.BifrostFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.FileContentRequest, provider.GetProviderKey())
+}
+
+func (provider *ReplicateProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.CountTokensRequest, provider.GetProviderKey())
+}
+
+// ContainerCreate is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerCreateRequest) (*schemas.BifrostContainerCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerList is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerListRequest) (*schemas.BifrostContainerListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerListRequest, provider.GetProviderKey())
+}
+
+// ContainerRetrieve is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerRetrieveRequest) (*schemas.BifrostContainerRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerDelete is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerDeleteRequest) (*schemas.BifrostContainerDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerDeleteRequest, provider.GetProviderKey())
+}
+
+// ContainerFileCreate is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerFileCreate(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostContainerFileCreateRequest) (*schemas.BifrostContainerFileCreateResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileCreateRequest, provider.GetProviderKey())
+}
+
+// ContainerFileList is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerFileList(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileListRequest) (*schemas.BifrostContainerFileListResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileListRequest, provider.GetProviderKey())
+}
+
+// ContainerFileRetrieve is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerFileRetrieve(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileRetrieveRequest) (*schemas.BifrostContainerFileRetrieveResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileRetrieveRequest, provider.GetProviderKey())
+}
+
+// ContainerFileContent is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerFileContent(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileContentRequest) (*schemas.BifrostContainerFileContentResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileContentRequest, provider.GetProviderKey())
+}
+
+// ContainerFileDelete is not supported by replicate provider.
+func (provider *ReplicateProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}

--- a/core/providers/replicate/replicate_test.go
+++ b/core/providers/replicate/replicate_test.go
@@ -1,0 +1,1534 @@
+package replicate_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/internal/llmtests"
+	"github.com/maximhq/bifrost/core/providers/replicate"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplicate(t *testing.T) {
+	t.Parallel()
+	if strings.TrimSpace(os.Getenv("REPLICATE_API_KEY")) == "" {
+		t.Skip("Skipping Replicate tests because REPLICATE_API_KEY is not set")
+	}
+
+	client, ctx, cancel, err := llmtests.SetupTest()
+	if err != nil {
+		t.Fatalf("Error initializing test setup: %v", err)
+	}
+	defer cancel()
+
+	testConfig := llmtests.ComprehensiveTestConfig{
+		Provider:             schemas.Replicate,
+		ChatModel:            "openai/gpt-4.1-mini",
+		TextModel:            "openai/gpt-4.1-mini",
+		ImageGenerationModel: "black-forest-labs/flux-dev",
+		ImageEditModel:       "black-forest-labs/flux-dev",
+		FileExtraParams: map[string]interface{}{
+			"owner":  os.Getenv("REPLICATE_OWNER"),
+			"expiry": 1830297599,
+		},
+		Scenarios: llmtests.TestScenarios{
+			TextCompletion:        true,
+			SimpleChat:            true,
+			CompletionStream:      true,
+			MultiTurnConversation: false,
+			ToolCalls:             false,
+			ToolCallsStreaming:    false,
+			MultipleToolCalls:     false,
+			End2EndToolCalling:    false,
+			AutomaticFunctionCall: false,
+			ImageURL:              false,
+			ImageBase64:           false,
+			ImageGeneration:       true,
+			ImageEdit:             true,
+			ImageEditStream:       true,
+			ImageGenerationStream: true,
+			FileBase64:            false,
+			FileURL:               false,
+			MultipleImages:        false,
+			CompleteEnd2End:       false,
+			Reasoning:             false,
+			Embedding:             false,
+			ListModels:            true,
+			FileUpload:            true,
+			FileList:              true,
+			FileRetrieve:          true,
+			FileDelete:            true,
+			FileContent:           false,
+		},
+	}
+
+	t.Run("ReplicateTests", func(t *testing.T) {
+		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
+	})
+	client.Shutdown()
+}
+
+// TestBifrostToReplicateChatRequestConversion tests the conversion from Bifrost chat request to Replicate format
+// with special handling based on model names
+func TestBifrostToReplicateChatRequestConversion(t *testing.T) {
+	maxTokens := 100
+	temp := 0.7
+	topP := 0.9
+	seed := 42
+	presencePenalty := 0.5
+	frequencyPenalty := 0.3
+
+	tests := []struct {
+		name     string
+		input    *schemas.BifrostChatRequest
+		validate func(t *testing.T, result *replicate.ReplicatePredictionRequest)
+		wantErr  bool
+	}{
+		{
+			name: "OpenAI_Model_With_Messages",
+			input: &schemas.BifrostChatRequest{
+				Model: "openai/gpt-4.1-mini",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleSystem,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("You are a helpful assistant."),
+						},
+					},
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hello!"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// OpenAI models should use Messages field
+				assert.NotNil(t, result.Input.Messages)
+				assert.Len(t, result.Input.Messages, 2)
+				assert.Equal(t, schemas.ChatMessageRoleSystem, result.Input.Messages[0].Role)
+				assert.Equal(t, schemas.ChatMessageRoleUser, result.Input.Messages[1].Role)
+			},
+		},
+		{
+			name: "OpenAI_Model_MaxCompletionTokens",
+			input: &schemas.BifrostChatRequest{
+				Model: "openai/gpt-4o",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: &maxTokens,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// OpenAI models should use MaxCompletionTokens field
+				assert.NotNil(t, result.Input.MaxCompletionTokens)
+				assert.Equal(t, maxTokens, *result.Input.MaxCompletionTokens)
+				assert.Nil(t, result.Input.MaxTokens)
+			},
+		},
+		{
+			name: "Deepseek_Model_NoSystemPrompt",
+			input: &schemas.BifrostChatRequest{
+				Model: "deepseek-ai/deepseek-coder-33b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleSystem,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("You are a helpful assistant."),
+						},
+					},
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hello!"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Deepseek models don't support system_prompt, it should be prepended to prompt
+				assert.Nil(t, result.Input.SystemPrompt)
+				assert.NotNil(t, result.Input.Prompt)
+				// System prompt should be prepended to conversation
+				assert.Contains(t, *result.Input.Prompt, "You are a helpful assistant.")
+				assert.Contains(t, *result.Input.Prompt, "Hello!")
+			},
+		},
+		{
+			name: "Meta_Llama_NoSystemPrompt",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/meta-llama-3-8b",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleSystem,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Be concise."),
+						},
+					},
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("What is AI?"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Meta llama models don't support system_prompt
+				assert.Nil(t, result.Input.SystemPrompt)
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Contains(t, *result.Input.Prompt, "Be concise.")
+				assert.Contains(t, *result.Input.Prompt, "What is AI?")
+			},
+		},
+		{
+			name: "Regular_Model_WithSystemPrompt",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleSystem,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("You are helpful."),
+						},
+					},
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Hi there"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Regular models support system_prompt
+				assert.NotNil(t, result.Input.SystemPrompt)
+				assert.Equal(t, "You are helpful.", *result.Input.SystemPrompt)
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Equal(t, "Hi there", *result.Input.Prompt)
+			},
+		},
+		{
+			name: "Non_OpenAI_Model_MaxTokens",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: &maxTokens,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Non-OpenAI models should use MaxTokens field
+				assert.NotNil(t, result.Input.MaxTokens)
+				assert.Equal(t, maxTokens, *result.Input.MaxTokens)
+				assert.Nil(t, result.Input.MaxCompletionTokens)
+			},
+		},
+		{
+			name: "Model_With_Version_ID",
+			input: &schemas.BifrostChatRequest{
+				Model: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test version ID"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				// Version ID should be set in Version field
+				assert.NotNil(t, result.Version)
+				assert.Equal(t, "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", *result.Version)
+			},
+		},
+		{
+			name: "AllParameters",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test all params"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: &maxTokens,
+					Temperature:         &temp,
+					TopP:                &topP,
+					Seed:                &seed,
+					PresencePenalty:     &presencePenalty,
+					FrequencyPenalty:    &frequencyPenalty,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.Equal(t, maxTokens, *result.Input.MaxTokens)
+				assert.Equal(t, temp, *result.Input.Temperature)
+				assert.Equal(t, topP, *result.Input.TopP)
+				assert.Equal(t, seed, *result.Input.Seed)
+				assert.Equal(t, presencePenalty, *result.Input.PresencePenalty)
+				assert.Equal(t, frequencyPenalty, *result.Input.FrequencyPenalty)
+			},
+		},
+		{
+			name: "MultipartContent_WithImageURL",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentBlocks: []schemas.ChatContentBlock{
+								{
+									Text: schemas.Ptr("Describe this image"),
+								},
+								{
+									ImageURLStruct: &schemas.ChatInputImage{
+										URL: "https://example.com/image.jpg",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Image URL should be added to ImageInput
+				assert.NotNil(t, result.Input.ImageInput)
+				assert.Len(t, result.Input.ImageInput, 1)
+				assert.Equal(t, "https://example.com/image.jpg", result.Input.ImageInput[0])
+				// Text should be in prompt
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Equal(t, "Describe this image", *result.Input.Prompt)
+			},
+		},
+		{
+			name: "MultipartContent_Base64Images",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentBlocks: []schemas.ChatContentBlock{
+								{
+									Text: schemas.Ptr("Test"),
+								},
+								{
+									ImageURLStruct: &schemas.ChatInputImage{
+										URL: "data:image/png;base64,iVBORw0KGgoAAAANS",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ImageInput)
+			},
+		},
+		{
+			name: "ReasoningEffort",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{
+					{
+						Role: schemas.ChatMessageRoleUser,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: schemas.Ptr("Test reasoning"),
+						},
+					},
+				},
+				Params: &schemas.ChatParameters{
+					Reasoning: &schemas.ChatReasoning{
+						Effort: schemas.Ptr("high"),
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ReasoningEffort)
+				assert.Equal(t, "high", *result.Input.ReasoningEffort)
+			},
+		},
+		{
+			name:    "NilRequest",
+			input:   nil,
+			wantErr: true,
+		},
+		{
+			name: "NilInput",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "EmptyMessages",
+			input: &schemas.BifrostChatRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ChatMessage{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := replicate.ToReplicateChatRequest(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, actual)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, actual)
+				if tt.validate != nil {
+					tt.validate(t, actual)
+				}
+			}
+		})
+	}
+}
+
+// TestBifrostToReplicateImageGenerationConversion tests the conversion from Bifrost image generation request
+// to Replicate format with special handling for different model families
+func TestBifrostToReplicateImageGenerationConversion(t *testing.T) {
+	prompt := "A beautiful sunset"
+	aspectRatio := "16:9"
+	numImages := 2
+	seed := 42
+	negativePrompt := "blurry"
+	numInferenceSteps := 50
+	quality := "high"
+	outputFormat := "png"
+	background := "white"
+
+	tests := []struct {
+		name     string
+		input    *schemas.BifrostImageGenerationRequest
+		validate func(t *testing.T, result *replicate.ReplicatePredictionRequest)
+		wantErr  bool
+	}{
+		{
+			name: "Flux_1_1_Pro_ImagePrompt",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-1.1-pro",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Flux 1.1 Pro should use ImagePrompt field
+				assert.NotNil(t, result.Input.ImagePrompt)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.ImagePrompt)
+				assert.Nil(t, result.Input.InputImage)
+				assert.Nil(t, result.Input.Image)
+				assert.Nil(t, result.Input.InputImages)
+			},
+		},
+		{
+			name: "Flux_1_1_Pro_Ultra_ImagePrompt",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-1.1-pro-ultra",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ImagePrompt)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.ImagePrompt)
+			},
+		},
+		{
+			name: "Flux_Pro_ImagePrompt",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-pro",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ImagePrompt)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.ImagePrompt)
+			},
+		},
+		{
+			name: "Flux_Kontext_Pro_InputImage",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-kontext-pro",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Kontext models should use InputImage field
+				assert.NotNil(t, result.Input.InputImage)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.InputImage)
+				assert.Nil(t, result.Input.ImagePrompt)
+				assert.Nil(t, result.Input.Image)
+				assert.Nil(t, result.Input.InputImages)
+			},
+		},
+		{
+			name: "Flux_Kontext_Max_InputImage",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-kontext-max",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.InputImage)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.InputImage)
+			},
+		},
+		{
+			name: "Flux_Dev_Image",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-dev",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Flux Dev should use Image field
+				assert.NotNil(t, result.Input.Image)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.Image)
+				assert.Nil(t, result.Input.ImagePrompt)
+				assert.Nil(t, result.Input.InputImage)
+				assert.Nil(t, result.Input.InputImages)
+			},
+		},
+		{
+			name: "Flux_Fill_Pro_Image",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-fill-pro",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.Image)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.Image)
+			},
+		},
+		{
+			name: "Other_Model_InputImages",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "stability-ai/sdxl",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input1.jpg", "https://example.com/input2.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Other models should use InputImages array
+				assert.NotNil(t, result.Input.InputImages)
+				assert.Len(t, result.Input.InputImages, 2)
+				assert.Equal(t, "https://example.com/input1.jpg", result.Input.InputImages[0])
+				assert.Equal(t, "https://example.com/input2.jpg", result.Input.InputImages[1])
+				assert.Nil(t, result.Input.ImagePrompt)
+				assert.Nil(t, result.Input.InputImage)
+				assert.Nil(t, result.Input.Image)
+			},
+		},
+		{
+			name: "Model_With_Version",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-1.1-pro:v1.0",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					InputImages: []string{"https://example.com/input.jpg"},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Should still match flux-1.1-pro and use ImagePrompt
+				assert.NotNil(t, result.Input.ImagePrompt)
+				assert.Equal(t, "https://example.com/input.jpg", *result.Input.ImagePrompt)
+			},
+		},
+		{
+			name: "AllParameters",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-dev",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					N:                 &numImages,
+					AspectRatio:       &aspectRatio,
+					Seed:              &seed,
+					NegativePrompt:    &negativePrompt,
+					NumInferenceSteps: &numInferenceSteps,
+					Quality:           &quality,
+					OutputFormat:      &outputFormat,
+					Background:        &background,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.Equal(t, prompt, *result.Input.Prompt)
+				assert.Equal(t, numImages, *result.Input.NumberOfImages)
+				assert.Equal(t, aspectRatio, *result.Input.AspectRatio)
+				assert.Equal(t, seed, *result.Input.Seed)
+				assert.Equal(t, negativePrompt, *result.Input.NegativePrompt)
+				assert.Equal(t, numInferenceSteps, *result.Input.NumInferenceStep)
+				assert.Equal(t, quality, *result.Input.Quality)
+				assert.Equal(t, outputFormat, *result.Input.OutputFormat)
+				assert.Equal(t, background, *result.Input.Background)
+			},
+		},
+		{
+			name: "Version_ID",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				// Version ID should be set in Version field
+				assert.NotNil(t, result.Version)
+				assert.Equal(t, "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", *result.Version)
+			},
+		},
+		{
+			name: "ExtraParams",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-dev",
+				Input: &schemas.ImageGenerationInput{
+					Prompt: prompt,
+				},
+				Params: &schemas.ImageGenerationParameters{
+					ExtraParams: map[string]interface{}{
+						"custom_param": "value",
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ExtraParams)
+				assert.Equal(t, "value", result.Input.ExtraParams["custom_param"])
+			},
+		},
+		{
+			name:    "NilRequest",
+			input:   nil,
+			wantErr: false, // Function returns nil, not error
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				assert.Nil(t, result)
+			},
+		},
+		{
+			name: "NilInput",
+			input: &schemas.BifrostImageGenerationRequest{
+				Model: "black-forest-labs/flux-dev",
+				Input: nil,
+			},
+			wantErr: false,
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				assert.Nil(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := replicate.ToReplicateImageGenerationInput(tt.input)
+			if tt.wantErr {
+				assert.Nil(t, actual)
+			} else {
+				if tt.validate != nil {
+					tt.validate(t, actual)
+				}
+			}
+		})
+	}
+}
+
+// TestBifrostToReplicateResponsesRequestConversion tests the conversion from Bifrost responses request to Replicate format
+func TestBifrostToReplicateResponsesRequestConversion(t *testing.T) {
+	maxOutputTokens := 100
+	temp := 0.7
+	topP := 0.9
+	reasoningEffort := "medium"
+	instructions := "Be concise"
+
+	tests := []struct {
+		name     string
+		input    *schemas.BifrostResponsesRequest
+		validate func(t *testing.T, result *replicate.ReplicatePredictionRequest)
+		wantErr  bool
+	}{
+		{
+			name: "GPT5_Structured_With_InputItemList",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "openai/gpt-5-structured",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Hello, how are you?"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Instructions:    &instructions,
+					MaxOutputTokens: &maxOutputTokens,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// GPT-5 structured models should use InputItemList
+				assert.NotNil(t, result.Input.InputItemList)
+				assert.Len(t, result.Input.InputItemList, 1)
+				assert.Equal(t, schemas.ResponsesInputMessageRoleUser, *result.Input.InputItemList[0].Role)
+				assert.Equal(t, "Hello, how are you?", *result.Input.InputItemList[0].Content.ContentStr)
+				// Check parameters
+				assert.Equal(t, &instructions, result.Input.Instructions)
+				assert.Equal(t, &maxOutputTokens, result.Input.MaxOutputTokens)
+			},
+		},
+		{
+			name: "GPT5_Structured_With_Tools",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "openai/gpt-5-structured-preview",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("What's the weather?"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type:        schemas.ResponsesToolTypeFunction,
+							Name:        schemas.Ptr("get_weather"),
+							Description: schemas.Ptr("Get weather information"),
+							ResponsesToolFunction: &schemas.ResponsesToolFunction{
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("location", map[string]interface{}{
+											"type": "string",
+										}),
+									),
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.Tools)
+				assert.Len(t, result.Input.Tools, 1)
+				assert.Equal(t, "get_weather", *result.Input.Tools[0].Name)
+				assert.NotNil(t, result.Input.InputItemList)
+			},
+		},
+		{
+			name: "OpenAI_Family_With_Messages",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "openai/gpt-4o",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("You are helpful."),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Hello!"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// OpenAI family (non-gpt5-structured) should use Messages
+				assert.NotNil(t, result.Input.Messages)
+				assert.Len(t, result.Input.Messages, 2)
+				assert.Equal(t, schemas.ChatMessageRoleSystem, result.Input.Messages[0].Role)
+				assert.Equal(t, schemas.ChatMessageRoleUser, result.Input.Messages[1].Role)
+				assert.Nil(t, result.Input.InputItemList)
+			},
+		},
+		{
+			name: "NonOpenAI_Model_With_SystemPrompt",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Be helpful."),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Hi there!"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Non-OpenAI models that support system_prompt
+				assert.NotNil(t, result.Input.SystemPrompt)
+				assert.Equal(t, "Be helpful.", *result.Input.SystemPrompt)
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Equal(t, "Hi there!", *result.Input.Prompt)
+			},
+		},
+		{
+			name: "NonOpenAI_Model_NoSystemPrompt_Support",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "deepseek-ai/deepseek-coder-33b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleSystem),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("You are a code assistant."),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Write a function."),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Deepseek models don't support system_prompt, should be prepended to prompt
+				assert.Nil(t, result.Input.SystemPrompt)
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Contains(t, *result.Input.Prompt, "You are a code assistant.")
+				assert.Contains(t, *result.Input.Prompt, "Write a function.")
+			},
+		},
+		{
+			name: "ContentBlocks_With_Text",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Text: schemas.Ptr("Part 1"),
+								},
+								{
+									Text: schemas.Ptr("Part 2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.Prompt)
+				// Text parts should be joined with newline
+				assert.Equal(t, "Part 1\nPart 2", *result.Input.Prompt)
+			},
+		},
+		{
+			name: "ContentBlocks_With_ImageURL",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Text: schemas.Ptr("Describe this"),
+								},
+								{
+									ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+										ImageURL: schemas.Ptr("https://example.com/image.jpg"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Non-base64 image URLs should be added to ImageInput
+				assert.NotNil(t, result.Input.ImageInput)
+				assert.Len(t, result.Input.ImageInput, 1)
+				assert.Equal(t, "https://example.com/image.jpg", result.Input.ImageInput[0])
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Equal(t, "Describe this", *result.Input.Prompt)
+			},
+		},
+		{
+			name: "ContentBlocks_Base64_Images",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentBlocks: []schemas.ResponsesMessageContentBlock{
+								{
+									Text: schemas.Ptr("Test"),
+								},
+								{
+									ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+										ImageURL: schemas.Ptr("data:image/png;base64,abc123"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ImageInput)
+			},
+		},
+		{
+			name: "MultipleMessages_Assistant_User",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("What is AI?"),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("AI is artificial intelligence."),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Tell me more."),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.Prompt)
+				// All conversation parts should be joined
+				assert.Contains(t, *result.Input.Prompt, "What is AI?")
+				assert.Contains(t, *result.Input.Prompt, "AI is artificial intelligence.")
+				assert.Contains(t, *result.Input.Prompt, "Tell me more.")
+			},
+		},
+		{
+			name: "Parameters_OpenAI_MaxCompletionTokens",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "openai/gpt-4o",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Test"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: &maxOutputTokens,
+					Temperature:     &temp,
+					TopP:            &topP,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// OpenAI models should use MaxCompletionTokens
+				assert.NotNil(t, result.Input.MaxCompletionTokens)
+				assert.Equal(t, maxOutputTokens, *result.Input.MaxCompletionTokens)
+				assert.Nil(t, result.Input.MaxTokens)
+				// Check other parameters
+				assert.Equal(t, temp, *result.Input.Temperature)
+				assert.Equal(t, topP, *result.Input.TopP)
+			},
+		},
+		{
+			name: "Parameters_NonOpenAI_MaxTokens",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Test"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: &maxOutputTokens,
+					Temperature:     &temp,
+					TopP:            &topP,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Non-OpenAI models should use MaxTokens
+				assert.NotNil(t, result.Input.MaxTokens)
+				assert.Equal(t, maxOutputTokens, *result.Input.MaxTokens)
+				assert.Nil(t, result.Input.MaxCompletionTokens)
+			},
+		},
+		{
+			name: "ReasoningEffort",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Test reasoning"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Reasoning: &schemas.ResponsesParametersReasoning{
+						Effort: &reasoningEffort,
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.ReasoningEffort)
+				assert.Equal(t, reasoningEffort, *result.Input.ReasoningEffort)
+			},
+		},
+		{
+			name: "Instructions_With_SystemPrompt_Support",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Hello"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Instructions: &instructions,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Models that support system_prompt should use it for instructions
+				assert.NotNil(t, result.Input.SystemPrompt)
+				assert.Equal(t, instructions, *result.Input.SystemPrompt)
+			},
+		},
+		{
+			name: "Instructions_Without_SystemPrompt_Support",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "deepseek-ai/deepseek-coder-33b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Hello"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Instructions: &instructions,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				// Models that don't support system_prompt should prepend instructions to prompt
+				assert.Nil(t, result.Input.SystemPrompt)
+				assert.NotNil(t, result.Input.Prompt)
+				assert.Contains(t, *result.Input.Prompt, instructions)
+				assert.Contains(t, *result.Input.Prompt, "Hello")
+			},
+		},
+		{
+			name: "Instructions_Prepended_To_Existing_Prompt",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "deepseek-ai/deepseek-coder-33b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Existing content"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Instructions: &instructions,
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.Prompt)
+				// Instructions should be prepended before existing content
+				promptStr := *result.Input.Prompt
+				instrIdx := strings.Index(promptStr, instructions)
+				contentIdx := strings.Index(promptStr, "Existing content")
+				assert.Less(t, instrIdx, contentIdx, "Instructions should come before content")
+			},
+		},
+		{
+			name: "Version_ID",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Test version"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				// Version ID should be set in Version field
+				assert.NotNil(t, result.Version)
+				assert.Equal(t, "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", *result.Version)
+			},
+		},
+		{
+			name: "EmptyContent_Messages_Skipped",
+			input: &schemas.BifrostResponsesRequest{
+				Model: "meta/llama-3.1-70b-instruct",
+				Input: []schemas.ResponsesMessage{
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr(""),
+						},
+					},
+					{
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Valid message"),
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *replicate.ReplicatePredictionRequest) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Input)
+				assert.NotNil(t, result.Input.Prompt)
+				// Only valid message should be present
+				assert.Equal(t, "Valid message", *result.Input.Prompt)
+			},
+		},
+		{
+			name:    "NilRequest",
+			input:   nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := replicate.ToReplicateResponsesRequest(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, actual)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, actual)
+				if tt.validate != nil {
+					tt.validate(t, actual)
+				}
+			}
+		})
+	}
+}
+
+// TestReplicateToBifrostResponsesResponse tests the conversion from Replicate prediction response to Bifrost responses format
+func TestReplicateToBifrostResponsesResponse(t *testing.T) {
+	predictionID := "test-prediction-123"
+	model := "openai/gpt-4o"
+	createdAt := "2024-01-25T12:00:00.000000Z"
+	completedAt := "2024-01-25T12:00:05.000000Z"
+	errorMsg := "Something went wrong"
+
+	tests := []struct {
+		name     string
+		input    *replicate.ReplicatePredictionResponse
+		validate func(t *testing.T, result *schemas.BifrostResponsesResponse)
+	}{
+		{
+			name: "Successful_Response_OutputStr",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusSucceeded,
+				Output: &replicate.ReplicateOutput{
+					OutputStr: schemas.Ptr("This is the response text."),
+				},
+				Logs: schemas.Ptr("Input token count: 10\nOutput token count: 20\nTotal token count: 30"),
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.Equal(t, predictionID, *result.ID)
+				assert.Equal(t, model, result.Model)
+				assert.NotNil(t, result.Status)
+				assert.Equal(t, "completed", *result.Status)
+				// Check output messages
+				require.NotNil(t, result.Output)
+				require.Len(t, result.Output, 1)
+				assert.Equal(t, schemas.ResponsesMessageTypeMessage, *result.Output[0].Type)
+				assert.Equal(t, schemas.ResponsesInputMessageRoleAssistant, *result.Output[0].Role)
+				assert.Equal(t, "This is the response text.", *result.Output[0].Content.ContentStr)
+				// Check usage
+				require.NotNil(t, result.Usage)
+				assert.Equal(t, 10, result.Usage.InputTokens)
+				assert.Equal(t, 20, result.Usage.OutputTokens)
+				assert.Equal(t, 30, result.Usage.TotalTokens)
+			},
+		},
+		{
+			name: "Successful_Response_OutputArray",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusSucceeded,
+				Output: &replicate.ReplicateOutput{
+					OutputArray: []string{"Part 1", " Part 2", " Part 3"},
+				},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Output)
+				require.Len(t, result.Output, 1)
+				// Array should be joined into a single string
+				assert.Equal(t, "Part 1 Part 2 Part 3", *result.Output[0].Content.ContentStr)
+			},
+		},
+		{
+			name: "Successful_Response_OutputObject",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusSucceeded,
+				Output: &replicate.ReplicateOutput{
+					OutputObject: &replicate.ReplicateOutputText{
+						Text: schemas.Ptr("Object text content"),
+					},
+				},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Output)
+				require.Len(t, result.Output, 1)
+				assert.Equal(t, "Object text content", *result.Output[0].Content.ContentStr)
+			},
+		},
+		{
+			name: "Failed_Response_With_Error",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusFailed,
+				Error:     &errorMsg,
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.NotNil(t, result.Status)
+				assert.Equal(t, "failed", *result.Status)
+				// Check error
+				require.NotNil(t, result.Error)
+				assert.Equal(t, "provider_error", result.Error.Code)
+				assert.Equal(t, errorMsg, result.Error.Message)
+			},
+		},
+		{
+			name: "Cancelled_Response",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusCanceled,
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.NotNil(t, result.Status)
+				assert.Equal(t, "cancelled", *result.Status)
+			},
+		},
+		{
+			name: "InProgress_Response",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusProcessing,
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.NotNil(t, result.Status)
+				assert.Equal(t, "in_progress", *result.Status)
+			},
+		},
+		{
+			name: "Queued_Response",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusStarting,
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.NotNil(t, result.Status)
+				assert.Equal(t, "queued", *result.Status)
+			},
+		},
+		{
+			name: "Response_With_CompletedAt",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:          predictionID,
+				Model:       model,
+				CreatedAt:   createdAt,
+				CompletedAt: &completedAt,
+				Status:      replicate.ReplicatePredictionStatusSucceeded,
+				Output: &replicate.ReplicateOutput{
+					OutputStr: schemas.Ptr("Done"),
+				},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.NotZero(t, result.CreatedAt)
+				assert.NotNil(t, result.CompletedAt)
+				assert.NotZero(t, *result.CompletedAt)
+			},
+		},
+		{
+			name: "Response_With_Partial_Usage",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusSucceeded,
+				Output: &replicate.ReplicateOutput{
+					OutputStr: schemas.Ptr("Response"),
+				},
+				Logs: schemas.Ptr("Input token count: 15\nOutput token count: 0"),
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				require.NotNil(t, result.Usage)
+				assert.Equal(t, 15, result.Usage.InputTokens)
+				assert.Equal(t, 0, result.Usage.OutputTokens)
+				assert.Equal(t, 15, result.Usage.TotalTokens)
+			},
+		},
+		{
+			name: "Empty_Output_Content",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusSucceeded,
+				Output: &replicate.ReplicateOutput{
+					OutputStr: schemas.Ptr(""),
+				},
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				// Empty content should not create output messages
+				assert.Empty(t, result.Output)
+			},
+		},
+		{
+			name: "No_Output",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusProcessing,
+				Output:    nil,
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				assert.Empty(t, result.Output)
+			},
+		},
+		{
+			name: "Empty_Error_Not_Set",
+			input: &replicate.ReplicatePredictionResponse{
+				ID:        predictionID,
+				Model:     model,
+				CreatedAt: createdAt,
+				Status:    replicate.ReplicatePredictionStatusFailed,
+				Error:     schemas.Ptr(""),
+			},
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				require.NotNil(t, result)
+				// Empty error string should not set error field
+				assert.Nil(t, result.Error)
+			},
+		},
+		{
+			name:  "Nil_Response",
+			input: nil,
+			validate: func(t *testing.T, result *schemas.BifrostResponsesResponse) {
+				assert.Nil(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.input.ToBifrostResponsesResponse()
+			if tt.validate != nil {
+				tt.validate(t, actual)
+			}
+		})
+	}
+}

--- a/core/providers/replicate/responses.go
+++ b/core/providers/replicate/responses.go
@@ -1,0 +1,300 @@
+package replicate
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func ToReplicateResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*ReplicatePredictionRequest, error) {
+	if bifrostReq == nil {
+		return nil, fmt.Errorf("bifrost request is nil")
+	}
+
+	input := &ReplicatePredictionRequestInput{}
+
+	if strings.HasPrefix(bifrostReq.Model, "openai/") && strings.Contains(bifrostReq.Model, "gpt-5-structured") {
+		// handle responses style request
+		if len(bifrostReq.Input) > 0 {
+			input.InputItemList = bifrostReq.Input
+		}
+		if bifrostReq.Params != nil {
+			if bifrostReq.Params.Instructions != nil {
+				input.Instructions = bifrostReq.Params.Instructions
+			}
+			if bifrostReq.Params.Tools != nil {
+				input.Tools = bifrostReq.Params.Tools
+			}
+			if bifrostReq.Params.MaxOutputTokens != nil {
+				input.MaxOutputTokens = bifrostReq.Params.MaxOutputTokens
+			}
+			if bifrostReq.Params.Text != nil {
+				input.JsonSchema = bifrostReq.Params.Text
+			}
+			if bifrostReq.Params.ExtraParams != nil {
+				input.ExtraParams = bifrostReq.Params.ExtraParams
+			}
+		}
+	} else {
+		// handle chat style request (same logic as chat converter)
+		if len(bifrostReq.Input) > 0 {
+			// if model is from openai family, use messages
+			if strings.HasPrefix(bifrostReq.Model, string(schemas.OpenAI)) {
+				input.Messages = schemas.ToChatMessages(bifrostReq.Input)
+			} else {
+				// convert input to prompt and system prompt
+				var systemPrompt string
+				var conversationParts []string
+				var imageInput []string
+
+				for _, msg := range bifrostReq.Input {
+					if msg.Content == nil {
+						continue
+					}
+
+					// Get message content as string
+					var contentStr string
+					if msg.Content.ContentStr != nil {
+						contentStr = *msg.Content.ContentStr
+					} else if msg.Content.ContentBlocks != nil {
+						// Concatenate text blocks only
+						var textParts []string
+						for _, block := range msg.Content.ContentBlocks {
+							if block.Text != nil && *block.Text != "" {
+								textParts = append(textParts, *block.Text)
+							}
+							if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil && *block.ResponsesInputMessageContentBlockImage.ImageURL != "" {
+								imageInput = append(imageInput, *block.ResponsesInputMessageContentBlockImage.ImageURL)
+							}
+						}
+						contentStr = strings.Join(textParts, "\n")
+					}
+
+					if contentStr == "" {
+						continue
+					}
+
+					// Handle different roles
+					if msg.Role != nil {
+						switch *msg.Role {
+						case schemas.ResponsesInputMessageRoleSystem:
+							if systemPrompt == "" {
+								systemPrompt = contentStr
+							} else {
+								systemPrompt += "\n" + contentStr
+							}
+						case schemas.ResponsesInputMessageRoleUser:
+							conversationParts = append(conversationParts, contentStr)
+						case schemas.ResponsesInputMessageRoleAssistant:
+							// For assistant messages, we can include them in the conversation context
+							conversationParts = append(conversationParts, contentStr)
+						}
+					}
+				}
+
+				// Set system prompt if present and model supports it
+				modelSupportsSystemPrompt := supportsSystemPrompt(bifrostReq.Model)
+
+				if systemPrompt != "" {
+					if modelSupportsSystemPrompt {
+						// Model supports system_prompt field
+						input.SystemPrompt = &systemPrompt
+					} else {
+						// Model doesn't support system_prompt - prepend to prompt
+						if len(conversationParts) > 0 {
+							// Prepend system prompt to conversation
+							conversationParts = append([]string{systemPrompt}, conversationParts...)
+						} else {
+							// No conversation parts, use system prompt as the prompt
+							conversationParts = []string{systemPrompt}
+						}
+					}
+				}
+
+				// Build the final prompt from conversation parts
+				if len(conversationParts) > 0 {
+					prompt := strings.Join(conversationParts, "\n\n")
+					input.Prompt = &prompt
+				}
+
+				if len(imageInput) > 0 {
+					input.ImageInput = imageInput
+				}
+			}
+		}
+
+		// Map parameters if present
+		if bifrostReq.Params != nil {
+			params := bifrostReq.Params
+
+			// Temperature
+			if params.Temperature != nil {
+				input.Temperature = params.Temperature
+			}
+
+			// Top P
+			if params.TopP != nil {
+				input.TopP = params.TopP
+			}
+
+			// Max tokens - use max_completion_tokens if available
+			if params.MaxOutputTokens != nil {
+				if strings.HasPrefix(bifrostReq.Model, string(schemas.OpenAI)) {
+					input.MaxCompletionTokens = params.MaxOutputTokens
+				} else {
+					input.MaxTokens = params.MaxOutputTokens
+				}
+			}
+
+			// Reasoning effort
+			if params.Reasoning != nil {
+				if params.Reasoning.Effort != nil {
+					input.ReasoningEffort = params.Reasoning.Effort
+				}
+			}
+
+			if params.Instructions != nil && *params.Instructions != "" {
+				if supportsSystemPrompt(bifrostReq.Model) {
+					if input.SystemPrompt == nil {
+						input.SystemPrompt = params.Instructions
+					}
+				} else {
+					if input.Prompt != nil && *input.Prompt != "" {
+						prefixed := *params.Instructions + "\n\n" + *input.Prompt
+						input.Prompt = schemas.Ptr(prefixed)
+					} else if input.Prompt == nil {
+						input.Prompt = params.Instructions
+					}
+				}
+			}
+
+			if params.ExtraParams != nil {
+				input.ExtraParams = params.ExtraParams
+			}
+		}
+	}
+
+	// Check if model is a version ID and set version field accordingly
+	req := &ReplicatePredictionRequest{
+		Input: input,
+	}
+
+	if isVersionID(bifrostReq.Model) {
+		req.Version = &bifrostReq.Model
+	}
+
+	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
+		if webhook, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["webhook"]); ok {
+			req.Webhook = webhook
+		}
+		if webhookEventsFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["webhook_events_filter"]); ok {
+			req.WebhookEventsFilter = webhookEventsFilter
+		}
+	}
+
+	return req, nil
+}
+
+func (response *ReplicatePredictionResponse) ToBifrostResponsesResponse() *schemas.BifrostResponsesResponse {
+	if response == nil {
+		return nil
+	}
+
+	// Parse timestamps
+	createdAt := ParseReplicateTimestamp(response.CreatedAt)
+	if createdAt == 0 {
+		createdAt = time.Now().Unix()
+	}
+
+	var completedAt *int
+	if response.CompletedAt != nil {
+		completed := int(ParseReplicateTimestamp(*response.CompletedAt))
+		if completed > 0 {
+			completedAt = &completed
+		}
+	}
+
+	// Initialize Bifrost response
+	bifrostResponse := &schemas.BifrostResponsesResponse{
+		ID:          schemas.Ptr(response.ID),
+		Model:       response.Model,
+		CreatedAt:   int(createdAt),
+		CompletedAt: completedAt,
+	}
+
+	// Convert output to ResponsesMessage
+	var outputMessages []schemas.ResponsesMessage
+	if response.Output != nil {
+		var contentStr *string
+
+		// Handle different output types
+		if response.Output.OutputStr != nil {
+			contentStr = response.Output.OutputStr
+		} else if response.Output.OutputArray != nil {
+			// Join array of strings into a single string
+			joined := strings.Join(response.Output.OutputArray, "")
+			contentStr = &joined
+		} else if response.Output.OutputObject != nil && response.Output.OutputObject.Text != nil {
+			// Use text field from OutputObject
+			contentStr = response.Output.OutputObject.Text
+		}
+
+		if contentStr != nil && *contentStr != "" {
+			messageType := schemas.ResponsesMessageTypeMessage
+			role := schemas.ResponsesInputMessageRoleAssistant
+
+			outputMsg := schemas.ResponsesMessage{
+				Type: &messageType,
+				Role: &role,
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: contentStr,
+				},
+			}
+			outputMessages = append(outputMessages, outputMsg)
+		}
+	}
+
+	bifrostResponse.Output = outputMessages
+
+	// Set status based on prediction status
+	var status string
+	switch response.Status {
+	case ReplicatePredictionStatusSucceeded:
+		status = "completed"
+	case ReplicatePredictionStatusFailed:
+		status = "failed"
+	case ReplicatePredictionStatusCanceled:
+		status = "cancelled"
+	case ReplicatePredictionStatusProcessing:
+		status = "in_progress"
+	case ReplicatePredictionStatusStarting:
+		status = "queued"
+	default:
+		status = string(response.Status)
+	}
+	bifrostResponse.Status = &status
+
+	// Set error if present
+	if response.Error != nil && *response.Error != "" {
+		bifrostResponse.Error = &schemas.ResponsesResponseError{
+			Code:    "provider_error",
+			Message: *response.Error,
+		}
+	}
+
+	// Extract usage information from logs
+	if response.Logs != nil {
+		inputTokens, outputTokens, totalTokens, found := parseTokenUsageFromLogs(response.Logs, schemas.ResponsesRequest)
+		if found {
+			bifrostResponse.Usage = &schemas.ResponsesResponseUsage{
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
+				TotalTokens:  totalTokens,
+			}
+		}
+	}
+
+	return bifrostResponse
+}

--- a/core/providers/replicate/text.go
+++ b/core/providers/replicate/text.go
@@ -1,0 +1,148 @@
+package replicate
+
+import (
+	"fmt"
+	"strings"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func ToReplicateTextRequest(bifrostReq *schemas.BifrostTextCompletionRequest) (*ReplicatePredictionRequest, error) {
+	if bifrostReq == nil || bifrostReq.Input == nil {
+		return nil, fmt.Errorf("bifrost request is nil or prompt is nil")
+	}
+
+	input := &ReplicatePredictionRequestInput{}
+	if bifrostReq.Input.PromptStr != nil {
+		input.Prompt = bifrostReq.Input.PromptStr
+	} else if len(bifrostReq.Input.PromptArray) > 0 {
+		prompt := strings.Join(bifrostReq.Input.PromptArray, "\n")
+		input.Prompt = &prompt
+	}
+
+	// Map parameters if present
+	if bifrostReq.Params != nil {
+		params := bifrostReq.Params
+
+		// Temperature
+		if params.Temperature != nil {
+			input.Temperature = params.Temperature
+		}
+
+		// Top P
+		if params.TopP != nil {
+			input.TopP = params.TopP
+		}
+
+		// Max tokens
+		if params.MaxTokens != nil {
+			input.MaxTokens = params.MaxTokens
+		}
+
+		// Presence penalty
+		if params.PresencePenalty != nil {
+			input.PresencePenalty = params.PresencePenalty
+		}
+
+		// Frequency penalty
+		if params.FrequencyPenalty != nil {
+			input.FrequencyPenalty = params.FrequencyPenalty
+		}
+
+		// Top K (from ExtraParams)
+		if topK, ok := schemas.SafeExtractIntPointer(params.ExtraParams["top_k"]); ok {
+			input.TopK = topK
+		}
+
+		// Seed
+		if params.Seed != nil {
+			input.Seed = params.Seed
+		}
+
+		if params.ExtraParams != nil {
+			input.ExtraParams = params.ExtraParams
+		}
+	}
+
+	// Check if model is a version ID and set version field accordingly
+	req := &ReplicatePredictionRequest{
+		Input: input,
+	}
+
+	if isVersionID(bifrostReq.Model) {
+		req.Version = &bifrostReq.Model
+	}
+
+	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
+		if webhook, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["webhook"]); ok {
+			req.Webhook = webhook
+		}
+		if webhookEventsFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["webhook_events_filter"]); ok {
+			req.WebhookEventsFilter = webhookEventsFilter
+		}
+	}
+
+	return req, nil
+}
+
+// ToBifrostTextCompletionResponse converts a Replicate prediction response to Bifrost format
+func (response *ReplicatePredictionResponse) ToBifrostTextCompletionResponse() *schemas.BifrostTextCompletionResponse {
+	if response == nil {
+		return nil
+	}
+
+	// Initialize Bifrost response
+	bifrostResponse := &schemas.BifrostTextCompletionResponse{
+		ID:     response.ID,
+		Model:  response.Model,
+		Object: "text_completion",
+	}
+
+	// Convert output to text
+	var textOutput *string
+	if response.Output != nil {
+		if response.Output.OutputStr != nil {
+			textOutput = response.Output.OutputStr
+		} else if response.Output.OutputArray != nil {
+			// Join array of strings into a single string
+			joined := strings.Join(response.Output.OutputArray, "")
+			textOutput = &joined
+		}
+	}
+
+	// Determine finish reason based on status
+	var finishReason *string
+	switch response.Status {
+	case ReplicatePredictionStatusSucceeded:
+		finishReason = schemas.Ptr("stop")
+	case ReplicatePredictionStatusFailed:
+		finishReason = schemas.Ptr("error")
+	case ReplicatePredictionStatusCanceled:
+		finishReason = schemas.Ptr("stop")
+	}
+
+	// Create choice with text completion response choice
+	choice := schemas.BifrostResponseChoice{
+		Index: 0,
+		TextCompletionResponseChoice: &schemas.TextCompletionResponseChoice{
+			Text: textOutput,
+		},
+		FinishReason: finishReason,
+	}
+
+	bifrostResponse.Choices = []schemas.BifrostResponseChoice{choice}
+
+	// Extract usage information from logs
+	if response.Logs != nil {
+		inputTokens, outputTokens, totalTokens, found := parseTokenUsageFromLogs(response.Logs, schemas.TextCompletionRequest)
+		if found {
+			bifrostResponse.Usage = &schemas.BifrostLLMUsage{
+				PromptTokens:     inputTokens,
+				CompletionTokens: outputTokens,
+				TotalTokens:      totalTokens,
+			}
+		}
+	}
+
+	return bifrostResponse
+}

--- a/core/providers/replicate/types.go
+++ b/core/providers/replicate/types.go
@@ -1,0 +1,511 @@
+package replicate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bytedance/sonic"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// ==================== REQUEST TYPES ====================
+
+// ReplicatePredictionRequest represents a request to create a prediction
+type ReplicatePredictionRequest struct {
+	Version             *string                          `json:"version,omitempty"`                // Required: Model version ID
+	Input               *ReplicatePredictionRequestInput `json:"input"`                            // Required: Input parameters for the model
+	Stream              *bool                            `json:"stream,omitempty"`                 // Enable streaming output
+	Webhook             *string                          `json:"webhook,omitempty"`                // Webhook URL for notifications
+	WebhookEventsFilter []string                         `json:"webhook_events_filter,omitempty"`  // Filter webhook events: start, output, logs, completed
+	OutputFileURLPrefix *string                          `json:"output_file_url_prefix,omitempty"` // Custom prefix for output file URLs
+	PollTimeout         *int                             `json:"poll_timeout,omitempty"`           // Timeout in seconds for polling (used with Prefer: wait header)
+	UseFileOutput       *bool                            `json:"use_file_output,omitempty"`        // Output files as URLs instead of data URIs
+	ExtraParams         map[string]interface{}           `json:"-"`                                // Extra parameters to merge into the request
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *ReplicatePredictionRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
+}
+
+// ReplicatePredictionRequestInput represents the input parameters for a model prediction
+// This is flexible to support different model types - exact fields depend on the model
+type ReplicatePredictionRequestInput struct {
+	Prompt           *string               `json:"prompt,omitempty"`
+	Messages         []schemas.ChatMessage `json:"messages,omitempty"`
+	SystemPrompt     *string               `json:"system_prompt,omitempty"`
+	Image            *string               `json:"image,omitempty"`               // URL or data URI
+	NumberOfImages   *int                  `json:"number_of_images,omitempty"`    // Number of images to generate
+	Quality          *string               `json:"quality,omitempty"`             // Quality of the image
+	Background       *string               `json:"background,omitempty"`          // Background of the image
+	Seed             *int                  `json:"seed,omitempty"`                // Random seed
+	ReasoningEffort  *string               `json:"reasoning_effort,omitempty"`    // Reasoning effort
+	NumInferenceStep *int                  `json:"num_inference_steps,omitempty"` // Number of inference steps
+	NegativePrompt   *string               `json:"negative_prompt,omitempty"`     // Negative prompt
+
+	// Responses parameters
+	Instructions    *string                      `json:"instructions,omitempty"`
+	InputItemList   []schemas.ResponsesMessage   `json:"input_item_list,omitempty"`
+	Tools           []schemas.ResponsesTool      `json:"tools,omitempty"`
+	MaxOutputTokens *int                         `json:"max_output_tokens,omitempty"`
+	JsonSchema      *schemas.ResponsesTextConfig `json:"json_schema,omitempty"`
+
+	// Chat parameters
+	Temperature         *float64 `json:"temperature,omitempty"`           // Temperature for sampling
+	TopP                *float64 `json:"top_p,omitempty"`                 // Top-p sampling
+	TopK                *int     `json:"top_k,omitempty"`                 // Top-k sampling
+	MaxTokens           *int     `json:"max_tokens,omitempty"`            // Maximum tokens to generate
+	MaxCompletionTokens *int     `json:"max_completion_tokens,omitempty"` // Maximum completion tokens to generate
+	PresencePenalty     *float64 `json:"presence_penalty,omitempty"`      // Presence penalty
+	FrequencyPenalty    *float64 `json:"frequency_penalty,omitempty"`     // Frequency penalty
+
+	// Image generation parameters
+	AspectRatio  *string  `json:"aspect_ratio,omitempty"`
+	OutputFormat *string  `json:"output_format,omitempty"`
+	Resolution   *string  `json:"resolution,omitempty"`   // e.g., "1 MP"
+	InputImages  []string `json:"input_images,omitempty"` // Image input for image-to-image models
+	ImagePrompt  *string  `json:"image_prompt,omitempty"` // Image prompt for image models (flux family)
+	ImageInput   []string `json:"image_input,omitempty"`  // Image input for chat models (openai family)
+	InputImage   *string  `json:"input_image,omitempty"`  // Image input for image-to-image models
+
+	ExtraParams map[string]interface{} `json:"-"` // Additional model-specific parameters
+}
+
+// MarshalJSON implements custom JSON marshalling for ReplicatePredictionRequestInput.
+// It marshals all defined fields and then flattens ExtraParams at the top level.
+func (r *ReplicatePredictionRequestInput) MarshalJSON() ([]byte, error) {
+	if r == nil {
+		return []byte("null"), nil
+	}
+
+	// Create a temporary type to avoid infinite recursion
+	type Alias ReplicatePredictionRequestInput
+
+	// Marshal the struct normally (ExtraParams will be omitted due to json:"-" tag)
+	aliasData, err := sonic.Marshal((*Alias)(r))
+	if err != nil {
+		return nil, err
+	}
+
+	// If there are no ExtraParams, return the marshaled data as-is
+	if len(r.ExtraParams) == 0 {
+		return aliasData, nil
+	}
+
+	// Unmarshal into a map to merge with ExtraParams
+	var result map[string]interface{}
+	if err := sonic.Unmarshal(aliasData, &result); err != nil {
+		return nil, err
+	}
+
+	// Add all ExtraParams to the top level
+	for key, value := range r.ExtraParams {
+		result[key] = value
+	}
+
+	// Marshal the final result
+	return sonic.Marshal(result)
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for ReplicatePredictionRequestInput.
+// It unmarshals known fields and captures any unrecognized fields in ExtraParams.
+func (r *ReplicatePredictionRequestInput) UnmarshalJSON(data []byte) error {
+	// Create a temporary type to avoid infinite recursion
+	type Alias ReplicatePredictionRequestInput
+
+	// Unmarshal into the alias type
+	aux := (*Alias)(r)
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Unmarshal into a map to find extra fields
+	var rawMap map[string]interface{}
+	if err := sonic.Unmarshal(data, &rawMap); err != nil {
+		return err
+	}
+
+	// List of known field names (in JSON format)
+	knownFields := map[string]bool{
+		"prompt":                true,
+		"messages":              true,
+		"system_prompt":         true,
+		"image":                 true,
+		"number_of_images":      true,
+		"quality":               true,
+		"background":            true,
+		"seed":                  true,
+		"reasoning_effort":      true,
+		"num_inference_steps":   true,
+		"negative_prompt":       true,
+		"instructions":          true,
+		"input_item_list":       true,
+		"tools":                 true,
+		"max_output_tokens":     true,
+		"json_schema":           true,
+		"temperature":           true,
+		"top_p":                 true,
+		"top_k":                 true,
+		"max_tokens":            true,
+		"max_completion_tokens": true,
+		"presence_penalty":      true,
+		"frequency_penalty":     true,
+		"aspect_ratio":          true,
+		"output_format":         true,
+		"resolution":            true,
+		"input_images":          true,
+		"image_prompt":          true,
+		"input_image":           true,
+		"image_input":           true,
+	}
+
+	// Collect extra fields
+	r.ExtraParams = make(map[string]interface{})
+	for key, value := range rawMap {
+		if !knownFields[key] {
+			r.ExtraParams[key] = value
+		}
+	}
+
+	// If no extra params found, keep it as nil instead of empty map
+	if len(r.ExtraParams) == 0 {
+		r.ExtraParams = nil
+	}
+
+	return nil
+}
+
+// ReplicateModelListRequest represents a request to list/search models
+type ReplicateModelListRequest struct {
+	Query *string `json:"query,omitempty"` // Search query
+	Limit *int    `json:"limit,omitempty"` // Maximum results (1-50, default 20)
+}
+
+// ==================== RESPONSE TYPES ====================
+
+// ReplicatePredictionStatus represents the status of a prediction
+type ReplicatePredictionStatus string
+
+const (
+	ReplicatePredictionStatusStarting   ReplicatePredictionStatus = "starting"
+	ReplicatePredictionStatusProcessing ReplicatePredictionStatus = "processing"
+	ReplicatePredictionStatusSucceeded  ReplicatePredictionStatus = "succeeded"
+	ReplicatePredictionStatusFailed     ReplicatePredictionStatus = "failed"
+	ReplicatePredictionStatusCanceled   ReplicatePredictionStatus = "canceled"
+)
+
+// ReplicatePredictionResponse represents a prediction response
+type ReplicatePredictionResponse struct {
+	ID               string                    `json:"id"`
+	Model            string                    `json:"model"`                       // Model identifier (owner/name or owner/name:version)
+	Version          string                    `json:"version"`                     // Model version ID
+	Input            map[string]interface{}    `json:"input"`                       // Input parameters used
+	Output           *ReplicateOutput          `json:"output,omitempty"`            // Output data (can be various types)
+	Logs             *string                   `json:"logs,omitempty"`              // Execution logs
+	Error            *string                   `json:"error,omitempty"`             // Error message if failed
+	Status           ReplicatePredictionStatus `json:"status"`                      // Current status
+	CreatedAt        string                    `json:"created_at"`                  // ISO 8601 timestamp
+	StartedAt        *string                   `json:"started_at,omitempty"`        // ISO 8601 timestamp
+	CompletedAt      *string                   `json:"completed_at,omitempty"`      // ISO 8601 timestamp
+	URLs             *ReplicatePredictionURLs  `json:"urls,omitempty"`              // URLs for API operations
+	Metrics          *ReplicateMetrics         `json:"metrics,omitempty"`           // Execution metrics
+	DataRemoved      *bool                     `json:"data_removed,omitempty"`      // Whether data has been removed
+	Source           *string                   `json:"source,omitempty"`            // Source of the prediction (web/api)
+	WebhookCompleted *bool                     `json:"webhook_completed,omitempty"` // Whether webhook was completed
+	Stream           *bool                     `json:"stream,omitempty"`            // Whether the prediction is streaming
+}
+
+type ReplicateOutputText struct {
+	ResponseId *string `json:"response_id,omitempty"`
+	Text       *string `json:"text,omitempty"`
+}
+type ReplicateOutput struct {
+	OutputStr    *string
+	OutputArray  []string
+	OutputObject *ReplicateOutputText
+}
+
+// MarshalJSON implements custom JSON marshalling for ReplicateOutput.
+// It marshals either OutputStr, OutputArray, or OutputObject directly without wrapping.
+func (mc ReplicateOutput) MarshalJSON() ([]byte, error) {
+	// Validation: ensure only one field is set at a time
+	fieldsSet := 0
+	if mc.OutputStr != nil {
+		fieldsSet++
+	}
+	if mc.OutputArray != nil {
+		fieldsSet++
+	}
+	if mc.OutputObject != nil {
+		fieldsSet++
+	}
+	if fieldsSet > 1 {
+		return nil, fmt.Errorf("multiple output fields are set; only one should be non-nil")
+	}
+
+	if mc.OutputStr != nil {
+		return sonic.Marshal(*mc.OutputStr)
+	}
+	if mc.OutputArray != nil {
+		return sonic.Marshal(mc.OutputArray)
+	}
+	if mc.OutputObject != nil {
+		return sonic.Marshal(mc.OutputObject)
+	}
+	// If all are nil, return null
+	return sonic.Marshal(nil)
+}
+
+// UnmarshalJSON implements custom JSON unmarshalling for ReplicateOutput.
+// It determines whether "content" is a string, array, or object and assigns to the appropriate field.
+func (mc *ReplicateOutput) UnmarshalJSON(data []byte) error {
+	mc.OutputStr = nil
+	mc.OutputArray = nil
+	mc.OutputObject = nil
+
+	if string(data) == "null" || len(data) == 0 {
+		return nil
+	}
+
+	// First, try to unmarshal as a direct string
+	var stringContent string
+	if err := sonic.Unmarshal(data, &stringContent); err == nil {
+		mc.OutputStr = schemas.Ptr(stringContent)
+		return nil
+	}
+
+	// Try to unmarshal as a direct array of strings
+	var arrayContent []string
+	if err := sonic.Unmarshal(data, &arrayContent); err == nil {
+		mc.OutputArray = arrayContent
+		return nil
+	}
+
+	// Try to unmarshal as an object (ReplicateOutputText)
+	var objectContent ReplicateOutputText
+	if err := sonic.Unmarshal(data, &objectContent); err == nil {
+		mc.OutputObject = &objectContent
+		return nil
+	}
+
+	return fmt.Errorf("output field is neither a string, array of strings, nor a valid object")
+}
+
+// ReplicatePredictionURLs represents URLs for prediction operations
+type ReplicatePredictionURLs struct {
+	Get    string  `json:"get"`              // URL to get prediction details
+	Cancel string  `json:"cancel"`           // URL to cancel prediction
+	Stream *string `json:"stream,omitempty"` // URL for streaming output (if applicable)
+	Web    *string `json:"web,omitempty"`    // URL for web output (if applicable)
+}
+
+// ReplicateMetrics represents execution metrics
+type ReplicateMetrics struct {
+	PredictTime      *float64 `json:"predict_time,omitempty"`        // Time spent in prediction (seconds)
+	TotalTime        *float64 `json:"total_time,omitempty"`          // Total time including queue (seconds)
+	ImageCount       *int     `json:"image_count,omitempty"`         // Number of images generated
+	TimeToFirstToken *float64 `json:"time_to_first_token,omitempty"` // Time to first token (seconds)
+	TokensPerSecond  *float64 `json:"tokens_per_second,omitempty"`   // Tokens generated per second
+}
+
+// ReplicatePredictionListResponse represents a paginated list of predictions
+type ReplicatePredictionListResponse struct {
+	Next     *string                       `json:"next"`     // URL for next page
+	Previous *string                       `json:"previous"` // URL for previous page
+	Results  []ReplicatePredictionResponse `json:"results"`  // List of predictions
+}
+
+// ReplicateModelResponse represents a model response
+type ReplicateModelResponse struct {
+	URL             string                  `json:"url"`                        // Model API URL
+	Owner           string                  `json:"owner"`                      // Owner username or org name
+	Name            string                  `json:"name"`                       // Model name
+	Description     *string                 `json:"description,omitempty"`      // Model description
+	Visibility      string                  `json:"visibility"`                 // "public" or "private"
+	GithubURL       *string                 `json:"github_url,omitempty"`       // GitHub repository URL
+	PaperURL        *string                 `json:"paper_url,omitempty"`        // Research paper URL
+	LicenseURL      *string                 `json:"license_url,omitempty"`      // License URL
+	RunCount        *int                    `json:"run_count,omitempty"`        // Number of times run
+	CoverImageURL   *string                 `json:"cover_image_url,omitempty"`  // Cover image URL
+	DefaultExample  *map[string]interface{} `json:"default_example,omitempty"`  // Default example prediction
+	LatestVersion   *ReplicateModelVersion  `json:"latest_version,omitempty"`   // Latest version details
+	FeaturedVersion *ReplicateModelVersion  `json:"featured_version,omitempty"` // Featured version details
+}
+
+// ReplicateModelVersion represents a model version
+type ReplicateModelVersion struct {
+	ID            string                 `json:"id"`                        // Version ID
+	CreatedAt     string                 `json:"created_at"`                // ISO 8601 timestamp
+	CogVersion    *string                `json:"cog_version,omitempty"`     // Cog version used
+	OpenAPISchema map[string]interface{} `json:"openapi_schema,omitempty"`  // OpenAPI schema for the model
+	DockerImageID *string                `json:"docker_image_id,omitempty"` // Docker image ID
+}
+
+// ReplicateModelListResponse represents a paginated list of models
+type ReplicateModelListResponse struct {
+	Next     *string                  `json:"next"`     // URL for next page
+	Previous *string                  `json:"previous"` // URL for previous page
+	Results  []ReplicateModelResponse `json:"results"`  // List of models
+}
+
+// ReplicateDeploymentOwner represents the owner of a deployment
+type ReplicateDeploymentOwner struct {
+	Type      string  `json:"type"`                 // "user" or "organization"
+	Username  string  `json:"username"`             // Username or organization name
+	Name      *string `json:"name,omitempty"`       // Display name
+	AvatarURL *string `json:"avatar_url,omitempty"` // Avatar URL
+	GithubURL *string `json:"github_url,omitempty"` // GitHub URL
+}
+
+// ReplicateDeploymentConfiguration represents the deployment configuration
+type ReplicateDeploymentConfiguration struct {
+	Hardware     string `json:"hardware"`      // Hardware type (e.g., "gpu-t4")
+	MinInstances int    `json:"min_instances"` // Minimum number of instances
+	MaxInstances int    `json:"max_instances"` // Maximum number of instances
+}
+
+// ReplicateDeploymentRelease represents a deployment release
+type ReplicateDeploymentRelease struct {
+	Number        int                               `json:"number"`        // Release number
+	Model         string                            `json:"model"`         // Model identifier (owner/name)
+	Version       string                            `json:"version"`       // Model version ID
+	CreatedAt     string                            `json:"created_at"`    // ISO 8601 timestamp
+	CreatedBy     *ReplicateDeploymentOwner         `json:"created_by"`    // User or organization that created the release
+	Configuration *ReplicateDeploymentConfiguration `json:"configuration"` // Deployment configuration
+}
+
+// ReplicateDeployment represents a deployment
+type ReplicateDeployment struct {
+	Owner          string                      `json:"owner"`           // Owner username or org name
+	Name           string                      `json:"name"`            // Deployment name
+	CurrentRelease *ReplicateDeploymentRelease `json:"current_release"` // Current active release
+}
+
+// ReplicateDeploymentListResponse represents a paginated list of deployments
+type ReplicateDeploymentListResponse struct {
+	Next     *string               `json:"next"`     // URL for next page
+	Previous *string               `json:"previous"` // URL for previous page
+	Results  []ReplicateDeployment `json:"results"`  // List of deployments
+}
+
+// ==================== ERROR TYPES ====================
+
+// ReplicateError represents an error response from the Replicate API
+type ReplicateError struct {
+	Detail string  `json:"detail"`          // Error message
+	Status int     `json:"status"`          // HTTP status code
+	Title  *string `json:"title,omitempty"` // Error title
+	Type   *string `json:"type,omitempty"`  // Error type
+}
+
+// ==================== STREAMING TYPES ====================
+
+// ReplicateStreamEvent represents a streaming event
+type ReplicateStreamEvent struct {
+	Event string      `json:"event,omitempty"` // Event type (output, logs, done, error)
+	Data  interface{} `json:"data,omitempty"`  // Event data
+	Error *string     `json:"error,omitempty"` // Error message if event is error
+}
+
+// ==================== WEBHOOK TYPES ====================
+
+// ReplicateWebhookPayload represents a webhook payload
+type ReplicateWebhookPayload struct {
+	ID          string                    `json:"id"`
+	Model       string                    `json:"model"`
+	Version     string                    `json:"version"`
+	Input       map[string]interface{}    `json:"input"`
+	Output      interface{}               `json:"output,omitempty"`
+	Logs        *string                   `json:"logs,omitempty"`
+	Error       *string                   `json:"error,omitempty"`
+	Status      ReplicatePredictionStatus `json:"status"`
+	CreatedAt   string                    `json:"created_at"`
+	StartedAt   *string                   `json:"started_at,omitempty"`
+	CompletedAt *string                   `json:"completed_at,omitempty"`
+	URLs        *ReplicatePredictionURLs  `json:"urls,omitempty"`
+	Metrics     *ReplicateMetrics         `json:"metrics,omitempty"`
+}
+
+// ==================== SSE TYPES ====================
+
+// ReplicateSSEEvent represents a Server-Sent Event from Replicate streaming API
+type ReplicateSSEEvent struct {
+	Event string // Event type: "output", "done", "error"
+	Data  string // Event data - can be plain text, JSON object, or data URI
+	ID    string // Event ID (e.g., "1690212292:0")
+}
+
+// ReplicateDoneEvent represents the data payload of a "done" event
+type ReplicateDoneEvent struct {
+	Reason string      `json:"reason,omitempty"` // Reason for completion: "canceled", "error", or empty for success
+	Output interface{} `json:"output,omitempty"` // Output data if available (e.g., error message)
+}
+
+// ReplicateErrorEvent represents the data payload of an "error" event
+type ReplicateErrorEvent struct {
+	Detail string `json:"detail"` // Error message
+}
+
+// ==================== UTILITY FUNCTIONS ====================
+
+// ParseReplicateTimestamp parses a Replicate ISO 8601 timestamp to Unix timestamp
+func ParseReplicateTimestamp(timestamp string) int64 {
+	if timestamp == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339Nano, timestamp)
+	if err != nil {
+		return 0
+	}
+	return t.Unix()
+}
+
+// ToBifrostPredictionStatus converts Replicate status to Bifrost status
+func ToBifrostPredictionStatus(status ReplicatePredictionStatus) string {
+	switch status {
+	case ReplicatePredictionStatusStarting:
+		return "starting"
+	case ReplicatePredictionStatusProcessing:
+		return "processing"
+	case ReplicatePredictionStatusSucceeded:
+		return "succeeded"
+	case ReplicatePredictionStatusFailed:
+		return "failed"
+	case ReplicatePredictionStatusCanceled:
+		return "canceled"
+	default:
+		return string(status)
+	}
+}
+
+// ==================== FILE API TYPES ====================
+
+// ReplicateFileResponse represents a file resource from Replicate API
+type ReplicateFileResponse struct {
+	ID          string                 `json:"id"`                   // Unique file identifier
+	Checksums   *ReplicateFileChecksum `json:"checksums,omitempty"`  // File checksums
+	ContentType string                 `json:"content_type"`         // MIME type
+	CreatedAt   string                 `json:"created_at"`           // ISO 8601 timestamp
+	ExpiresAt   string                 `json:"expires_at,omitempty"` // ISO 8601 timestamp
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`   // User-provided metadata
+	Name        string                 `json:"name,omitempty"`       // File name
+	Size        int64                  `json:"size"`                 // File size in bytes
+	URLs        *ReplicateFileURLs     `json:"urls,omitempty"`       // Associated URLs
+}
+
+// ReplicateFileChecksum represents checksums for a file
+type ReplicateFileChecksum struct {
+	SHA256 string `json:"sha256,omitempty"` // SHA256 checksum
+}
+
+// ReplicateFileURLs represents URLs associated with a file
+type ReplicateFileURLs struct {
+	Get string `json:"get"` // URL to retrieve file metadata
+}
+
+// ReplicateFileListResponse represents a paginated list of files
+type ReplicateFileListResponse struct {
+	Next     *string                 `json:"next,omitempty"`     // URL for next page
+	Previous *string                 `json:"previous,omitempty"` // URL for previous page
+	Results  []ReplicateFileResponse `json:"results"`            // List of files
+}

--- a/core/providers/replicate/utils.go
+++ b/core/providers/replicate/utils.go
@@ -1,0 +1,290 @@
+package replicate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// isTerminalStatus checks if a prediction status is terminal (completed/failed/canceled)
+func isTerminalStatus(status ReplicatePredictionStatus) bool {
+	return status == ReplicatePredictionStatusSucceeded ||
+		status == ReplicatePredictionStatusFailed ||
+		status == ReplicatePredictionStatusCanceled
+}
+
+// checkForErrorStatus returns an error if the prediction failed
+func checkForErrorStatus(prediction *ReplicatePredictionResponse) *schemas.BifrostError {
+	if prediction.Status == ReplicatePredictionStatusFailed {
+		errorMsg := "prediction failed"
+		if prediction.Error != nil && *prediction.Error != "" {
+			errorMsg = *prediction.Error
+		}
+		return providerUtils.NewBifrostOperationError(
+			"prediction failed",
+			fmt.Errorf("%s", errorMsg),
+			schemas.Replicate,
+		)
+	}
+
+	if prediction.Status == ReplicatePredictionStatusCanceled {
+		return providerUtils.NewBifrostOperationError(
+			"prediction was canceled",
+			fmt.Errorf("prediction was canceled"),
+			schemas.Replicate,
+		)
+	}
+
+	return nil
+}
+
+// parsePreferHeader parses the Prefer header to extract wait duration
+// Examples: "wait", "wait=30", "wait=60"
+// Returns the header value to use and whether sync mode should be enabled
+func parsePreferHeader(extraHeaders map[string]string) bool {
+	if preferValue, exists := extraHeaders["Prefer"]; exists {
+		if strings.HasPrefix(preferValue, "wait") {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// Streaming requests should always be async and not wait for completion,
+// so the Prefer header (which enables sync mode) must be excluded.
+func stripPreferHeader(extraHeaders map[string]string) map[string]string {
+	if extraHeaders == nil {
+		return nil
+	}
+
+	// Check if Prefer header exists
+	if _, exists := extraHeaders["Prefer"]; !exists {
+		// No Prefer header, return original map
+		return extraHeaders
+	}
+
+	// Create new map without Prefer header
+	filtered := make(map[string]string, len(extraHeaders)-1)
+	for key, value := range extraHeaders {
+		if key != "Prefer" {
+			filtered[key] = value
+		}
+	}
+
+	return filtered
+}
+
+// listenToReplicateStreamURL listens to a Replicate stream URL and processes SSE events.
+// This is a reusable utility for any Replicate streaming endpoint.
+// It returns the response body stream (as io.Reader) and any error that occurred during connection.
+func listenToReplicateStreamURL(
+	client *fasthttp.Client,
+	streamURL string,
+	key schemas.Key,
+) (io.Reader, *fasthttp.Response, *schemas.BifrostError) {
+	// Create request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+
+	// Set URL and headers
+	req.SetRequestURI(streamURL)
+	req.Header.SetMethod(http.MethodGet)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+
+	// Set authorization header
+	if value := key.Value.GetValue(); value != "" {
+		req.Header.Set("Authorization", "Bearer "+value)
+	}
+
+	// Make request
+	err := client.Do(req, resp)
+	fasthttp.ReleaseRequest(req)
+
+	if err != nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(err, context.Canceled) {
+			return nil, nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, schemas.Replicate)
+		}
+		return nil, nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, schemas.Replicate)
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode() != fasthttp.StatusOK {
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		return nil, nil, parseReplicateError(resp.Body(), resp.StatusCode())
+	}
+
+	return resp.BodyStream(), resp, nil
+}
+
+// parseDataURIImage extracts the base64 data from a data URI
+// Example: "data:image/webp;base64,UklGRmSu..." -> "UklGRmSu..."
+func parseDataURIImage(dataURI string) (base64Data string, mimeType string) {
+	// Format: data:image/webp;base64,<base64-data>
+	if !strings.HasPrefix(dataURI, "data:") {
+		return dataURI, "" // Return as-is if not a data URI
+	}
+
+	// Split by comma to separate metadata and data
+	parts := strings.SplitN(dataURI[len("data:"):], ",", 2)
+	if len(parts) != 2 {
+		return dataURI, ""
+	}
+
+	// Parse MIME type from metadata (e.g., "image/webp;base64")
+	metadata := parts[0]
+	metaParts := strings.Split(metadata, ";")
+	if len(metaParts) > 0 {
+		mimeType = metaParts[0]
+	}
+
+	// Return the base64 data
+	return parts[1], mimeType
+}
+
+// versionIDPattern matches a 64-character hexadecimal string (Replicate version ID format)
+var versionIDPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+// isVersionID checks if a string is a Replicate version ID (64-character hex string)
+func isVersionID(s string) bool {
+	return versionIDPattern.MatchString(s)
+}
+
+// resolveDeploymentModel checks if the model maps to a deployment.
+// Returns the resolved model and whether it is a deployment.
+func resolveDeploymentModel(model string, key schemas.Key) (string, bool) {
+	if key.ReplicateKeyConfig == nil || key.ReplicateKeyConfig.Deployments == nil {
+		return model, false
+	}
+	if deployment, ok := key.ReplicateKeyConfig.Deployments[model]; ok && deployment != "" {
+		return deployment, true
+	}
+	return model, false
+}
+
+// buildPredictionURL builds the appropriate URL for creating a prediction
+// Returns the URL for the appropriate prediction endpoint.
+func buildPredictionURL(ctx *schemas.BifrostContext, baseURL, model string, customProviderConfig *schemas.CustomProviderConfig, requestType schemas.RequestType, isDeployment bool) string {
+	var defaultPath string
+
+	if isDeployment {
+		defaultPath = "/v1/deployments/" + model + "/predictions"
+	} else if isVersionID(model) {
+		// If model is a version ID, use base predictions endpoint
+		defaultPath = "/v1/predictions"
+	} else {
+		// If model is a name (owner/name), use model-specific endpoint
+		defaultPath = "/v1/models/" + model + "/predictions"
+	}
+
+	path, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, customProviderConfig, requestType)
+	if isCompleteURL {
+		return path
+	}
+	return baseURL + path
+}
+
+// parseTokenUsageFromLogs extracts token counts from Replicate's logs field
+// Handles multiple log formats with varying levels of detail
+func parseTokenUsageFromLogs(logs *string, requestType schemas.RequestType) (inputTokens, outputTokens, totalTokens int, found bool) {
+    if logs == nil || *logs == "" {
+        return 0, 0, 0, false
+    }
+    
+    logText := *logs
+    foundAny := false
+    
+    // Pattern 1: Detailed format with input/output breakdown
+    // "Input token count: 20"
+    // "Input text token count: 15"
+    inputPatterns := []string{
+        `Input token count:\s*(\d+)`,
+        `Input text token count:\s*(\d+)`,
+    }
+    for _, pattern := range inputPatterns {
+        if matches := regexp.MustCompile(pattern).FindStringSubmatch(logText); len(matches) > 1 {
+            if val, err := strconv.Atoi(matches[1]); err == nil {
+                inputTokens = val
+                foundAny = true
+                break
+            }
+        }
+    }
+    
+    // "Input image token count: 0" (for image generation)
+    if matches := regexp.MustCompile(`Input image token count:\s*(\d+)`).FindStringSubmatch(logText); len(matches) > 1 {
+        if val, err := strconv.Atoi(matches[1]); err == nil {
+            inputTokens += val // Add to text input tokens
+            foundAny = true
+        }
+    }
+    
+    // "Output token count: 28"
+    if matches := regexp.MustCompile(`Output token count:\s*(\d+)`).FindStringSubmatch(logText); len(matches) > 1 {
+        if val, err := strconv.Atoi(matches[1]); err == nil {
+            outputTokens = val
+            foundAny = true
+        }
+    }
+    
+    // "Total token count: 48"
+    if matches := regexp.MustCompile(`Total token count:\s*(\d+)`).FindStringSubmatch(logText); len(matches) > 1 {
+        if val, err := strconv.Atoi(matches[1]); err == nil {
+            totalTokens = val
+            foundAny = true
+        }
+    }
+    
+    // Pattern 2: Simple "Tokens: X" format (ambiguous - need heuristic)
+    // Only use if detailed format not found
+    if !foundAny {
+        if matches := regexp.MustCompile(`Tokens:\s*(\d+)`).FindStringSubmatch(logText); len(matches) > 1 {
+            if val, err := strconv.Atoi(matches[1]); err == nil {
+                // Heuristic based on response type
+                switch requestType {
+                case schemas.ImageGenerationRequest:
+                    // For image generation, "Tokens: X" typically means output tokens
+                    outputTokens = val
+                    totalTokens = val
+                case schemas.TextCompletionRequest, schemas.ChatCompletionRequest, schemas.ResponsesRequest:
+                    // For text, unclear - could be total or output
+                    // Conservative approach: treat as total tokens
+                    totalTokens = val
+                default:
+                    // Unknown type - treat as total
+                    totalTokens = val
+                }
+                foundAny = true
+            }
+        }
+    }
+    
+    // If we found input/output but not total, compute it
+    if foundAny && totalTokens == 0 {
+        totalTokens = inputTokens + outputTokens
+    }
+    
+    return inputTokens, outputTokens, totalTokens, foundAny
+}

--- a/core/providers/utils/file.go
+++ b/core/providers/utils/file.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+)
+
+// FileBytesToBase64DataURL converts raw file bytes to base64 data URL format
+func FileBytesToBase64DataURL(fileBytes []byte) string {
+	mimeType := http.DetectContentType(fileBytes)
+	b64Data := base64.StdEncoding.EncodeToString(fileBytes)
+	return fmt.Sprintf("data:%s;base64,%s", mimeType, b64Data)
+}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -15,6 +15,7 @@ type Key struct {
 	VertexKeyConfig      *VertexKeyConfig      `json:"vertex_key_config,omitempty"`      // Vertex-specific key configuration
 	BedrockKeyConfig     *BedrockKeyConfig     `json:"bedrock_key_config,omitempty"`     // AWS Bedrock-specific key configuration
 	HuggingFaceKeyConfig *HuggingFaceKeyConfig `json:"huggingface_key_config,omitempty"` // Hugging Face-specific key configuration
+	ReplicateKeyConfig   *ReplicateKeyConfig   `json:"replicate_key_config,omitempty"`   // Replicate-specific key configuration
 	Enabled              *bool                 `json:"enabled,omitempty"`                // Whether the key is active (default:true)
 	UseForBatchAPI       *bool                 `json:"use_for_batch_api,omitempty"`      // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
 	ConfigHash           string                `json:"config_hash,omitempty"`            // Hash of config.json version, used for change detection
@@ -74,6 +75,10 @@ type BedrockKeyConfig struct {
 // To use Bedrock API Key authentication, set Value in Key struct instead.
 
 type HuggingFaceKeyConfig struct {
+	Deployments map[string]string `json:"deployments,omitempty"` // Mapping of model identifiers to deployment names
+}
+
+type ReplicateKeyConfig struct {
 	Deployments map[string]string `json:"deployments,omitempty"` // Mapping of model identifiers to deployment names
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -51,6 +51,7 @@ const (
 	HuggingFace ModelProvider = "huggingface"
 	Nebius      ModelProvider = "nebius"
 	XAI         ModelProvider = "xai"
+	Replicate   ModelProvider = "replicate"
 )
 
 // SupportedBaseProviders is the list of base providers allowed for custom providers.
@@ -61,6 +62,7 @@ var SupportedBaseProviders = []ModelProvider{
 	Gemini,
 	OpenAI,
 	HuggingFace,
+	Replicate,
 }
 
 // StandardProviders is the list of all built-in (non-custom) providers.
@@ -84,6 +86,7 @@ var StandardProviders = []ModelProvider{
 	HuggingFace,
 	Nebius,
 	XAI,
+	Replicate,
 }
 
 // RequestType represents the type of request being made to a provider.

--- a/core/schemas/files.go
+++ b/core/schemas/files.go
@@ -55,9 +55,10 @@ type BifrostFileUploadRequest struct {
 	Model    *string       `json:"model"`
 
 	// File content
-	File     []byte      `json:"-"`        // Raw file content (not serialized)
-	Filename string      `json:"filename"` // Original filename
-	Purpose  FilePurpose `json:"purpose"`  // Purpose of the file (e.g., "batch")
+	File        []byte      `json:"-"`                      // Raw file content (not serialized)
+	Filename    string      `json:"filename"`               // Original filename
+	Purpose     FilePurpose `json:"purpose"`                // Purpose of the file (e.g., "batch")
+	ContentType *string     `json:"content_type,omitempty"` // MIME type of the file
 
 	// Storage configuration (for S3/GCS backends)
 	StorageConfig *FileStorageConfig `json:"storage_config,omitempty"`

--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -45,6 +45,9 @@ type ImageGenerationParameters struct {
 	NegativePrompt    *string                `json:"negative_prompt,omitempty"`     // negative prompt for image generation
 	NumInferenceSteps *int                   `json:"num_inference_steps,omitempty"` // number of inference steps
 	User              *string                `json:"user,omitempty"`
+	InputImages       []string               `json:"input_images,omitempty"` // input images for image generation, base64 encoded or URL
+	AspectRatio       *string                `json:"aspect_ratio,omitempty"` // aspect ratio of the image
+	Resolution        *string                `json:"resolution,omitempty"`   // resolution of the image
 	ExtraParams       map[string]interface{} `json:"-"`
 }
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,6 +106,7 @@
                   "providers/supported-providers/openrouter",
                   "providers/supported-providers/parasail",
                   "providers/supported-providers/perplexity",
+                  "providers/supported-providers/replicate",
                   "providers/supported-providers/sgl",
                   "providers/supported-providers/vertex",
                   "providers/supported-providers/xai"

--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -254,6 +254,7 @@ Custom providers can be built on these supported providers:
 - `bedrock` - AWS Bedrock
 - `cohere` - Cohere
 - `gemini` - Gemini
+- `replicate` - Replicate
 
 ### Request Path Overrides
 

--- a/docs/providers/supported-providers/replicate.mdx
+++ b/docs/providers/supported-providers/replicate.mdx
@@ -1,0 +1,644 @@
+---
+title: "Replicate"
+description: "Replicate API conversion guide - prediction-based architecture, model-specific parameters, and async/sync modes"
+icon: "R"
+---
+
+## Overview
+
+Replicate is architecturally different from other providers in Bifrost. It uses a **prediction-based API** where every request creates a "prediction" that runs asynchronously. Each model on Replicate defines its own input schema, making it highly flexible but requiring model-specific parameter knowledge.
+
+### Key Architectural Differences
+
+1. **Prediction-Based System**: All operations create predictions via `/v1/predictions` or deployment endpoints
+2. **Model-Specific Inputs**: Each model has its own parameter schema (use `extra_params` for model-specific fields)
+3. **Async/Sync Modes**: Predictions can run synchronously (with `Prefer: wait` header) or asynchronously (with polling)
+4. **Flexible Output**: Output can be strings, arrays, URLs, or data URIs depending on the model
+
+### Supported Operations
+
+| Operation | Non-Streaming | Streaming | Endpoint |
+|-----------|---------------|-----------|----------|
+| Chat Completions | ✅ | ✅ | `/v1/predictions` |
+| Responses API | ✅ | ✅ | `/v1/predictions` |
+| Text Completions | ✅ | ✅ | `/v1/predictions` |
+| Image Generation | ✅ | ✅ | `/v1/predictions` |
+| Files | ✅ | - | `/v1/files` |
+| List Models | ✅ | - | `/v1/deployments` |
+| Embeddings | ❌ | ❌ | - |
+| Speech (TTS) | ❌ | ❌ | - |
+| Transcriptions (STT) | ❌ | ❌ | - |
+| Batch | ❌ | ❌ | - |
+
+<Note>
+**List Models** returns account-specific deployments only, not all public models on Replicate.
+</Note>
+
+---
+
+# Model Identification
+
+Replicate models can be specified in three ways:
+
+## 1. Version ID
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "replicate/5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+## 2. Model Name
+
+Format: `owner/model-name`
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "replicate/meta/llama-2-7b-chat",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+## 3. Deployment
+
+Configure deployed models in the Replicate key configuration. Deployments map custom model identifiers to actual deployment paths.
+
+**Configuration Example:**
+
+```json
+{
+  "provider": "replicate",
+  "value": "your-api-key",
+  "replicate_key_config": {
+    "deployments": {
+      "my-model": "owner/my-deployment-name"
+    }
+  }
+}
+```
+
+**Usage:**
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "replicate/my-model",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+---
+
+# Prediction Modes
+
+## Sync Mode
+
+Bifrost uses sync mode with the `Prefer: wait` header if it is present in the request headers. The request blocks until the prediction completes or times out (default 60 seconds).
+
+**How it works:**
+1. Creates prediction with `Prefer: wait=60` header
+2. Replicate holds connection open for up to 60 seconds
+3. If prediction completes within timeout, returns result immediately
+4. If timeout expires, falls back to polling mode
+
+## Async Mode (Polling)
+
+It is the default mode of Replicate predictions. Bifrost automatically polls the prediction URL every 2 seconds until completion.
+
+**Status Flow**: `starting` → `processing` → `succeeded`/`failed`/`canceled`
+
+---
+
+# 1. Chat Completions
+
+### Message Conversion
+
+**System Messages**: Extracted from messages array and concatenated into `system_prompt` field.
+
+**User/Assistant Messages**: Preserved as conversation context. Text content from content blocks is concatenated with newlines.
+
+**Image Content**: Non-base64 image URLs from message content blocks are extracted and passed as `image_input` array.
+
+```json
+// Input
+{
+  "messages": [
+    {"role": "system", "content": "You are helpful"},
+    {"role": "user", "content": "Hello"}
+  ]
+}
+
+// Converted to Replicate format
+{
+  "input": {
+    "system_prompt": "You are helpful",
+    "prompt": "Hello",
+    "messages": [...] // Original messages array also included
+  }
+}
+```
+
+### System Prompt Filtering
+
+**Important**: Not all Replicate models support the `system_prompt` field. For unsupported models, the system prompt is automatically prepended to the conversation prompt.
+
+**Models without system_prompt support:**
+- `meta/meta-llama-3-8b`
+- `meta/llama-2-70b`
+- `openai/gpt-oss-20b`
+- `openai/o1-mini`
+- `xai/grok-4`
+- All `deepseek-ai/deepseek*` models (e.g., `deepseek-r1`, `deepseek-v3`)
+
+### Model-Specific Parameters
+
+Use `extra_params` to pass model-specific parameters. These are **flattened into the input object**:
+
+<Tabs>
+<Tab title="Gateway">
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "replicate/meta/llama-2-7b-chat",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "temperature": 0.7,
+    "top_k": 50,
+    "repetition_penalty": 1.1,
+    "min_new_tokens": 10
+  }'
+```
+
+</Tab>
+<Tab title="Go SDK">
+
+```go
+resp, err := client.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+    Provider: schemas.Replicate,
+    Model:    "meta/llama-2-7b-chat",
+    Input:    messages,
+    Params: &schemas.ChatParameters{
+        Temperature: schemas.Ptr(0.7),
+        ExtraParams: map[string]interface{}{
+            "top_k": 50,
+            "repetition_penalty": 1.1,
+            "min_new_tokens": 10,
+        },
+    },
+})
+```
+
+</Tab>
+</Tabs>
+
+<Warning>
+**Model Schema Discovery**: Each Replicate model has unique parameters. Check the model's documentation on replicate.com or use the OpenAPI schema from the model version to discover available parameters.
+</Warning>
+
+## Response Conversion
+
+### Field Mapping
+
+- **Output**: 
+  - String → `choices[0].message.content`
+  - Array of strings → joined and mapped to `choices[0].message.content`
+  - Object with `text` field → `text` value mapped to `choices[0].message.content`
+- **Status**: `succeeded` → `finish_reason: "stop"`, `failed` → `finish_reason: "error"`
+- **Metrics**: `input_token_count` → `prompt_tokens`, `output_token_count` → `completion_tokens`
+
+### Example Response
+
+```json
+{
+  "id": "abc123",
+  "model": "meta/llama-2-7b-chat",
+  "object": "chat.completion",
+  "created": 1234567890,
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "Hello! How can I help you?"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 10,
+    "completion_tokens": 8,
+    "total_tokens": 18
+  }
+}
+```
+
+## Streaming
+
+Replicate streaming uses Server-Sent Events (SSE) with the following event types:
+
+| Event Type | Description | Data Format |
+|------------|-------------|-------------|
+| `output` | Content chunk | Plain text string |
+| `done` | Completion | JSON: `{"reason": ""}` (empty = success) |
+| `error` | Error occurred | JSON: `{"detail": "error message"}` |
+
+**Streaming Flow:**
+1. Bifrost sets `stream: true` in prediction input
+2. Replicate returns `urls.stream` in initial response
+3. Bifrost connects to stream URL and processes SSE events
+4. `output` events → content deltas
+5. `done` event → final chunk with `finish_reason`
+
+**Done Event Reasons:**
+- Empty or no reason = success (`finish_reason: "stop"`)
+- `"canceled"` = prediction was canceled
+- `"error"` = prediction failed
+
+---
+
+# 2. Responses API
+
+The Responses API is converted internally to Chat Completions or native Replicate format depending on the model:
+
+```go
+// Responses request → Replicate prediction conversion
+ResponsesRequest → ReplicatePredictionRequest → ReplicatePredictionResponse → BifrostResponsesResponse
+```
+
+**Conversion Logic:**
+
+1. **For OpenAI models with `gpt-5-structured`**: Uses native Responses format with `input_item_list`, `tools`, and `json_schema` support
+2. **For all other models**: Converted to Chat Completions format using message conversion logic
+
+Same parameter mapping and system prompt handling as [Chat Completions](#1-chat-completions).
+
+## Response Format
+
+Responses follow standard Responses API format with status mapping:
+
+| Replicate Status | Responses Status |
+|------------------|------------------|
+| `succeeded` | `completed` |
+| `failed` | `failed` |
+| `canceled` | `cancelled` |
+| `processing` | `in_progress` |
+| `starting` | `queued` |
+
+---
+
+# 3. Text Completions (Legacy)
+
+### Conversion
+
+- **Prompt array**: Joined with newlines into single `prompt` field
+- **top_k**: Pass via `extra_params` (model-specific)
+
+### Example
+
+```bash
+curl -X POST http://localhost:8080/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "replicate/meta/llama-2-7b",
+    "prompt": "Once upon a time",
+    "max_tokens": 100,
+    "temperature": 0.8,
+    "top_k": 40
+  }'
+```
+
+## Response
+
+Same conversion as chat completions: output string/array → `choices[0].text`, with usage metrics from prediction metrics.
+
+---
+
+# 4. Image Generation
+
+### Parameter Mapping
+
+```json
+{
+  "prompt": "prompt",
+  "n": "number_of_images",
+  "aspect_ratio": "aspect_ratio",
+  "resolution": "resolution",
+  "output_format": "output_format",
+  "quality": "quality",
+  "background": "background",
+  "seed": "seed",
+  "negative_prompt": "negative_prompt",
+  "num_inference_steps": "num_inference_steps",
+  "input_images": "input_images"
+}
+```
+
+### Input Image Field Mapping
+
+**Important**: Different Replicate models expect input images in different fields. Bifrost automatically maps `input_images` to the correct field based on the model.
+
+**Field Mapping by Model:**
+
+| Field | Models |
+|-------|--------|
+| `image_prompt` | `black-forest-labs/flux-1.1-pro`<br/>`black-forest-labs/flux-1.1-pro-ultra`<br/>`black-forest-labs/flux-pro`<br/>`black-forest-labs/flux-1.1-pro-ultra-finetuned` |
+| `input_image` | `black-forest-labs/flux-kontext-pro`<br/>`black-forest-labs/flux-kontext-max`<br/>`black-forest-labs/flux-kontext-dev` |
+| `image` | `black-forest-labs/flux-dev`<br/>`black-forest-labs/flux-fill-pro`<br/>`black-forest-labs/flux-dev-lora`<br/>`black-forest-labs/flux-krea-dev` |
+| `input_images` | All other models (default) |
+
+<Note>
+For models that expect a single image field (`image_prompt`, `input_image`, `image`), only the first image from the `input_images` array is used.
+</Note>
+
+### Example
+
+<Tabs>
+<Tab title="Gateway">
+
+```bash
+curl -X POST http://localhost:8080/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "replicate/black-forest-labs/flux-schnell",
+    "prompt": "A serene mountain landscape at sunset",
+    "aspect_ratio": "16:9",
+    "output_format": "webp",
+    "num_inference_steps": 4,
+    "seed": 42
+  }'
+```
+
+</Tab>
+<Tab title="Go SDK">
+
+```go
+resp, err := client.ImageGenerationRequest(ctx, &schemas.BifrostImageGenerationRequest{
+    Provider: schemas.Replicate,
+    Model:    "black-forest-labs/flux-schnell",
+    Input: &schemas.ImageGenerationInput{
+        Prompt: "A serene mountain landscape at sunset",
+    },
+    Params: &schemas.ImageGenerationParameters{
+        AspectRatio: schemas.Ptr("16:9"),
+        OutputFormat: schemas.Ptr("webp"),
+        NumInferenceSteps: schemas.Ptr(4),
+        Seed: schemas.Ptr(42),
+    },
+})
+```
+
+</Tab>
+</Tabs>
+
+## Response Conversion
+
+Replicate output can be:
+- **Single URL**: String → `data[0].url`
+- **Multiple URLs**: Array → `data[i].url` for each image
+- **Data URIs**: Base64-encoded images in data URI format
+
+```json
+{
+  "id": "xyz789",
+  "created": 1234567890,
+  "model": "black-forest-labs/flux-schnell",
+  "data": [
+    {
+      "url": "https://replicate.delivery/pbxt/...",
+      "index": 0
+    }
+  ],
+  "usage": {
+    "input_tokens": 15,
+    "output_tokens": 0,
+    "total_tokens": 15
+  }
+}
+```
+
+## Streaming
+
+Image generation streaming provides progressive image updates as data URIs:
+
+**SSE Events:**
+- `output`: Data URI chunk (partial image)
+- `done`: Final completion with reason
+- `error`: Error details
+
+**Flow:**
+1. Each `output` event contains a complete data URI (e.g., `data:image/webp;base64,...`)
+2. Progressive refinement shows generation progress
+3. `done` event signals completion with final image
+4. Each chunk includes `Index`, `ChunkIndex`, and `B64JSON` fields
+
+---
+
+# 5. Files API
+
+Replicate's Files API supports uploading, listing, and managing files for use in predictions.
+
+## Upload
+
+**Request**: Multipart form-data
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `file` | binary | ✅ | File content |
+| `filename` | string | ❌ | Custom filename |
+| `content_type` | string | ❌ | MIME type (auto-detected from extension) |
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:8080/v1/files \
+  -H "Authorization: Bearer $API_KEY" \
+  -F "file=@document.pdf" \
+  -F "filename=my-document.pdf"
+```
+
+**Response:**
+
+```json
+{
+  "id": "file_abc123",
+  "object": "file",
+  "bytes": 12345,
+  "created_at": 1234567890,
+  "filename": "my-document.pdf",
+  "purpose": "batch",
+  "status": "processed"
+}
+```
+
+## List Files
+
+**Query Parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `limit` | int | Results per page |
+| `after` | string | Pagination cursor |
+
+**Example:**
+
+```bash
+curl -X GET "http://localhost:8080/v1/files?limit=20" \
+  -H "Authorization: Bearer $API_KEY"
+```
+
+**Pagination**: Uses cursor-based pagination with `next` URL in response. Bifrost serializes this into the `after` cursor.
+
+## Retrieve / Delete
+
+**Operations:**
+- GET `/v1/files/{file_id}` - Retrieve file metadata
+- DELETE `/v1/files/{file_id}` - Delete file
+
+## File Content Download
+
+<Warning>
+Replicate requires signed download URLs with `owner`, `expiry`, and `signature` parameters.
+</Warning>
+
+**Required Parameters in ExtraParams:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `owner` | string | File owner username |
+| `expiry` | int64 | Unix timestamp for expiration |
+| `signature` | string | Base64-encoded HMAC-SHA256 signature |
+
+**Signature Format**: HMAC-SHA256 of `"{owner} {file_id} {expiry}"` using Files API signing secret
+
+**Example:**
+
+```bash
+curl -X POST http://localhost:8080/v1/files/file_abc123/content \
+  -H "Content-Type: application/json" \
+  -d '{
+    "owner": "my-username",
+    "expiry": 1735689600,
+    "signature": "base64-encoded-signature"
+  }'
+```
+
+---
+
+# 6. List Models
+
+**Endpoint**: `/v1/models`
+
+<Warning>
+List Models returns **account-specific deployments only**, not all public models on Replicate.
+</Warning>
+
+Deployments are private or organization models with dedicated infrastructure. The response includes:
+
+```json
+{
+  "data": [
+    {
+      "id": "replicate/my-org/my-deployment",
+      "name": "my-deployment",
+      "owner": "my-org"
+    }
+  ],
+  "has_more": false
+}
+```
+
+**Usage:**
+1. List your deployments via this endpoint
+2. Use deployment name as model identifier: `replicate/my-org/my-deployment`
+3. Predictions route to deployment-specific endpoint: `/v1/deployments/my-org/my-deployment/predictions`
+
+---
+
+# Extra Parameters
+
+## Model-Specific Parameters
+
+The most important feature for Replicate integration is **extra_params**. Parameters not in Bifrost's standard schema are flattened directly into the prediction `input` object.
+
+### How It Works
+
+```json
+// Request with extra params
+{
+  "model": "replicate/stability-ai/sdxl",
+  "prompt": "A photo of an astronaut",
+  "temperature": 0.7,          // Standard param
+  "guidance_scale": 7.5,       // Model-specific (extra param)
+  "num_inference_steps": 50,   // Model-specific (extra param)
+  "scheduler": "DPMSolverMultistep"  // Model-specific (extra param)
+}
+
+// Converted to Replicate prediction input
+{
+  "version": "...",
+  "input": {
+    "prompt": "A photo of an astronaut",
+    "temperature": 0.7,
+    "guidance_scale": 7.5,       // Flattened from extra_params
+    "num_inference_steps": 50,   // Flattened from extra_params
+    "scheduler": "DPMSolverMultistep"  // Flattened from extra_params
+  }
+}
+```
+
+### Discovering Model Parameters
+
+Each Replicate model has unique parameters. To find available parameters:
+
+1. **Model Page**: Visit the model on [replicate.com](https://replicate.com)
+2. **OpenAPI Schema**: Available at `/v1/models/{owner}/{name}/versions/{version_id}` (includes `openapi_schema`)
+3. **Cog Definition**: Check the model's source code (if public)
+
+---
+
+## Caveats
+
+<Accordion title="System Prompt Field Support">
+**Severity**: Medium
+**Behavior**: Not all models support `system_prompt` field. For unsupported models, system prompt is prepended to conversation prompt.
+**Impact**: Prompt structure differs between models
+**Models Affected**: `meta/meta-llama-3-8b`, `meta/llama-2-70b`, `openai/gpt-oss-20b`, `openai/o1-mini`, `xai/grok-4`, and all `deepseek-ai/deepseek*` models
+**Code**: `chat.go:300-318`
+</Accordion>
+
+<Accordion title="Input Image Field Mapping">
+**Severity**: Medium
+**Behavior**: Different models expect input images in different fields (`image_prompt`, `input_image`, `image`, `input_images`)
+**Impact**: Bifrost automatically maps to correct field based on model
+**Models Affected**: Flux family models (see Input Image Field Mapping table)
+**Code**: `images.go:192-209`
+</Accordion>
+
+<Accordion title="Image Content in Chat">
+**Severity**: Low
+**Behavior**: Only non-base64 image URLs from message content blocks are extracted to `image_input`
+**Impact**: Base64-encoded images in messages are ignored
+**Code**: `chat.go:58-63`
+</Accordion>
+
+<Accordion title="Model-Specific Parameters">
+**Severity**: Medium
+**Behavior**: Each model has unique input schema; standard parameters may not work for all models
+**Impact**: Requires checking model documentation for available parameters
+**Mitigation**: Use `extra_params` for model-specific fields
+</Accordion>
+
+
+
+## Reference Links
+
+- [Replicate API Documentation](https://replicate.com/docs/topics/predictions/create-a-prediction)
+- [Replicate Models](https://replicate.com/explore)
+- [Bifrost Replicate Provider Source](https://github.com/maximhq/bifrost/tree/main/core/providers/replicate)

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -333,6 +333,13 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			}
 			redactedConfig.Keys[i].BedrockKeyConfig = bedrockConfig
 		}
+
+		if key.ReplicateKeyConfig != nil {
+			replicateConfig := &schemas.ReplicateKeyConfig{
+				Deployments: key.ReplicateKeyConfig.Deployments,
+			}
+			redactedConfig.Keys[i].ReplicateKeyConfig = replicateConfig
+		}
 	}
 	return &redactedConfig
 }
@@ -444,6 +451,14 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	// Hash BedrockKeyConfig
 	if key.BedrockKeyConfig != nil {
 		data, err := sonic.Marshal(key.BedrockKeyConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+	// Hash ReplicateKeyConfig
+	if key.ReplicateKeyConfig != nil {
+		data, err := sonic.Marshal(key.ReplicateKeyConfig)
 		if err != nil {
 			return "", err
 		}
@@ -951,8 +966,8 @@ func GeneratePluginHash(p tables.TablePlugin) (string, error) {
 type AuthConfig struct {
 	AdminUserName          *schemas.EnvVar `json:"admin_username"`
 	AdminPassword          *schemas.EnvVar `json:"admin_password"`
-	IsEnabled              bool           `json:"is_enabled"`
-	DisableAuthOnInference bool           `json:"disable_auth_on_inference"`
+	IsEnabled              bool            `json:"is_enabled"`
+	DisableAuthOnInference bool            `json:"disable_auth_on_inference"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -267,19 +267,20 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				}
 			}
 			dbKey := tables.TableKey{
-				Provider:         dbProvider.Name,
-				ProviderID:       dbProvider.ID,
-				KeyID:            key.ID,
-				Name:             key.Name,
-				Value:            key.Value,
-				Models:           key.Models,
-				Weight:           &key.Weight,
-				Enabled:          key.Enabled,
-				UseForBatchAPI:   key.UseForBatchAPI,
-				AzureKeyConfig:   key.AzureKeyConfig,
-				VertexKeyConfig:  key.VertexKeyConfig,
-				BedrockKeyConfig: key.BedrockKeyConfig,
-				ConfigHash:       keyHash,
+				Provider:           dbProvider.Name,
+				ProviderID:         dbProvider.ID,
+				KeyID:              key.ID,
+				Name:               key.Name,
+				Value:              key.Value,
+				Models:             key.Models,
+				Weight:             &key.Weight,
+				Enabled:            key.Enabled,
+				UseForBatchAPI:     key.UseForBatchAPI,
+				AzureKeyConfig:     key.AzureKeyConfig,
+				VertexKeyConfig:    key.VertexKeyConfig,
+				BedrockKeyConfig:   key.BedrockKeyConfig,
+				ReplicateKeyConfig: key.ReplicateKeyConfig,
+				ConfigHash:         keyHash,
 			}
 
 			// Handle Azure config
@@ -420,19 +421,20 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			return fmt.Errorf("failed to generate key hash: %w", err)
 		}
 		dbKey := tables.TableKey{
-			Provider:         dbProvider.Name,
-			ProviderID:       dbProvider.ID,
-			KeyID:            key.ID,
-			Name:             key.Name,
-			Value:            key.Value,
-			Models:           key.Models,
-			Weight:           &key.Weight,
-			Enabled:          key.Enabled,
-			UseForBatchAPI:   key.UseForBatchAPI,
-			AzureKeyConfig:   key.AzureKeyConfig,
-			VertexKeyConfig:  key.VertexKeyConfig,
-			BedrockKeyConfig: key.BedrockKeyConfig,
-			ConfigHash:       keyHash,
+			Provider:           dbProvider.Name,
+			ProviderID:         dbProvider.ID,
+			KeyID:              key.ID,
+			Name:               key.Name,
+			Value:              key.Value,
+			Models:             key.Models,
+			Weight:             &key.Weight,
+			Enabled:            key.Enabled,
+			UseForBatchAPI:     key.UseForBatchAPI,
+			AzureKeyConfig:     key.AzureKeyConfig,
+			VertexKeyConfig:    key.VertexKeyConfig,
+			BedrockKeyConfig:   key.BedrockKeyConfig,
+			ReplicateKeyConfig: key.ReplicateKeyConfig,
+			ConfigHash:         keyHash,
 		}
 
 		// Handle Azure config
@@ -534,19 +536,20 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 	// Create keys for this provider
 	for _, key := range configCopy.Keys {
 		dbKey := tables.TableKey{
-			Provider:         dbProvider.Name,
-			ProviderID:       dbProvider.ID,
-			KeyID:            key.ID,
-			Name:             key.Name,
-			Value:            key.Value,
-			Models:           key.Models,
-			Weight:           &key.Weight,
-			Enabled:          key.Enabled,
-			UseForBatchAPI:   key.UseForBatchAPI,
-			AzureKeyConfig:   key.AzureKeyConfig,
-			VertexKeyConfig:  key.VertexKeyConfig,
-			BedrockKeyConfig: key.BedrockKeyConfig,
-			ConfigHash:       key.ConfigHash,
+			Provider:           dbProvider.Name,
+			ProviderID:         dbProvider.ID,
+			KeyID:              key.ID,
+			Name:               key.Name,
+			Value:              key.Value,
+			Models:             key.Models,
+			Weight:             &key.Weight,
+			Enabled:            key.Enabled,
+			UseForBatchAPI:     key.UseForBatchAPI,
+			AzureKeyConfig:     key.AzureKeyConfig,
+			VertexKeyConfig:    key.VertexKeyConfig,
+			BedrockKeyConfig:   key.BedrockKeyConfig,
+			ReplicateKeyConfig: key.ReplicateKeyConfig,
+			ConfigHash:         key.ConfigHash,
 		}
 		// Handle Azure config
 		if key.AzureKeyConfig != nil {
@@ -649,17 +652,18 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 		keys := make([]schemas.Key, len(dbProvider.Keys))
 		for i, dbKey := range dbProvider.Keys {
 			keys[i] = schemas.Key{
-				ID:               dbKey.KeyID,
-				Name:             dbKey.Name,
-				Value:            dbKey.Value,
-				Models:           dbKey.Models,
-				Weight:           getWeight(dbKey.Weight),
-				Enabled:          dbKey.Enabled,
-				UseForBatchAPI:   dbKey.UseForBatchAPI,
-				AzureKeyConfig:   dbKey.AzureKeyConfig,
-				VertexKeyConfig:  dbKey.VertexKeyConfig,
-				BedrockKeyConfig: dbKey.BedrockKeyConfig,
-				ConfigHash:       dbKey.ConfigHash,
+				ID:                 dbKey.KeyID,
+				Name:               dbKey.Name,
+				Value:              dbKey.Value,
+				Models:             dbKey.Models,
+				Weight:             getWeight(dbKey.Weight),
+				Enabled:            dbKey.Enabled,
+				UseForBatchAPI:     dbKey.UseForBatchAPI,
+				AzureKeyConfig:     dbKey.AzureKeyConfig,
+				VertexKeyConfig:    dbKey.VertexKeyConfig,
+				BedrockKeyConfig:   dbKey.BedrockKeyConfig,
+				ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
+				ConfigHash:         dbKey.ConfigHash,
 			}
 		}
 		providerConfig := ProviderConfig{
@@ -690,17 +694,18 @@ func (s *RDBConfigStore) GetProviderConfig(ctx context.Context, provider schemas
 	keys := make([]schemas.Key, len(dbProvider.Keys))
 	for i, dbKey := range dbProvider.Keys {
 		keys[i] = schemas.Key{
-			ID:               dbKey.KeyID,
-			Name:             dbKey.Name,
-			Value:            dbKey.Value,
-			Models:           dbKey.Models,
-			Weight:           getWeight(dbKey.Weight),
-			Enabled:          dbKey.Enabled,
-			UseForBatchAPI:   dbKey.UseForBatchAPI,
-			AzureKeyConfig:   dbKey.AzureKeyConfig,
-			VertexKeyConfig:  dbKey.VertexKeyConfig,
-			BedrockKeyConfig: dbKey.BedrockKeyConfig,
-			ConfigHash:       dbKey.ConfigHash,
+			ID:                 dbKey.KeyID,
+			Name:               dbKey.Name,
+			Value:              dbKey.Value,
+			Models:             dbKey.Models,
+			Weight:             getWeight(dbKey.Weight),
+			Enabled:            dbKey.Enabled,
+			UseForBatchAPI:     dbKey.UseForBatchAPI,
+			AzureKeyConfig:     dbKey.AzureKeyConfig,
+			VertexKeyConfig:    dbKey.VertexKeyConfig,
+			BedrockKeyConfig:   dbKey.BedrockKeyConfig,
+			ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
+			ConfigHash:         dbKey.ConfigHash,
 		}
 	}
 	return &ProviderConfig{

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -126,6 +126,10 @@ func (pc *TableVirtualKeyProviderConfig) AfterFind(tx *gorm.DB) error {
 			key.BedrockDeploymentsJSON = nil
 			key.BedrockKeyConfig = nil
 
+			// Clear all Replicate-related sensitive fields
+			key.ReplicateDeploymentsJSON = nil
+			key.ReplicateKeyConfig = nil
+
 			pc.Keys[i] = *key
 		}
 	}

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -42,8 +42,8 @@ func NewInferenceHandler(client *bifrost.Bifrost, config *lib.Config) *Completio
 
 // Known fields for CompletionRequest
 var textParamsKnownFields = map[string]bool{
+	"prompt":            true,
 	"model":             true,
-	"text":              true,
 	"fallbacks":         true,
 	"best_of":           true,
 	"echo":              true,

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1987,6 +1987,7 @@ func loadDefaultProviders(ctx context.Context, config *Config) error {
 					AzureKeyConfig:   dbKey.AzureKeyConfig,
 					VertexKeyConfig:  dbKey.VertexKeyConfig,
 					BedrockKeyConfig: dbKey.BedrockKeyConfig,
+					ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
 					ConfigHash:       dbKey.ConfigHash,
 				}
 			}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+feat: added support for replicate provider

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -145,6 +145,7 @@ export default function AddCustomProviderSheet({ show, onClose, onSave }: Props)
 														<SelectItem value="gemini">Gemini</SelectItem>
 														<SelectItem value="cohere">Cohere</SelectItem>
 														<SelectItem value="bedrock">AWS Bedrock</SelectItem>
+														<SelectItem value="replicate">Replicate</SelectItem>
 													</SelectContent>
 												</Select>
 											</FormControl>

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -53,6 +53,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 	const isBedrock = providerName === "bedrock";
 	const isVertex = providerName === "vertex";
 	const isAzure = providerName === "azure";
+	const isReplicate = providerName === "replicate";
 	const supportsBatchAPI = BATCH_SUPPORTED_PROVIDERS.includes(providerName);
 
 	// Auth type state for Azure: 'api_key' or 'entra_id'
@@ -460,6 +461,49 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 								<FormControl>
 									<Textarea
 										placeholder='{"custom-gemini-2.5-pro": "123456789", "custom-gemini-2.0-flash-001": "987654321"}'
+										value={typeof field.value === "string" ? field.value : JSON.stringify(field.value || {}, null, 2)}
+										onChange={(e) => {
+											// Store as string during editing to allow intermediate invalid states
+											field.onChange(e.target.value);
+										}}
+										onBlur={(e) => {
+											// Try to parse as JSON on blur, but keep as string if invalid
+											const value = e.target.value.trim();
+											if (value) {
+												try {
+													const parsed = JSON.parse(value);
+													if (typeof parsed === "object" && parsed !== null) {
+														field.onChange(parsed);
+													}
+												} catch {
+													// Keep as string for validation on submit
+												}
+											}
+											field.onBlur();
+										}}
+										rows={3}
+										className="max-w-full font-mono text-sm wrap-anywhere"
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</div>
+			)}
+			{isReplicate && (
+				<div className="space-y-4">
+					<Separator className="my-6" />
+					<FormField
+						control={control}
+						name={`key.replicate_key_config.deployments`}
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Deployments (Optional)</FormLabel>
+								<FormDescription>JSON object mapping model names to deployment names</FormDescription>
+								<FormControl>
+									<Textarea
+										placeholder='{"my-model": "my-deployment", "another-model": "another-deployment"}'
 										value={typeof field.value === "string" ? field.value : JSON.stringify(field.value || {}, null, 2)}
 										onChange={(e) => {
 											// Store as string during editing to allow intermediate invalid states

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -114,6 +114,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 										<SelectItem value="bedrock">AWS Bedrock</SelectItem>
 										<SelectItem value="cohere">Cohere</SelectItem>
 										<SelectItem value="gemini">Gemini</SelectItem>
+										<SelectItem value="replicate">Replicate</SelectItem>
 									</SelectContent>
 								</Select>
 								<FormDescription>The underlying provider this custom provider will use</FormDescription>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -49,6 +49,7 @@ export const ModelPlaceholders = {
 	vertex: "e.g. gemini-1.5-pro, text-bison, chat-bison",
 	nebius: "e.g. openai/gpt-oss-120b, google/gemma-2-9b-it-fast, Qwen/Qwen2.5-VL-72B-Instruct",
 	xai: "e.g. grok-4-0709, grok-3-mini, grok-3, grok-2-vision-1212",
+	replicate: "e.g. meta/llama3-1-8b-instruct, black-forest-labs/flux-dev",
 };
 
 export const isKeyRequiredByProvider: Record<ProviderName, boolean> = {
@@ -71,6 +72,7 @@ export const isKeyRequiredByProvider: Record<ProviderName, boolean> = {
 	perplexity: true,
 	nebius: true,
 	xai: true,
+	replicate: true,
 };
 
 export const DefaultNetworkConfig = {

--- a/ui/lib/constants/icons.tsx
+++ b/ui/lib/constants/icons.tsx
@@ -1336,6 +1336,13 @@ export const ProviderIcons = {
 			</svg>
 		);
 	},
+	replicate: ({ size = "md", className = "" }: IconProps) => {
+		const resolvedSize = resolveSize(size);
+
+		return (
+			<svg fill="currentColor" fillRule="evenodd" height={resolvedSize} style={{ flex: "none", lineHeight: "1" }} viewBox="0 0 24 24" width={resolvedSize} xmlns="http://www.w3.org/2000/svg" className={className}><title>Replicate</title><path d="M22 10.552v2.26h-7.932V22H11.54V10.552H22zM22 2v2.264H4.528V22H2V2h20zm0 4.276V8.54H9.296V22H6.768V6.276H22z"></path></svg>
+		);
+	},
 } as const;
 
 // Routing Engine Icons

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -19,6 +19,7 @@ export const KnownProvidersNames = [
 	"vertex",
 	"nebius",
 	"xai",
+	"replicate",
 ] as const;
 
 // Local Provider type derived from KNOWN_PROVIDERS constant
@@ -79,6 +80,7 @@ export const ProviderLabels: Record<ProviderName, string> = {
 	huggingface: "HuggingFace",
 	nebius: "Nebius Token Factory",
 	xai: "xAI",
+	replicate: "Replicate",
 } as const;
 
 // Helper function to get provider label, supporting custom providers

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -146,6 +146,13 @@ const BedrockKeyConfigSchema = z
 		},
 	);
 
+const ReplicateKeyConfigSchema = z.object({
+	deployments: z
+		.union([z.record(z.string(), z.string()), z.string()])
+		.optional()
+		.refine((value) => !value || isValidDeployments(value), { message: "Valid Deployments (JSON object) are required for Replicate keys" }),
+});
+
 const KeySchema = z.object({
 	id: z.string(),
 	name: z.string().min(1, "Name is required for the key"),
@@ -155,6 +162,7 @@ const KeySchema = z.object({
 	azure_key_config: AzureKeyConfigSchema.optional(),
 	vertex_key_config: VertexKeyConfigSchema.optional(),
 	bedrock_key_config: BedrockKeyConfigSchema.optional(),
+	replicate_key_config: ReplicateKeyConfigSchema.optional(),
 	use_for_batch_api: z.boolean().optional(),
 });
 

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -7,7 +7,7 @@ import { EnvVar } from "./schemas";
 export type KnownProvider = (typeof KnownProvidersNames)[number];
 
 // Base provider names - all supported base providers
-export type BaseProvider = "openai" | "anthropic" | "cohere" | "gemini" | "bedrock";
+export type BaseProvider = "openai" | "anthropic" | "cohere" | "gemini" | "bedrock" | "replicate";
 
 // Branded type for custom provider names to prevent collision with known providers
 export type CustomProviderName = string & { readonly __brand: "CustomProviderName" };
@@ -90,6 +90,16 @@ export const DefaultBedrockKeyConfig: BedrockKeyConfig = {
 	batch_s3_config: undefined as unknown as BatchS3Config,
 } as const satisfies Required<BedrockKeyConfig>;
 
+// ReplicateKeyConfig matching Go's schemas.ReplicateKeyConfig
+export interface ReplicateKeyConfig {
+	deployments?: Record<string, string> | string; // Allow string during editing
+}
+
+// Default ReplicateKeyConfig
+export const DefaultReplicateKeyConfig: ReplicateKeyConfig = {
+	deployments: {},
+} as const satisfies Required<ReplicateKeyConfig>;
+
 // Key structure matching Go's schemas.Key
 export interface ModelProviderKey {
 	id: string;
@@ -102,6 +112,7 @@ export interface ModelProviderKey {
 	azure_key_config?: AzureKeyConfig;
 	vertex_key_config?: VertexKeyConfig;
 	bedrock_key_config?: BedrockKeyConfig;
+	replicate_key_config?: ReplicateKeyConfig;
 	config_hash?: string; // Present when config is synced from config.json
 }
 

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -148,6 +148,11 @@ export const bedrockKeyConfigSchema = z
 		},
 	);
 
+// Replicate key config schema
+export const replicateKeyConfigSchema = z.object({
+	deployments: z.union([z.record(z.string(), z.string()), z.string()]).optional(),
+});
+
 // Model provider key schema
 export const modelProviderKeySchema = z
 	.object({
@@ -178,6 +183,7 @@ export const modelProviderKeySchema = z
 		azure_key_config: azureKeyConfigSchema.optional(),
 		vertex_key_config: vertexKeyConfigSchema.optional(),
 		bedrock_key_config: bedrockKeyConfigSchema.optional(),
+		replicate_key_config: replicateKeyConfigSchema.optional(),
 		use_for_batch_api: z.boolean().optional(),
 	})
 	.refine(

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1171,7 +1171,6 @@
 			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25"
@@ -3069,7 +3068,6 @@
 			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -3146,6 +3144,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
 			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -3156,6 +3155,7 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -3221,6 +3221,7 @@
 			"integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.41.0",
 				"@typescript-eslint/types": "8.41.0",
@@ -3721,7 +3722,6 @@
 			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.13.2",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -3732,24 +3732,21 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
 			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
 			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
 			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.13.2",
@@ -3757,7 +3754,6 @@
 			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -3769,8 +3765,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
 			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.14.1",
@@ -3778,7 +3773,6 @@
 			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -3792,7 +3786,6 @@
 			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -3803,7 +3796,6 @@
 			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -3813,8 +3805,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
 			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.14.1",
@@ -3822,7 +3813,6 @@
 			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -3840,7 +3830,6 @@
 			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -3855,7 +3844,6 @@
 			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -3869,7 +3857,6 @@
 			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -3885,7 +3872,6 @@
 			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
@@ -3896,16 +3882,14 @@
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
 			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
@@ -3913,6 +3897,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3926,7 +3911,6 @@
 			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			},
@@ -3967,7 +3951,6 @@
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -3986,7 +3969,6 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4003,8 +3985,7 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
@@ -4376,8 +4357,7 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
@@ -4490,7 +4470,6 @@
 			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.0"
 			}
@@ -4575,8 +4554,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -4968,8 +4946,7 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
 			"integrity": "sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
@@ -5131,8 +5108,7 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
 			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -5208,7 +5184,6 @@
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -5231,6 +5206,7 @@
 			"integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -5320,6 +5296,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -5421,6 +5398,7 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -5752,7 +5730,6 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -5830,8 +5807,7 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
-			"license": "BSD-3-Clause",
-			"peer": true
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -6100,8 +6076,7 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/globals": {
 			"version": "14.0.0",
@@ -6779,7 +6754,6 @@
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -6795,7 +6769,6 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -7198,7 +7171,6 @@
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -7299,8 +7271,7 @@
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -7406,7 +7377,8 @@
 			"version": "0.52.2",
 			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
 			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/monaco-editor-webpack-plugin": {
 			"version": "7.1.0",
@@ -7474,14 +7446,14 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/next": {
 			"version": "15.5.9",
 			"resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
 			"integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@next/env": "15.5.9",
 				"@swc/helpers": "0.5.15",
@@ -7572,8 +7544,7 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
 			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/numeric-quantity": {
 			"version": "2.1.0",
@@ -7950,6 +7921,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -8120,7 +8092,6 @@
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8130,6 +8101,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
 			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8174,6 +8146,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -8186,6 +8159,7 @@
 			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
 			"integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -8278,6 +8252,7 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -8433,7 +8408,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -8494,7 +8470,6 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8618,8 +8593,7 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/safe-push-apply": {
 			"version": "1.0.0",
@@ -8668,7 +8642,6 @@
 			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -8707,7 +8680,6 @@
 			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			},
@@ -8720,8 +8692,7 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/semver": {
 			"version": "7.7.2",
@@ -8742,7 +8713,6 @@
 			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -8954,7 +8924,6 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8974,7 +8943,6 @@
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -9263,7 +9231,6 @@
 			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.14.0",
@@ -9283,7 +9250,6 @@
 			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
@@ -9360,6 +9326,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -9532,6 +9499,7 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9630,7 +9598,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -9759,7 +9726,6 @@
 			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -9774,7 +9740,6 @@
 			"integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -9824,7 +9789,6 @@
 			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -9835,7 +9799,6 @@
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -9850,7 +9813,6 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}


### PR DESCRIPTION
## Add Replicate provider support

This PR adds support for the Replicate API, enabling access to Replicate's models through Bifrost. Replicate offers a wide range of open and closed-source models through a prediction-based API architecture.

## Changes

- Added new Replicate provider implementation with support for:
  - Chat completions (sync and streaming)
  - Text completions (sync and streaming)
  - Image generation (sync and streaming)
  - File operations (upload, list, retrieve, delete)
  - Model listing (deployments)
- Implemented conversion between Bifrost's standard formats and Replicate's prediction-based API
- Added comprehensive test configuration for Replicate provider
- Added documentation for the Replicate provider

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

Set the `REPLICATE_API_KEY` environment variable with your Replicate API key, then run the tests:

```sh
# Core tests
export REPLICATE_API_KEY=your_api_key_here
go test ./core/providers/replicate/...

# Integration tests
go test ./core/internal/testutil/... -run TestReplicate
```

You can also test with the HTTP gateway:

```sh
# Chat completion
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "replicate/openai/gpt-4.1-mini",
    "messages": [{"role": "user", "content": "Hello"}]
  }'

# Image generation
curl -X POST http://localhost:8080/v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "model": "replicate/black-forest-labs/flux-dev",
    "prompt": "A serene mountain landscape at sunset"
  }'
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

The implementation handles API keys securely and follows the same security patterns as other providers.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)