### PR TITLE
weaviate docker repo change

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     # Weaviate instance for basic tests
     weaviate:
-        image: cr.weaviate.io/semitechnologies/weaviate:1.32.4
+        image: semitechnologies/weaviate:1.32.4
         command:
             - --host
             - 0.0.0.0


### PR DESCRIPTION
## Summary

Update the Weaviate Docker image reference from `cr.weaviate.io/semitechnologies/weaviate:1.32.4` to `semitechnologies/weaviate:1.32.4` in the test Docker Compose configuration.

## Changes

- Changed the Weaviate Docker image source from the container registry (`cr.weaviate.io/semitechnologies/weaviate:1.32.4`) to Docker Hub (`semitechnologies/weaviate:1.32.4`) while maintaining the same version
- This ensures tests use the publicly available Docker Hub image instead of the private container registry

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the tests to verify they work with the updated Docker image:

```sh
cd tests
docker-compose up -d weaviate
# Run tests that depend on the Weaviate instance
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this only changes the source of the Docker image to a public repository while maintaining the same version.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable