### PR TITLE
auto-open chat window on email submission

### DIFF
--- a/docs/supportWidget.js
+++ b/docs/supportWidget.js
@@ -118,6 +118,31 @@
     return true;
   }
 
+  function openChatWhenReady() {
+    var attempts = 0;
+    var maxAttempts = 20;
+    var intervalMs = 300;
+
+    function tryOpen() {
+      attempts += 1;
+      if (typeof window.Pylon === "function") {
+        window.Pylon("show");
+        return true;
+      }
+      return false;
+    }
+
+    if (tryOpen()) {
+      return;
+    }
+
+    var interval = window.setInterval(function () {
+      if (tryOpen() || attempts >= maxAttempts) {
+        window.clearInterval(interval);
+      }
+    }, intervalMs);
+  }
+
   function injectStyles() {
     if (document.getElementById(STYLE_ID)) {
       return;
@@ -285,6 +310,7 @@
       var ok = setPylonUser(email);
       if (ok) {
         safeSetItem(STORAGE_KEY, email);
+        openChatWhenReady();
         closeModal();
         removeTrigger();
       }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1091,6 +1091,9 @@
         ],
         "additionalProperties": false
       }
+    },
+    "audit_logs": {
+      "$ref": "#/$defs/audit_logs_config"
     }
   },
   "additionalProperties": false,
@@ -2529,6 +2532,22 @@
             ],
             "additionalProperties": false
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "audit_logs_config": {
+      "type": "object",
+      "description": "Audit logs configuration for CADF-compliant activity logging",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "Whether audit logging is disabled (default: false)",
+          "default": false
+        },
+        "hmac_key": {
+          "type": "string",
+          "description": "HMAC secret key for signing audit events (minimum 32 bytes). Can use env. prefix for environment variables (e.g., 'env.AUDIT_HMAC_KEY')."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

Added automatic chat opening after email submission in the support widget and introduced audit logs configuration schema.

## Changes

- Added `openChatWhenReady()` function to the support widget that attempts to open the Pylon chat window once the widget is ready
- Modified the email submission handler to automatically open the chat after successful email submission
- Added audit logs configuration schema to the transports config with options for disabling and setting an HMAC key

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Docs

## How to test

1. Test the support widget chat auto-opening:
   - Submit an email in the support widget
   - Verify the chat window opens automatically after submission

2. Test the audit logs configuration:
   - Add audit logs configuration to your config file:
   ```yaml
   audit_logs:
     disabled: false
     hmac_key: "your-secret-key-at-least-32-bytes-long"
   ```
   - Verify the configuration is properly parsed

## Breaking changes

- [x] No

## Security considerations

The audit logs feature introduces an HMAC key configuration for signing audit events. This key should be kept secure and should be at least 32 bytes long. The configuration supports loading the key from environment variables for better security practices.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)