### PR TITLE
adds missing anthropic flags

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -177,6 +177,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 				}
 			}
 		}
+
+		// Convert service tier
+		anthropicReq.ServiceTier = bifrostReq.Params.ServiceTier
 	}
 
 	// Convert messages - group consecutive tool messages into single user messages
@@ -513,6 +516,10 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 			},
 			TotalTokens: response.Usage.InputTokens + response.Usage.OutputTokens,
 		}
+		// Forward service tier from usage to response
+		if response.Usage.ServiceTier != nil {
+			bifrostResponse.ServiceTier = response.Usage.ServiceTier
+		}
 	}
 
 	return bifrostResponse
@@ -544,6 +551,10 @@ func ToAnthropicChatResponse(bifrostResp *schemas.BifrostChatResponse) *Anthropi
 		}
 		if bifrostResp.Usage.CompletionTokensDetails != nil && bifrostResp.Usage.CompletionTokensDetails.CachedTokens > 0 {
 			anthropicResp.Usage.CacheCreationInputTokens = bifrostResp.Usage.CompletionTokensDetails.CachedTokens
+		}
+		// Forward service tier
+		if bifrostResp.ServiceTier != nil {
+			anthropicResp.Usage.ServiceTier = bifrostResp.ServiceTier
 		}
 	}
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2086,6 +2086,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				}
 			}
 		}
+		// Convert service tier
+		anthropicReq.ServiceTier = bifrostReq.Params.ServiceTier
+
 		if bifrostReq.Params.ExtraParams != nil {
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -64,6 +64,7 @@ type AnthropicMessageRequest struct {
 	MCPServers    []AnthropicMCPServer `json:"mcp_servers,omitempty"` // This feature requires the beta header: "anthropic-beta": "mcp-client-2025-04-04"
 	Thinking      *AnthropicThinking   `json:"thinking,omitempty"`
 	OutputFormat  interface{}          `json:"output_format,omitempty"` // This feature requires the beta header: "anthropic-beta": "structured-outputs-2025-11-13" and currently only supported for Claude Sonnet 4.5 and Claude Opus 4.1
+	ServiceTier   *string             `json:"service_tier,omitempty"`  // "auto" or "standard_only"
 
 	// Extra params for advanced use cases
 	ExtraParams map[string]interface{} `json:"extra_params,omitempty"`
@@ -103,6 +104,7 @@ var anthropicMessageRequestKnownFields = map[string]bool{
 	"mcp_servers":    true,
 	"thinking":       true,
 	"output_format":  true,
+	"service_tier":   true,
 	"extra_params":   true,
 	"fallbacks":      true,
 }
@@ -396,6 +398,7 @@ type AnthropicToolComputerUse struct {
 type AnthropicToolWebSearchUserLocation struct {
 	Type     *string `json:"type,omitempty"` // "approximate"
 	City     *string `json:"city,omitempty"`
+	Region   *string `json:"region,omitempty"`
 	Country  *string `json:"country,omitempty"`
 	Timezone *string `json:"timezone,omitempty"`
 }
@@ -503,6 +506,8 @@ type AnthropicUsage struct {
 	CacheReadInputTokens     int                         `json:"cache_read_input_tokens"`
 	CacheCreation            AnthropicUsageCacheCreation `json:"cache_creation"`
 	OutputTokens             int                         `json:"output_tokens"`
+	ServerToolUse            *int                        `json:"server_tool_use,omitempty"` // Number of server tool use requests (e.g., web search)
+	ServiceTier              *string                     `json:"service_tier,omitempty"`    // "standard", "priority", or "batch"
 }
 
 type AnthropicUsageCacheCreation struct {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1036,6 +1036,17 @@ func convertChatResponseFormatToAnthropicOutputFormat(responseFormat *interface{
 		"type": formatType,
 	}
 
+	// Forward name, description, and strict from the json_schema object
+	if name, ok := jsonSchemaObj["name"].(string); ok && name != "" {
+		outputFormat["name"] = name
+	}
+	if description, ok := jsonSchemaObj["description"].(string); ok && description != "" {
+		outputFormat["description"] = description
+	}
+	if strict, ok := jsonSchemaObj["strict"].(bool); ok {
+		outputFormat["strict"] = strict
+	}
+
 	if schema, ok := jsonSchemaObj["schema"].(map[string]interface{}); ok {
 		// Normalize the schema to handle type arrays like ["string", "null"]
 		normalizedSchema := normalizeSchemaForAnthropic(schema)

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -508,6 +508,7 @@ func TestConvertChatResponseFormatToAnthropicOutputFormat(t *testing.T) {
 			}(),
 			expected: map[string]interface{}{
 				"type": "json_schema",
+				"name": "TestSchema",
 				"schema": map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{


### PR DESCRIPTION
## Summary

Added support for service tier parameter in Anthropic API requests and responses, allowing clients to specify service tiers like "auto" or "standard_only" and receive service tier information in responses.

## Changes

- Added `ServiceTier` field to `AnthropicMessageRequest` struct to support the service tier parameter
- Implemented conversion of service tier from Bifrost request parameters to Anthropic requests
- Added forwarding of service tier information from Anthropic usage data to Bifrost responses
- Enhanced `AnthropicToolWebSearchUserLocation` struct with a new `Region` field
- Added `ServerToolUse` field to track the number of server tool use requests
- Enhanced JSON schema output format conversion to forward name, description, and strict parameters

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the service tier parameter with Anthropic API:

```sh
# Core/Transports
go version
go test ./...

# Test with service_tier parameter
curl -X POST "http://localhost:8080/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-3-opus-20240229",
    "messages": [{"role": "user", "content": "Hello"}],
    "service_tier": "standard_only"
  }'
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Implements service tier support for Anthropic provider

## Security considerations

No security implications as this only adds a new parameter option.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)