### PR TITLE
fix: ensure ExtraParams are propagated into provider request body

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,5 @@
 - feat: added support for image editing and variations
 - fix: skip OpenAI parameter filtering for custom providers
 - fix: add finish reason to Gemini chat completion response
+- fix: ensure ExtraParams are propagated into provider request body
+- docs: add supported headers reference documentation

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -20,60 +20,61 @@ const ProviderOpenAICustom = schemas.ModelProvider("openai-custom")
 
 // TestScenarios defines the comprehensive test scenarios
 type TestScenarios struct {
-	TextCompletion        bool
-	TextCompletionStream  bool
-	SimpleChat            bool
-	CompletionStream      bool
-	MultiTurnConversation bool
-	ToolCalls             bool
-	ToolCallsStreaming    bool // Streaming tool calls functionality
-	MultipleToolCalls     bool
-	End2EndToolCalling    bool
-	AutomaticFunctionCall bool
-	ImageURL              bool
-	ImageBase64           bool
-	MultipleImages        bool
-	FileBase64            bool
-	FileURL               bool
-	CompleteEnd2End       bool
-	SpeechSynthesis       bool // Text-to-speech functionality
-	SpeechSynthesisStream bool // Streaming text-to-speech functionality
-	Transcription         bool // Speech-to-text functionality
-	TranscriptionStream   bool // Streaming speech-to-text functionality
-	Embedding             bool // Embedding functionality
-	Reasoning             bool // Reasoning/thinking functionality via Responses API
-	PromptCaching         bool // Prompt caching functionality
-	ListModels            bool // List available models functionality
-	ImageGeneration       bool // Image generation functionality
-	ImageGenerationStream bool // Streaming image generation functionality
-	ImageEdit             bool // Image edit functionality
-	ImageEditStream       bool // Streaming image edit functionality
-	ImageVariation        bool // Image variation functionality
-	ImageVariationStream  bool // Streaming image variation functionality (if supported)
-	BatchCreate           bool // Batch API create functionality
-	BatchList             bool // Batch API list functionality
-	BatchRetrieve         bool // Batch API retrieve functionality
-	BatchCancel           bool // Batch API cancel functionality
-	BatchResults          bool // Batch API results functionality
-	FileUpload            bool // File API upload functionality
-	FileList              bool // File API list functionality
-	FileRetrieve          bool // File API retrieve functionality
-	FileDelete            bool // File API delete functionality
-	FileContent           bool // File API content download functionality
-	FileBatchInput        bool // Whether batch create supports file-based input (InputFileID)
-	CountTokens           bool // Count tokens functionality
-	ChatAudio             bool // Chat completion with audio input/output functionality
-	StructuredOutputs     bool // Structured outputs (JSON schema) functionality
-	WebSearchTool         bool // Web search tool functionality
-	ContainerCreate       bool // Container API create functionality
-	ContainerList         bool // Container API list functionality
-	ContainerRetrieve     bool // Container API retrieve functionality
-	ContainerDelete       bool // Container API delete functionality
-	ContainerFileCreate   bool // Container File API create functionality
-	ContainerFileList     bool // Container File API list functionality
-	ContainerFileRetrieve bool // Container File API retrieve functionality
-	ContainerFileContent  bool // Container File API content functionality
-	ContainerFileDelete   bool // Container File API delete functionality
+	TextCompletion         bool
+	TextCompletionStream   bool
+	SimpleChat             bool
+	CompletionStream       bool
+	MultiTurnConversation  bool
+	ToolCalls              bool
+	ToolCallsStreaming     bool // Streaming tool calls functionality
+	MultipleToolCalls      bool
+	End2EndToolCalling     bool
+	AutomaticFunctionCall  bool
+	ImageURL               bool
+	ImageBase64            bool
+	MultipleImages         bool
+	FileBase64             bool
+	FileURL                bool
+	CompleteEnd2End        bool
+	SpeechSynthesis        bool // Text-to-speech functionality
+	SpeechSynthesisStream  bool // Streaming text-to-speech functionality
+	Transcription          bool // Speech-to-text functionality
+	TranscriptionStream    bool // Streaming speech-to-text functionality
+	Embedding              bool // Embedding functionality
+	Reasoning              bool // Reasoning/thinking functionality via Responses API
+	PromptCaching          bool // Prompt caching functionality
+	ListModels             bool // List available models functionality
+	ImageGeneration        bool // Image generation functionality
+	ImageGenerationStream  bool // Streaming image generation functionality
+	ImageEdit              bool // Image edit functionality
+	ImageEditStream        bool // Streaming image edit functionality
+	ImageVariation         bool // Image variation functionality
+	ImageVariationStream   bool // Streaming image variation functionality (if supported)
+	BatchCreate            bool // Batch API create functionality
+	BatchList              bool // Batch API list functionality
+	BatchRetrieve          bool // Batch API retrieve functionality
+	BatchCancel            bool // Batch API cancel functionality
+	BatchResults           bool // Batch API results functionality
+	FileUpload             bool // File API upload functionality
+	FileList               bool // File API list functionality
+	FileRetrieve           bool // File API retrieve functionality
+	FileDelete             bool // File API delete functionality
+	FileContent            bool // File API content download functionality
+	FileBatchInput         bool // Whether batch create supports file-based input (InputFileID)
+	CountTokens            bool // Count tokens functionality
+	ChatAudio              bool // Chat completion with audio input/output functionality
+	StructuredOutputs      bool // Structured outputs (JSON schema) functionality
+	WebSearchTool          bool // Web search tool functionality
+	ContainerCreate        bool // Container API create functionality
+	ContainerList          bool // Container API list functionality
+	ContainerRetrieve      bool // Container API retrieve functionality
+	ContainerDelete        bool // Container API delete functionality
+	ContainerFileCreate    bool // Container File API create functionality
+	ContainerFileList      bool // Container File API list functionality
+	ContainerFileRetrieve  bool // Container File API retrieve functionality
+	ContainerFileContent   bool // Container File API content functionality
+	ContainerFileDelete    bool // Container File API delete functionality
+	PassThroughExtraParams bool // Pass through extra params functionality
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios

--- a/core/internal/llmtests/passthrough.go
+++ b/core/internal/llmtests/passthrough.go
@@ -1,0 +1,170 @@
+package llmtests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunPassthroughExtraParamsTest executes the passthrough extraParams test scenario
+// This test verifies that extraParams are properly propagated into the provider request body
+// when the passthrough flag is set in the context.
+func RunPassthroughExtraParamsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.SimpleChat {
+		t.Logf("Simple chat not supported for provider %s, skipping passthrough test", testConfig.Provider)
+		return
+	}
+
+	t.Run("PassthroughExtraParams", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		// Create a Bifrost context with passthrough extraParams enabled
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		bfCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+		bfCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
+
+		// Prepare chat request with extraParams
+		// custom_param will be at root level
+		// custom_nested will be a nested structure to test recursive merging
+		chatReq := &schemas.BifrostChatRequest{
+			Provider: testConfig.Provider,
+			Model:    testConfig.ChatModel,
+			Input: []schemas.ChatMessage{
+				CreateBasicChatMessage("Say hello in one word"),
+			},
+			Params: &schemas.ChatParameters{
+				MaxCompletionTokens: bifrost.Ptr(10),
+				// Set extraParams with custom_param and nested structure
+				ExtraParams: map[string]interface{}{
+					"custom_param": "test_value_123",
+					"custom_nested": map[string]interface{}{
+						"custom_field": "nested_custom_value_456",
+						"another_nested": map[string]interface{}{
+							"deep_field": "deep_value_789",
+						},
+					},
+				},
+			},
+			Fallbacks: testConfig.Fallbacks,
+		}
+
+		// Make the request
+		response, err := client.ChatCompletionRequest(bfCtx, chatReq)
+		if err != nil {
+			t.Fatalf("❌ Chat completion request failed: %s", GetErrorMessage(err))
+		}
+
+		if response == nil {
+			t.Fatalf("❌ Chat completion response is nil")
+		}
+
+		// Verify the response is valid
+		chatContent := GetChatContent(response)
+		if chatContent == "" {
+			t.Fatalf("❌ Chat response content is empty")
+		}
+
+		t.Logf("✅ Chat completion request completed successfully")
+		t.Logf("Response content: %s", chatContent)
+
+		// Verify raw request is present in ExtraFields
+		if response.ExtraFields.RawRequest == nil {
+			t.Logf("⚠️  Raw request not found in ExtraFields - this may be provider-specific")
+			t.Logf("   Check Bifrost logs for the raw request body sent to provider")
+			t.Logf("   Expected in raw request:")
+			t.Logf("     - 'custom_param': 'test_value_123'")
+			t.Logf("     - 'custom_nested.custom_field': 'nested_custom_value_456'")
+			t.Logf("     - 'custom_nested.another_nested.deep_field': 'deep_value_789'")
+			return
+		}
+
+		// Parse raw request
+		var rawRequest map[string]interface{}
+		rawRequestBytes, marshalErr := sonic.Marshal(response.ExtraFields.RawRequest)
+		if marshalErr != nil {
+			t.Fatalf("❌ Failed to marshal raw request: %v", marshalErr)
+		}
+
+		if err := sonic.Unmarshal(rawRequestBytes, &rawRequest); err != nil {
+			t.Fatalf("❌ Failed to unmarshal raw request: %v", err)
+		}
+
+		t.Logf("✅ Found raw request in response ExtraFields")
+		t.Logf("Raw request keys: %v", getMapKeys(rawRequest))
+
+		// Verify custom_param is in raw request
+		if customParam, exists := rawRequest["custom_param"]; !exists {
+			t.Errorf("❌ custom_param not found in raw request")
+		} else {
+			if customParamStr, ok := customParam.(string); !ok || customParamStr != "test_value_123" {
+				t.Errorf("❌ custom_param value mismatch: expected 'test_value_123', got %v", customParam)
+			} else {
+				t.Logf("✅ Verified custom_param in raw request: %s", customParamStr)
+			}
+		}
+
+		// Verify nested custom_nested structure
+		if customNested, exists := rawRequest["custom_nested"]; !exists {
+			t.Errorf("❌ custom_nested not found in raw request")
+		} else {
+			customNestedMap, ok := customNested.(map[string]interface{})
+			if !ok {
+				t.Errorf("❌ custom_nested is not a map: %T", customNested)
+			} else {
+				// Verify custom_field
+				if customField, exists := customNestedMap["custom_field"]; !exists {
+					t.Errorf("❌ custom_field not found in custom_nested")
+				} else {
+					if customFieldStr, ok := customField.(string); !ok || customFieldStr != "nested_custom_value_456" {
+						t.Errorf("❌ custom_field value mismatch: expected 'nested_custom_value_456', got %v", customField)
+					} else {
+						t.Logf("✅ Verified custom_field in custom_nested: %s", customFieldStr)
+					}
+				}
+
+				// Verify deeply nested another_nested.deep_field
+				if anotherNested, exists := customNestedMap["another_nested"]; !exists {
+					t.Errorf("❌ another_nested not found in custom_nested")
+				} else {
+					anotherNestedMap, ok := anotherNested.(map[string]interface{})
+					if !ok {
+						t.Errorf("❌ another_nested is not a map: %T", anotherNested)
+					} else {
+						if deepField, exists := anotherNestedMap["deep_field"]; !exists {
+							t.Errorf("❌ deep_field not found in another_nested")
+						} else {
+							if deepFieldStr, ok := deepField.(string); !ok || deepFieldStr != "deep_value_789" {
+								t.Errorf("❌ deep_field value mismatch: expected 'deep_value_789', got %v", deepField)
+							} else {
+								t.Logf("✅ Verified deep_field in another_nested: %s", deepFieldStr)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Log the full raw request for debugging (pretty printed)
+		rawRequestJSON, marshalErr := sonic.MarshalIndent(rawRequest, "", "  ")
+		if marshalErr == nil {
+			t.Logf("📋 Full raw request body:\n%s", string(rawRequestJSON))
+		}
+
+		t.Logf("🎉 PassthroughExtraParams test completed successfully!")
+	})
+}
+
+// getMapKeys returns all keys from a map as a slice of strings
+func getMapKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -96,6 +96,7 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunContainerFileContentTest,
 		RunContainerFileDeleteTest,
 		RunContainerFileUnsupportedTest,
+		RunPassthroughExtraParamsTest,
 	}
 
 	// Execute all test scenarios

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -262,7 +262,9 @@ func (provider *AnthropicProvider) TextCompletion(ctx *schemas.BifrostContext, k
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToAnthropicTextCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToAnthropicTextCompletionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -25,6 +25,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 
 	// Convert parameters
 	if bifrostReq.Params != nil {
+		anthropicReq.ExtraParams = bifrostReq.Params.ExtraParams
 		if bifrostReq.Params.MaxCompletionTokens != nil {
 			anthropicReq.MaxTokens = *bifrostReq.Params.MaxCompletionTokens
 		}
@@ -34,7 +35,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		anthropicReq.StopSequences = bifrostReq.Params.Stop
 		topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 		if ok {
+			delete(anthropicReq.ExtraParams, "top_k")
 			anthropicReq.TopK = topK
+
 		}
 		if bifrostReq.Params.ResponseFormat != nil {
 			// Vertex doesn't support native structured outputs, so convert to tool

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2090,11 +2090,14 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		anthropicReq.ServiceTier = bifrostReq.Params.ServiceTier
 
 		if bifrostReq.Params.ExtraParams != nil {
+			anthropicReq.ExtraParams = bifrostReq.Params.ExtraParams
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {
+				delete(anthropicReq.ExtraParams, "top_k")
 				anthropicReq.TopK = topK
 			}
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
+				delete(anthropicReq.ExtraParams, "stop")
 				anthropicReq.StopSequences = stop
 			}
 		}

--- a/core/providers/anthropic/text.go
+++ b/core/providers/anthropic/text.go
@@ -37,7 +37,9 @@ func ToAnthropicTextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionR
 		anthropicReq.StopSequences = bifrostReq.Params.Stop
 
 		if bifrostReq.Params.ExtraParams != nil {
+			anthropicReq.ExtraParams = bifrostReq.Params.ExtraParams
 			if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
+				delete(anthropicReq.ExtraParams, "top_k")
 				anthropicReq.TopK = topK
 			}
 		}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -39,7 +39,13 @@ type AnthropicTextRequest struct {
 	StopSequences     []string `json:"stop_sequences,omitempty"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *AnthropicTextRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -67,10 +73,15 @@ type AnthropicMessageRequest struct {
 	ServiceTier   *string             `json:"service_tier,omitempty"`  // "auto" or "standard_only"
 
 	// Extra params for advanced use cases
-	ExtraParams map[string]interface{} `json:"extra_params,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
 	Fallbacks []string `json:"fallbacks,omitempty"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (mr *AnthropicMessageRequest) GetExtraParams() map[string]interface{} {
+	return mr.ExtraParams
 }
 
 type AnthropicMetaData struct {
@@ -418,15 +429,15 @@ type AnthropicToolInputExample struct {
 
 // AnthropicTool represents a tool in Anthropic format
 type AnthropicTool struct {
-	Name          string                          `json:"name"`
-	Type          *AnthropicToolType              `json:"type,omitempty"`
-	Description   *string                         `json:"description,omitempty"`
-	InputSchema   *schemas.ToolFunctionParameters `json:"input_schema,omitempty"`
-	CacheControl  *schemas.CacheControl           `json:"cache_control,omitempty"`
-	DeferLoading  *bool                           `json:"defer_loading,omitempty"`   // Beta: defer loading of tool definition
-	Strict        *bool                           `json:"strict,omitempty"`          // Whether to enforce strict parameter validation
-	AllowedCallers []string                       `json:"allowed_callers,omitempty"` // Beta: which callers can use this tool
-	InputExamples []AnthropicToolInputExample     `json:"input_examples,omitempty"`  // Beta: example inputs for the tool
+	Name           string                          `json:"name"`
+	Type           *AnthropicToolType              `json:"type,omitempty"`
+	Description    *string                         `json:"description,omitempty"`
+	InputSchema    *schemas.ToolFunctionParameters `json:"input_schema,omitempty"`
+	CacheControl   *schemas.CacheControl           `json:"cache_control,omitempty"`
+	DeferLoading   *bool                           `json:"defer_loading,omitempty"`   // Beta: defer loading of tool definition
+	Strict         *bool                           `json:"strict,omitempty"`          // Whether to enforce strict parameter validation
+	AllowedCallers []string                        `json:"allowed_callers,omitempty"` // Beta: which callers can use this tool
+	InputExamples  []AnthropicToolInputExample     `json:"input_examples,omitempty"`  // Beta: example inputs for the tool
 
 	*AnthropicToolComputerUse
 	*AnthropicToolWebSearch

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -350,7 +350,9 @@ func (provider *AzureProvider) TextCompletion(ctx *schemas.BifrostContext, key s
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return openai.ToOpenAITextCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return openai.ToOpenAITextCompletionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -459,7 +461,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			if schemas.IsAnthropicModel(deployment) {
 				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
@@ -567,7 +569,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 		jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
-			func() (any, error) {
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
 				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
 				if err != nil {
 					return nil, err
@@ -656,7 +658,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
-			func() (any, error) {
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
 				reqBody := openai.ToOpenAIResponsesRequest(request)
 				if reqBody != nil {
 					reqBody.Model = deployment
@@ -826,7 +828,9 @@ func (provider *AzureProvider) Embedding(ctx *schemas.BifrostContext, key schema
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return openai.ToOpenAIEmbeddingRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return openai.ToOpenAIEmbeddingRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -976,7 +980,7 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := openai.ToOpenAISpeechRequest(request)
 			if reqBody != nil {
 				reqBody.StreamFormat = schemas.Ptr("sse")

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -576,7 +576,9 @@ func (provider *BedrockProvider) TextCompletion(ctx *schemas.BifrostContext, key
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockTextCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockTextCompletionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -650,7 +652,9 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockTextCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockTextCompletionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -776,7 +780,9 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockChatCompletionRequest(ctx, request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockChatCompletionRequest(ctx, request)
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -852,7 +858,9 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockChatCompletionRequest(ctx, request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockChatCompletionRequest(ctx, request)
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1113,7 +1121,9 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockResponsesRequest(ctx, request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockResponsesRequest(ctx, request)
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1181,7 +1191,9 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockResponsesRequest(ctx, request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockResponsesRequest(ctx, request)
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1450,7 +1462,9 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
-			func() (any, error) { return ToBedrockTitanEmbeddingRequest(request) },
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return ToBedrockTitanEmbeddingRequest(request)
+			},
 			provider.GetProviderKey())
 		if bifrostError != nil {
 			return nil, bifrostError
@@ -1462,7 +1476,9 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
-			func() (any, error) { return ToBedrockCohereEmbeddingRequest(request) },
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return ToBedrockCohereEmbeddingRequest(request)
+			},
 			provider.GetProviderKey())
 		if bifrostError != nil {
 			return nil, bifrostError
@@ -1559,7 +1575,9 @@ func (provider *BedrockProvider) ImageGeneration(ctx *schemas.BifrostContext, ke
 	jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockImageGenerationRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockImageGenerationRequest(request)
+		},
 		provider.GetProviderKey())
 	if bifrostError != nil {
 		return nil, bifrostError
@@ -1629,7 +1647,7 @@ func (provider *BedrockProvider) ImageEdit(ctx *schemas.BifrostContext, key sche
 	jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockImageEditRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) { return ToBedrockImageEditRequest(request) },
 		provider.GetProviderKey())
 	if bifrostError != nil {
 		return nil, bifrostError
@@ -1700,7 +1718,9 @@ func (provider *BedrockProvider) ImageVariation(ctx *schemas.BifrostContext, key
 	jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToBedrockImageVariationRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToBedrockImageVariationRequest(request)
+		},
 		provider.GetProviderKey())
 	if bifrostError != nil {
 		return nil, bifrostError

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -43,6 +43,10 @@ func ToBedrockChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *sch
 	// Ensure tool config is present when needed
 	ensureChatToolConfigForConversation(bifrostReq, bedrockReq)
 
+	if bifrostReq.Params != nil {
+		bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
+
 	return bedrockReq, nil
 }
 

--- a/core/providers/bedrock/embedding.go
+++ b/core/providers/bedrock/embedding.go
@@ -36,6 +36,9 @@ func ToBedrockTitanEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest)
 		}
 		titanReq.InputText = embeddingText
 	}
+	if bifrostReq.Params != nil {
+		titanReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 
 	return titanReq, nil
 }

--- a/core/providers/bedrock/images.go
+++ b/core/providers/bedrock/images.go
@@ -90,8 +90,10 @@ func ToBedrockImageGenerationRequest(request *schemas.BifrostImageGenerationRequ
 		}
 		if request.Params.ExtraParams != nil {
 			if cfgScale, ok := schemas.SafeExtractFloat64Pointer(request.Params.ExtraParams["cfgScale"]); ok {
+				delete(request.Params.ExtraParams, "cfgScale")
 				bedrockReq.ImageGenerationConfig.CfgScale = cfgScale
 			}
+			bedrockReq.ExtraParams = request.Params.ExtraParams
 		}
 	}
 
@@ -125,6 +127,7 @@ func ToBedrockImageVariationRequest(request *schemas.BifrostImageVariationReques
 	// Additional images from ExtraParams (stored as [][]byte)
 	if request.Params != nil && request.Params.ExtraParams != nil {
 		if additionalImages, ok := request.Params.ExtraParams["images"]; ok {
+			delete(request.Params.ExtraParams, "images")
 			// Handle array of byte arrays (stored by HTTP handler)
 			if imagesArray, ok := additionalImages.([][]byte); ok {
 				for _, imgBytes := range imagesArray {
@@ -138,19 +141,23 @@ func ToBedrockImageVariationRequest(request *schemas.BifrostImageVariationReques
 
 		// Extract optional fields from ExtraParams
 		if prompt, ok := schemas.SafeExtractStringPointer(request.Params.ExtraParams["prompt"]); ok {
+			delete(request.Params.ExtraParams, "prompt")
 			bedrockReq.ImageVariationParams.Text = prompt
 		}
 		if negativeText, ok := schemas.SafeExtractStringPointer(request.Params.ExtraParams["negativeText"]); ok {
+			delete(request.Params.ExtraParams, "negativeText")
 			bedrockReq.ImageVariationParams.NegativeText = negativeText
 		}
 
 		if similarityStrength, ok := schemas.SafeExtractFloat64Pointer(request.Params.ExtraParams["similarityStrength"]); ok {
+			delete(request.Params.ExtraParams, "similarityStrength")
 			// Validate similarityStrength range (0.2 to 1.0)
 			if *similarityStrength < 0.2 || *similarityStrength > 1.0 {
 				return nil, fmt.Errorf("similarityStrength must be between 0.2 and 1.0, got %f", *similarityStrength)
 			}
 			bedrockReq.ImageVariationParams.SimilarityStrength = similarityStrength
 		}
+		bedrockReq.ExtraParams = request.Params.ExtraParams
 	}
 
 	// Map standard params to ImageGenerationConfig
@@ -238,6 +245,7 @@ func ToBedrockImageEditRequest(request *schemas.BifrostImageEditRequest) (*Bedro
 		return nil, fmt.Errorf("unsupported type for Bedrock: %s (must be inpainting, outpainting, or background_removal)", editType)
 	}
 
+	bedrockReq.ExtraParams = request.Params.ExtraParams
 	return bedrockReq, nil
 }
 
@@ -254,9 +262,11 @@ func buildInPaintingParams(imageBase64 string, request *schemas.BifrostImageEdit
 
 	if request.Params.ExtraParams != nil {
 		if maskPrompt, ok := schemas.SafeExtractStringPointer(request.Params.ExtraParams["mask_prompt"]); ok {
+			delete(request.Params.ExtraParams, "mask_prompt")
 			params.MaskPrompt = maskPrompt
 		}
 		if returnMask, ok := schemas.SafeExtractBoolPointer(request.Params.ExtraParams["return_mask"]); ok {
+			delete(request.Params.ExtraParams, "return_mask")
 			params.ReturnMask = returnMask
 		}
 	}
@@ -282,15 +292,18 @@ func buildOutPaintingParams(imageBase64 string, request *schemas.BifrostImageEdi
 
 	if request.Params.ExtraParams != nil {
 		if maskPrompt, ok := schemas.SafeExtractStringPointer(request.Params.ExtraParams["mask_prompt"]); ok {
+			delete(request.Params.ExtraParams, "mask_prompt")
 			params.MaskPrompt = maskPrompt
 		}
 		if returnMask, ok := schemas.SafeExtractBoolPointer(request.Params.ExtraParams["return_mask"]); ok {
+			delete(request.Params.ExtraParams, "return_mask")
 			params.ReturnMask = returnMask
 		}
 		if outPaintingMode, ok := schemas.SafeExtractStringPointer(request.Params.ExtraParams["outpainting_mode"]); ok {
 			// Validate mode
 			mode := strings.ToUpper(*outPaintingMode)
 			if mode == "DEFAULT" || mode == "PRECISE" {
+				delete(request.Params.ExtraParams, "outpainting_mode")
 				params.OutPaintingMode = &mode
 			}
 		}
@@ -337,6 +350,7 @@ func buildImageGenerationConfig(params *schemas.ImageEditParameters) *ImageGener
 
 	if params.ExtraParams != nil {
 		if cfgScale, ok := schemas.SafeExtractFloat64Pointer(params.ExtraParams["cfgScale"]); ok {
+			delete(params.ExtraParams, "cfgScale")
 			config.CfgScale = cfgScale
 		}
 	}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1744,12 +1744,15 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 			}
 		}
 		if bifrostReq.Params.ExtraParams != nil {
+			bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
+				delete(bedrockReq.ExtraParams, "stop")
 				inferenceConfig.StopSequences = stop
 			}
 
 			if requestFields, exists := bifrostReq.Params.ExtraParams["additionalModelRequestFieldPaths"]; exists {
 				if orderedFields, ok := schemas.SafeExtractOrderedMap(requestFields); ok {
+					delete(bedrockReq.ExtraParams, "additionalModelRequestFieldPaths")
 					bedrockReq.AdditionalModelRequestFields = orderedFields
 				}
 			}
@@ -1767,6 +1770,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 					if len(stringFields) > 0 {
 						bedrockReq.AdditionalModelResponseFieldPaths = stringFields
 					}
+				}
+				if len(bedrockReq.AdditionalModelResponseFieldPaths) > 0 {
+					delete(bedrockReq.ExtraParams, "additionalModelResponseFieldPaths")
 				}
 			}
 		}

--- a/core/providers/bedrock/text.go
+++ b/core/providers/bedrock/text.go
@@ -34,7 +34,9 @@ func ToBedrockTextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionReq
 		bedrockReq.TopP = bifrostReq.Params.TopP
 
 		if bifrostReq.Params.ExtraParams != nil {
+			bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
 			if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
+				delete(bedrockReq.ExtraParams, "top_k")
 				bedrockReq.TopK = topK
 			}
 		}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -36,10 +36,16 @@ type BedrockTextCompletionRequest struct {
 	StopSequences []string `json:"stop_sequences,omitempty"` // Stop sequences (Anthropic format)
 
 	// Messages API parameters (Anthropic Claude 3)
-	Messages         []BedrockMessage `json:"messages,omitempty"`
-	System           interface{}      `json:"system,omitempty"`
-	AnthropicVersion string           `json:"anthropic_version,omitempty"`
-	Stream           bool             `json:"-"` // Whether streaming is requested (internal)
+	Messages         []BedrockMessage       `json:"messages,omitempty"`
+	System           interface{}            `json:"system,omitempty"`
+	AnthropicVersion string                 `json:"anthropic_version,omitempty"`
+	Stream           bool                   `json:"-"` // Whether streaming is requested (internal)
+	ExtraParams      map[string]interface{} `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *BedrockTextCompletionRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -68,10 +74,15 @@ type BedrockConverseRequest struct {
 	Stream                            bool                             `json:"-"`                                           // Whether streaming is requested (internal, not in JSON)
 
 	// Extra params for advanced use cases
-	ExtraParams map[string]interface{} `json:"extra_params,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
 	Fallbacks []string `json:"fallbacks,omitempty"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *BedrockConverseRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -558,9 +569,15 @@ type BedrockMetadataEvent struct {
 
 // BedrockTitanEmbeddingRequest represents a Bedrock Titan embedding request
 type BedrockTitanEmbeddingRequest struct {
-	InputText string `json:"inputText"` // Required: Text to embed
+	InputText   string                 `json:"inputText"` // Required: Text to embed
+	ExtraParams map[string]interface{} `json:"-"`
 	// Note: Titan models have fixed dimensions and don't support the dimensions parameter
 	// ExtraParams can be used for any additional model-specific parameters
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *BedrockTitanEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 // BedrockTitanEmbeddingResponse represents a Bedrock Titan embedding response
@@ -580,6 +597,12 @@ type BedrockImageGenerationRequest struct {
 	TaskType              *string                   `json:"taskType"`              // Should be "TEXT_IMAGE"
 	TextToImageParams     *BedrockTextToImageParams `json:"textToImageParams"`     // Parameters for text-to-image
 	ImageGenerationConfig *ImageGenerationConfig    `json:"imageGenerationConfig"` // Image generation config
+	ExtraParams           map[string]interface{}    `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *BedrockImageGenerationRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 type BedrockTextToImageParams struct {
@@ -602,6 +625,12 @@ type BedrockImageVariationRequest struct {
 	TaskType              *string                      `json:"taskType"`              // Should be "IMAGE_VARIATION"
 	ImageVariationParams  *BedrockImageVariationParams `json:"imageVariationParams"`  // Parameters for image variation
 	ImageGenerationConfig *ImageGenerationConfig       `json:"imageGenerationConfig"` // Image generation config (reused)
+	ExtraParams           map[string]interface{}       `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *BedrockImageVariationRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 type BedrockImageVariationParams struct {
@@ -618,6 +647,12 @@ type BedrockImageEditRequest struct {
 	OutPaintingParams       *BedrockOutPaintingParams       `json:"outPaintingParams,omitempty"`
 	BackgroundRemovalParams *BedrockBackgroundRemovalParams `json:"backgroundRemovalParams,omitempty"`
 	ImageGenerationConfig   *ImageGenerationConfig          `json:"imageGenerationConfig,omitempty"` // Used by INPAINTING and OUTPAINTING
+	ExtraParams             map[string]interface{}          `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *BedrockImageEditRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 type BedrockInPaintingParams struct {

--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -146,29 +146,36 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Coh
 		// Convert extra params
 		if bifrostReq.Params.ExtraParams != nil {
 			// Handle thinking parameter
+			cohereReq.ExtraParams = bifrostReq.Params.ExtraParams
 			if thinkingParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "thinking"); ok {
 				if thinkingMap, ok := thinkingParam.(map[string]interface{}); ok {
 					thinking := &CohereThinking{}
 					if typeStr, ok := schemas.SafeExtractString(thinkingMap["type"]); ok {
+						delete(thinkingMap, "type")
 						thinking.Type = CohereThinkingType(typeStr)
 					}
 					if tokenBudget, ok := schemas.SafeExtractIntPointer(thinkingMap["token_budget"]); ok {
+						delete(thinkingMap, "token_budget")
 						thinking.TokenBudget = tokenBudget
 					}
 					cohereReq.Thinking = thinking
+					cohereReq.ExtraParams["thinking"] = thinkingMap
 				}
 			}
 
 			// Handle other Cohere-specific extra params
 			if safetyMode, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["safety_mode"]); ok {
+				delete(cohereReq.ExtraParams, "safety_mode")
 				cohereReq.SafetyMode = safetyMode
 			}
 
 			if logProbs, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["log_probs"]); ok {
+				delete(cohereReq.ExtraParams, "log_probs")
 				cohereReq.LogProbs = logProbs
 			}
 
 			if strictToolChoice, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["strict_tool_choice"]); ok {
+				delete(cohereReq.ExtraParams, "strict_tool_choice")
 				cohereReq.StrictToolChoice = strictToolChoice
 			}
 		}

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -289,7 +289,9 @@ func (provider *CohereProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToCohereChatCompletionRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToCohereChatCompletionRequest(request)
+		},
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -347,7 +349,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody, err := ToCohereChatCompletionRequest(request)
 			if err != nil {
 				return nil, err
@@ -542,7 +544,9 @@ func (provider *CohereProvider) Responses(ctx *schemas.BifrostContext, key schem
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToCohereResponsesRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToCohereResponsesRequest(request)
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -602,7 +606,7 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody, err := ToCohereResponsesRequest(request)
 			if err != nil {
 				return nil, err
@@ -818,7 +822,9 @@ func (provider *CohereProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToCohereEmbeddingRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToCohereEmbeddingRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -970,7 +976,9 @@ func (provider *CohereProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToCohereCountTokensRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToCohereCountTokensRequest(request)
+		},
 		providerName,
 	)
 	if bifrostErr != nil {

--- a/core/providers/cohere/count_tokens.go
+++ b/core/providers/cohere/count_tokens.go
@@ -52,10 +52,15 @@ func ToCohereCountTokensRequest(bifrostReq *schemas.BifrostResponsesRequest) (*C
 		return nil, fmt.Errorf("count tokens text length must be between %d and %d characters", cohereTokenizeMinTextLength, cohereTokenizeMaxTextLength)
 	}
 
-	return &CohereCountTokensRequest{
+	cohereReq := &CohereCountTokensRequest{
 		Model: bifrostReq.Model,
 		Text:  trimmed,
-	}, nil
+	}
+	if bifrostReq.Params != nil {
+		cohereReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
+
+	return cohereReq, nil
 }
 
 // ToBifrostCountTokensResponse converts a Cohere tokenize response to Bifrost format.

--- a/core/providers/cohere/embedding.go
+++ b/core/providers/cohere/embedding.go
@@ -33,9 +33,10 @@ func ToCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Cohe
 
 	if bifrostReq.Params != nil {
 		cohereReq.OutputDimension = bifrostReq.Params.Dimensions
-
+		cohereReq.ExtraParams = bifrostReq.Params.ExtraParams
 		if bifrostReq.Params.ExtraParams != nil {
 			if maxTokens, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["max_tokens"]); ok {
+				delete(cohereReq.ExtraParams, "max_tokens")
 				cohereReq.MaxTokens = maxTokens
 			}
 		}
@@ -45,18 +46,21 @@ func ToCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Cohe
 	if bifrostReq.Params != nil && bifrostReq.Params.ExtraParams != nil {
 		// Input type
 		if inputType, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["input_type"]); ok {
+			delete(cohereReq.ExtraParams, "input_type")
 			cohereReq.InputType = inputType
 		}
 
 		// Embedding types
 		if embeddingTypes, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["embedding_types"]); ok {
 			if len(embeddingTypes) > 0 {
+				delete(cohereReq.ExtraParams, "embedding_types")
 				cohereReq.EmbeddingTypes = embeddingTypes
 			}
 		}
 
 		// Truncate
 		if truncate, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["truncate"]); ok {
+			delete(cohereReq.ExtraParams, "truncate")
 			cohereReq.Truncate = truncate
 		}
 	}

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -1092,28 +1092,36 @@ func ToCohereResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Coh
 			cohereReq.ResponseFormat = convertResponsesTextFormatToCohere(bifrostReq.Params.Text.Format)
 		}
 		if bifrostReq.Params.ExtraParams != nil {
+			cohereReq.ExtraParams = bifrostReq.Params.ExtraParams
 			if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
+				delete(cohereReq.ExtraParams, "top_k")
 				cohereReq.K = topK
 			}
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
+				delete(cohereReq.ExtraParams, "stop")
 				cohereReq.StopSequences = stop
 			}
 			if frequencyPenalty, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["frequency_penalty"]); ok {
+				delete(cohereReq.ExtraParams, "frequency_penalty")
 				cohereReq.FrequencyPenalty = frequencyPenalty
 			}
 			if presencePenalty, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["presence_penalty"]); ok {
+				delete(cohereReq.ExtraParams, "presence_penalty")
 				cohereReq.PresencePenalty = presencePenalty
 			}
 			if thinkingParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "thinking"); ok {
 				if thinkingMap, ok := thinkingParam.(map[string]interface{}); ok {
 					thinking := &CohereThinking{}
 					if typeStr, ok := schemas.SafeExtractString(thinkingMap["type"]); ok {
+						delete(thinkingMap, "type")
 						thinking.Type = CohereThinkingType(typeStr)
 					}
 					if tokenBudget, ok := schemas.SafeExtractIntPointer(thinkingMap["token_budget"]); ok {
+						delete(thinkingMap, "token_budget")
 						thinking.TokenBudget = tokenBudget
 					}
 					cohereReq.Thinking = thinking
+					bifrostReq.Params.ExtraParams["thinking"] = thinkingMap
 				}
 			}
 		}

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -37,11 +37,16 @@ type CohereChatRequest struct {
 	StrictToolChoice *bool                   `json:"strict_tool_choice,omitempty"` // Optional: Strict tool choice
 	Thinking         *CohereThinking         `json:"thinking,omitempty"`           // Optional: Reasoning configuration
 	ResponseFormat   *CohereResponseFormat   `json:"response_format,omitempty"`    // Optional: Format for the response
+	ExtraParams      map[string]interface{}  `json:"-"`                            // Optional: Extra parameters
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
 func (r *CohereChatRequest) IsStreamingRequested() bool {
 	return r.Stream != nil && *r.Stream
+}
+
+func (r *CohereChatRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type CohereChatRequestTool struct {
@@ -243,8 +248,13 @@ type CohereTool struct {
 
 // CohereCountTokensRequest represents a Cohere tokenize request
 type CohereCountTokensRequest struct {
-	Model string `json:"model"` // Required: Model whose tokenizer should be used
-	Text  string `json:"text"`  // Required: Text to tokenize (1-65536 chars)
+	Model       string                 `json:"model"` // Required: Model whose tokenizer should be used
+	Text        string                 `json:"text"`  // Required: Text to tokenize (1-65536 chars)
+	ExtraParams map[string]interface{} `json:"-"`     // Optional: Extra parameters
+}
+
+func (r *CohereCountTokensRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // CohereEmbeddingRequest represents a Cohere embedding request
@@ -258,6 +268,11 @@ type CohereEmbeddingRequest struct {
 	OutputDimension *int                   `json:"output_dimension,omitempty"` // Optional: Embedding dimensions (256, 512, 1024, 1536)
 	EmbeddingTypes  []string               `json:"embedding_types,omitempty"`  // Optional: Types of embeddings to return
 	Truncate        *string                `json:"truncate,omitempty"`         // Optional: How to handle long inputs
+	ExtraParams     map[string]interface{} `json:"-"`                          // Optional: Extra parameters
+}
+
+func (r *CohereEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // CohereEmbeddingInput represents a mixed text/image input

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -219,7 +219,9 @@ func (provider *ElevenlabsProvider) Speech(ctx *schemas.BifrostContext, key sche
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToElevenlabsSpeechRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToElevenlabsSpeechRequest(request), nil
+		},
 		providerName)
 
 	if bifrostErr != nil {
@@ -303,15 +305,12 @@ func (provider *ElevenlabsProvider) SpeechStream(ctx *schemas.BifrostContext, po
 
 	providerName := provider.GetProviderKey()
 
-	reqBody := ToElevenlabsSpeechRequest(request)
-	if reqBody == nil {
-		return nil, providerUtils.NewBifrostOperationError("speech input is not provided", nil, providerName)
-	}
-
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToElevenlabsSpeechRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToElevenlabsSpeechRequest(request), nil
+		},
 		providerName)
 
 	if bifrostErr != nil {

--- a/core/providers/elevenlabs/speech.go
+++ b/core/providers/elevenlabs/speech.go
@@ -15,6 +15,7 @@ func ToElevenlabsSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest) *Eleven
 	}
 
 	if bifrostReq.Params != nil {
+		elevenlabsReq.ExtraParams = bifrostReq.Params.ExtraParams
 		voiceSettings := ElevenlabsVoiceSettings{}
 		hasVoiceSettings := false
 
@@ -25,43 +26,55 @@ func ToElevenlabsSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest) *Eleven
 
 		if bifrostReq.Params.ExtraParams != nil {
 			if stability, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["stability"]); ok {
+				delete(elevenlabsReq.ExtraParams, "stability")
 				voiceSettings.Stability = *stability
 				hasVoiceSettings = true
 			}
 			if useSpeakerBoost, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["use_speaker_boost"]); ok {
+				delete(elevenlabsReq.ExtraParams, "use_speaker_boost")
 				voiceSettings.UseSpeakerBoost = *useSpeakerBoost
 				hasVoiceSettings = true
 			}
 			if similarityBoost, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["similarity_boost"]); ok {
+				delete(elevenlabsReq.ExtraParams, "similarity_boost")
 				voiceSettings.SimilarityBoost = *similarityBoost
 				hasVoiceSettings = true
 			}
 			if style, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["style"]); ok {
+				delete(elevenlabsReq.ExtraParams, "style")
 				voiceSettings.Style = *style
 				hasVoiceSettings = true
 			}
 			if seed, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["seed"]); ok {
+				delete(elevenlabsReq.ExtraParams, "seed")
 				elevenlabsReq.Seed = seed
 			}
 			if previousText, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["previous_text"]); ok {
+				delete(elevenlabsReq.ExtraParams, "previous_text")
 				elevenlabsReq.PreviousText = previousText
 			}
 			if nextText, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["next_text"]); ok {
+				delete(elevenlabsReq.ExtraParams, "next_text")
 				elevenlabsReq.NextText = nextText
 			}
 			if previousRequestIDs, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["previous_request_ids"]); ok {
+				delete(elevenlabsReq.ExtraParams, "previous_request_ids")
 				elevenlabsReq.PreviousRequestIDs = previousRequestIDs
 			}
 			if nextRequestIDs, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["next_request_ids"]); ok {
+				delete(elevenlabsReq.ExtraParams, "next_request_ids")
 				elevenlabsReq.NextRequestIDs = nextRequestIDs
 			}
 			if applyTextNormalization, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["apply_text_normalization"]); ok {
+				delete(elevenlabsReq.ExtraParams, "apply_text_normalization")
 				elevenlabsReq.ApplyTextNormalization = applyTextNormalization
 			}
 			if applyLanguageTextNormalization, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["apply_language_text_normalization"]); ok {
+				delete(elevenlabsReq.ExtraParams, "apply_language_text_normalization")
 				elevenlabsReq.ApplyLanguageTextNormalization = applyLanguageTextNormalization
 			}
 			if usePVCAsIVC, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["use_pvc_as_ivc"]); ok {
+				delete(elevenlabsReq.ExtraParams, "use_pvc_as_ivc")
 				elevenlabsReq.UsePVCAsIVC = usePVCAsIVC
 			}
 		}

--- a/core/providers/elevenlabs/transcription.go
+++ b/core/providers/elevenlabs/transcription.go
@@ -33,43 +33,56 @@ func ToElevenlabsTranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionRe
 
 	if params.ExtraParams != nil {
 		if tagAudioEvents, ok := schemas.SafeExtractBoolPointer(params.ExtraParams["tag_audio_events"]); ok {
+			delete(params.ExtraParams, "tag_audio_events")
 			req.TagAudioEvents = tagAudioEvents
 		}
 		if numSpeakers, ok := schemas.SafeExtractIntPointer(params.ExtraParams["num_speakers"]); ok {
+			delete(params.ExtraParams, "num_speakers")
 			req.NumSpeakers = numSpeakers
 		}
 		if timestampsGranularity, ok := schemas.SafeExtractStringPointer(params.ExtraParams["timestamps_granularity"]); ok {
 			granularity := ElevenlabsTimestampsGranularity(*timestampsGranularity)
+			delete(params.ExtraParams, "timestamps_granularity")
 			req.TimestampsGranularity = &granularity
 		}
 		if diarize, ok := schemas.SafeExtractBoolPointer(params.ExtraParams["diarize"]); ok {
+			delete(params.ExtraParams, "diarize")
 			req.Diarize = diarize
 		}
 		if diarizationThreshold, ok := schemas.SafeExtractFloat64Pointer(params.ExtraParams["diarization_threshold"]); ok {
+			delete(params.ExtraParams, "diarization_threshold")
 			req.DiarizationThreshold = diarizationThreshold
 		}
 		if fileFormat, ok := schemas.SafeExtractStringPointer(params.ExtraParams["file_format"]); ok {
 			fileFormat := ElevenlabsFileFormat(*fileFormat)
+			delete(params.ExtraParams, "file_format")
 			req.FileFormat = &fileFormat
 		}
 		if cloudStorageURL, ok := schemas.SafeExtractStringPointer(params.ExtraParams["cloud_storage_url"]); ok {
+			delete(params.ExtraParams, "cloud_storage_url")
 			req.CloudStorageURL = cloudStorageURL
 		}
 		if webhook, ok := schemas.SafeExtractBoolPointer(params.ExtraParams["webhook"]); ok {
+			delete(params.ExtraParams, "webhook")
 			req.Webhook = webhook
 		}
 		if webhookID, ok := schemas.SafeExtractStringPointer(params.ExtraParams["webhook_id"]); ok {
+			delete(params.ExtraParams, "webhook_id")
 			req.WebhookID = webhookID
 		}
 		if temperature, ok := schemas.SafeExtractFloat64Pointer(params.ExtraParams["temperature"]); ok {
+			delete(params.ExtraParams, "temperature")
 			req.Temperature = temperature
 		}
 		if seed, ok := schemas.SafeExtractIntPointer(params.ExtraParams["seed"]); ok {
+			delete(params.ExtraParams, "seed")
 			req.Seed = seed
 		}
 		if useMultiChannel, ok := schemas.SafeExtractBoolPointer(params.ExtraParams["use_multi_channel"]); ok {
+			delete(params.ExtraParams, "use_multi_channel")
 			req.UseMultiChannel = useMultiChannel
 		}
+		req.ExtraParams = bifrostReq.Params.ExtraParams
 	}
 
 	if len(params.AdditionalFormats) > 0 {

--- a/core/providers/elevenlabs/types.go
+++ b/core/providers/elevenlabs/types.go
@@ -22,6 +22,12 @@ type ElevenlabsSpeechRequest struct {
 	ApplyTextNormalization          *string                                    `json:"apply_text_normalization,omitempty"`
 	ApplyLanguageTextNormalization  *bool                                      `json:"apply_language_text_normalization,omitempty"`
 	UsePVCAsIVC                     *bool                                      `json:"use_pvc_as_ivc,omitempty"` // deprecated
+	ExtraParams                     map[string]interface{}                     `json:"-"`
+}
+
+// GetExtraParams implements the providerUtils.RequestBodyWithExtraParams interface.
+func (r *ElevenlabsSpeechRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // ElevenlabsSpeechWithTimestampsResponse represents the response from the with-timestamps endpoint
@@ -70,6 +76,12 @@ type ElevenlabsTranscriptionRequest struct {
 	Seed                  *int                             `json:"seed,omitempty"`
 	UseMultiChannel       *bool                            `json:"use_multi_channel,omitempty"`
 	WebhookMetadata       interface{}                      `json:"webhook_metadata,omitempty"`
+	ExtraParams           map[string]interface{}           `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *ElevenlabsTranscriptionRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 type ElevenlabsTimestampsGranularity string

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -22,6 +22,7 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Gemi
 
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
+		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		geminiReq.GenerationConfig = convertParamsToGenerationConfig(bifrostReq.Params, []string{}, bifrostReq.Model)
 
 		// Handle tool-related parameters
@@ -38,6 +39,7 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Gemi
 		if bifrostReq.Params.ExtraParams != nil {
 			// Safety settings
 			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
+				delete(geminiReq.ExtraParams, "safety_settings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
@@ -45,11 +47,13 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Gemi
 
 			// Cached content
 			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
+				delete(geminiReq.ExtraParams, "cached_content")
 				geminiReq.CachedContent = cachedContent
 			}
 
 			// Labels
 			if labels, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "labels"); ok {
+				delete(geminiReq.ExtraParams, "labels")
 				if labelMap, ok := schemas.SafeExtractStringMap(labels); ok {
 					geminiReq.Labels = labelMap
 				}

--- a/core/providers/gemini/embedding.go
+++ b/core/providers/gemini/embedding.go
@@ -31,6 +31,9 @@ func ToGeminiEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Gemi
 	batchRequest := &GeminiBatchEmbeddingRequest{
 		Requests: make([]GeminiEmbeddingRequest, len(texts)),
 	}
+	if bifrostReq.Params != nil {
+		batchRequest.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 
 	// Create individual embedding requests for each text
 	for i, text := range texts {
@@ -54,9 +57,11 @@ func ToGeminiEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Gemi
 			// Handle extra parameters
 			if bifrostReq.Params.ExtraParams != nil {
 				if taskType, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["taskType"]); ok {
+					delete(batchRequest.ExtraParams, "taskType")
 					embeddingReq.TaskType = taskType
 				}
 				if title, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["title"]); ok {
+					delete(batchRequest.ExtraParams, "title")
 					embeddingReq.Title = title
 				}
 			}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -230,7 +230,9 @@ func (provider *GeminiProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiChatCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiChatCompletionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -277,7 +279,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := ToGeminiChatCompletionRequest(request)
 			if reqBody == nil {
 				return nil, fmt.Errorf("chat completion request is not provided or could not be converted to Gemini format")
@@ -554,7 +556,7 @@ func (provider *GeminiProvider) Responses(ctx *schemas.BifrostContext, key schem
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := ToGeminiResponsesRequest(request)
 			if reqBody == nil {
 				return nil, fmt.Errorf("responses input is not provided or could not be converted to Gemini format")
@@ -608,7 +610,7 @@ func (provider *GeminiProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := ToGeminiResponsesRequest(request)
 			if reqBody == nil {
 				return nil, fmt.Errorf("responses input is not provided or could not be converted to Gemini format")
@@ -944,7 +946,9 @@ func (provider *GeminiProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiEmbeddingRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiEmbeddingRequest(request), nil
+		},
 		providerName)
 	if err != nil {
 		return nil, err
@@ -1035,7 +1039,9 @@ func (provider *GeminiProvider) Speech(ctx *schemas.BifrostContext, key schemas.
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiSpeechRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiSpeechRequest(request)
+		},
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -1088,7 +1094,9 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiSpeechRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiSpeechRequest(request)
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1330,7 +1338,9 @@ func (provider *GeminiProvider) Transcription(ctx *schemas.BifrostContext, key s
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiTranscriptionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiTranscriptionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1378,7 +1388,9 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiTranscriptionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiTranscriptionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1633,7 +1645,9 @@ func (provider *GeminiProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiImageGenerationRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiImageGenerationRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1691,7 +1705,9 @@ func (provider *GeminiProvider) handleImagenImageGeneration(ctx *schemas.Bifrost
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToImagenImageGenerationRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToImagenImageGenerationRequest(request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1779,7 +1795,9 @@ func (provider *GeminiProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
-			func() (any, error) { return ToImagenImageEditRequest(request), nil },
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return ToImagenImageEditRequest(request), nil
+			},
 			providerName)
 		if bifrostErr != nil {
 			return nil, bifrostErr
@@ -1846,7 +1864,9 @@ func (provider *GeminiProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiImageEditRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiImageEditRequest(request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -3229,7 +3249,9 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToGeminiResponsesRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToGeminiResponsesRequest(request), nil
+		},
 		provider.GetProviderKey(),
 	)
 	if bifrostErr != nil {

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -403,6 +403,7 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 	geminiReq := &GeminiGenerationRequest{
 		Model: bifrostReq.Model,
 	}
+	geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 
 	// Set response modalities to indicate this is an image generation request
 	geminiReq.GenerationConfig.ResponseModalities = []Modality{ModalityImage}
@@ -414,10 +415,12 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 		if bifrostReq.Params.ExtraParams != nil {
 			// Safety settings - support both camelCase (canonical) and snake_case (legacy) keys
 			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safetySettings"); ok {
+				delete(geminiReq.ExtraParams, "safetySettings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
 			} else if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
+				delete(geminiReq.ExtraParams, "safety_settings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
@@ -425,8 +428,10 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 
 			// Cached content - support both camelCase (canonical) and snake_case (legacy) keys
 			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cachedContent"]); ok {
+				delete(geminiReq.ExtraParams, "cachedContent")
 				geminiReq.CachedContent = cachedContent
 			} else if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
+				delete(geminiReq.ExtraParams, "cached_content")
 				geminiReq.CachedContent = cachedContent
 			}
 
@@ -434,6 +439,7 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 			if labels, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "labels"); ok {
 				switch m := labels.(type) {
 				case map[string]string:
+					delete(geminiReq.ExtraParams, "labels")
 					geminiReq.Labels = m
 				case map[string]interface{}:
 					out := make(map[string]string, len(m))
@@ -443,6 +449,7 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 						}
 					}
 					if len(out) > 0 {
+						delete(geminiReq.ExtraParams, "labels")
 						geminiReq.Labels = out
 					}
 				}
@@ -534,34 +541,42 @@ func ToImagenImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 
 		// Handle extra parameters for Imagen-specific fields
 		if bifrostReq.Params.ExtraParams != nil {
+			req.ExtraParams = bifrostReq.Params.ExtraParams
 			if addWatermark, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["addWatermark"]); ok {
+				delete(req.ExtraParams, "addWatermark")
 				req.Parameters.AddWatermark = addWatermark
 			}
 			if sampleImageSize, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["sampleImageSize"]); ok {
+				delete(req.ExtraParams, "sampleImageSize")
 				req.Parameters.SampleImageSize = &sampleImageSize
 			}
 
 			if aspectRatio, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["aspectRatio"]); ok {
+				delete(req.ExtraParams, "aspectRatio")
 				req.Parameters.AspectRatio = &aspectRatio
 			}
 
 			if personGeneration, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["personGeneration"]); ok {
+				delete(req.ExtraParams, "personGeneration")
 				req.Parameters.PersonGeneration = &personGeneration
 			}
 
 			// Map language from ExtraParams
 			if language, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["language"]); ok {
+				delete(req.ExtraParams, "language")
 				req.Parameters.Language = &language
 			}
 
 			// Map enhancePrompt from ExtraParams
 			if enhancePrompt, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["enhancePrompt"]); ok {
+				delete(req.ExtraParams, "enhancePrompt")
 				req.Parameters.EnhancePrompt = enhancePrompt
 			}
 
 			// Map safetySettings from ExtraParams
 			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safetySettings"); ok {
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
+					delete(req.ExtraParams, "safetySettings")
 					req.Parameters.SafetySettings = settings
 				}
 			}
@@ -769,21 +784,23 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 	geminiReq := &GeminiGenerationRequest{
 		Model: bifrostReq.Model,
 	}
-
 	// Set response modalities to indicate this is an image generation request
 	geminiReq.GenerationConfig.ResponseModalities = []Modality{ModalityImage}
 
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
+		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 
 		// Handle extra parameters
 		if bifrostReq.Params.ExtraParams != nil {
 			// Safety settings - support both camelCase (canonical) and snake_case (legacy) keys
 			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safetySettings"); ok {
+				delete(geminiReq.ExtraParams, "safetySettings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
 			} else if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
+				delete(geminiReq.ExtraParams, "safety_settings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
@@ -791,8 +808,10 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 
 			// Cached content - support both camelCase (canonical) and snake_case (legacy) keys
 			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cachedContent"]); ok {
+				delete(geminiReq.ExtraParams, "cachedContent")
 				geminiReq.CachedContent = cachedContent
 			} else if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
+				delete(geminiReq.ExtraParams, "cached_content")
 				geminiReq.CachedContent = cachedContent
 			}
 
@@ -800,6 +819,7 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 			if labels, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "labels"); ok {
 				switch m := labels.(type) {
 				case map[string]string:
+					delete(geminiReq.ExtraParams, "labels")
 					geminiReq.Labels = m
 				case map[string]interface{}:
 					out := make(map[string]string, len(m))
@@ -809,6 +829,7 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 						}
 					}
 					if len(out) > 0 {
+						delete(geminiReq.ExtraParams, "labels")
 						geminiReq.Labels = out
 					}
 				}
@@ -952,6 +973,10 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 		return nil
 	}
 
+	req := &GeminiImagenRequest{
+		Parameters: GeminiImagenParameters{},
+	}
+
 	var refImages []ImagenReferenceImage
 	refID := 1
 
@@ -972,7 +997,7 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 		var hasMaskData bool
 		var dilation *float64
 		var maskClasses []int
-
+		req.ExtraParams = bifrostReq.Params.ExtraParams
 		// Check if user provided a mask
 		if len(bifrostReq.Params.Mask) > 0 {
 			hasMaskData = true
@@ -983,6 +1008,7 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 		if bifrostReq.Params.ExtraParams != nil {
 			// Allow override or specification of mask mode
 			if v, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["maskMode"]); ok {
+				delete(req.ExtraParams, "maskMode")
 				maskMode = v
 			}
 
@@ -990,12 +1016,14 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 			if v, ok := schemas.SafeExtractFloat64Pointer(bifrostReq.Params.ExtraParams["dilation"]); ok {
 				// Validate dilation is in valid range
 				if *v >= 0 && *v <= 1 {
+					delete(req.ExtraParams, "dilation")
 					dilation = v
 				}
 			}
 
 			// Extract maskClasses (for MASK_MODE_SEMANTIC)
 			if v, ok := bifrostReq.Params.ExtraParams["maskClasses"]; ok {
+				delete(req.ExtraParams, "maskClasses")
 				maskClasses = extractIntArray(v)
 			}
 		}
@@ -1023,15 +1051,10 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 		}
 	}
 
-	req := &GeminiImagenRequest{
-		Instances: []ImagenInstance{
-			{
-				ReferenceImages: refImages,
-				Prompt:          bifrostReq.Input.Prompt,
-			},
-		},
-		Parameters: GeminiImagenParameters{},
-	}
+	req.Instances = append(req.Instances, ImagenInstance{
+		ReferenceImages: refImages,
+		Prompt:          bifrostReq.Input.Prompt,
+	})
 
 	// Set parameters
 	if bifrostReq.Params != nil {
@@ -1071,34 +1094,44 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 			// Only use editMode from ExtraParams if Type was not set
 			if bifrostReq.Params.Type == nil {
 				if v, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["editMode"]); ok {
+					delete(req.ExtraParams, "editMode")
 					req.Parameters.EditMode = &v
 				}
 			}
 			if v, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["guidanceScale"]); ok {
+				delete(req.ExtraParams, "guidanceScale")
 				req.Parameters.GuidanceScale = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["baseSteps"]); ok {
+				delete(req.ExtraParams, "baseSteps")
 				req.Parameters.BaseSteps = v
 			}
 			if v, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["addWatermark"]); ok {
+				delete(req.ExtraParams, "addWatermark")
 				req.Parameters.AddWatermark = v
 			}
 			if v, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["includeRaiReason"]); ok {
+				delete(req.ExtraParams, "includeRaiReason")
 				req.Parameters.IncludeRaiReason = v
 			}
 			if v, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["includeSafetyAttributes"]); ok {
+				delete(req.ExtraParams, "includeSafetyAttributes")
 				req.Parameters.IncludeSafetyAttributes = v
 			}
 			if v, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["personGeneration"]); ok {
+				delete(req.ExtraParams, "personGeneration")
 				req.Parameters.PersonGeneration = &v
 			}
 			if v, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["language"]); ok {
+				delete(req.ExtraParams, "language")
 				req.Parameters.Language = &v
 			}
 			if v, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["storageUri"]); ok {
+				delete(req.ExtraParams, "storageUri")
 				req.Parameters.StorageUri = &v
 			}
 			if v, ok := SafeExtractSafetySettings(bifrostReq.Params.ExtraParams["safetySettings"]); ok {
+				delete(req.ExtraParams, "safetySettings")
 				req.Parameters.SafetySettings = v
 			}
 		}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -83,7 +83,7 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Gemi
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
 		geminiReq.GenerationConfig = geminiReq.convertParamsToGenerationConfigResponses(bifrostReq.Params)
-
+		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {
 			geminiReq.Tools = convertResponsesToolsToGemini(bifrostReq.Params.Tools)
@@ -122,11 +122,13 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Gemi
 
 		if bifrostReq.Params.ExtraParams != nil {
 			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
+				delete(geminiReq.ExtraParams, "safety_settings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
 			}
 			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
+				delete(geminiReq.ExtraParams, "cached_content")
 				geminiReq.CachedContent = cachedContent
 			}
 		}
@@ -2560,21 +2562,25 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 
 	if params.ExtraParams != nil {
 		if topK, ok := params.ExtraParams["top_k"]; ok {
+			delete(params.ExtraParams, "top_k")
 			if val, success := schemas.SafeExtractInt(topK); success {
 				config.TopK = schemas.Ptr(val)
 			}
 		}
 		if frequencyPenalty, ok := params.ExtraParams["frequency_penalty"]; ok {
+			delete(params.ExtraParams, "frequency_penalty")
 			if val, success := schemas.SafeExtractFloat64(frequencyPenalty); success {
 				config.FrequencyPenalty = schemas.Ptr(val)
 			}
 		}
 		if presencePenalty, ok := params.ExtraParams["presence_penalty"]; ok {
+			delete(params.ExtraParams, "presence_penalty")
 			if val, success := schemas.SafeExtractFloat64(presencePenalty); success {
 				config.PresencePenalty = schemas.Ptr(val)
 			}
 		}
 		if stopSequences, ok := params.ExtraParams["stop_sequences"]; ok {
+			delete(params.ExtraParams, "stop_sequences")
 			if val, success := schemas.SafeExtractStringSlice(stopSequences); success {
 				config.StopSequences = val
 			}

--- a/core/providers/gemini/speech.go
+++ b/core/providers/gemini/speech.go
@@ -116,6 +116,7 @@ func ToGeminiSpeechRequest(bifrostReq *schemas.BifrostSpeechRequest) (*GeminiGen
 			if bifrostReq.Params.VoiceConfig.Voice != nil || len(bifrostReq.Params.VoiceConfig.MultiVoiceConfig) > 0 {
 				addSpeechConfigToGenerationConfig(&geminiReq.GenerationConfig, bifrostReq.Params.VoiceConfig)
 			}
+			geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		}
 	}
 	return geminiReq, nil

--- a/core/providers/gemini/transcription.go
+++ b/core/providers/gemini/transcription.go
@@ -115,11 +115,12 @@ func ToGeminiTranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReques
 
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
-
+		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		// Handle extra parameters
 		if bifrostReq.Params.ExtraParams != nil {
 			// Safety settings
 			if safetySettings, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "safety_settings"); ok {
+				delete(geminiReq.ExtraParams, "safety_settings")
 				if settings, ok := SafeExtractSafetySettings(safetySettings); ok {
 					geminiReq.SafetySettings = settings
 				}
@@ -127,12 +128,14 @@ func ToGeminiTranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReques
 
 			// Cached content
 			if cachedContent, ok := schemas.SafeExtractString(bifrostReq.Params.ExtraParams["cached_content"]); ok {
+				delete(geminiReq.ExtraParams, "cached_content")
 				geminiReq.CachedContent = cachedContent
 			}
 
 			// Labels
 			if labels, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "labels"); ok {
 				if labelMap, ok := schemas.SafeExtractStringMap(labels); ok {
+					delete(geminiReq.ExtraParams, "labels")
 					geminiReq.Labels = labelMap
 				}
 			}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -89,7 +89,13 @@ type GeminiGenerationRequest struct {
 	Parameters *GeminiImagenParameters `json:"parameters,omitempty"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *GeminiGenerationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // ImagenInstance represents a single instance in an Imagen request
@@ -1100,16 +1106,28 @@ func (tc *GenerationConfigThinkingConfig) UnmarshalJSON(data []byte) error {
 }
 
 type GeminiBatchEmbeddingRequest struct {
-	Requests []GeminiEmbeddingRequest `json:"requests,omitempty"`
+	Requests    []GeminiEmbeddingRequest `json:"requests,omitempty"`
+	ExtraParams map[string]interface{}   `json:"-"` // Optional: Extra parameters
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *GeminiBatchEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // GeminiEmbeddingRequest represents a single embedding request in a batch.
 type GeminiEmbeddingRequest struct {
-	Content              *Content `json:"content,omitempty"`
-	TaskType             *string  `json:"taskType,omitempty"`
-	Title                *string  `json:"title,omitempty"`
-	OutputDimensionality *int     `json:"outputDimensionality,omitempty"`
-	Model                string   `json:"model,omitempty"`
+	Content              *Content               `json:"content,omitempty"`
+	TaskType             *string                `json:"taskType,omitempty"`
+	Title                *string                `json:"title,omitempty"`
+	OutputDimensionality *int                   `json:"outputDimensionality,omitempty"`
+	Model                string                 `json:"model,omitempty"`
+	ExtraParams          map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *GeminiEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // Content contains the multi-part content of a message.
@@ -2119,8 +2137,13 @@ type GeminiCountTokensResponse struct {
 }
 
 type GeminiImagenRequest struct {
-	Instances  []ImagenInstance       `json:"instances"`
-	Parameters GeminiImagenParameters `json:"parameters"`
+	Instances   []ImagenInstance       `json:"instances"`
+	Parameters  GeminiImagenParameters `json:"parameters"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *GeminiImagenRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type GeminiImagenParameters struct {

--- a/core/providers/huggingface/chat.go
+++ b/core/providers/huggingface/chat.go
@@ -100,6 +100,7 @@ func ToHuggingFaceChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) 
 				hfReq.ToolChoice = hfToolChoice
 			}
 		}
+		hfReq.ExtraParams = bifrostReq.Params.ExtraParams
 	}
 
 	return hfReq, nil

--- a/core/providers/huggingface/embedding.go
+++ b/core/providers/huggingface/embedding.go
@@ -60,18 +60,23 @@ func ToHuggingFaceEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) 
 		// Check for HuggingFace-specific parameters in ExtraParams
 		if params.ExtraParams != nil {
 			if normalize, ok := params.ExtraParams["normalize"].(bool); ok {
+				delete(params.ExtraParams, "normalize")
 				hfReq.Normalize = &normalize
 			}
 			if promptName, ok := params.ExtraParams["prompt_name"].(string); ok {
+				delete(params.ExtraParams, "prompt_name")
 				hfReq.PromptName = &promptName
 			}
 			if truncate, ok := params.ExtraParams["truncate"].(bool); ok {
+				delete(params.ExtraParams, "truncate")
 				hfReq.Truncate = &truncate
 			}
 			if truncationDirection, ok := params.ExtraParams["truncation_direction"].(string); ok {
+				delete(params.ExtraParams, "truncation_direction")
 				hfReq.TruncationDirection = &truncationDirection
 			}
 		}
+		hfReq.ExtraParams = params.ExtraParams
 	}
 
 	return hfReq, nil

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -463,7 +463,7 @@ func (provider *HuggingFaceProvider) ChatCompletion(ctx *schemas.BifrostContext,
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody, err := ToHuggingFaceChatCompletionRequest(request)
 			if err != nil {
 				return nil, err
@@ -548,7 +548,7 @@ func (provider *HuggingFaceProvider) ChatCompletionStream(ctx *schemas.BifrostCo
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
 	}
 
-	customRequestConverter := func(request *schemas.BifrostChatRequest) (any, error) {
+	customRequestConverter := func(request *schemas.BifrostChatRequest) (providerUtils.RequestBodyWithExtraParams, error) {
 		reqBody, err := ToHuggingFaceChatCompletionRequest(request)
 		if err != nil {
 			return nil, err
@@ -634,7 +634,7 @@ func (provider *HuggingFaceProvider) Embedding(ctx *schemas.BifrostContext, key 
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			req, err := ToHuggingFaceEmbeddingRequest(request)
 			return req, err
 		},
@@ -721,7 +721,9 @@ func (provider *HuggingFaceProvider) Speech(ctx *schemas.BifrostContext, key sch
 	jsonData, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToHuggingFaceSpeechRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToHuggingFaceSpeechRequest(request)
+		},
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -819,7 +821,9 @@ func (provider *HuggingFaceProvider) Transcription(ctx *schemas.BifrostContext, 
 		jsonData, err = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
-			func() (any, error) { return ToHuggingFaceTranscriptionRequest(request) },
+			func() (providerUtils.RequestBodyWithExtraParams, error) {
+				return ToHuggingFaceTranscriptionRequest(request)
+			},
 			provider.GetProviderKey())
 		if err != nil {
 			return nil, err
@@ -914,7 +918,7 @@ func (provider *HuggingFaceProvider) ImageGeneration(ctx *schemas.BifrostContext
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			req, err := ToHuggingFaceImageGenerationRequest(request)
 			return req, err
 		},
@@ -1065,7 +1069,7 @@ func HandleHuggingFaceImageGenerationStreaming(
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			return ToHuggingFaceImageStreamRequest(request)
 		},
 		providerName)
@@ -1345,7 +1349,7 @@ func (provider *HuggingFaceProvider) ImageEdit(ctx *schemas.BifrostContext, key 
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			req, err := ToHuggingFaceImageEditRequest(request)
 			return req, err
 		},
@@ -1466,7 +1470,7 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			return ToHuggingFaceImageEditRequest(request)
 		},
 		providerName)

--- a/core/providers/huggingface/speech.go
+++ b/core/providers/huggingface/speech.go
@@ -36,61 +36,79 @@ func ToHuggingFaceSpeechRequest(request *schemas.BifrostSpeechRequest) (*Hugging
 			genParams := &HuggingFaceTranscriptionGenerationParameters{}
 
 			if val, ok := request.Params.ExtraParams["do_sample"].(bool); ok {
+				delete(request.Params.ExtraParams, "do_sample")
 				genParams.DoSample = &val
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["max_new_tokens"]); ok {
+				delete(request.Params.ExtraParams, "max_new_tokens")
 				genParams.MaxNewTokens = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["max_length"]); ok {
+				delete(request.Params.ExtraParams, "max_length")
 				genParams.MaxLength = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["min_length"]); ok {
+				delete(request.Params.ExtraParams, "min_length")
 				genParams.MinLength = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["min_new_tokens"]); ok {
+				delete(request.Params.ExtraParams, "min_new_tokens")
 				genParams.MinNewTokens = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["num_beams"]); ok {
+				delete(request.Params.ExtraParams, "num_beams")
 				genParams.NumBeams = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["num_beam_groups"]); ok {
+				delete(request.Params.ExtraParams, "num_beam_groups")
 				genParams.NumBeamGroups = v
 			}
 			if val, ok := request.Params.ExtraParams["penalty_alpha"].(float64); ok {
+				delete(request.Params.ExtraParams, "penalty_alpha")
 				genParams.PenaltyAlpha = &val
 			}
 			if val, ok := request.Params.ExtraParams["temperature"].(float64); ok {
+				delete(request.Params.ExtraParams, "temperature")
 				genParams.Temperature = &val
 			}
 			if v, ok := schemas.SafeExtractIntPointer(request.Params.ExtraParams["top_k"]); ok {
+				delete(request.Params.ExtraParams, "top_k")
 				genParams.TopK = v
 			}
 			if val, ok := request.Params.ExtraParams["top_p"].(float64); ok {
+				delete(request.Params.ExtraParams, "top_p")
 				genParams.TopP = &val
 			}
 			if val, ok := request.Params.ExtraParams["typical_p"].(float64); ok {
+				delete(request.Params.ExtraParams, "typical_p")
 				genParams.TypicalP = &val
 			}
 			if val, ok := request.Params.ExtraParams["use_cache"].(bool); ok {
+				delete(request.Params.ExtraParams, "use_cache")
 				genParams.UseCache = &val
 			}
 			if val, ok := request.Params.ExtraParams["epsilon_cutoff"].(float64); ok {
+				delete(request.Params.ExtraParams, "epsilon_cutoff")
 				genParams.EpsilonCutoff = &val
 			}
 			if val, ok := request.Params.ExtraParams["eta_cutoff"].(float64); ok {
+				delete(request.Params.ExtraParams, "eta_cutoff")
 				genParams.EtaCutoff = &val
 			}
 
 			// Handle early_stopping (can be bool or string "never")
 			if val, ok := request.Params.ExtraParams["early_stopping"].(bool); ok {
+				delete(request.Params.ExtraParams, "early_stopping")
 				genParams.EarlyStopping = &HuggingFaceTranscriptionEarlyStopping{BoolValue: &val}
 			} else if val, ok := request.Params.ExtraParams["early_stopping"].(string); ok {
+				delete(request.Params.ExtraParams, "early_stopping")
 				genParams.EarlyStopping = &HuggingFaceTranscriptionEarlyStopping{StringValue: &val}
 			}
 
 			hfRequest.Parameters.GenerationParameters = genParams
 		}
 	}
+	hfRequest.ExtraParams = request.Params.ExtraParams
 
 	return hfRequest, nil
 }

--- a/core/providers/huggingface/transcription.go
+++ b/core/providers/huggingface/transcription.go
@@ -66,52 +66,66 @@ func ToHuggingFaceTranscriptionRequest(request *schemas.BifrostTranscriptionRequ
 		if request.Params.ExtraParams != nil {
 			extra := request.Params.ExtraParams
 			if val, ok := extra["do_sample"].(bool); ok {
+				delete(extra, "do_sample")
 				genParams.DoSample = &val
 			}
 			if v, ok := schemas.SafeExtractIntPointer(extra["num_beams"]); ok {
+				delete(extra, "num_beams")
 				genParams.NumBeams = v
 			}
 			if v, ok := schemas.SafeExtractIntPointer(extra["num_beam_groups"]); ok {
+				delete(extra, "num_beam_groups")
 				genParams.NumBeamGroups = v
 			}
 			if val, ok := extra["penalty_alpha"].(float64); ok {
+				delete(extra, "penalty_alpha")
 				genParams.PenaltyAlpha = &val
 			}
 			if val, ok := extra["temperature"].(float64); ok {
+				delete(extra, "temperature")
 				genParams.Temperature = &val
 			}
 			if v, ok := schemas.SafeExtractIntPointer(extra["top_k"]); ok {
+				delete(extra, "top_k")
 				genParams.TopK = v
 			}
 			if val, ok := extra["top_p"].(float64); ok {
+				delete(extra, "top_p")
 				genParams.TopP = &val
 			}
 			if val, ok := extra["typical_p"].(float64); ok {
+				delete(extra, "typical_p")
 				genParams.TypicalP = &val
 			}
 			if val, ok := extra["use_cache"].(bool); ok {
+				delete(extra, "use_cache")
 				genParams.UseCache = &val
 			}
 			if val, ok := extra["epsilon_cutoff"].(float64); ok {
+				delete(extra, "epsilon_cutoff")
 				genParams.EpsilonCutoff = &val
 			}
 			if val, ok := extra["eta_cutoff"].(float64); ok {
+				delete(extra, "eta_cutoff")
 				genParams.EtaCutoff = &val
 			}
 
 			// Handle early_stopping (can be bool or string "never")
 			if val, ok := extra["early_stopping"].(bool); ok {
+				delete(extra, "early_stopping")
 				genParams.EarlyStopping = &HuggingFaceTranscriptionEarlyStopping{BoolValue: &val}
 			} else if val, ok := extra["early_stopping"].(string); ok {
+				delete(extra, "early_stopping")
 				genParams.EarlyStopping = &HuggingFaceTranscriptionEarlyStopping{StringValue: &val}
 			}
 
 			// Handle return_timestamps
 			if val, ok := extra["return_timestamps"].(bool); ok {
+				delete(extra, "return_timestamps")
 				hfRequest.Parameters.ReturnTimestamps = &val
 			}
 		}
-
+		hfRequest.ExtraParams = request.Params.ExtraParams
 		hfRequest.Parameters.GenerationParameters = genParams
 	}
 

--- a/core/providers/huggingface/types.go
+++ b/core/providers/huggingface/types.go
@@ -91,6 +91,11 @@ type HuggingFaceChatRequest struct {
 	Tools            []schemas.ChatTool         `json:"tools,omitempty"`
 	TopLogprobs      *int                       `json:"top_logprobs,omitempty"`
 	TopP             *float64                   `json:"top_p,omitempty"`
+	ExtraParams      map[string]interface{}     `json:"-"`
+}
+
+func (req *HuggingFaceChatRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 // HuggingFaceToolChoice represents the flexible `tool_choice` field which
@@ -167,16 +172,21 @@ type HuggingFaceErrorDetail struct {
 // HuggingFaceEmbeddingRequest represents the request format for HuggingFace embeddings API
 // Based on the HuggingFace Router API specification
 type HuggingFaceEmbeddingRequest struct {
-	Input               *InputsCustomType `json:"input,omitempty"`    // string or []string used by all inference providers other than hf-inference
-	Inputs              *InputsCustomType `json:"inputs,omitempty"`   // string or []string used by hf-inference provider
-	Provider            *string           `json:"provider,omitempty"` // used by all inference providers other than hf-inference
-	Model               *string           `json:"model,omitempty"`    // used by all inference providers other than hf-inference
-	Normalize           *bool             `json:"normalize,omitempty"`
-	PromptName          *string           `json:"prompt_name,omitempty"`
-	Truncate            *bool             `json:"truncate,omitempty"`
-	TruncationDirection *string           `json:"truncation_direction,omitempty"` // "left" or "right"
-	EncodingFormat      *EncodingType     `json:"encoding_format,omitempty"`
-	Dimensions          *int              `json:"dimensions,omitempty"`
+	Input               *InputsCustomType      `json:"input,omitempty"`    // string or []string used by all inference providers other than hf-inference
+	Inputs              *InputsCustomType      `json:"inputs,omitempty"`   // string or []string used by hf-inference provider
+	Provider            *string                `json:"provider,omitempty"` // used by all inference providers other than hf-inference
+	Model               *string                `json:"model,omitempty"`    // used by all inference providers other than hf-inference
+	Normalize           *bool                  `json:"normalize,omitempty"`
+	PromptName          *string                `json:"prompt_name,omitempty"`
+	Truncate            *bool                  `json:"truncate,omitempty"`
+	TruncationDirection *string                `json:"truncation_direction,omitempty"` // "left" or "right"
+	EncodingFormat      *EncodingType          `json:"encoding_format,omitempty"`
+	Dimensions          *int                   `json:"dimensions,omitempty"`
+	ExtraParams         map[string]interface{} `json:"-"`
+}
+
+func (req *HuggingFaceEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 type InputsCustomType struct {
@@ -235,11 +245,15 @@ const (
 
 // Speech request represents the inputs for Text To Speech inference.
 type HuggingFaceSpeechRequest struct {
-	Text       string                       `json:"text"`
-	Provider   string                       `json:"provider" validate:"required"`
-	Model      string                       `json:"model" validate:"required"`
-	Parameters *HuggingFaceSpeechParameters `json:"parameters,omitempty"`
-	Extra      map[string]any               `json:"-"`
+	Text        string                       `json:"text"`
+	Provider    string                       `json:"provider" validate:"required"`
+	Model       string                       `json:"model" validate:"required"`
+	Parameters  *HuggingFaceSpeechParameters `json:"parameters,omitempty"`
+	ExtraParams map[string]interface{}       `json:"-"`
+}
+
+func (req *HuggingFaceSpeechRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 // Speech parameters are additional inference parameters for Text To Speech
@@ -264,11 +278,16 @@ type HuggingFaceSpeechAudio struct {
 
 // HuggingFaceTranscriptionRequest represents the request for Automatic Speech Recognition inference
 type HuggingFaceTranscriptionRequest struct {
-	Inputs     []byte                                     `json:"inputs,omitempty"`    // raw audio bytes
-	AudioURL   string                                     `json:"audio_url,omitempty"` // URL to audio file only needed for fal ai
-	Provider   *string                                    `json:"provider,omitempty"`
-	Model      *string                                    `json:"model,omitempty"`
-	Parameters *HuggingFaceTranscriptionRequestParameters `json:"parameters,omitempty"`
+	Inputs      []byte                                     `json:"inputs,omitempty"`    // raw audio bytes
+	AudioURL    string                                     `json:"audio_url,omitempty"` // URL to audio file only needed for fal ai
+	Provider    *string                                    `json:"provider,omitempty"`
+	Model       *string                                    `json:"model,omitempty"`
+	Parameters  *HuggingFaceTranscriptionRequestParameters `json:"parameters,omitempty"`
+	ExtraParams map[string]interface{}                     `json:"-"`
+}
+
+func (req *HuggingFaceTranscriptionRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
 }
 
 // HuggingFaceTranscriptionRequestParameters contains additional inference parameters for Automatic Speech Recognition
@@ -353,7 +372,12 @@ type HuggingFaceEarlyStoppingUnion = HuggingFaceTranscriptionEarlyStopping
 
 // HuggingFaceHFInferenceImageGenerationRequest for hf-inference image generation
 type HuggingFaceHFInferenceImageGenerationRequest struct {
-	Inputs string `json:"inputs"`
+	Inputs      string         `json:"inputs"`
+	ExtraParams map[string]any `json:"-"`
+}
+
+func (req *HuggingFaceHFInferenceImageGenerationRequest) GetExtraParams() map[string]any {
+	return req.ExtraParams
 }
 
 // HuggingFaceFalAIImageGenerationRequest for fal-ai image generation
@@ -371,6 +395,11 @@ type HuggingFaceFalAIImageGenerationRequest struct {
 	EnableSafetyChecker   *bool                 `json:"enable_safety_checker,omitempty"`
 	Acceleration          *string               `json:"acceleration,omitempty"`
 	EnablePromptExpansion *bool                 `json:"enable_prompt_expansion,omitempty"`
+	ExtraParams           map[string]any        `json:"-"`
+}
+
+func (req *HuggingFaceFalAIImageGenerationRequest) GetExtraParams() map[string]any {
+	return req.ExtraParams
 }
 
 type HuggingFaceFalAISize struct {
@@ -416,14 +445,19 @@ type FalAITimings struct {
 
 // HuggingFaceTogetherImageGenerationRequest for together image generation
 type HuggingFaceTogetherImageGenerationRequest struct {
-	Prompt         string  `json:"prompt"`
-	Model          string  `json:"model"`
-	ResponseFormat *string `json:"response_format,omitempty"`
-	Size           *string `json:"size,omitempty"`
-	Width          *int    `json:"width,omitempty"`
-	Height         *int    `json:"height,omitempty"`
-	N              *int    `json:"n,omitempty"`
-	Steps          *int    `json:"steps,omitempty"`
+	Prompt         string         `json:"prompt"`
+	Model          string         `json:"model"`
+	ResponseFormat *string        `json:"response_format,omitempty"`
+	Size           *string        `json:"size,omitempty"`
+	Width          *int           `json:"width,omitempty"`
+	Height         *int           `json:"height,omitempty"`
+	N              *int           `json:"n,omitempty"`
+	Steps          *int           `json:"steps,omitempty"`
+	ExtraParams    map[string]any `json:"-"`
+}
+
+func (req *HuggingFaceTogetherImageGenerationRequest) GetExtraParams() map[string]any {
+	return req.ExtraParams
 }
 
 // HuggingFaceTogetherImageGenerationResponse for together image generation
@@ -459,6 +493,11 @@ type HuggingFaceFalAIImageStreamRequest struct {
 	SyncMode              *bool                 `json:"sync_mode,omitempty"`
 	EnableSafetyChecker   *bool                 `json:"enable_safety_checker,omitempty"`
 	OutputFormat          *string               `json:"output_format,omitempty"`
+	ExtraParams           map[string]any        `json:"-"`
+}
+
+func (req *HuggingFaceFalAIImageStreamRequest) GetExtraParams() map[string]any {
+	return req.ExtraParams
 }
 
 // HuggingFaceFalAIImageStreamResponse for fal-ai SSE events
@@ -481,4 +520,9 @@ type HuggingFaceFalAIImageEditRequest struct {
 	OutputFormat        *string               `json:"output_format,omitempty"`
 	EnableSafetyChecker *bool                 `json:"enable_safety_checker,omitempty"`
 	Acceleration        *string               `json:"acceleration,omitempty"`
+	ExtraParams         map[string]any        `json:"-"`
+}
+
+func (req *HuggingFaceFalAIImageEditRequest) GetExtraParams() map[string]any {
+	return req.ExtraParams
 }

--- a/core/providers/nebius/images.go
+++ b/core/providers/nebius/images.go
@@ -61,13 +61,16 @@ func (provider *NebiusProvider) ToNebiusImageGenerationRequest(bifrostReq *schem
 		}
 		// Handle extra params
 		if bifrostReq.Params.ExtraParams != nil {
+			req.ExtraParams = bifrostReq.Params.ExtraParams
 			// Map guidance_scale
 			if v, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["guidance_scale"]); ok {
+				delete(req.ExtraParams, "guidance_scale")
 				req.GuidanceScale = v
 			}
 
 			// Map loras in array format [{"url": "...", "scale": ...}]
 			if lorasValue, exists := bifrostReq.Params.ExtraParams["loras"]; exists && lorasValue != nil {
+				delete(req.ExtraParams, "loras")
 				// Check if lorasValue is an array of maps
 				if lorasArray, ok := lorasValue.([]interface{}); ok {
 					for _, item := range lorasArray {

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -289,7 +289,9 @@ func (provider *NebiusProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return provider.ToNebiusImageGenerationRequest(request) },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return provider.ToNebiusImageGenerationRequest(request)
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr

--- a/core/providers/nebius/types.go
+++ b/core/providers/nebius/types.go
@@ -9,18 +9,24 @@ import (
 
 // NebiusImageGenerationRequest represents a Nebius image generation request
 type NebiusImageGenerationRequest struct {
-	Model             *string      `json:"model"`
-	Prompt            *string      `json:"prompt"`
-	Loras             []NebiusLora `json:"loras,omitempty"`               // List of compatible LoRAs
-	Width             *int         `json:"width,omitempty"`               // Width of output image (64-2048)
-	Height            *int         `json:"height,omitempty"`              // Height of output image (64-2048)
-	NumInferenceSteps *int         `json:"num_inference_steps,omitempty"` // number of denoising steps
-	Seed              *int         `json:"seed,omitempty"`                // seed for image generation
-	GuidanceScale     *int         `json:"guidance_scale,omitempty"`      // 0-100
-	NegativePrompt    *string      `json:"negative_prompt,omitempty"`
-	ResponseExtension *string      `json:"response_extension,omitempty"` // webp, jpg, png
-	ResponseFormat    *string      `json:"response_format,omitempty"`    // b64_json, url
-	Fallbacks         []string     `json:"fallbacks,omitempty"`
+	Model             *string                `json:"model"`
+	Prompt            *string                `json:"prompt"`
+	Loras             []NebiusLora           `json:"loras,omitempty"`               // List of compatible LoRAs
+	Width             *int                   `json:"width,omitempty"`               // Width of output image (64-2048)
+	Height            *int                   `json:"height,omitempty"`              // Height of output image (64-2048)
+	NumInferenceSteps *int                   `json:"num_inference_steps,omitempty"` // number of denoising steps
+	Seed              *int                   `json:"seed,omitempty"`                // seed for image generation
+	GuidanceScale     *int                   `json:"guidance_scale,omitempty"`      // 0-100
+	NegativePrompt    *string                `json:"negative_prompt,omitempty"`
+	ResponseExtension *string                `json:"response_extension,omitempty"` // webp, jpg, png
+	ResponseFormat    *string                `json:"response_format,omitempty"`    // b64_json, url
+	Fallbacks         []string               `json:"fallbacks,omitempty"`
+	ExtraParams       map[string]interface{} `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *NebiusImageGenerationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type NebiusLora struct {

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -38,8 +38,8 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		}
 		// Drop user field if it exceeds OpenAI's 64 character limit
 		openaiReq.ChatParameters.User = SanitizeUserField(openaiReq.ChatParameters.User)
+		openaiReq.ExtraParams = bifrostReq.Params.ExtraParams
 	}
-
 	switch bifrostReq.Provider {
 	case schemas.OpenAI:
 		return openaiReq

--- a/core/providers/openai/embedding.go
+++ b/core/providers/openai/embedding.go
@@ -36,5 +36,8 @@ func ToOpenAIEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Open
 		openaiReq.EmbeddingParameters = *params
 	}
 
+	if bifrostReq.Params != nil {
+		openaiReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 	return openaiReq
 }

--- a/core/providers/openai/images.go
+++ b/core/providers/openai/images.go
@@ -31,6 +31,9 @@ func ToOpenAIImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 	case schemas.OpenAI, schemas.Azure:
 		filterOpenAISpecificParameters(req)
 	}
+	if bifrostReq.Params != nil {
+		req.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 	return req
 }
 
@@ -110,6 +113,10 @@ func ToOpenAIImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Open
 
 	if bifrostReq.Params != nil {
 		req.ImageEditParameters = *bifrostReq.Params
+	}
+
+	if bifrostReq.Params != nil {
+		req.ExtraParams = bifrostReq.Params.ExtraParams
 	}
 
 	return req
@@ -280,6 +287,10 @@ func ToOpenAIImageVariationRequest(bifrostReq *schemas.BifrostImageVariationRequ
 
 	if bifrostReq.Params != nil {
 		req.ImageVariationParameters = *bifrostReq.Params
+	}
+
+	if bifrostReq.Params != nil {
+		req.ExtraParams = bifrostReq.Params.ExtraParams
 	}
 
 	return req

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -266,7 +266,9 @@ func HandleOpenAITextCompletionRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAITextCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAITextCompletionRequest(request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -376,7 +378,7 @@ func HandleOpenAITextCompletionStreaming(
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := ToOpenAITextCompletionRequest(request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)
@@ -692,7 +694,9 @@ func HandleOpenAIChatCompletionRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAIChatRequest(ctx, request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIChatRequest(ctx, request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -791,7 +795,7 @@ func HandleOpenAIChatCompletionStreaming(
 	sendBackRawResponse bool,
 	providerName schemas.ModelProvider,
 	postHookRunner schemas.PostHookRunner,
-	customRequestConverter func(*schemas.BifrostChatRequest) (any, error),
+	customRequestConverter func(*schemas.BifrostChatRequest) (providerUtils.RequestBodyWithExtraParams, error),
 	customErrorConverter ErrorConverter,
 	postRequestConverter func(*OpenAIChatRequest) *OpenAIChatRequest,
 	postResponseConverter func(*schemas.BifrostChatResponse) *schemas.BifrostChatResponse,
@@ -822,7 +826,7 @@ func HandleOpenAIChatCompletionStreaming(
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			if customRequestConverter != nil {
 				return customRequestConverter(request)
 			}
@@ -1216,7 +1220,9 @@ func HandleOpenAIResponsesRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAIResponsesRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIResponsesRequest(request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1332,7 +1338,7 @@ func HandleOpenAIResponsesStreaming(
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := ToOpenAIResponsesRequest(request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)
@@ -1597,7 +1603,9 @@ func HandleOpenAIEmbeddingRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAIEmbeddingRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIEmbeddingRequest(request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1703,7 +1711,7 @@ func HandleOpenAISpeechRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAISpeechRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) { return ToOpenAISpeechRequest(request), nil },
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -1835,7 +1843,7 @@ func HandleOpenAISpeechStreamRequest(
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			reqBody := ToOpenAISpeechRequest(request)
 			if reqBody != nil {
 				reqBody.StreamFormat = schemas.Ptr("sse")
@@ -2445,7 +2453,9 @@ func HandleOpenAIImageGenerationRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAIImageGenerationRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIImageGenerationRequest(request), nil
+		},
 		providerName)
 	if bifrostErr != nil {
 		return nil, bifrostErr
@@ -2549,7 +2559,7 @@ func HandleOpenAIImageGenerationStreaming(
 	sendBackRawResponse bool,
 	providerName schemas.ModelProvider,
 	postHookRunner schemas.PostHookRunner,
-	customRequestConverter func(*schemas.BifrostImageGenerationRequest) (any, error),
+	customRequestConverter func(*schemas.BifrostImageGenerationRequest) (providerUtils.RequestBodyWithExtraParams, error),
 	postRequestConverter func(*OpenAIImageGenerationRequest) *OpenAIImageGenerationRequest,
 	postResponseConverter func(*schemas.BifrostImageGenerationStreamResponse) *schemas.BifrostImageGenerationStreamResponse,
 	logger schemas.Logger,
@@ -2570,7 +2580,7 @@ func HandleOpenAIImageGenerationStreaming(
 	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) {
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			if customRequestConverter != nil {
 				return customRequestConverter(request)
 			}
@@ -2956,7 +2966,9 @@ func HandleOpenAICountTokensRequest(
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToOpenAIResponsesRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIResponsesRequest(request), nil
+		},
 		providerName,
 	)
 	if bifrostErr != nil {
@@ -3148,7 +3160,7 @@ func HandleOpenAIImageEditStreamRequest(
 	sendBackRawResponse bool,
 	providerName schemas.ModelProvider,
 	postHookRunner schemas.PostHookRunner,
-	customRequestConverter func(*schemas.BifrostImageEditRequest) (any, error),
+	customRequestConverter func(*schemas.BifrostImageEditRequest) (providerUtils.RequestBodyWithExtraParams, error),
 	postRequestConverter func(*OpenAIImageEditRequest) *OpenAIImageEditRequest,
 	postResponseConverter func(*schemas.BifrostImageGenerationStreamResponse) *schemas.BifrostImageGenerationStreamResponse,
 	logger schemas.Logger,

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -167,6 +167,9 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 		req.filterUnsupportedTools()
 	}
 
+	if bifrostReq.Params != nil {
+		req.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 	return req
 }
 

--- a/core/providers/openai/speech.go
+++ b/core/providers/openai/speech.go
@@ -36,5 +36,8 @@ func ToOpenAISpeechRequest(bifrostReq *schemas.BifrostSpeechRequest) *OpenAISpee
 		openaiReq.SpeechParameters = *params
 	}
 
+	if bifrostReq.Params != nil {
+		openaiReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 	return openaiReq
 }

--- a/core/providers/openai/text.go
+++ b/core/providers/openai/text.go
@@ -20,6 +20,9 @@ func ToOpenAITextCompletionRequest(bifrostReq *schemas.BifrostTextCompletionRequ
 		// Drop user field if it exceeds OpenAI's 64 character limit
 		openaiReq.TextCompletionParameters.User = SanitizeUserField(openaiReq.TextCompletionParameters.User)
 	}
+	if bifrostReq.Params != nil {
+		openaiReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 	return openaiReq
 }
 

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -25,7 +25,12 @@ type OpenAITextCompletionRequest struct {
 	Stream *bool `json:"stream,omitempty"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAITextCompletionRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -41,7 +46,12 @@ type OpenAIEmbeddingRequest struct {
 	schemas.EmbeddingParameters
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAIEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // OpenAIChatRequest represents an OpenAI chat completion request
@@ -57,7 +67,12 @@ type OpenAIChatRequest struct {
 	MaxTokens *int `json:"max_tokens,omitempty"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAIChatRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type OpenAIMessage struct {
@@ -516,6 +531,10 @@ func filterSupportedAnnotations(annotations []schemas.ResponsesOutputMessageCont
 	return supportedAnnotations
 }
 
+func (r *OpenAIResponsesRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
 type OpenAIResponsesRequest struct {
 	Model string                      `json:"model"`
 	Input OpenAIResponsesRequestInput `json:"input"`
@@ -524,7 +543,8 @@ type OpenAIResponsesRequest struct {
 	Stream *bool `json:"stream,omitempty"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
 }
 
 // MarshalJSON implements custom JSON marshalling for OpenAIResponsesRequest.
@@ -613,7 +633,12 @@ type OpenAISpeechRequest struct {
 	StreamFormat *string `json:"stream_format,omitempty"`
 
 	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAISpeechRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // OpenAITranscriptionRequest represents an OpenAI transcription request
@@ -666,6 +691,13 @@ type OpenAIImageGenerationRequest struct {
 
 	Stream    *bool    `json:"stream,omitempty"`
 	Fallbacks []string `json:"fallbacks,omitempty"`
+
+	// Bifrost specific field (only parsed when converting from Provider -> Bifrost request)
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAIImageGenerationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -702,18 +734,28 @@ type OpenAIImageEditRequest struct {
 
 	schemas.ImageEditParameters
 
-	Stream    *bool    `json:"stream,omitempty"`
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Stream      *bool                  `json:"stream,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAIImageEditRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // OpenAIImageVariationRequest is the struct for Image Variation requests in OpenAI format.
 type OpenAIImageVariationRequest struct {
-	Model string                      `json:"model"`
+	Model string                       `json:"model"`
 	Input *schemas.ImageVariationInput `json:"input"`
 
 	schemas.ImageVariationParameters
 
-	Fallbacks []string `json:"fallbacks,omitempty"`
+	Fallbacks   []string               `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{} `json:"-"` // Optional: Extra parameters
+}
+
+func (r *OpenAIImageVariationRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // IsStreamingRequested implements the StreamingRequest interface

--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -37,60 +37,75 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 
 		// Handle extra parameters for Perplexity-specific fields
 		if bifrostReq.Params.ExtraParams != nil {
+			perplexityReq.ExtraParams = bifrostReq.Params.ExtraParams
 			// Search-related parameters
 			if searchMode, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_mode"]); ok {
+				delete(perplexityReq.ExtraParams, "search_mode")
 				perplexityReq.SearchMode = searchMode
 			}
 
 			if languagePreference, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["language_preference"]); ok {
+				delete(perplexityReq.ExtraParams, "language_preference")
 				perplexityReq.LanguagePreference = languagePreference
 			}
 
 			if searchDomainFilter, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["search_domain_filter"]); ok {
+				delete(perplexityReq.ExtraParams, "search_domain_filter")
 				perplexityReq.SearchDomainFilter = searchDomainFilter
 			}
 
 			if returnImages, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_images"]); ok {
+				delete(perplexityReq.ExtraParams, "return_images")
 				perplexityReq.ReturnImages = returnImages
 			}
 
 			if returnRelatedQuestions, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["return_related_questions"]); ok {
+				delete(perplexityReq.ExtraParams, "return_related_questions")
 				perplexityReq.ReturnRelatedQuestions = returnRelatedQuestions
 			}
 
 			if searchRecencyFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_recency_filter"]); ok {
+				delete(perplexityReq.ExtraParams, "search_recency_filter")
 				perplexityReq.SearchRecencyFilter = searchRecencyFilter
 			}
 
 			if searchAfterDateFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_after_date_filter"]); ok {
+				delete(perplexityReq.ExtraParams, "search_after_date_filter")
 				perplexityReq.SearchAfterDateFilter = searchAfterDateFilter
 			}
 
 			if searchBeforeDateFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["search_before_date_filter"]); ok {
+				delete(perplexityReq.ExtraParams, "search_before_date_filter")
 				perplexityReq.SearchBeforeDateFilter = searchBeforeDateFilter
 			}
 
 			if lastUpdatedAfterFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["last_updated_after_filter"]); ok {
+				delete(perplexityReq.ExtraParams, "last_updated_after_filter")
 				perplexityReq.LastUpdatedAfterFilter = lastUpdatedAfterFilter
 			}
 
 			if lastUpdatedBeforeFilter, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["last_updated_before_filter"]); ok {
+				delete(perplexityReq.ExtraParams, "last_updated_before_filter")
 				perplexityReq.LastUpdatedBeforeFilter = lastUpdatedBeforeFilter
 			}
 
 			if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
+				delete(perplexityReq.ExtraParams, "top_k")
 				perplexityReq.TopK = topK
 			}
 
 			if stream, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["stream"]); ok {
+				delete(perplexityReq.ExtraParams, "stream")
 				perplexityReq.Stream = stream
 			}
 
 			if disableSearch, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["disable_search"]); ok {
+				delete(perplexityReq.ExtraParams, "disable_search")
 				perplexityReq.DisableSearch = disableSearch
 			}
 
 			if enableSearchClassifier, ok := schemas.SafeExtractBoolPointer(bifrostReq.Params.ExtraParams["enable_search_classifier"]); ok {
+				delete(perplexityReq.ExtraParams, "enable_search_classifier")
 				perplexityReq.EnableSearchClassifier = enableSearchClassifier
 			}
 
@@ -98,15 +113,18 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 			if webSearchOptionsParam, ok := schemas.SafeExtractFromMap(bifrostReq.Params.ExtraParams, "web_search_options"); ok {
 				if webSearchOptionsSlice, ok := webSearchOptionsParam.([]interface{}); ok {
 					var webSearchOptions []WebSearchOption
+					updatedWebSearchOptionsSlice := make([]interface{}, 0, len(webSearchOptionsSlice))
 					for _, optionInterface := range webSearchOptionsSlice {
 						if optionMap, ok := optionInterface.(map[string]interface{}); ok {
 							option := WebSearchOption{}
 
 							if searchContextSize, ok := schemas.SafeExtractStringPointer(optionMap["search_context_size"]); ok {
+								delete(optionMap, "search_context_size")
 								option.SearchContextSize = searchContextSize
 							}
 
 							if imageSearchRelevanceEnhanced, ok := schemas.SafeExtractBoolPointer(optionMap["image_search_relevance_enhanced"]); ok {
+								delete(optionMap, "image_search_relevance_enhanced")
 								option.ImageSearchRelevanceEnhanced = imageSearchRelevanceEnhanced
 							}
 
@@ -116,29 +134,50 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 									userLocation := &WebSearchOptionUserLocation{}
 
 									if latitude, ok := schemas.SafeExtractFloat64Pointer(userLocationMap["latitude"]); ok {
+										delete(userLocationMap, "latitude")
 										userLocation.Latitude = latitude
 									}
 									if longitude, ok := schemas.SafeExtractFloat64Pointer(userLocationMap["longitude"]); ok {
+										delete(userLocationMap, "longitude")
 										userLocation.Longitude = longitude
 									}
 									if city, ok := schemas.SafeExtractStringPointer(userLocationMap["city"]); ok {
+										delete(userLocationMap, "city")
 										userLocation.City = city
 									}
 									if country, ok := schemas.SafeExtractStringPointer(userLocationMap["country"]); ok {
+										delete(userLocationMap, "country")
 										userLocation.Country = country
 									}
 									if region, ok := schemas.SafeExtractStringPointer(userLocationMap["region"]); ok {
+										delete(userLocationMap, "region")
 										userLocation.Region = region
 									}
-
+									if len(userLocationMap) == 0 {
+										delete(optionMap, "user_location")
+									} else {
+										optionMap["user_location"] = userLocationMap
+									}
 									option.UserLocation = userLocation
 								}
 							}
-
 							webSearchOptions = append(webSearchOptions, option)
+							// Persist remaining custom fields from optionMap back to ExtraParams
+							if len(optionMap) > 0 {
+								updatedWebSearchOptionsSlice = append(updatedWebSearchOptionsSlice, optionMap)
+							}
+						} else {
+							// Preserve non-map entries as-is
+							updatedWebSearchOptionsSlice = append(updatedWebSearchOptionsSlice, optionInterface)
 						}
 					}
 					perplexityReq.WebSearchOptions = webSearchOptions
+					// Put remaining custom fields back into ExtraParams
+					if len(updatedWebSearchOptionsSlice) > 0 {
+						perplexityReq.ExtraParams["web_search_options"] = updatedWebSearchOptionsSlice
+					} else {
+						delete(perplexityReq.ExtraParams, "web_search_options")
+					}
 				}
 			}
 
@@ -152,16 +191,23 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 							overrides := MediaResponseOverrides{}
 
 							if returnVideos, ok := schemas.SafeExtractBoolPointer(overridesMap["return_videos"]); ok {
+								delete(overridesMap, "return_videos")
 								overrides.ReturnVideos = returnVideos
 							}
 							if returnImages, ok := schemas.SafeExtractBoolPointer(overridesMap["return_images"]); ok {
+								delete(overridesMap, "return_images")
 								overrides.ReturnImages = returnImages
 							}
-
+							// Put remaining overridesMap fields back into mediaResponseMap at correct nested location
+							if len(overridesMap) > 0 {
+								mediaResponseMap["overrides"] = overridesMap
+							} else {
+								delete(mediaResponseMap, "overrides")
+							}
 							mediaResponse.Overrides = overrides
 						}
 					}
-
+					perplexityReq.ExtraParams["media_response"] = mediaResponseMap
 					perplexityReq.MediaResponse = mediaResponse
 				}
 			}

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -129,7 +129,9 @@ func (provider *PerplexityProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 	jsonBody, err := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
-		func() (any, error) { return ToPerplexityChatCompletionRequest(request), nil },
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToPerplexityChatCompletionRequest(request), nil
+		},
 		provider.GetProviderKey())
 	if err != nil {
 		return nil, err
@@ -176,7 +178,7 @@ func (provider *PerplexityProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
 	}
-	customRequestConverter := func(request *schemas.BifrostChatRequest) (any, error) {
+	customRequestConverter := func(request *schemas.BifrostChatRequest) (providerUtils.RequestBodyWithExtraParams, error) {
 		reqBody := ToPerplexityChatCompletionRequest(request)
 		reqBody.Stream = schemas.Ptr(true)
 		return reqBody, nil

--- a/core/providers/perplexity/perplexity_test.go
+++ b/core/providers/perplexity/perplexity_test.go
@@ -28,22 +28,23 @@ func TestPerplexity(t *testing.T) {
 		TextModel:      "", // Perplexity doesn't support text completion
 		EmbeddingModel: "", // Perplexity doesn't support embedding
 		Scenarios: llmtests.TestScenarios{
-			TextCompletion:        false, // Not supported
-			SimpleChat:            true,
-			CompletionStream:      true,
-			MultiTurnConversation: true,
-			ToolCalls:             false,
-			MultipleToolCalls:     false,
-			End2EndToolCalling:    false,
-			AutomaticFunctionCall: false,
-			ImageURL:              false, // Not supported yet
-			ImageBase64:           false, // Not supported yet
-			MultipleImages:        false, // Not supported yet
-			CompleteEnd2End:       false,
-			FileBase64:            false,
-			FileURL:               false,
-			Embedding:             false, // Not supported yet
-			ListModels:            false,
+			TextCompletion:         false, // Not supported
+			SimpleChat:             true,
+			CompletionStream:       true,
+			MultiTurnConversation:  true,
+			ToolCalls:              false,
+			MultipleToolCalls:      false,
+			End2EndToolCalling:     false,
+			AutomaticFunctionCall:  false,
+			ImageURL:               false, // Not supported yet
+			ImageBase64:            false, // Not supported yet
+			MultipleImages:         false, // Not supported yet
+			CompleteEnd2End:        false,
+			FileBase64:             false,
+			FileURL:                false,
+			Embedding:              false, // Not supported yet
+			ListModels:             false,
+			PassThroughExtraParams: true,
 		},
 	}
 

--- a/core/providers/perplexity/types.go
+++ b/core/providers/perplexity/types.go
@@ -4,31 +4,37 @@ import "github.com/maximhq/bifrost/core/schemas"
 
 // PerplexityChatRequest represents a Perplexity chat completion request
 type PerplexityChatRequest struct {
-	Model                   string                `json:"model"`                                // Required: Model to use for chat completion
-	Messages                []schemas.ChatMessage `json:"messages"`                             // Required: Array of message objects
-	SearchMode              *string               `json:"search_mode"`                          // Required: Search mode
-	ReasoningEffort         *string               `json:"reasoning_effort"`                     // Required: Reasoning effort (low, medium, high)
-	MaxTokens               *int                  `json:"max_tokens,omitempty"`                 // Optional: Maximum tokens to generate
-	Temperature             *float64              `json:"temperature,omitempty"`                // Optional: Sampling temperature
-	TopP                    *float64              `json:"top_p,omitempty"`                      // Optional: Top-p sampling
-	LanguagePreference      *string               `json:"language_preference,omitempty"`        // Optional: Language preference
-	SearchDomainFilter      []string              `json:"search_domain_filter,omitempty"`       // Optional: Search domain filter
-	ReturnImages            *bool                 `json:"return_images,omitempty"`              // Optional: Return images
-	ReturnRelatedQuestions  *bool                 `json:"return_related_questions,omitempty"`   // Optional: Return related questions
-	SearchRecencyFilter     *string               `json:"search_recency_filter,omitempty"`      // Optional: Search recency filter
-	SearchAfterDateFilter   *string               `json:"search_after_date_filter,omitempty"`   // Optional: Search after date filter
-	SearchBeforeDateFilter  *string               `json:"search_before_date_filter,omitempty"`  // Optional: Search before date filter
-	LastUpdatedAfterFilter  *string               `json:"last_updated_after_filter,omitempty"`  // Optional: Last updated after filter
-	LastUpdatedBeforeFilter *string               `json:"last_updated_before_filter,omitempty"` // Optional: Last updated before filter
-	TopK                    *int                  `json:"top_k,omitempty"`                      // Optional: Top-k sampling
-	Stream                  *bool                 `json:"stream,omitempty"`                     // Optional: Enable streaming
-	PresencePenalty         *float64              `json:"presence_penalty,omitempty"`           // Optional: Presence penalty
-	FrequencyPenalty        *float64              `json:"frequency_penalty,omitempty"`          // Optional: Frequency penalty
-	ResponseFormat          *interface{}          `json:"response_format,omitempty"`            // Format for the response
-	DisableSearch           *bool                 `json:"disable_search,omitempty"`             // Optional: Disable search
-	EnableSearchClassifier  *bool                 `json:"enable_search_classifier,omitempty"`   // Optional: Enable search classifier
-	WebSearchOptions        []WebSearchOption     `json:"web_search_options,omitempty"`         // Optional: Web search options
-	MediaResponse           *MediaResponse        `json:"media_response,omitempty"`             // Optional: Media response
+	Model                   string                 `json:"model"`                                // Required: Model to use for chat completion
+	Messages                []schemas.ChatMessage  `json:"messages"`                             // Required: Array of message objects
+	SearchMode              *string                `json:"search_mode"`                          // Required: Search mode
+	ReasoningEffort         *string                `json:"reasoning_effort"`                     // Required: Reasoning effort (low, medium, high)
+	MaxTokens               *int                   `json:"max_tokens,omitempty"`                 // Optional: Maximum tokens to generate
+	Temperature             *float64               `json:"temperature,omitempty"`                // Optional: Sampling temperature
+	TopP                    *float64               `json:"top_p,omitempty"`                      // Optional: Top-p sampling
+	LanguagePreference      *string                `json:"language_preference,omitempty"`        // Optional: Language preference
+	SearchDomainFilter      []string               `json:"search_domain_filter,omitempty"`       // Optional: Search domain filter
+	ReturnImages            *bool                  `json:"return_images,omitempty"`              // Optional: Return images
+	ReturnRelatedQuestions  *bool                  `json:"return_related_questions,omitempty"`   // Optional: Return related questions
+	SearchRecencyFilter     *string                `json:"search_recency_filter,omitempty"`      // Optional: Search recency filter
+	SearchAfterDateFilter   *string                `json:"search_after_date_filter,omitempty"`   // Optional: Search after date filter
+	SearchBeforeDateFilter  *string                `json:"search_before_date_filter,omitempty"`  // Optional: Search before date filter
+	LastUpdatedAfterFilter  *string                `json:"last_updated_after_filter,omitempty"`  // Optional: Last updated after filter
+	LastUpdatedBeforeFilter *string                `json:"last_updated_before_filter,omitempty"` // Optional: Last updated before filter
+	TopK                    *int                   `json:"top_k,omitempty"`                      // Optional: Top-k sampling
+	Stream                  *bool                  `json:"stream,omitempty"`                     // Optional: Enable streaming
+	PresencePenalty         *float64               `json:"presence_penalty,omitempty"`           // Optional: Presence penalty
+	FrequencyPenalty        *float64               `json:"frequency_penalty,omitempty"`          // Optional: Frequency penalty
+	ResponseFormat          *interface{}           `json:"response_format,omitempty"`            // Format for the response
+	DisableSearch           *bool                  `json:"disable_search,omitempty"`             // Optional: Disable search
+	EnableSearchClassifier  *bool                  `json:"enable_search_classifier,omitempty"`   // Optional: Enable search classifier
+	WebSearchOptions        []WebSearchOption      `json:"web_search_options,omitempty"`         // Optional: Web search options
+	MediaResponse           *MediaResponse         `json:"media_response,omitempty"`             // Optional: Media response
+	ExtraParams             map[string]interface{} `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (r *PerplexityChatRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 type WebSearchOption struct {

--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -9,7 +9,11 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 	if bifrostReq == nil || bifrostReq.Input == nil || (bifrostReq.Input.Text == nil && bifrostReq.Input.Texts == nil) {
 		return nil
 	}
-
+	// Create the request
+	vertexReq := &VertexEmbeddingRequest{}
+	if bifrostReq.Params != nil {
+		vertexReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
 	var texts []string
 	if bifrostReq.Input.Text != nil {
 		texts = []string{*bifrostReq.Input.Text}
@@ -27,21 +31,18 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 		// Add optional task_type and title from params
 		if bifrostReq.Params != nil {
 			if taskTypeStr, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["task_type"]); ok {
+				delete(vertexReq.ExtraParams, "task_type")
 				instance.TaskType = taskTypeStr
 			}
 			if title, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["title"]); ok {
+				delete(vertexReq.ExtraParams, "title")
 				instance.Title = title
 			}
 		}
 
 		instances = append(instances, instance)
 	}
-
-	// Create the request
-	vertexReq := &VertexEmbeddingRequest{
-		Instances: instances,
-	}
-
+	vertexReq.Instances = instances
 	// Add parameters if present
 	if bifrostReq.Params != nil {
 		parameters := &VertexEmbeddingParameters{}
@@ -50,6 +51,7 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 		autoTruncate := true
 		if bifrostReq.Params.ExtraParams != nil {
 			if autoTruncateVal, ok := schemas.SafeExtractBool(bifrostReq.Params.ExtraParams["autoTruncate"]); ok {
+				delete(vertexReq.ExtraParams, "autoTruncate")
 				autoTruncate = autoTruncateVal
 			}
 		}
@@ -57,6 +59,7 @@ func ToVertexEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) *Vert
 
 		// Add outputDimensionality if specified
 		if bifrostReq.Params.Dimensions != nil {
+			delete(vertexReq.ExtraParams, "dimensions")
 			parameters.OutputDimensionality = bifrostReq.Params.Dimensions
 		}
 

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -1,6 +1,10 @@
 package vertex
 
-import "time"
+import (
+	"time"
+
+	"github.com/bytedance/sonic"
+)
 
 // Vertex AI Embedding API types
 
@@ -69,6 +73,21 @@ type VertexAudioConfig struct {
 	EffectsProfileID []string `json:"effectsProfileId,omitempty"`
 }
 
+type VertexRequestBody struct {
+	RequestBody map[string]interface{} `json:"-"`
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+func (r *VertexRequestBody) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
+// MarshalJSON implements custom JSON marshalling for VertexRequestBody.
+// It marshals the RequestBody field directly without wrapping.
+func (r *VertexRequestBody) MarshalJSON() ([]byte, error) {
+	return sonic.Marshal(r.RequestBody)
+}
+
 // VertexAdvancedVoiceOptions represents advanced voice options for TTS synthesis.
 type VertexAdvancedVoiceOptions struct {
 	LowLatencyJourneySynthesis bool `json:"lowLatencyJourneySynthesis,omitempty"`
@@ -89,8 +108,13 @@ type VertexEmbeddingParameters struct {
 
 // VertexEmbeddingRequest represents the complete embedding request to Vertex AI
 type VertexEmbeddingRequest struct {
-	Instances  []VertexEmbeddingInstance  `json:"instances"`            // List of embedding instances
-	Parameters *VertexEmbeddingParameters `json:"parameters,omitempty"` // Optional parameters
+	Instances   []VertexEmbeddingInstance  `json:"instances"`            // List of embedding instances
+	Parameters  *VertexEmbeddingParameters `json:"parameters,omitempty"` // Optional parameters
+	ExtraParams map[string]interface{}     `json:"-"`                    // Optional: Extra parameters
+}
+
+func (r *VertexEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
 }
 
 // VertexEmbeddingStatistics represents statistics computed from the input text

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -183,6 +183,7 @@ const (
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -32,6 +32,7 @@ type BifrostChatResponse struct {
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`
 	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
+	ExtraParams       map[string]interface{}     `json:"-"`
 
 	// Perplexity-specific fields
 	SearchResults []SearchResult `json:"search_results,omitempty"`
@@ -152,34 +153,34 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 
 // ChatParameters represents the parameters for a chat completion.
 type ChatParameters struct {
-	Audio               *ChatAudioParameters `json:"audio,omitempty"`                 // Audio parameters
-	FrequencyPenalty    *float64             `json:"frequency_penalty,omitempty"`     // Penalizes frequent tokens
-	LogitBias           *map[string]float64  `json:"logit_bias,omitempty"`            // Bias for logit values
-	LogProbs            *bool                `json:"logprobs,omitempty"`              // Number of logprobs to return
-	MaxCompletionTokens *int                 `json:"max_completion_tokens,omitempty"` // Maximum number of tokens to generate
-	Metadata            *map[string]any      `json:"metadata,omitempty"`              // Metadata to be returned with the response
-	Modalities          []string             `json:"modalities,omitempty"`            // Modalities to be returned with the response
-	ParallelToolCalls   *bool                `json:"parallel_tool_calls,omitempty"`
-	Prediction          *ChatPrediction      `json:"prediction,omitempty"`        // Predicted output content (OpenAI only)
-	PresencePenalty     *float64             `json:"presence_penalty,omitempty"`  // Penalizes repeated tokens
-	PromptCacheKey      *string              `json:"prompt_cache_key,omitempty"`  // Prompt cache key
-	PromptCacheRetention *string             `json:"prompt_cache_retention,omitempty"` // Prompt cache retention ("in-memory" or "24h")
-	Reasoning           *ChatReasoning       `json:"reasoning,omitempty"`         // Reasoning parameters
-	ResponseFormat      *interface{}         `json:"response_format,omitempty"`   // Format for the response
-	SafetyIdentifier    *string              `json:"safety_identifier,omitempty"` // Safety identifier
-	Seed                *int                 `json:"seed,omitempty"`
-	ServiceTier         *string              `json:"service_tier,omitempty"`
-	StreamOptions       *ChatStreamOptions   `json:"stream_options,omitempty"`
-	Stop                []string             `json:"stop,omitempty"`
-	Store               *bool                `json:"store,omitempty"`
-	Temperature         *float64             `json:"temperature,omitempty"`
-	TopLogProbs         *int                 `json:"top_logprobs,omitempty"`
-	TopP                *float64             `json:"top_p,omitempty"`       // Controls diversity via nucleus sampling
-	ToolChoice          *ChatToolChoice      `json:"tool_choice,omitempty"` // Whether to call a tool
-	Tools               []ChatTool           `json:"tools,omitempty"`       // Tools to use
-	User                *string              `json:"user,omitempty"`        // User identifier for tracking
-	Verbosity           *string              `json:"verbosity,omitempty"`   // "low" | "medium" | "high"
-	WebSearchOptions    *ChatWebSearchOptions `json:"web_search_options,omitempty"` // Web search options (OpenAI only)
+	Audio                *ChatAudioParameters  `json:"audio,omitempty"`                 // Audio parameters
+	FrequencyPenalty     *float64              `json:"frequency_penalty,omitempty"`     // Penalizes frequent tokens
+	LogitBias            *map[string]float64   `json:"logit_bias,omitempty"`            // Bias for logit values
+	LogProbs             *bool                 `json:"logprobs,omitempty"`              // Number of logprobs to return
+	MaxCompletionTokens  *int                  `json:"max_completion_tokens,omitempty"` // Maximum number of tokens to generate
+	Metadata             *map[string]any       `json:"metadata,omitempty"`              // Metadata to be returned with the response
+	Modalities           []string              `json:"modalities,omitempty"`            // Modalities to be returned with the response
+	ParallelToolCalls    *bool                 `json:"parallel_tool_calls,omitempty"`
+	Prediction           *ChatPrediction       `json:"prediction,omitempty"`             // Predicted output content (OpenAI only)
+	PresencePenalty      *float64              `json:"presence_penalty,omitempty"`       // Penalizes repeated tokens
+	PromptCacheKey       *string               `json:"prompt_cache_key,omitempty"`       // Prompt cache key
+	PromptCacheRetention *string               `json:"prompt_cache_retention,omitempty"` // Prompt cache retention ("in-memory" or "24h")
+	Reasoning            *ChatReasoning        `json:"reasoning,omitempty"`              // Reasoning parameters
+	ResponseFormat       *interface{}          `json:"response_format,omitempty"`        // Format for the response
+	SafetyIdentifier     *string               `json:"safety_identifier,omitempty"`      // Safety identifier
+	Seed                 *int                  `json:"seed,omitempty"`
+	ServiceTier          *string               `json:"service_tier,omitempty"`
+	StreamOptions        *ChatStreamOptions    `json:"stream_options,omitempty"`
+	Stop                 []string              `json:"stop,omitempty"`
+	Store                *bool                 `json:"store,omitempty"`
+	Temperature          *float64              `json:"temperature,omitempty"`
+	TopLogProbs          *int                  `json:"top_logprobs,omitempty"`
+	TopP                 *float64              `json:"top_p,omitempty"`              // Controls diversity via nucleus sampling
+	ToolChoice           *ChatToolChoice       `json:"tool_choice,omitempty"`        // Whether to call a tool
+	Tools                []ChatTool            `json:"tools,omitempty"`              // Tools to use
+	User                 *string               `json:"user,omitempty"`               // User identifier for tracking
+	Verbosity            *string               `json:"verbosity,omitempty"`          // "low" | "medium" | "high"
+	WebSearchOptions     *ChatWebSearchOptions `json:"web_search_options,omitempty"` // Web search options (OpenAI only)
 
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
@@ -252,7 +253,7 @@ type ChatPrediction struct {
 
 // ChatWebSearchOptions represents web search options for chat completions (OpenAI only).
 type ChatWebSearchOptions struct {
-	SearchContextSize *string                          `json:"search_context_size,omitempty"` // "low" | "medium" | "high"
+	SearchContextSize *string                           `json:"search_context_size,omitempty"` // "low" | "medium" | "high"
 	UserLocation      *ChatWebSearchOptionsUserLocation `json:"user_location,omitempty"`
 }
 

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -349,6 +349,13 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, hea
 			}
 			return true
 		}
+		// Add passthrough extra params header support
+		if keyStr == "x-bf-passthrough-extra-params" {
+			if valueStr := string(value); valueStr == "true" {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+			}
+			return true
+		}
 		return true
 	})
 


### PR DESCRIPTION
## Summary

Implement proper handling of extra parameters in provider requests, allowing for passthrough of custom parameters while maintaining clean request objects.

## Issue

Closes #1457 

## Changes

- Added `RequestBodyWithExtraParams` interface to standardize handling of extra parameters
- Implemented the interface across all providers (Anthropic, Azure, Bedrock, Cohere, Elevenlabs, Gemini, HuggingFace, Nebius, OpenAI, Perplexity, Vertex)
- Added proper cleanup of known parameters from `ExtraParams` to avoid duplication
- Added support for passing through remaining extra parameters when enabled via context
- Added `BifrostContextKeyPassthroughExtraParams` context key to control parameter passthrough

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test that extra parameters are properly handled by each provider:

```sh
# Core/Transports
go version
go test ./...
```

You can also test with API calls that include extra parameters in the request, with and without the passthrough context key set.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves handling of provider-specific parameters and enables cleaner passthrough of custom parameters.

## Security considerations

This change improves parameter handling but doesn't introduce new security concerns as it only affects how existing parameters are processed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable