### PR TITLE
feat: add virtual key provider configs to budget/rate limit status and sort results

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1303,6 +1303,7 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 		}).
 		Preload("MCPConfigs").
 		Preload("MCPConfigs.MCPClient").
+		Order("created_at ASC").
 		Find(&virtualKeys).Error; err != nil {
 		return nil, err
 	}
@@ -1812,7 +1813,7 @@ func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tab
 		query = query.Where("customer_id = ?", customerID)
 	}
 	var teams []tables.TableTeam
-	if err := query.Find(&teams).Error; err != nil {
+	if err := query.Order("created_at ASC").Find(&teams).Error; err != nil {
 		return nil, err
 	}
 	return teams, nil
@@ -1900,7 +1901,7 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 // GetCustomers retrieves all customers from the database.
 func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustomer, error) {
 	var customers []tables.TableCustomer
-	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Find(&customers).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Order("created_at ASC").Find(&customers).Error; err != nil {
 		return nil, err
 	}
 	return customers, nil
@@ -1992,7 +1993,7 @@ func (s *RDBConfigStore) DeleteCustomer(ctx context.Context, id string) error {
 // GetRateLimits retrieves all rate limits from the database.
 func (s *RDBConfigStore) GetRateLimits(ctx context.Context) ([]tables.TableRateLimit, error) {
 	var rateLimits []tables.TableRateLimit
-	if err := s.db.WithContext(ctx).Find(&rateLimits).Error; err != nil {
+	if err := s.db.WithContext(ctx).Order("created_at ASC").Find(&rateLimits).Error; err != nil {
 		return nil, err
 	}
 	return rateLimits, nil
@@ -2057,7 +2058,7 @@ func (s *RDBConfigStore) UpdateRateLimits(ctx context.Context, rateLimits []*tab
 // GetBudgets retrieves all budgets from the database.
 func (s *RDBConfigStore) GetBudgets(ctx context.Context) ([]tables.TableBudget, error) {
 	var budgets []tables.TableBudget
-	if err := s.db.WithContext(ctx).Find(&budgets).Error; err != nil {
+	if err := s.db.WithContext(ctx).Order("created_at ASC").Find(&budgets).Error; err != nil {
 		return nil, err
 	}
 	return budgets, nil

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -543,14 +543,14 @@ func TestGovernanceStore_RateLimitStatus(t *testing.T) {
 	store.providers.Store("openai", providerConfig)
 
 	// Get status
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
 
 	assert.NotNil(t, status)
 	assert.Equal(t, 50.0, status.RateLimitTokenPercentUsed)
 
 	// Update usage to exhausted state
 	rl.TokenCurrentUsage = 1000
-	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
+	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
 
 	assert.Equal(t, 100.0, status.RateLimitTokenPercentUsed)
 }
@@ -578,14 +578,14 @@ func TestGovernanceStore_BudgetStatus(t *testing.T) {
 	store.providers.Store("openai", providerConfig)
 
 	// Get status
-	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
+	status := store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
 
 	assert.NotNil(t, status)
 	assert.Equal(t, 60.0, status.BudgetPercentUsed)
 
 	// Update usage to exhausted state
 	budget.CurrentUsage = 100.0
-	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil)
+	status = store.GetBudgetAndRateLimitStatus(context.Background(), "", schemas.ModelProvider("openai"), nil, nil, nil, nil)
 
 	assert.Equal(t, 100.0, status.BudgetPercentUsed)
 }

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -191,7 +191,7 @@ export function RoutingRuleSheet({
 			model: data.model,
 			fallbacks: validFallbacks,
 			scope: data.scope,
-			scope_id: data.scope_id || undefined,
+			scope_id: data.scope === "global" ? undefined : (data.scope_id || undefined),
 			priority: data.priority,
 			enabled: data.enabled,
 			query: query,

--- a/ui/lib/types/routingRules.ts
+++ b/ui/lib/types/routingRules.ts
@@ -25,8 +25,8 @@ export interface RoutingRule {
 export interface CreateRoutingRuleRequest {
 	name: string;
 	description?: string;
-	cel_expression: string;
-	provider: string;
+	cel_expression?: string;
+	provider?: string;
 	model?: string;
 	fallbacks?: string[];
 	scope: string;


### PR DESCRIPTION
## Summary

Added consistent ordering to database queries and enhanced virtual key provider-specific rate limits and budgets in the routing system.

## Changes

- Added `Order("created_at ASC")` to database queries for virtual keys, teams, customers, rate limits, and budgets to ensure consistent ordering in API responses
- Enhanced the `GetBudgetAndRateLimitStatus` function to consider virtual key level provider-specific rate limits and budgets
- Fixed routing rule updates to properly handle scope changes by removing rules from all scopes before adding to the new scope
- Added sorting of governance data by creation time for consistent API responses
- Updated the UI to properly handle scope_id when scope is "global"
- Fixed routing rule scope handling in the HTTP transport

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (Next.js)

## How to test

Test the ordering of items in the UI to ensure they appear in a consistent order:
```sh
# Core/Transports
go test ./plugins/governance/...
go test ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

Test virtual key provider-specific rate limits by creating a virtual key with provider configs and verifying the rate limits are applied correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses inconsistent ordering in API responses and improves virtual key provider-specific rate limiting.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)