### PR TITLE
backward compatibility for plugins

### DIFF
--- a/core/schemas/plugin_native.go
+++ b/core/schemas/plugin_native.go
@@ -25,3 +25,7 @@ type MCPPluginShortCircuit struct {
 	Response *BifrostMCPResponse // If set, short-circuit with this response (skips MCP call)
 	Error    *BifrostError       // If set, short-circuit with this error (can set AllowFallbacks field)
 }
+
+// PluginShortCircuit is the legacy name for LLMPluginShortCircuit (v1.3.x compatibility).
+// Deprecated: Use LLMPluginShortCircuit instead.
+type PluginShortCircuit = LLMPluginShortCircuit

--- a/core/schemas/plugin_wasm.go
+++ b/core/schemas/plugin_wasm.go
@@ -9,3 +9,7 @@ type LLMPluginShortCircuit struct {
 	Response *BifrostResponse // If set, short-circuit with this response (skips provider call)
 	Error    *BifrostError    // If set, short-circuit with this error (can set AllowFallbacks field)
 }
+
+// PluginShortCircuit is the legacy name for LLMPluginShortCircuit (v1.3.x compatibility).
+// Deprecated: Use LLMPluginShortCircuit instead.
+type PluginShortCircuit = LLMPluginShortCircuit

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -206,18 +206,18 @@ func TransportInterceptor(ctx *schemas.BifrostContext, url string, headers map[s
 	return headers, body, nil
 }
 
-// PreLLMHook is called before the request is sent to the provider
+// PreHook is called before the request is sent to the provider
 // This is where you can modify requests or short-circuit the flow
-func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
-	fmt.Println("PreLLMHook called")
+func PreHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.PluginShortCircuit, error) {
+	fmt.Println("PreHook called")
 	// Modify the request or return a short-circuit to skip provider call
 	return req, nil, nil
 }
 
-// PostLLMHook is called after receiving a response from the provider
+// PostHook is called after receiving a response from the provider
 // This is where you can modify responses or handle errors
-func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
-	fmt.Println("PostLLMHook called")
+func PostHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	fmt.Println("PostHook called")
 	// Modify the response or error before returning to caller
 	return resp, bifrostErr, nil
 }
@@ -547,16 +547,16 @@ HTTPTransportPostHook called
   <Tab title="v1.4.x+ (streaming)">
 ```
 HTTPTransportPreHook called
-PreHook called
-PostHook called
+PreLLMHook called
+PostLLMHook called
 HTTPTransportStreamChunkHook called (per chunk)
 ```
   </Tab>
   <Tab title="v1.3.x">
 ```
 TransportInterceptor called
-PreLLMHook called
-PostLLMHook called
+PreHook called
+PostHook called
 ```
   </Tab>
 </Tabs>

--- a/framework/plugins/soloader.go
+++ b/framework/plugins/soloader.go
@@ -94,17 +94,27 @@ func (l *SharedObjectPluginLoader) LoadPlugin(path string, config any) (schemas.
 		}
 	}
 
-	// Optional: PreLLMHook
+	// Optional: PreLLMHook (with backward compatibility for legacy PreHook)
 	if sym, err := pluginObj.Lookup("PreLLMHook"); err == nil {
 		if dp.preLLMHook, ok = sym.(func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error)); !ok {
 			return nil, fmt.Errorf("failed to cast PreLLMHook to expected signature")
 		}
+	} else if sym, err := pluginObj.Lookup("PreHook"); err == nil {
+		// Legacy backward compatibility (v1.3.x): treat PreHook as PreLLMHook
+		if dp.preLLMHook, ok = sym.(func(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error)); !ok {
+			return nil, fmt.Errorf("failed to cast PreHook to expected signature (legacy backward compatibility)")
+		}
 	}
 
-	// Optional: PostLLMHook
+	// Optional: PostLLMHook (with backward compatibility for legacy PostHook)
 	if sym, err := pluginObj.Lookup("PostLLMHook"); err == nil {
 		if dp.postLLMHook, ok = sym.(func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error)); !ok {
 			return nil, fmt.Errorf("failed to cast PostLLMHook to expected signature")
+		}
+	} else if sym, err := pluginObj.Lookup("PostHook"); err == nil {
+		// Legacy backward compatibility (v1.3.x): treat PostHook as PostLLMHook
+		if dp.postLLMHook, ok = sym.(func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error)); !ok {
+			return nil, fmt.Errorf("failed to cast PostHook to expected signature (legacy backward compatibility)")
 		}
 	}
 

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -74,7 +74,7 @@ export function MCPLogsDataTable({
 	const totalPages = Math.ceil(totalItems / pagination.limit);
 	const startItem = pagination.offset + 1;
 	const endItem = Math.min(pagination.offset + pagination.limit, totalItems);
-	
+
 	// Display values that handle the case when totalItems is 0
 	const startItemDisplay = totalItems === 0 ? 0 : startItem;
 	const endItemDisplay = totalItems === 0 ? 0 : endItem;
@@ -89,7 +89,7 @@ export function MCPLogsDataTable({
 
 	return (
 		<div className="space-y-2">
-			<MCPLogFilters filters={filters} onFiltersChange={onFiltersChange} liveEnabled={liveEnabled} onLiveToggle={onLiveToggle} fetchLogs={fetchLogs} fetchStats={fetchStats} />
+			<MCPLogFilters filters={filters} onFiltersChange={onFiltersChange} liveEnabled={liveEnabled} onLiveToggle={onLiveToggle} />
 			<div className="max-h-[calc(100vh-16.5rem)] rounded-sm border">
 				<Table containerClassName="max-h-[calc(100vh-16.5rem)]">
 					<TableHeader className="px-2">


### PR DESCRIPTION
## Summary

Added backward compatibility for v1.3.x plugin hooks to ensure plugins written for older versions continue to work with v1.4.x+.

## Changes

- Added type alias `PluginShortCircuit` for `LLMPluginShortCircuit` in both native and WASM plugin schemas for backward compatibility
- Updated the plugin loader to recognize both `PreHook`/`PostHook` (v1.3.x) and `PreLLMHook`/`PostLLMHook` (v1.4.x+) function names
- Fixed documentation examples to correctly show the hook naming conventions for different versions

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Test with plugins written for v1.3.x to ensure they continue to work:

```sh
# Core/Transports
go version
go test ./...

# Test with a v1.3.x plugin
bifrost start --plugin path/to/v1.3.x/plugin.so
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Resolves compatibility issues with v1.3.x plugins

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable