### PR TITLE
fix whitelist router

### DIFF
--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -626,7 +626,7 @@ func TestAuthMiddleware_WhitelistedRoutes(t *testing.T) {
 	whitelistedRoutes := []string{
 		"/api/session/is-auth-enabled",
 		"/api/session/login",
-		"/api/session/logout",
+		"/api/oauth/callback",
 		"/health",
 	}
 


### PR DESCRIPTION
## Summary

Update authentication whitelist routes by replacing `/api/session/logout` with `/api/oauth/callback` in the test configuration.

## Changes

- Modified the whitelisted routes in the authentication middleware test to include `/api/oauth/callback` instead of `/api/session/logout`
- This change ensures that OAuth callback endpoints are properly whitelisted for authentication, allowing OAuth flows to complete without requiring authentication

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the OAuth callback endpoint works without authentication:

```sh
# Run the tests to ensure the whitelist is working correctly
cd transports/bifrost-http/handlers
go test -v -run TestAuthMiddleware_WhitelistedRoutes
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Ensures OAuth authentication flows can complete properly by allowing callback endpoints to bypass authentication checks.

## Security considerations

This change maintains security while enabling OAuth flows to function correctly. The OAuth callback endpoint needs to be accessible without prior authentication to complete the OAuth flow.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable