### PR TITLE
fixes groq streaming batch detection

### DIFF
--- a/core/internal/testutil/chat_completion_stream.go
+++ b/core/internal/testutil/chat_completion_stream.go
@@ -30,12 +30,12 @@ func detectBatchedStream(chunkTimings []chunkTiming, minChunks int) (bool, strin
 
 	// Check if first-to-second chunk has reasonable delay (TTFT indicator)
 	// True streaming usually has >1ms between first and second chunk
-	if len(chunkTimings) >= 2 && chunkTimings[1].timeSincePrev > 1*time.Millisecond {
+	if len(chunkTimings) >= 2 && chunkTimings[1].timeSincePrev > 50*time.Microsecond {
 		return false, "" // First chunk delay indicates real streaming
 	}
 
 	var nearInstantCount int
-	threshold := 1 * time.Millisecond
+	threshold := 50 * time.Microsecond
 
 	// Start from index 1 (skip first chunk - no previous reference)
 	for i := 1; i < len(chunkTimings); i++ {


### PR DESCRIPTION
## Summary

Adjusted the timing thresholds in the stream detection logic to better identify batched vs. true streaming responses.

## Changes

- Reduced the threshold for detecting true streaming from 1 millisecond to 50 microseconds
- Updated both the first-to-second chunk delay check and the near-instant count threshold
- These changes make the detection more sensitive to smaller timing differences between chunks

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the streaming detection tests to verify the updated thresholds correctly identify batched vs. true streaming:

```sh
# Core/Transports
go version
go test ./core/internal/testutil -run TestDetectBatchedStream
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)