### PR TITLE
feat: add from_memory governance endpoints, WebSocket event broadcasting, and base models API

### DIFF
--- a/transports/bifrost-http/handlers/websocket.go
+++ b/transports/bifrost-http/handlers/websocket.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fasthttp/websocket"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
-	"github.com/maximhq/bifrost/plugins/logging"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -27,7 +26,6 @@ type WebSocketClient struct {
 // WebSocketHandler manages WebSocket connections for real-time updates
 type WebSocketHandler struct {
 	ctx            context.Context
-	logManager     logging.LogManager
 	allowedOrigins []string
 	clients        map[*websocket.Conn]*WebSocketClient
 	mu             sync.RWMutex
@@ -36,10 +34,9 @@ type WebSocketHandler struct {
 }
 
 // NewWebSocketHandler creates a new WebSocket handler instance
-func NewWebSocketHandler(ctx context.Context, logManager logging.LogManager, allowedOrigins []string) *WebSocketHandler {
+func NewWebSocketHandler(ctx context.Context, allowedOrigins []string) *WebSocketHandler {
 	return &WebSocketHandler{
 		ctx:            ctx,
-		logManager:     logManager,
 		allowedOrigins: allowedOrigins,
 		clients:        make(map[*websocket.Conn]*WebSocketClient),
 		stopChan:       make(chan struct{}),
@@ -259,6 +256,26 @@ func (h *WebSocketHandler) BroadcastUpdatesToClients(tags []string) {
 	}
 
 	h.BroadcastMarshaledMessage(data)
+}
+
+// BroadcastEvent sends a typed event to all connected WebSocket clients.
+// Any subsystem can use this to push real-time updates to the frontend.
+func (h *WebSocketHandler) BroadcastEvent(eventType string, data interface{}) {
+	message := struct {
+		Type string      `json:"type"`
+		Data interface{} `json:"data"`
+	}{
+		Type: eventType,
+		Data: data,
+	}
+
+	bytes, err := json.Marshal(message)
+	if err != nil {
+		logger.Error("failed to marshal event %s: %v", eventType, err)
+		return
+	}
+
+	h.BroadcastMarshaledMessage(bytes)
 }
 
 // BroadcastMarshaledMessage sends an adaptive routing update to all connected WebSocket clients

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -275,6 +275,10 @@ type Config struct {
 	// Catalog managers
 	ModelCatalog *modelcatalog.ModelCatalog
 	MCPCatalog   *mcpcatalog.MCPCatalog
+
+	// Optional event broadcaster for real-time updates (e.g., WebSocket).
+	// Set by HTTP server at startup; may be nil in non-HTTP usage.
+	EventBroadcaster schemas.EventBroadcaster
 }
 
 var DefaultClientConfig = configstore.ClientConfig{

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -70,7 +70,7 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 		inMemoryStore := &GovernanceInMemoryStore{Config: bifrostConfig}
 		return governance.Init(ctx, governanceConfig, logger, bifrostConfig.ConfigStore,
 			bifrostConfig.GovernanceConfig, bifrostConfig.ModelCatalog,
-			bifrostConfig.MCPCatalog, inMemoryStore)
+			bifrostConfig.MCPCatalog, inMemoryStore, bifrostConfig.EventBroadcaster)
 
 	case maxim.PluginName:
 		maximConfig, err := MarshalPluginConfig[maxim.Config](pluginConfig)


### PR DESCRIPTION
## Summary

Wires the governance store's real-time mutation events to WebSocket clients and
adds `from_memory=true` query parameter support to governance GET endpoints.
This enables the frontend to read governance data directly from the in-memory
store (fast, no DB round-trip) and receive incremental budget/rate-limit diffs
via WebSocket instead of polling.

Also adds a new `/api/models/base` endpoint for listing distinct base model
names from the catalog (used by the model limits UI when no provider is
selected).

WebSocket event broadcasting is now injected into governance at init time, wired through the HTTP server config.

## Changes

- Add `from_memory=true` support to `getVirtualKeys`, `getModelConfigs`, and
  `getProviderGovernance` handlers — reads from `GovernanceData` in-memory
  struct instead of querying the database
- Fix virtual keys `from_memory` response to convert the Go map to a slice (JSON
  object → JSON array), fixing the frontend
  `TypeError: virtualKeys.map is not a function`
- Add generic `BroadcastEvent(eventType string, data interface{})` to
  `WebSocketHandler` — sends a `{ type, data }` JSON message to all connected
  clients
- Add `GET /api/models/base` endpoint with query filtering (case-insensitive
  partial match + fuzzy match) and limit support
- Initialize WebSocket handler early in `Bootstrap`, set `Config.EventBroadcaster`.
- Pass `EventBroadcaster` into `governance.Init(...)` in `loadBuiltinPlugins`.
- Remove `SetEventBroadcaster` from handler/server interfaces.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run transport handler tests
go test github.com/maximhq/bifrost/transports/bifrost-http/... -v -count=1

# Manual: start the server and verify endpoints
# GET /api/governance/virtual-keys?from_memory=true  → should return { virtual_keys: [...], count: N }
# GET /api/governance/model-configs?from_memory=true  → should return { model_configs: [...], count: N }
# GET /api/governance/providers?from_memory=true      → should return { providers: [...], count: N }
# GET /api/models/base?query=gpt&limit=10            → should return { models: [...], total: N }

# Verify WebSocket receives governance_update events:
# 1. Connect to WebSocket
# 2. Make an LLM request through Bifrost
# 3. Observe { type: "governance_update", data: { budgets: {...} } } messages
```

## Screenshots/Recordings

N/A — backend-only change. Frontend consumption is in the next PR.

## Breaking changes

- [x] Yes
- [ ] No

**Interface changes:**

- Server config now carries `EventBroadcaster` for plugin init wiring (HTTP transport only).

## Related issues

N/A

## Security considerations

The `from_memory=true` endpoints return the same data as the DB-backed endpoints
— no additional data exposure. The WebSocket `governance_update` events contain
budget/rate-limit usage data which is already accessible through the existing
governance GET endpoints.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
