### PR TITLE
fixes race condition while loading mcp servers from config file

### DIFF
--- a/.github/workflows/configs/withpostgresmcpclientsinconfig/config.json
+++ b/.github/workflows/configs/withpostgresmcpclientsinconfig/config.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "allow_direct_keys": false,
+    "allowed_origins": [
+      "*"
+    ],
+    "disable_content_logging": false,
+    "drop_excess_requests": false,
+    "enable_governance": true,
+    "enable_litellm_fallbacks": false,
+    "enable_logging": true,
+    "enforce_governance_header": true,
+    "initial_pool_size": 300,
+    "log_retention_days": 365,
+    "max_request_body_size_mb": 100
+  },
+  "config_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "localhost",
+      "port": "5432",
+      "user": "bifrost",
+      "password": "bifrost_password",
+      "db_name": "bifrost",
+      "ssl_mode": "disable"
+    }
+  },
+  "logs_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "localhost",
+      "port": "5432",
+      "user": "bifrost",
+      "password": "bifrost_password",
+      "db_name": "bifrost",
+      "ssl_mode": "disable"
+    }
+  },
+  "mcp": {
+    "client_configs": [
+      {
+        "id": "weather-mcp-server",
+        "name": "WeatherService",
+        "connection_type": "http",
+        "http_url": "http://localhost:8080/mcp",
+        "is_enabled": true
+      },
+      {
+        "id": "calendar-mcp-server",
+        "name": "CalendarService",
+        "connection_type": "http",
+        "http_url": "http://localhost:8081/mcp",
+        "is_enabled": true
+      }
+    ]
+  },
+  "governance": {
+    "auth_config": {
+      "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+      "admin_username": "env.BIFROST_ADMIN_USERNAME",
+      "disable_auth_on_inference": true,
+      "is_enabled": false
+    },
+    "virtual_keys": [
+      {
+        "id": "vk-ai-portal-prod",
+        "is_active": true,
+        "name": "ai-portal-production-key",
+        "description": "Virtual key for AI portal with MCP access to weather and calendar services",
+        "value": "env.BIFROST_VK_AI_PORTAL",
+        "mcp_configs": [
+          {
+            "mcp_client_name": "WeatherService",
+            "tools_to_execute": [
+              "*"
+            ]
+          },
+          {
+            "mcp_client_name": "CalendarService",
+            "tools_to_execute": [
+              "get_events",
+              "create_event"
+            ]
+          }
+        ],
+        "provider_configs": [
+          {
+            "provider": "openai",
+            "weight": 1.0
+          }
+        ]
+      },
+      {
+        "id": "vk-internal-tools",
+        "is_active": true,
+        "name": "internal-tools-key",
+        "description": "Virtual key for internal tools with limited MCP access",
+        "value": "env.BIFROST_VK_INTERNAL",
+        "mcp_configs": [
+          {
+            "mcp_client_name": "WeatherService",
+            "tools_to_execute": [
+              "get_current_weather"
+            ]
+          }
+        ],
+        "provider_configs": [
+          {
+            "provider": "openai",
+            "weight": 1.0
+          }
+        ]
+      }
+    ]
+  },
+  "plugins": [
+    {
+      "config": {
+        "is_vk_mandatory": true
+      },
+      "enabled": true,
+      "name": "governance"
+    }
+  ],
+  "providers": {
+    "openai": {
+      "keys": [
+        {
+          "name": "openai-primary",
+          "value": "env.OPENAI_API_KEY",
+          "weight": 1
+        }
+      ]
+    }
+  }
+}

--- a/.github/workflows/scripts/release-bifrost-http.sh
+++ b/.github/workflows/scripts/release-bifrost-http.sh
@@ -151,6 +151,7 @@ CONFIGS_TO_TEST=(
   "withdynamicplugin"
   "withobservability"
   "withsemanticcache"
+  "withpostgresmcpclientsinconfig"
 )
 
 TEST_BINARY="../tmp/bifrost-http"

--- a/examples/configs/withpostgresmcpclientsinconfig/config.json
+++ b/examples/configs/withpostgresmcpclientsinconfig/config.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "allow_direct_keys": false,
+    "allowed_origins": [
+      "*"
+    ],
+    "disable_content_logging": false,
+    "drop_excess_requests": false,
+    "enable_governance": true,
+    "enable_litellm_fallbacks": false,
+    "enable_logging": true,
+    "enforce_governance_header": true,
+    "initial_pool_size": 300,
+    "log_retention_days": 365,
+    "max_request_body_size_mb": 100
+  },
+  "config_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "localhost",
+      "port": "5432",
+      "user": "bifrost",
+      "password": "bifrost_password",
+      "db_name": "bifrost",
+      "ssl_mode": "disable"
+    }
+  },
+  "logs_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "localhost",
+      "port": "5432",
+      "user": "bifrost",
+      "password": "bifrost_password",
+      "db_name": "bifrost",
+      "ssl_mode": "disable"
+    }
+  },
+  "mcp": {
+    "client_configs": [
+      {
+        "id": "weather-mcp-server",
+        "name": "WeatherService",
+        "connection_type": "http",
+        "http_url": "http://localhost:8080/mcp",
+        "is_enabled": true
+      },
+      {
+        "id": "calendar-mcp-server",
+        "name": "CalendarService",
+        "connection_type": "http",
+        "http_url": "http://localhost:8081/mcp",
+        "is_enabled": true
+      }
+    ]
+  },
+  "governance": {
+    "auth_config": {
+      "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+      "admin_username": "env.BIFROST_ADMIN_USERNAME",
+      "disable_auth_on_inference": true,
+      "is_enabled": false
+    },
+    "virtual_keys": [
+      {
+        "id": "vk-ai-portal-prod",
+        "is_active": true,
+        "name": "ai-portal-production-key",
+        "description": "Virtual key for AI portal with MCP access to weather and calendar services",
+        "value": "env.BIFROST_VK_AI_PORTAL",
+        "mcp_configs": [
+          {
+            "mcp_client_name": "WeatherService",
+            "tools_to_execute": [
+              "*"
+            ]
+          },
+          {
+            "mcp_client_name": "CalendarService",
+            "tools_to_execute": [
+              "get_events",
+              "create_event"
+            ]
+          }
+        ],
+        "provider_configs": [
+          {
+            "provider": "openai",
+            "weight": 1.0
+          }
+        ]
+      },
+      {
+        "id": "vk-internal-tools",
+        "is_active": true,
+        "name": "internal-tools-key",
+        "description": "Virtual key for internal tools with limited MCP access",
+        "value": "env.BIFROST_VK_INTERNAL",
+        "mcp_configs": [
+          {
+            "mcp_client_name": "WeatherService",
+            "tools_to_execute": [
+              "get_current_weather"
+            ]
+          }
+        ],
+        "provider_configs": [
+          {
+            "provider": "openai",
+            "weight": 1.0
+          }
+        ]
+      }
+    ]
+  },
+  "plugins": [
+    {
+      "config": {
+        "is_vk_mandatory": true
+      },
+      "enabled": true,
+      "name": "governance"
+    }
+  ],
+  "providers": {
+    "openai": {
+      "keys": [
+        {
+          "name": "openai-primary",
+          "value": "env.OPENAI_API_KEY",
+          "weight": 1
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Support for MCP Client Names in Virtual Key Configurations

This PR adds support for referencing MCP clients by name in virtual key configurations, making it easier to define MCP access permissions in config files.

## Issue

Closes #1462

## Changes

- Added support for `mcp_client_name` in virtual key MCP configurations, allowing config files to reference MCP clients by their human-readable names instead of database IDs
- Implemented a resolution mechanism that converts MCP client names to their corresponding database IDs during config loading
- Added graceful handling for unresolvable MCP client names, with appropriate warning logs
- Created a new example configuration demonstrating the feature with PostgreSQL and MCP clients
- Added comprehensive tests to verify the name resolution works correctly

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
# Run the tests for the new functionality
go test ./transports/bifrost-http/lib -run TestSQLite_VKMCPConfig_MCPClientNameResolution
go test ./transports/bifrost-http/lib -run TestSQLite_VKMCPConfig_MCPClientNameNotFound

# Try the example config
cp examples/configs/withpostgresmcpclientsinconfig/config.json ./config.json
# Set required environment variables
# Start Bifrost
```

## Breaking changes

- [x] No

## Related issues

Fixes an issue where virtual keys with MCP configurations in config files would fail with foreign key constraint violations when using client names instead of IDs.

## Security considerations

No security implications - this is a usability improvement that maintains the same access control model.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I added example configuration