### PR TITLE
fixes huggingface test cases

### DIFF
--- a/core/providers/huggingface/huggingface_test.go
+++ b/core/providers/huggingface/huggingface_test.go
@@ -23,7 +23,7 @@ func TestHuggingface(t *testing.T) {
 
 	testConfig := llmtests.ComprehensiveTestConfig{
 		Provider:             schemas.HuggingFace,
-		ChatModel:            "sambanova/meta-llama/Llama-3.1-8B-Instruct",
+		ChatModel:            "groq/meta-llama/Llama-3.3-70B-Instruct",
 		VisionModel:          "cohere/CohereLabs/aya-vision-32b",
 		EmbeddingModel:       "sambanova/intfloat/e5-mistral-7b-instruct",
 		TranscriptionModel:   "fal-ai/openai/whisper-large-v3",


### PR DESCRIPTION
## Summary

Update the Hugging Face test configuration to use Groq's Llama-3.3-70B-Instruct model and fix a potential race condition in the HTTP response body handling.

## Changes

- Changed the chat model in Hugging Face tests from `sambanova/meta-llama/Llama-3.1-8B-Instruct` to `groq/meta-llama/Llama-3.3-70B-Instruct`
- Fixed a potential race condition in `CheckAndDecodeBody` by creating a copy of the response body before returning it, preventing issues when the response is released back to fasthttp's buffer pool

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Hugging Face provider tests to verify the updated model works correctly:

```sh
go test ./core/providers/huggingface/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The fix for the race condition in HTTP response handling improves the stability and reliability of the system, preventing potential memory corruption issues.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)