### PR TITLE
increase timeout for semantic caching plugin tests

### DIFF
--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -111,7 +111,7 @@ if [ -f "go.mod" ]; then
       # cd "$PLUGIN_DIR"
     else
       echo "🧪 Running plugin tests with coverage..."
-      go test -coverprofile=coverage.txt -coverpkg=./... ./...
+      go test -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
       
       # Upload coverage to Codecov
       if [ -n "${CODECOV_TOKEN:-}" ]; then


### PR DESCRIPTION
## Summary

Increase the timeout for plugin tests in the release script to accommodate longer-running tests.

## Changes

- Modified the plugin test command in `release-single-plugin.sh` to include a 20-minute timeout parameter (`-timeout 20m`)
- This prevents tests from being terminated prematurely when they take longer to complete

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script for a plugin with tests that take longer than the default timeout:

```sh
./.github/workflows/scripts/release-single-plugin.sh <plugin-name>
```

Verify that tests complete successfully without timing out.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses test timeouts occurring during plugin releases.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable