### PR TITLE
feat: real-time governance updates via WebSocket and base model selection in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ tmp/
 tmp-*
 private
 **/bin
+build/
+target/
 
 # Go workspaces (local only)
 go.work
@@ -43,8 +45,10 @@ go.work.sum
 # Test reports
 test-reports
 
-# Cursor specific
-.claude
+# AI Agent specific
+.claude/
+.codex/
+.cursor/
 
 # Python specific
 **/__pycache__/**
@@ -54,11 +58,6 @@ test-reports
 **/.coverage/
 **/.pytest_cache/
 
-
-# Cursor specific
-.cursor/
-build/
-target/
 
 # Nix specific
 .direnv

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,2 @@
+- feat: add EventBroadcaster type for real-time event streaming to WebSocket clients
+- fix: model names with namespaces (e.g., `meta-llama/Llama-3.1-8B`) are now correctly preserved instead of being incorrectly split as provider-prefixed models

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,3 @@
+- feat: add base_model support to model catalog for cross-provider model matching
+- feat: add GetBaseModelName, IsSameModel, and GetDistinctBaseModelNames methods to ModelCatalog for resolving model aliases and checking model equivalence
+- feat: add database migration for base_model column on model pricing table

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,4 @@
+- feat: cross-provider model matching - budget/rate-limit configs for `gpt-4o` now apply to `openai/gpt-4o`, `gpt-4o-2024-08-06`, etc.
+- feat: add EventBroadcaster support for real-time governance update notifications
+- feat: expand GovernanceData with ModelConfigs and Providers for in-memory reads
+- fix: model/provider usage is now tracked even when no virtual key is present

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,8 @@
 - fix: duplicate mcp server creation when adding non oauth mcp client
+- feat: add model and provider level governance - set budgets and rate limits on specific models or providers independent of virtual keys
+- feat: real-time governance updates - budget/rate-limit changes are now pushed to clients via WebSocket instead of polling
+- feat: cross-provider model matching - governance configs for `gpt-4o` now correctly apply to `openai/gpt-4o`, `gpt-4o-2024-08-06`, etc.
+- feat: add `from_memory=true` query parameter for faster governance reads (virtual keys, model configs, provider governance)
+- feat: add `GET /api/models/base` endpoint for listing distinct base model names with search/filter support
+- feat: base model selection in model limits UI when no provider is selected
+- fix: edit sheets now show live data instead of stale cached values

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -235,7 +235,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 												onChange={field.onChange}
 												placeholder="Select a model..."
 												isSingleSelect
-												loadModelsOnEmptyProvider
+												loadModelsOnEmptyProvider="base_models"
 											/>
 										</FormControl>
 										<FormMessage />

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -25,7 +25,7 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Edit, Plus, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
 
@@ -41,7 +41,13 @@ interface ModelLimitsTableProps {
 
 export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimitsTableProps) {
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
-	const [editingModelConfig, setEditingModelConfig] = useState<ModelConfig | null>(null);
+	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
+
+	// Derive editingModelConfig from props so it stays in sync with RTK cache updates
+	const editingModelConfig = useMemo(
+		() => (editingModelConfigId ? modelConfigs.find((mc) => mc.id === editingModelConfigId) ?? null : null),
+		[editingModelConfigId, modelConfigs],
+	);
 
 	const hasCreateAccess = useRbac(RbacResource.Governance, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.Governance, RbacOperation.Update);
@@ -60,19 +66,19 @@ export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimit
 	};
 
 	const handleAddModelLimit = () => {
-		setEditingModelConfig(null);
+		setEditingModelConfigId(null);
 		setShowModelLimitSheet(true);
 	};
 
 	const handleEditModelLimit = (config: ModelConfig, e: React.MouseEvent) => {
 		e.stopPropagation();
-		setEditingModelConfig(config);
+		setEditingModelConfigId(config.id);
 		setShowModelLimitSheet(true);
 	};
 
 	const handleModelLimitSaved = () => {
 		setShowModelLimitSheet(false);
-		setEditingModelConfig(null);
+		setEditingModelConfigId(null);
 		onRefresh();
 	};
 

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -21,9 +21,7 @@ export default function ModelLimitsView() {
 		refetch: refetchModelConfigs,
 	} = useGetModelConfigsQuery(undefined, {
 		skip: !governanceEnabled || !hasGovernanceAccess,
-		pollingInterval: governanceEnabled && hasGovernanceAccess ? 10000 : 0,
 		refetchOnFocus: true,
-		skipPollingIfUnfocused: true,
 	});
 
 	const isLoading = modelConfigsLoading || governanceEnabled === null;

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -67,9 +67,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 
 	const { data: providerGovernanceData, isLoading: isLoadingGovernance } = useGetProviderGovernanceQuery(undefined, {
 		skip: !hasViewAccess || !governanceEnabled,
-		pollingInterval: hasViewAccess && governanceEnabled ? 10000 : 0,
 		refetchOnFocus: true,
-		skipPollingIfUnfocused: true,
 	});
 	const [updateProviderGovernance, { isLoading: isUpdating }] = useUpdateProviderGovernanceMutation();
 	const [deleteProviderGovernance, { isLoading: isDeleting }] = useDeleteProviderGovernanceMutation();

--- a/ui/app/workspace/providers/views/providerGovernanceTable.tsx
+++ b/ui/app/workspace/providers/views/providerGovernanceTable.tsx
@@ -173,9 +173,7 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 
 	const { data: providerGovernanceData, isLoading } = useGetProviderGovernanceQuery(undefined, {
 		skip: !hasViewAccess || !governanceEnabled,
-		pollingInterval: hasViewAccess && governanceEnabled ? 10000 : 0,
 		refetchOnFocus: true,
-		skipPollingIfUnfocused: true,
 	});
 
 	// Find governance data for this provider

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils"
 import { formatCurrency } from "@/lib/utils/governance"
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
 import { Copy, Edit, Eye, EyeOff, Plus, Trash2 } from "lucide-react"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 import VirtualKeyDetailSheet from "./virtualKeyDetailsSheet"
 import VirtualKeySheet from "./virtualKeySheet"
@@ -34,10 +34,20 @@ interface VirtualKeysTableProps {
 
 export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefresh }: VirtualKeysTableProps) {
   const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false)
-  const [editingVirtualKey, setEditingVirtualKey] = useState<VirtualKey | null>(null)
+  const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null)
   const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
-  const [selectedVirtualKey, setSelectedVirtualKey] = useState<VirtualKey | null>(null)
+  const [selectedVirtualKeyId, setSelectedVirtualKeyId] = useState<string | null>(null)
   const [showDetailSheet, setShowDetailSheet] = useState(false)
+
+  // Derive objects from props so they stay in sync with RTK cache updates
+  const editingVirtualKey = useMemo(
+    () => (editingVirtualKeyId ? virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null : null),
+    [editingVirtualKeyId, virtualKeys],
+  )
+  const selectedVirtualKey = useMemo(
+    () => (selectedVirtualKeyId ? virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null : null),
+    [selectedVirtualKeyId, virtualKeys],
+  )
 
   const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create)
   const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update)
@@ -56,30 +66,30 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefr
 	};
 
 	const handleAddVirtualKey = () => {
-		setEditingVirtualKey(null);
+		setEditingVirtualKeyId(null);
 		setShowVirtualKeySheet(true);
 	};
 
 	const handleEditVirtualKey = (vk: VirtualKey, e: React.MouseEvent) => {
 		e.stopPropagation(); // Prevent row click
-		setEditingVirtualKey(vk);
+		setEditingVirtualKeyId(vk.id);
 		setShowVirtualKeySheet(true);
 	};
 
 	const handleVirtualKeySaved = () => {
 		setShowVirtualKeySheet(false);
-		setEditingVirtualKey(null);
+		setEditingVirtualKeyId(null);
 		onRefresh();
 	};
 
 	const handleRowClick = (vk: VirtualKey) => {
-		setSelectedVirtualKey(vk);
+		setSelectedVirtualKeyId(vk.id);
 		setShowDetailSheet(true);
 	};
 
 	const handleDetailSheetClose = () => {
 		setShowDetailSheet(false);
-		setSelectedVirtualKey(null);
+		setSelectedVirtualKeyId(null);
 	};
 
 	const toggleKeyVisibility = (vkId: string) => {

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -21,6 +21,7 @@ import {
 	LayoutGrid,
 	LogOut,
 	Logs,
+	Network,
 	PanelLeftClose,
 	Puzzle,
 	ScrollText,
@@ -172,6 +173,7 @@ const SidebarItemView = ({
 	router,
 	isSidebarCollapsed,
 	expandSidebar,
+	isGovernanceEnabled,
 }: {
 	item: SidebarItem;
 	isActive: boolean;
@@ -184,6 +186,7 @@ const SidebarItemView = ({
 	router: ReturnType<typeof useRouter>;
 	isSidebarCollapsed: boolean;
 	expandSidebar: () => void;
+	isGovernanceEnabled: boolean;
 }) => {
 	const hasSubItems = "subItems" in item && item.subItems && item.subItems.length > 0;
 	const isAnySubItemActive =
@@ -265,6 +268,8 @@ const SidebarItemView = ({
 			{hasSubItems && isExpanded && (
 				<SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
 					{item.subItems?.map((subItem: SidebarItem) => {
+						// Hide governance-dependent subitems when governance is disabled
+						if ((subItem.url === "/workspace/model-limits" || subItem.url === "/workspace/routing-rules") && !isGovernanceEnabled) return null;
 						// For query param based subitems, check if tab matches
 						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : pathname.startsWith(subItem.url);
 						const SubItemIcon = subItem.icon;
@@ -423,20 +428,20 @@ export default function AppSidebar() {
 					description: "Configure models",
 					hasAccess: hasModelProvidersAccess,
 				},
-				// {
-				// 	title: "Budgets & Limits",
-				// 	url: "/workspace/model-limits",
-				// 	icon: Gauge,
-				// 	description: "Model limits",
-				// 	hasAccess: hasGovernanceAccess,
-				// },
-				// {
-				// 	title: "Routing Rules",
-				// 	url: "/workspace/routing-rules",
-				// 	icon: Network,
-				// 	description: "Intelligent routing rules",
-				// 	hasAccess: hasRoutingRulesAccess,
-				// },
+				{
+					title: "Budgets & Limits",
+					url: "/workspace/model-limits",
+					icon: Gauge,
+					description: "Model limits",
+					hasAccess: hasGovernanceAccess,
+				},
+				{
+					title: "Routing Rules",
+					url: "/workspace/routing-rules",
+					icon: Network,
+					description: "Intelligent routing rules",
+					hasAccess: hasRoutingRulesAccess,
+				},
 			],
 		},
 		{
@@ -873,6 +878,7 @@ export default function AppSidebar() {
 										router={router}
 										isSidebarCollapsed={sidebarState === "collapsed"}
 										expandSidebar={() => toggleSidebar()}
+										isGovernanceEnabled={isGovernanceEnabled}
 									/>
 								);
 							})}

--- a/ui/hooks/useStoreSync.tsx
+++ b/ui/hooks/useStoreSync.tsx
@@ -1,28 +1,93 @@
 "use client";
 
 import { baseApi } from "@/lib/store/apis/baseApi";
+import { governanceApi } from "@/lib/store/apis/governanceApi";
 import { useAppDispatch } from "@/lib/store/hooks";
 import { useEffect } from "react";
 import { useWebSocket } from "./useWebSocket";
 
 /**
- * Hook that subscribes to WebSocket store_update messages and invalidates
- * RTK Query cache tags accordingly. This enables real-time cache invalidation
- * when data changes on the backend.
+ * Hook that subscribes to WebSocket messages for real-time cache updates.
  *
- * Expected message format: { type: "store_update", tags: ["Providers", "VirtualKeys", ...] }
+ * Handles two message types:
+ * - store_update: Invalidates RTK Query cache tags (triggers refetch)
+ * - governance_update: Merges budget/rate-limit diffs into cached governance queries
  */
 export function useStoreSync() {
 	const { subscribe } = useWebSocket();
 	const dispatch = useAppDispatch();
 
 	useEffect(() => {
-		const unsubscribe = subscribe("store_update", (data) => {
+		const unsubTagSync = subscribe("store_update", (data) => {
 			if (data.tags && Array.isArray(data.tags)) {
 				dispatch(baseApi.util.invalidateTags(data.tags));
 			}
 		});
 
-		return unsubscribe;
+		const unsubGovUpdate = subscribe("governance_update", (data) => {
+			const { budgets, rate_limits } = data.data || {};
+			if (!budgets && !rate_limits) return;
+
+			// Merge into model configs cache
+			dispatch(
+				governanceApi.util.updateQueryData("getModelConfigs", undefined, (draft) => {
+					if (!draft?.model_configs) return;
+					for (const mc of draft.model_configs) {
+						if (budgets && mc.budget?.id && budgets[mc.budget.id]) {
+							mc.budget = budgets[mc.budget.id];
+						}
+						if (rate_limits && mc.rate_limit?.id && rate_limits[mc.rate_limit.id]) {
+							mc.rate_limit = rate_limits[mc.rate_limit.id];
+						}
+					}
+				})
+			);
+
+			// Merge into provider governance cache
+			dispatch(
+				governanceApi.util.updateQueryData("getProviderGovernance", undefined, (draft) => {
+					if (!draft?.providers) return;
+					for (const p of draft.providers) {
+						if (budgets && p.budget?.id && budgets[p.budget.id]) {
+							p.budget = budgets[p.budget.id];
+						}
+						if (rate_limits && p.rate_limit?.id && rate_limits[p.rate_limit.id]) {
+							p.rate_limit = rate_limits[p.rate_limit.id];
+						}
+					}
+				})
+			);
+
+			// Merge into virtual keys cache (virtual_keys is an array)
+			dispatch(
+				governanceApi.util.updateQueryData("getVirtualKeys", undefined, (draft) => {
+					if (!draft?.virtual_keys) return;
+					for (const vk of draft.virtual_keys) {
+						if (budgets && vk.budget?.id && budgets[vk.budget.id]) {
+							vk.budget = budgets[vk.budget.id];
+						}
+						if (rate_limits && vk.rate_limit?.id && rate_limits[vk.rate_limit.id]) {
+							vk.rate_limit = rate_limits[vk.rate_limit.id];
+						}
+						// Also merge into provider_configs
+						if (vk.provider_configs) {
+							for (const pc of vk.provider_configs) {
+								if (budgets && pc.budget?.id && budgets[pc.budget.id]) {
+									pc.budget = budgets[pc.budget.id];
+								}
+								if (rate_limits && pc.rate_limit?.id && rate_limits[pc.rate_limit.id]) {
+									pc.rate_limit = rate_limits[pc.rate_limit.id];
+								}
+							}
+						}
+					}
+				})
+			);
+		});
+
+		return () => {
+			unsubTagSync();
+			unsubGovUpdate();
+		};
 	}, [subscribe, dispatch]);
 }

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -156,6 +156,7 @@ export const baseApi = createApi({
 		"HealthCheck",
 		"DBKeys",
 		"Models",
+		"BaseModels",
 		"ModelConfigs",
 		"ProviderGovernance",
 		"Plugins",

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -35,7 +35,7 @@ export const governanceApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Virtual Keys
 		getVirtualKeys: builder.query<GetVirtualKeysResponse, void>({
-			query: () => "/governance/virtual-keys",
+			query: () => ({ url: "/governance/virtual-keys", params: { from_memory: true } }),
 			providesTags: ["VirtualKeys"],
 		}),
 
@@ -234,7 +234,7 @@ export const governanceApi = baseApi.injectEndpoints({
 
 		// Model Configs
 		getModelConfigs: builder.query<GetModelConfigsResponse, void>({
-			query: () => "/governance/model-configs",
+			query: () => ({ url: "/governance/model-configs", params: { from_memory: true } }),
 			providesTags: ["ModelConfigs"],
 		}),
 
@@ -271,7 +271,7 @@ export const governanceApi = baseApi.injectEndpoints({
 
 		// Provider Governance
 		getProviderGovernance: builder.query<GetProviderGovernanceResponse, void>({
-			query: () => "/governance/providers",
+			query: () => ({ url: "/governance/providers", params: { from_memory: true } }),
 			providesTags: ["ProviderGovernance"],
 		}),
 

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -21,6 +21,16 @@ export interface GetModelsRequest {
 	limit?: number;
 }
 
+export interface GetBaseModelsRequest {
+	query?: string;
+	limit?: number;
+}
+
+export interface ListBaseModelsResponse {
+	models: string[];
+	total: number;
+}
+
 export const providersApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Get all providers
@@ -83,6 +93,17 @@ export const providersApi = baseApi.injectEndpoints({
 			},
 			providesTags: ["Models"],
 		}),
+
+		// Get distinct base model names from the catalog
+		getBaseModels: builder.query<ListBaseModelsResponse, GetBaseModelsRequest>({
+			query: ({ query, limit }) => {
+				const params = new URLSearchParams();
+				if (query) params.append("query", query);
+				if (limit !== undefined) params.append("limit", limit.toString());
+				return `/models/base?${params.toString()}`;
+			},
+			providesTags: ["BaseModels"],
+		}),
 	}),
 });
 
@@ -94,8 +115,10 @@ export const {
 	useDeleteProviderMutation,
 	useGetAllKeysQuery,
 	useGetModelsQuery,
+	useGetBaseModelsQuery,
 	useLazyGetProvidersQuery,
 	useLazyGetProviderQuery,
 	useLazyGetAllKeysQuery,
 	useLazyGetModelsQuery,
+	useLazyGetBaseModelsQuery,
 } = providersApi;


### PR DESCRIPTION
## Summary

The frontend now receives real-time budget and rate-limit updates via WebSocket
instead of polling every 10 seconds. When a governance mutation occurs (e.g.
budget usage increases after an LLM call), the backend emits a minimal diff
(`{ budgets: { "id": {...} } }` or `{ rate_limits: { "id": {...} } }`). The
frontend merges this diff into the RTK Query cache using Immer draft mutations,
updating all affected views (model limits, provider governance, virtual keys)
immediately.

Also switches governance queries to `from_memory=true` for faster reads, removes
all 10-second polling intervals, adds base model selection support in the model
limits form, and fixes stale data in edit/detail sheets.

- **Re-enable sidebar navigation** — restore "Budgets & Limits" and "Routing
  Rules" menu items in the sidebar that were temporarily hidden, and restore the
  `Network` icon import.

- **Disabled state UX for governance-dependent items** — when governance is
  disabled, show governance-dependent sidebar items and provider config tabs as
  disabled with tooltips explaining how to enable them, instead of hiding them
  completely.

## Changes

- **`useStoreSync.tsx`**: Subscribe to `governance_update` WebSocket events and
  merge budget/rate-limit diffs into `getModelConfigs`, `getProviderGovernance`,
  and `getVirtualKeys` RTK Query caches using Immer draft mutations (mutate
  draft, don't return)
- **`governanceApi.ts`**: Switch `getVirtualKeys`, `getModelConfigs`, and
  `getProviderGovernance` queries to use `from_memory=true` query parameter
- **`baseApi.ts`**: Add `BaseModels` tag type
- **`providersApi.ts`**: Add `getBaseModels` query endpoint for
  `GET /api/models/base`
- **`modelMultiselect.tsx`**: Support `loadModelsOnEmptyProvider="base_models"`
  mode — when no provider is selected, loads distinct base model names instead
  of all models from all providers. Adds `useLazyGetBaseModelsQuery` integration
  with search/filter support.
- **`modelLimitSheet.tsx`**: Use `loadModelsOnEmptyProvider="base_models"` for
  the model selector (governance configs should use canonical base model names)
- **`modelLimitsTable.tsx`**: Store `editingModelConfigId` (string) instead of
  full `ModelConfig` object in state; derive current object via `useMemo` from
  props so it stays reactive to RTK cache updates
- **`modelLimitsView.tsx`**: Remove `pollingInterval: 10000` and
  `skipPollingIfUnfocused`
- **`governanceFormFragment.tsx`**: Remove `pollingInterval: 10000` and
  `skipPollingIfUnfocused`
- **`providerGovernanceTable.tsx`**: Remove `pollingInterval: 10000` and
  `skipPollingIfUnfocused`
- **`virtualKeysTable.tsx`**: Store `editingVirtualKeyId` and
  `selectedVirtualKeyId` (strings) instead of full objects; derive via `useMemo`
  from props for live updates
- Re-enable "Budgets & Limits" sidebar nav item (`/workspace/model-limits`)
- Re-enable "Routing Rules" sidebar nav item (`/workspace/routing-rules`)
- Restore `Network` icon import from `lucide-react`
- **`sidebar.tsx`**: Add disabled state styling for governance-dependent sidebar
  items (Budgets & Limits, Routing Rules) when governance is disabled — show
  items with muted styling, not-allowed cursor, and tooltip explaining how to
  enable governance. Remove `pointer-events-none` to allow hover effects.
- **`modelProviderConfig.tsx`**: Show "Governance" tab in provider configuration
  even when governance is disabled, but display it as disabled with tooltip.
  Previously the tab was completely hidden.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
# UI build
cd ui
pnpm i || npm i
pnpm build || npm run build
```

**Manual testing:**

1. **Real-time budget updates**: Open the Model Limits page. Make an LLM request
   through Bifrost. Observe that "Current Usage" values update immediately
   without page refresh.

2. **Real-time rate limit updates**: Open the Provider Governance page for a
   provider with rate limits. Make an LLM request. Observe token/request usage
   bars update in real-time.

3. **Virtual keys live updates**: Open a virtual key's detail sheet. Make
   requests using that virtual key. Budget and rate limit displays should update
   live.

4. **Edit sheet live data**: Open the edit sheet for a model config. While the
   sheet is open, make LLM requests that affect that model's budget. The
   "Current Usage" in the edit sheet should reflect the latest value.

5. **Base model selection**: Go to Model Limits → Add Model Limit. Leave the
   provider dropdown empty. The model selector should show distinct base model
   names (e.g. `gpt-4o`, `claude-3-5-sonnet`) instead of provider-specific
   variants.

6. **No polling**: Open browser DevTools Network tab. Verify there are no
   repeated GET requests to `/api/governance/*` every 10 seconds. Updates should
   only arrive via WebSocket.

7. **Disabled governance sidebar items**: Disable governance in Config →
   Governance. Verify that "Budgets & Limits" and "Routing Rules" sidebar items
   appear with muted/disabled styling. Hover over them to see tooltip explaining
   how to enable. Clicking should do nothing.

8. **Disabled governance tab in provider config**: With governance disabled, go
   to Model Providers → select a provider. In "Provider level configuration",
   verify the "Governance" tab is visible but disabled/grayed out with a tooltip.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The WebSocket subscription consumes the same
governance data already accessible through authenticated GET endpoints. No new
data is exposed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
