### PR TITLE
enhancement: support full url along with paths in request_path_overrides for custom provider

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,3 +2,5 @@
 - fix: model names with namespaces (e.g., `meta-llama/Llama-3.1-8B`) are now correctly preserved instead of being incorrectly split as provider-prefixed models
 - fix: mapping of multiple modality tokens from gemini usage metadata to bifrost usage
 - fix: embedding thought signature in tool call id for valid tool calling cycle in gemini chat
+- feat: request path override functionality to support full URLs (with scheme and host) as well as custom paths
+- fix: missing and duplicated tool results in Bedrock - [@hhieuu](https://github.com/hhieuu)

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -121,7 +121,11 @@ func (provider *AnthropicProvider) GetProviderKey() schemas.ModelProvider {
 
 // buildRequestURL constructs the full request URL using the provider's configuration.
 func (provider *AnthropicProvider) buildRequestURL(ctx *schemas.BifrostContext, defaultPath string, requestType schemas.RequestType) string {
-	return provider.networkConfig.BaseURL + providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	path, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	if isCompleteURL {
+		return path
+	}
+	return provider.networkConfig.BaseURL + path
 }
 
 // completeRequest sends a request to Anthropic's API and handles the response.

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -108,7 +108,11 @@ func (provider *HuggingFaceProvider) GetProviderKey() schemas.ModelProvider {
 
 // buildRequestURL composes the final request URL based on context overrides.
 func (provider *HuggingFaceProvider) buildRequestURL(ctx *schemas.BifrostContext, defaultPath string, requestType schemas.RequestType) string {
-	return provider.networkConfig.BaseURL + providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	path, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	if isCompleteURL {
+		return path
+	}
+	return provider.networkConfig.BaseURL + path
 }
 
 // completeRequestWithModelAliasCache performs a request and retries once on 404 by clearing the cache and refetching model info
@@ -1022,8 +1026,7 @@ func (provider *HuggingFaceProvider) ImageGenerationStream(ctx *schemas.BifrostC
 
 	// Build streaming URL - append /stream to the fal-ai route, honoring path overrides
 	defaultPath := fmt.Sprintf("/fal-ai/%s/stream", modelName)
-	streamPath := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, schemas.ImageGenerationStreamRequest)
-	streamURL := provider.networkConfig.BaseURL + streamPath
+	streamURL := provider.buildRequestURL(ctx, defaultPath, schemas.ImageGenerationStreamRequest)
 
 	return HandleHuggingFaceImageGenerationStreaming(
 		ctx,
@@ -1449,8 +1452,7 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 
 	// Build streaming URL - append /stream to the fal-ai edit route, honoring path overrides
 	defaultPath := fmt.Sprintf("/fal-ai/%s/stream", modelName)
-	streamPath := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, schemas.ImageEditStreamRequest)
-	streamURL := provider.networkConfig.BaseURL + streamPath
+	streamURL := provider.buildRequestURL(ctx, defaultPath, schemas.ImageEditStreamRequest)
 
 	// Set headers
 	headers := map[string]string{

--- a/core/providers/huggingface/utils.go
+++ b/core/providers/huggingface/utils.go
@@ -147,7 +147,7 @@ func splitIntoModelProvider(bifrostModelName string) (inferenceProvider, string,
 }
 
 // Defined for tasks given by https://huggingface.co/docs/inference-providers/en/index and makeURL logic at https://github.com/huggingface/huggingface.js/blob/c02dd89eff24593b304d72715247f7eef79b3b73/packages/inference/src/providers/providerHelper.ts#L111
-func (provider *HuggingFaceProvider) getInferenceProviderRouteURL(ctx context.Context, inferenceProvider inferenceProvider, modelName string, requestType schemas.RequestType) (string, error) {
+func (provider *HuggingFaceProvider) getInferenceProviderRouteURL(ctx *schemas.BifrostContext, inferenceProvider inferenceProvider, modelName string, requestType schemas.RequestType) (string, error) {
 	defaultPath := ""
 	switch inferenceProvider {
 	case falAI:
@@ -160,9 +160,9 @@ func (provider *HuggingFaceProvider) getInferenceProviderRouteURL(ctx context.Co
 		case schemas.SpeechRequest:
 			pipeline = "text-to-speech"
 		case schemas.ImageGenerationRequest:
-			return provider.networkConfig.BaseURL + providerUtils.GetRequestPath(ctx, fmt.Sprintf("/hf-inference/models/%s", modelName), provider.customProviderConfig, requestType), nil
+			return provider.buildRequestURL(ctx, fmt.Sprintf("/hf-inference/models/%s", modelName), requestType), nil
 		case schemas.TranscriptionRequest:
-			return provider.networkConfig.BaseURL + providerUtils.GetRequestPath(ctx, fmt.Sprintf("/hf-inference/models/%s", modelName), provider.customProviderConfig, requestType), nil
+			return provider.buildRequestURL(ctx, fmt.Sprintf("/hf-inference/models/%s", modelName), requestType), nil
 		default:
 			pipeline = "chat-completion"
 		}
@@ -199,7 +199,7 @@ func (provider *HuggingFaceProvider) getInferenceProviderRouteURL(ctx context.Co
 	default:
 		return "", fmt.Errorf("unsupported inference provider: %s for action: %s", inferenceProvider, requestType)
 	}
-	return provider.networkConfig.BaseURL + providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType), nil
+	return provider.buildRequestURL(ctx, defaultPath, requestType), nil
 }
 
 // convertToInferenceProviderMappings converts HuggingFaceInferenceProviderMappingResponse to a map of HuggingFaceInferenceProviderMapping with ProviderName as key

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -76,7 +76,11 @@ func (provider *OpenAIProvider) GetProviderKey() schemas.ModelProvider {
 
 // buildRequestURL constructs the full request URL using the provider's configuration.
 func (provider *OpenAIProvider) buildRequestURL(ctx *schemas.BifrostContext, defaultPath string, requestType schemas.RequestType) string {
-	return provider.networkConfig.BaseURL + providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	path, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
+	if isCompleteURL {
+		return path
+	}
+	return provider.networkConfig.BaseURL + path
 }
 
 func (provider *OpenAIProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {

--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -267,8 +267,9 @@ The `request_path_overrides` field allows you to override the default API endpoi
 **Not Supported:** `request_path_overrides` is not supported for `gemini` and `bedrock` base provider types due to their specialized API implementations.
 </Warning>
 
-The field accepts a mapping of request types to custom paths:
+The field accepts a mapping of request types to either custom **paths** or **full URLs**:
 
+**Using Paths (relative to `base_url`):**
 ```json
 {
     "request_path_overrides": {
@@ -279,6 +280,20 @@ The field accepts a mapping of request types to custom paths:
     }
 }
 ```
+
+**Using Full URLs (bypasses `base_url`):**
+```json
+{
+    "request_path_overrides": {
+        "chat_completion": "https://specific-endpoint.com/chat",
+        "embedding": "http://another-service:8080/embeddings"
+    }
+}
+```
+
+<Info>
+When a full URL (with scheme and host) is provided in `request_path_overrides`, Bifrost will use that URL directly and ignore the `base_url` from `network_config` for that specific request type. This allows you to route different request types to completely different endpoints.
+</Info>
 
 **Example: OpenAI-Compatible Endpoint with Custom Paths**
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -8,3 +8,5 @@
 - fix: edit sheets now show live data instead of stale cached values
 - fix: mapping of multiple modality tokens from gemini usage metadata to bifrost usage
 - fix: embedding thought signature in tool call id for valid tool calling cycle in gemini chat
+- feat: request path override functionality to support full URLs (with scheme and host) as well as custom paths
+- fix: missing and duplicated tool results in Bedrock - [@hhieuu](https://github.com/hhieuu)

--- a/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
+++ b/ui/app/workspace/providers/fragments/allowedRequestsFields.tsx
@@ -134,8 +134,11 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 											</PopoverTrigger>
 											<PopoverContent className="w-80" align="end" onOpenAutoFocus={(e) => e.preventDefault()}>
 												<div className="space-y-2">
-													<h4 className="text-sm font-medium">Custom Path</h4>
-													<p className="text-muted-foreground text-xs">Override the default endpoint path</p>
+													<h4 className="text-sm font-medium">Custom Path or URL</h4>
+													<p className="text-muted-foreground text-xs">
+														Override with a path (e.g., /v1/chat) or a full URL (e.g., https://api.example.com/chat) to bypass
+														base_url
+													</p>
 													<Input placeholder={placeholder} {...pathField} value={pathField.value || ""} className="h-9" />
 												</div>
 											</PopoverContent>
@@ -175,7 +178,7 @@ export function AllowedRequestsFields({ control, namePrefix = "allowed_requests"
 				<div className="text-sm font-medium">Allowed Request Types</div>
 				<p className="text-muted-foreground text-xs">
 					Select which request types this custom provider can handle.{" "}
-					{!isPathOverrideDisabled ? "Click the settings icon to customize endpoint paths." : ""}
+					{!isPathOverrideDisabled ? "Click the settings icon to customize endpoint paths or use full URLs." : ""}
 				</p>
 			</div>
 


### PR DESCRIPTION
## Support for full URL overrides in request path configuration

This PR enhances the request path override functionality to support full URLs (with scheme and host), allowing requests to be routed to completely different endpoints based on request type.

## Changes

- Modified `GetRequestPath` in `utils.go` to detect and handle full URLs in path overrides
- Updated all provider implementations to respect the new URL detection logic
- Added comprehensive test cases for the enhanced path resolution logic
- Updated documentation to explain the new full URL override capability
- Updated UI tooltips to indicate that both paths and full URLs are supported

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (Next.js)
- [x] Docs

## How to test

Test with a custom provider configuration that uses full URLs in request path overrides:

```json
{
  "base_provider": "openai",
  "network_config": {
    "base_url": "https://default-api.example.com"
  },
  "custom_provider_config": {
    "request_path_overrides": {
      "chat_completion": "https://chat-api.example.com/v1/chat",
      "embedding": "http://embedding-service:8080/embeddings"
    }
  }
}
```

Verify that requests are sent to the specified URLs rather than being appended to the base_url.

## Breaking changes

- [x] No

## Related issues

Enhances custom provider configuration flexibility

## Security considerations

This change allows more flexible routing of API requests, which should be considered when configuring providers in production environments.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)