### PR TITLE
feat: add request type context for dynamic routing rules

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -182,6 +182,7 @@ const (
 	BifrostContextKeyRawRequestResponseForLogging        BifrostContextKey = "bifrost-raw-request-response-for-logging"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -27,6 +27,9 @@ func createAnthropicCompleteRouteConfig(pathPrefix string) RouteConfig {
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/complete",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.TextCompletionRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicTextRequest{}
 		},
@@ -63,6 +66,9 @@ func createAnthropicMessagesRouteConfig(pathPrefix string) []RouteConfig {
 			Type:   RouteConfigTypeAnthropic,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ResponsesRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &anthropic.AnthropicMessageRequest{}
 			},
@@ -145,6 +151,9 @@ func CreateAnthropicListModelsRouteConfigs(pathPrefix string, handlerStore lib.H
 			Type:   RouteConfigTypeAnthropic,
 			Path:   pathPrefix + "/v1/models",
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ListModelsRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostListModelsRequest{}
 			},
@@ -282,6 +291,9 @@ func CreateAnthropicCountTokensRouteConfigs(pathPrefix string, handlerStore lib.
 			Type:   RouteConfigTypeAnthropic,
 			Path:   pathPrefix + "/v1/messages/count_tokens",
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.CountTokensRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &anthropic.AnthropicMessageRequest{}
 			},
@@ -311,6 +323,9 @@ func CreateAnthropicBatchRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/messages/batches",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchCreateRequest
+		},
 		GetRequestTypeInstance: func() any {
 			return &anthropic.AnthropicBatchCreateRequest{}
 		},
@@ -386,6 +401,9 @@ func CreateAnthropicBatchRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/messages/batches",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchListRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicBatchListRequest{}
 		},
@@ -428,6 +446,9 @@ func CreateAnthropicBatchRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/messages/batches/{batch_id}",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchRetrieveRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicBatchRetrieveRequest{}
 		},
@@ -464,6 +485,9 @@ func CreateAnthropicBatchRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/messages/batches/{batch_id}/cancel",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchCancelRequest
+		},
 		GetRequestTypeInstance: func() any {
 			return &anthropic.AnthropicBatchCancelRequest{}
 		},
@@ -500,6 +524,9 @@ func CreateAnthropicBatchRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/messages/batches/{batch_id}/results",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchResultsRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicBatchResultsRequest{}
 		},
@@ -680,6 +707,9 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/files",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileUploadRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicFileUploadRequest{}
 		},
@@ -769,6 +799,9 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/files",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileListRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicFileListRequest{}
 		},
@@ -810,6 +843,9 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/files/{file_id}/content",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileContentRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicFileRetrieveRequest{}
 		},
@@ -847,6 +883,9 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 		Type:   RouteConfigTypeAnthropic,
 		Path:   pathPrefix + "/v1/files/{file_id}",
 		Method: "DELETE",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileDeleteRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &anthropic.AnthropicFileDeleteRequest{}
 		},

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -38,6 +38,9 @@ func createBedrockConverseRouteConfig(pathPrefix string, handlerStore lib.Handle
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockConverseRequest{}
 		},
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 			if bedrockReq, ok := req.(*bedrock.BedrockConverseRequest); ok {
 				bifrostReq, err := bedrockReq.ToBifrostResponsesRequest(ctx)
@@ -67,6 +70,9 @@ func createBedrockConverseStreamRouteConfig(pathPrefix string, handlerStore lib.
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model/{modelId}/converse-stream",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ResponsesRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockConverseRequest{}
 		},
@@ -112,6 +118,9 @@ func createBedrockInvokeWithResponseStreamRouteConfig(pathPrefix string, handler
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model/{modelId}/invoke-with-response-stream",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.TextCompletionRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockTextCompletionRequest{}
 		},
@@ -157,6 +166,9 @@ func createBedrockInvokeRouteConfig(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model/{modelId}/invoke",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.TextCompletionRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockTextCompletionRequest{}
 		},
@@ -197,6 +209,9 @@ func createBedrockBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model-invocation-job",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchCreateRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockBatchJobRequest{}
 		},
@@ -296,6 +311,9 @@ func createBedrockBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model-invocation-jobs",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchListRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockBatchListRequest{}
 		},
@@ -338,6 +356,9 @@ func createBedrockBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model-invocation-job/{job_arn}",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchRetrieveRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockBatchRetrieveRequest{}
 		},
@@ -380,6 +401,9 @@ func createBedrockBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model-invocation-job/{job_arn}/stop",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchCancelRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockBatchCancelRequest{}
 		},
@@ -589,6 +613,9 @@ func createBedrockFilesRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/{bucket}/{key:*}",
 		Method: "PUT",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileUploadRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockFileUploadRequest{}
 		},
@@ -643,6 +670,9 @@ func createBedrockFilesRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/{bucket}/{key:*}",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileContentRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockFileContentRequest{}
 		},
@@ -675,6 +705,9 @@ func createBedrockFilesRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/{bucket}/{key:*}",
 		Method: "HEAD",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileRetrieveRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockFileRetrieveRequest{}
 		},
@@ -721,6 +754,9 @@ func createBedrockFilesRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/{bucket}/{key:*}",
 		Method: "DELETE",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileDeleteRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockFileDeleteRequest{}
 		},
@@ -767,6 +803,9 @@ func createBedrockFilesRouteConfigs(pathPrefix string, handlerStore lib.HandlerS
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/{bucket}",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileListRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &bedrock.BedrockFileListRequest{}
 		},

--- a/transports/bifrost-http/integrations/cohere.go
+++ b/transports/bifrost-http/integrations/cohere.go
@@ -7,6 +7,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/cohere"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
 )
 
 // CohereRouter holds route registrations for Cohere endpoints.
@@ -28,8 +29,12 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 
 	// Chat completions endpoint (v2/chat)
 	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeCohere,
 		Path:   pathPrefix + "/v2/chat",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ChatCompletionRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &cohere.CohereChatRequest{}
 		},
@@ -69,8 +74,12 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 
 	// Embeddings endpoint (v2/embed)
 	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeCohere,
 		Path:   pathPrefix + "/v2/embed",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.EmbeddingRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &cohere.CohereEmbeddingRequest{}
 		},
@@ -97,8 +106,12 @@ func CreateCohereRouteConfigs(pathPrefix string) []RouteConfig {
 
 	// Tokenize endpoint (v1/tokenize)
 	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeCohere,
 		Path:   pathPrefix + "/v1/tokenize",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.CountTokensRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &cohere.CohereCountTokensRequest{}
 		},

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
 
 	"github.com/maximhq/bifrost/core/providers/gemini"
@@ -30,6 +31,10 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 		Type:   RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/v1beta/models/{model:*}",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			_, requestType := extractModelAndRequestType(ctx)
+			return requestType
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &gemini.GeminiGenerationRequest{}
 		},
@@ -113,13 +118,16 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 				return gemini.ToGeminiError(err)
 			},
 		},
-		PreCallback: extractAndSetModelFromURL,
+		PreCallback: extractAndSetModelAndRequestType,
 	})
 
 	routes = append(routes, RouteConfig{
 		Type:   RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/v1beta/models",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ListModelsRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &schemas.BifrostListModelsRequest{}
 		},
@@ -152,6 +160,9 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		Type:   RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/upload/v1beta/files",
 		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileUploadRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &schemas.BifrostFileUploadRequest{}
 		},
@@ -182,6 +193,9 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		Type:   RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/v1beta/files",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileListRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &schemas.BifrostFileListRequest{}
 		},
@@ -212,6 +226,9 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		Type:   RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/v1beta/files/{file_id}",
 		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileRetrieveRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &schemas.BifrostFileRetrieveRequest{}
 		},
@@ -242,6 +259,9 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		Type:   RouteConfigTypeGenAI,
 		Path:   pathPrefix + "/v1beta/files/{file_id}",
 		Method: "DELETE",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.FileDeleteRequest
+		},
 		GetRequestTypeInstance: func() interface{} {
 			return &schemas.BifrostFileDeleteRequest{}
 		},
@@ -374,8 +394,8 @@ var embeddingPaths = []string{
 	":batchEmbedContents",
 }
 
-// extractAndSetModelFromURL extracts model from URL and sets it in the request
-func extractAndSetModelFromURL(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+// extractAndSetModelAndRequestType extracts model and request type from URL and request object and sets it in the request
+func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
 	model := ctx.UserValue("model")
 	if model == nil {
 		return fmt.Errorf("model parameter is required")
@@ -441,6 +461,83 @@ func extractAndSetModelFromURL(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 	}
 
 	return fmt.Errorf("invalid request type for GenAI")
+}
+
+// extractAndSetModelFromURL extracts model from URL and sets it in the request
+func extractModelAndRequestType(ctx *fasthttp.RequestCtx) (string, schemas.RequestType) {
+	model := ctx.UserValue("model")
+	if model == nil {
+		return "", ""
+	}
+
+	modelStr := model.(string)
+
+	// Check if this is a count tokens request
+	if strings.HasSuffix(modelStr, ":countTokens") {
+		return modelStr, schemas.CountTokensRequest
+	}
+
+	isPredict := strings.HasSuffix(modelStr, ":predict")
+
+	// Check if this is an embedding request
+	isEmbedding := false
+	for _, path := range embeddingPaths {
+		if strings.HasSuffix(modelStr, path) {
+			isEmbedding = true
+			break
+		}
+	}
+	if isEmbedding {
+		return modelStr, schemas.EmbeddingRequest
+	}
+
+	// Remove Google GenAI API endpoint suffixes if present
+	for _, sfx := range gemini.GeminiRequestSuffixPaths {
+		modelStr = strings.TrimSuffix(modelStr, sfx)
+	}
+
+	// Remove trailing colon if present
+	if len(modelStr) > 0 && modelStr[len(modelStr)-1] == ':' {
+		modelStr = modelStr[:len(modelStr)-1]
+	}
+
+	// Determine if :predict is for image generation (Imagen) or embedding
+	// Imagen models use :predict for image generation
+	isImagenPredict := isPredict && schemas.IsImagenModel(modelStr)
+	if isPredict && !isImagenPredict {
+		// :predict for non-Imagen models is embedding
+		isEmbedding = true
+	}
+
+	if isEmbedding {
+		return modelStr, schemas.EmbeddingRequest
+	}
+
+	// Create a proper GeminiGenerationRequest to detect request type
+	geminiReq := &gemini.GeminiGenerationRequest{}
+	if err := sonic.Unmarshal(ctx.Request.Body(), geminiReq); err != nil {
+		return modelStr, ""
+	}
+
+	// Set the model on the request so detection functions can use it
+	geminiReq.Model = modelStr
+
+	// Detect if this is a speech or transcription request by examining the request body
+	// Speech detection takes priority over transcription
+	if isSpeechRequest(geminiReq) {
+		return modelStr, schemas.SpeechRequest
+	}
+	if isTranscriptionRequest(geminiReq) {
+		return modelStr, schemas.TranscriptionRequest
+	}
+	if isImageGenerationRequest(geminiReq) {
+		return modelStr, schemas.ImageGenerationRequest
+	}
+	if isImageEditRequest(geminiReq) {
+		return modelStr, schemas.ImageEditRequest
+	}
+
+	return modelStr, schemas.ResponsesRequest
 }
 
 // isSpeechRequest checks if the request is for speech generation (text-to-speech)

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -117,6 +117,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.TextCompletionRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAITextCompletionRequest{}
 			},
@@ -166,6 +169,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ChatCompletionRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIChatRequest{}
 			},
@@ -215,6 +221,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ResponsesRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIResponsesRequest{}
 			},
@@ -269,6 +278,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.CountTokensRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIResponsesRequest{}
 			},
@@ -305,6 +317,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.EmbeddingRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIEmbeddingRequest{}
 			},
@@ -341,6 +356,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.SpeechRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAISpeechRequest{}
 			},
@@ -382,6 +400,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.TranscriptionRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAITranscriptionRequest{}
 			},
@@ -432,6 +453,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ImageGenerationRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIImageGenerationRequest{}
 			},
@@ -480,6 +504,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ImageEditRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIImageEditRequest{}
 			},
@@ -528,6 +555,9 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ImageVariationRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &openai.OpenAIImageVariationRequest{}
 			},
@@ -583,6 +613,9 @@ func CreateOpenAIListModelsRouteConfigs(pathPrefix string, handlerStore lib.Hand
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ListModelsRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostListModelsRequest{}
 			},
@@ -647,6 +680,9 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.BatchCreateRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostBatchCreateRequest{}
 			},
@@ -756,6 +792,9 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.BatchListRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostBatchListRequest{}
 			},
@@ -802,6 +841,9 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.BatchRetrieveRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostBatchRetrieveRequest{}
 			},
@@ -853,6 +895,9 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.BatchCancelRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostBatchCancelRequest{}
 			},
@@ -908,6 +953,9 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.FileUploadRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostFileUploadRequest{}
 			},
@@ -959,6 +1007,9 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.FileListRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostFileListRequest{}
 			},
@@ -1006,6 +1057,9 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.FileRetrieveRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostFileRetrieveRequest{}
 			},
@@ -1052,6 +1106,9 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "DELETE",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.FileDeleteRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostFileDeleteRequest{}
 			},
@@ -1100,6 +1157,9 @@ func CreateOpenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerSto
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.FileContentRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostFileContentRequest{}
 			},
@@ -1471,6 +1531,9 @@ func CreateOpenAIContainerRouteConfigs(pathPrefix string, handlerStore lib.Handl
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerCreateRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerCreateRequest{}
 			},
@@ -1510,6 +1573,9 @@ func CreateOpenAIContainerRouteConfigs(pathPrefix string, handlerStore lib.Handl
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerListRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerListRequest{}
 			},
@@ -1545,6 +1611,9 @@ func CreateOpenAIContainerRouteConfigs(pathPrefix string, handlerStore lib.Handl
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerRetrieveRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerRetrieveRequest{}
 			},
@@ -1580,6 +1649,9 @@ func CreateOpenAIContainerRouteConfigs(pathPrefix string, handlerStore lib.Handl
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "DELETE",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerDeleteRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerDeleteRequest{}
 			},
@@ -1707,6 +1779,9 @@ func CreateOpenAIContainerFileRouteConfigs(pathPrefix string, handlerStore lib.H
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "POST",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerFileCreateRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerFileCreateRequest{}
 			},
@@ -1740,6 +1815,9 @@ func CreateOpenAIContainerFileRouteConfigs(pathPrefix string, handlerStore lib.H
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerFileListRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerFileListRequest{}
 			},
@@ -1772,6 +1850,9 @@ func CreateOpenAIContainerFileRouteConfigs(pathPrefix string, handlerStore lib.H
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerFileRetrieveRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerFileRetrieveRequest{}
 			},
@@ -1804,6 +1885,9 @@ func CreateOpenAIContainerFileRouteConfigs(pathPrefix string, handlerStore lib.H
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "GET",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerFileContentRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerFileContentRequest{}
 			},
@@ -1836,6 +1920,9 @@ func CreateOpenAIContainerFileRouteConfigs(pathPrefix string, handlerStore lib.H
 			Type:   RouteConfigTypeOpenAI,
 			Path:   pathPrefix + path,
 			Method: "DELETE",
+			GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+				return schemas.ContainerFileDeleteRequest
+			},
 			GetRequestTypeInstance: func() interface{} {
 				return &schemas.BifrostContainerFileDeleteRequest{}
 			},

--- a/ui/app/workspace/routing-rules/components/celBuilder/valueEditor.tsx
+++ b/ui/app/workspace/routing-rules/components/celBuilder/valueEditor.tsx
@@ -162,7 +162,7 @@ export function ValueEditor({ value, handleOnChange, operator, fieldData, type }
 					isNonAsync={true}
 					isClearable={false}
 					placeholder="Select providers..."
-					className="w-[240px]"
+					className="w-[360px]"
 					triggerClassName="!shadow-none !border-border h-10"
 					menuClassName="!z-[100] w-full cursor-pointer"
 				/>
@@ -174,7 +174,7 @@ export function ValueEditor({ value, handleOnChange, operator, fieldData, type }
 
 		return (
 			<Select value={value || ""} onValueChange={handleOnChange}>
-				<SelectTrigger className="w-[240px]">
+				<SelectTrigger className="w-[360px]">
 					{isProviderField && value ? (
 						<div className="flex items-center gap-2">
 							<RenderProviderIcon
@@ -258,7 +258,7 @@ export function ValueEditor({ value, handleOnChange, operator, fieldData, type }
 				value={value || ""}
 				onChange={(e) => handleOnChange(e.target.value)}
 				placeholder={placeholder}
-				className="min-h-[80px] w-[240px] font-mono text-sm"
+				className="min-h-[80px] w-[360px] font-mono text-sm"
 			/>
 		);
 	}
@@ -274,7 +274,7 @@ export function ValueEditor({ value, handleOnChange, operator, fieldData, type }
 					value={value || ""}
 					onChange={(e) => handleOnChange(e.target.value)}
 					placeholder={placeholder}
-					className={`w-[240px] font-mono text-sm ${regexError ? "border-red-500 bg-red-50 dark:bg-red-950" : ""
+					className={`w-[360px] font-mono text-sm ${regexError ? "border-red-500 bg-red-50 dark:bg-red-950" : ""
 						}`}
 				/>
 				{regexError && (
@@ -291,7 +291,7 @@ export function ValueEditor({ value, handleOnChange, operator, fieldData, type }
 			value={value || ""}
 			onChange={(e) => handleOnChange(e.target.value)}
 			placeholder={placeholder}
-			className="w-[240px]"
+			className="w-[360px]"
 		/>
 	);
 }

--- a/ui/lib/config/celFieldsRouting.ts
+++ b/ui/lib/config/celFieldsRouting.ts
@@ -6,92 +6,118 @@
 import { getProviderLabel } from "@/lib/constants/logs";
 
 export interface CELFieldDefinition {
-  name: string;
-  label: string;
-  placeholder?: string;
-  inputType?: 'text' | 'select' | 'keyValue' | 'number';
-  valueEditorType?: 'text' | 'select' | 'keyValue' | 'number' | 'textarea' | 'budgetNumber' | ((operator: string) => 'text' | 'select' | 'keyValue' | 'number' | 'textarea' | 'budgetNumber');
-  operators?: string[];
-  defaultOperator?: string;
-  defaultValue?: any;
-  values?: Array<{ name: string; label: string; disabled?: boolean }>;
-  metricOptions?: Array<{ name: string; label: string }>; // For budgetNumber type
-  description?: string; // Helpful note for the user
+	name: string;
+	label: string;
+	placeholder?: string;
+	inputType?: "text" | "select" | "keyValue" | "number";
+	valueEditorType?:
+		| "text"
+		| "select"
+		| "keyValue"
+		| "number"
+		| "textarea"
+		| "budgetNumber"
+		| ((operator: string) => "text" | "select" | "keyValue" | "number" | "textarea" | "budgetNumber");
+	operators?: string[];
+	defaultOperator?: string;
+	defaultValue?: any;
+	values?: Array<{ name: string; label: string; disabled?: boolean }>;
+	metricOptions?: Array<{ name: string; label: string }>; // For budgetNumber type
+	description?: string; // Helpful note for the user
 }
 
 export const baseRoutingFields: CELFieldDefinition[] = [
-  {
-    name: 'model',
-    label: 'Model',
-    placeholder: 'e.g., gpt-4, claude-3-sonnet',
-    inputType: 'text',
-    valueEditorType: (operator: string) =>
-      operator === '=' || operator === '!=' ? 'select' :
-      operator === 'in' || operator === 'notIn' ? 'select' :
-      'text',
-    operators: ['=', '!=', 'in', 'notIn', 'contains', 'beginsWith', 'endsWith', 'matches'],
-    defaultOperator: '=',
-  },
-  {
-    name: 'provider',
-    label: 'Provider',
-    placeholder: 'Select provider',
-    inputType: 'select',
-    valueEditorType: (operator: string) =>
-      operator === 'matches' ? 'text' :
-      operator === 'in' || operator === 'notIn' ? 'select' :
-      'select',
-    operators: ['=', '!=', 'in', 'notIn', 'matches'],
-    defaultOperator: '=',
-  },
-  {
-    name: 'headers',
-    label: 'Header',
-    placeholder: 'e.g., authorization, x-custom-header (use lowercase)',
-    inputType: 'keyValue',
-    valueEditorType: 'keyValue',
-    operators: ['=', '!=', 'contains', 'beginsWith', 'endsWith', 'matches', 'null', 'notNull'],
-    defaultOperator: '=',
-  },
-  {
-    name: 'tokens_used',
-    label: 'Tokens Used (%)',
-    placeholder: 'e.g., 80',
-    inputType: 'text',
-    valueEditorType: 'number',
-    operators: ['=', '!=', '>', '<', '>=', '<='],
-    defaultOperator: '>=',
-    description: 'Check token usage as percentage. Checked against max of model and provider configs.',
-  },
-  {
-    name: 'request',
-    label: 'Request (%)',
-    placeholder: 'e.g., 80',
-    inputType: 'text',
-    valueEditorType: 'number',
-    operators: ['=', '!=', '>', '<', '>=', '<='],
-    defaultOperator: '>=',
-    description: 'Check request usage as percentage. Checked against max of model and provider configs.',
-  },
-  {
-    name: 'budget_used',
-    label: 'Budget Used (%)',
-    placeholder: 'e.g., 50',
-    inputType: 'text',
-    valueEditorType: 'number',
-    operators: ['=', '!=', '>', '<', '>=', '<='],
-    defaultOperator: '>=',
-    description: 'Check budget usage as percentage. Checked against max of model and provider configs.',
-  },
-  {
-    name: 'params',
-    label: 'Query Parameter',
-    placeholder: 'e.g., api_key, user_id',
-    inputType: 'keyValue',
-    valueEditorType: 'keyValue',
-    operators: ['=', '!=', 'contains', 'beginsWith', 'endsWith', 'matches', 'null', 'notNull'],
-    defaultOperator: '=',
-  },
+	{
+		name: "model",
+		label: "Model",
+		placeholder: "e.g., gpt-4, claude-3-sonnet",
+		inputType: "text",
+		valueEditorType: (operator: string) =>
+			operator === "=" || operator === "!=" ? "select" : operator === "in" || operator === "notIn" ? "select" : "text",
+		operators: ["=", "!=", "in", "notIn", "contains", "beginsWith", "endsWith", "matches"],
+		defaultOperator: "=",
+	},
+	{
+		name: "provider",
+		label: "Provider",
+		placeholder: "Select provider",
+		inputType: "select",
+		valueEditorType: (operator: string) =>
+			operator === "matches" ? "text" : operator === "in" || operator === "notIn" ? "select" : "select",
+		operators: ["=", "!=", "in", "notIn", "matches"],
+		defaultOperator: "=",
+	},
+	{
+		name: "request_type",
+		label: "Request Type",
+		placeholder: "Select request type",
+		inputType: "select",
+		valueEditorType: (operator: string) =>
+			operator === "matches" ? "text" : operator === "in" || operator === "notIn" ? "select" : "select",
+		operators: ["=", "!=", "in", "notIn", "matches"],
+		defaultOperator: "=",
+		values: [
+			{ name: "text_completion", label: "Text Completion" },
+			{ name: "chat_completion", label: "Chat Completion" },
+			{ name: "responses", label: "Responses" },
+			{ name: "embedding", label: "Embeddings" },
+			{ name: "image_generation", label: "Image Generation" },
+			{ name: "image_edit", label: "Image Edit" },
+			{ name: "image_variation", label: "Image Variation" },
+			{ name: "speech", label: "Speech" },
+			{ name: "transcription", label: "Transcription" },
+			{ name: "count_tokens", label: "Count Tokens" },
+		],
+		description: "Filter rules by the type of API request (chat, text, embeddings, images, audio, etc.)",
+	},
+	{
+		name: "headers",
+		label: "Header",
+		placeholder: "e.g., authorization, x-custom-header (use lowercase)",
+		inputType: "keyValue",
+		valueEditorType: "keyValue",
+		operators: ["=", "!=", "contains", "beginsWith", "endsWith", "matches", "null", "notNull"],
+		defaultOperator: "=",
+	},
+	{
+		name: "tokens_used",
+		label: "Tokens Used (%)",
+		placeholder: "e.g., 80",
+		inputType: "text",
+		valueEditorType: "number",
+		operators: ["=", "!=", ">", "<", ">=", "<="],
+		defaultOperator: ">=",
+		description: "Check token usage as percentage. Checked against max of model and provider configs.",
+	},
+	{
+		name: "request",
+		label: "Request (%)",
+		placeholder: "e.g., 80",
+		inputType: "text",
+		valueEditorType: "number",
+		operators: ["=", "!=", ">", "<", ">=", "<="],
+		defaultOperator: ">=",
+		description: "Check request usage as percentage. Checked against max of model and provider configs.",
+	},
+	{
+		name: "budget_used",
+		label: "Budget Used (%)",
+		placeholder: "e.g., 50",
+		inputType: "text",
+		valueEditorType: "number",
+		operators: ["=", "!=", ">", "<", ">=", "<="],
+		defaultOperator: ">=",
+		description: "Check budget usage as percentage. Checked against max of model and provider configs.",
+	},
+	{
+		name: "params",
+		label: "Query Parameter",
+		placeholder: "e.g., api_key, user_id",
+		inputType: "keyValue",
+		valueEditorType: "keyValue",
+		operators: ["=", "!=", "contains", "beginsWith", "endsWith", "matches", "null", "notNull"],
+		defaultOperator: "=",
+	},
 ];
 
 /**
@@ -100,68 +126,68 @@ export const baseRoutingFields: CELFieldDefinition[] = [
  * Metric options for rate limits and budget are populated from available providers and models
  */
 export function getRoutingFields(providers: string[] = [], models: string[] = []): CELFieldDefinition[] {
-  // Create provider field values
-  const providerValues =
-    providers.length > 0
-      ? providers.map((provider) => ({
-          name: provider,
-          label: getProviderLabel(provider),
-        }))
-      : [{ name: '_no_providers', label: 'No providers configured', disabled: true }];
+	// Create provider field values
+	const providerValues =
+		providers.length > 0
+			? providers.map((provider) => ({
+					name: provider,
+					label: getProviderLabel(provider),
+				}))
+			: [{ name: "_no_providers", label: "No providers configured", disabled: true }];
 
-  // Create model field values
-  const modelValues =
-    models.length > 0
-      ? models.map((model) => ({
-          name: model,
-          label: model,
-        }))
-      : [];
+	// Create model field values
+	const modelValues =
+		models.length > 0
+			? models.map((model) => ({
+					name: model,
+					label: model,
+				}))
+			: [];
 
-  // Create metric options for scope input: providers + models
-  const scopeOptions = [
-    { name: '', label: '(provider-level)' }, // Empty scope for provider-level
-    ...providers.map((provider) => ({
-      name: provider,
-      label: `${provider} (provider)`,
-    })),
-    ...models.map((model) => ({
-      name: model,
-      label: `${model} (model)`,
-    })),
-  ];
+	// Create metric options for scope input: providers + models
+	const scopeOptions = [
+		{ name: "", label: "(provider-level)" }, // Empty scope for provider-level
+		...providers.map((provider) => ({
+			name: provider,
+			label: `${provider} (provider)`,
+		})),
+		...models.map((model) => ({
+			name: model,
+			label: `${model} (model)`,
+		})),
+	];
 
-  // Update provider field with dynamic values and rate limit/budget fields with scope options
-  const fieldsWithDynamicValues = baseRoutingFields.map((field) => {
-    if (field.name === 'provider') {
-      return {
-        ...field,
-        values: providerValues,
-      };
-    }
-    if (field.name === 'model') {
-      return {
-        ...field,
-        values: modelValues,
-      };
-    }
-    if (field.name === 'tokens_used' || field.name === 'request' || field.name === 'budget_used') {
-      return {
-        ...field,
-        metricOptions: scopeOptions,
-      };
-    }
-    return field;
-  });
+	// Update provider field with dynamic values and rate limit/budget fields with scope options
+	const fieldsWithDynamicValues = baseRoutingFields.map((field) => {
+		if (field.name === "provider") {
+			return {
+				...field,
+				values: providerValues,
+			};
+		}
+		if (field.name === "model") {
+			return {
+				...field,
+				values: modelValues,
+			};
+		}
+		if (field.name === "tokens_used" || field.name === "request" || field.name === "budget_used") {
+			return {
+				...field,
+				metricOptions: scopeOptions,
+			};
+		}
+		return field;
+	});
 
-  return fieldsWithDynamicValues;
+	return fieldsWithDynamicValues;
 }
 
 export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  azure: 'Azure OpenAI',
-  gemini: 'Google Gemini',
-  vertex: 'Vertex AI',
-  cohere: 'Cohere',
+	openai: "OpenAI",
+	anthropic: "Anthropic",
+	azure: "Azure OpenAI",
+	gemini: "Google Gemini",
+	vertex: "Vertex AI",
+	cohere: "Cohere",
 };

--- a/ui/lib/types/routingRules.ts
+++ b/ui/lib/types/routingRules.ts
@@ -6,88 +6,88 @@
 import { RuleGroupType } from "react-querybuilder";
 
 export interface RoutingRule {
-  id: string
-  name: string
-  description: string
-  cel_expression: string
-  provider: string
-  model?: string
-  fallbacks?: string[]
-  scope: "global" | "team" | "customer" | "virtual_key"
-  scope_id?: string
-  priority: number
-  enabled: boolean
-  query?: RuleGroupType
-  created_at: string
-  updated_at: string
+	id: string;
+	name: string;
+	description: string;
+	cel_expression: string;
+	provider: string;
+	model?: string;
+	fallbacks?: string[];
+	scope: "global" | "team" | "customer" | "virtual_key";
+	scope_id?: string;
+	priority: number;
+	enabled: boolean;
+	query?: RuleGroupType;
+	created_at: string;
+	updated_at: string;
 }
 
 export interface CreateRoutingRuleRequest {
-  name: string
-  description?: string
-  cel_expression: string
-  provider: string
-  model?: string
-  fallbacks?: string[]
-  scope: string
-  scope_id?: string
-  priority: number
-  enabled?: boolean
-  query?: RuleGroupType
+	name: string;
+	description?: string;
+	cel_expression: string;
+	provider: string;
+	model?: string;
+	fallbacks?: string[];
+	scope: string;
+	scope_id?: string;
+	priority: number;
+	enabled?: boolean;
+	query?: RuleGroupType;
 }
 
 /** Partial update: only sent fields are applied; allows clearing fields by sending "" or []. */
 export type UpdateRoutingRuleRequest = Partial<CreateRoutingRuleRequest>;
 
 export interface GetRoutingRulesResponse {
-  rules: RoutingRule[]
-  count: number
+	rules: RoutingRule[];
+	count: number;
 }
 
 export interface GetRoutingRuleResponse {
-  rule: RoutingRule
+	rule: RoutingRule;
 }
 
 export interface RoutingRuleFormData {
-  id?: string
-  name: string
-  description: string
-  cel_expression: string
-  provider: string
-  model: string
-  fallbacks: string[]
-  scope: string
-  scope_id: string
-  priority: number
-  enabled: boolean
-  query?: RuleGroupType
-  isDirty?: boolean
+	id?: string;
+	name: string;
+	description: string;
+	cel_expression: string;
+	provider: string;
+	model: string;
+	fallbacks: string[];
+	scope: string;
+	scope_id: string;
+	priority: number;
+	enabled: boolean;
+	query?: RuleGroupType;
+	isDirty?: boolean;
 }
 
 export enum RoutingRuleScope {
-  Global = "global",
-  Team = "team",
-  Customer = "customer",
-  VirtualKey = "virtual_key",
+	Global = "global",
+	Team = "team",
+	Customer = "customer",
+	VirtualKey = "virtual_key",
 }
 
 export const ROUTING_RULE_SCOPES = [
-  { value: RoutingRuleScope.Global, label: "Global" },
-  { value: RoutingRuleScope.Team, label: "Team" },
-  { value: RoutingRuleScope.Customer, label: "Customer" },
-  { value: RoutingRuleScope.VirtualKey, label: "Virtual Key" },
-]
+	{ value: RoutingRuleScope.Global, label: "Global" },
+	{ value: RoutingRuleScope.Team, label: "Team" },
+	{ value: RoutingRuleScope.Customer, label: "Customer" },
+	{ value: RoutingRuleScope.VirtualKey, label: "Virtual Key" },
+];
 
 export const DEFAULT_ROUTING_RULE_FORM_DATA: RoutingRuleFormData = {
-  name: "",
-  description: "",
-  cel_expression: "",
-  provider: "",
-  model: "",
-  fallbacks: [],
-  scope: RoutingRuleScope.Global,
-  scope_id: "",
-  priority: 0,
-  enabled: true,
-  isDirty: false,
-}
+	name: "",
+	description: "",
+	cel_expression: "",
+	provider: "",
+	model: "",
+	fallbacks: [],
+	scope: RoutingRuleScope.Global,
+	scope_id: "",
+	priority: 0,
+	enabled: true,
+	isDirty: false,
+};


### PR DESCRIPTION
## Summary

Add request type context to routing rules to enable filtering by API operation type (chat, embeddings, etc.)

## Changes

- Added `BifrostContextKeyHTTPRequestType` to store the normalized request type in the context
- Created a middleware to detect and set request type based on API path
- Enhanced routing context to include request type for CEL expressions
- Updated CEL environment to expose `request_type` variable in routing rules
- Added UI support for filtering rules by request type with a dropdown selector
- Removed unnecessary logging in governance plugin

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)

## How to test

Test routing rules with the new request type condition:

```sh
# Create a routing rule that only applies to chat completions
curl -X POST http://localhost:8000/api/v1/routing-rules \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Chat Only Rule",
    "description": "Only applies to chat completion requests",
    "cel_expression": "request_type == \"chat_completion\"",
    "provider": "openai",
    "model": "gpt-4",
    "scope": "global",
    "priority": 10,
    "enabled": true
  }'

# Test with a chat completion request
curl -X POST http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo",
    "messages": [{"role": "user", "content": "Hello"}]
  }'

# Test with an embedding request (should not match the rule)
curl -X POST http://localhost:8000/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "model": "text-embedding-ada-002",
    "input": "Hello"
  }'
```

## Related issues

Enhances routing capabilities by allowing rules to target specific API operations.

## Security considerations

No security implications. This change only adds metadata to requests for routing purposes.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)