### PR TITLE
virtual key fixes

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -496,7 +496,7 @@ func GenerateVirtualKeyHash(vk tables.TableVirtualKey) (string, error) {
 	hash.Write([]byte(vk.Name))
 	// Hash Description
 	hash.Write([]byte(vk.Description))
-	// Note: Value is intentionally NOT hashed - it's a generated secret that shouldn't affect config sync
+	hash.Write([]byte(vk.Value))
 	// Hash IsActive
 	if vk.IsActive {
 		hash.Write([]byte("isActive:true"))


### PR DESCRIPTION
## Summary

Enhance virtual key handling in the configuration system to support environment variable resolution and improve value persistence.

## Changes

- Modified `GenerateVirtualKeyHash` to include the virtual key value in the hash calculation, ensuring proper synchronization
- Added support for resolving environment variables in virtual key values using the `env.` prefix
- Improved handling of existing virtual key values during config synchronization
- Added validation to ensure virtual key values have the correct prefix, generating new ones when needed
- Replaced generic warnings with more specific messages about virtual key format requirements

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Configure a virtual key with an environment variable value using the `env.` prefix
2. Set the corresponding environment variable
3. Verify the virtual key resolves to the environment variable value
4. Test synchronization between config files and database storage

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change improves the handling of virtual keys, which are sensitive values used for authentication and authorization. The implementation ensures proper validation and generation of secure values.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)