### PR TITLE
fix: modality tokens mapping for gemini usage metadata

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - feat: add EventBroadcaster type for real-time event streaming to WebSocket clients
 - fix: model names with namespaces (e.g., `meta-llama/Llama-3.1-8B`) are now correctly preserved instead of being incorrectly split as provider-prefixed models
+- fix: mapping of multiple modality tokens from gemini usage metadata to bifrost usage

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -253,7 +253,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	}
 
 	// Set usage information
-	bifrostResp.Usage = convertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
+	bifrostResp.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
 
 	return bifrostResp
 }
@@ -435,7 +435,7 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream() (*schem
 
 	// Add usage information if this is the last chunk
 	if isLastChunk && response.UsageMetadata != nil {
-		streamResponse.Usage = convertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
+		streamResponse.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
 	}
 
 	return streamResponse, nil, isLastChunk
@@ -487,7 +487,7 @@ func createErrorResponse(response *GenerateContentResponse, finishReason string,
 		Model:   response.ModelVersion,
 		Object:  objectType,
 		Choices: []schemas.BifrostResponseChoice{choice},
-		Usage:   convertGeminiUsageMetadataToChatUsage(response.UsageMetadata),
+		Usage:   ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata),
 	}
 
 	if !response.CreateTime.IsZero() {

--- a/core/providers/gemini/count_tokens.go
+++ b/core/providers/gemini/count_tokens.go
@@ -21,7 +21,7 @@ func (resp *GeminiCountTokensResponse) ToBifrostCountTokensResponse(model string
 			continue
 		}
 		inputTokens += int(m.TokenCount)
-		mod := strings.ToLower(m.Modality)
+		mod := strings.ToLower(string(m.Modality))
 		// handle audio modality
 		if strings.Contains(mod, "audio") {
 			inputDetails.AudioTokens += int(m.TokenCount)
@@ -39,7 +39,7 @@ func (resp *GeminiCountTokensResponse) ToBifrostCountTokensResponse(model string
 				continue
 			}
 			cachedSum += int(m.TokenCount)
-			if strings.Contains(strings.ToLower(m.Modality), "audio") {
+			if strings.Contains(strings.ToLower(string(m.Modality)), "audio") {
 				// also populate audio tokens from cache into AudioTokens (additive)
 				inputDetails.AudioTokens += int(m.TokenCount)
 			}

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -333,9 +333,6 @@ func (response *GenerateContentResponse) ToBifrostImageGenerationResponse() (*sc
 		Data:  []schemas.ImageData{},
 	}
 
-	// Extract usage metadata
-	inputTokens, outputTokens, totalTokens, _, _ := response.extractUsageMetadata()
-
 	// Process candidates to extract image data
 	if len(response.Candidates) > 0 {
 		candidate := response.Candidates[0]
@@ -359,12 +356,8 @@ func (response *GenerateContentResponse) ToBifrostImageGenerationResponse() (*sc
 				}
 			}
 
-			// Set usage information
-			bifrostResp.Usage = &schemas.ImageUsage{
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-				TotalTokens:  totalTokens,
-			}
+			// Set usage information with modality details
+			bifrostResp.Usage = convertGeminiUsageMetadataToImageUsage(response.UsageMetadata)
 			// Only assign imageData when it has elements
 			if len(imageData) > 0 {
 				bifrostResp.Data = imageData
@@ -763,14 +756,8 @@ func ToGeminiImageGenerationResponse(ctx context.Context, bifrostResp *schemas.B
 		}
 	}
 
-	// Convert usage metadata
-	if bifrostResp.Usage != nil {
-		geminiResp.UsageMetadata = &GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(bifrostResp.Usage.InputTokens),
-			CandidatesTokenCount: int32(bifrostResp.Usage.OutputTokens),
-			TotalTokenCount:      int32(bifrostResp.Usage.TotalTokens),
-		}
-	}
+	// Convert usage metadata with modality details
+	geminiResp.UsageMetadata = convertBifrostImageUsageToGeminiUsageMetadata(bifrostResp.Usage)
 
 	return geminiResp, nil
 }

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -151,7 +151,7 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 	}
 
 	// Convert usage information
-	bifrostResp.Usage = convertGeminiUsageMetadataToResponsesUsage(response.UsageMetadata)
+	bifrostResp.Usage = ConvertGeminiUsageMetadataToResponsesUsage(response.UsageMetadata)
 
 	// Convert candidates to Responses output messages
 	if len(response.Candidates) > 0 {
@@ -419,14 +419,7 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 
 	// Convert usage metadata
 	if bifrostResp.Usage != nil {
-		geminiResp.UsageMetadata = &GenerateContentResponseUsageMetadata{
-			PromptTokenCount:     int32(bifrostResp.Usage.InputTokens),
-			CandidatesTokenCount: int32(bifrostResp.Usage.OutputTokens),
-			TotalTokenCount:      int32(bifrostResp.Usage.TotalTokens),
-		}
-		if bifrostResp.Usage.OutputTokensDetails != nil {
-			geminiResp.UsageMetadata.ThoughtsTokenCount = int32(bifrostResp.Usage.OutputTokensDetails.ReasoningTokens)
-		}
+		geminiResp.UsageMetadata = ConvertBifrostResponsesUsageToGeminiUsageMetadata(bifrostResp.Usage)
 	}
 
 	return geminiResp
@@ -622,24 +615,7 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 
 			// Convert usage metadata if available
 			if bifrostResp.Response.Usage != nil {
-				streamResp.UsageMetadata = &GenerateContentResponseUsageMetadata{
-					PromptTokenCount:     int32(bifrostResp.Response.Usage.InputTokens),
-					CandidatesTokenCount: int32(bifrostResp.Response.Usage.OutputTokens),
-					TotalTokenCount:      int32(bifrostResp.Response.Usage.TotalTokens),
-				}
-				if bifrostResp.Response.Usage.InputTokensDetails != nil {
-					streamResp.UsageMetadata.CachedContentTokenCount = int32(bifrostResp.Response.Usage.InputTokensDetails.CachedTokens)
-				}
-				if bifrostResp.Response.Usage.OutputTokensDetails != nil {
-					streamResp.UsageMetadata.ThoughtsTokenCount = int32(bifrostResp.Response.Usage.OutputTokensDetails.ReasoningTokens)
-				}
-				if bifrostResp.Response.Usage.OutputTokensDetails != nil && bifrostResp.Response.Usage.OutputTokensDetails.AudioTokens > 0 {
-					// Store audio tokens separately or add proper field
-					streamResp.UsageMetadata.CandidatesTokensDetails = append(streamResp.UsageMetadata.CandidatesTokensDetails, &ModalityTokenCount{
-						Modality:   "AUDIO",
-						TokenCount: int32(bifrostResp.Response.Usage.OutputTokensDetails.AudioTokens),
-					})
-				}
+				streamResp.UsageMetadata = ConvertBifrostResponsesUsageToGeminiUsageMetadata(bifrostResp.Response.Usage)
 			}
 
 			// Set finish reason
@@ -1625,7 +1601,7 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *
 	}
 
 	// Emit response.completed with usage
-	bifrostUsage := convertGeminiUsageMetadataToResponsesUsage(usage)
+	bifrostUsage := ConvertGeminiUsageMetadataToResponsesUsage(usage)
 
 	completedResp := &schemas.BifrostResponsesResponse{
 		ID:        state.MessageID,

--- a/core/providers/gemini/speech.go
+++ b/core/providers/gemini/speech.go
@@ -158,6 +158,11 @@ func (response *GenerateContentResponse) ToBifrostSpeechResponse(ctx context.Con
 					bifrostResp.Audio = audioData
 				}
 			}
+
+			// Set usage information
+			if response.UsageMetadata != nil {
+				bifrostResp.Usage = convertGeminiUsageMetadataToSpeechUsage(response.UsageMetadata)
+			}
 		}
 	}
 	return bifrostResp, nil
@@ -183,6 +188,11 @@ func ToGeminiSpeechResponse(bifrostResp *schemas.BifrostSpeechResponse) *Generat
 			},
 			Role: string(RoleModel),
 		},
+	}
+
+	// Set usage metadata if present
+	if bifrostResp.Usage != nil {
+		genaiResp.UsageMetadata = convertBifrostSpeechUsageToGeminiUsageMetadata(bifrostResp.Usage)
 	}
 
 	genaiResp.Candidates = []*Candidate{candidate}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1780,7 +1780,7 @@ type GenerateContentResponsePromptFeedback struct {
 // ModalityTokenCount represents token counting info for a single modality.
 type ModalityTokenCount struct {
 	// Optional. The modality associated with this token count.
-	Modality string `json:"modality,omitempty"`
+	Modality Modality `json:"modality,omitempty"`
 	// Number of tokens.
 	TokenCount int32 `json:"tokenCount,omitempty"`
 }

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -895,6 +895,7 @@ func (ru *ResponsesResponseUsage) ToBifrostLLMUsage() *BifrostLLMUsage {
 			TextTokens:               ru.OutputTokensDetails.TextTokens,
 			AcceptedPredictionTokens: ru.OutputTokensDetails.AcceptedPredictionTokens,
 			AudioTokens:              ru.OutputTokensDetails.AudioTokens,
+			ImageTokens:              ru.OutputTokensDetails.ImageTokens,
 			ReasoningTokens:          ru.OutputTokensDetails.ReasoningTokens,
 			RejectedPredictionTokens: ru.OutputTokensDetails.RejectedPredictionTokens,
 			CitationTokens:           ru.OutputTokensDetails.CitationTokens,

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -439,6 +439,7 @@ type ResponsesResponseOutputTokens struct {
 	TextTokens               int  `json:"text_tokens,omitempty"`
 	AcceptedPredictionTokens int  `json:"accepted_prediction_tokens,omitempty"`
 	AudioTokens              int  `json:"audio_tokens,omitempty"`
+	ImageTokens              *int `json:"image_tokens,omitempty"`
 	ReasoningTokens          int  `json:"reasoning_tokens"` // Required for few OpenAI models
 	RejectedPredictionTokens int  `json:"rejected_prediction_tokens,omitempty"`
 	CitationTokens           *int `json:"citation_tokens,omitempty"`

--- a/core/schemas/speech.go
+++ b/core/schemas/speech.go
@@ -135,8 +135,13 @@ type BifrostSpeechStreamResponse struct {
 	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
 }
 
+type SpeechUsageInputTokenDetails struct {
+	TextTokens  int `json:"text_tokens,omitempty"`
+	AudioTokens int `json:"audio_tokens,omitempty"`
+}
 type SpeechUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
-	TotalTokens  int `json:"total_tokens"`
+	InputTokens       int                           `json:"input_tokens"`
+	InputTokenDetails *SpeechUsageInputTokenDetails `json:"input_token_details,omitempty"`
+	OutputTokens      int                           `json:"output_tokens"`
+	TotalTokens       int                           `json:"total_tokens"`
 }


### PR DESCRIPTION
## Summary

Improves the Gemini provider's token usage tracking by enhancing the conversion between Gemini's usage metadata and Bifrost's usage structures, adding proper type safety, and adding comprehensive test coverage.

## Changes

- Made `convertGeminiUsageMetadataToChatUsage` and `convertGeminiUsageMetadataToResponsesUsage` public by renaming them to `ConvertGeminiUsageMetadataToChatUsage` and `ConvertGeminiUsageMetadataToResponsesUsage`
- Added a new `ConvertBifrostResponsesUsageToGeminiUsageMetadata` function for bidirectional conversion
- Changed `Modality` field in `ModalityTokenCount` from string to the proper `Modality` type for better type safety
- Fixed string conversion in `count_tokens.go` to properly handle the Modality type
- Added comprehensive test coverage for the usage metadata conversion functions
- Added support for image tokens in `ResponsesResponseOutputTokens`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Gemini provider tests to verify the token usage conversion functions work correctly:

```sh
go test ./core/providers/gemini/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable