### PR TITLE
feat: add base_model support to model catalog for cross-provider model matching

### DIFF
--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -4,6 +4,7 @@ package tables
 type TableModelPricing struct {
 	ID                 uint    `gorm:"primaryKey;autoIncrement" json:"id"`
 	Model              string  `gorm:"type:varchar(255);not null;uniqueIndex:idx_model_provider_mode" json:"model"`
+	BaseModel          string  `gorm:"type:varchar(255);default:null" json:"base_model,omitempty"`
 	Provider           string  `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"provider"`
 	InputCostPerToken  float64 `gorm:"not null" json:"input_cost_per_token"`
 	OutputCostPerToken float64 `gorm:"not null" json:"output_cost_per_token"`

--- a/framework/modelcatalog/main_test.go
+++ b/framework/modelcatalog/main_test.go
@@ -1,0 +1,146 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestCatalog creates a minimal ModelCatalog for testing within the package.
+func newTestCatalog(modelPool map[schemas.ModelProvider][]string, baseModelIndex map[string]string) *ModelCatalog {
+	if modelPool == nil {
+		modelPool = make(map[schemas.ModelProvider][]string)
+	}
+	if baseModelIndex == nil {
+		baseModelIndex = make(map[string]string)
+	}
+	return &ModelCatalog{
+		modelPool:      modelPool,
+		baseModelIndex: baseModelIndex,
+		pricingData:    make(map[string]configstoreTables.TableModelPricing),
+	}
+}
+
+// --- GetBaseModelName tests ---
+
+func TestGetBaseModelName_Simple(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	// No catalog data, no prefix — returns as-is (no date suffix to strip either)
+	assert.Equal(t, "gpt-4o", mc.GetBaseModelName("gpt-4o"))
+}
+
+func TestGetBaseModelName_Prefixed(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	// Provider prefix stripped, no catalog — algorithmic fallback returns base
+	assert.Equal(t, "gpt-4o", mc.GetBaseModelName("openai/gpt-4o"))
+}
+
+func TestGetBaseModelName_PrefixedAnthropic(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.Equal(t, "claude-3-5-sonnet", mc.GetBaseModelName("anthropic/claude-3-5-sonnet"))
+}
+
+func TestGetBaseModelName_FromCatalog(t *testing.T) {
+	// Model has a pre-computed base_model in the catalog
+	mc := newTestCatalog(nil, map[string]string{
+		"gpt-4o":            "gpt-4o",
+		"gpt-4o-2024-08-06": "gpt-4o",
+	})
+	assert.Equal(t, "gpt-4o", mc.GetBaseModelName("gpt-4o"))
+	assert.Equal(t, "gpt-4o", mc.GetBaseModelName("gpt-4o-2024-08-06"))
+}
+
+func TestGetBaseModelName_ProviderPrefixWithCatalog(t *testing.T) {
+	// Model has provider prefix — strip prefix, then find in catalog
+	mc := newTestCatalog(nil, map[string]string{
+		"gpt-4o": "gpt-4o",
+	})
+	assert.Equal(t, "gpt-4o", mc.GetBaseModelName("openai/gpt-4o"))
+}
+
+func TestGetBaseModelName_FallbackAlgorithmic(t *testing.T) {
+	// Model NOT in catalog — falls back to schemas.BaseModelName (date stripping)
+	mc := newTestCatalog(nil, nil)
+	// Anthropic-style date suffix
+	assert.Equal(t, "claude-sonnet-4", mc.GetBaseModelName("claude-sonnet-4-20250514"))
+	// OpenAI-style date suffix
+	assert.Equal(t, "gpt-4o", mc.GetBaseModelName("gpt-4o-2024-08-06"))
+}
+
+func TestGetBaseModelName_FallbackAlgorithmicWithPrefix(t *testing.T) {
+	// Provider prefix + not in catalog — strip prefix, then algorithmic fallback
+	mc := newTestCatalog(nil, nil)
+	assert.Equal(t, "claude-sonnet-4", mc.GetBaseModelName("anthropic/claude-sonnet-4-20250514"))
+}
+
+func TestGetBaseModelName_UnknownModel(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.Equal(t, "some-random-model", mc.GetBaseModelName("some-random-model"))
+}
+
+func TestGetBaseModelName_CatalogTakesPrecedence(t *testing.T) {
+	// If catalog says the base_model is X, use it even if algorithmic would give Y
+	mc := newTestCatalog(nil, map[string]string{
+		"my-custom-model-20250101": "my-custom-model-20250101", // catalog says keep the date
+	})
+	assert.Equal(t, "my-custom-model-20250101", mc.GetBaseModelName("my-custom-model-20250101"))
+}
+
+// --- IsSameModel tests ---
+
+func TestIsSameModel_DirectMatch(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.True(t, mc.IsSameModel("gpt-4o", "gpt-4o"))
+}
+
+func TestIsSameModel_ProviderPrefix(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.True(t, mc.IsSameModel("openai/gpt-4o", "gpt-4o"))
+	assert.True(t, mc.IsSameModel("gpt-4o", "openai/gpt-4o"))
+}
+
+func TestIsSameModel_BothPrefixed(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.True(t, mc.IsSameModel("openai/gpt-4o", "openai/gpt-4o"))
+}
+
+func TestIsSameModel_DifferentProvidersSameBase(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	// Both have the same base model after stripping different provider prefixes
+	assert.True(t, mc.IsSameModel("openai/gpt-4o", "azure/gpt-4o"))
+}
+
+func TestIsSameModel_DifferentModels(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.False(t, mc.IsSameModel("gpt-4o", "claude-3-5-sonnet"))
+}
+
+func TestIsSameModel_DifferentModelsBothPrefixed(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.False(t, mc.IsSameModel("openai/gpt-4o", "anthropic/claude-3-5-sonnet"))
+}
+
+func TestIsSameModel_CatalogBacked(t *testing.T) {
+	// Two model strings that look different but the catalog says they have the same base_model
+	mc := newTestCatalog(nil, map[string]string{
+		"claude-3-5-sonnet":          "claude-3-5-sonnet",
+		"claude-3-5-sonnet-20241022": "claude-3-5-sonnet",
+	})
+	assert.True(t, mc.IsSameModel("claude-3-5-sonnet", "claude-3-5-sonnet-20241022"))
+	assert.True(t, mc.IsSameModel("claude-3-5-sonnet-20241022", "claude-3-5-sonnet"))
+}
+
+func TestIsSameModel_AlgorithmicFallback(t *testing.T) {
+	// Models not in catalog — use algorithmic date stripping
+	mc := newTestCatalog(nil, nil)
+	assert.True(t, mc.IsSameModel("custom-model-20250101", "custom-model"))
+}
+
+func TestIsSameModel_EmptyStrings(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	assert.True(t, mc.IsSameModel("", ""))
+	assert.False(t, mc.IsSameModel("gpt-4o", ""))
+	assert.False(t, mc.IsSameModel("", "gpt-4o"))
+}

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -67,6 +67,7 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 
 	pricing := configstoreTables.TableModelPricing{
 		Model:              modelName,
+		BaseModel:          entry.BaseModel,
 		Provider:           provider,
 		InputCostPerToken:  entry.InputCostPerToken,
 		OutputCostPerToken: entry.OutputCostPerToken,
@@ -114,6 +115,7 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 // convertTableModelPricingToPricingData converts the TableModelPricing struct to a DataSheetPricingEntry struct
 func convertTableModelPricingToPricingData(pricing *configstoreTables.TableModelPricing) *PricingEntry {
 	return &PricingEntry{
+		BaseModel:                                  pricing.BaseModel,
 		Provider:                                   pricing.Provider,
 		Mode:                                       pricing.Mode,
 		InputCostPerToken:                          pricing.InputCostPerToken,


### PR DESCRIPTION
## Summary

Adds foundational infrastructure for cross-provider model name matching. Models
like `gpt-4o-2024-08-06` and `openai/gpt-4o` should resolve to the same
canonical base model (`gpt-4o`) for governance budget/rate-limit enforcement.
This PR introduces the `base_model` field in pricing data, fixes
`ParseModelString` to not incorrectly split model namespaces (e.g.
`meta-llama/Llama-3.1-8B`), and adds `GetBaseModelName`/`IsSameModel` methods to
`ModelCatalog`.

## Changes

- Fix `ParseModelString` to only split on known Bifrost provider prefixes,
  preserving model namespaces like `meta-llama/Llama-3.1-8B` that contain `/`
  but aren't provider-prefixed
- Build a `knownProviders` set from `StandardProviders` at package init time for
  O(1) lookup
- Add `BaseModel` field to `TableModelPricing` and `PricingEntry` structs
- Add DB migration for the `base_model` column on the model pricing table
- Add `baseModelIndex` map to `ModelCatalog`, populated during
  `populateModelPoolFromPricingData`
- Implement `GetBaseModelName` with 3-step resolution: catalog lookup → provider
  prefix strip + retry → algorithmic date/version fallback
- Implement `IsSameModel` for cross-provider model equivalence checking
- Add `GetDistinctBaseModelNames` for retrieving unique base model names (used
  later for governance model selection UI)
- Carry `BaseModel` through `convertPricingDataToTableModelPricing` and
  `convertTableModelPricingToPricingData`
- Add comprehensive unit tests for `GetBaseModelName` and `IsSameModel`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run model catalog tests
go test github.com/maximhq/bifrost/framework/modelcatalog -v -run "TestGetBaseModelName|TestIsSameModel"

# Run core schemas tests (ParseModelString)
go test github.com/maximhq/bifrost/core/schemas -v

# Verify full framework builds
go build github.com/maximhq/bifrost/framework/...
```

## Screenshots/Recordings

N/A — backend-only infrastructure change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The `ParseModelString` change is a correctness fix —
it was incorrectly treating model namespaces as provider prefixes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
