### PR TITLE
fix: correct content type constant in Bedrock provider

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2432,7 +2432,7 @@ func ConvertBifrostMessagesToBedrockMessages(bifrostMessages []schemas.Responses
 						// Handle structured output blocks
 						for _, block := range msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
 							switch block.Type {
-							case schemas.ResponsesOutputMessageContentTypeText:
+							case schemas.ResponsesInputMessageContentBlockTypeText:
 								if block.Text != nil {
 									resultContent = append(resultContent, BedrockContentBlock{
 										Text: block.Text,

--- a/ui/app/workspace/logs/views/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/views/logDetailsSheet.tsx
@@ -69,7 +69,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 	if (log.params?.tools) {
 		try {
 			toolsParameter = JSON.stringify(log.params.tools, null, 2);
-		} catch (ignored) {}
+		} catch (ignored) { }
 	}
 
 	const copyRequestBody = async () => {
@@ -292,9 +292,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								label="Type"
 								value={
 									<div
-										className={`${
-											RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
-										} rounded-sm px-3 py-1`}
+										className={`${RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
+											} rounded-sm px-3 py-1`}
 									>
 										{RequestTypeLabels[log.object as keyof typeof RequestTypeLabels] ?? log.object ?? "unknown"}
 									</div>


### PR DESCRIPTION
## Summary

Fix incorrect schema type reference in Bedrock provider and format code in log details sheet.

## Changes

- Fixed a type reference in the Bedrock provider from `ResponsesOutputMessageContentTypeText` to `ResponsesInputMessageContentBlockTypeText` to ensure proper handling of structured output blocks

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Test the Bedrock provider with structured output blocks:
```sh
# Core/Transports
go test ./core/providers/bedrock/...
```

2. Verify the log details sheet renders correctly in the UI:
```sh
cd ui
pnpm i
pnpm dev
```
Then navigate to the logs view and open a log detail sheet to verify proper rendering.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes incorrect schema type reference in Bedrock provider.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable