### PR TITLE
feat(ci): publish helm chart to oci registry

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -93,6 +93,13 @@ jobs:
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
 
+      - name: Login to OCI Registry
+        uses: docker/login-action@v3.6.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Push Helm charts to OCI registry
         shell: bash
         env:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write  
+  contents: write
 
 jobs:
   release:
@@ -92,3 +92,11 @@ jobs:
           enable_jekyll: false
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Push Helm charts to OCI registry
+        shell: bash
+        env:
+          PACKAGE_FILE: bifrost-${{ steps.chart-version.outputs.version }}.tgz
+          CHART_TAG_BASE: docker.io/maximhq/bifrost-helm
+        run: |-
+          helm push "${PACKAGE_FILE}" oci://${CHART_TAG_BASE}

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2026-01-23T12:43:49.37006539Z"

--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,0 @@
-apiVersion: v1
-entries: {}
-generated: "2026-01-23T12:43:49.37006539Z"


### PR DESCRIPTION
## Summary

Publishes Helm chart to OCI registry. The corresponding OCI registry does NOT exist yet. My suggestion is to create `docker.io/maximhq/bifrost-helm` which is used in the workflow file.

Due to the nature of this change, I could not test it.

## Changes

- Helm chart release pipeline pushes chart to oci now.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs
- [x] CI

## How to test

Run Helm release workflow.

## Related issues

Closes #1403 

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


