### PR TITLE
adds missing openai fields

### DIFF
--- a/core/providers/openai/batch.go
+++ b/core/providers/openai/batch.go
@@ -10,10 +10,11 @@ import (
 
 // OpenAIBatchRequest represents the request body for creating a batch.
 type OpenAIBatchRequest struct {
-	InputFileID      string            `json:"input_file_id"`
-	Endpoint         string            `json:"endpoint"`
-	CompletionWindow string            `json:"completion_window"`
-	Metadata         map[string]string `json:"metadata,omitempty"`
+	InputFileID        string                    `json:"input_file_id"`
+	Endpoint           string                    `json:"endpoint"`
+	CompletionWindow   string                    `json:"completion_window"`
+	Metadata           map[string]string         `json:"metadata,omitempty"`
+	OutputExpiresAfter *schemas.BatchExpiresAfter `json:"output_expires_after,omitempty"`
 }
 
 // OpenAIBatchResponse represents an OpenAI batch response.

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -102,14 +102,23 @@ func (request *OpenAIChatRequest) filterOpenAISpecificParameters() {
 		}
 	}
 
+	if request.ChatParameters.Prediction != nil {
+		request.ChatParameters.Prediction = nil
+	}
 	if request.ChatParameters.PromptCacheKey != nil {
 		request.ChatParameters.PromptCacheKey = nil
+	}
+	if request.ChatParameters.PromptCacheRetention != nil {
+		request.ChatParameters.PromptCacheRetention = nil
 	}
 	if request.ChatParameters.Verbosity != nil {
 		request.ChatParameters.Verbosity = nil
 	}
 	if request.ChatParameters.Store != nil {
 		request.ChatParameters.Store = nil
+	}
+	if request.ChatParameters.WebSearchOptions != nil {
+		request.ChatParameters.WebSearchOptions = nil
 	}
 }
 

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -3608,6 +3608,16 @@ func (provider *OpenAIProvider) FileUpload(ctx *schemas.BifrostContext, key sche
 		return nil, providerUtils.NewBifrostOperationError("failed to write purpose field", err, providerName)
 	}
 
+	// Add expires_after fields if provided
+	if request.ExpiresAfter != nil {
+		if err := writer.WriteField("expires_after[anchor]", request.ExpiresAfter.Anchor); err != nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to write expires_after[anchor] field", err, providerName)
+		}
+		if err := writer.WriteField("expires_after[seconds]", fmt.Sprintf("%d", request.ExpiresAfter.Seconds)); err != nil {
+			return nil, providerUtils.NewBifrostOperationError("failed to write expires_after[seconds] field", err, providerName)
+		}
+	}
+
 	// Add file field
 	filename := request.Filename
 	if filename == "" {
@@ -4108,10 +4118,11 @@ func (provider *OpenAIProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 
 	// Build request body
 	openAIReq := &OpenAIBatchRequest{
-		InputFileID:      inputFileID,
-		Endpoint:         string(request.Endpoint),
-		CompletionWindow: request.CompletionWindow,
-		Metadata:         request.Metadata,
+		InputFileID:        inputFileID,
+		Endpoint:           string(request.Endpoint),
+		CompletionWindow:   request.CompletionWindow,
+		Metadata:           request.Metadata,
+		OutputExpiresAfter: request.OutputExpiresAfter,
 	}
 
 	// Set default completion window if not provided

--- a/core/providers/openai/transcription.go
+++ b/core/providers/openai/transcription.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"fmt"
 	"mime/multipart"
 
 	"github.com/maximhq/bifrost/core/providers/utils"
@@ -75,6 +76,24 @@ func parseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, openaiR
 	if openaiReq.ResponseFormat != nil {
 		if err := writer.WriteField("response_format", *openaiReq.ResponseFormat); err != nil {
 			return utils.NewBifrostOperationError("failed to write response_format field", err, providerName)
+		}
+	}
+
+	if openaiReq.Temperature != nil {
+		if err := writer.WriteField("temperature", fmt.Sprintf("%g", *openaiReq.Temperature)); err != nil {
+			return utils.NewBifrostOperationError("failed to write temperature field", err, providerName)
+		}
+	}
+
+	for _, granularity := range openaiReq.TimestampGranularities {
+		if err := writer.WriteField("timestamp_granularities[]", granularity); err != nil {
+			return utils.NewBifrostOperationError("failed to write timestamp_granularities field", err, providerName)
+		}
+	}
+
+	for _, include := range openaiReq.Include {
+		if err := writer.WriteField("include[]", include); err != nil {
+			return utils.NewBifrostOperationError("failed to write include field", err, providerName)
 		}
 	}
 

--- a/core/schemas/batch.go
+++ b/core/schemas/batch.go
@@ -74,12 +74,19 @@ type BifrostBatchCreateRequest struct {
 	Requests []BatchRequestItem `json:"requests,omitempty"` // Inline request items
 
 	// Common fields
-	Endpoint         BatchEndpoint     `json:"endpoint,omitempty"`          // Target endpoint for batch requests
-	CompletionWindow string            `json:"completion_window,omitempty"` // Time window (e.g., "24h")
-	Metadata         map[string]string `json:"metadata,omitempty"`          // User-provided metadata
+	Endpoint            BatchEndpoint      `json:"endpoint,omitempty"`              // Target endpoint for batch requests
+	CompletionWindow    string             `json:"completion_window,omitempty"`     // Time window (e.g., "24h")
+	Metadata            map[string]string  `json:"metadata,omitempty"`              // User-provided metadata
+	OutputExpiresAfter  *BatchExpiresAfter `json:"output_expires_after,omitempty"` // Expiration for batch output (OpenAI only)
 
 	// Extra parameters for provider-specific features
 	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// BatchExpiresAfter represents an expiration configuration for batch output.
+type BatchExpiresAfter struct {
+	Anchor  string `json:"anchor"`  // e.g., "created_at"
+	Seconds int    `json:"seconds"` // 3600-2592000 (1 hour to 30 days)
 }
 
 // GetRawRequestBody returns the raw request body.

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -160,8 +160,10 @@ type ChatParameters struct {
 	Metadata            *map[string]any      `json:"metadata,omitempty"`              // Metadata to be returned with the response
 	Modalities          []string             `json:"modalities,omitempty"`            // Modalities to be returned with the response
 	ParallelToolCalls   *bool                `json:"parallel_tool_calls,omitempty"`
+	Prediction          *ChatPrediction      `json:"prediction,omitempty"`        // Predicted output content (OpenAI only)
 	PresencePenalty     *float64             `json:"presence_penalty,omitempty"`  // Penalizes repeated tokens
 	PromptCacheKey      *string              `json:"prompt_cache_key,omitempty"`  // Prompt cache key
+	PromptCacheRetention *string             `json:"prompt_cache_retention,omitempty"` // Prompt cache retention ("in-memory" or "24h")
 	Reasoning           *ChatReasoning       `json:"reasoning,omitempty"`         // Reasoning parameters
 	ResponseFormat      *interface{}         `json:"response_format,omitempty"`   // Format for the response
 	SafetyIdentifier    *string              `json:"safety_identifier,omitempty"` // Safety identifier
@@ -177,6 +179,7 @@ type ChatParameters struct {
 	Tools               []ChatTool           `json:"tools,omitempty"`       // Tools to use
 	User                *string              `json:"user,omitempty"`        // User identifier for tracking
 	Verbosity           *string              `json:"verbosity,omitempty"`   // "low" | "medium" | "high"
+	WebSearchOptions    *ChatWebSearchOptions `json:"web_search_options,omitempty"` // Web search options (OpenAI only)
 
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
@@ -238,6 +241,33 @@ type ChatAudioParameters struct {
 type ChatReasoning struct {
 	Effort    *string `json:"effort,omitempty"`     // "none" |  "minimal" | "low" | "medium" | "high" (any value other than "none" will enable reasoning)
 	MaxTokens *int    `json:"max_tokens,omitempty"` // Maximum number of tokens to generate for the reasoning output (required for anthropic)
+}
+
+// ChatPrediction represents predicted output content for the model to reference (OpenAI only).
+// Providing prediction content can significantly reduce latency for certain models.
+type ChatPrediction struct {
+	Type    string      `json:"type"`    // Always "content"
+	Content interface{} `json:"content"` // String or array of content parts
+}
+
+// ChatWebSearchOptions represents web search options for chat completions (OpenAI only).
+type ChatWebSearchOptions struct {
+	SearchContextSize *string                          `json:"search_context_size,omitempty"` // "low" | "medium" | "high"
+	UserLocation      *ChatWebSearchOptionsUserLocation `json:"user_location,omitempty"`
+}
+
+// ChatWebSearchOptionsUserLocation represents user location for web search.
+type ChatWebSearchOptionsUserLocation struct {
+	Type        string                                       `json:"type"` // "approximate"
+	Approximate *ChatWebSearchOptionsUserLocationApproximate `json:"approximate,omitempty"`
+}
+
+// ChatWebSearchOptionsUserLocationApproximate represents approximate user location details.
+type ChatWebSearchOptionsUserLocationApproximate struct {
+	City     *string `json:"city,omitempty"`
+	Country  *string `json:"country,omitempty"`  // Two-letter ISO country code (e.g., "US")
+	Region   *string `json:"region,omitempty"`   // e.g., "California"
+	Timezone *string `json:"timezone,omitempty"` // IANA timezone (e.g., "America/Los_Angeles")
 }
 
 // ChatStreamOptions represents the stream options for a chat completion.

--- a/core/schemas/files.go
+++ b/core/schemas/files.go
@@ -62,6 +62,9 @@ type BifrostFileUploadRequest struct {
 	// Storage configuration (for S3/GCS backends)
 	StorageConfig *FileStorageConfig `json:"storage_config,omitempty"`
 
+	// Expiration configuration (OpenAI only)
+	ExpiresAfter *FileExpiresAfter `json:"expires_after,omitempty"`
+
 	// Extra parameters for provider-specific features
 	ExtraParams map[string]interface{} `json:"-"`
 }
@@ -78,6 +81,12 @@ type GCSStorageConfig struct {
 	Bucket  string `json:"bucket,omitempty"`
 	Project string `json:"project,omitempty"`
 	Prefix  string `json:"prefix,omitempty"`
+}
+
+// FileExpiresAfter represents an expiration configuration for uploaded files.
+type FileExpiresAfter struct {
+	Anchor  string `json:"anchor"`  // e.g., "created_at"
+	Seconds int    `json:"seconds"` // 3600-2592000 (1 hour to 30 days)
 }
 
 // FileStorageConfig represents storage configuration for cloud storage backends.

--- a/core/schemas/transcriptions.go
+++ b/core/schemas/transcriptions.go
@@ -30,14 +30,17 @@ type TranscriptionInput struct {
 }
 
 type TranscriptionParameters struct {
-	Language       *string `json:"language,omitempty"`
-	Prompt         *string `json:"prompt,omitempty"`
-	ResponseFormat *string `json:"response_format,omitempty"` // Default is "json"
-	Format         *string `json:"file_format,omitempty"`     // Type of file, not required in openai, but required in gemini
-	MaxLength      *int    `json:"max_length,omitempty"`      // Maximum length of the transcription used by HuggingFace
-	MinLength      *int    `json:"min_length,omitempty"`      // Minimum length of the transcription used by HuggingFace
-	MaxNewTokens   *int    `json:"max_new_tokens,omitempty"`  // Maximum new tokens to generate used by HuggingFace
-	MinNewTokens   *int    `json:"min_new_tokens,omitempty"`  // Minimum new tokens to generate used by HuggingFace
+	Language                *string  `json:"language,omitempty"`
+	Prompt                  *string  `json:"prompt,omitempty"`
+	ResponseFormat          *string  `json:"response_format,omitempty"`           // Default is "json"
+	Temperature             *float64 `json:"temperature,omitempty"`               // Sampling temperature (0.0-1.0)
+	TimestampGranularities  []string `json:"timestamp_granularities,omitempty"`   // "word" and/or "segment"; requires response_format=verbose_json
+	Include                 []string `json:"include,omitempty"`                   // Additional response info (e.g., logprobs)
+	Format                  *string  `json:"file_format,omitempty"`               // Type of file, not required in openai, but required in gemini
+	MaxLength               *int     `json:"max_length,omitempty"`                // Maximum length of the transcription used by HuggingFace
+	MinLength               *int     `json:"min_length,omitempty"`                // Minimum length of the transcription used by HuggingFace
+	MaxNewTokens            *int     `json:"max_new_tokens,omitempty"`            // Maximum new tokens to generate used by HuggingFace
+	MinNewTokens            *int     `json:"min_new_tokens,omitempty"`            // Minimum new tokens to generate used by HuggingFace
 
 	// Elevenlabs-specific fields
 	AdditionalFormats []TranscriptionAdditionalFormat `json:"additional_formats,omitempty"`


### PR DESCRIPTION
## Summary

Added support for new OpenAI API features including file expiration, batch output expiration, additional transcription parameters, and enhanced chat completion options.

## Changes

- Added `ExpiresAfter` field to file upload requests to support OpenAI's file expiration feature
- Added `OutputExpiresAfter` field to batch requests for configuring batch output expiration
- Enhanced transcription support with additional parameters:
  - Temperature control
  - Timestamp granularities
  - Include options for additional response information
- Added new chat completion parameters:
  - `Prediction` for providing predicted output to reduce latency
  - `PromptCacheRetention` for controlling prompt cache duration
  - `WebSearchOptions` for configuring web search capabilities
- Updated filtering of OpenAI-specific parameters to handle new fields

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new OpenAI features with appropriate API calls:

```sh
# Test file upload with expiration
curl -X POST "http://localhost:8080/v1/files" \
  -H "Content-Type: multipart/form-data" \
  -F "file=@myfile.txt" \
  -F "purpose=fine-tune" \
  -F "expires_after.anchor=created_at" \
  -F "expires_after.seconds=86400"

# Test batch creation with output expiration
curl -X POST "http://localhost:8080/v1/batches" \
  -H "Content-Type: application/json" \
  -d '{
    "input_file_id": "file-123",
    "endpoint": "chat",
    "output_expires_after": {
      "anchor": "created_at",
      "seconds": 86400
    }
  }'

# Run core tests
go test ./core/providers/openai/...
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

Implements support for OpenAI's file and batch expiration features.

## Security considerations

The expiration features help improve security by automatically removing files and batch outputs after a specified time period.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable