### PR TITLE
feat: add EventBroadcaster, governance model matching, and fix early return bug

### DIFF
--- a/core/schemas/plugin_native.go
+++ b/core/schemas/plugin_native.go
@@ -11,6 +11,11 @@ import (
 // Used internally for CORS, Auth, Tracing middleware. Plugins use HTTPTransportIntercept instead.
 type BifrostHTTPMiddleware func(next fasthttp.RequestHandler) fasthttp.RequestHandler
 
+// EventBroadcaster is a generic callback for broadcasting typed events to connected clients (e.g., via WebSocket).
+// Any plugin or subsystem can use this to push real-time updates to the frontend.
+// eventType identifies the message (e.g., "governance_update"), data is the JSON-serializable payload.
+type EventBroadcaster func(eventType string, data interface{})
+
 // LLMPluginShortCircuit represents a plugin's decision to short-circuit the normal flow.
 // It can contain either a response (success short-circuit), a stream (streaming short-circuit), or an error (error short-circuit).
 type LLMPluginShortCircuit struct {

--- a/plugins/governance/model_provider_governance_test.go
+++ b/plugins/governance/model_provider_governance_test.go
@@ -3,6 +3,7 @@ package governance
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
@@ -17,7 +18,7 @@ import (
 
 func TestStore_CheckProviderBudget_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	err = store.CheckProviderBudget(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
@@ -29,7 +30,7 @@ func TestStore_CheckProviderBudget_NoBudget(t *testing.T) {
 	provider := buildProviderWithGovernance("openai", nil, nil)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.CheckProviderBudget(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
@@ -43,7 +44,7 @@ func TestStore_CheckProviderBudget_WithinLimit(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
 		Budgets:   []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.CheckProviderBudget(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
@@ -57,7 +58,7 @@ func TestStore_CheckProviderBudget_Exceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
 		Budgets:   []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.CheckProviderBudget(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil)
@@ -72,7 +73,7 @@ func TestStore_CheckProviderBudget_WithBaseline(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
 		Budgets:   []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// With baseline that would exceed limit
@@ -88,7 +89,7 @@ func TestStore_CheckProviderBudget_WithBaseline(t *testing.T) {
 
 func TestStore_CheckProviderRateLimit_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	err, decision := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
@@ -101,7 +102,7 @@ func TestStore_CheckProviderRateLimit_NoRateLimit(t *testing.T) {
 	provider := buildProviderWithGovernance("openai", nil, nil)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err, decision := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
@@ -116,7 +117,7 @@ func TestStore_CheckProviderRateLimit_TokenLimitExceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err, decision := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
@@ -132,7 +133,7 @@ func TestStore_CheckProviderRateLimit_RequestLimitExceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err, decision := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
@@ -148,7 +149,7 @@ func TestStore_CheckProviderRateLimit_BothLimitsExceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err, decision := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
@@ -164,7 +165,7 @@ func TestStore_CheckProviderRateLimit_WithinLimits(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err, decision := store.CheckProviderRateLimit(context.Background(), &EvaluationRequest{Provider: schemas.OpenAI}, nil, nil)
@@ -178,7 +179,7 @@ func TestStore_CheckProviderRateLimit_WithinLimits(t *testing.T) {
 
 func TestStore_CheckModelBudget_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -193,7 +194,7 @@ func TestStore_CheckModelBudget_ModelOnly_WithinLimit(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -208,7 +209,7 @@ func TestStore_CheckModelBudget_ModelOnly_Exceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -225,7 +226,7 @@ func TestStore_CheckModelBudget_ModelWithProvider_WithinLimit(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -241,7 +242,7 @@ func TestStore_CheckModelBudget_ModelWithProvider_Exceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -262,7 +263,7 @@ func TestStore_CheckModelBudget_BothModelAndModelProvider_ChecksBoth(t *testing.
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig1, *modelConfig2},
 		Budgets:      []configstoreTables.TableBudget{*budget1, *budget2},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -280,7 +281,7 @@ func TestStore_CheckModelBudget_ProviderSpecific_DifferentProvider_Passes(t *tes
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Request with Azure (different provider) for same model should pass
@@ -295,7 +296,7 @@ func TestStore_CheckModelBudget_ProviderSpecific_DifferentProvider_Passes(t *tes
 
 func TestStore_CheckModelRateLimit_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -311,7 +312,7 @@ func TestStore_CheckModelRateLimit_ModelOnly_TokenLimitExceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -328,7 +329,7 @@ func TestStore_CheckModelRateLimit_ModelOnly_RequestLimitExceeded(t *testing.T) 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -346,7 +347,7 @@ func TestStore_CheckModelRateLimit_ModelWithProvider_WithinLimits(t *testing.T) 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -367,7 +368,7 @@ func TestStore_CheckModelRateLimit_BothModelAndModelProvider_ChecksBoth(t *testi
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig1, *modelConfig2},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit1, *rateLimit2},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -389,7 +390,7 @@ func TestStore_CheckModelRateLimit_BothModelAndModelProvider_ChecksBoth_RequestL
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig1, *modelConfig2},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit1, *rateLimit2},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -408,7 +409,7 @@ func TestStore_CheckModelRateLimit_ProviderSpecific_DifferentProvider_Passes(t *
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Request with Azure (different provider) for same model should pass
@@ -427,7 +428,7 @@ func TestStore_CheckModelRateLimit_ProviderSpecific_DifferentProvider_Passes_Req
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Request with Azure (different provider) for same model should pass
@@ -443,7 +444,7 @@ func TestStore_CheckModelRateLimit_ProviderSpecific_DifferentProvider_Passes_Req
 
 func TestStore_UpdateProviderBudgetUsage_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "", schemas.OpenAI, 10.0)
@@ -457,7 +458,7 @@ func TestStore_UpdateProviderBudgetUsage_UpdatesUsage(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
 		Budgets:   []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "", schemas.OpenAI, 10.0)
@@ -483,7 +484,7 @@ func TestStore_UpdateProviderBudgetUsage_UpdatesUsage(t *testing.T) {
 
 func TestStore_UpdateProviderRateLimitUsage_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 1000, true, true)
@@ -497,7 +498,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesTokens(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "", schemas.OpenAI, 5000, true, false)
@@ -526,7 +527,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesRequests(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Update requests 500 times
@@ -559,7 +560,7 @@ func TestStore_UpdateProviderRateLimitUsage_UpdatesRequests(t *testing.T) {
 
 func TestStore_UpdateModelBudgetUsage_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -574,7 +575,7 @@ func TestStore_UpdateModelBudgetUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -607,7 +608,7 @@ func TestStore_UpdateModelBudgetUsage_ModelWithProvider_UpdatesBoth(t *testing.T
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig1, *modelConfig2},
 		Budgets:      []configstoreTables.TableBudget{*budget1, *budget2},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -635,7 +636,7 @@ func TestStore_UpdateModelBudgetUsage_ModelWithProvider_UpdatesBoth(t *testing.T
 
 func TestStore_UpdateModelRateLimitUsage_NoConfig(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -650,7 +651,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -685,7 +686,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage(t *testi
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig1, *modelConfig2},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit1, *rateLimit2},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -715,7 +716,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelOnly_UpdatesUsage_RequestLimit(t *
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -755,7 +756,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage_RequestL
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig1, *modelConfig2},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit1, *rateLimit2},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	provider := schemas.OpenAI
@@ -789,7 +790,7 @@ func TestStore_UpdateModelRateLimitUsage_ModelWithProvider_UpdatesUsage_RequestL
 
 func TestResolver_EvaluateModelAndProviderRequest_NoConfigs(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -806,7 +807,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderBudgetExceeded(t *test
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
 		Budgets:   []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -824,7 +825,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderRateLimitExceeded(t *t
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers:  []configstoreTables.TableProvider{*provider},
 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -842,7 +843,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelBudgetExceeded(t *testing
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -860,7 +861,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelRateLimitExceeded(t *test
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -878,7 +879,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelRateLimitExceeded_Request
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -901,7 +902,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderBudgetThenModelBudget(
 		Providers:    []configstoreTables.TableProvider{*provider},
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -925,7 +926,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderRateLimitThenModelRate
 		Providers:    []configstoreTables.TableProvider{*provider},
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*providerRateLimit, *modelRateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -949,7 +950,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderRateLimitThenModelRate
 		Providers:    []configstoreTables.TableProvider{*provider},
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*providerRateLimit, *modelRateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -976,7 +977,7 @@ func TestResolver_EvaluateModelAndProviderRequest_AllChecksPass(t *testing.T) {
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget},
 		RateLimits:   []configstoreTables.TableRateLimit{*providerRateLimit, *modelRateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -994,7 +995,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderOnly_NoModel(t *testin
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Providers: []configstoreTables.TableProvider{*provider},
 		Budgets:   []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -1012,7 +1013,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelOnly_NoProvider(t *testin
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -1032,7 +1033,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificBudget_Differe
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -1052,7 +1053,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificRateLimit_Diff
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -1072,7 +1073,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificRateLimit_Diff
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -1087,850 +1088,1012 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificRateLimit_Diff
 // End-to-End Tests - PreLLMHook Integration
 // ============================================================================
 
-// func TestPreLLMHook_ProviderBudgetExceeded_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
-// 	provider := buildProviderWithGovernance("openai", budget, nil)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers: []configstoreTables.TableProvider{*provider},
-// 		Budgets:   []configstoreTables.TableBudget{*budget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when provider budget is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
-// }
-
-// func TestPreLLMHook_ProviderRateLimitExceeded_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
-// 	provider := buildProviderWithGovernance("openai", nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers:  []configstoreTables.TableProvider{*provider},
-// 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when provider rate limit is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
-// }
-
-// func TestPreLLMHook_ModelBudgetExceeded_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, budget, nil)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		Budgets:      []configstoreTables.TableBudget{*budget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model budget is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
-// }
-
-// func TestPreLLMHook_ModelRateLimitExceeded_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model rate limit is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
-// }
-
-// func TestPreLLMHook_ModelRateLimitExceeded_NoVirtualKey_RequestLimit(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	rateLimit := buildRateLimitWithUsage("rl1", 10000, 0, 1000, 1000) // Requests at max
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model rate limit (request limit) is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
-// }
-
-// func TestPreLLMHook_AllChecksPass_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Provider budget and rate limit within limits
-// 	providerBudget := buildBudget("budget1", 100.0, "1h")
-// 	providerRateLimit := buildRateLimit("rl1", 10000, 1000)
-// 	provider := buildProviderWithGovernance("openai", providerBudget, providerRateLimit)
-// 	// Model budget and rate limit within limits
-// 	modelBudget := buildBudget("budget2", 200.0, "1h")
-// 	modelRateLimit := buildRateLimit("rl2", 20000, 2000)
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, modelBudget, modelRateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers:    []configstoreTables.TableProvider{*provider},
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget},
-// 		RateLimits:   []configstoreTables.TableRateLimit{*providerRateLimit, *modelRateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.Nil(t, shortCircuit, "Should not short circuit when all checks pass")
-// 	assert.NotNil(t, result)
-// }
-
-// func TestPreLLMHook_ProviderBudgetThenModelBudget_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Provider budget exceeded
-// 	providerBudget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h")
-// 	provider := buildProviderWithGovernance("openai", providerBudget, nil)
-// 	// Model budget within limit
-// 	modelBudget := buildBudget("budget2", 200.0, "1h")
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, modelBudget, nil)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers:    []configstoreTables.TableProvider{*provider},
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	// Should fail at provider level (checked first)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when provider budget is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
-// }
-
-// func TestPreLLMHook_ProviderSpecificModelBudget_DifferentProvider_Passes_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// OpenAI GPT-4O has budget (exceeded)
-// 	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
-// 	providerStr := "openai"
-// 	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, budget, nil)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		Budgets:      []configstoreTables.TableBudget{*budget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.Azure, // Different provider
-// 			Model:    "gpt-4o",      // Same model
-// 		},
-// 	}
-
-// 	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.Nil(t, shortCircuit, "Should not short circuit when model config is provider-specific and different provider is used")
-// 	assert.NotNil(t, result)
-// }
-
-// func TestPreLLMHook_ProviderSpecificModelRateLimit_DifferentProvider_Passes_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// OpenAI GPT-4O has rate limit (exceeded)
-// 	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
-// 	providerStr := "openai"
-// 	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.Azure, // Different provider
-// 			Model:    "gpt-4o",      // Same model
-// 		},
-// 	}
-
-// 	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.Nil(t, shortCircuit, "Should not short circuit when model config is provider-specific and different provider is used")
-// 	assert.NotNil(t, result)
-// }
-
-// func TestPreLLMHook_ProviderSpecificModelRateLimit_DifferentProvider_Passes_NoVirtualKey_RequestLimit(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// OpenAI GPT-4O has rate limit (request limit exceeded)
-// 	rateLimit := buildRateLimitWithUsage("rl1", 10000, 0, 1000, 1000) // Requests at max
-// 	providerStr := "openai"
-// 	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.Azure, // Different provider
-// 			Model:    "gpt-4o",      // Same model
-// 		},
-// 	}
-
-// 	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.Nil(t, shortCircuit, "Should not short circuit when model config is provider-specific and different provider is used (request limit)")
-// 	assert.NotNil(t, result)
-// }
-
-// // ============================================================================
-// // End-to-End Tests - PreLLMHook Integration with Virtual Key Fallback
-// // ============================================================================
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key budget exceeded
-// 	vkBudget := buildBudgetWithUsage("vk-budget1", 100.0, 100.1, "1h") // Over limit
-// 	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", vkBudget)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 		Budgets:     []configstoreTables.TableBudget{*vkBudget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK budget is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyRateLimitExceeded_Token(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key rate limit exceeded (token)
-// 	vkRateLimit := buildRateLimitWithUsage("vk-rl1", 10000, 10000, 1000, 0) // Tokens at max
-// 	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", vkRateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 		RateLimits:  []configstoreTables.TableRateLimit{*vkRateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK token rate limit is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyRateLimitExceeded_Request(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key rate limit exceeded (request)
-// 	vkRateLimit := buildRateLimitWithUsage("vk-rl1", 10000, 0, 1000, 1000) // Requests at max
-// 	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", vkRateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 		RateLimits:  []configstoreTables.TableRateLimit{*vkRateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK request rate limit is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyChecksPass(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key checks also pass
-// 	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.Nil(t, shortCircuit, "Should not short circuit when both model/provider and VK checks pass")
-// 	assert.NotNil(t, result)
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyNotFound(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key not found
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-nonexistent")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK is not found")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "not found")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyBlocked(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key is inactive
-// 	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", false) // Inactive
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK is inactive")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "inactive")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyProviderBlocked(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key blocks OpenAI provider
-// 	providerConfigs := []configstoreTables.TableVirtualKeyProviderConfig{
-// 		buildProviderConfig("anthropic", []string{"claude-3-sonnet"}), // Only Anthropic allowed
-// 	}
-// 	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", providerConfigs)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI, // Not allowed by VK
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK blocks provider")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "not allowed")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyModelBlocked(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (no limits)
-// 	// Virtual key blocks specific model
-// 	providerConfigs := []configstoreTables.TableVirtualKeyProviderConfig{
-// 		buildProviderConfig("openai", []string{"gpt-4", "gpt-4-turbo"}), // Only these models allowed
-// 	}
-// 	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", providerConfigs)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-3.5-turbo", // Not in allowed list
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK blocks model")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "not allowed")
-// }
-
-// func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded_WithModelProviderLimits(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Model/provider checks pass (within limits)
-// 	providerBudget := buildBudget("provider-budget1", 200.0, "1h")
-// 	provider := buildProviderWithGovernance("openai", providerBudget, nil)
-// 	modelBudget := buildBudget("model-budget1", 150.0, "1h")
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, modelBudget, nil)
-// 	// Virtual key budget exceeded
-// 	vkBudget := buildBudgetWithUsage("vk-budget1", 100.0, 100.1, "1h") // Over limit
-// 	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", vkBudget)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers:    []configstoreTables.TableProvider{*provider},
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
-// 		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget, *vkBudget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
-// 	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
-// 	req := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
-// 	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK budget is exceeded")
-// 	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
-// }
-
-// // ============================================================================
-// // End-to-End Tests - PostHook Integration (Usage Tracking)
-// // ============================================================================
-
-// func TestPostHook_UpdatesProviderBudgetUsage_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Set budget with initial usage close to limit to test the flow
-// 	// Note: Without model catalog, cost will be 0, so we test the flow even if budget isn't actually updated
-// 	budget := buildBudgetWithUsage("budget1", 100.0, 50.0, "1h")
-// 	provider := buildProviderWithGovernance("openai", budget, nil)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers: []configstoreTables.TableProvider{*provider},
-// 		Budgets:   []configstoreTables.TableBudget{*budget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	// First request: PreLLMHook should pass, PostHook updates usage
-// 	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
-// 	req1 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
-// 	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
-
-// 	result1 := &schemas.BifrostResponse{
-// 		ChatResponse: &schemas.BifrostChatResponse{
-// 			Model: "gpt-4",
-// 			Usage: &schemas.BifrostLLMUsage{
-// 				PromptTokens:     1000,
-// 				CompletionTokens: 500,
-// 				TotalTokens:      1500,
-// 			},
-// 			ExtraFields: schemas.BifrostResponseExtraFields{
-// 				RequestType:    schemas.ChatCompletionRequest,
-// 				Provider:       schemas.OpenAI,
-// 				ModelRequested: "gpt-4",
-// 			},
-// 		},
-// 	}
-
-// 	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
-// 	assert.NoError(t, err, "Should successfully process PostHook for provider budget usage update")
-
-// 	// Wait for async processing to complete
-// 	time.Sleep(200 * time.Millisecond)
-
-// 	// Second request: Verify the flow works (budget check should still pass since cost is 0 without model catalog)
-// 	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
-// 	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
-// 	req2 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
-// 	// Without model catalog, cost is 0, so budget won't be exceeded
-// 	// This test verifies the PostHook -> PreLLMHook flow works correctly
-// 	assert.Nil(t, shortCircuit2, "Second request should pass PreLLMHook (cost is 0 without model catalog)")
-// }
-
-// func TestPostHook_UpdatesProviderRateLimitUsage_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Set rate limit: 10000 tokens, 1000 requests
-// 	// First request: 10000 tokens, 1 request (brings usage to exactly the limit)
-// 	// Second request: Should fail because we're already at the limit
-// 	rateLimit := buildRateLimit("rl1", 10000, 1000)
-// 	provider := buildProviderWithGovernance("openai", nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		Providers:  []configstoreTables.TableProvider{*provider},
-// 		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	// First request: PreLLMHook should pass, PostHook updates usage to 10000
-// 	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
-// 	req1 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
-// 	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
-
-// 	result1 := &schemas.BifrostResponse{
-// 		ChatResponse: &schemas.BifrostChatResponse{
-// 			Model: "gpt-4",
-// 			Usage: &schemas.BifrostLLMUsage{
-// 				PromptTokens:     6000,
-// 				CompletionTokens: 4000,
-// 				TotalTokens:      10000, // 10000 tokens used (exactly at limit)
-// 			},
-// 			ExtraFields: schemas.BifrostResponseExtraFields{
-// 				RequestType:    schemas.ChatCompletionRequest,
-// 				Provider:       schemas.OpenAI,
-// 				ModelRequested: "gpt-4",
-// 			},
-// 		},
-// 	}
-
-// 	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
-// 	assert.NoError(t, err, "Should successfully process PostHook for provider rate limit usage update")
-
-// 	// Wait for async processing to complete
-// 	time.Sleep(200 * time.Millisecond)
-
-// 	// Second request: Should fail because we're already at the token limit (10000/10000)
-// 	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
-// 	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
-// 	req2 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
-// 	assert.NotNil(t, shortCircuit2, "Second request should fail PreLLMHook due to token limit exceeded")
-// 	assert.Contains(t, shortCircuit2.Error.Error.Message, "token limit exceeded", "Error should indicate token limit exceeded")
-// }
-
-// func TestPostHook_UpdatesModelBudgetUsage_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Set budget with initial usage close to limit to test the flow
-// 	// Note: Without model catalog, cost will be 0, so we test the flow even if budget isn't actually updated
-// 	budget := buildBudgetWithUsage("budget1", 100.0, 50.0, "1h")
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, budget, nil)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		Budgets:      []configstoreTables.TableBudget{*budget},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	// First request: PreLLMHook should pass, PostHook updates usage
-// 	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
-// 	req1 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
-// 	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
-
-// 	result1 := &schemas.BifrostResponse{
-// 		ChatResponse: &schemas.BifrostChatResponse{
-// 			Model: "gpt-4",
-// 			Usage: &schemas.BifrostLLMUsage{
-// 				PromptTokens:     1000,
-// 				CompletionTokens: 500,
-// 				TotalTokens:      1500,
-// 			},
-// 			ExtraFields: schemas.BifrostResponseExtraFields{
-// 				RequestType:    schemas.ChatCompletionRequest,
-// 				Provider:       schemas.OpenAI,
-// 				ModelRequested: "gpt-4",
-// 			},
-// 		},
-// 	}
-
-// 	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
-// 	assert.NoError(t, err, "Should successfully process PostHook for model budget usage update")
-
-// 	// Wait for async processing to complete
-// 	time.Sleep(200 * time.Millisecond)
-
-// 	// Second request: Verify the flow works (budget check should still pass since cost is 0 without model catalog)
-// 	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
-// 	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
-// 	req2 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
-// 	// Without model catalog, cost is 0, so budget won't be exceeded
-// 	// This test verifies the PostHook -> PreLLMHook flow works correctly
-// 	assert.Nil(t, shortCircuit2, "Second request should pass PreLLMHook (cost is 0 without model catalog)")
-// }
-
-// func TestPostHook_UpdatesModelRateLimitUsage_NoVirtualKey(t *testing.T) {
-// 	logger := NewMockLogger()
-// 	// Set rate limit: 10000 tokens, 1000 requests
-// 	// First request: 10000 tokens, 1 request (brings usage to exactly the limit)
-// 	// Second request: Should fail because we're already at the limit
-// 	rateLimit := buildRateLimit("rl1", 10000, 1000)
-// 	modelConfig := buildModelConfig("mc1", "gpt-4", nil, nil, rateLimit)
-// 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
-// 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
-// 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
-// 	})
-// 	require.NoError(t, err)
-
-// 	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
-// 	require.NoError(t, err)
-
-// 	// First request: PreLLMHook should pass, PostHook updates usage to 10000
-// 	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
-// 	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
-// 	req1 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
-// 	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
-
-// 	result1 := &schemas.BifrostResponse{
-// 		ChatResponse: &schemas.BifrostChatResponse{
-// 			Model: "gpt-4",
-// 			Usage: &schemas.BifrostLLMUsage{
-// 				PromptTokens:     6000,
-// 				CompletionTokens: 4000,
-// 				TotalTokens:      10000, // 10000 tokens used (exactly at limit)
-// 			},
-// 			ExtraFields: schemas.BifrostResponseExtraFields{
-// 				RequestType:    schemas.ChatCompletionRequest,
-// 				Provider:       schemas.OpenAI,
-// 				ModelRequested: "gpt-4",
-// 			},
-// 		},
-// 	}
-
-// 	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
-// 	assert.NoError(t, err, "Should successfully process PostHook for model rate limit usage update")
-
-// 	// Wait for async processing to complete
-// 	time.Sleep(200 * time.Millisecond)
-
-// 	// Second request: Should fail because we're already at the token limit (10000/10000)
-// 	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
-// 	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
-// 	req2 := &schemas.BifrostRequest{
-// 		RequestType: schemas.ChatCompletionRequest,
-// 		ChatRequest: &schemas.BifrostChatRequest{
-// 			Provider: schemas.OpenAI,
-// 			Model:    "gpt-4",
-// 		},
-// 	}
-
-// 	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
-// 	assert.NotNil(t, shortCircuit2, "Second request should fail PreLLMHook due to token limit exceeded")
-// 	assert.Contains(t, shortCircuit2.Error.Error.Message, "token limit exceeded", "Error should indicate token limit exceeded")
-// }
+func TestPreLLMHook_ProviderBudgetExceeded_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	provider := buildProviderWithGovernance("openai", budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers: []configstoreTables.TableProvider{*provider},
+		Budgets:   []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when provider budget is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
+}
+
+func TestPreLLMHook_ProviderRateLimitExceeded_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
+	provider := buildProviderWithGovernance("openai", nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers:  []configstoreTables.TableProvider{*provider},
+		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when provider rate limit is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
+}
+
+func TestPreLLMHook_ModelBudgetExceeded_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model budget is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
+}
+
+func TestPreLLMHook_ModelRateLimitExceeded_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model rate limit is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
+}
+
+func TestPreLLMHook_ModelRateLimitExceeded_NoVirtualKey_RequestLimit(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 0, 1000, 1000) // Requests at max
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model rate limit (request limit) is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
+}
+
+func TestPreLLMHook_AllChecksPass_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// Provider budget and rate limit within limits
+	providerBudget := buildBudget("budget1", 100.0, "1h")
+	providerRateLimit := buildRateLimit("rl1", 10000, 1000)
+	provider := buildProviderWithGovernance("openai", providerBudget, providerRateLimit)
+	// Model budget and rate limit within limits
+	modelBudget := buildBudget("budget2", 200.0, "1h")
+	modelRateLimit := buildRateLimit("rl2", 20000, 2000)
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, modelBudget, modelRateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers:    []configstoreTables.TableProvider{*provider},
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget},
+		RateLimits:   []configstoreTables.TableRateLimit{*providerRateLimit, *modelRateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.Nil(t, shortCircuit, "Should not short circuit when all checks pass")
+	assert.NotNil(t, result)
+}
+
+func TestPreLLMHook_ProviderBudgetThenModelBudget_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// Provider budget exceeded
+	providerBudget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h")
+	provider := buildProviderWithGovernance("openai", providerBudget, nil)
+	// Model budget within limit
+	modelBudget := buildBudget("budget2", 200.0, "1h")
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, modelBudget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers:    []configstoreTables.TableProvider{*provider},
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	// Should fail at provider level (checked first)
+	assert.NotNil(t, shortCircuit, "Should short circuit when provider budget is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
+}
+
+func TestPreLLMHook_ProviderSpecificModelBudget_DifferentProvider_Passes_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// OpenAI GPT-4O has budget (exceeded)
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	providerStr := "openai"
+	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.Azure, // Different provider
+			Model:    "gpt-4o",      // Same model
+		},
+	}
+
+	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.Nil(t, shortCircuit, "Should not short circuit when model config is provider-specific and different provider is used")
+	assert.NotNil(t, result)
+}
+
+func TestPreLLMHook_ProviderSpecificModelRateLimit_DifferentProvider_Passes_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// OpenAI GPT-4O has rate limit (exceeded)
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Tokens at max
+	providerStr := "openai"
+	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.Azure, // Different provider
+			Model:    "gpt-4o",      // Same model
+		},
+	}
+
+	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.Nil(t, shortCircuit, "Should not short circuit when model config is provider-specific and different provider is used")
+	assert.NotNil(t, result)
+}
+
+func TestPreLLMHook_ProviderSpecificModelRateLimit_DifferentProvider_Passes_NoVirtualKey_RequestLimit(t *testing.T) {
+	logger := NewMockLogger()
+	// OpenAI GPT-4O has rate limit (request limit exceeded)
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 0, 1000, 1000) // Requests at max
+	providerStr := "openai"
+	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.Azure, // Different provider
+			Model:    "gpt-4o",      // Same model
+		},
+	}
+
+	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.Nil(t, shortCircuit, "Should not short circuit when model config is provider-specific and different provider is used (request limit)")
+	assert.NotNil(t, result)
+}
+
+// ============================================================================
+// End-to-End Tests - PreLLMHook Integration with Virtual Key Fallback
+// ============================================================================
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key budget exceeded
+	vkBudget := buildBudgetWithUsage("vk-budget1", 100.0, 100.1, "1h") // Over limit
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", vkBudget)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*vkBudget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK budget is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyRateLimitExceeded_Token(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key rate limit exceeded (token)
+	vkRateLimit := buildRateLimitWithUsage("vk-rl1", 10000, 10000, 1000, 0) // Tokens at max
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", vkRateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*vkRateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK token rate limit is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyRateLimitExceeded_Request(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key rate limit exceeded (request)
+	vkRateLimit := buildRateLimitWithUsage("vk-rl1", 10000, 0, 1000, 1000) // Requests at max
+	vk := buildVirtualKeyWithRateLimit("vk1", "sk-bf-test", "Test VK", vkRateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*vkRateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK request rate limit is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "rate limit")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyChecksPass(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key checks also pass
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	result, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.Nil(t, shortCircuit, "Should not short circuit when both model/provider and VK checks pass")
+	assert.NotNil(t, result)
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyNotFound(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key not found
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-nonexistent")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK is not found")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "not found")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyBlocked(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key is inactive
+	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", false) // Inactive
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK is inactive")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "inactive")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyProviderBlocked(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key blocks OpenAI provider
+	providerConfigs := []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("anthropic", []string{"claude-3-sonnet"}), // Only Anthropic allowed
+	}
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", providerConfigs)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI, // Not allowed by VK
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK blocks provider")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "not allowed")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyModelBlocked(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (no limits)
+	// Virtual key blocks specific model
+	providerConfigs := []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"gpt-4", "gpt-4-turbo"}), // Only these models allowed
+	}
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", providerConfigs)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-3.5-turbo", // Not in allowed list
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK blocks model")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "not allowed")
+}
+
+func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded_WithModelProviderLimits(t *testing.T) {
+	logger := NewMockLogger()
+	// Model/provider checks pass (within limits)
+	providerBudget := buildBudget("provider-budget1", 200.0, "1h")
+	provider := buildProviderWithGovernance("openai", providerBudget, nil)
+	modelBudget := buildBudget("model-budget1", 150.0, "1h")
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, modelBudget, nil)
+	// Virtual key budget exceeded
+	vkBudget := buildBudgetWithUsage("vk-budget1", 100.0, 100.1, "1h") // Over limit
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-test", "Test VK", vkBudget)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers:    []configstoreTables.TableProvider{*provider},
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		Budgets:      []configstoreTables.TableBudget{*providerBudget, *modelBudget, *vkBudget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	parentCtx = context.WithValue(parentCtx, schemas.BifrostContextKeyRequestID, "req-1")
+	ctx := schemas.NewBifrostContext(parentCtx, schemas.NoDeadline)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit, _ := plugin.PreLLMHook(ctx, req)
+	assert.NotNil(t, shortCircuit, "Should short circuit when model/provider pass but VK budget is exceeded")
+	assert.Contains(t, shortCircuit.Error.Error.Message, "budget exceeded")
+}
+
+// ============================================================================
+// End-to-End Tests - PostHook Integration (Usage Tracking)
+// ============================================================================
+
+func TestPostHook_UpdatesProviderBudgetUsage_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// Set budget with initial usage close to limit to test the flow
+	// Note: Without model catalog, cost will be 0, so we test the flow even if budget isn't actually updated
+	budget := buildBudgetWithUsage("budget1", 100.0, 50.0, "1h")
+	provider := buildProviderWithGovernance("openai", budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers: []configstoreTables.TableProvider{*provider},
+		Budgets:   []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// First request: PreLLMHook should pass, PostHook updates usage
+	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
+	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
+	req1 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
+	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
+
+	result1 := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4",
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     1000,
+				CompletionTokens: 500,
+				TotalTokens:      1500,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ChatCompletionRequest,
+				Provider:       schemas.OpenAI,
+				ModelRequested: "gpt-4",
+			},
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
+	assert.NoError(t, err, "Should successfully process PostHook for provider budget usage update")
+
+	// Wait for async processing to complete
+	time.Sleep(200 * time.Millisecond)
+
+	// Second request: Verify the flow works (budget check should still pass since cost is 0 without model catalog)
+	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
+	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
+	req2 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
+	// Without model catalog, cost is 0, so budget won't be exceeded
+	// This test verifies the PostHook -> PreLLMHook flow works correctly
+	assert.Nil(t, shortCircuit2, "Second request should pass PreLLMHook (cost is 0 without model catalog)")
+}
+
+func TestPostHook_UpdatesProviderRateLimitUsage_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// Set rate limit: 10000 tokens, 1000 requests
+	// First request: 10000 tokens, 1 request (brings usage to exactly the limit)
+	// Second request: Should fail because we're already at the limit
+	rateLimit := buildRateLimit("rl1", 10000, 1000)
+	provider := buildProviderWithGovernance("openai", nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		Providers:  []configstoreTables.TableProvider{*provider},
+		RateLimits: []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// First request: PreLLMHook should pass, PostHook updates usage to 10000
+	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
+	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
+	req1 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
+	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
+
+	result1 := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4",
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     6000,
+				CompletionTokens: 4000,
+				TotalTokens:      10000, // 10000 tokens used (exactly at limit)
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ChatCompletionRequest,
+				Provider:       schemas.OpenAI,
+				ModelRequested: "gpt-4",
+			},
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
+	assert.NoError(t, err, "Should successfully process PostHook for provider rate limit usage update")
+
+	// Wait for async processing to complete
+	time.Sleep(200 * time.Millisecond)
+
+	// Second request: Should fail because we're already at the token limit (10000/10000)
+	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
+	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
+	req2 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
+	assert.NotNil(t, shortCircuit2, "Second request should fail PreLLMHook due to token limit exceeded")
+	assert.Contains(t, shortCircuit2.Error.Error.Message, "token limit exceeded", "Error should indicate token limit exceeded")
+}
+
+func TestPostHook_UpdatesModelBudgetUsage_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// Set budget with initial usage close to limit to test the flow
+	// Note: Without model catalog, cost will be 0, so we test the flow even if budget isn't actually updated
+	budget := buildBudgetWithUsage("budget1", 100.0, 50.0, "1h")
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, budget, nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// First request: PreLLMHook should pass, PostHook updates usage
+	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
+	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
+	req1 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
+	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
+
+	result1 := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4",
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     1000,
+				CompletionTokens: 500,
+				TotalTokens:      1500,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ChatCompletionRequest,
+				Provider:       schemas.OpenAI,
+				ModelRequested: "gpt-4",
+			},
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
+	assert.NoError(t, err, "Should successfully process PostHook for model budget usage update")
+
+	// Wait for async processing to complete
+	time.Sleep(200 * time.Millisecond)
+
+	// Second request: Verify the flow works (budget check should still pass since cost is 0 without model catalog)
+	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
+	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
+	req2 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
+	// Without model catalog, cost is 0, so budget won't be exceeded
+	// This test verifies the PostHook -> PreLLMHook flow works correctly
+	assert.Nil(t, shortCircuit2, "Second request should pass PreLLMHook (cost is 0 without model catalog)")
+}
+
+func TestPostHook_UpdatesModelRateLimitUsage_NoVirtualKey(t *testing.T) {
+	logger := NewMockLogger()
+	// Set rate limit: 10000 tokens, 1000 requests
+	// First request: 10000 tokens, 1 request (brings usage to exactly the limit)
+	// Second request: Should fail because we're already at the limit
+	rateLimit := buildRateLimit("rl1", 10000, 1000)
+	modelConfig := buildModelConfig("mc1", "gpt-4", nil, nil, rateLimit)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// First request: PreLLMHook should pass, PostHook updates usage to 10000
+	parentCtx1 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-1")
+	ctx1 := schemas.NewBifrostContext(parentCtx1, schemas.NoDeadline)
+	req1 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit1, _ := plugin.PreLLMHook(ctx1, req1)
+	assert.Nil(t, shortCircuit1, "First request should pass PreLLMHook")
+
+	result1 := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Model: "gpt-4",
+			Usage: &schemas.BifrostLLMUsage{
+				PromptTokens:     6000,
+				CompletionTokens: 4000,
+				TotalTokens:      10000, // 10000 tokens used (exactly at limit)
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ChatCompletionRequest,
+				Provider:       schemas.OpenAI,
+				ModelRequested: "gpt-4",
+			},
+		},
+	}
+
+	_, _, err = plugin.PostLLMHook(ctx1, result1, nil)
+	assert.NoError(t, err, "Should successfully process PostHook for model rate limit usage update")
+
+	// Wait for async processing to complete
+	time.Sleep(200 * time.Millisecond)
+
+	// Second request: Should fail because we're already at the token limit (10000/10000)
+	parentCtx2 := context.WithValue(context.Background(), schemas.BifrostContextKeyRequestID, "req-2")
+	ctx2 := schemas.NewBifrostContext(parentCtx2, schemas.NoDeadline)
+	req2 := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4",
+		},
+	}
+
+	_, shortCircuit2, _ := plugin.PreLLMHook(ctx2, req2)
+	assert.NotNil(t, shortCircuit2, "Second request should fail PreLLMHook due to token limit exceeded")
+	assert.Contains(t, shortCircuit2.Error.Error.Message, "token limit exceeded", "Error should indicate token limit exceeded")
+}
+
+// ============================================================================
+// Cross-Provider Model Matching Tests
+// ============================================================================
+
+// TestStore_CheckModelBudget_CrossProviderModelMatch tests that a model-only config
+// for "gpt-4o" is matched when the request uses "openai/gpt-4o" (OpenRouter-style prefix).
+func TestStore_CheckModelBudget_CrossProviderModelMatch(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
+
+	mc := newMockModelMatcher(t)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, mc)
+	require.NoError(t, err)
+
+	// Request with provider-prefixed model name should match the "gpt-4o" config
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil)
+	assert.Error(t, err, "Should reject: openai/gpt-4o should match model-only config for gpt-4o")
+	assert.Contains(t, err.Error(), "budget exceeded")
+}
+
+// TestStore_CheckModelBudget_CrossProviderModelMatch_WithinLimit tests that the match works
+// and correctly allows requests within the budget.
+func TestStore_CheckModelBudget_CrossProviderModelMatch_WithinLimit(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudget("budget1", 100.0, "1h")
+	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
+
+	mc := newMockModelMatcher(t)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, mc)
+	require.NoError(t, err)
+
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil)
+	assert.NoError(t, err, "Should allow: budget is within limit")
+}
+
+// TestStore_CheckModelRateLimit_CrossProviderModelMatch tests that a model-only rate limit config
+// for "gpt-4o" is matched when the request uses "openai/gpt-4o".
+func TestStore_CheckModelRateLimit_CrossProviderModelMatch(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Token limit at max
+	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, nil, rateLimit)
+
+	mc := newMockModelMatcher(t)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, mc)
+	require.NoError(t, err)
+
+	errResult, decision := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil, nil)
+	assert.Error(t, errResult, "Should reject: openai/gpt-4o should match model-only rate limit for gpt-4o")
+	assert.Contains(t, errResult.Error(), "token limit exceeded")
+	assert.NotEqual(t, DecisionAllow, decision)
+}
+
+// TestStore_UpdateModelBudgetUsage_CrossProviderModelMatch tests that usage for "openai/gpt-4o"
+// is correctly attributed to the model-only config for "gpt-4o".
+func TestStore_UpdateModelBudgetUsage_CrossProviderModelMatch(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudget("budget1", 100.0, "1h")
+	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
+
+	mc := newMockModelMatcher(t)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, mc)
+	require.NoError(t, err)
+
+	// Update usage with prefixed model name
+	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "openai/gpt-4o", schemas.OpenRouter, 50.0)
+	assert.NoError(t, err, "Should successfully update budget usage via cross-provider match")
+
+	// Now exceed the budget
+	err = store.UpdateProviderAndModelBudgetUsageInMemory(context.Background(), "openai/gpt-4o", schemas.OpenRouter, 55.0)
+	assert.NoError(t, err)
+
+	// Budget should now be exceeded
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil)
+	assert.Error(t, err, "Budget should be exceeded after usage updates via cross-provider match")
+	assert.Contains(t, err.Error(), "budget exceeded")
+}
+
+// TestStore_UpdateModelRateLimitUsage_CrossProviderModelMatch tests that rate limit usage
+// for "openai/gpt-4o" is correctly attributed to the model-only config for "gpt-4o".
+func TestStore_UpdateModelRateLimitUsage_CrossProviderModelMatch(t *testing.T) {
+	logger := NewMockLogger()
+	rateLimit := buildRateLimitWithUsage("rl1", 100, 0, 1000, 0) // Low token limit
+	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, nil, rateLimit)
+
+	mc := newMockModelMatcher(t)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
+	}, mc)
+	require.NoError(t, err)
+
+	// Update token usage with prefixed model name
+	err = store.UpdateProviderAndModelRateLimitUsageInMemory(context.Background(), "openai/gpt-4o", schemas.OpenRouter, 100, true, false)
+	assert.NoError(t, err, "Should successfully update rate limit via cross-provider match")
+
+	// Rate limit should now be exceeded
+	errResult, decision := store.CheckModelRateLimit(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil, nil)
+	assert.Error(t, errResult, "Token limit should be exceeded after usage update via cross-provider match")
+	assert.Contains(t, errResult.Error(), "token limit exceeded")
+	assert.NotEqual(t, DecisionAllow, decision)
+}
+
+// TestStore_CheckModelBudget_ModelWithProvider_ExactMatchOnly tests that model+provider configs
+// (e.g., "gpt-4o:openai") use exact matching and do NOT fuzzy-match.
+func TestStore_CheckModelBudget_ModelWithProvider_ExactMatchOnly(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	providerStr := "openai"
+	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, budget, nil)
+
+	mc := newMockModelMatcher(t)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, mc)
+	require.NoError(t, err)
+
+	// Request with the exact matching model+provider should be rejected (budget exceeded)
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "Exact model+provider match should apply budget")
+
+	// Request with a different provider should NOT match the provider-specific config
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenRouter}, nil)
+	assert.NoError(t, err, "Different provider should not match provider-specific config")
+}
+
+// TestStore_CheckModelBudget_NoCatalog_NoMatch tests that without a model catalog,
+// cross-provider matching does not happen (graceful degradation).
+func TestStore_CheckModelBudget_NoCatalog_NoMatch(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
+	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
+
+	// No model catalog passed (nil)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
+		Budgets:      []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	// Without catalog, "openai/gpt-4o" won't match "gpt-4o" config
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "openai/gpt-4o", Provider: schemas.OpenRouter}, nil)
+	assert.NoError(t, err, "Without model catalog, cross-provider matching should not happen")
+
+	// Direct match should still work
+	err = store.CheckModelBudget(context.Background(), &EvaluationRequest{Model: "gpt-4o", Provider: schemas.OpenAI}, nil)
+	assert.Error(t, err, "Direct match should still work without catalog")
+}

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -20,7 +20,7 @@ func TestBudgetResolver_EvaluateRequest_AllowedRequest(t *testing.T) {
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -35,7 +35,7 @@ func TestBudgetResolver_EvaluateRequest_AllowedRequest(t *testing.T) {
 // TestBudgetResolver_EvaluateRequest_VirtualKeyNotFound tests missing VK
 func TestBudgetResolver_EvaluateRequest_VirtualKeyNotFound(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -53,7 +53,7 @@ func TestBudgetResolver_EvaluateRequest_VirtualKeyBlocked(t *testing.T) {
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -76,7 +76,7 @@ func TestBudgetResolver_EvaluateRequest_ProviderBlocked(t *testing.T) {
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -108,7 +108,7 @@ func TestBudgetResolver_EvaluateRequest_ModelBlocked(t *testing.T) {
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -131,7 +131,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExceeded_TokenLimit(t *testing.
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -154,7 +154,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExceeded_RequestLimit(t *testin
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -187,7 +187,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExpired(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Reset expired rate limits (simulating ticker behavior)
@@ -214,7 +214,7 @@ func TestBudgetResolver_EvaluateRequest_BudgetExceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		Budgets:     []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -241,7 +241,7 @@ func TestBudgetResolver_EvaluateRequest_BudgetExpired(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		Budgets:     []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -275,7 +275,7 @@ func TestBudgetResolver_EvaluateRequest_MultiLevelBudgetHierarchy(t *testing.T) 
 		Budgets:     []configstoreTables.TableBudget{*vkBudget, *teamBudget, *customerBudget},
 		Teams:       []configstoreTables.TableTeam{*team},
 		Customers:   []configstoreTables.TableCustomer{*customer},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -309,7 +309,7 @@ func TestBudgetResolver_EvaluateRequest_ProviderLevelRateLimit(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*providerRL},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -332,7 +332,7 @@ func TestBudgetResolver_CheckRateLimits_BothExceeded(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -347,7 +347,7 @@ func TestBudgetResolver_CheckRateLimits_BothExceeded(t *testing.T) {
 // TestBudgetResolver_IsProviderAllowed tests provider filtering logic
 func TestBudgetResolver_IsProviderAllowed(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -395,7 +395,7 @@ func TestBudgetResolver_IsProviderAllowed(t *testing.T) {
 // TestBudgetResolver_IsModelAllowed tests model filtering logic
 func TestBudgetResolver_IsModelAllowed(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -470,7 +470,7 @@ func TestBudgetResolver_ContextPopulation(t *testing.T) {
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		Teams:       []configstoreTables.TableTeam{*team},
 		Customers:   []configstoreTables.TableCustomer{*customer},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -190,7 +190,7 @@ func TestValidateRoutingDecision_MissingModel(t *testing.T) {
 
 // TestEvaluateRoutingRules_NilContext tests EvaluateRoutingRules with nil context
 func TestEvaluateRoutingRules_NilContext(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	engine, err := NewRoutingEngine(store, NewMockLogger())
@@ -203,7 +203,7 @@ func TestEvaluateRoutingRules_NilContext(t *testing.T) {
 
 // TestEvaluateRoutingRules_NoRulesMatch tests EvaluateRoutingRules when no rules match
 func TestEvaluateRoutingRules_NoRulesMatch(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	engine, err := NewRoutingEngine(store, NewMockLogger())
@@ -223,7 +223,7 @@ func TestEvaluateRoutingRules_NoRulesMatch(t *testing.T) {
 
 // TestEvaluateRoutingRules_GlobalRuleMatches tests global scope rule matching
 func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -266,7 +266,7 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 
 // TestEvaluateRoutingRules_ScopePrecedence tests virtual_key scope takes precedence over global
 func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -328,7 +328,7 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 // TestEvaluateRoutingRules_PriorityOrdering tests rules within scope are evaluated by priority.
 // Lower numeric Priority is higher precedence (model/UI semantics); rules are ordered ASC.
 func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -379,7 +379,7 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 
 // TestResolveRoutingWithFallback_RuleMatches tests resolving with matching rule
 func TestResolveRoutingWithFallback_RuleMatches(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -415,7 +415,7 @@ func TestResolveRoutingWithFallback_RuleMatches(t *testing.T) {
 
 // TestResolveRoutingWithFallback_NoMatch tests resolving when no rule matches
 func TestResolveRoutingWithFallback_NoMatch(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	ctx := &RoutingContext{
@@ -440,7 +440,7 @@ func TestResolveRoutingWithFallback_NoMatch(t *testing.T) {
 
 // TestEvaluateRoutingRules_DisabledRulesIgnored tests that disabled rules are ignored
 func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -490,7 +490,7 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 
 // TestEvaluateRoutingRules_ComplexExpression tests evaluation with complex CEL expression
 func TestEvaluateRoutingRules_ComplexExpression(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -533,7 +533,7 @@ func TestEvaluateRoutingRules_ComplexExpression(t *testing.T) {
 
 // TestEvaluateRoutingRules_NilVirtualKey tests evaluation without VirtualKey
 func TestEvaluateRoutingRules_NilVirtualKey(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -568,7 +568,7 @@ func TestEvaluateRoutingRules_NilVirtualKey(t *testing.T) {
 
 // TestEvaluateRoutingRules_MissingHeaderGracefully tests that missing headers don't cause evaluation errors
 func TestEvaluateRoutingRules_MissingHeaderGracefully(t *testing.T) {
-	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 	bgCtx := &schemas.BifrostContext{}
 
@@ -613,7 +613,7 @@ func TestEvaluateRoutingRules_MissingHeaderGracefully(t *testing.T) {
 func TestCompileAndCacheProgram_ValidExpression_Routing(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -638,7 +638,7 @@ func TestCompileAndCacheProgram_ValidExpression_Routing(t *testing.T) {
 func TestCompileAndCacheProgram_EmptyExpression_Routing(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -658,7 +658,7 @@ func TestCompileAndCacheProgram_EmptyExpression_Routing(t *testing.T) {
 func TestCompileAndCacheProgram_InvalidExpression_Routing(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -677,7 +677,7 @@ func TestCompileAndCacheProgram_InvalidExpression_Routing(t *testing.T) {
 func TestCompileAndCacheProgram_NilRule(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	_, err = store.GetRoutingProgram(nil)
@@ -689,7 +689,7 @@ func TestCompileAndCacheProgram_NilRule(t *testing.T) {
 func TestCompileAndCacheProgram_ListExpression(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -709,7 +709,7 @@ func TestCompileAndCacheProgram_ListExpression(t *testing.T) {
 func TestCompileAndCacheProgram_RegexExpression(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -729,7 +729,7 @@ func TestCompileAndCacheProgram_RegexExpression(t *testing.T) {
 func TestCompileAndCacheProgram_HeaderExpression(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -749,7 +749,7 @@ func TestCompileAndCacheProgram_HeaderExpression(t *testing.T) {
 func TestCompileAndCacheProgram_RateLimitExpression(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -769,7 +769,7 @@ func TestCompileAndCacheProgram_RateLimitExpression(t *testing.T) {
 func TestCompileAndCacheProgram_BudgetExpression(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -789,7 +789,7 @@ func TestCompileAndCacheProgram_BudgetExpression(t *testing.T) {
 func TestCompileAndCacheProgram_ComplexExpression(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -843,7 +843,7 @@ func TestValidateCELExpression_Invalid(t *testing.T) {
 func TestEvaluateCELExpression_TrueResult(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -872,7 +872,7 @@ func TestEvaluateCELExpression_TrueResult(t *testing.T) {
 func TestEvaluateCELExpression_FalseResult(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -901,7 +901,7 @@ func TestEvaluateCELExpression_FalseResult(t *testing.T) {
 func TestEvaluateCELExpression_ListMembership(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -937,7 +937,7 @@ func TestEvaluateCELExpression_ListMembership(t *testing.T) {
 func TestEvaluateCELExpression_HeaderAccess(t *testing.T) {
 	ctx := context.Background()
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(ctx, logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -22,7 +22,7 @@ func TestGovernanceStore_GetVirtualKey(t *testing.T) {
 			*buildVirtualKey("vk1", "sk-bf-test1", "Test VK 1", true),
 			*buildVirtualKey("vk2", "sk-bf-test2", "Test VK 2", false),
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -71,7 +71,7 @@ func TestGovernanceStore_ConcurrentReads(t *testing.T) {
 	vk := buildVirtualKey("vk1", "sk-bf-test", "Test VK", true)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Launch 100 concurrent readers
@@ -109,7 +109,7 @@ func TestGovernanceStore_CheckBudget_SingleBudget(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		Budgets:     []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Retrieve VK with budget
@@ -149,7 +149,7 @@ func TestGovernanceStore_CheckBudget_SingleBudget(t *testing.T) {
 			testStore, _ := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 				VirtualKeys: []configstoreTables.TableVirtualKey{*testVK},
 				Budgets:     []configstoreTables.TableBudget{*testBudget},
-			})
+			}, nil)
 
 			testVK, _ = testStore.GetVirtualKey("sk-bf-test")
 			err := testStore.CheckBudget(context.Background(), testVK, &EvaluationRequest{Provider: schemas.OpenAI}, nil)
@@ -186,7 +186,7 @@ func TestGovernanceStore_CheckBudget_HierarchyValidation(t *testing.T) {
 		Budgets:     []configstoreTables.TableBudget{*vkBudget, *teamBudget, *customerBudget},
 		Teams:       []configstoreTables.TableTeam{*team},
 		Customers:   []configstoreTables.TableCustomer{*customer},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	vk, _ = store.GetVirtualKey("sk-bf-test")
@@ -219,7 +219,7 @@ func TestGovernanceStore_UpdateRateLimitUsage_TokensAndRequests(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Test updating tokens
@@ -272,7 +272,7 @@ func TestGovernanceStore_ResetExpiredRateLimits(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Reset expired rate limits
@@ -307,7 +307,7 @@ func TestGovernanceStore_ResetExpiredBudgets(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		Budgets:     []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	// Reset expired budgets
@@ -335,7 +335,7 @@ func TestGovernanceStore_GetAllBudgets(t *testing.T) {
 
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		Budgets: budgets,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	allBudgets := store.GetGovernanceData().Budgets
@@ -348,7 +348,7 @@ func TestGovernanceStore_GetAllBudgets(t *testing.T) {
 // TestGovernanceStore_RoutingRules_CreateAndRetrieve tests creating and retrieving routing rules
 func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	// Create a global routing rule
@@ -411,7 +411,7 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 // TestGovernanceStore_RoutingRules_PriorityOrdering tests that rules are sorted by priority
 func TestGovernanceStore_RoutingRules_PriorityOrdering(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	// Create rules with different priorities
@@ -458,7 +458,7 @@ func TestGovernanceStore_RoutingRules_PriorityOrdering(t *testing.T) {
 // TestGovernanceStore_RoutingRules_DisabledRulesFiltered tests that disabled rules are filtered out
 func TestGovernanceStore_RoutingRules_DisabledRulesFiltered(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	enabledRule := &configstoreTables.TableRoutingRule{
@@ -491,7 +491,7 @@ func TestGovernanceStore_RoutingRules_DisabledRulesFiltered(t *testing.T) {
 // TestGovernanceStore_RoutingRules_DeleteRule tests deleting a routing rule
 func TestGovernanceStore_RoutingRules_DeleteRule(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -521,7 +521,7 @@ func TestGovernanceStore_RoutingRules_DeleteRule(t *testing.T) {
 // TestGovernanceStore_RateLimitStatus tests rate limit status calculation
 func TestGovernanceStore_RateLimitStatus(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	// Create a rate limit with 1000 token limit
@@ -558,7 +558,7 @@ func TestGovernanceStore_RateLimitStatus(t *testing.T) {
 // TestGovernanceStore_BudgetStatus tests budget status calculation
 func TestGovernanceStore_BudgetStatus(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	budgetID := "provider:openai:budget"
@@ -593,7 +593,7 @@ func TestGovernanceStore_BudgetStatus(t *testing.T) {
 // TestGovernanceStore_RoutingRules_MultipleScopes tests rules with multiple scopes
 func TestGovernanceStore_RoutingRules_MultipleScopes(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	customerID := "cust-123"
@@ -640,7 +640,7 @@ func TestGovernanceStore_RoutingRules_MultipleScopes(t *testing.T) {
 // TestCompileAndCacheProgram tests CEL program compilation and caching
 func TestCompileAndCacheProgram(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -668,7 +668,7 @@ func TestCompileAndCacheProgram(t *testing.T) {
 // TestCompileAndCacheProgram_InvalidExpression tests error handling for invalid CEL
 func TestCompileAndCacheProgram_InvalidExpression(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -690,7 +690,7 @@ func TestCompileAndCacheProgram_InvalidExpression(t *testing.T) {
 // TestCompileAndCacheProgram_CacheInvalidation tests cache invalidation on rule update
 func TestCompileAndCacheProgram_CacheInvalidation(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -721,7 +721,7 @@ func TestCompileAndCacheProgram_CacheInvalidation(t *testing.T) {
 // TestCompileAndCacheProgram_CacheInvalidationOnDelete tests cache invalidation on rule deletion
 func TestCompileAndCacheProgram_CacheInvalidationOnDelete(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{
@@ -747,7 +747,7 @@ func TestCompileAndCacheProgram_CacheInvalidationOnDelete(t *testing.T) {
 // TestCompileAndCacheProgram_EmptyExpression tests compilation of empty CEL expression (defaults to "true")
 func TestCompileAndCacheProgram_EmptyExpression(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	rule := &configstoreTables.TableRoutingRule{

--- a/plugins/governance/tracker_test.go
+++ b/plugins/governance/tracker_test.go
@@ -22,7 +22,7 @@ func TestUsageTracker_UpdateUsage_FailedRequest(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		Budgets:     []configstoreTables.TableBudget{*budget},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -57,7 +57,7 @@ func TestUsageTracker_UpdateUsage_FailedRequest(t *testing.T) {
 func TestUsageTracker_UpdateUsage_VirtualKeyNotFound(t *testing.T) {
 	logger := NewMockLogger()
 
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -91,7 +91,7 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
 		RateLimits:  []configstoreTables.TableRateLimit{*rateLimit},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)
@@ -154,7 +154,7 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 // TestUsageTracker_Cleanup tests cleanup of the usage tracker
 func TestUsageTracker_Cleanup(t *testing.T) {
 	logger := NewMockLogger()
-	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
 	resolver := NewBudgetResolver(store, nil, logger)


### PR DESCRIPTION
## Summary

Three things in one PR:

1. Governance now wires the event broadcaster at init time.
2. **Cross-provider model matching in governance** — governance
   budget/rate-limit checks now use `ModelMatcher` (backed by `ModelCatalog`) to
   normalize model names, so a config for `gpt-4o` correctly applies to requests
   for `openai/gpt-4o` or `gpt-4o-2024-08-06`.
3. **Bug fixes** — `evaluateGovernanceRequest` was calling
   `EvaluateVirtualKeyRequest` unconditionally instead of first evaluating
   model/provider checks via `EvaluateModelAndProviderRequest`, meaning model
   configs and provider governance were completely bypassed. Same issue existed
   in `PostLLMHook` which skipped usage updates when no virtual key was present.
   Routing rules in `HTTPTransportPreHook` were re-enabled. Provider/model-level
   budget and rate limit usage tracking in `UsageTracker.UpdateUsage` was also
   re-enabled — without this, only VK-level usage was being tracked.

## Changes

- Add `ModelMatcher` interface to governance store (`GetBaseModelName`,
  `IsSameModel`)
- Accept `ModelMatcher` as optional parameter in `NewLocalGovernanceStore`
- Implement `findModelOnlyConfig` helper with base model name normalization for
  budget/rate-limit lookups
- Normalize model names in `rebuildInMemoryStructures` so `gpt-4o` and
  `openai/gpt-4o` don't create duplicate config entries
- Add `emitBudgetUpdate` / `emitRateLimitUpdate` helpers that fire
  `governance_update` events via `EventBroadcaster` at all 6 `Store()` call
  sites (budget usage, rate limit usage, budget reset, rate limit reset)
- Expand `GovernanceData` struct with `ModelConfigs` and `Providers` fields
- Add live budget/rate-limit cross-referencing in `GetGovernanceData()` — clones
  virtual keys, model configs, and providers, then replaces embedded
  budget/rate-limit pointers with fresh values from the standalone
  `budgets`/`rateLimits` sync.Maps (since usage updates clone into those maps,
  embedded pointers go stale)
- Fix `evaluateGovernanceRequest`: restore the two-phase evaluation — first
  `EvaluateModelAndProviderRequest`, then conditionally
  `EvaluateVirtualKeyRequest` only when model/provider checks pass and a virtual
  key exists
- Re-enable routing rules in `HTTPTransportPreHook`: restore `HasRoutingRules`
  check, combined early-return guard
  (`virtualKeyValue == nil && !hasRoutingRules`), and the full routing rules
  application block
- Re-enable provider/model-level usage tracking in `tracker.go`: restore
  `UpdateProviderAndModelRateLimitUsageInMemory` and
  `UpdateProviderAndModelBudgetUsageInMemory` calls in `UpdateUsage` — without
  these, only virtual-key-level budgets and rate limits were updated
- Fix `PostLLMHook`: remove the `if virtualKey == "" { return }` skip, so
  model/provider usage is still tracked for requests without virtual keys
- Update `mockModelMatcher` in `test_utils.go` to fetch the real datasheet from
  `DefaultPricingURL` via `sync.Once` and build a `baseModelIndex`, matching
  production `ModelCatalog` behavior
- Update all test files for the new `NewLocalGovernanceStore` 5-parameter
  signature (pass `nil` for model matcher in existing tests)
- Inject EventBroadcaster into governance Init/InitFromStore; LocalGovernanceStore keeps
  broadcaster as a private field.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run all governance tests (includes model/provider governance, resolver, routing, store, tracker)
go test github.com/maximhq/bifrost/plugins/governance -v -count=1

# Specifically test model+provider governance scenarios
go test github.com/maximhq/bifrost/plugins/governance -v -run "TestPreLLMHook|TestResolver_Evaluate|TestStore_Check"
```

The early return bug fix can be verified by the existing
`TestPreLLMHook_ProviderBudgetExceeded_NoVirtualKey` and similar tests — these
tests exercise the code path where no virtual key is present but model/provider
budgets should still be enforced.

## Screenshots/Recordings

N/A — backend-only change.

## Breaking changes

- [x] Yes
- [ ] No

**Interface changes:**

- `NewLocalGovernanceStore` now takes 5 parameters (added
  `modelMatcher ModelMatcher` as the 5th). Pass `nil` if not using
  cross-provider model matching.


**Behavioral change:**

- Post-LLM usage tracking now correctly updates model/provider budgets and rate
  limits for requests without virtual keys.
- `governance.Init(...)` and `governance.InitFromStore(...)` take a new eventBroadcaster schemas.EventBroadcaster parameter (optional; nil-safe).

## Related issues

N/A

## Security considerations

No security implications. The behavioral fix (enforcing governance without
virtual keys) is actually a security improvement — budgets and rate limits are
now consistently enforced regardless of virtual key presence.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
