### PR TITLE
adds pinecone for framework tests

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -57,6 +57,22 @@ services:
             bifrost_network:
                 ipv4_address: 172.28.0.14
 
+    # Pinecone Local instance for vector store tests
+    pinecone-local:
+        image: ghcr.io/pinecone-io/pinecone-index:latest
+        environment:
+            PORT: 5081
+            INDEX_TYPE: serverless
+            VECTOR_TYPE: dense
+            DIMENSION: 1536
+            METRIC: cosine
+        ports:
+            - "5081:5081"
+        platform: linux/amd64
+        networks:
+            bifrost_network:
+                ipv4_address: 172.28.0.15
+
 networks:
     bifrost_network:
         driver: bridge


### PR DESCRIPTION
## Summary

Added Pinecone Local instance to the Docker Compose configuration for vector store testing.

## Changes

- Added a new service `pinecone-local` to the Docker Compose file
- Configured the Pinecone service with necessary environment variables (PORT, INDEX_TYPE, VECTOR_TYPE, DIMENSION, METRIC)
- Set up network configuration with a static IP address (172.28.0.15)
- Exposed port 5081 for the Pinecone service
- Specified platform as linux/amd64

## Type of change

- [x] Feature
- [x] Providers/Integrations

## Affected areas

- [x] Providers/Integrations

## How to test

Run the Docker Compose setup and verify that the Pinecone Local instance is accessible:

```sh
cd tests
docker-compose up -d pinecone-local
curl http://172.28.0.15:5081/health
```

The Pinecone service should be available at http://localhost:5081 or http://172.28.0.15:5081 within the Docker network.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

This change only affects the test environment and doesn't introduce any security concerns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)