### PR TITLE
fix: encode provider names in API URLs

### DIFF
--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
 - feat: added support for image editing and variations
+- fix: encode provider names in API URLs

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -32,7 +32,7 @@ export const providersApi = baseApi.injectEndpoints({
 
 		// Get single provider
 		getProvider: builder.query<ModelProvider, string>({
-			query: (provider) => `/providers/${provider}`,
+			query: (provider) => `/providers/${encodeURIComponent(provider)}`,
 			providesTags: (result, error, provider) => [{ type: "Providers", id: provider }],
 		}),
 
@@ -49,7 +49,7 @@ export const providersApi = baseApi.injectEndpoints({
 		// Update existing provider
 		updateProvider: builder.mutation<ModelProvider, ModelProvider>({
 			query: (provider) => ({
-				url: `/providers/${provider.name}`,
+				url: `/providers/${encodeURIComponent(provider.name)}`,
 				method: "PUT",
 				body: provider,
 			}),
@@ -59,7 +59,7 @@ export const providersApi = baseApi.injectEndpoints({
 		// Delete provider
 		deleteProvider: builder.mutation<ModelProviderName, string>({
 			query: (provider) => ({
-				url: `/providers/${provider}`,
+				url: `/providers/${encodeURIComponent(provider)}`,
 				method: "DELETE",
 			}),
 			invalidatesTags: ["Providers"],


### PR DESCRIPTION
## Summary

Added URL encoding to provider names in API endpoints to properly handle special characters in provider names.

## Changes

- Added `encodeURIComponent()` to all provider name parameters in API endpoint URLs
- Modified the `getProvider`, `updateProvider`, and `deleteProvider` API calls to properly encode provider names
- This ensures that provider names containing special characters (like spaces, slashes, etc.) are properly URL-encoded when making API requests

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create a provider with a name containing special characters (e.g., "Test Provider/With Special&Chars")
2. Verify that you can view, update, and delete the provider without URL encoding issues

```sh
# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with provider names containing special characters causing API request failures.

## Security considerations

This change improves URL handling which prevents potential URL injection issues.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable