### PR TITLE
fix: bedrock tool results missing and duplicated issues

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2,7 +2,6 @@ package bedrock
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -2408,42 +2407,12 @@ func ConvertBifrostMessagesToBedrockMessages(bifrostMessages []schemas.Responses
 				// Convert result content to Bedrock format
 				if msg.ResponsesToolMessage.Output != nil {
 					if msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr != nil {
-						// Try to parse as JSON, otherwise treat as text
-						var parsed interface{}
-						if err := json.Unmarshal([]byte(*msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr), &parsed); err != nil {
-							resultContent = append(resultContent, BedrockContentBlock{
-								Text: msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr,
-							})
-						} else {
-							// Bedrock does not accept primitives or arrays directly in the json field
-							switch v := parsed.(type) {
-							case map[string]any:
-								// Objects are valid as-is
-								resultContent = append(resultContent, BedrockContentBlock{
-									JSON: v,
-								})
-							case []any:
-								// Arrays need to be wrapped
-								resultContent = append(resultContent, BedrockContentBlock{
-									JSON: map[string]any{"results": v},
-								})
-							default:
-								// Primitives (string, number, boolean, null) need to be wrapped
-								resultContent = append(resultContent, BedrockContentBlock{
-									JSON: map[string]any{"value": v},
-								})
-							}
-						}
+						resultContent = append(resultContent, tryParseJSONIntoContentBlock(*msg.ResponsesToolMessage.Output.ResponsesToolCallOutputStr))
 					} else if msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
 						// Handle structured output blocks
 						for _, block := range msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
-							switch block.Type {
-							case schemas.ResponsesInputMessageContentBlockTypeText:
-								if block.Text != nil {
-									resultContent = append(resultContent, BedrockContentBlock{
-										Text: block.Text,
-									})
-								}
+							if block.Text != nil {
+								resultContent = append(resultContent, tryParseJSONIntoContentBlock(*block.Text))
 							}
 						}
 					}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2175,6 +2175,17 @@ func (m *ToolCallStateManager) RegisterToolCall(callID, toolName, arguments stri
 
 // RegisterToolResult registers a tool result
 func (m *ToolCallStateManager) RegisterToolResult(callID string, content []BedrockContentBlock, status string) {
+	// Attemp to deduplicate the result similar to tool call. Need to check in 2 places, since after moving
+	// on from pendingResults into a completed toolCall, the same ID might come again.
+	if _, ok := m.pendingResults[callID]; ok {
+		return
+	}
+
+	if toolCall, exists := m.toolCalls[callID]; exists && toolCall.Result != nil {
+		// Tool result already processed for this call ID, skip
+		return
+	}
+
 	result := &ToolResult{
 		CallID:  callID,
 		Content: content,


### PR DESCRIPTION
## Summary

This PR fix 2 issues with Anthropic integration -> Bedrock provider for Claude models (and maybe more):
- Tool results are missing due to insufficient checks during conversion. It also does not attempt to convert text to JSON.
- Tool results are not deduplicated while tool uses are. CC has an issue where it potentially sends duplicated tool uses and results (same ID, same content) when resuming a session, which then for bedrock provider leads to mismatched tool use vs tool result message, i.e. 1 tool use but multiple tool results of the same ID. This is the error from Bedrock
```
{"type":"error","error":{"type":"","message":"The number of toolResult blocks at messages.108.content exceeds the number of toolUse blocks of previous turn."}}
```

## Changes

- Unify Bedrock tool result text JSON parsing attempt into a utils `tryParseJSONIntoContentBlock` to be reused.
- Parse tool output for all content block type instead of only for `schemas.ResponsesInputMessageContentBlockTypeText` which fixes the issue with missing/empty tool result content.
- Check if tool result for a tool use has been emitted and skip if it is by checking tool call with the same id already exists and if result has been set.
- Add tests around JSON parsing attempts, missing tool call case, and duplicated tool uses + tool results. Does not care about content for deduplication, just tool ID since practically same tool ID should have exactly same content for both tool use and too result.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go test ./core/providers/bedrock/...
```

## Screenshots/Recordings

NA

## Breaking changes

- [ ] Yes
- [x] No

## Related issues



## Security considerations

NA

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


