### PR TITLE
fix: mcp client header updates

### DIFF
--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3025,7 +3025,8 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].ToolsToExecute = updatedConfig.ToolsToExecute
 	c.MCPConfig.ClientConfigs[configIndex].ToolsToAutoExecute = updatedConfig.ToolsToAutoExecute
 	c.MCPConfig.ClientConfigs[configIndex].ToolPricing = updatedConfig.ToolPricing
-
+	c.MCPConfig.ClientConfigs[configIndex].IsPingAvailable = updatedConfig.IsPingAvailable
+	c.MCPConfig.ClientConfigs[configIndex].ToolSyncInterval = updatedConfig.ToolSyncInterval
 	return nil
 }
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -60,7 +60,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
-			tool_sync_interval: mcpClient.config.tool_sync_interval,
+			tool_sync_interval: mcpClient.config.tool_sync_interval ?? 0,
 		},
 	});
 
@@ -74,7 +74,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
-			tool_sync_interval: mcpClient.config.tool_sync_interval,
+			tool_sync_interval: mcpClient.config.tool_sync_interval ?? 0,
 		});
 	}, [form, mcpClient]);
 
@@ -90,7 +90,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					tools_to_execute: data.tools_to_execute,
 					tools_to_auto_execute: data.tools_to_auto_execute,
 					tool_pricing: data.tool_pricing,
-					tool_sync_interval: data.tool_sync_interval,
+					tool_sync_interval: data.tool_sync_interval ?? 0,
 				},
 			}).unwrap();
 


### PR DESCRIPTION
## Summary

Fix MCP client update functionality to properly handle existing configuration values when updating clients.

## Changes

- Fixed the MCP client update handler to preserve existing configuration values when not explicitly provided in the update request
- Added logic to update the in-memory MCP client configuration after a successful database update
- Improved header handling during updates to properly merge incoming headers with existing ones
- Fixed UI handling of `tool_sync_interval` to default to 0 when the value is null

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create an MCP client with connection settings, headers, and auth configuration
2. Edit the client and update only some fields (like name or tools)
3. Verify that the unmodified fields (connection string, auth settings) are preserved
4. Verify that headers are properly merged when updating

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm test
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #1560.

## Security considerations

This change ensures sensitive configuration values like connection strings and OAuth credentials are properly preserved during updates.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable