### PR TITLE
anthropic test case fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PROMETHEUS_LABELS ?=
 LOG_STYLE ?= json
 LOG_LEVEL ?= info
 TEST_REPORTS_DIR ?= test-reports
-GOTESTSUM_FORMAT ?= testname
+GOTESTSUM_FORMAT ?= standard-verbose
 VERSION ?= dev-build
 LOCAL ?=
 DEBUG ?=
@@ -48,7 +48,7 @@ help: ## Show this help message
 	@echo ""
 	@echo "$(YELLOW)Test Configuration:$(NC)"
 	@echo "  TEST_REPORTS_DIR  Directory for HTML test reports (default: test-reports)"
-	@echo "  GOTESTSUM_FORMAT  Test output format: testname|dots|pkgname|standard-verbose (default: testname)"
+	@echo "  GOTESTSUM_FORMAT  Test output format: testname|dots|pkgname|standard-verbose (default: standard-verbose)"
 	@echo "  TESTCASE          Exact test name to run (e.g., TestVirtualKeyTokenRateLimit)"
 	@echo "  PATTERN           Substring pattern to filter tests (alternative to TESTCASE)"
 

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -147,20 +147,7 @@ type tracerWrapper struct {
 }
 
 // Global logger instance which is set in the Init function (thread-safe via atomic.Pointer)
-var globalLogger atomic.Pointer[schemas.Logger]
-
-// getGlobalLogger returns the global logger (thread-safe).
-func getGlobalLogger() schemas.Logger {
-	if l := globalLogger.Load(); l != nil {
-		return *l
-	}
-	return nil
-}
-
-// setGlobalLogger sets the global logger (thread-safe).
-func setGlobalLogger(l schemas.Logger) {
-	globalLogger.Store(&l)
-}
+var logger schemas.Logger
 
 // INITIALIZATION
 
@@ -176,7 +163,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 	if config.Logger == nil {
 		config.Logger = NewDefaultLogger(schemas.LogLevelInfo)
 	}
-
+	logger = config.Logger
 	providerUtils.SetLogger(config.Logger)
 
 	// Initialize tracer (use NoOpTracer if not provided)
@@ -330,10 +317,6 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 			bifrost.logger.Warn("failed to prepare provider %s: %v", providerKey, err)
 		}
 	}
-
-	// Set global logger (thread-safe)
-	setGlobalLogger(bifrost.logger)
-
 	return bifrost, nil
 }
 
@@ -3223,9 +3206,7 @@ func (bifrost *Bifrost) getProviderByKey(providerKey schemas.ModelProvider) sche
 	config, err := bifrost.account.GetConfigForProvider(providerKey)
 	if err != nil || config == nil {
 		if slices.Contains(dynamicallyConfigurableProviders, providerKey) {
-			if l := getGlobalLogger(); l != nil {
-				l.Info(fmt.Sprintf("initializing provider %s with default config", providerKey))
-			}
+			logger.Info(fmt.Sprintf("initializing provider %s with default config", providerKey))
 			// If no config found, use default config
 			config = &schemas.ProviderConfig{
 				NetworkConfig:            schemas.DefaultNetworkConfig,
@@ -4068,28 +4049,21 @@ func executeRequestWithRetries[T any](
 					retryMsg += ", type=" + *bifrostError.Type
 				}
 			}
-			if l := getGlobalLogger(); l != nil {
-				l.Debug("retrying request (attempt %d/%d) for model %s: %s", attempts, config.NetworkConfig.MaxRetries, model, retryMsg)
-			}
+			logger.Debug("retrying request (attempt %d/%d) for model %s: %s", attempts, config.NetworkConfig.MaxRetries, model, retryMsg)
 
 			// Calculate and apply backoff
 			backoff := calculateBackoff(attempts-1, config)
-			if l := getGlobalLogger(); l != nil {
-				l.Debug("sleeping for %s before retry", backoff)
-			}
+			logger.Debug("sleeping for %s before retry", backoff)
+
 			time.Sleep(backoff)
 		}
 
-		if l := getGlobalLogger(); l != nil {
-			l.Debug("attempting %s request for provider %s", requestType, providerKey)
-		}
+		logger.Debug("attempting %s request for provider %s", requestType, providerKey)
 
 		// Start span for LLM call (or retry attempt)
 		tracer, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
 		if !ok || tracer == nil {
-			if l := getGlobalLogger(); l != nil {
-				l.Error("tracer not found in context of executeRequestWithRetries")
-			}
+			logger.Error("tracer not found in context of executeRequestWithRetries")
 			return result, newBifrostErrorFromMsg("tracer not found in context")
 		}
 		var spanName string
@@ -4155,9 +4129,7 @@ func executeRequestWithRetries[T any](
 			}
 		}
 
-		if l := getGlobalLogger(); l != nil {
-			l.Debug("request %s for provider %s completed", requestType, providerKey)
-		}
+		logger.Debug("request %s for provider %s completed", requestType, providerKey)
 
 		// Check if successful or if we should retry
 		if bifrostError == nil ||
@@ -4171,9 +4143,7 @@ func executeRequestWithRetries[T any](
 
 		if bifrostError.Error != nil && (bifrostError.Error.Message == schemas.ErrProviderDoRequest || bifrostError.Error.Message == schemas.ErrProviderNetworkError) {
 			shouldRetry = true
-			if l := getGlobalLogger(); l != nil {
-				l.Debug("detected request HTTP/network error, will retry: %s", bifrostError.Error.Message)
-			}
+			logger.Debug("detected request HTTP/network error, will retry: %s", bifrostError.Error.Message)
 		}
 
 		// Retry if status code or error object indicates rate limiting
@@ -4182,9 +4152,7 @@ func executeRequestWithRetries[T any](
 				(IsRateLimitErrorMessage(bifrostError.Error.Message) ||
 					(bifrostError.Error.Type != nil && IsRateLimitErrorMessage(*bifrostError.Error.Type)))) {
 			shouldRetry = true
-			if l := getGlobalLogger(); l != nil {
-				l.Debug("detected rate limit error in message, will retry: %s", bifrostError.Error.Message)
-			}
+			logger.Debug("detected rate limit error in message, will retry: %s", bifrostError.Error.Message)
 		}
 
 		if !shouldRetry {
@@ -4194,9 +4162,7 @@ func executeRequestWithRetries[T any](
 
 	// Add retry information to error
 	if attempts > 0 {
-		if l := getGlobalLogger(); l != nil {
-			l.Debug("request failed after %d %s", attempts, map[bool]string{true: "attempts", false: "attempt"}[attempts > 1])
-		}
+		logger.Debug("request failed after %d %s", attempts, map[bool]string{true: "attempts", false: "attempt"}[attempts > 1])
 	}
 
 	return result, bifrostError

--- a/core/internal/llmtests/passthrough.go
+++ b/core/internal/llmtests/passthrough.go
@@ -13,9 +13,18 @@ import (
 // RunPassthroughExtraParamsTest executes the passthrough extraParams test scenario
 // This test verifies that extraParams are properly propagated into the provider request body
 // when the passthrough flag is set in the context.
+// Note: This test only runs for providers that support arbitrary extra params at the root level
+// of the request body. Providers like Anthropic have strict schema validation and don't accept
+// unknown fields, so they should set PassThroughExtraParams: false in their test config.
 func RunPassthroughExtraParamsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
-	if !testConfig.Scenarios.SimpleChat {
-		t.Logf("Simple chat not supported for provider %s, skipping passthrough test", testConfig.Provider)
+	// Guard: Check if ChatModel is configured
+	if testConfig.ChatModel == "" {
+		t.Logf("ChatModel not configured for provider %s, skipping passthrough test", testConfig.Provider)
+		return
+	}
+
+	if !testConfig.Scenarios.PassThroughExtraParams {
+		t.Logf("PassThroughExtraParams not supported for provider %s, skipping passthrough test", testConfig.Provider)
 		return
 	}
 

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -176,6 +176,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"ContainerFileContent", testConfig.Scenarios.ContainerFileContent},
 		{"ContainerFileDelete", testConfig.Scenarios.ContainerFileDelete},
 		{"ContainerFileUnsupported", !testConfig.Scenarios.ContainerFileCreate && !testConfig.Scenarios.ContainerFileList && !testConfig.Scenarios.ContainerFileRetrieve && !testConfig.Scenarios.ContainerFileContent && !testConfig.Scenarios.ContainerFileDelete},
+		{"PassThroughExtraParams", testConfig.Scenarios.PassThroughExtraParams},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -52,7 +52,13 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					}
 				}
 			} else {
-				anthropicReq.OutputFormat = convertChatResponseFormatToAnthropicOutputFormat(bifrostReq.Params.ResponseFormat)
+				// Use GA structured outputs (output_config.format) instead of beta (output_format)
+				outputFormat := convertChatResponseFormatToAnthropicOutputFormat(bifrostReq.Params.ResponseFormat)
+				if outputFormat != nil {
+					anthropicReq.OutputConfig = &AnthropicOutputConfig{
+						Format: outputFormat,
+					}
+				}
 			}
 		}
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -339,13 +339,13 @@ type RequestBodyWithExtraParams interface {
 
 type RequestBodyConverter func() (RequestBodyWithExtraParams, error)
 
-// mergeExtraParams merges extraParams into jsonMap, handling nested maps recursively.
-func mergeExtraParams(jsonMap map[string]interface{}, extraParams map[string]interface{}) {
+// MergeExtraParams merges extraParams into jsonMap, handling nested maps recursively.
+func MergeExtraParams(jsonMap map[string]interface{}, extraParams map[string]interface{}) {
 	for k, v := range extraParams {
 		if existingVal, exists := jsonMap[k]; exists {
 			if existingMap, ok := existingVal.(map[string]interface{}); ok {
 				if newMap, ok := v.(map[string]interface{}); ok {
-					mergeExtraParams(existingMap, newMap)
+					MergeExtraParams(existingMap, newMap)
 					continue
 				}
 			}
@@ -380,7 +380,7 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 				}
 
 				// Merge ExtraParams recursively (handles nested maps)
-				mergeExtraParams(jsonMap, extraParams)
+				MergeExtraParams(jsonMap, extraParams)
 
 				// Re-marshal the merged map
 				jsonBody, err = sonic.MarshalIndent(jsonMap, "", "  ")


### PR DESCRIPTION
## Summary

Improves Anthropic provider implementation by updating structured outputs to use GA API instead of beta, simplifies batch results testing, and enhances passthrough extra parameters handling.

## Issues

Closes #1493

## Changes

- Updated Anthropic provider to use GA structured outputs (`output_config.format`) instead of beta (`output_format`)
- Simplified batch results test to use a fake batch ID and verify API reachability
- Fixed passthrough extra parameters test to check the correct scenario flag
- Enhanced request body handling in Anthropic provider using shared utility functions
- Updated Anthropic types to support new response formats and server tool usage statistics
- Changed default test output format to `standard-verbose` for better debugging

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Test Anthropic provider with structured outputs
go test ./core/providers/anthropic/...

# Test batch results functionality
go test ./core/internal/llmtests/... -run TestBatchResults

# Test passthrough extra parameters
go test ./core/internal/llmtests/... -run TestPassthroughExtraParams
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves Anthropic provider compatibility with latest API changes.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable