### PR TITLE
fixes #1556

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.2
+version: 2.0.3
 appVersion: "1.4.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -33,6 +33,11 @@ app.kubernetes.io/name: {{ include "bifrost.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
+{{- define "bifrost.serverSelectorLabels" -}}
+{{ include "bifrost.selectorLabels" . }}
+app.kubernetes.io/component: server
+{{- end }}
+
 {{- define "bifrost.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "bifrost.fullname" .) .Values.serviceAccount.name }}

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "bifrost.selectorLabels" . | nindent 6 }}
+      {{- include "bifrost.serverSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -35,6 +35,7 @@ spec:
         {{- end }}
       labels:
         {{- include "bifrost.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm-charts/bifrost/templates/service-headless.yaml
+++ b/helm-charts/bifrost/templates/service-headless.yaml
@@ -26,5 +26,5 @@ spec:
       name: gossip-udp
     {{- end }}
   selector:
-    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+    {{- include "bifrost.serverSelectorLabels" . | nindent 4 }}
 {{- end }}

--- a/helm-charts/bifrost/templates/service.yaml
+++ b/helm-charts/bifrost/templates/service.yaml
@@ -27,4 +27,4 @@ spec:
       name: gossip-udp
     {{- end }}
   selector:
-    {{- include "bifrost.selectorLabels" . | nindent 4 }}
+    {{- include "bifrost.serverSelectorLabels" . | nindent 4 }}

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "bifrost.selectorLabels" . | nindent 6 }}
+      {{- include "bifrost.serverSelectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -35,6 +35,7 @@ spec:
         {{- end }}
       labels:
         {{- include "bifrost.labels" . | nindent 8 }}
+        app.kubernetes.io/component: server
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,28 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.3
+    created: "2026-02-05T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.3.tgz
+    version: 2.0.3
+  - apiVersion: v2
+    appVersion: 1.4.3
     created: "2026-01-31T21:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -289,4 +311,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-01-31T21:00:00.000000+00:00"
+generated: "2026-02-05T12:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Improved Kubernetes label management in the Bifrost Helm chart by adding a dedicated component label for server resources.

## Changes

- Added a new `bifrost.serverSelectorLabels` helper template that includes the component label
- Updated all server-related resources to use the new selector labels
- Added explicit `app.kubernetes.io/component: server` label to pod templates
- Bumped chart version from 2.0.2 to 2.0.3
- Updated the Helm chart index with the new version

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

```sh
# Install the updated Helm chart
helm install bifrost ./helm-charts/bifrost

# Verify the labels are correctly applied
kubectl get pods -l app.kubernetes.io/component=server
kubectl get services -l app.kubernetes.io/component=server
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this change only affects Kubernetes resource labeling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable