### PR TITLE
mcp tool groups

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -73,7 +73,7 @@ type Bifrost struct {
 	oauth2Provider      schemas.OAuth2Provider              // OAuth provider instance
 	logger              schemas.Logger                      // logger instance, default logger is used if not provided
 	tracer              atomic.Value                        // tracer for distributed tracing (stores schemas.Tracer, NoOpTracer if not configured)
-	mcpManager          *mcp.MCPManager                     // MCP integration manager (nil if MCP not configured)
+	McpManager          mcp.MCPManagerInterface             // MCP integration manager (nil if MCP not configured)
 	mcpInitOnce         sync.Once                           // Ensures MCP manager is initialized only once
 	dropExcessRequests  atomic.Bool                         // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
 	keySelector         schemas.KeySelector                 // Custom key selector function
@@ -286,7 +286,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 				}
 			}
 			codeMode := starlark.NewStarlarkCodeMode(codeModeConfig)
-			bifrost.mcpManager = mcp.NewMCPManager(bifrostCtx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
+			bifrost.McpManager = mcp.NewMCPManager(bifrostCtx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
 			bifrost.logger.Info("MCP integration initialized successfully")
 		})
 	}
@@ -713,8 +713,8 @@ func (bifrost *Bifrost) ChatCompletionRequest(ctx *schemas.BifrostContext, req *
 	}
 
 	// Check if we should enter agent mode
-	if bifrost.mcpManager != nil {
-		return bifrost.mcpManager.CheckAndExecuteAgentForChatRequest(
+	if bifrost.McpManager != nil {
+		return bifrost.McpManager.CheckAndExecuteAgentForChatRequest(
 			ctx,
 			req,
 			response,
@@ -810,8 +810,8 @@ func (bifrost *Bifrost) ResponsesRequest(ctx *schemas.BifrostContext, req *schem
 	}
 
 	// Check if we should enter agent mode
-	if bifrost.mcpManager != nil {
-		return bifrost.mcpManager.CheckAndExecuteAgentForResponsesRequest(
+	if bifrost.McpManager != nil {
+		return bifrost.McpManager.CheckAndExecuteAgentForResponsesRequest(
 			ctx,
 			req,
 			response,
@@ -2661,11 +2661,11 @@ func (bifrost *Bifrost) getProviderMutex(providerKey schemas.ModelProvider) *syn
 //	        return args.Message, nil
 //	    }, toolSchema)
 func (bifrost *Bifrost) RegisterMCPTool(name, description string, handler func(args any) (string, error), toolSchema schemas.ChatTool) error {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.RegisterTool(name, description, handler, toolSchema)
+	return bifrost.McpManager.RegisterTool(name, description, handler, toolSchema)
 }
 
 // IMPORTANT: Running the MCP client management operations (GetMCPClients, AddMCPClient, RemoveMCPClient, EditMCPClientTools)
@@ -2679,11 +2679,11 @@ func (bifrost *Bifrost) RegisterMCPTool(name, description string, handler func(a
 //   - []schemas.MCPClient: List of all MCP clients
 //   - error: Any retrieval error
 func (bifrost *Bifrost) GetMCPClients() ([]schemas.MCPClient, error) {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return nil, fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	clients := bifrost.mcpManager.GetClients()
+	clients := bifrost.McpManager.GetClients()
 	clientsInConfig := make([]schemas.MCPClient, 0, len(clients))
 
 	for _, client := range clients {
@@ -2721,10 +2721,10 @@ func (bifrost *Bifrost) GetMCPClients() ([]schemas.MCPClient, error) {
 // Returns:
 //   - []schemas.ChatTool: List of available tools
 func (bifrost *Bifrost) GetAvailableMCPTools(ctx context.Context) []schemas.ChatTool {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return nil
 	}
-	return bifrost.mcpManager.GetAvailableTools(ctx)
+	return bifrost.McpManager.GetAvailableTools(ctx)
 }
 
 // AddMCPClient adds a new MCP client to the Bifrost instance.
@@ -2744,7 +2744,7 @@ func (bifrost *Bifrost) GetAvailableMCPTools(ctx context.Context) []schemas.Chat
 //	    ConnectionString: &url,
 //	})
 func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		// Use sync.Once to ensure thread-safe initialization
 		bifrost.mcpInitOnce.Do(func() {
 			// Initialize with empty config - client will be added via AddClient below
@@ -2763,16 +2763,16 @@ func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
 			// Create Starlark CodeMode for code execution (with default config)
 			starlark.SetLogger(bifrost.logger)
 			codeMode := starlark.NewStarlarkCodeMode(nil)
-			bifrost.mcpManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
+			bifrost.McpManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
 		})
 	}
 
 	// Handle case where initialization succeeded elsewhere but manager is still nil
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return fmt.Errorf("MCP manager is not initialized")
 	}
 
-	return bifrost.mcpManager.AddClient(config)
+	return bifrost.McpManager.AddClient(config)
 }
 
 // RemoveMCPClient removes an MCP client from the Bifrost instance.
@@ -2791,20 +2791,20 @@ func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
 //	    log.Fatalf("Failed to remove MCP client: %v", err)
 //	}
 func (bifrost *Bifrost) RemoveMCPClient(id string) error {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.RemoveClient(id)
+	return bifrost.McpManager.RemoveClient(id)
 }
 
 // SetMCPManager sets the MCP manager for this Bifrost instance.
-// This is primarily used for testing purposes to inject a custom MCP manager.
+// This allows injecting a custom MCP manager implementation (e.g., for enterprise features).
 //
 // Parameters:
-//   - manager: The MCP manager to set
-func (bifrost *Bifrost) SetMCPManager(manager *mcp.MCPManager) {
-	bifrost.mcpManager = manager
+//   - manager: The MCP manager to set (must implement MCPManagerInterface)
+func (bifrost *Bifrost) SetMCPManager(manager mcp.MCPManagerInterface) {
+	bifrost.McpManager = manager
 }
 
 // UpdateMCPClient updates the MCP client.
@@ -2824,11 +2824,11 @@ func (bifrost *Bifrost) SetMCPManager(manager *mcp.MCPManager) {
 //	    ToolsToExecute: []string{"tool1", "tool2"},
 //	})
 func (bifrost *Bifrost) EditMCPClient(id string, updatedConfig *schemas.MCPClientConfig) error {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.EditClient(id, updatedConfig)
+	return bifrost.McpManager.EditClient(id, updatedConfig)
 }
 
 // ReconnectMCPClient attempts to reconnect an MCP client if it is disconnected.
@@ -2839,21 +2839,21 @@ func (bifrost *Bifrost) EditMCPClient(id string, updatedConfig *schemas.MCPClien
 // Returns:
 //   - error: Any reconnection error
 func (bifrost *Bifrost) ReconnectMCPClient(id string) error {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	return bifrost.mcpManager.ReconnectClient(id)
+	return bifrost.McpManager.ReconnectClient(id)
 }
 
 // UpdateToolManagerConfig updates the tool manager config for the MCP manager.
 // This allows for hot-reloading of the tool manager config at runtime.
 func (bifrost *Bifrost) UpdateToolManagerConfig(maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string) error {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return fmt.Errorf("MCP is not configured in this Bifrost instance")
 	}
 
-	bifrost.mcpManager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
+	bifrost.McpManager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        maxAgentDepth,
 		ToolExecutionTimeout: time.Duration(toolExecutionTimeoutInSeconds) * time.Second,
 		CodeModeBindingLevel: schemas.CodeModeBindingLevel(codeModeBindingLevel),
@@ -3445,8 +3445,8 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	}
 
 	// Add MCP tools to request if MCP is configured and requested
-	if bifrost.mcpManager != nil {
-		req = bifrost.mcpManager.AddToolsToRequest(ctx, req)
+	if bifrost.McpManager != nil {
+		req = bifrost.McpManager.AddToolsToRequest(ctx, req)
 	}
 
 	tracer := bifrost.getTracer()
@@ -3635,8 +3635,8 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 	}
 
 	// Add MCP tools to request if MCP is configured and requested
-	if req.RequestType != schemas.SpeechStreamRequest && req.RequestType != schemas.TranscriptionStreamRequest && bifrost.mcpManager != nil {
-		req = bifrost.mcpManager.AddToolsToRequest(ctx, req)
+	if req.RequestType != schemas.SpeechStreamRequest && req.RequestType != schemas.TranscriptionStreamRequest && bifrost.McpManager != nil {
+		req = bifrost.McpManager.AddToolsToRequest(ctx, req)
 	}
 
 	tracer := bifrost.getTracer()
@@ -4411,7 +4411,7 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, r
 //   - *schemas.BifrostMCPResponse: The MCP response after all hooks
 //   - *schemas.BifrostError: Any execution error
 func (bifrost *Bifrost) handleMCPToolExecution(ctx *schemas.BifrostContext, mcpRequest *schemas.BifrostMCPRequest, requestType schemas.RequestType) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
-	if bifrost.mcpManager == nil {
+	if bifrost.McpManager == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
@@ -4470,7 +4470,7 @@ func (bifrost *Bifrost) handleMCPToolExecution(ctx *schemas.BifrostContext, mcpR
 	}
 
 	// Execute tool with modified request
-	result, err := bifrost.mcpManager.ExecuteToolCall(ctx, preReq)
+	result, err := bifrost.McpManager.ExecuteToolCall(ctx, preReq)
 
 	// Prepare MCP response and error for post-hooks
 	var mcpResp *schemas.BifrostMCPResponse
@@ -5278,8 +5278,8 @@ func (bifrost *Bifrost) Shutdown() {
 	})
 
 	// Cleanup MCP manager
-	if bifrost.mcpManager != nil {
-		err := bifrost.mcpManager.Cleanup()
+	if bifrost.McpManager != nil {
+		err := bifrost.McpManager.Cleanup()
 		if err != nil {
 			bifrost.logger.Warn("Error cleaning up MCP manager: %s", err.Error())
 		}

--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -182,8 +182,8 @@ func executeAgent(
 			toolName := *toolCall.Function.Name
 			client := clientManager.GetClientForTool(toolName)
 			if client == nil {
-				// Allow code mode list and read tool tools
-				if toolName == ToolTypeListToolFiles || toolName == ToolTypeReadToolFile {
+				// Allow code mode list, read, and docs tools (all read-only operations)
+				if toolName == ToolTypeListToolFiles || toolName == ToolTypeReadToolFile || toolName == ToolTypeGetToolDocs {
 					autoExecutableTools = append(autoExecutableTools, toolCall)
 					logger.Debug("Tool %s can be auto-executed", toolName)
 					continue

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -1,0 +1,73 @@
+//go:build !tinygo && !wasm
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// MCPManagerInterface defines the interface for MCP management functionality.
+// This interface allows different implementations (OSS and Enterprise) to be used
+// interchangeably in the Bifrost core.
+type MCPManagerInterface interface {
+	// Tool Operations
+	// AddToolsToRequest parses available MCP tools and adds them to the request
+	AddToolsToRequest(ctx context.Context, req *schemas.BifrostRequest) *schemas.BifrostRequest
+
+	// GetAvailableTools returns all available MCP tools for the given context
+	GetAvailableTools(ctx context.Context) []schemas.ChatTool
+
+	// ExecuteToolCall executes a single tool call and returns the result
+	ExecuteToolCall(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error)
+
+	// UpdateToolManagerConfig updates the configuration for the tool manager
+	UpdateToolManagerConfig(config *schemas.MCPToolManagerConfig)
+
+	// Agent Mode Operations
+	// CheckAndExecuteAgentForChatRequest handles agent mode for Chat Completions API
+	CheckAndExecuteAgentForChatRequest(
+		ctx *schemas.BifrostContext,
+		req *schemas.BifrostChatRequest,
+		response *schemas.BifrostChatResponse,
+		makeReq func(ctx *schemas.BifrostContext, req *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError),
+		executeTool func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	) (*schemas.BifrostChatResponse, *schemas.BifrostError)
+
+	// CheckAndExecuteAgentForResponsesRequest handles agent mode for Responses API
+	CheckAndExecuteAgentForResponsesRequest(
+		ctx *schemas.BifrostContext,
+		req *schemas.BifrostResponsesRequest,
+		response *schemas.BifrostResponsesResponse,
+		makeReq func(ctx *schemas.BifrostContext, req *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError),
+		executeTool func(ctx *schemas.BifrostContext, request *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error),
+	) (*schemas.BifrostResponsesResponse, *schemas.BifrostError)
+
+	// Client Management
+	// GetClients returns all MCP clients
+	GetClients() []schemas.MCPClientState
+
+	// AddClient adds a new MCP client with the given configuration
+	AddClient(config *schemas.MCPClientConfig) error
+
+	// RemoveClient removes an MCP client by ID
+	RemoveClient(id string) error
+
+	// EditClient updates an existing MCP client configuration
+	EditClient(id string, updatedConfig *schemas.MCPClientConfig) error
+
+	// ReconnectClient reconnects an MCP client by ID
+	ReconnectClient(id string) error
+
+	// Tool Registration
+	// RegisterTool registers a local tool with the MCP server
+	RegisterTool(name, description string, toolFunction MCPToolFunction[any], toolSchema schemas.ChatTool) error
+
+	// Lifecycle
+	// Cleanup performs cleanup of all MCP resources
+	Cleanup() error
+}
+
+// Ensure MCPManager implements MCPManagerInterface
+var _ MCPManagerInterface = (*MCPManager)(nil)

--- a/ui/components/ui/entityAssociationSelect.tsx
+++ b/ui/components/ui/entityAssociationSelect.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import { AsyncMultiSelect } from "./asyncMultiselect"
+import { Option } from "./multiselectUtils"
+import { cn } from "./utils"
+
+// Entity types supported by this component
+export type EntityType = "virtualKey" | "team" | "customer" | "user" | "provider" | "apiKey"
+
+// Generic entity option
+export interface EntityOption {
+  id: string | number
+  label: string
+  description?: string
+  metadata?: Record<string, unknown>
+}
+
+// Meta type for AsyncMultiSelect
+interface EntityOptionMeta {
+  id: string | number
+  description?: string
+  metadata?: Record<string, unknown>
+}
+
+interface EntityAssociationSelectProps {
+  /** The type of entity being selected */
+  entityType: EntityType
+  /** Currently selected entity IDs */
+  value: (string | number)[]
+  /** Callback when selection changes */
+  onChange: (ids: (string | number)[]) => void
+  /** Placeholder text */
+  placeholder?: string
+  /** Whether the component is disabled */
+  disabled?: boolean
+  /** Additional CSS classes */
+  className?: string
+  /** 
+   * Custom reload function for fetching options.
+   * If provided, this will be used instead of the default behavior.
+   * The function should call the callback with filtered options.
+   */
+  customReload?: (query: string, callback: (options: Option<EntityOptionMeta>[]) => void) => void
+  /**
+   * Static options to use when customReload is not provided.
+   * This is useful for simple use cases where all options are already available.
+   */
+  options?: EntityOption[]
+  /**
+   * Whether to allow creating new options
+   */
+  isCreatable?: boolean
+  /**
+   * Callback when a new option is created
+   */
+  onCreateOption?: (value: string) => void
+  /**
+   * Format function for creating new option labels
+   */
+  formatCreateLabel?: (inputValue: string) => string
+  /**
+   * Message to display when no options are available
+   */
+  noOptionsMessage?: () => string
+}
+
+// Default placeholder text for each entity type
+const defaultPlaceholders: Record<EntityType, string> = {
+  virtualKey: "Add virtual key names...",
+  team: "Add team names...",
+  customer: "Add customer names...",
+  user: "Add user names...",
+  provider: "Add provider names...",
+  apiKey: "Add API key names...",
+}
+
+// Default no options messages for each entity type
+const defaultNoOptionsMessages: Record<EntityType, string> = {
+  virtualKey: "No virtual keys found",
+  team: "No teams found",
+  customer: "No customers found",
+  user: "No users found",
+  provider: "No providers found",
+  apiKey: "No API keys found",
+}
+
+// Label text for each entity type
+export const entityTypeLabels: Record<EntityType, string> = {
+  virtualKey: "Virtual Keys",
+  team: "Teams",
+  customer: "Customers",
+  user: "Users",
+  provider: "Providers",
+  apiKey: "API Keys",
+}
+
+export function EntityAssociationSelect({
+  entityType,
+  value,
+  onChange,
+  placeholder,
+  disabled = false,
+  className,
+  customReload,
+  options = [],
+  isCreatable = false,
+  onCreateOption,
+  formatCreateLabel,
+  noOptionsMessage,
+}: EntityAssociationSelectProps) {
+  // Convert static options to AsyncMultiSelect format using meta for complex data
+  const defaultOptions = useMemo((): Option<EntityOptionMeta>[] => {
+    return options.map((opt) => ({
+      label: opt.label,
+      value: String(opt.id),
+      meta: {
+        id: opt.id,
+        description: opt.description,
+        metadata: opt.metadata,
+      },
+    }))
+  }, [options])
+
+  // Convert selected IDs to Option format
+  const selectedValues = useMemo((): Option<EntityOptionMeta>[] => {
+    return value.map((id) => {
+      // Try to find the option in the provided options
+      const existingOption = options.find((opt) => opt.id === id)
+      if (existingOption) {
+        return {
+          label: existingOption.label,
+          value: String(existingOption.id),
+          meta: {
+            id: existingOption.id,
+            description: existingOption.description,
+            metadata: existingOption.metadata,
+          },
+        }
+      }
+      // If not found, create a basic option
+      return {
+        label: String(id),
+        value: String(id),
+        meta: {
+          id,
+        },
+      }
+    })
+  }, [value, options])
+
+  // Filter options based on query
+  const filterOptions = useCallback(
+    (query: string, callback: (options: Option<EntityOptionMeta>[]) => void) => {
+      const lowerQuery = query.toLowerCase()
+      const filtered = defaultOptions.filter(
+        (opt) =>
+          opt.label.toLowerCase().includes(lowerQuery) ||
+          opt.meta?.description?.toLowerCase().includes(lowerQuery)
+      )
+      callback(filtered)
+    },
+    [defaultOptions]
+  )
+
+  // Use custom reload if provided, otherwise use local filter
+  const reload = customReload || filterOptions
+
+  // Handle selection change
+  const handleChange = useCallback(
+    (selected: Option<EntityOptionMeta>[]) => {
+      const ids = selected.map((opt) => opt.meta?.id ?? opt.value)
+      onChange(ids)
+    },
+    [onChange]
+  )
+
+  // Handle creating new option
+  const handleCreateOption = useCallback(
+    (inputValue: string) => {
+      if (onCreateOption) {
+        onCreateOption(inputValue)
+      }
+    },
+    [onCreateOption]
+  )
+
+  return (
+    <div className={cn("w-full", className)}>
+      <AsyncMultiSelect<EntityOptionMeta>
+        placeholder={placeholder || defaultPlaceholders[entityType]}
+        disabled={disabled}
+        defaultOptions={defaultOptions}
+        reload={reload}
+        debounce={200}
+        onChange={handleChange}
+        value={selectedValues}
+        isClearable
+        closeMenuOnSelect={false}
+        hideSelectedOptions={false}
+        isCreatable={isCreatable}
+        onCreateOption={handleCreateOption}
+        formatCreateLabel={formatCreateLabel || ((value) => `Add "${value}"`)}
+        noOptionsMessage={noOptionsMessage || (() => defaultNoOptionsMessages[entityType])}
+        views={{
+          option: (props) => {
+            // Access data as Option<EntityOptionMeta> since that's the actual runtime type
+            const data = props.data as unknown as Option<EntityOptionMeta>
+            return (
+              <div
+                className={cn(
+                  "flex w-full cursor-pointer flex-col gap-0.5 rounded-sm p-2 text-sm",
+                  props.isFocused && "bg-background-highlight-primary/60",
+                  props.isSelected && "bg-background-highlight-primary/40"
+                )}
+                onClick={() => props.selectOption(props.data)}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="text-content-primary font-medium">
+                    {data.label}
+                  </span>
+                  {props.isSelected && (
+                    <span className="text-primary text-xs">Selected</span>
+                  )}
+                </div>
+                {data.meta?.description && (
+                  <span className="text-content-tertiary line-clamp-1 text-xs">
+                    {data.meta.description}
+                  </span>
+                )}
+              </div>
+            )
+          },
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * Helper function to create EntityOption from simple ID list
+ * Useful when you just have IDs without full entity info
+ */
+export function createOptionsFromIds(ids: (string | number)[]): EntityOption[] {
+  return ids.map((id) => ({
+    id,
+    label: String(id),
+  }))
+}
+
+/**
+ * Helper function to create EntityOption with label mapping
+ */
+export function createOptionsWithLabels(
+  items: { id: string | number; name?: string; label?: string; description?: string }[]
+): EntityOption[] {
+  return items.map((item) => ({
+    id: item.id,
+    label: item.name || item.label || String(item.id),
+    description: item.description,
+  }))
+}

--- a/ui/components/ui/mcpServerSelector.tsx
+++ b/ui/components/ui/mcpServerSelector.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import { ExternalLink, X } from "lucide-react"
+import { useCallback, useMemo } from "react"
+import { AsyncMultiSelect } from "./asyncMultiselect"
+import { Badge } from "./badge"
+import { Button } from "./button"
+import { Option } from "./multiselectUtils"
+import { cn } from "./utils"
+
+// Types
+export interface MCPServerInfo {
+  config: {
+    client_id: string
+    name: string
+    connection_type?: string
+  }
+  tools?: { name: string }[]
+  state?: string
+}
+
+interface ServerOptionMeta {
+  clientId: string
+  name: string
+  connectionType?: string
+  toolCount: number
+  state?: string
+}
+
+interface MCPServerSelectorProps {
+  value: string[]
+  onChange: (serverIds: string[]) => void
+  mcpClients: MCPServerInfo[]
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+  /** Base URL path for the MCP registry page (default: /workspace/mcp-registry) */
+  registryPath?: string
+}
+
+export function MCPServerSelector({
+  value,
+  onChange,
+  mcpClients,
+  placeholder = "Search and select MCP servers...",
+  disabled = false,
+  className,
+  registryPath = "/workspace/mcp-registry",
+}: MCPServerSelectorProps) {
+  // Create options from MCP clients using meta for complex data
+  const allServerOptions = useMemo((): Option<ServerOptionMeta>[] => {
+    return mcpClients.map((client) => ({
+      label: client.config.name,
+      value: client.config.client_id,
+      meta: {
+        clientId: client.config.client_id,
+        name: client.config.name,
+        connectionType: client.config.connection_type,
+        toolCount: client.tools?.length || 0,
+        state: client.state,
+      },
+    }))
+  }, [mcpClients])
+
+  // Get full server info for selected servers
+  const selectedServersWithInfo = useMemo(() => {
+    return value.map((serverId) => {
+      const client = mcpClients.find((c) => c.config.client_id === serverId)
+      return {
+        clientId: serverId,
+        name: client?.config.name || serverId,
+        connectionType: client?.config.connection_type,
+        toolCount: client?.tools?.length || 0,
+        state: client?.state,
+      }
+    })
+  }, [value, mcpClients])
+
+  // Filter out already selected servers from options
+  const availableOptions = useMemo(() => {
+    const selectedSet = new Set(value)
+    return allServerOptions.filter((opt) => !selectedSet.has(opt.value))
+  }, [allServerOptions, value])
+
+  const handleSelectServer = useCallback(
+    (selected: Option<ServerOptionMeta>[]) => {
+      if (selected.length === 0) return
+
+      const newServer = selected[selected.length - 1]
+      if (!newServer?.meta) return
+
+      // Check if already selected
+      if (!value.includes(newServer.meta.clientId)) {
+        onChange([...value, newServer.meta.clientId])
+      }
+    },
+    [value, onChange]
+  )
+
+  const handleRemoveServer = useCallback(
+    (serverId: string) => {
+      onChange(value.filter((id) => id !== serverId))
+    },
+    [value, onChange]
+  )
+
+  const reload = useCallback(
+    (query: string, callback: (options: Option<ServerOptionMeta>[]) => void) => {
+      const lowerQuery = query.toLowerCase()
+      const filtered = availableOptions.filter((opt) =>
+        opt.label.toLowerCase().includes(lowerQuery)
+      )
+      callback(filtered)
+    },
+    [availableOptions]
+  )
+
+  const getConnectionTypeBadgeVariant = (type?: string) => {
+    switch (type) {
+      case "http":
+        return "default"
+      case "stdio":
+        return "secondary"
+      case "sse":
+        return "outline"
+      default:
+        return "outline"
+    }
+  }
+
+  const getStateBadgeVariant = (state?: string) => {
+    switch (state) {
+      case "connected":
+        return "success"
+      case "error":
+        return "destructive"
+      default:
+        return "secondary"
+    }
+  }
+
+  return (
+		<div className={cn("space-y-3", className)}>
+			{/* Search dropdown */}
+			<AsyncMultiSelect<ServerOptionMeta>
+				placeholder={placeholder}
+				disabled={disabled}
+				defaultOptions={availableOptions}
+				reload={reload}
+				debounce={150}
+				onChange={handleSelectServer}
+				value={[]}
+				isClearable={false}
+				closeMenuOnSelect={true}
+				hideSelectedOptions={true}
+				controlShouldRenderValue={false}
+				noOptionsMessage={() => "No MCP servers found"}
+				views={{
+					option: (props) => {
+						// Access data as Option<ServerOptionMeta> since that's the actual runtime type
+						const data = props.data as unknown as Option<ServerOptionMeta>;
+						return (
+							<div
+								className={cn(
+									"my-1 flex w-full cursor-pointer items-center justify-between rounded-sm p-2 text-sm",
+									props.isFocused && "bg-accent dark:!bg-card",
+									"hover:bg-accent",
+									props.isSelected && "bg-accent dark:!bg-card",
+								)}
+								onClick={() => props.selectOption(props.data)}
+							>
+								<div className="flex items-center gap-2">
+									<span className="text-content-primary font-medium">{data.meta?.name}</span>
+									{data.meta?.connectionType && (
+										<Badge variant={getConnectionTypeBadgeVariant(data.meta.connectionType)} className="text-xs uppercase">
+											{data.meta.connectionType}
+										</Badge>
+									)}
+								</div>
+								<span className="text-content-tertiary text-xs">{data.meta?.toolCount} tools</span>
+							</div>
+						);
+					},
+				}}
+			/>
+
+			{/* Selected servers list */}
+			{selectedServersWithInfo.length > 0 && (
+				<div className="space-y-2">
+					{selectedServersWithInfo.map((server) => (
+						<div key={server.clientId} className="bg-muted/50 flex items-center justify-between rounded-md border px-3 py-2">
+							<div className="flex items-center gap-2">
+								<span className="text-foreground text-sm font-medium">{server.name}</span>
+								{server.connectionType && (
+									<Badge variant={getConnectionTypeBadgeVariant(server.connectionType)} className="text-xs uppercase">
+										{server.connectionType}
+									</Badge>
+								)}
+								{server.state && (
+									<Badge variant={getStateBadgeVariant(server.state)} className="text-xs capitalize">
+										{server.state}
+									</Badge>
+								)}
+								<span className="text-muted-foreground text-xs">{server.toolCount} tools</span>
+							</div>
+							<div className="flex items-center gap-1">
+								<Button type="button" variant="ghost" size="sm" className="h-8 w-8 p-0" asChild>
+									<a
+										href={`${registryPath}?server=${server.clientId}`}
+										target="_blank"
+										rel="noopener noreferrer"
+										title="Open server details in new tab"
+									>
+										<ExternalLink className="h-4 w-4" />
+									</a>
+								</Button>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-8 w-8 p-0"
+									onClick={() => handleRemoveServer(server.clientId)}
+									disabled={disabled}
+								>
+									<X className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					))}
+				</div>
+			)}
+
+			{/* Empty state */}
+			{selectedServersWithInfo.length === 0 && (
+				<div className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+					No servers selected. Use the search above to add MCP servers.
+				</div>
+			)}
+		</div>
+	);
+}

--- a/ui/components/ui/mcpToolSelector.tsx
+++ b/ui/components/ui/mcpToolSelector.tsx
@@ -1,0 +1,323 @@
+"use client"
+
+import { CodeEditor } from "@/app/workspace/logs/views/codeEditor";
+import { ChevronDown, ChevronRight, X } from "lucide-react"
+import { useCallback, useMemo, useState } from "react"
+import { components, OptionProps } from "react-select";
+import { AsyncMultiSelect } from "./asyncMultiselect"
+import { Badge } from "./badge"
+import { Button } from "./button"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./collapsible"
+import { Option } from "./multiselectUtils";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./table";
+import { cn } from "./utils"
+
+// Types
+export interface SelectedTool {
+  mcpClientId: string
+  toolName: string
+}
+
+export interface ToolFunction {
+  name: string
+  description?: string
+  // Parameters can be any object type to support various schema formats
+  parameters?: Record<string, unknown> | object
+  strict?: boolean
+}
+
+export interface MCPClientInfo {
+  config: {
+    client_id: string
+    name: string
+    connection_type?: string
+  }
+  tools: ToolFunction[]
+  state?: string
+}
+
+interface ToolOptionMeta {
+  mcpClientId: string
+  mcpClientName: string
+  toolName: string
+  description?: string
+  parameters?: Record<string, unknown> | object
+}
+
+interface MCPToolSelectorProps {
+  value: SelectedTool[]
+  onChange: (tools: SelectedTool[]) => void
+  mcpClients: MCPClientInfo[]
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+}
+
+export function MCPToolSelector({
+  value,
+  onChange,
+  mcpClients,
+  placeholder = "Search and select tools...",
+  disabled = false,
+  className,
+}: MCPToolSelectorProps) {
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set())
+
+  // Flatten all tools from all MCP clients into searchable options
+  // Using meta field for complex data as per Option type definition
+  const allToolOptions = useMemo(() => {
+    const options: Option<ToolOptionMeta>[] = []
+    
+    for (const client of mcpClients) {
+      if (!client.tools) continue
+      
+      for (const tool of client.tools) {
+        const key = `${client.config.client_id}:${tool.name}`
+        
+        options.push({
+          label: `${client.config.name} / ${tool.name}`,
+          value: key,
+          meta: {
+            mcpClientId: client.config.client_id,
+            mcpClientName: client.config.name,
+            toolName: tool.name,
+            description: tool.description,
+            parameters: tool.parameters,
+          },
+        })
+      }
+    }
+    
+    return options
+  }, [mcpClients])
+
+  // Get full tool info for selected tools
+  const selectedToolsWithInfo = useMemo(() => {
+    return value.map((selected) => {
+      const client = mcpClients.find((c) => c.config.client_id === selected.mcpClientId)
+      const tool = client?.tools?.find((t) => t.name === selected.toolName)
+      return {
+        ...selected,
+        mcpClientName: client?.config.name || selected.mcpClientId,
+        description: tool?.description,
+        parameters: tool?.parameters,
+      }
+    })
+  }, [value, mcpClients])
+
+  // Filter out already selected tools from options
+  const availableOptions = useMemo(() => {
+    const selectedKeys = new Set(
+      value.map((t) => `${t.mcpClientId}:${t.toolName}`)
+    )
+    return allToolOptions.filter((opt) => !selectedKeys.has(opt.value))
+  }, [allToolOptions, value])
+
+  const toggleExpanded = useCallback((key: string) => {
+    setExpandedTools((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }, [])
+
+  const handleSelectTool = useCallback(
+    (selected: Option<ToolOptionMeta>[]) => {
+      if (selected.length === 0) return
+      
+      const newTool = selected[selected.length - 1]
+      if (!newTool?.meta) return
+      
+      const newSelectedTool: SelectedTool = {
+        mcpClientId: newTool.meta.mcpClientId,
+        toolName: newTool.meta.toolName,
+      }
+      
+      // Check if already selected
+      const exists = value.some(
+        (t) => t.mcpClientId === newSelectedTool.mcpClientId && t.toolName === newSelectedTool.toolName
+      )
+      
+      if (!exists) {
+        onChange([...value, newSelectedTool])
+      }
+    },
+    [value, onChange]
+  )
+
+  const handleRemoveTool = useCallback(
+    (mcpClientId: string, toolName: string) => {
+      onChange(value.filter((t) => !(t.mcpClientId === mcpClientId && t.toolName === toolName)))
+    },
+    [value, onChange]
+  )
+
+  const reload = useCallback(
+    (query: string, callback: (options: Option<ToolOptionMeta>[]) => void) => {
+      const lowerQuery = query.toLowerCase()
+      const filtered = availableOptions.filter(
+        (opt) =>
+          opt.label.toLowerCase().includes(lowerQuery) ||
+          opt.meta?.description?.toLowerCase().includes(lowerQuery)
+      )
+      callback(filtered)
+    },
+    [availableOptions]
+  )
+
+  return (
+		<div className={cn("space-y-3", className)}>
+			{/* Search dropdown */}
+			<AsyncMultiSelect<ToolOptionMeta>
+				placeholder={placeholder}
+				disabled={disabled}
+				defaultOptions={availableOptions}
+				reload={reload}
+				debounce={150}
+				onChange={handleSelectTool}
+				value={[]}
+				isClearable={false}
+				closeMenuOnSelect={true}
+				hideSelectedOptions={true}
+				controlShouldRenderValue={false}
+				noOptionsMessage={() => "No results found"}
+				views={{
+					option: (optionProps: OptionProps<ToolOptionMeta>) => {
+						const { Option } = components;
+						// Access data as Option<ToolOptionMeta> since that's the actual runtime type
+						const data = optionProps.data as unknown as Option<ToolOptionMeta>;
+						return (
+							<Option
+								{...optionProps}
+								className={cn(
+									"my-1 flex w-full cursor-pointer flex-col gap-0.5 rounded-sm p-2 text-sm",
+									optionProps.isFocused && "bg-accent dark:!bg-card",
+									"hover:bg-accent",
+									optionProps.isSelected && "bg-accent dark:!bg-card",
+								)}
+							>
+								<div className="flex items-center gap-2">
+									<span className="text-content-primary font-medium">{data.meta?.toolName}</span>
+									<Badge variant="outline" className="text-xs">
+										{data.meta?.mcpClientName}
+									</Badge>
+								</div>
+								{data.meta?.description && <span className="text-content-tertiary line-clamp-2 text-xs">{data.meta.description}</span>}
+							</Option>
+						);
+					},
+				}}
+			/>
+
+			{/* Selected tools table */}
+			{selectedToolsWithInfo.length > 0 && (
+				<div className="overflow-hidden rounded-md border">
+					<Table className="table-fixed">
+						<TableHeader>
+							<TableRow>
+								<TableHead className="w-10"></TableHead>
+								<TableHead className="w-auto">Tool</TableHead>
+								<TableHead className="hidden w-32 md:table-cell">Server</TableHead>
+								<TableHead className="w-10"></TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{selectedToolsWithInfo.map((tool) => {
+								const key = `${tool.mcpClientId}:${tool.toolName}`;
+								const isExpanded = expandedTools.has(key);
+
+								return (
+									<Collapsible key={key} open={isExpanded} onOpenChange={() => toggleExpanded(key)} asChild>
+										<>
+											<TableRow className="group">
+												<TableCell className="p-2">
+													<CollapsibleTrigger asChild>
+														<button
+															type="button"
+															className="hover:bg-muted flex h-8 w-8 items-center justify-center rounded-md transition-colors"
+															disabled={!tool.parameters}
+														>
+															{tool.parameters ? (
+																isExpanded ? (
+																	<ChevronDown className="h-4 w-4" />
+																) : (
+																	<ChevronRight className="h-4 w-4" />
+																)
+															) : (
+																<span className="h-4 w-4" />
+															)}
+														</button>
+													</CollapsibleTrigger>
+												</TableCell>
+												<TableCell className="overflow-hidden">
+													<div className="min-w-0 overflow-hidden">
+														<div className="text-foreground truncate text-sm font-medium">{tool.toolName}</div>
+														{tool.description && <p className="text-muted-foreground mt-0.5 truncate text-xs">{tool.description}</p>}
+													</div>
+												</TableCell>
+												<TableCell className="hidden md:table-cell">
+													<Badge variant="outline">{tool.mcpClientName}</Badge>
+												</TableCell>
+												<TableCell className="p-2">
+													<Button
+														type="button"
+														variant="ghost"
+														size="sm"
+														className="h-8 w-8 p-0"
+														onClick={() => handleRemoveTool(tool.mcpClientId, tool.toolName)}
+														disabled={disabled}
+													>
+														<X className="h-4 w-4" />
+													</Button>
+												</TableCell>
+											</TableRow>
+											<CollapsibleContent asChild>
+												<tr>
+													<td colSpan={4} className="p-0">
+														<div className="bg-muted/30 border-t px-4 py-3">
+															<div className="text-muted-foreground mb-2 text-xs font-medium">Parameters Schema</div>
+															{tool.parameters ? (
+																<CodeEditor
+																	className="z-0 w-full rounded-md border"
+																	shouldAdjustInitialHeight={true}
+																	maxHeight={300}
+																	wrap={true}
+																	code={JSON.stringify(tool.parameters, null, 2)}
+																	lang="json"
+																	readonly={true}
+																	options={{
+																		scrollBeyondLastLine: false,
+																		collapsibleBlocks: true,
+																		lineNumbers: "off",
+																		alwaysConsumeMouseWheel: false,
+																	}}
+																/>
+															) : (
+																<div className="text-muted-foreground text-sm">No parameters defined</div>
+															)}
+														</div>
+													</td>
+												</tr>
+											</CollapsibleContent>
+										</>
+									</Collapsible>
+								);
+							})}
+						</TableBody>
+					</Table>
+				</div>
+			)}
+
+			{/* Empty state */}
+			{selectedToolsWithInfo.length === 0 && (
+				<div className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+					No tools selected. Use the search above to add tools.
+				</div>
+			)}
+		</div>
+	);
+}

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -171,6 +171,7 @@ export const baseApi = createApi({
 		"Permissions",
 		"APIKeys",
 		"OAuth2Config",
+		"MCPToolGroups",
 	],
 	endpoints: () => ({}),
 });

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -91,3 +91,15 @@ export interface UpdateMCPClientRequest {
 	tool_pricing?: Record<string, number>;
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
 }
+
+// Types for MCP Tool Selector component
+export interface SelectedTool {
+	mcpClientId: string;
+	toolName: string;
+}
+
+// MCP Tool Spec for tool groups (matches backend schema)
+export interface MCPToolSpec {
+	mcp_client_id: string;
+	tool_names: string[];
+}


### PR DESCRIPTION
## Summary

Refactor the MCP (Model Control Protocol) manager to use an interface instead of a concrete implementation, enabling enterprise extensions and custom implementations. Also add new UI components for MCP server and tool selection.

## Changes

- Converted `mcpManager` field in Bifrost struct to `McpManager` (exported) with interface type
- Created new `MCPManagerInterface` in `core/mcp/interface.go` to define the contract
- Updated all references to use the interface methods instead of direct implementation
- Added new UI components for MCP integration:
  - `EntityAssociationSelect`: Generic component for selecting entities with metadata
  - `MCPServerSelector`: Component for selecting MCP servers with status indicators
  - `MCPToolSelector`: Component for selecting and viewing MCP tools with parameter schemas

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test the interface implementation by verifying core functionality works as before:

```sh
# Core/Transports
go version
go test ./core/mcp/...
go test ./core/...

# UI
cd ui
pnpm i
pnpm build
```

For UI components, create a test page that uses the new selectors with mock data.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enables enterprise extensions to the MCP system while maintaining compatibility.

## Security considerations

No security implications as this is a refactoring of existing functionality with new UI components.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable