### PR TITLE
fix: prevent duplicate MCP clients by checking name uniqueness

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -81,6 +81,11 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 	// Make a copy of the config to use after unlocking
 	configCopy := config
 
+	// Check if a client with the same name already exists (GetClientByName has its own lock)
+	if client := m.GetClientByName(config.Name); client != nil {
+		return fmt.Errorf("MCP client with name '%s' already exists", config.Name)
+	}
+
 	m.mu.Lock()
 
 	if _, ok := m.clientMap[config.ID]; ok {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -832,7 +832,6 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 	}, nil
 }
 
-
 // GetMCPClientByID retrieves an MCP client by ID from the database.
 func (s *RDBConfigStore) GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error) {
 	var mcpClient tables.TableMCPClient
@@ -860,6 +859,10 @@ func (s *RDBConfigStore) GetMCPClientByName(ctx context.Context, name string) (*
 // CreateMCPClientConfig creates a new MCP client configuration in the database.
 func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
 	return s.db.Transaction(func(tx *gorm.DB) error {
+		// Check if a client with the same name already exists
+		if _, err := s.GetMCPClientByName(ctx, clientConfig.Name); err == nil {
+			return fmt.Errorf("MCP client with name '%s' already exists", clientConfig.Name)
+		}
 		// Create a deep copy to avoid modifying the original
 		clientConfigCopy, err := deepCopy(*clientConfig)
 		if err != nil {


### PR DESCRIPTION
## Summary

Improved MCP client management by adding duplicate name checks and enhancing error handling to maintain consistency between in-memory state and database storage.

## Changes

- Added validation to prevent creating MCP clients with duplicate names in both the client manager and database layer
- Reordered operations in the add client handler to check database constraints before adding to memory
- Implemented cleanup logic to delete database entries when in-memory operations fail
- Enhanced error messages with more specific information and logging
- Added proper transaction rollback when errors occur to maintain data consistency

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Try to create an MCP client with a unique name - should succeed
2. Try to create another MCP client with the same name - should fail with a clear error message
3. Verify that database and in-memory state remain consistent after failed operations

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change improves system integrity by preventing duplicate client names which could lead to confusion or potential security issues with client identification.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable