### PR TITLE
fixes anthropic files api 404 issue

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1754,6 +1754,7 @@ func (provider *AnthropicProvider) FileUpload(ctx *schemas.BifrostContext, key s
 		req.Header.Set("x-api-key", key.Value.GetValue())
 	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
+	appendBetaHeader(req, AnthropicFilesAPIBetaHeader)
 	req.SetBody(buf.Bytes())
 
 	// Make request
@@ -1847,6 +1848,7 @@ func (provider *AnthropicProvider) FileList(ctx *schemas.BifrostContext, keys []
 		req.Header.Set("x-api-key", key.Value.GetValue())
 	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
+	appendBetaHeader(req, AnthropicFilesAPIBetaHeader)
 
 	// Make request
 	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
@@ -1944,6 +1946,7 @@ func (provider *AnthropicProvider) FileRetrieve(ctx *schemas.BifrostContext, key
 			req.Header.Set("x-api-key", key.Value.GetValue())
 		}
 		req.Header.Set("anthropic-version", provider.apiVersion)
+		appendBetaHeader(req, AnthropicFilesAPIBetaHeader)
 
 		// Make request
 		latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
@@ -2020,6 +2023,7 @@ func (provider *AnthropicProvider) FileDelete(ctx *schemas.BifrostContext, keys 
 			req.Header.Set("x-api-key", key.Value.GetValue())
 		}
 		req.Header.Set("anthropic-version", provider.apiVersion)
+		appendBetaHeader(req, AnthropicFilesAPIBetaHeader)
 
 		// Make request
 		latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
@@ -2128,6 +2132,7 @@ func (provider *AnthropicProvider) FileContent(ctx *schemas.BifrostContext, keys
 			req.Header.Set("x-api-key", key.Value.GetValue())
 		}
 		req.Header.Set("anthropic-version", provider.apiVersion)
+		appendBetaHeader(req, AnthropicFilesAPIBetaHeader)
 		// Make request
 		latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
 		if bifrostErr != nil {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/bytedance/sonic"
+	"github.com/valyala/fasthttp"
+
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -137,6 +139,22 @@ func appendUniqueHeader(slice []string, item string) []string {
 		}
 	}
 	return append(slice, item)
+}
+
+// appendBetaHeader appends a beta header to the request, preserving any existing beta headers
+func appendBetaHeader(req *fasthttp.Request, betaHeader string) {
+	existing := string(req.Header.Peek("anthropic-beta"))
+	if existing == "" {
+		req.Header.Set("anthropic-beta", betaHeader)
+		return
+	}
+	// Check if header already present
+	for _, h := range strings.Split(existing, ",") {
+		if strings.TrimSpace(h) == betaHeader {
+			return
+		}
+	}
+	req.Header.Set("anthropic-beta", existing+","+betaHeader)
 }
 
 // convertChatResponseFormatToTool converts a response_format config to an Anthropic tool for structured output


### PR DESCRIPTION
## Summary

Add Anthropic Files API beta header to all file-related API requests to ensure compatibility with Anthropic's file operations.

## Changes

- Added `appendBetaHeader` utility function to handle adding beta headers while preserving existing ones
- Applied the `AnthropicFilesAPIBetaHeader` to all file operation endpoints:
  - FileUpload
  - FileList
  - FileRetrieve
  - FileDelete
  - FileContent

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test file operations with the Anthropic provider to ensure they work correctly:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses compatibility with Anthropic's Files API requirements

## Security considerations

No security implications as this only adds required headers for API compatibility.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable