### PR TITLE
fix: postgresql existing secret didn't included when storage.mode: sq…

### DIFF
--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
                   key: {{ .Values.bifrost.plugins.semanticCache.secretRef.key | default "api-key" }}
             {{- end }}
             {{- /* PostgreSQL password from existing secret */ -}}
-            {{- if and (eq .Values.storage.mode "postgres") .Values.postgresql.external.enabled .Values.postgresql.external.existingSecret }}
+            {{- if and .Values.postgresql.external.enabled .Values.postgresql.external.existingSecret }}
             - name: BIFROST_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -94,7 +94,7 @@ spec:
                   key: {{ .Values.bifrost.plugins.semanticCache.secretRef.key | default "api-key" }}
             {{- end }}
             {{- /* PostgreSQL password from existing secret */ -}}
-            {{- if and (eq .Values.storage.mode "postgres") .Values.postgresql.external.enabled .Values.postgresql.external.existingSecret }}
+            {{- if and .Values.postgresql.external.enabled .Values.postgresql.external.existingSecret }}
             - name: BIFROST_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
…lite in mixed storage backend configuration

## Summary
By following the https://github.com/maximhq/bifrost/blob/main/helm-charts/bifrost/values-examples/mixed-backend.yaml example, the container returned this log 

```
{"level":"error","time":"2026-01-31T18:05:54Z","message":"failed to bootstrap server: failed to load config postgres password is required"}
```

while the `postgresql.external.enabled: true` and `postgresql.external.existingSecret` is set, the BIFROST_POSTGRES_PASSWORD env is not set if `storage.mode: sqlite`

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


