### PR TITLE
fix: exclude errored requests from missing cost filter

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -89,7 +89,8 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		baseQuery = baseQuery.Where("cost <= ?", *filters.MaxCost)
 	}
 	if filters.MissingCostOnly {
-		baseQuery = baseQuery.Where("cost IS NULL OR cost <= 0")
+		// cost is null and status is not error
+		baseQuery = baseQuery.Where("(cost IS NULL OR cost <= 0) AND status NOT IN ('error')")
 	}
 	if filters.ContentSearch != "" {
 		baseQuery = baseQuery.Where("content_summary LIKE ?", "%"+filters.ContentSearch+"%")

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -10,3 +10,4 @@
 - fix: embedding thought signature in tool call id for valid tool calling cycle in gemini chat
 - feat: request path override functionality to support full URLs (with scheme and host) as well as custom paths
 - fix: missing and duplicated tool results in Bedrock - [@hhieuu](https://github.com/hhieuu)
+- fix: errored request logs are now not counted in missing cost filter


### PR DESCRIPTION
## Summary

Exclude errored requests from the missing cost filter to improve log filtering accuracy.

## Changes

- Modified the `MissingCostOnly` filter in the RDB log store to exclude logs with 'error' status
- Updated the changelog to document this fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Create some logs with error status and null cost
2. Apply the missing cost filter in the logs view
3. Verify that logs with error status are not included in the results

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable