### PR TITLE
fix: prevent duplicate MCP server creation by skipping DB updates

### DIFF
--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -127,7 +127,7 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 			go func(clientConfig *schemas.MCPClientConfig) {
 				defer wg.Done()
 				if err := manager.AddClient(clientConfig); err != nil {
-					manager.logger.Warn("%s Failed to add MCP client %s: %v", MCPLogPrefix, clientConfig.Name, err)
+					manager.logger.Warn("%s Failed to register MCP client %s: %v", MCPLogPrefix, clientConfig.Name, err)
 				}
 			}(clientConfig)
 		}

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -420,7 +420,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		OauthConfigID:      req.OauthConfigID,
 		IsPingAvailable:    isPingAvailable,
 		ToolSyncInterval:   toolSyncInterval,
-		ToolPricing:        req.ToolPricing,		
+		ToolPricing:        req.ToolPricing,
 	}
 	// Update MCP client in memory
 	if err := h.mcpManager.UpdateMCPClient(ctx, id, schemasConfig); err != nil {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: duplicate mcp server creation when adding non oauth mcp client


### PR DESCRIPTION
## Summary

Fix duplicate MCP server creation issue when adding non-OAuth MCP clients by skipping database updates during MCP client operations.

## Changes

- Added `BifrostContextKeySkipDBUpdate` flag to MCP client operations (add, update, delete) to prevent duplicate database updates
- This prevents the creation of duplicate MCP servers when adding non-OAuth MCP clients
- Updated version from 1.4.4 to 1.4.5

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Attempt to add a non-OAuth MCP client
2. Verify that only one MCP server is created in the database
3. Test update and delete operations to ensure they work correctly

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issue with duplicate MCP server creation

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable