### PR TITLE
feat: enhance MCP client persistence and redacted field handling

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2180,10 +2180,10 @@ func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error 
 
 	// Step 1: Create new ProviderQueue with updated buffer size
 	newPq := &ProviderQueue{
-		queue: make(chan *ChannelMessage, providerConfig.ConcurrencyAndBufferSize.BufferSize),
-		done:  make(chan struct{}),
+		queue:      make(chan *ChannelMessage, providerConfig.ConcurrencyAndBufferSize.BufferSize),
+		done:       make(chan struct{}),
 		signalOnce: sync.Once{},
-		closeOnce: sync.Once{},
+		closeOnce:  sync.Once{},
 	}
 
 	// Step 2: Atomically replace the queue FIRST (new producers immediately get the new queue)
@@ -2695,10 +2695,10 @@ func (bifrost *Bifrost) createBaseProvider(providerKey schemas.ModelProvider, co
 func (bifrost *Bifrost) prepareProvider(providerKey schemas.ModelProvider, config *schemas.ProviderConfig) error {
 	// Create ProviderQueue with lifecycle management
 	pq := &ProviderQueue{
-		queue: make(chan *ChannelMessage, config.ConcurrencyAndBufferSize.BufferSize),
-		done:  make(chan struct{}),
+		queue:      make(chan *ChannelMessage, config.ConcurrencyAndBufferSize.BufferSize),
+		done:       make(chan struct{}),
 		signalOnce: sync.Once{},
-		closeOnce: sync.Once{},
+		closeOnce:  sync.Once{},
 	}
 
 	bifrost.requestQueues.Store(providerKey, pq)

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -468,7 +468,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 			if ctx.Err() != nil {
 				return
 			}
-			
+
 			line := scanner.Text()
 
 			// Skip empty lines (event delimiter)
@@ -507,7 +507,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 		// Handle scanner errors
 		if err := scanner.Err(); err != nil {
 			// If context was cancelled/timed out, let defer handle it
-			if ctx.Err() != nil {	
+			if ctx.Err() != nil {
 				return
 			}
 			ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -84,7 +84,6 @@ func NewMCPClientConfigFromMap(configMap map[string]any) *MCPClientConfig {
 	return &config
 }
 
-
 // HttpHeaders returns the HTTP headers for the MCP client config.
 func (c *MCPClientConfig) HttpHeaders() map[string]string {
 	headers := make(map[string]string)

--- a/ui/app/workspace/mcp-gateway/page.tsx
+++ b/ui/app/workspace/mcp-gateway/page.tsx
@@ -7,9 +7,10 @@ import { getErrorMessage, useGetMCPClientsQuery } from "@/lib/store";
 import { useEffect } from "react";
 
 export default function MCPServersPage() {
-	const { data: mcpClients, error, isLoading } = useGetMCPClientsQuery();
+	const { data: mcpClients, error, isLoading, refetch } = useGetMCPClientsQuery();
 
 	const { toast } = useToast();
+
 
 	useEffect(() => {
 		if (error) {
@@ -27,7 +28,7 @@ export default function MCPServersPage() {
 
 	return (
 		<div className="mx-auto w-full max-w-7xl">
-			<MCPClientsTable mcpClients={mcpClients || []} />
+			<MCPClientsTable mcpClients={mcpClients || []} refetch={refetch} />
 		</div>
 	);
 }

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -10,7 +10,7 @@ export const mcpApi = baseApi.injectEndpoints({
 		}),
 
 		// Create new MCP client
-		createMCPClient: builder.mutation<null, CreateMCPClientRequest>({
+		createMCPClient: builder.mutation<any, CreateMCPClientRequest>({
 			query: (data) => ({
 				url: "/mcp/client",
 				method: "POST",
@@ -20,7 +20,7 @@ export const mcpApi = baseApi.injectEndpoints({
 		}),
 
 		// Update existing MCP client
-		updateMCPClient: builder.mutation<null, { id: string; data: UpdateMCPClientRequest }>({
+		updateMCPClient: builder.mutation<any, { id: string; data: UpdateMCPClientRequest }>({
 			query: ({ id, data }) => ({
 				url: `/mcp/client/${id}`,
 				method: "PUT",
@@ -30,7 +30,7 @@ export const mcpApi = baseApi.injectEndpoints({
 		}),
 
 		// Delete MCP client
-		deleteMCPClient: builder.mutation<null, string>({
+		deleteMCPClient: builder.mutation<any, string>({
 			query: (id) => ({
 				url: `/mcp/client/${id}`,
 				method: "DELETE",
@@ -39,7 +39,7 @@ export const mcpApi = baseApi.injectEndpoints({
 		}),
 
 		// Reconnect MCP client
-		reconnectMCPClient: builder.mutation<null, string>({
+		reconnectMCPClient: builder.mutation<any, string>({
 			query: (id) => ({
 				url: `/mcp/client/${id}/reconnect`,
 				method: "POST",


### PR DESCRIPTION
## Summary

Improves MCP client management with better error handling, logging, and configuration persistence. This PR enhances the reliability of MCP client connections and provides a more robust user experience when managing MCP clients through the UI.

## Changes

- Fixed MCP client health monitoring to use client names in logs instead of IDs for better readability
- Improved error handling in health monitor start/stop operations
- Enhanced MCP client configuration management to properly handle redacted sensitive fields
- Fixed UI state management for MCP clients with proper refetching after operations
- Reorganized code to separate core MCP client management from configuration persistence
- Added UUID generation for MCP clients when ID is not provided
- Improved code formatting and whitespace consistency

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create a new MCP client through the UI
2. Edit the client, changing only non-sensitive fields
3. Verify that redacted fields (like headers) are preserved correctly
4. Reconnect the client and verify it connects successfully
5. Delete the client and verify it's removed from both UI and backend

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves MCP client management reliability and user experience

## Security considerations

Ensures sensitive fields in MCP client configurations are properly handled during updates to prevent accidental data loss or exposure.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable