### PR TITLE
adds back arm instance for docker arm

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -708,7 +708,7 @@ jobs:
         bifrost-http-release,
       ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## Summary

Update the Docker release job runner from `ubuntu-latest-arm` to `ubuntu-24.04-arm` in the release pipeline workflow.

## Changes

- Changed the runner for the Docker release job from `ubuntu-latest-arm` to `ubuntu-24.04-arm` to use a specific Ubuntu version instead of the latest available

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)

## How to test

Verify that the Docker release job runs successfully on the new runner by triggering the release pipeline workflow.

```sh
# Verify GitHub Actions workflow locally with act (if available)
act -j docker-release
```

## Breaking changes

- [x] No

## Security considerations

This change ensures we're using a specific, pinned version of Ubuntu for our ARM builds, which provides better predictability and stability for our CI/CD pipeline.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable