### PR TITLE
fix: gemini thought signature handling in chat converter

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
 - feat: add EventBroadcaster type for real-time event streaming to WebSocket clients
 - fix: model names with namespaces (e.g., `meta-llama/Llama-3.1-8B`) are now correctly preserved instead of being incorrectly split as provider-prefixed models
 - fix: mapping of multiple modality tokens from gemini usage metadata to bifrost usage
+- fix: embedding thought signature in tool call id for valid tool calling cycle in gemini chat

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -94,9 +94,9 @@ providers:
       - "claude-3-haiku-20240307"
     
   gemini:
-    chat: "gemini-2.5-flash"
-    vision: "gemini-2.5-flash"
-    tools: "gemini-2.5-flash"
+    chat: "gemini-3-flash-preview"
+    vision: "gemini-3-flash-preview"
+    tools: "gemini-3-flash-preview"
     file: "gemini-2.5-flash"
     thinking: "gemini-3-pro-preview"
     speech: "gemini-2.5-flash-preview-tts"
@@ -105,7 +105,7 @@ providers:
     image_generation: "gemini-2.5-flash-image"
     image_edit: "gemini-3-pro-image-preview"
     imagen: "imagen-4.0-generate-001"
-    streaming: "gemini-2.5-flash"
+    streaming: "gemini-3-flash-preview"
     batch_create: "gemini-2.5-flash"
     batch_inline: "gemini-2.5-flash"
     batch_file_upload: "gemini-2.5-flash"

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -6,3 +6,5 @@
 - feat: add `GET /api/models/base` endpoint for listing distinct base model names with search/filter support
 - feat: base model selection in model limits UI when no provider is selected
 - fix: edit sheets now show live data instead of stale cached values
+- fix: mapping of multiple modality tokens from gemini usage metadata to bifrost usage
+- fix: embedding thought signature in tool call id for valid tool calling cycle in gemini chat


### PR DESCRIPTION
## Improved Thought Signature Handling for Gemini Provider

This PR enhances how thought signatures are handled in the Gemini provider, ensuring consistent behavior between streaming and non-streaming responses and maintaining backward compatibility.

## Changes

- Added support for embedding thought signatures in tool call IDs for both streaming and non-streaming responses
- Improved handling of thought signatures associated with text content
- Fixed signature extraction logic to properly handle round-trip conversions
- Added comprehensive tests to verify thought signature embedding and extraction
- Updated Python integration tests to use Gemini 3 models and added an end-to-end tool calling test
- Added support for code execution results and executable code in response parsing

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Gemini provider tests to verify thought signature handling:

```sh
# Run Gemini provider tests
go test ./core/providers/gemini/...

# Run Python integration tests
cd tests/integrations/python
python -m pytest tests/test_pydanticai.py -v
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves thought signature handling for Gemini provider, ensuring compatibility with other providers.

## Security considerations

Ensures proper encoding and decoding of thought signatures which may contain sensitive reasoning information.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable