### PR TITLE
semantic test fixes

### DIFF
--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -111,7 +111,7 @@ if [ -f "go.mod" ]; then
       # cd "$PLUGIN_DIR"
     else
       echo "🧪 Running plugin tests with coverage..."
-      go test -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
+      go test -v -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
       
       # Upload coverage to Codecov
       if [ -n "${CODECOV_TOKEN:-}" ]; then

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -540,7 +540,7 @@ func AssertNoCacheHit(t *testing.T, response *schemas.BifrostResponse) {
 
 // WaitForCache waits for async cache operations to complete
 func WaitForCache() {
-	time.Sleep(10 * time.Second)
+	time.Sleep(1 * time.Second)
 }
 
 // CreateEmbeddingRequest creates an embedding request for testing


### PR DESCRIPTION
## Summary

Improve semantic cache plugin behavior and test reliability by adding verbose test output, implementing zero vectors for direct-only cache entries, and reducing test wait times.

## Changes

- Added verbose flag (`-v`) to Go test command in the release script to provide more detailed test output
- Implemented zero vectors for direct-only cache entries instead of generating embeddings, which preserves cache type isolation by preventing semantic search from matching direct-only entries
- Reduced the wait time in cache tests from 10 seconds to 1 second to speed up test execution

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache plugin tests to verify the changes:

```sh
cd plugins/semanticcache
go test -v ./...
```

Verify that direct-only cache entries don't appear in semantic search results.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The use of zero vectors for direct-only cache entries improves isolation between cache types, preventing potential information leakage between different caching strategies.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable