### PR TITLE
fix: remove eventBroadcaster and rely on polling instead for governance; also added onQueryStarted support instead of invalidatesTags for CRUDs that send back data

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -128,7 +128,6 @@ func Init(
 	modelCatalog *modelcatalog.ModelCatalog,
 	mcpCatalog *mcpcatalog.MCPCatalog,
 	inMemoryStore InMemoryStore,
-	eventBroadcaster schemas.EventBroadcaster,
 ) (*GovernancePlugin, error) {
 	if configStore == nil {
 		logger.Warn("governance plugin requires config store to persist data, running in memory only mode")
@@ -150,7 +149,6 @@ func Init(
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize governance store: %w", err)
 	}
-	governanceStore.eventBroadcaster = eventBroadcaster
 	// Initialize components in dependency order with fixed, optimal settings
 	// Resolver (pure decision engine for hierarchical governance, depends only on store)
 	resolver := NewBudgetResolver(governanceStore, modelCatalog, logger)
@@ -232,7 +230,6 @@ func InitFromStore(
 	modelCatalog *modelcatalog.ModelCatalog,
 	mcpCatalog *mcpcatalog.MCPCatalog,
 	inMemoryStore InMemoryStore,
-	eventBroadcaster schemas.EventBroadcaster,
 ) (*GovernancePlugin, error) {
 	if configStore == nil {
 		logger.Warn("governance plugin requires config store to persist data, running in memory only mode")
@@ -250,9 +247,6 @@ func InitFromStore(
 	var isVkMandatory *bool
 	if config != nil {
 		isVkMandatory = config.IsVkMandatory
-	}
-	if localStore, ok := governanceStore.(*LocalGovernanceStore); ok {
-		localStore.eventBroadcaster = eventBroadcaster
 	}
 	resolver := NewBudgetResolver(governanceStore, modelCatalog, logger)
 	tracker := NewUsageTracker(ctx, governanceStore, resolver, configStore, logger)

--- a/plugins/governance/model_provider_governance_test.go
+++ b/plugins/governance/model_provider_governance_test.go
@@ -1098,7 +1098,7 @@ func TestPreLLMHook_ProviderBudgetExceeded_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1125,7 +1125,7 @@ func TestPreLLMHook_ProviderRateLimitExceeded_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1152,7 +1152,7 @@ func TestPreLLMHook_ModelBudgetExceeded_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1179,7 +1179,7 @@ func TestPreLLMHook_ModelRateLimitExceeded_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1206,7 +1206,7 @@ func TestPreLLMHook_ModelRateLimitExceeded_NoVirtualKey_RequestLimit(t *testing.
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1241,7 +1241,7 @@ func TestPreLLMHook_AllChecksPass_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1273,7 +1273,7 @@ func TestPreLLMHook_ProviderBudgetThenModelBudget_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1303,7 +1303,7 @@ func TestPreLLMHook_ProviderSpecificModelBudget_DifferentProvider_Passes_NoVirtu
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1332,7 +1332,7 @@ func TestPreLLMHook_ProviderSpecificModelRateLimit_DifferentProvider_Passes_NoVi
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1361,7 +1361,7 @@ func TestPreLLMHook_ProviderSpecificModelRateLimit_DifferentProvider_Passes_NoVi
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -1394,7 +1394,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1425,7 +1425,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyRateLimitExceeded_Token(t *testi
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1456,7 +1456,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyRateLimitExceeded_Request(t *tes
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1485,7 +1485,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyChecksPass(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1511,7 +1511,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyNotFound(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-nonexistent")
@@ -1540,7 +1540,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyBlocked(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1572,7 +1572,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyProviderBlocked(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1604,7 +1604,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyModelBlocked(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1641,7 +1641,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded_WithModelProvider
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	parentCtx := context.WithValue(context.Background(), schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
@@ -1676,7 +1676,7 @@ func TestPostHook_UpdatesProviderBudgetUsage_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// First request: PreLLMHook should pass, PostHook updates usage
@@ -1745,7 +1745,7 @@ func TestPostHook_UpdatesProviderRateLimitUsage_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// First request: PreLLMHook should pass, PostHook updates usage to 10000
@@ -1812,7 +1812,7 @@ func TestPostHook_UpdatesModelBudgetUsage_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// First request: PreLLMHook should pass, PostHook updates usage
@@ -1881,7 +1881,7 @@ func TestPostHook_UpdatesModelRateLimitUsage_NoVirtualKey(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil, nil)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// First request: PreLLMHook should pass, PostHook updates usage to 10000

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -70,7 +70,7 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 		inMemoryStore := &GovernanceInMemoryStore{Config: bifrostConfig}
 		return governance.Init(ctx, governanceConfig, logger, bifrostConfig.ConfigStore,
 			bifrostConfig.GovernanceConfig, bifrostConfig.ModelCatalog,
-			bifrostConfig.MCPCatalog, inMemoryStore, bifrostConfig.EventBroadcaster)
+			bifrostConfig.MCPCatalog, inMemoryStore)
 
 	case maxim.PluginName:
 		maximConfig, err := MarshalPluginConfig[maxim.Config](pluginConfig)

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -36,10 +36,9 @@ const formatResetDuration = (duration: string) => {
 
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
-	onRefresh: () => void;
 }
 
-export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimitsTableProps) {
+export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps) {
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
 	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
 
@@ -59,7 +58,6 @@ export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimit
 		try {
 			await deleteModelConfig(id).unwrap();
 			toast.success("Model limit deleted successfully");
-			onRefresh();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
@@ -79,7 +77,6 @@ export default function ModelLimitsTable({ modelConfigs, onRefresh }: ModelLimit
 	const handleModelLimitSaved = () => {
 		setShowModelLimitSheet(false);
 		setEditingModelConfigId(null);
-		onRefresh();
 	};
 
 	return (

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -13,15 +13,14 @@ export default function ModelLimitsView() {
 
 	const [triggerGetConfig] = useLazyGetCoreConfigQuery();
 
-	// Use regular query with skip, polling, and refetch on focus
+	// Use regular query with skip and polling
 	const {
 		data: modelConfigsData,
 		error: modelConfigsError,
 		isLoading: modelConfigsLoading,
-		refetch: refetchModelConfigs,
 	} = useGetModelConfigsQuery(undefined, {
 		skip: !governanceEnabled || !hasGovernanceAccess,
-		refetchOnFocus: true,
+		pollingInterval: 5000,
 	});
 
 	const isLoading = modelConfigsLoading || governanceEnabled === null;
@@ -50,19 +49,13 @@ export default function ModelLimitsView() {
 		}
 	}, [modelConfigsError]);
 
-	const handleRefresh = () => {
-		if (governanceEnabled) {
-			refetchModelConfigs();
-		}
-	};
-
 	if (isLoading) {
 		return <FullPageLoader />;
 	}
 
 	return (
 		<div className="mx-auto w-full max-w-7xl">
-			<ModelLimitsTable modelConfigs={modelConfigsData?.model_configs || []} onRefresh={handleRefresh} />
+			<ModelLimitsTable modelConfigs={modelConfigsData?.model_configs || []} />
 		</div>
 	);
 }

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -67,7 +67,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 
 	const { data: providerGovernanceData, isLoading: isLoadingGovernance } = useGetProviderGovernanceQuery(undefined, {
 		skip: !hasViewAccess || !governanceEnabled,
-		refetchOnFocus: true,
+		pollingInterval: 5000,
 	});
 	const [updateProviderGovernance, { isLoading: isUpdating }] = useUpdateProviderGovernanceMutation();
 	const [deleteProviderGovernance, { isLoading: isDeleting }] = useDeleteProviderGovernanceMutation();

--- a/ui/app/workspace/providers/views/providerGovernanceTable.tsx
+++ b/ui/app/workspace/providers/views/providerGovernanceTable.tsx
@@ -173,7 +173,7 @@ export default function ProviderGovernanceTable({ provider, className }: Props) 
 
 	const { data: providerGovernanceData, isLoading } = useGetProviderGovernanceQuery(undefined, {
 		skip: !hasViewAccess || !governanceEnabled,
-		refetchOnFocus: true,
+		pollingInterval: 5000,
 	});
 
 	// Find governance data for this provider

--- a/ui/app/workspace/user-groups/views/customerTable.tsx
+++ b/ui/app/workspace/user-groups/views/customerTable.tsx
@@ -29,10 +29,9 @@ interface CustomersTableProps {
 	customers: Customer[];
 	teams: Team[];
 	virtualKeys: VirtualKey[];
-	onRefresh: () => void;
 }
 
-export default function CustomersTable({ customers, teams, virtualKeys, onRefresh }: CustomersTableProps) {
+export default function CustomersTable({ customers, teams, virtualKeys }: CustomersTableProps) {
   const [showCustomerDialog, setShowCustomerDialog] = useState(false)
   const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null)
 
@@ -46,7 +45,6 @@ export default function CustomersTable({ customers, teams, virtualKeys, onRefres
 		try {
 			await deleteCustomer(customerId).unwrap();
 			toast.success("Customer deleted successfully");
-			onRefresh();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
@@ -65,7 +63,6 @@ export default function CustomersTable({ customers, teams, virtualKeys, onRefres
 	const handleCustomerSaved = () => {
 		setShowCustomerDialog(false);
 		setEditingCustomer(null);
-		onRefresh();
 	};
 
 	const getTeamsForCustomer = (customerId: string) => {

--- a/ui/app/workspace/user-groups/views/teamsTable.tsx
+++ b/ui/app/workspace/user-groups/views/teamsTable.tsx
@@ -29,10 +29,9 @@ interface TeamsTableProps {
 	teams: Team[];
 	customers: Customer[];
 	virtualKeys: VirtualKey[];
-	onRefresh: () => void;
 }
 
-export default function TeamsTable({ teams, customers, virtualKeys, onRefresh }: TeamsTableProps) {
+export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTableProps) {
   const [showTeamDialog, setShowTeamDialog] = useState(false)
   const [editingTeam, setEditingTeam] = useState<Team | null>(null)
 
@@ -46,7 +45,6 @@ export default function TeamsTable({ teams, customers, virtualKeys, onRefresh }:
 		try {
 			await deleteTeam(teamId).unwrap();
 			toast.success("Team deleted successfully");
-			onRefresh();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
@@ -65,7 +63,6 @@ export default function TeamsTable({ teams, customers, virtualKeys, onRefresh }:
 	const handleTeamSaved = () => {
 		setShowTeamDialog(false);
 		setEditingTeam(null);
-		onRefresh();
 	};
 
 	const getVirtualKeysForTeam = (teamId: string) => {

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -29,10 +29,9 @@ interface VirtualKeysTableProps {
 	virtualKeys: VirtualKey[];
 	teams: Team[];
 	customers: Customer[];
-	onRefresh: () => void;
 }
 
-export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefresh }: VirtualKeysTableProps) {
+export default function VirtualKeysTable({ virtualKeys, teams, customers }: VirtualKeysTableProps) {
   const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false)
   const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null)
   const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
@@ -59,7 +58,6 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefr
 		try {
 			await deleteVirtualKey(vkId).unwrap();
 			toast.success("Virtual key deleted successfully");
-			onRefresh();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
@@ -79,7 +77,6 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers, onRefr
 	const handleVirtualKeySaved = () => {
 		setShowVirtualKeySheet(false);
 		setEditingVirtualKeyId(null);
-		onRefresh();
 	};
 
 	const handleRowClick = (vk: VirtualKey) => {

--- a/ui/hooks/useStoreSync.tsx
+++ b/ui/hooks/useStoreSync.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { baseApi } from "@/lib/store/apis/baseApi";
-import { governanceApi } from "@/lib/store/apis/governanceApi";
 import { useAppDispatch } from "@/lib/store/hooks";
 import { useEffect } from "react";
 import { useWebSocket } from "./useWebSocket";
@@ -9,9 +8,7 @@ import { useWebSocket } from "./useWebSocket";
 /**
  * Hook that subscribes to WebSocket messages for real-time cache updates.
  *
- * Handles two message types:
- * - store_update: Invalidates RTK Query cache tags (triggers refetch)
- * - governance_update: Merges budget/rate-limit diffs into cached governance queries
+ * Handles store_update messages to invalidate RTK Query cache tags (triggers refetch).
  */
 export function useStoreSync() {
 	const { subscribe } = useWebSocket();
@@ -24,70 +21,8 @@ export function useStoreSync() {
 			}
 		});
 
-		const unsubGovUpdate = subscribe("governance_update", (data) => {
-			const { budgets, rate_limits } = data.data || {};
-			if (!budgets && !rate_limits) return;
-
-			// Merge into model configs cache
-			dispatch(
-				governanceApi.util.updateQueryData("getModelConfigs", undefined, (draft) => {
-					if (!draft?.model_configs) return;
-					for (const mc of draft.model_configs) {
-						if (budgets && mc.budget?.id && budgets[mc.budget.id]) {
-							mc.budget = budgets[mc.budget.id];
-						}
-						if (rate_limits && mc.rate_limit?.id && rate_limits[mc.rate_limit.id]) {
-							mc.rate_limit = rate_limits[mc.rate_limit.id];
-						}
-					}
-				})
-			);
-
-			// Merge into provider governance cache
-			dispatch(
-				governanceApi.util.updateQueryData("getProviderGovernance", undefined, (draft) => {
-					if (!draft?.providers) return;
-					for (const p of draft.providers) {
-						if (budgets && p.budget?.id && budgets[p.budget.id]) {
-							p.budget = budgets[p.budget.id];
-						}
-						if (rate_limits && p.rate_limit?.id && rate_limits[p.rate_limit.id]) {
-							p.rate_limit = rate_limits[p.rate_limit.id];
-						}
-					}
-				})
-			);
-
-			// Merge into virtual keys cache (virtual_keys is an array)
-			dispatch(
-				governanceApi.util.updateQueryData("getVirtualKeys", undefined, (draft) => {
-					if (!draft?.virtual_keys) return;
-					for (const vk of draft.virtual_keys) {
-						if (budgets && vk.budget?.id && budgets[vk.budget.id]) {
-							vk.budget = budgets[vk.budget.id];
-						}
-						if (rate_limits && vk.rate_limit?.id && rate_limits[vk.rate_limit.id]) {
-							vk.rate_limit = rate_limits[vk.rate_limit.id];
-						}
-						// Also merge into provider_configs
-						if (vk.provider_configs) {
-							for (const pc of vk.provider_configs) {
-								if (budgets && pc.budget?.id && budgets[pc.budget.id]) {
-									pc.budget = budgets[pc.budget.id];
-								}
-								if (rate_limits && pc.rate_limit?.id && rate_limits[pc.rate_limit.id]) {
-									pc.rate_limit = rate_limits[pc.rate_limit.id];
-								}
-							}
-						}
-					}
-				})
-			);
-		});
-
 		return () => {
 			unsubTagSync();
-			unsubGovUpdate();
 		};
 	}, [subscribe, dispatch]);
 }


### PR DESCRIPTION
## Summary

Removed the event broadcaster from the governance plugin and replaced real-time
UI updates with polling. This change simplifies the codebase by eliminating the
WebSocket-based event broadcasting mechanism for governance updates.

## Changes

- Removed `eventBroadcaster` parameter from governance plugin initialization
  functions
- Removed `emitBudgetUpdate` and `emitRateLimitUpdate` methods from the
  governance store
- Replaced WebSocket-based real-time updates with polling in UI components
  (5-second interval)
- Implemented optimistic updates in Redux store for better UX during mutations
- Updated UI components to no longer require refresh callbacks

## Type of change

- [x] Refactor
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (Next.js)

## How to test

Verify that governance data updates correctly in the UI:

```sh
# Core/Transports
go test ./plugins/governance/...

# UI
cd ui
pnpm i
pnpm dev
```

1. Create/update/delete virtual keys, teams, customers, or model limits
2. Verify changes appear in UI within 5 seconds
3. Verify usage tracking updates correctly when making API calls

## Breaking changes

- [x] No

## Security considerations

This change removes a potential attack vector by eliminating the WebSocket-based
event broadcasting for governance updates, which could potentially leak
sensitive usage data if not properly secured.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)

