### PR TITLE
azure and bedrock test case fixes

### DIFF
--- a/.github/workflows/scripts/release-core.sh
+++ b/.github/workflows/scripts/release-core.sh
@@ -55,7 +55,7 @@ echo "✅ MCP test servers built"
 # Run core tests with coverage
 echo "🔧 Running core tests with coverage..."
 cd core
-go test -race -v -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
+go test -race -timeout 20m -coverprofile=coverage.txt -coverpkg=./... ./...
 
 # Upload coverage to Codecov
 if [ -n "${CODECOV_TOKEN:-}" ]; then

--- a/core/internal/llmtests/image_generation.go
+++ b/core/internal/llmtests/image_generation.go
@@ -19,6 +19,11 @@ import (
 
 // RunImageGenerationTest executes the end-to-end image generation test (non-streaming)
 func RunImageGenerationTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.ImageGeneration {
+		t.Logf("Image generation not supported for provider %s", testConfig.Provider)
+		return
+	}
+
 	if testConfig.ImageGenerationModel == "" {
 		t.Logf("Image generation not configured for provider %s", testConfig.Provider)
 		return

--- a/core/providers/azure/azure_test.go
+++ b/core/providers/azure/azure_test.go
@@ -61,11 +61,11 @@ func TestAzure(t *testing.T) {
 			TranscriptionStream:   false, // Not properly supported yet by Azure
 			SpeechSynthesis:       true,
 			SpeechSynthesisStream: true,
-			StructuredOutputs:     true, // Structured outputs with nullable enum support
+			StructuredOutputs:     true,  // Structured outputs with nullable enum support
 			ImageGeneration:       false, // Skipped for Azure
 			ImageGenerationStream: false, // Skipped for Azure
-			ImageEdit:             true,
-			ImageEditStream:       true,
+			ImageEdit:             false, // Model not deployed on Azure endpoint
+			ImageEditStream:       false, // Model not deployed on Azure endpoint
 			ImageVariation:        false, // Not supported by Azure
 		},
 		DisableParallelFor: []string{"Transcription"}, // Azure Whisper has 3 calls/minute quota

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -43,10 +43,6 @@ func ToBedrockChatCompletionRequest(ctx *schemas.BifrostContext, bifrostReq *sch
 	// Ensure tool config is present when needed
 	ensureChatToolConfigForConversation(bifrostReq, bedrockReq)
 
-	if bifrostReq.Params != nil {
-		bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
-	}
-
 	return bedrockReq, nil
 }
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -207,18 +207,15 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 				config := &BedrockGuardrailConfig{}
 
 				if identifier, ok := gc["guardrailIdentifier"].(string); ok {
-					delete(gc, "guardrailIdentifier")
 					config.GuardrailIdentifier = identifier
 				}
 				if version, ok := gc["guardrailVersion"].(string); ok {
-					delete(gc, "guardrailVersion")
 					config.GuardrailVersion = version
 				}
 				if trace, ok := gc["trace"].(string); ok {
-					delete(gc, "trace")
 					config.Trace = &trace
 				}
-				bedrockReq.ExtraParams["guardrailConfig"] = gc
+				delete(bedrockReq.ExtraParams, "guardrailConfig")
 				bedrockReq.GuardrailConfig = config
 			}
 		}
@@ -253,13 +250,11 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 			// Handle performance configuration
 			if perfConfig, exists := bifrostReq.Params.ExtraParams["performanceConfig"]; exists {
 				if pc, ok := perfConfig.(map[string]interface{}); ok {
-
 					config := &BedrockPerformanceConfig{}
 					if latency, ok := pc["latency"].(string); ok {
-						delete(pc, "latency")
 						config.Latency = &latency
 					}
-					bedrockReq.ExtraParams["performanceConfig"] = pc
+					delete(bedrockReq.ExtraParams, "performanceConfig")
 					bedrockReq.PerformanceConfig = config
 				}
 			}
@@ -291,6 +286,10 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 					bedrockReq.RequestMetadata = metadata
 				}
 			}
+		}
+		// Set ExtraParams to nil if all keys were extracted to dedicated fields
+		if len(bedrockReq.ExtraParams) == 0 {
+			bedrockReq.ExtraParams = nil
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary

Improves test reliability and fixes provider-specific issues in Azure speech streaming and Bedrock parameter handling.

## Changes

- Removed verbose flag (`-v`) from core tests to reduce CI log size
- Fixed batch test IDs for Bedrock and Gemini to match provider requirements
- Enhanced batch results test error handling to recognize validation errors in addition to "not found" errors
- Added early return in image generation tests when the feature is not supported
- Fixed Azure speech stream response parsing to properly handle JSON-wrapped responses
- Fixed Bedrock parameter handling to properly extract guardrail and performance configurations without duplicating them in extraParams

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/providers/azure/...
go test ./core/providers/bedrock/...
go test ./core/internal/llmtests/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable