### PR TITLE
stateful hel chart fixes

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "1.4.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,15 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.0
+**Latest Version:** 2.0.1
 
 ## Changelog
+
+### v2.0.1
+
+- Added missing StatefulSet template for SQLite with persistence mode
+- Added headless service for StatefulSet DNS resolution
+- v2.0.0 documented StatefulSet support but the template was not included - this release fixes that
 
 ### v2.0.0 (Breaking Change)
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,28 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.3
+    created: "2026-01-31T20:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.1.tgz
+    version: 2.0.1
+  - apiVersion: v2
+    appVersion: 1.4.3
     created: "2026-01-31T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -245,4 +267,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-01-31T12:00:00.000000+00:00"
+generated: "2026-01-31T20:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Bump Bifrost Helm chart version from 2.0.0 to 2.0.1 while maintaining the same application version (1.4.3).

## Changes

- Updated Helm chart version to 2.0.1 in Chart.yaml
- Added new entry for version 2.0.1 in the Helm chart index.yaml
- Updated the generated timestamp in index.yaml from 12:00:00 to 20:00:00

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the Helm chart can be installed with the new version:

```sh
# Add the Bifrost Helm repository
helm repo add bifrost https://maximhq.github.io/bifrost/helm-charts

# Update repositories
helm repo update

# Install the chart
helm install bifrost bifrost/bifrost --version 2.0.1
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is only a version bump in the Helm chart.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable