### PR TITLE
anthropic format test fix, azure whisper parallelism fix

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -106,6 +106,7 @@ type ComprehensiveTestConfig struct {
 	ExternalTTSModel         string                 // External TTS model to use for testing
 	BatchExtraParams         map[string]interface{} // Extra params for batch operations (e.g., role_arn, output_s3_uri for Bedrock)
 	FileExtraParams          map[string]interface{} // Extra params for file operations (e.g., s3_bucket for Bedrock)
+	DisableParallelFor       []string               // Test scenarios to disable parallel execution for (e.g., "Transcription" for rate-limited APIs)
 }
 
 // ComprehensiveTestAccount provides a test implementation of the Account interface for comprehensive testing.
@@ -920,6 +921,7 @@ var AllProviderConfigs = []ComprehensiveTestConfig{
 		Fallbacks: []schemas.Fallback{
 			{Provider: schemas.OpenAI, Model: "gpt-4o-mini"},
 		},
+		DisableParallelFor: []string{"Transcription"}, // Azure Whisper has 3 calls/minute quota
 	},
 	{
 		Provider:             schemas.Vertex,

--- a/core/internal/llmtests/transcription.go
+++ b/core/internal/llmtests/transcription.go
@@ -56,9 +56,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 
 		for _, tc := range roundTripCases {
 			t.Run(tc.name, func(t *testing.T) {
-				if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-					t.Parallel()
-				}
+				ShouldRunParallel(t, testConfig, "Transcription")
 
 				speechSynthesisProvider := testConfig.Provider
 				if testConfig.ExternalTTSProvider != "" {
@@ -246,9 +244,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 
 			for _, tc := range customCases {
 				t.Run(tc.name, func(t *testing.T) {
-					if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-						t.Parallel()
-					}
+					ShouldRunParallel(t, testConfig, "Transcription")
 
 					speechSynthesisProvider := testConfig.Provider
 					if testConfig.ExternalTTSProvider != "" {
@@ -355,9 +351,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 
 			for _, format := range formats {
 				t.Run("Format_"+format, func(t *testing.T) {
-					if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-						t.Parallel()
-					}
+					ShouldRunParallel(t, testConfig, "Transcription")
 
 					speechSynthesisProvider := testConfig.Provider
 					if testConfig.ExternalTTSProvider != "" {
@@ -450,9 +444,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 		})
 
 		t.Run("WithCustomParameters", func(t *testing.T) {
-			if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-				t.Parallel()
-			}
+			ShouldRunParallel(t, testConfig, "Transcription")
 
 			speechSynthesisProvider := testConfig.Provider
 			if testConfig.ExternalTTSProvider != "" {
@@ -549,9 +541,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 
 			for _, lang := range languages {
 				t.Run("Language_"+lang, func(t *testing.T) {
-					if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-						t.Parallel()
-					}
+					ShouldRunParallel(t, testConfig, "Transcription")
 
 					speechSynthesisProvider := testConfig.Provider
 					if testConfig.ExternalTTSProvider != "" {

--- a/core/internal/llmtests/transcription_stream.go
+++ b/core/internal/llmtests/transcription_stream.go
@@ -21,9 +21,7 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 	}
 
 	t.Run("TranscriptionStream", func(t *testing.T) {
-		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-			t.Parallel()
-		}
+		ShouldRunParallel(t, testConfig, "Transcription")
 
 		// Generate TTS audio for streaming round-trip validation
 		streamRoundTripCases := []struct {
@@ -58,9 +56,7 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 
 		for _, tc := range streamRoundTripCases {
 			t.Run(tc.name, func(t *testing.T) {
-				if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-					t.Parallel()
-				}
+				ShouldRunParallel(t, testConfig, "Transcription")
 
 				speechSynthesisProvider := testConfig.Provider
 				if testConfig.ExternalTTSProvider != "" {
@@ -342,9 +338,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 
 	t.Run("TranscriptionStreamAdvanced", func(t *testing.T) {
 		t.Run("JSONStreaming", func(t *testing.T) {
-			if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-				t.Parallel()
-			}
+			ShouldRunParallel(t, testConfig, "Transcription")
 
 			speechSynthesisProvider := testConfig.Provider
 			if testConfig.ExternalTTSProvider != "" {
@@ -438,9 +432,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 		})
 
 		t.Run("MultipleLanguages_Streaming", func(t *testing.T) {
-			if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-				t.Parallel()
-			}
+			ShouldRunParallel(t, testConfig, "Transcription")
 
 			speechSynthesisProvider := testConfig.Provider
 			if testConfig.ExternalTTSProvider != "" {
@@ -459,9 +451,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 
 			for _, lang := range languages {
 				t.Run("StreamLang_"+lang, func(t *testing.T) {
-					if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-						t.Parallel()
-					}
+					ShouldRunParallel(t, testConfig, "Transcription")
 
 					langCopy := lang
 					request := &schemas.BifrostTranscriptionRequest{
@@ -538,9 +528,7 @@ func RunTranscriptionStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost, c
 		})
 
 		t.Run("WithCustomPrompt_Streaming", func(t *testing.T) {
-			if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
-				t.Parallel()
-			}
+			ShouldRunParallel(t, testConfig, "Transcription")
 
 			speechSynthesisProvider := testConfig.Provider
 			if testConfig.ExternalTTSProvider != "" {

--- a/core/internal/llmtests/utils.go
+++ b/core/internal/llmtests/utils.go
@@ -677,3 +677,28 @@ func GetErrorMessage(err *schemas.BifrostError) string {
 
 	return errorString
 }
+
+// ShouldRunParallel checks if a test should run in parallel based on environment
+// variables and provider-specific configuration. It marks the test as parallel
+// if parallel execution is allowed for this scenario.
+//
+// Parameters:
+//   - t: the testing.T instance
+//   - testConfig: the comprehensive test config containing DisableParallelFor settings
+//   - scenario: the test scenario name (e.g., "Transcription", "SpeechSynthesis")
+func ShouldRunParallel(t *testing.T, testConfig ComprehensiveTestConfig, scenario string) {
+	// Check global environment variable first
+	if os.Getenv("SKIP_PARALLEL_TESTS") == "true" {
+		return
+	}
+
+	// Check if this scenario is disabled for this provider
+	for _, disabled := range testConfig.DisableParallelFor {
+		if disabled == scenario {
+			return
+		}
+	}
+
+	// Allow parallel execution
+	t.Parallel()
+}

--- a/core/internal/mcptests/agent_request_id_test.go
+++ b/core/internal/mcptests/agent_request_id_test.go
@@ -21,7 +21,7 @@ import (
 func setupMCPManagerWithRequestIDFunc(t *testing.T, fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string, clientConfigs ...schemas.MCPClientConfig) *mcp.MCPManager {
 	t.Helper()
 
-	logger := &testLogger{t: t}
+	logger := newTestLogger(t)
 
 	// Convert to pointer slice for MCPConfig
 	clientConfigPtrs := make([]*schemas.MCPClientConfig, len(clientConfigs))

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -508,7 +508,6 @@ func TestConvertChatResponseFormatToAnthropicOutputFormat(t *testing.T) {
 			}(),
 			expected: map[string]interface{}{
 				"type": "json_schema",
-				"name": "TestSchema",
 				"schema": map[string]interface{}{
 					"type": "object",
 					"properties": map[string]interface{}{

--- a/core/providers/azure/azure_test.go
+++ b/core/providers/azure/azure_test.go
@@ -68,6 +68,7 @@ func TestAzure(t *testing.T) {
 			ImageEditStream:       true,
 			ImageVariation:        false, // Not supported by Azure
 		},
+		DisableParallelFor: []string{"Transcription"}, // Azure Whisper has 3 calls/minute quota
 	}
 
 	t.Run("AzureTests", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR improves test reliability by addressing rate limiting issues in Azure Whisper transcription tests and refactors the global logger implementation. It also enhances Starlark code execution environment handling in MCP tests.

## Changes

- Added provider-specific test parallelization control via `DisableParallelFor` configuration
- Disabled parallel execution for Azure Whisper transcription tests to avoid rate limit errors
- Replaced global logger variable with imported logger package
- Updated MCP tests to handle Starlark environment limitations correctly
- Fixed test expectations for non-bound servers in Starlark environment
- Improved error handling in code mode tests

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the test suite with a focus on Azure transcription tests and MCP code mode tests:

```sh
# Run all tests
go test ./...

# Run specific Azure tests
go test ./core/providers/azure -v

# Run MCP code mode tests
go test ./core/internal/mcptests -run TestCodeMode
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses test flakiness in Azure Whisper transcription tests due to rate limiting.

## Security considerations

No security implications. Changes are limited to test improvements and internal refactoring.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable