### PR TITLE
fix: fixed image gen input on logs

### DIFF
--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -53,6 +53,12 @@ function getMessage(log?: LogEntry) {
 		return log.speech_input.input;
 	} else if (log?.transcription_input) {
 		return "Audio file";
+	} else if (log?.image_generation_input?.prompt) {
+		return log.image_generation_input.prompt;
+	} 
+	const obj = log?.object as string | undefined;
+	if (obj === "image_edit" || obj === "image_edit_stream" || obj === "image_variation") {
+		return "Image file";
 	}
 	return "";
 }


### PR DESCRIPTION
## Summary

Add support for displaying image generation prompts in the logs view.

## Changes

- Enhanced the `getMessage` function in the logs view to handle image generation inputs
- Added a condition to check for `image_generation_input.prompt` and return it as the message

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the logs view in the workspace
2. Generate an image using a prompt
3. Verify that the prompt text appears in the logs view

```sh
# UI
cd ui
pnpm i
pnpm dev
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is only displaying user-provided prompt data that was already being stored.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable