### PR TITLE
[DO NOT MERGE] feat: add support for image generation, editing, and variation requests in maxim plugin

### DIFF
--- a/plugins/maxim/changelog.md
+++ b/plugins/maxim/changelog.md
@@ -1,1 +1,1 @@
-- chore: upgrade core to 1.4.1 and framework to 1.2.19
+- feat: added support for image generation, image editing, and image variation requests and responses


### PR DESCRIPTION
## Summary

Added support for image-related operations in the Maxim plugin, enabling logging and tracking of image generation, editing, and variation requests and responses.

## Changes

- Added handlers for image generation, image editing, and image variation request types in PreLLMHook
- Implemented response handling for image operations in PostLLMHook
- Replaced json package with bytedance/sonic for improved performance
- Added unit tests for image generation and image editing logging functionality
- Updated changelog to reflect the new image operation capabilities

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the plugin tests
go test ./plugins/maxim/...

# Test image generation request logging
# Make an image generation request through the API and verify logs are captured
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enhances the Maxim plugin's capabilities to support the full range of AI operations including image-based workflows.

## Security considerations

The plugin now processes image data, but maintains the same security model as the existing text-based operations.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)