### PR TITLE
fix: disable enforce governance header when governance is disabled

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -322,8 +322,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		restartReasons = append(restartReasons, "Governance enabled")
 	}
 	updatedConfig.EnableGovernance = payload.ClientConfig.EnableGovernance
-
-	updatedConfig.EnforceGovernanceHeader = payload.ClientConfig.EnforceGovernanceHeader
+	if !payload.ClientConfig.EnableGovernance {
+		// If governance is disabled, we will disable the enforcement of the governance header
+		updatedConfig.EnforceGovernanceHeader = false
+	} else {
+		updatedConfig.EnforceGovernanceHeader = payload.ClientConfig.EnforceGovernanceHeader
+	}
 	updatedConfig.AllowDirectKeys = payload.ClientConfig.AllowDirectKeys
 
 	if payload.ClientConfig.MaxRequestBodySizeMB != currentConfig.MaxRequestBodySizeMB {

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -350,7 +350,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*se
 	defer h.mu.RUnlock()
 
 	h.config.Mu.RLock()
-	enforceVK := h.config.ClientConfig.EnforceGovernanceHeader
+	enforceVK := h.config.ClientConfig.EnforceGovernanceHeader && h.config.ClientConfig.EnableGovernance
 	h.config.Mu.RUnlock()
 
 	vk := getVKFromRequest(ctx)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -12,3 +12,4 @@
 - fix: missing and duplicated tool results in Bedrock - [@hhieuu](https://github.com/hhieuu)
 - fix: errored request logs are now not counted in missing cost filter
 - feat: adds support for custom OAuth scopes when authenticating with Azure Entra ID
+- fix: if governance is disabled set enforce virtual key header to false


### PR DESCRIPTION
## Summary

Automatically disable governance header enforcement when governance is disabled in the configuration.

## Changes

- Modified the `updateConfig` function in the ConfigHandler to automatically set `EnforceGovernanceHeader` to false when `EnableGovernance` is set to false
- Added a changelog entry to document this fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Disable governance in the configuration
2. Verify that the `EnforceGovernanceHeader` setting is automatically set to false
3. Enable governance and set `EnforceGovernanceHeader` to true
4. Verify that the setting is preserved

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where governance header enforcement could remain enabled even when governance itself was disabled.

## Security considerations

This change ensures a more consistent security posture by preventing a situation where governance headers would be enforced when the governance feature itself is disabled.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)