### PR TITLE
race condition fixes

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           go-version: "1.25.5"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -80,6 +85,7 @@ jobs:
 
           **Test Suite Includes:**
           - 📦 Core Build Validation
+          - 🔌 MCP Test Servers Build
           - 🔧 Core Provider Tests
           - 🛡️ Governance Tests
           - 🔗 Integration Tests

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -82,7 +82,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25.5"
-      
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Configure Git
         run: |
           git config user.name "GitHub Actions Bot"

--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -35,6 +35,23 @@ go build ./...
 cd ..
 echo "✅ Core build validation successful"
 
+# Build MCP test servers for STDIO tests
+echo "🔧 Building MCP test servers..."
+for mcp_dir in examples/mcps/*/; do
+  if [ -d "$mcp_dir" ]; then
+    mcp_name=$(basename "$mcp_dir")
+    if [ -f "$mcp_dir/go.mod" ]; then
+      echo "  Building $mcp_name (Go)..."
+      mkdir -p "$mcp_dir/bin"
+      cd "$mcp_dir" && GOWORK=off go build -o "bin/$mcp_name" . && cd - > /dev/null
+    elif [ -f "$mcp_dir/package.json" ]; then
+      echo "  Building $mcp_name (TypeScript)..."
+      cd "$mcp_dir" && npm install --silent && npm run build && cd - > /dev/null
+    fi
+  fi
+done
+echo "✅ MCP test servers built"
+
 # Run core tests with coverage
 echo "🔧 Running core tests with coverage..."
 cd core

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -277,7 +277,6 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 				}
 			}
 			// Create Starlark CodeMode for code execution
-			starlark.SetLogger(bifrost.logger)
 			var codeModeConfig *mcp.CodeModeConfig
 			if mcpConfig.ToolManagerConfig != nil {
 				codeModeConfig = &mcp.CodeModeConfig{
@@ -285,7 +284,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 					ToolExecutionTimeout: mcpConfig.ToolManagerConfig.ToolExecutionTimeout,
 				}
 			}
-			codeMode := starlark.NewStarlarkCodeMode(codeModeConfig)
+			codeMode := starlark.NewStarlarkCodeMode(codeModeConfig, bifrost.logger)
 			bifrost.McpManager = mcp.NewMCPManager(bifrostCtx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
 			bifrost.logger.Info("MCP integration initialized successfully")
 		})
@@ -2933,8 +2932,7 @@ func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
 				}
 			}
 			// Create Starlark CodeMode for code execution (with default config)
-			starlark.SetLogger(bifrost.logger)
-			codeMode := starlark.NewStarlarkCodeMode(nil)
+			codeMode := starlark.NewStarlarkCodeMode(nil, bifrost.logger)
 			bifrost.McpManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
 		})
 	}

--- a/core/go.mod
+++ b/core/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0
 	github.com/aws/smithy-go v1.24.0
+	github.com/bytedance/gopkg v0.1.3
 	github.com/bytedance/sonic v1.14.2
 	github.com/google/uuid v1.6.0
 	github.com/hajimehoshi/go-mp3 v0.3.4
@@ -44,7 +45,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.4.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/core/internal/mcptests/agent_request_id_test.go
+++ b/core/internal/mcptests/agent_request_id_test.go
@@ -36,8 +36,7 @@ func setupMCPManagerWithRequestIDFunc(t *testing.T, fetchNewRequestIDFunc func(c
 	}
 
 	// Create Starlark CodeMode
-	starlark.SetLogger(logger)
-	codeMode := starlark.NewStarlarkCodeMode(nil)
+	codeMode := starlark.NewStarlarkCodeMode(nil, logger)
 
 	// Create MCP manager - dependencies are injected automatically
 	manager := mcp.NewMCPManager(context.Background(), *mcpConfig, nil, logger, codeMode)

--- a/core/internal/mcptests/codemode_agent_singleturn_test.go
+++ b/core/internal/mcptests/codemode_agent_singleturn_test.go
@@ -58,7 +58,7 @@ func TestCodeMode_Agent_AutoExecuteSingleTool(t *testing.T) {
 	mocker.AddChatResponse(CreateDynamicChatResponse(func(history []schemas.ChatMessage) *schemas.BifrostChatResponse {
 		return CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
 			CreateExecuteToolCodeCall("call-1",
-				`const temp = await TemperatureMCPServer.get_temperature({location: "London"}); return temp;`),
+				`result = TemperatureMCPServer.get_temperature(location="London")`),
 		})
 	}))
 
@@ -188,7 +188,7 @@ func TestCodeMode_Agent_NonAutoToolInCode(t *testing.T) {
 	// Turn 1: LLM returns executeToolCode (auto-executable)
 	mocker.AddChatResponse(CreateDynamicChatResponse(func(history []schemas.ChatMessage) *schemas.BifrostChatResponse {
 		return CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-			CreateExecuteToolCodeCall("call-1", `return {value: 42};`),
+			CreateExecuteToolCodeCall("call-1", `result = {"value": 42}`),
 		})
 	}))
 

--- a/core/internal/mcptests/codemode_agent_test.go
+++ b/core/internal/mcptests/codemode_agent_test.go
@@ -38,7 +38,7 @@ func TestCodeModeAgent_Basic(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "const result = await mcpserver.echo({message: 'test'}); return result;"),
+				CreateExecuteToolCodeCall("call-1", "result = mcpserver.echo(message='test')"),
 			}),
 			CreateChatResponseWithText("Execution complete"),
 		},
@@ -106,7 +106,7 @@ func TestCodeModeAgent_NonAutoToolInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "return 'code result';"),
+				CreateExecuteToolCodeCall("call-1", "result = 'code result'"),
 			}),
 			// After code execution, LLM returns non-auto tool
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
@@ -182,10 +182,10 @@ func TestCodeModeAgent_AutoToolInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "await mcpserver.echo({message: 'test'}); return 'done';"),
+				CreateExecuteToolCodeCall("call-1", "mcpserver.echo(message='test')\nresult = 'done'"),
 			}),
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-2", "return 'second iteration';"),
+				CreateExecuteToolCodeCall("call-2", "result = 'second iteration'"),
 			}),
 			CreateChatResponseWithText("All done"),
 		},
@@ -249,7 +249,7 @@ func TestCodeModeAgent_MixedToolsInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "return 'step 1';"),
+				CreateExecuteToolCodeCall("call-1", "result = 'step 1'"),
 			}),
 			// After code, LLM returns mixed tools
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
@@ -330,7 +330,7 @@ func TestCodeModeAgent_NoToolCallsInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "return 'final result';"),
+				CreateExecuteToolCodeCall("call-1", "result = 'final result'"),
 			}),
 			CreateChatResponseWithText("Done, no more tools"),
 		},
@@ -398,7 +398,7 @@ func TestCodeModeAgent_FilteringInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "const result = await mcpserver.calculator({operation: 'add', x: 5, y: 3}); return result;"),
+				CreateExecuteToolCodeCall("call-1", "result = mcpserver.calculator(operation='add', x=5, y=3)"),
 			}),
 			// Agent makes follow-up call with tool execution error
 			CreateChatResponseWithText("Tool was blocked by filtering"),
@@ -464,7 +464,7 @@ func TestCodeModeAgent_AutoExecuteFiltering(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "const result = await mcpserver.echo({message: 'test'}); return result;"),
+				CreateExecuteToolCodeCall("call-1", "result = mcpserver.echo(message='test')"),
 			}),
 			CreateChatResponseWithText("Complete"),
 			CreateChatResponseWithText("Error handled"), // For code execution error follow-up
@@ -542,13 +542,13 @@ func TestCodeModeAgent_MaxDepth(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "await mcpserver.echo({message: 'iter 1'}); return 'done1';"),
+				CreateExecuteToolCodeCall("call-1", "mcpserver.echo(message='iter 1')\nresult = 'done1'"),
 			}),
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-2", "await mcpserver.echo({message: 'iter 2'}); return 'done2';"),
+				CreateExecuteToolCodeCall("call-2", "mcpserver.echo(message='iter 2')\nresult = 'done2'"),
 			}),
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-3", "await mcpserver.echo({message: 'iter 3'}); return 'done3';"),
+				CreateExecuteToolCodeCall("call-3", "mcpserver.echo(message='iter 3')\nresult = 'done3'"),
 			}),
 			CreateChatResponseWithText("Should not reach - max depth hit"),
 		},
@@ -615,10 +615,10 @@ func TestCodeModeAgent_MaxDepth_ChatFormat(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "return 'test1';"),
+				CreateExecuteToolCodeCall("call-1", "result = 'test1'"),
 			}),
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-2", "return 'test2';"),
+				CreateExecuteToolCodeCall("call-2", "result = 'test2'"),
 			}),
 			CreateChatResponseWithText("Done"),
 		},
@@ -759,7 +759,7 @@ func TestCodeModeAgent_Timeout(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "while(true) {}; return 'timeout';"),
+				CreateExecuteToolCodeCall("call-1", "def loop():\n    while True:\n        pass\n    return 'timeout'\nresult = loop()"),
 			}),
 			// Agent makes follow-up call with timeout error
 			CreateChatResponseWithText("Code execution timed out"),
@@ -822,7 +822,7 @@ func TestCodeModeAgent_Timeout_ChatFormat(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "while(true) {}; return 'timeout';"),
+				CreateExecuteToolCodeCall("call-1", "def loop():\n    while True:\n        pass\n    return 'timeout'\nresult = loop()"),
 			}),
 			// Agent makes follow-up call with timeout error
 			CreateChatResponseWithText("Code execution timed out"),
@@ -947,7 +947,7 @@ func TestCodeModeAgent_ErrorInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "throw new Error('intentional error');"),
+				CreateExecuteToolCodeCall("call-1", "fail('intentional error')"),
 			}),
 			// Agent makes follow-up call with error
 			CreateChatResponseWithText("Error occurred during execution"),
@@ -1012,7 +1012,7 @@ func TestCodeModeAgent_ToolErrorInCode(t *testing.T) {
 	mockLLM := &MockLLMCaller{
 		chatResponses: []*schemas.BifrostChatResponse{
 			CreateChatResponseWithToolCalls([]schemas.ChatAssistantMessageToolCall{
-				CreateExecuteToolCodeCall("call-1", "await mcpserver.calculator({operation: 'invalid', x: 1, y: 2}); return 'done';"),
+				CreateExecuteToolCodeCall("call-1", "mcpserver.calculator(operation='invalid', x=1, y=2)\nresult = 'done'"),
 			}),
 			// Agent makes follow-up call with tool error
 			CreateChatResponseWithText("Tool error occurred"),

--- a/core/internal/mcptests/codemode_stdio_test.go
+++ b/core/internal/mcptests/codemode_stdio_test.go
@@ -131,22 +131,22 @@ func TestCodeMode_STDIO_SingleServerBasicExecution(t *testing.T) {
 	}{
 		{
 			name:           "simple_return",
-			code:           `return 42`,
+			code:           `result = 42`,
 			expectedResult: float64(42),
 		},
 		{
 			name:           "string_return",
-			code:           `return "Hello from test-tools-server"`,
+			code:           `result = "Hello from test-tools-server"`,
 			expectedResult: "Hello from test-tools-server",
 		},
 		{
 			name:           "object_return",
-			code:           `return { status: "success", value: 123 }`,
+			code:           `result = {"status": "success", "value": 123}`,
 			expectedResult: map[string]interface{}{"status": "success", "value": float64(123)},
 		},
 		{
 			name:           "array_return",
-			code:           `return [1, 2, 3, 4, 5]`,
+			code:           `result = [1, 2, 3, 4, 5]`,
 			expectedResult: []interface{}{float64(1), float64(2), float64(3), float64(4), float64(5)},
 		},
 	}
@@ -182,8 +182,7 @@ func TestCodeMode_STDIO_ToolCallSingleServer(t *testing.T) {
 	}{
 		{
 			name: "echo_tool",
-			code: `const result = await testToolsServer.echo({message: "test message"});
-return result`,
+			code: `result = testToolsServer.echo(message="test message")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok, "result should be an object")
@@ -192,8 +191,7 @@ return result`,
 		},
 		{
 			name: "calculator_add",
-			code: `const result = await testToolsServer.calculator({operation: "add", x: 15, y: 27});
-return result`,
+			code: `result = testToolsServer.calculator(operation="add", x=15, y=27)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok, "result should be an object")
@@ -202,8 +200,7 @@ return result`,
 		},
 		{
 			name: "calculator_multiply",
-			code: `const result = await testToolsServer.calculator({operation: "multiply", x: 6, y: 7});
-return result`,
+			code: `result = testToolsServer.calculator(operation="multiply", x=6, y=7)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok, "result should be an object")
@@ -212,8 +209,7 @@ return result`,
 		},
 		{
 			name: "get_weather",
-			code: `const result = await testToolsServer.get_weather({location: "San Francisco", units: "celsius"});
-return result`,
+			code: `result = testToolsServer.get_weather(location="San Francisco", units="celsius")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok, "result should be an object")
@@ -223,9 +219,9 @@ return result`,
 		},
 		{
 			name: "sequential_tool_calls",
-			code: `const echo1 = await testToolsServer.echo({message: "first"});
-const echo2 = await testToolsServer.echo({message: "second"});
-return {first: echo1, second: echo2}`,
+			code: `echo1 = testToolsServer.echo(message="first")
+echo2 = testToolsServer.echo(message="second")
+result = {"first": echo1, "second": echo2}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok, "result should be an object")
@@ -278,8 +274,7 @@ func TestCodeMode_STDIO_MultipleServers(t *testing.T) {
 	}{
 		{
 			name: "call_tool_from_first_server",
-			code: `const result = await testToolsServer.echo({message: "from test-tools"});
-return result`,
+			code: `result = testToolsServer.echo(message="from test-tools")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -288,8 +283,7 @@ return result`,
 		},
 		{
 			name: "call_tool_from_second_server",
-			code: `const result = await temperature.get_temperature({location: "Tokyo"});
-return result`,
+			code: `result = temperature.get_temperature(location="Tokyo")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result := execResult["result"]
 				require.NotNil(t, result)
@@ -301,9 +295,9 @@ return result`,
 		},
 		{
 			name: "call_tools_from_both_servers",
-			code: `const echo = await testToolsServer.echo({message: "hello"});
-const temp = await temperature.get_temperature({location: "London"});
-return {echo: echo, temp: temp}`,
+			code: `echo = testToolsServer.echo(message="hello")
+temp = temperature.get_temperature(location="London")
+result = {"echo": echo, "temp": temp}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -317,9 +311,9 @@ return {echo: echo, temp: temp}`,
 		},
 		{
 			name: "calculator_from_both_servers",
-			code: `const calc1 = await testToolsServer.calculator({operation: "add", x: 10, y: 5});
-const calc2 = await temperature.calculator({operation: "multiply", x: 3, y: 4});
-return {tools: calc1, temp: calc2}`,
+			code: `calc1 = testToolsServer.calculator(operation="add", x=10, y=5)
+calc2 = temperature.calculator(operation="multiply", x=3, y=4)
+result = {"tools": calc1, "temp": calc2}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -375,41 +369,37 @@ func TestCodeMode_STDIO_ServerFiltering(t *testing.T) {
 		{
 			name:           "allow_only_test_tools_server",
 			includeClients: []string{"testToolsServer"},
-			code: `const result = await testToolsServer.echo({message: "allowed"});
-return result`,
+			code:           `result = testToolsServer.echo(message="allowed")`,
 			shouldSucceed:    true,
 			expectedInResult: "allowed",
 		},
 		{
 			name:           "block_test_tools_server",
 			includeClients: []string{"temperature"},
-			code: `const result = await testToolsServer.echo({message: "blocked"});
-return result`,
+			code:           `result = testToolsServer.echo(message="blocked")`,
 			shouldSucceed: false,
-			expectedError: "testToolsServer is not defined",
+			expectedError: "undefined: testToolsServer",
 		},
 		{
 			name:           "allow_only_temperature_server",
 			includeClients: []string{"temperature"},
-			code: `const result = await temperature.get_temperature({location: "Paris"});
-return result`,
+			code:           `result = temperature.get_temperature(location="Paris")`,
 			shouldSucceed:    true,
 			expectedInResult: "Paris",
 		},
 		{
 			name:           "block_temperature_server",
 			includeClients: []string{"testToolsServer"},
-			code: `const result = await temperature.get_temperature({location: "blocked"});
-return result`,
+			code:           `result = temperature.get_temperature(location="blocked")`,
 			shouldSucceed: false,
-			expectedError: "temperature is not defined",
+			expectedError: "undefined: temperature",
 		},
 		{
 			name:           "allow_both_servers",
 			includeClients: []string{"testToolsServer", "temperature"},
-			code: `const echo = await testToolsServer.echo({message: "both"});
-const temp = await temperature.get_temperature({location: "NYC"});
-return {echo: echo, temp: temp}`,
+			code: `echo = testToolsServer.echo(message="both")
+temp = temperature.get_temperature(location="NYC")
+result = {"echo": echo, "temp": temp}`,
 			shouldSucceed:    true,
 			expectedInResult: "both",
 		},
@@ -490,46 +480,43 @@ func TestCodeMode_STDIO_ToolFiltering(t *testing.T) {
 		expectedError    string
 	}{
 		{
-			name:         "allow_only_echo",
-			includeTools: []string{"testToolsServer-echo"},
-			code: `const result = await testToolsServer.echo({message: "allowed"});
-return result`,
+			name:             "allow_only_echo",
+			includeTools:     []string{"testToolsServer-echo"},
+			code:             `result = testToolsServer.echo(message="allowed")`,
 			shouldSucceed:    true,
 			expectedInResult: "allowed",
 		},
 		{
-			name:         "block_calculator_allow_echo",
-			includeTools: []string{"testToolsServer-echo"},
-			code: `const result = await testToolsServer.calculator({operation: "add", x: 1, y: 2});
-return result`,
+			name:          "block_calculator_allow_echo",
+			includeTools:  []string{"testToolsServer-echo"},
+			code:          `result = testToolsServer.calculator(operation="add", x=1, y=2)`,
 			shouldSucceed: false,
 			expectedError: "calculator",
 		},
 		{
 			name:         "wildcard_for_client",
 			includeTools: []string{"testToolsServer-*"},
-			code: `const echo = await testToolsServer.echo({message: "test"});
-const calc = await testToolsServer.calculator({operation: "add", x: 5, y: 3});
-return {echo: echo, calc: calc}`,
+			code: `echo = testToolsServer.echo(message="test")
+calc = testToolsServer.calculator(operation="add", x=5, y=3)
+result = {"echo": echo, "calc": calc}`,
 			shouldSucceed:    true,
 			expectedInResult: "test",
 		},
 		{
 			name:         "allow_multiple_specific_tools",
 			includeTools: []string{"testToolsServer-echo", "testToolsServer-calculator"},
-			code: `const echo = await testToolsServer.echo({message: "multi"});
-const calc = await testToolsServer.calculator({operation: "multiply", x: 6, y: 7});
-return {echo: echo, calc: calc}`,
+			code: `echo = testToolsServer.echo(message="multi")
+calc = testToolsServer.calculator(operation="multiply", x=6, y=7)
+result = {"echo": echo, "calc": calc}`,
 			shouldSucceed:    true,
 			expectedInResult: "multi",
 		},
 		{
-			name:         "block_all_tools_empty_filter",
-			includeTools: []string{},
-			code: `const result = await testToolsServer.echo({message: "blocked"});
-return result`,
+			name:          "block_all_tools_empty_filter",
+			includeTools:  []string{},
+			code:          `result = testToolsServer.echo(message="blocked")`,
 			shouldSucceed: false,
-			expectedError: "testToolsServer is not defined",
+			expectedError: "undefined: testToolsServer",
 		},
 	}
 
@@ -604,11 +591,10 @@ func TestCodeMode_STDIO_CombinedFiltering(t *testing.T) {
 		expectedInResult string
 	}{
 		{
-			name:           "allow_server_and_specific_tool",
-			includeClients: []string{"testToolsServer"},
-			includeTools:   []string{"testToolsServer-echo"},
-			code: `const result = await testToolsServer.echo({message: "filtered"});
-return result`,
+			name:             "allow_server_and_specific_tool",
+			includeClients:   []string{"testToolsServer"},
+			includeTools:     []string{"testToolsServer-echo"},
+			code:             `result = testToolsServer.echo(message="filtered")`,
 			shouldSucceed:    true,
 			expectedInResult: "filtered",
 		},
@@ -616,17 +602,16 @@ return result`,
 			name:           "allow_server_but_block_tool",
 			includeClients: []string{"testToolsServer"},
 			includeTools:   []string{"testToolsServer-calculator"},
-			code: `const result = await testToolsServer.echo({message: "blocked"});
-return result`,
-			shouldSucceed: false,
+			code:           `result = testToolsServer.echo(message="blocked")`,
+			shouldSucceed:  false,
 		},
 		{
 			name:           "allow_all_clients_specific_tools_from_each",
 			includeClients: []string{"*"},
 			includeTools:   []string{"testToolsServer-echo", "temperature-get_temperature"},
-			code: `const echo = await testToolsServer.echo({message: "test"});
-const temp = await temperature.get_temperature({location: "Berlin"});
-return {echo: echo, temp: temp}`,
+			code: `echo = testToolsServer.echo(message="test")
+temp = temperature.get_temperature(location="Berlin")
+result = {"echo": echo, "temp": temp}`,
 			shouldSucceed:    true,
 			expectedInResult: "test",
 		},
@@ -690,12 +675,13 @@ func TestCodeMode_STDIO_ComplexCodePatterns(t *testing.T) {
 	}{
 		{
 			name: "for_loop_with_tool_calls",
-			code: `const results = [];
-for (let i = 0; i < 3; i++) {
-  const r = await testToolsServer.echo({message: "count_" + i});
-  results.push(r);
-}
-return results`,
+			code: `def main():
+    results = []
+    for i in range(3):
+        r = testToolsServer.echo(message="count_" + str(i))
+        results.append(r)
+    return results
+result = main()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				results, ok := execResult["result"].([]interface{})
 				require.True(t, ok, "result should be array")
@@ -704,14 +690,13 @@ return results`,
 		},
 		{
 			name: "conditional_tool_calls",
-			code: `const x = 10;
-let result;
-if (x > 5) {
-  result = await testToolsServer.calculator({operation: "add", x: x, y: 5});
-} else {
-  result = await testToolsServer.echo({message: "small"});
-}
-return result`,
+			code: `def main():
+    x = 10
+    if x > 5:
+        return testToolsServer.calculator(operation="add", x=x, y=5)
+    else:
+        return testToolsServer.echo(message="small")
+result = main()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -719,28 +704,11 @@ return result`,
 			},
 		},
 		{
-			name: "error_handling_try_catch",
-			code: `let result;
-try {
-  result = await testToolsServer.calculator({operation: "divide", x: 10, y: 0});
-} catch (error) {
-  result = {error: "caught_error", message: error.message};
-}
-return result`,
-			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
-				result := execResult["result"]
-				assert.NotNil(t, result)
-			},
-		},
-		{
-			name: "parallel_tool_calls_promise_all",
-			code: `const promises = [
-  testToolsServer.echo({message: "one"}),
-  testToolsServer.echo({message: "two"}),
-  testToolsServer.echo({message: "three"})
-];
-const results = await Promise.all(promises);
-return results`,
+			name: "sequential_tool_calls_list",
+			code: `r1 = testToolsServer.echo(message="one")
+r2 = testToolsServer.echo(message="two")
+r3 = testToolsServer.echo(message="three")
+result = [r1, r2, r3]`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				results, ok := execResult["result"].([]interface{})
 				require.True(t, ok)
@@ -749,12 +717,12 @@ return results`,
 		},
 		{
 			name: "data_transformation",
-			code: `const calc1 = await testToolsServer.calculator({operation: "add", x: 10, y: 20});
-const calc2 = await testToolsServer.calculator({operation: "multiply", x: 5, y: 3});
-return {
-  sum: calc1.result,
-  product: calc2.result,
-  total: calc1.result + calc2.result
+			code: `calc1 = testToolsServer.calculator(operation="add", x=10, y=20)
+calc2 = testToolsServer.calculator(operation="multiply", x=5, y=3)
+result = {
+    "sum": calc1["result"],
+    "product": calc2["result"],
+    "total": calc1["result"] + calc2["result"]
 }`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
@@ -803,8 +771,7 @@ func TestCodeMode_STDIO_EdgeCaseServer_Unicode(t *testing.T) {
 	}{
 		{
 			name: "unicode_emoji",
-			code: `const result = await edgeCaseServer.return_unicode({type: "emoji"});
-return result`,
+			code: `result = edgeCaseServer.return_unicode(type="emoji")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -816,8 +783,8 @@ return result`,
 		},
 		{
 			name: "unicode_has_length",
-			code: `const result = await edgeCaseServer.return_unicode({type: "emoji"});
-return {type: result.type, length: result.length, starts_with_hello: result.text.startsWith("Hello")}`,
+			code: `r = edgeCaseServer.return_unicode(type="emoji")
+result = {"type": r["type"], "length": r["length"], "starts_with_hello": r["text"].startswith("Hello")}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -861,11 +828,7 @@ func TestCodeMode_STDIO_EdgeCaseServer_BinaryAndEncoding(t *testing.T) {
 	}{
 		{
 			name: "binary_data_base64",
-			code: `const result = await edgeCaseServer.return_binary({
-  size: 100,
-  encoding: "base64"
-});
-return result`,
+			code: `result = edgeCaseServer.return_binary(size=100, encoding="base64")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -876,11 +839,7 @@ return result`,
 		},
 		{
 			name: "binary_data_hex",
-			code: `const result = await edgeCaseServer.return_binary({
-  size: 50,
-  encoding: "hex"
-});
-return result`,
+			code: `result = edgeCaseServer.return_binary(size=50, encoding="hex")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -891,11 +850,8 @@ return result`,
 		},
 		{
 			name: "binary_data_small",
-			code: `const result = await edgeCaseServer.return_binary({
-  size: 10,
-  encoding: "base64"
-});
-return {size: result.size, encoding: result.encoding, data_length: result.data.length}`,
+			code: `r = edgeCaseServer.return_binary(size=10, encoding="base64")
+result = {"size": r["size"], "encoding": r["encoding"], "data_length": len(r["data"])}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -939,8 +895,8 @@ func TestCodeMode_STDIO_EdgeCaseServer_EmptyAndNull(t *testing.T) {
 	}{
 		{
 			name: "null_empty_string",
-			code: `const result = await edgeCaseServer.return_null({});
-return {empty_string: result.empty_string, empty_array: result.empty_array}`,
+			code: `r = edgeCaseServer.return_null()
+result = {"empty_string": r["empty_string"], "empty_array": r["empty_array"]}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -952,8 +908,8 @@ return {empty_string: result.empty_string, empty_array: result.empty_array}`,
 		},
 		{
 			name: "null_empty_object",
-			code: `const result = await edgeCaseServer.return_null({});
-return {empty_object: result.empty_object, has_property: 'empty_object' in result}`,
+			code: `r = edgeCaseServer.return_null()
+result = {"empty_object": r["empty_object"], "has_property": "empty_object" in r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -962,8 +918,8 @@ return {empty_object: result.empty_object, has_property: 'empty_object' in resul
 		},
 		{
 			name: "null_null_value",
-			code: `const result = await edgeCaseServer.return_null({});
-return {has_null: result.null_value === null, zero: result.zero, false: result.false}`,
+			code: `r = edgeCaseServer.return_null()
+result = {"has_null": r["null_value"] == None, "zero": r["zero"], "false": r["false"]}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -974,9 +930,9 @@ return {has_null: result.null_value === null, zero: result.zero, false: result.f
 		},
 		{
 			name: "null_all_values",
-			code: `const result = await edgeCaseServer.return_null({});
-const keys = Object.keys(result);
-return {key_count: keys.length, has_empty_string: 'empty_string' in result}`,
+			code: `r = edgeCaseServer.return_null()
+keys = list(r.keys())
+result = {"key_count": len(keys), "has_empty_string": "empty_string" in r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1019,8 +975,7 @@ func TestCodeMode_STDIO_EdgeCaseServer_NestedAndSpecialChars(t *testing.T) {
 	}{
 		{
 			name: "nested_structure_default",
-			code: `const result = await edgeCaseServer.return_nested_structure({depth: 5});
-return result`,
+			code: `result = edgeCaseServer.return_nested_structure(depth=5)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1033,10 +988,7 @@ return result`,
 		},
 		{
 			name: "nested_structure_deeper",
-			code: `const result = await edgeCaseServer.return_nested_structure({
-  depth: 10
-});
-return result`,
+			code: `result = edgeCaseServer.return_nested_structure(depth=10)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1045,8 +997,8 @@ return result`,
 		},
 		{
 			name: "special_chars_quotes",
-			code: `const result = await edgeCaseServer.return_special_chars({});
-return {has_quotes: 'quotes' in result, has_backslashes: 'backslashes' in result}`,
+			code: `r = edgeCaseServer.return_special_chars()
+result = {"has_quotes": "quotes" in r, "has_backslashes": "backslashes" in r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1056,8 +1008,8 @@ return {has_quotes: 'quotes' in result, has_backslashes: 'backslashes' in result
 		},
 		{
 			name: "special_chars_newlines",
-			code: `const result = await edgeCaseServer.return_special_chars({});
-return {has_newlines: 'newlines' in result, has_tabs: 'tabs' in result}`,
+			code: `r = edgeCaseServer.return_special_chars()
+result = {"has_newlines": "newlines" in r, "has_tabs": "tabs" in r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1067,9 +1019,9 @@ return {has_newlines: 'newlines' in result, has_tabs: 'tabs' in result}`,
 		},
 		{
 			name: "special_chars_all",
-			code: `const result = await edgeCaseServer.return_special_chars({});
-const keys = Object.keys(result);
-return {count: keys.length, has_mixed: 'mixed' in result}`,
+			code: `r = edgeCaseServer.return_special_chars()
+keys = list(r.keys())
+result = {"count": len(keys), "has_mixed": "mixed" in r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1112,10 +1064,8 @@ func TestCodeMode_STDIO_EdgeCaseServer_ExtremeSizes(t *testing.T) {
 	}{
 		{
 			name: "extreme_sizes_small",
-			code: `const result = await edgeCaseServer.return_large_payload({
-  size_kb: 1
-});
-return {item_count: result.item_count, requested_size_kb: result.requested_size_kb}`,
+			code: `r = edgeCaseServer.return_large_payload(size_kb=1)
+result = {"item_count": r["item_count"], "requested_size_kb": r["requested_size_kb"]}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1125,10 +1075,8 @@ return {item_count: result.item_count, requested_size_kb: result.requested_size_
 		},
 		{
 			name: "extreme_sizes_normal",
-			code: `const result = await edgeCaseServer.return_large_payload({
-  size_kb: 10
-});
-return {item_count: result.item_count, requested_size_kb: result.requested_size_kb}`,
+			code: `r = edgeCaseServer.return_large_payload(size_kb=10)
+result = {"item_count": r["item_count"], "requested_size_kb": r["requested_size_kb"]}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1138,13 +1086,11 @@ return {item_count: result.item_count, requested_size_kb: result.requested_size_
 		},
 		{
 			name: "extreme_sizes_large",
-			code: `const result = await edgeCaseServer.return_large_payload({
-  size_kb: 100
-});
-return {
-  item_count: result.item_count,
-  requested_size_kb: result.requested_size_kb,
-  has_items: result.items !== undefined
+			code: `r = edgeCaseServer.return_large_payload(size_kb=100)
+result = {
+    "item_count": r["item_count"],
+    "requested_size_kb": r["requested_size_kb"],
+    "has_items": "items" in r
 }`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
@@ -1193,10 +1139,8 @@ func TestCodeMode_STDIO_ErrorTestServer_NetworkErrors(t *testing.T) {
 	}{
 		{
 			name: "return_error_network",
-			code: `const result = await errorTestServer.return_error({
-  error_type: "network"
-});
-return {error_message: result}`,
+			code: `r = errorTestServer.return_error(error_type="network")
+result = {"error_message": r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1205,10 +1149,8 @@ return {error_message: result}`,
 		},
 		{
 			name: "return_error_timeout",
-			code: `const result = await errorTestServer.return_error({
-  error_type: "timeout"
-});
-return {error_message: result}`,
+			code: `r = errorTestServer.return_error(error_type="timeout")
+result = {"error_message": r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1217,10 +1159,8 @@ return {error_message: result}`,
 		},
 		{
 			name: "return_error_validation",
-			code: `const result = await errorTestServer.return_error({
-  error_type: "validation"
-});
-return {error_message: result}`,
+			code: `r = errorTestServer.return_error(error_type="validation")
+result = {"error_message": r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1229,10 +1169,8 @@ return {error_message: result}`,
 		},
 		{
 			name: "return_error_permission",
-			code: `const result = await errorTestServer.return_error({
-  error_type: "permission"
-});
-return {error_message: result}`,
+			code: `r = errorTestServer.return_error(error_type="permission")
+result = {"error_message": r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1274,8 +1212,7 @@ func TestCodeMode_STDIO_ErrorTestServer_MalformedAndPartial(t *testing.T) {
 	}{
 		{
 			name: "return_malformed_json",
-			code: `const result = await errorTestServer.return_malformed_json({});
-return result`,
+			code: `result = errorTestServer.return_malformed_json()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				// return_malformed_json returns invalid JSON which should be handled
 				result := execResult["result"]
@@ -1284,10 +1221,7 @@ return result`,
 		},
 		{
 			name: "return_error",
-			code: `const result = await errorTestServer.timeout_after({
-  seconds: 0.05
-});
-return result`,
+			code: `result = errorTestServer.timeout_after(seconds=0.05)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				// Use timeout_after instead of return_error since return_error throws
 				result, ok := execResult["result"].(map[string]interface{})
@@ -1297,10 +1231,7 @@ return result`,
 		},
 		{
 			name: "timeout_after_short",
-			code: `const result = await errorTestServer.timeout_after({
-  seconds: 0.1
-});
-return result`,
+			code: `result = errorTestServer.timeout_after(seconds=0.1)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1309,10 +1240,7 @@ return result`,
 		},
 		{
 			name: "intermittent_fail_low_rate",
-			code: `const result = await errorTestServer.intermittent_fail({
-  fail_rate: 0.1
-});
-return result`,
+			code: `result = errorTestServer.intermittent_fail(fail_rate=0.1)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				// Either success or error
 				result := execResult["result"]
@@ -1321,10 +1249,8 @@ return result`,
 		},
 		{
 			name: "memory_intensive_small",
-			code: `const result = await errorTestServer.memory_intensive({
-  size_mb: 1
-});
-return {allocated_mb: result.allocated_mb, has_checksum: result.checksum !== undefined}`,
+			code: `r = errorTestServer.memory_intensive(size_mb=1)
+result = {"allocated_mb": r["allocated_mb"], "has_checksum": "checksum" in r}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1367,13 +1293,11 @@ func TestCodeMode_STDIO_ErrorTestServer_LargePayload(t *testing.T) {
 	}{
 		{
 			name: "memory_intensive_small",
-			code: `const result = await errorTestServer.memory_intensive({
-  size_mb: 5
-});
-return {
-  allocated_mb: result.allocated_mb,
-  allocated_bytes: result.allocated_bytes,
-  has_checksum: result.checksum !== undefined
+			code: `r = errorTestServer.memory_intensive(size_mb=5)
+result = {
+    "allocated_mb": r["allocated_mb"],
+    "allocated_bytes": r["allocated_bytes"],
+    "has_checksum": "checksum" in r
 }`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
@@ -1385,13 +1309,11 @@ return {
 		},
 		{
 			name: "memory_intensive_medium",
-			code: `const result = await errorTestServer.memory_intensive({
-  size_mb: 10
-});
-return {
-  allocated_mb: result.allocated_mb,
-  allocated_bytes: result.allocated_bytes,
-  has_message: result.message !== undefined
+			code: `r = errorTestServer.memory_intensive(size_mb=10)
+result = {
+    "allocated_mb": r["allocated_mb"],
+    "allocated_bytes": r["allocated_bytes"],
+    "has_message": "message" in r
 }`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
@@ -1436,11 +1358,7 @@ func TestCodeMode_STDIO_ErrorTestServer_IntermittentAndHandling(t *testing.T) {
 	}{
 		{
 			name: "intermittent_fail_low_rate",
-			code: `const result = await errorTestServer.intermittent_fail({
-  id: "test-1",
-  fail_rate: 0.1
-});
-return result`,
+			code: `result = errorTestServer.intermittent_fail(id="test-1", fail_rate=0.1)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1454,11 +1372,7 @@ return result`,
 		},
 		{
 			name: "intermittent_fail_high_rate",
-			code: `const result = await errorTestServer.intermittent_fail({
-  id: "test-2",
-  fail_rate: 0.9
-});
-return result`,
+			code: `result = errorTestServer.intermittent_fail(id="test-2", fail_rate=0.9)`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1468,20 +1382,10 @@ return result`,
 		},
 		{
 			name: "error_handling_in_code",
-			code: `let result;
-try {
-  result = await errorTestServer.network_error({
-    id: "test-3",
-    error_type: "connection_refused"
-  });
-} catch (error) {
-  result = {caught: true, message: error.message};
-}
-return result`,
+			code: `result = errorTestServer.return_error(error_type="network")`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
-				result, ok := execResult["result"].(map[string]interface{})
-				require.True(t, ok)
-				// Either caught error or network error response
+				// Either error message or error response
+				result := execResult["result"]
 				assert.NotNil(t, result)
 			},
 		},
@@ -1524,8 +1428,7 @@ func TestCodeMode_STDIO_ParallelTestServer_Sequential(t *testing.T) {
 	}{
 		{
 			name: "fast_tool_1",
-			code: `const result = await parallelTestServer.fast_operation({});
-return result`,
+			code: `result = parallelTestServer.fast_operation()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1535,8 +1438,7 @@ return result`,
 		},
 		{
 			name: "medium_tool_1",
-			code: `const result = await parallelTestServer.medium_operation({});
-return result`,
+			code: `result = parallelTestServer.medium_operation()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1546,8 +1448,7 @@ return result`,
 		},
 		{
 			name: "slow_tool_1",
-			code: `const result = await parallelTestServer.slow_operation({});
-return result`,
+			code: `result = parallelTestServer.slow_operation()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1557,8 +1458,7 @@ return result`,
 		},
 		{
 			name: "variable_delay",
-			code: `const result = await parallelTestServer.very_slow_operation({});
-return result`,
+			code: `result = parallelTestServer.very_slow_operation()`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1601,55 +1501,41 @@ func TestCodeMode_STDIO_ParallelTestServer_Concurrent(t *testing.T) {
 	}{
 		{
 			name: "parallel_fast_tools",
-			code: `const start = Date.now();
-const results = await Promise.all([
-  parallelTestServer.fast_operation({}),
-  parallelTestServer.return_timestamp({})
-]);
-const elapsed = Date.now() - start;
-return {results: results, elapsed: elapsed}`,
+			code: `r1 = parallelTestServer.fast_operation()
+r2 = parallelTestServer.return_timestamp()
+result = {"results": [r1, r2], "count": 2}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
 				results, ok := result["results"].([]interface{})
 				require.True(t, ok)
 				assert.Len(t, results, 2)
-				// Elapsed should be very quick since these are fast operations
-				elapsed := result["elapsed"].(float64)
-				assert.Less(t, elapsed, float64(100), "parallel execution should be fast")
 			},
 		},
 		{
 			name: "parallel_mixed_speeds",
-			code: `const start = Date.now();
-const results = await Promise.all([
-  parallelTestServer.fast_operation({}),
-  parallelTestServer.medium_operation({}),
-  parallelTestServer.slow_operation({})
-]);
-const elapsed = Date.now() - start;
-return {results: results, elapsed: elapsed, count: results.length}`,
+			code: `r1 = parallelTestServer.fast_operation()
+r2 = parallelTestServer.medium_operation()
+r3 = parallelTestServer.slow_operation()
+result = {"results": [r1, r2, r3], "count": 3}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
 				assert.Equal(t, float64(3), result["count"])
-				// Elapsed should be closer to max(fast, medium, slow) than to sum
-				// slow takes 750ms, so elapsed should be around 750ms
-				elapsed := result["elapsed"].(float64)
-				assert.Greater(t, elapsed, float64(700), "should include slow operation time")
-				assert.Less(t, elapsed, float64(1500), "should not be much more than slow operation")
 			},
 		},
 		{
 			name: "parallel_all_tools",
-			code: `const results = await Promise.all([
-  parallelTestServer.fast_operation({}),
-  parallelTestServer.return_timestamp({}),
-  parallelTestServer.medium_operation({}),
-  parallelTestServer.slow_operation({}),
-  parallelTestServer.very_slow_operation({})
-]);
-return {count: results.length, operations: results.map(r => r.operation || 'timestamp')}`,
+			code: `r1 = parallelTestServer.fast_operation()
+r2 = parallelTestServer.return_timestamp()
+r3 = parallelTestServer.medium_operation()
+r4 = parallelTestServer.slow_operation()
+r5 = parallelTestServer.very_slow_operation()
+def get_op(r):
+    if "operation" in r:
+        return r["operation"]
+    return "timestamp"
+result = {"count": 5, "operations": [get_op(r1), get_op(r2), get_op(r3), get_op(r4), get_op(r5)]}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
@@ -1688,7 +1574,7 @@ return {count: results.length, operations: results.map(r => r.operation || 'time
 func TestCodeMode_STDIO_MultiServer_AllServers(t *testing.T) {
 	t.Parallel()
 
-	_, bifrost := setupCodeModeWithSTDIOServers(t, "test-tools-server", "edge-case-server", "error-test-server", "parallel-test-server")
+	_, bifrost := setupCodeModeWithSTDIOServers(t, "go-test-server", "edge-case-server", "error-test-server", "parallel-test-server")
 	ctx := createTestContext()
 
 	tests := []struct {
@@ -1698,27 +1584,25 @@ func TestCodeMode_STDIO_MultiServer_AllServers(t *testing.T) {
 	}{
 		{
 			name: "call_tools_from_all_servers",
-			code: `const results = await Promise.all([
-  testToolsServer.echo({message: "test-tools"}),
-  edgeCaseServer.return_unicode({type: "emoji"}),
-  errorTestServer.timeout_after({seconds: 0.05}),
-  parallelTestServer.fast_operation({})
-]);
-return {
-  count: results.length,
-  testTools: results[0],
-  edgeCase: results[1],
-  errorTest: results[2],
-  parallelTest: results[3]
+			code: `r1 = goTestServer.string_transform(input="test-tools", operation="uppercase")
+r2 = edgeCaseServer.return_unicode(type="emoji")
+r3 = errorTestServer.timeout_after(seconds=0.05)
+r4 = parallelTestServer.fast_operation()
+result = {
+    "count": 4,
+    "goTest": r1,
+    "edgeCase": r2,
+    "errorTest": r3,
+    "parallelTest": r4
 }`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
 				assert.Equal(t, float64(4), result["count"])
 
-				testTools, ok := result["testTools"].(map[string]interface{})
+				goTest, ok := result["goTest"].(map[string]interface{})
 				require.True(t, ok)
-				assert.Equal(t, "test-tools", testTools["message"])
+				assert.Equal(t, "TEST-TOOLS", goTest["result"])
 
 				edgeCase, ok := result["edgeCase"].(map[string]interface{})
 				require.True(t, ok)
@@ -1735,14 +1619,14 @@ return {
 		},
 		{
 			name: "sequential_across_servers",
-			code: `const echo = await testToolsServer.echo({message: "first"});
-const unicode = await edgeCaseServer.return_unicode({type: "emoji"});
-const fast = await parallelTestServer.fast_operation({});
-return {echo: echo, unicode: unicode, fast: fast}`,
+			code: `transform = goTestServer.string_transform(input="first", operation="uppercase")
+unicode = edgeCaseServer.return_unicode(type="emoji")
+fast = parallelTestServer.fast_operation()
+result = {"transform": transform, "unicode": unicode, "fast": fast}`,
 			verifyResult: func(t *testing.T, execResult map[string]interface{}) {
 				result, ok := execResult["result"].(map[string]interface{})
 				require.True(t, ok)
-				assert.NotNil(t, result["echo"])
+				assert.NotNil(t, result["transform"])
 				assert.NotNil(t, result["unicode"])
 				assert.NotNil(t, result["fast"])
 			},
@@ -1772,7 +1656,7 @@ return {echo: echo, unicode: unicode, fast: fast}`,
 func TestCodeMode_STDIO_MultiServer_FilteringAcrossServers(t *testing.T) {
 	t.Parallel()
 
-	_, bifrost := setupCodeModeWithSTDIOServers(t, "test-tools-server", "edge-case-server", "parallel-test-server")
+	_, bifrost := setupCodeModeWithSTDIOServers(t, "go-test-server", "edge-case-server", "parallel-test-server")
 
 	tests := []struct {
 		name           string
@@ -1781,31 +1665,26 @@ func TestCodeMode_STDIO_MultiServer_FilteringAcrossServers(t *testing.T) {
 		shouldSucceed  bool
 	}{
 		{
-			name:           "allow_only_test_tools_and_edge_case",
-			includeClients: []string{"testToolsServer", "edgeCaseServer"},
-			code: `const results = await Promise.all([
-  testToolsServer.echo({message: "allowed"}),
-  edgeCaseServer.return_unicode({type: "emoji"})
-]);
-return results`,
+			name:           "allow_only_go_test_and_edge_case",
+			includeClients: []string{"goTestServer", "edgeCaseServer"},
+			code: `r1 = goTestServer.string_transform(input="allowed", operation="uppercase")
+r2 = edgeCaseServer.return_unicode(type="emoji")
+result = [r1, r2]`,
 			shouldSucceed: true,
 		},
 		{
 			name:           "block_parallel_server",
-			includeClients: []string{"testToolsServer", "edgeCaseServer"},
-			code: `const result = await parallelTestServer.fast_operation({});
-return result`,
-			shouldSucceed: false,
+			includeClients: []string{"goTestServer", "edgeCaseServer"},
+			code:           `result = parallelTestServer.fast_operation()`,
+			shouldSucceed:  false,
 		},
 		{
 			name:           "allow_all_servers",
 			includeClients: []string{"*"},
-			code: `const results = await Promise.all([
-  testToolsServer.echo({message: "all"}),
-  edgeCaseServer.return_unicode({type: "emoji"}),
-  parallelTestServer.fast_operation({})
-]);
-return {count: results.length}`,
+			code: `r1 = goTestServer.string_transform(input="all", operation="uppercase")
+r2 = edgeCaseServer.return_unicode(type="emoji")
+r3 = parallelTestServer.fast_operation()
+result = {"count": 3}`,
 			shouldSucceed: true,
 		},
 	}

--- a/core/internal/mcptests/fixtures.go
+++ b/core/internal/mcptests/fixtures.go
@@ -1478,8 +1478,7 @@ func setupMCPManager(t *testing.T, clientConfigs ...schemas.MCPClientConfig) *mc
 	}
 
 	// Create Starlark CodeMode
-	starlark.SetLogger(logger)
-	codeMode := starlark.NewStarlarkCodeMode(nil)
+	codeMode := starlark.NewStarlarkCodeMode(nil, logger)
 
 	// Create MCP manager - dependencies are injected automatically
 	manager := mcp.NewMCPManager(context.Background(), *mcpConfig, nil, logger, codeMode)
@@ -1881,61 +1880,61 @@ func GenerateInvalidJSON() []string {
 func GenerateValidCode(codeType string) string {
 	switch codeType {
 	case "simple_return":
-		return "return 42"
+		return "result = 42"
 	case "string_return":
-		return `return "Hello, World!"`
+		return `result = "Hello, World!"`
 	case "calculation":
-		return "const x = 10; const y = 20; return x + y"
+		return "x = 10\ny = 20\nresult = x + y"
 	case "object_return":
-		return `return { status: "success", value: 42 }`
+		return `result = {"status": "success", "value": 42}`
 	case "array_return":
-		return `return [1, 2, 3, 4, 5]`
+		return `result = [1, 2, 3, 4, 5]`
 	case "with_console_log":
-		return `console.log("test"); return "done"`
+		return `print("test")\nresult = "done"`
 	case "async_operation":
-		return `const result = await Promise.resolve(42); return result`
+		return `result = 42`
 	default:
-		return "return 'default'"
+		return "result = 'default'"
 	}
 }
 
-// GenerateInvalidCode generates invalid TypeScript/JavaScript code for testing
+// GenerateInvalidCode generates invalid Starlark code for testing
 func GenerateInvalidCode(errorType string) string {
 	switch errorType {
 	case "syntax_error":
-		return "const x = "
+		return "x = "
 	case "missing_semicolon":
-		return "const x = 10 const y = 20"
+		return "x = 10 y = 20"
 	case "unclosed_brace":
-		return "function foo() { return 42"
+		return "def foo():\n    return 42"
 	case "unclosed_bracket":
-		return "const arr = [1, 2, 3"
+		return "arr = [1, 2, 3"
 	case "invalid_keyword":
-		return "const 123invalid = 'value'"
+		return "123invalid = 'value'"
 	case "runtime_error":
-		return "throw new Error('test error')"
+		return "fail('test error')"
 	case "undefined_variable":
-		return "return undefinedVariable"
+		return "result = undefinedVariable"
 	case "null_reference":
-		return "const x = null; return x.property"
+		return "x = None\nresult = x.property"
 	default:
-		return "return invalid syntax {"
+		return "result = invalid syntax {"
 	}
 }
 
 // GeneratePathTraversalAttempts generates various path traversal attack strings
 func GeneratePathTraversalAttempts() []string {
 	return []string{
-		"../../../etc/passwd.d.ts",
-		"servers/../../secrets.d.ts",
-		"servers/../../../etc/passwd.d.ts",
-		"..\\..\\..\\windows\\system32\\config\\sam.d.ts",
-		"servers/test/../../../etc.d.ts",
-		"servers/test/../../other.d.ts",
-		"/etc/passwd.d.ts",
-		"C:\\Windows\\System32\\config\\sam.d.ts",
-		"servers/test\x00hidden/file.d.ts", // Null byte injection
-		"servers/test%00hidden/file.d.ts",  // URL encoded null byte
+		"../../../etc/passwd.pyi",
+		"servers/../../secrets.pyi",
+		"servers/../../../etc/passwd.pyi",
+		"..\\..\\..\\windows\\system32\\config\\sam.pyi",
+		"servers/test/../../../etc.pyi",
+		"servers/test/../../other.pyi",
+		"/etc/passwd.pyi",
+		"C:\\Windows\\System32\\config\\sam.pyi",
+		"servers/test\x00hidden/file.pyi", // Null byte injection
+		"servers/test%00hidden/file.pyi",  // URL encoded null byte
 	}
 }
 

--- a/core/logger.go
+++ b/core/logger.go
@@ -3,12 +3,15 @@ package bifrost
 
 import (
 	"os"
+	"sync"
 	"time"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
+
+var zerologOnce sync.Once
 
 // DefaultLogger implements the Logger interface with stdout/stderr printing.
 // It provides a simple logging implementation that writes to standard output
@@ -39,9 +42,11 @@ func toZerologLevel(l schemas.LogLevel) zerolog.Level {
 // The log level determines which messages will be output based on their severity.
 func NewDefaultLogger(level schemas.LogLevel) *DefaultLogger {
 	zerolog.SetGlobalLevel(toZerologLevel(level))
-	zerolog.DisableSampling(true)
-	zerolog.TimeFieldFormat = time.RFC3339
-	log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
+	zerologOnce.Do(func() {
+		zerolog.DisableSampling(true)
+		zerolog.TimeFieldFormat = time.RFC3339
+		log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
+	})
 	return &DefaultLogger{
 		stderrLogger: zerolog.New(os.Stderr).With().Timestamp().Logger(),
 		stdoutLogger: zerolog.New(os.Stdout).With().Timestamp().Logger(),

--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -199,9 +199,6 @@ func TestExtractToolCalls(t *testing.T) {
 }
 
 func TestExecuteAgentForChatRequest(t *testing.T) {
-	// Set up logger for the test
-	SetLogger(&MockLogger{})
-
 	// Test with response that has no tool calls - should return immediately
 	responseNoTools := &schemas.BifrostChatResponse{
 		Choices: []schemas.BifrostResponseChoice{
@@ -237,8 +234,10 @@ func TestExecuteAgentForChatRequest(t *testing.T) {
 	}
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
-	result, err := ExecuteAgentForChatRequest(ctx, 10, originalReq, responseNoTools, makeReq, nil, nil, &MockClientManager{})
+	agentModeExecutor := &AgentModeExecutor{
+		logger: &MockLogger{},
+	}
+	result, err := agentModeExecutor.ExecuteAgentForChatRequest(ctx, 10, originalReq, responseNoTools, makeReq, nil, nil, &MockClientManager{})
 	if err != nil {
 		t.Errorf("Expected no error for response without tool calls, got: %v", err)
 	}
@@ -248,8 +247,6 @@ func TestExecuteAgentForChatRequest(t *testing.T) {
 }
 
 func TestExecuteAgentForChatRequest_WithNonAutoExecutableTools(t *testing.T) {
-	// Set up logger for the test
-	SetLogger(&MockLogger{})
 
 	// Create a response with tool calls that will NOT be auto-executed
 	responseWithNonAutoTools := &schemas.BifrostChatResponse{
@@ -297,9 +294,11 @@ func TestExecuteAgentForChatRequest_WithNonAutoExecutableTools(t *testing.T) {
 	}
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
+	agentModeExecutor := &AgentModeExecutor{
+		logger: &MockLogger{},
+	}
 	// Execute agent mode - should return immediately with non-auto-executable tools
-	result, err := ExecuteAgentForChatRequest(ctx, 10, originalReq, responseWithNonAutoTools, makeReq, nil, nil, &MockClientManager{})
+	result, err := agentModeExecutor.ExecuteAgentForChatRequest(ctx, 10, originalReq, responseWithNonAutoTools, makeReq, nil, nil, &MockClientManager{})
 
 	// Should not return error for non-auto-executable tools
 	if err != nil {
@@ -377,8 +376,6 @@ func TestHasToolCallsForResponsesResponse(t *testing.T) {
 }
 
 func TestExecuteAgentForResponsesRequest(t *testing.T) {
-	// Set up logger for the test
-	SetLogger(&MockLogger{})
 
 	// Test with response that has no tool calls - should return immediately
 	responseNoTools := &schemas.BifrostResponsesResponse{
@@ -412,8 +409,10 @@ func TestExecuteAgentForResponsesRequest(t *testing.T) {
 	}
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
-	result, err := ExecuteAgentForResponsesRequest(ctx, 10, originalReq, responseNoTools, makeReq, nil, nil, &MockClientManager{})
+	agentModeExecutor := &AgentModeExecutor{
+		logger: &MockLogger{},
+	}
+	result, err := agentModeExecutor.ExecuteAgentForResponsesRequest(ctx, 10, originalReq, responseNoTools, makeReq, nil, nil, &MockClientManager{})
 	if err != nil {
 		t.Errorf("Expected no error for response without tool calls, got: %v", err)
 	}
@@ -423,8 +422,6 @@ func TestExecuteAgentForResponsesRequest(t *testing.T) {
 }
 
 func TestExecuteAgentForResponsesRequest_WithNonAutoExecutableTools(t *testing.T) {
-	// Set up logger for the test
-	SetLogger(&MockLogger{})
 
 	// Create a response with tool calls that will NOT be auto-executed
 	responseWithNonAutoTools := &schemas.BifrostResponsesResponse{
@@ -460,9 +457,11 @@ func TestExecuteAgentForResponsesRequest_WithNonAutoExecutableTools(t *testing.T
 	}
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-
+	agentModeExecutor := &AgentModeExecutor{
+		logger: &MockLogger{},
+	}
 	// Execute agent mode - should return immediately with non-auto-executable tools
-	result, err := ExecuteAgentForResponsesRequest(ctx, 10, originalReq, responseWithNonAutoTools, makeReq, nil, nil, &MockClientManager{})
+	result, err := agentModeExecutor.ExecuteAgentForResponsesRequest(ctx, 10, originalReq, responseWithNonAutoTools, makeReq, nil, nil, &MockClientManager{})
 
 	// Should not return error for non-auto-executable tools
 	if err != nil {

--- a/core/mcp/codemode/starlark/getdocs.go
+++ b/core/mcp/codemode/starlark/getdocs.go
@@ -76,7 +76,7 @@ func (s *StarlarkCodeMode) handleGetToolDocs(ctx context.Context, toolCall schem
 	for clientName, tools := range availableToolsPerClient {
 		client := s.clientManager.GetClientByName(clientName)
 		if client == nil {
-			logger.Warn("%s Client %s not found, skipping", codemcp.CodeModeLogPrefix, clientName)
+			s.logger.Warn("%s Client %s not found, skipping", codemcp.CodeModeLogPrefix, clientName)
 			continue
 		}
 		if !client.ExecutionConfig.IsCodeModeClient || len(tools) == 0 {

--- a/core/mcp/codemode/starlark/init.go
+++ b/core/mcp/codemode/starlark/init.go
@@ -4,9 +4,17 @@ package starlark
 
 import "github.com/maximhq/bifrost/core/schemas"
 
-var logger schemas.Logger
+// noopLogger is a no-op implementation of schemas.Logger used as a fallback
+// when no logger is provided.
+type noopLogger struct{}
 
-// SetLogger sets the logger for the starlark package.
-func SetLogger(l schemas.Logger) {
-	logger = l
-}
+func (noopLogger) Debug(string, ...any)                        {}
+func (noopLogger) Info(string, ...any)                         {}
+func (noopLogger) Warn(string, ...any)                         {}
+func (noopLogger) Error(string, ...any)                        {}
+func (noopLogger) Fatal(string, ...any)                        {}
+func (noopLogger) SetLevel(schemas.LogLevel)                   {}
+func (noopLogger) SetOutputType(schemas.LoggerOutputType)      {}
+
+// defaultLogger is used when nil is passed to NewStarlarkCodeMode.
+var defaultLogger schemas.Logger = noopLogger{}

--- a/core/mcp/codemode/starlark/listfiles.go
+++ b/core/mcp/codemode/starlark/listfiles.go
@@ -73,7 +73,7 @@ func (s *StarlarkCodeMode) handleListToolFiles(ctx context.Context, toolCall sch
 	for clientName, tools := range availableToolsPerClient {
 		client := s.clientManager.GetClientByName(clientName)
 		if client == nil {
-			logger.Warn("%s Client %s not found, skipping", codemcp.CodeModeLogPrefix, clientName)
+			s.logger.Warn("%s Client %s not found, skipping", codemcp.CodeModeLogPrefix, clientName)
 			continue
 		}
 		if !client.ExecutionConfig.IsCodeModeClient {
@@ -95,7 +95,7 @@ func (s *StarlarkCodeMode) handleListToolFiles(ctx context.Context, toolCall sch
 					toolName = strings.ReplaceAll(toolName, "-", "_")
 					// Validate normalized tool name to prevent path traversal
 					if err := validateNormalizedToolName(toolName); err != nil {
-						logger.Warn("%s Skipping tool '%s' from client '%s': %v", codemcp.CodeModeLogPrefix, tool.Function.Name, clientName, err)
+						s.logger.Warn("%s Skipping tool '%s' from client '%s': %v", codemcp.CodeModeLogPrefix, tool.Function.Name, clientName, err)
 						continue
 					}
 					toolFileName := fmt.Sprintf("servers/%s/%s.pyi", clientName, toolName)

--- a/core/mcp/codemode/starlark/readfile.go
+++ b/core/mcp/codemode/starlark/readfile.go
@@ -97,7 +97,7 @@ func (s *StarlarkCodeMode) handleReadToolFile(ctx context.Context, toolCall sche
 	for clientName, tools := range availableToolsPerClient {
 		client := s.clientManager.GetClientByName(clientName)
 		if client == nil {
-			logger.Warn("%s Client %s not found, skipping", codemcp.CodeModeLogPrefix, clientName)
+			s.logger.Warn("%s Client %s not found, skipping", codemcp.CodeModeLogPrefix, clientName)
 			continue
 		}
 		if !client.ExecutionConfig.IsCodeModeClient || len(tools) == 0 {

--- a/core/mcp/init.go
+++ b/core/mcp/init.go
@@ -2,8 +2,17 @@ package mcp
 
 import "github.com/maximhq/bifrost/core/schemas"
 
-var logger schemas.Logger
+// noopLogger is a no-op implementation of schemas.Logger used as a fallback
+// when no logger is provided.
+type noopLogger struct{}
 
-func SetLogger(l schemas.Logger) {
-	logger = l
-}
+func (noopLogger) Debug(string, ...any)                   {}
+func (noopLogger) Info(string, ...any)                    {}
+func (noopLogger) Warn(string, ...any)                    {}
+func (noopLogger) Error(string, ...any)                   {}
+func (noopLogger) Fatal(string, ...any)                   {}
+func (noopLogger) SetLevel(schemas.LogLevel)              {}
+func (noopLogger) SetOutputType(schemas.LoggerOutputType) {}
+
+// defaultLogger is used when nil is passed to NewMCPManager.
+var defaultLogger schemas.Logger = noopLogger{}

--- a/core/mcp/utils_test.go
+++ b/core/mcp/utils_test.go
@@ -21,7 +21,7 @@ func TestConvertMCPToolToBifrostSchema_EmptyParameters(t *testing.T) {
 	}
 
 	// Convert the tool
-	bifrostTool := convertMCPToolToBifrostSchema(mcpTool)
+	bifrostTool := convertMCPToolToBifrostSchema(mcpTool, defaultLogger)
 
 	// Verify the function was created
 	if bifrostTool.Function == nil {
@@ -72,7 +72,7 @@ func TestConvertMCPToolToBifrostSchema_WithParameters(t *testing.T) {
 	}
 
 	// Convert the tool
-	bifrostTool := convertMCPToolToBifrostSchema(mcpTool)
+	bifrostTool := convertMCPToolToBifrostSchema(mcpTool, defaultLogger)
 
 	// Verify the function was created
 	if bifrostTool.Function == nil {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -27,8 +27,27 @@ import (
 	"github.com/valyala/fasthttp/fasthttpproxy"
 )
 
+// logger is the global logger for the provider utils.
 var logger schemas.Logger
 
+// noopLogger is a no-op implementation of schemas.Logger.
+type noopLogger struct{}
+
+func (noopLogger) Debug(string, ...any)                   {}
+func (noopLogger) Info(string, ...any)                    {}
+func (noopLogger) Warn(string, ...any)                    {}
+func (noopLogger) Error(string, ...any)                   {}
+func (noopLogger) Fatal(string, ...any)                   {}
+func (noopLogger) SetLevel(schemas.LogLevel)              {}
+func (noopLogger) SetOutputType(schemas.LoggerOutputType) {}
+
+
+// Initialize with noop logger
+func init(){
+	logger = &noopLogger{}
+}
+
+// SetLogger sets the logger for the provider utils.
 func SetLogger(l schemas.Logger) {
 	logger = l
 }

--- a/plugins/governance/go.mod
+++ b/plugins/governance/go.mod
@@ -6,7 +6,7 @@ require gorm.io/gorm v1.31.1
 
 require (
 	github.com/bytedance/sonic v1.14.2
-	github.com/google/cel-go v0.22.1
+	github.com/google/cel-go v0.26.1
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.3.14
 	github.com/maximhq/bifrost/framework v1.2.16
@@ -106,7 +106,7 @@ require (
 	github.com/redis/go-redis/v9 v9.17.2 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/stoewer/go-strcase v1.2.0 // indirect
+	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.68.0 // indirect
@@ -122,7 +122,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.23.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
+	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/plugins/governance/go.sum
+++ b/plugins/governance/go.sum
@@ -159,8 +159,7 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
-github.com/google/cel-go v0.22.1 h1:AfVXx3chM2qwoSbM7Da8g8hX8OVSkBFwX+rz2+PcK40=
-github.com/google/cel-go v0.22.1/go.mod h1:BuznPXXfQDpXKWQ9sPW3TzlAJN5zzFe+i9tIs0yC4s8=
+github.com/google/cel-go v0.26.1 h1:iPbVVEdkhTX++hpe3lzSk7D3G3QSYqLGoHOcEio+UXQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f h1:HU1RgM6NALf/KW9HEY6zry3ADbDKcmpQ+hJedoNGQYQ=
@@ -238,8 +237,7 @@ github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
-github.com/stoewer/go-strcase v1.2.0 h1:Z2iHWqGXH00XYgqDmNgQbIBxf3wrNq0F3feEy0ainaU=
-github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -247,7 +245,6 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -291,8 +288,7 @@ golang.org/x/arch v0.23.0 h1:lKF64A2jF6Zd8L0knGltUnegD62JMFBiCPBmQpToHhg=
 golang.org/x/arch v0.23.0/go.mod h1:dNHoOeKiyja7GTvF9NJS1l3Z2yntpQNzgrjh1cU103A=
 golang.org/x/crypto v0.46.0 h1:cKRW/pmt1pKAfetfu+RCEvjvZkA9RimPbh7bhFjGVBU=
 golang.org/x/crypto v0.46.0/go.mod h1:Evb/oLKmMraqjZ2iQTwDwvCtJkczlDuTmdJXoZVzqU0=
-golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
-golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
+golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5ZsaDtB+a39EqjV0JSUM=
 golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
@@ -320,7 +316,6 @@ google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

Refactor logger implementation to use dependency injection instead of global variables, improving thread safety and testability.

## Changes

- Replaced global `logger` variables with instance-based logger fields in MCP, Starlark, and related components
- Added logger parameter to constructors and methods that need logging capabilities
- Implemented a thread-safe initialization for zerolog with `sync.Once` to prevent multiple initializations
- Added `noopLogger` implementations as fallbacks when no logger is provided
- Updated all code that previously used global loggers to use the injected logger instances

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the existing test suite to verify that logging functionality works correctly:

```sh
# Core/Transports
go version
go test ./core/mcp/...
go test ./core/mcp/codemode/starlark/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves thread safety and testability of the logging system.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable