### PR TITLE
[DO NOT MERGE] feat: add support for tool calls logs in MCP in maxim plugin

### DIFF
--- a/plugins/maxim/changelog.md
+++ b/plugins/maxim/changelog.md
@@ -1,1 +1,2 @@
 - feat: added support for image generation, image editing, and image variation requests and responses
+- feat: added support for tool calls logs for mcp


### PR DESCRIPTION
## Summary

Added support for logging Model Context Protocol (MCP) tool calls in the Maxim plugin, enabling tracing and monitoring of tool interactions.

## Changes

- Added `PreMCPHook` to create a trace and tool span for MCP tool calls
- Added `PostMCPHook` to complete the tool span with output and results
- Implemented error handling for tool call failures
- Added unit tests for MCP tool call logging functionality
- Updated changelog to reflect the new tool calls logging feature

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the plugin tests
go test ./plugins/maxim/...

# For integration testing, set environment variables:
export MAXIM_API_KEY="your-maxim-api-key"
export OPENAI_API_KEY="your-openai-api-key"
go test ./plugins/maxim/... -v
```

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

The implementation maintains the same security patterns as existing logging functionality, with no additional security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)