### PR TITLE
feat: prompt caching scope beta header anthropic

### DIFF
--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -55,6 +55,8 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 			reqBody.Stream = schemas.Ptr(true)
 		}
 
+		reqBody.SetStripCacheControlScope(true)
+
 		// Convert struct to map for Vertex API
 		reqBytes, err := sonic.Marshal(reqBody)
 		if err != nil {

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -787,8 +787,9 @@ const (
 )
 
 type CacheControl struct {
-	Type CacheControlType `json:"type"`
-	TTL  *string          `json:"ttl,omitempty"` // "1m" | "1h"
+	Type  CacheControlType `json:"type"`
+	TTL   *string          `json:"ttl,omitempty"`   // "1m" | "1h"
+	Scope *string          `json:"scope,omitempty"` // "user" | "global"
 }
 
 // ChatInputImage represents image data in a message.


### PR DESCRIPTION
## Add support for Anthropic prompt caching scope

This PR adds support for Anthropic's prompt caching scope feature, which allows specifying whether cached content should be scoped to a user or globally. The implementation includes handling for Vertex AI, which doesn't support this beta feature.

## Changes

- Added `AnthropicPromptCachingScopeBetaHeader` constant for the new beta header
- Extended `CacheControl` struct to include an optional `Scope` field
- Added logic to strip cache control scope when using Vertex AI provider
- Implemented header filtering to remove unsupported beta headers for Vertex AI
- Added detection of cache control scope in messages, system content, and tools
- Created passthrough header whitelist for safe headers

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Test with Anthropic API directly
curl -X POST "http://localhost:8080/v1/messages" \
  -H "Content-Type: application/json" \
  -H "anthropic-beta: prompt-caching-scope-2026-01-05" \
  -d '{
    "model": "claude-3-opus-20240229",
    "messages": [{
      "role": "user",
      "content": [{
        "type": "text",
        "text": "Hello",
        "cache_control": {
          "type": "no_store",
          "scope": "user"
        }
      }]
    }]
  }'

# Test with Vertex AI
curl -X POST "http://localhost:8080/v1/messages" \
  -H "Content-Type: application/json" \
  -H "anthropic-beta: prompt-caching-scope-2026-01-05" \
  -d '{
    "model": "vertex/claude-3-opus@20240229",
    "messages": [{
      "role": "user",
      "content": [{
        "type": "text",
        "text": "Hello",
        "cache_control": {
          "type": "no_store",
          "scope": "user"
        }
      }]
    }]
  }'
```

## Breaking changes

- [x] No

## Security considerations

The implementation ensures that cache control scopes are properly handled, which has security implications for how content is cached across users.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)