### PR TITLE
feat: add scopes field in azure key config for entra id auth

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -5,3 +5,4 @@
 - feat: request path override functionality to support full URLs (with scheme and host) as well as custom paths
 - fix: missing and duplicated tool results in Bedrock - [@hhieuu](https://github.com/hhieuu)
 - fix: support HuggingFace model names without an explicit provider prefix
+- feat: adds support for custom OAuth scopes when authenticating with Azure Entra ID

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -83,8 +83,10 @@ func (provider *AzureProvider) getAzureAuthHeaders(ctx *schemas.BifrostContext, 
 			return nil, providerUtils.NewBifrostOperationError("failed to get or create Azure authentication", err, schemas.Azure)
 		}
 
+		scopes := getAzureScopes(key.AzureKeyConfig.Scopes)
+
 		token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
-			Scopes: []string{DefaultAzureScope},
+			Scopes: scopes,
 		})
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError("failed to get Azure access token", err, schemas.Azure)

--- a/core/providers/azure/files.go
+++ b/core/providers/azure/files.go
@@ -26,8 +26,10 @@ func (provider *AzureProvider) setAzureAuth(ctx context.Context, req *fasthttp.R
 			return providerUtils.NewBifrostOperationError("failed to get or create Azure authentication", err, schemas.Azure)
 		}
 
+		scopes := getAzureScopes(key.AzureKeyConfig.Scopes)
+
 		token, err := cred.GetToken(ctx, policy.TokenRequestOptions{
-			Scopes: []string{DefaultAzureScope},
+			Scopes: scopes,
 		})
 		if err != nil {
 			return providerUtils.NewBifrostOperationError("failed to get Azure access token", err, schemas.Azure)

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -59,4 +60,22 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 	}
 
 	return jsonBody, nil
+}
+
+// getCleanedScopes returns cleaned scopes or default scope if none are valid.
+// It filters out empty/whitespace-only strings and returns the default scope if no valid scopes remain.
+func getAzureScopes(configuredScopes []string) []string {
+	scopes := []string{DefaultAzureScope}
+	if len(configuredScopes) > 0 {
+		cleaned := make([]string, 0, len(configuredScopes))
+		for _, s := range configuredScopes {
+			if strings.TrimSpace(s) != "" {
+				cleaned = append(cleaned, strings.TrimSpace(s))
+			}
+		}
+		if len(cleaned) > 0 {
+			scopes = cleaned
+		}
+	}
+	return scopes
 }

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -27,9 +27,10 @@ type AzureKeyConfig struct {
 	Deployments map[string]string `json:"deployments,omitempty"` // Mapping of model names to deployment names
 	APIVersion  *EnvVar           `json:"api_version,omitempty"` // Azure API version to use; defaults to "2024-10-21"
 
-	ClientID     *EnvVar `json:"client_id,omitempty"`     // Azure client ID for authentication
-	ClientSecret *EnvVar `json:"client_secret,omitempty"` // Azure client secret for authentication
-	TenantID     *EnvVar `json:"tenant_id,omitempty"`     // Azure tenant ID for authentication
+	ClientID     *EnvVar  `json:"client_id,omitempty"`     // Azure client ID for authentication
+	ClientSecret *EnvVar  `json:"client_secret,omitempty"` // Azure client secret for authentication
+	TenantID     *EnvVar  `json:"tenant_id,omitempty"`     // Azure tenant ID for authentication
+	Scopes       []string `json:"scopes,omitempty"`
 }
 
 // VertexKeyConfig represents the Vertex-specific configuration.

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -77,6 +77,11 @@ AzureKeyConfig:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
     tenant_id:
       $ref: '../../schemas/management/common.yaml#/EnvVar'
+    scopes:
+      type: array
+      items:
+        type: string
+      description: List of scopes to use for authentication
 
 VertexKeyConfig:
   type: object

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -104,6 +104,7 @@ If you set `client_id`, `client_secret`, and `tenant_id`, Azure Entra ID authent
     "client_id": "your-client-id",
     "client_secret": "your-client-secret",
     "tenant_id": "your-tenant-id",
+    "scopes": ["https://cognitiveservices.azure.com/.default"],
     "api_version": "2024-10-21",
     "deployments": {
       "gpt-4": "my-gpt4-deployment",
@@ -139,6 +140,7 @@ If you set `client_id`, `client_secret`, and `tenant_id`, Azure Entra ID authent
 - `client_id` - Azure Entra ID client ID (optional, for Service Principal auth)
 - `client_secret` - Azure Entra ID client secret (optional, for Service Principal auth)
 - `tenant_id` - Azure Entra ID tenant ID (optional, for Service Principal auth)
+- `scopes` - OAuth scopes for token requests (default: `["https://cognitiveservices.azure.com/.default"]`)
 - `api_version` - API version to use (default: `2024-10-21`)
 - `deployments` - Map of model names to deployment IDs (optional, can be provided per-request)
 - `allowed_models` - List of allowed models to use from this key (optional)

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -1031,6 +1031,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 "client_id": "env.AZURE_CLIENT_ID",
                 "client_secret": "env.AZURE_CLIENT_SECRET",
                 "tenant_id": "env.AZURE_TENANT_ID",
+                "scopes": ["https://cognitiveservices.azure.com/.default"],
                 "deployments": {
                     "gpt-4o": "gpt-4o-deployment",
                     "gpt-4o-mini": "gpt-4o-mini-deployment"
@@ -1061,6 +1062,7 @@ curl --location 'http://localhost:8080/api/providers' \
                         "client_id": "env.AZURE_CLIENT_ID",
                         "client_secret": "env.AZURE_CLIENT_SECRET",
                         "tenant_id": "env.AZURE_TENANT_ID",
+                        "scopes": ["https://cognitiveservices.azure.com/.default"],
                         "deployments": {
                             "gpt-4o": "gpt-4o-deployment",
                             "gpt-4o-mini": "gpt-4o-mini-deployment"

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -293,6 +293,9 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.AzureKeyConfig.TenantID != nil {
 				azureConfig.TenantID = key.AzureKeyConfig.TenantID.Redacted()
 			}
+			if len(key.AzureKeyConfig.Scopes) > 0 {
+				azureConfig.Scopes = key.AzureKeyConfig.Scopes
+			}
 			redactedConfig.Keys[i].AzureKeyConfig = azureConfig
 		}
 

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -106,6 +106,7 @@ func (pc *TableVirtualKeyProviderConfig) AfterFind(tx *gorm.DB) error {
 			key.AzureClientID = nil
 			key.AzureClientSecret = nil
 			key.AzureTenantID = nil
+			key.AzureScopesJSON = nil
 			key.AzureDeploymentsJSON = nil
 			key.AzureKeyConfig = nil
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -11,3 +11,4 @@
 - feat: request path override functionality to support full URLs (with scheme and host) as well as custom paths
 - fix: missing and duplicated tool results in Bedrock - [@hhieuu](https://github.com/hhieuu)
 - fix: errored request logs are now not counted in missing cost filter
+- feat: adds support for custom OAuth scopes when authenticating with Azure Entra ID

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -6,6 +6,7 @@ import { EnvVarInput } from "@/components/ui/envVarInput";
 import { FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
+import { TagInput } from "@/components/ui/tagInput";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -220,6 +221,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 								form.setValue('key.azure_key_config.client_id', undefined)
 								form.setValue('key.azure_key_config.client_secret', undefined)
 								form.setValue('key.azure_key_config.tenant_id', undefined)
+								form.setValue('key.azure_key_config.scopes', undefined)
 							}
 						}}>
 							<TabsList className="grid w-full grid-cols-2">
@@ -292,6 +294,38 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 										<FormLabel>Tenant ID (Required)</FormLabel>
 										<FormControl>
 											<EnvVarInput placeholder="your-tenant-id or env.AZURE_TENANT_ID" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={control}
+								name={`key.azure_key_config.scopes`}
+								render={({ field }) => (
+									<FormItem>
+										<div className="flex items-center gap-2">
+											<FormLabel>Scopes (Optional)</FormLabel>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<span>
+															<Info className="text-muted-foreground h-3 w-3" />
+														</span>
+													</TooltipTrigger>
+													<TooltipContent>
+														<p>Optional OAuth scopes for token requests. By default we use
+														https://cognitiveservices.azure.com/.default — add additional scopes here if your setup requires extra permissions.</p>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
+										<FormControl>
+											<TagInput
+												placeholder="Add scope (Enter or comma)"
+												value={field.value ?? []}
+												onValueChange={field.onChange}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -28,6 +28,7 @@ export interface AzureKeyConfig {
 	client_id?: EnvVar;
 	client_secret?: EnvVar;
 	tenant_id?: EnvVar;
+	scopes?: string[];
 }
 
 export const DefaultAzureKeyConfig: AzureKeyConfig = {
@@ -37,6 +38,7 @@ export const DefaultAzureKeyConfig: AzureKeyConfig = {
 	client_id: { value: "", env_var: "", from_env: false },
 	client_secret: { value: "", env_var: "", from_env: false },
 	tenant_id: { value: "", env_var: "", from_env: false },
+	scopes: [],
 } as const satisfies Required<AzureKeyConfig>;
 
 // VertexKeyConfig matching Go's schemas.VertexKeyConfig

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -28,6 +28,7 @@ export const azureKeyConfigSchema = z
 		client_id: envVarSchema.optional(),
 		client_secret: envVarSchema.optional(),
 		tenant_id: envVarSchema.optional(),
+		scopes: z.array(z.string()).optional(),
 	})
 	.refine(
 		(data) => {


### PR DESCRIPTION
## Add configurable OAuth scopes for Azure authentication

This PR adds support for custom OAuth scopes when authenticating with Azure Entra ID. Previously, the Azure provider used a hardcoded scope (`https://cognitiveservices.azure.com/.default`), but some Azure environments may require different or additional scopes.

## Changes

- Added a new `scopes` field to the `AzureKeyConfig` structure to allow specifying custom OAuth scopes
- Modified the Azure authentication code to use the custom scopes when provided, falling back to the default scope
- Added database migration to support storing the scopes in the database
- Updated UI to allow configuring custom scopes in the Azure provider settings
- Updated documentation to reflect the new configuration option

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (Next.js)
- [x] Docs

## How to test

1. Configure an Azure provider with custom scopes:

```json
{
  "provider": "azure",
  "azure_key_config": {
    "endpoint": "https://your-endpoint.openai.azure.com/",
    "client_id": "your-client-id",
    "client_secret": "your-client-secret",
    "tenant_id": "your-tenant-id",
    "scopes": ["https://cognitiveservices.azure.com/.default", "custom-scope"]
  }
}
```

2. Verify that the authentication works with the custom scopes
3. Verify that the default scope is used when no custom scopes are provided

## Breaking changes

- [x] No

## Security considerations

This change enhances security by allowing more granular control over the OAuth scopes used for Azure authentication, which follows the principle of least privilege.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)