### PR TITLE
semantic with latest mocker

### DIFF
--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.4.0
-	github.com/maximhq/bifrost/framework v1.2.17
-	github.com/maximhq/bifrost/plugins/mocker v1.4.15
+	github.com/maximhq/bifrost/framework v1.2.16
+	github.com/maximhq/bifrost/plugins/mocker v1.4.17
 )
 
 require (

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -195,10 +195,10 @@ github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuE
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/maximhq/bifrost/core v1.4.0 h1:1RvhQJXTQ+BP0HWoEeCVTDwVnseef8KeFj02VibEKsc=
 github.com/maximhq/bifrost/core v1.4.0/go.mod h1:658dDpcnkKso1zkuBKxZSAENgXjQloM8+phgoQRToTg=
-github.com/maximhq/bifrost/framework v1.2.17 h1:q1Guywfd1DKYkLCJjcBFPc01C4uL+ngsEWVzB11P3NY=
-github.com/maximhq/bifrost/framework v1.2.17/go.mod h1:2WJv19BkDKArQuMwgDHYZEYZZcV7fLiYo7P8i6FdXzk=
-github.com/maximhq/bifrost/plugins/mocker v1.4.15 h1:3Xy0z35DCXoI242YTy1mn6e/KcLldKE6h3lrguKbjxI=
-github.com/maximhq/bifrost/plugins/mocker v1.4.15/go.mod h1:miil0cVbfGIhcXmwvgoQ2TtKiyYcSOLMdbBPu+Ogtgk=
+github.com/maximhq/bifrost/framework v1.2.16 h1:QtN1R/fLHA3i2h+m3uOZzEX+k+O3T5qWaUvXRhSzpzw=
+github.com/maximhq/bifrost/framework v1.2.16/go.mod h1:mK/wEgseyqz9SqGFrhima18LzG/dELEf+VQX6MXko30=
+github.com/maximhq/bifrost/plugins/mocker v1.4.17 h1:CEItx77k22fS/N5K8/dCQpse88yfbgzVebQWJXOH4NY=
+github.com/maximhq/bifrost/plugins/mocker v1.4.17/go.mod h1:RrA/XyRkggxYiK10k6D6r9VjfmRyiGBIW92ZvhWAtUw=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=


### PR DESCRIPTION
## Summary

Update the mocker plugin dependency from v1.4.15 to v1.4.17 in the semanticcache plugin.

## Changes

- Upgraded the `github.com/maximhq/bifrost/plugins/mocker` dependency from v1.4.15 to v1.4.17

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Plugins

## How to test

```sh
# Core/Transports
cd plugins/semanticcache
go mod tidy
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

This is a minor dependency update with no security implications.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable