### PR TITLE
adds support for anthropic beta flags

### DIFF
--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -56,8 +56,10 @@ func (req *AnthropicTextRequest) IsStreamingRequested() bool {
 }
 
 // AnthropicOutputConfig represents the GA structured outputs config (output_config.format)
+// and the effort parameter (output_config.effort) for controlling token spending.
 type AnthropicOutputConfig struct {
 	Format interface{} `json:"format,omitempty"`
+	Effort *string     `json:"effort,omitempty"` // "low", "medium", "high", "max" (Opus 4.5+)
 }
 
 // AnthropicMessageRequest represents an Anthropic messages API request


### PR DESCRIPTION
## Summary

Implement support for Anthropic's adaptive thinking and native effort parameters for Claude Opus 4.5+ models, providing more efficient reasoning control.

## Changes

- Added support for Anthropic's `thinking.type: "adaptive"` parameter for Opus 4.6+ models
- Implemented native `output_config.effort` parameter for Opus 4.5+ models
- Created model-specific logic to use the appropriate reasoning approach based on model capabilities:
  - Opus 4.6+: adaptive thinking + native effort
  - Opus 4.5: native effort + budget_tokens thinking
  - Older models: budget_tokens only
- Added helper functions to detect model capabilities and map Bifrost effort levels to Anthropic effort levels
- Updated response handling to properly extract and convert effort parameters in both directions

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with different Claude Opus model versions to verify the appropriate reasoning approach is used:

```sh
# Test with Opus 4.6
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-3-opus-20240229",
    "messages": [{"role": "user", "content": "Solve this complex math problem step by step: 3x^2 + 6x - 9 = 0"}],
    "reasoning": {"effort": "high"}
  }'

# Test with Opus 4.5
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-3-opus-4-5",
    "messages": [{"role": "user", "content": "Solve this complex math problem step by step: 3x^2 + 6x - 9 = 0"}],
    "reasoning": {"effort": "medium"}
  }'

# Test with older model
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-2.1",
    "messages": [{"role": "user", "content": "Solve this complex math problem step by step: 3x^2 + 6x - 9 = 0"}],
    "reasoning": {"effort": "low"}
  }'
```

## Breaking changes

- [x] No

## Related issues

Implements support for Anthropic's latest reasoning capabilities.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)