### PR TITLE
fix: skip OpenAI parameter filtering for custom providers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3956,6 +3956,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		if cfg := config.CustomProviderConfig; cfg != nil && cfg.BaseProviderType != "" {
 			baseProvider = cfg.BaseProviderType
 		}
+		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
 
 		key := schemas.Key{}
 		var keys []schemas.Key

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 - feat: added support for image editing and variations
+- fix: skip OpenAI parameter filtering for custom providers

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -470,7 +470,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 				}
 				return reqBody, nil
 			} else {
-				return openai.ToOpenAIChatRequest(request), nil
+				return openai.ToOpenAIChatRequest(ctx, request), nil
 			}
 		},
 		provider.GetProviderKey())

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -21,7 +21,7 @@ func (request *OpenAIChatRequest) ToBifrostChatRequest(ctx *schemas.BifrostConte
 }
 
 // ToOpenAIChatRequest converts a Bifrost chat completion request to OpenAI format
-func ToOpenAIChatRequest(bifrostReq *schemas.BifrostChatRequest) *OpenAIChatRequest {
+func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostChatRequest) *OpenAIChatRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
 		return nil
 	}
@@ -65,6 +65,10 @@ func ToOpenAIChatRequest(bifrostReq *schemas.BifrostChatRequest) *OpenAIChatRequ
 		}
 		return openaiReq
 	default:
+		// Check if provider is a custom provider
+		if isCustomProvider, ok := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool); ok && isCustomProvider {
+			return openaiReq
+		}
 		openaiReq.filterOpenAISpecificParameters()
 		return openaiReq
 	}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -692,7 +692,7 @@ func HandleOpenAIChatCompletionRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAIChatRequest(request), nil },
+		func() (any, error) { return ToOpenAIChatRequest(ctx, request), nil },
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -826,7 +826,7 @@ func HandleOpenAIChatCompletionStreaming(
 			if customRequestConverter != nil {
 				return customRequestConverter(request)
 			}
-			reqBody := ToOpenAIChatRequest(request)
+			reqBody := ToOpenAIChatRequest(ctx, request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)
 				reqBody.StreamOptions = &schemas.ChatStreamOptions{

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -329,7 +329,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 				}
 			} else {
 				// Use centralized OpenAI converter for non-Claude models
-				reqBody := openai.ToOpenAIChatRequest(request)
+				reqBody := openai.ToOpenAIChatRequest(ctx, request)
 				if reqBody == nil {
 					return nil, fmt.Errorf("chat completion input is not provided")
 				}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -81,6 +81,7 @@ var StandardProviders = []ModelProvider{
 	Elevenlabs,
 	HuggingFace,
 	Nebius,
+	XAI,
 }
 
 // RequestType represents the type of request being made to a provider.
@@ -167,7 +168,8 @@ const (
 	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyAvailableProviders                  BifrostContextKey = "available-providers"                              // []ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyRawRequestResponseForLogging        BifrostContextKey = "bifrost-raw-request-response-for-logging"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyRetryDBFetch                       BifrostContextKey = "bifrost-retry-db-fetch"                            // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,


### PR DESCRIPTION
## Summary

Skip OpenAI parameter filtering for custom providers to allow passing all parameters without modification.

## Changes

- Added a check to determine if the provider is a custom provider (not in the `StandardProviders` list)
- When using a custom provider, the code now skips the `filterOpenAISpecificParameters()` function
- Updated changelog to document this fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with a custom provider that uses OpenAI-compatible API:

```sh
# Core/Transports
go version
go test ./...

# Test with a custom provider request that includes OpenAI-specific parameters
# Verify that parameters are not filtered out when using a custom provider
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #1465

## Security considerations

No security implications as this change only affects parameter handling for API requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable