### PR TITLE
add verbosity to core tests

### DIFF
--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -55,7 +55,7 @@ echo "✅ MCP test servers built"
 # Run core tests with coverage
 echo "🔧 Running core tests with coverage..."
 cd core
-go test -race -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
+go test -race -v -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
 
 # Upload coverage to Codecov
 if [ -n "${CODECOV_TOKEN:-}" ]; then


### PR DESCRIPTION
## Summary

Add verbose flag to core tests in the release workflow to provide more detailed test output.

## Changes

- Added the `-v` flag to the `go test` command in the release-core.sh script to enable verbose output during test execution
- This change will make it easier to debug test failures in the CI pipeline by showing more detailed information about each test case

## Type of change

- [x] Chore/CI
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the release script locally to verify the verbose output is displayed:

```sh
./.github/workflows/scripts/release-core.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable