### PR TITLE
adds env support for auth_config username and pwd and fixed helm_chart to render auth_config

### DIFF
--- a/core/schemas/envvar.go
+++ b/core/schemas/envvar.go
@@ -95,6 +95,10 @@ func (e *EnvVar) IsRedacted() bool {
 			return true
 		}
 	}
+	// Check if its string <redacted>
+	if e.Val == "<redacted>" {
+		return true
+	}
 	return false
 }
 

--- a/examples/configs/withconfigstore/config.json
+++ b/examples/configs/withconfigstore/config.json
@@ -7,6 +7,12 @@
       "path": "../../examples/configs/withconfigstore/config.db"
     }
   },
+  "auth_config": {
+    "admin_username": "env.ADMIN",
+    "admin_password": "env.PASS",
+    "is_enabled": true,
+    "disable_auth_on_inference": true
+  },
   "governance": {
     "virtual_keys": [
       {

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -949,10 +949,10 @@ func GeneratePluginHash(p tables.TablePlugin) (string, error) {
 
 // AuthConfig represents configured auth config for Bifrost dashboard
 type AuthConfig struct {
-	AdminUserName          string `json:"admin_username"`
-	AdminPassword          string `json:"admin_password"`
-	IsEnabled              bool   `json:"is_enabled"`
-	DisableAuthOnInference bool   `json:"disable_auth_on_inference"`
+	AdminUserName          *schemas.EnvVar `json:"admin_username"`
+	AdminPassword          *schemas.EnvVar `json:"admin_password"`
+	IsEnabled              bool           `json:"is_enabled"`
+	DisableAuthOnInference bool           `json:"disable_auth_on_inference"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -142,6 +142,7 @@ bifrost:
     adminUsername: ""
     adminPassword: ""
     isEnabled: false
+    disableAuthOnInference: false
     # Use existing Kubernetes secret for admin credentials
     existingSecret: ""
     usernameKey: "username"
@@ -405,6 +406,11 @@ bifrost:
       #   enabled: true
       #   config: {}
 
+  # Audit logs configuration for CADF-compliant activity logging
+  auditLogs:
+    disabled: false
+    hmacKey: ""
+
 # Storage configuration
 storage:
   # Default storage mode: sqlite or postgres
@@ -424,12 +430,18 @@ storage:
     enabled: true
     # Backend type for config store. Empty string uses storage.mode as default
     type: ""  # Options: sqlite, postgres, or "" (uses storage.mode)
+    # PostgreSQL connection pool tuning (only applies when type is postgres)
+    # maxIdleConns: 5
+    # maxOpenConns: 50
 
   # Logs store settings
   logsStore:
     enabled: true
     # Backend type for logs store. Empty string uses storage.mode as default
     type: ""  # Options: sqlite, postgres, or "" (uses storage.mode)
+    # PostgreSQL connection pool tuning (only applies when type is postgres)
+    # maxIdleConns: 5
+    # maxOpenConns: 50
 
 # PostgreSQL configuration (when any store uses postgres)
 postgresql:

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -350,11 +350,15 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 					return
 				}
 				// Verify the username and password
-				if username != authConfig.AdminUserName {
+				if authConfig.AdminUserName == nil || username != authConfig.AdminUserName.GetValue() {
 					SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 					return
 				}
-				compare, err := encrypt.CompareHash(authConfig.AdminPassword, password)
+				if authConfig.AdminPassword == nil {
+					SendError(ctx, fasthttp.StatusInternalServerError, "Authentication not properly configured")
+					return
+				}
+				compare, err := encrypt.CompareHash(authConfig.AdminPassword.GetValue(), password)
 				if err != nil {
 					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to compare password: %v", err))
 					return

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -557,8 +557,8 @@ func TestAuthMiddleware_DisabledAuthConfig(t *testing.T) {
 
 	am := &AuthMiddleware{}
 	am.UpdateAuthConfig(&configstore.AuthConfig{
-		AdminUserName: "admin",
-		AdminPassword: "password",
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("password"),
 		IsEnabled:     false,
 	})
 
@@ -586,8 +586,8 @@ func TestAuthMiddleware_EnabledAuthConfig_NoAuth(t *testing.T) {
 
 	am := &AuthMiddleware{}
 	am.UpdateAuthConfig(&configstore.AuthConfig{
-		AdminUserName: "admin",
-		AdminPassword: "hashedpassword",
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     true,
 	})
 
@@ -618,8 +618,8 @@ func TestAuthMiddleware_WhitelistedRoutes(t *testing.T) {
 
 	am := &AuthMiddleware{}
 	am.UpdateAuthConfig(&configstore.AuthConfig{
-		AdminUserName: "admin",
-		AdminPassword: "hashedpassword",
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     true,
 	})
 
@@ -677,8 +677,8 @@ func TestAuthMiddleware_UpdateAuthConfig_NilToEnabled(t *testing.T) {
 
 	// Now enable auth
 	am.UpdateAuthConfig(&configstore.AuthConfig{
-		AdminUserName: "admin",
-		AdminPassword: "hashedpassword",
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     true,
 	})
 
@@ -704,8 +704,8 @@ func TestAuthMiddleware_UpdateAuthConfig_EnabledToDisabled(t *testing.T) {
 	am := &AuthMiddleware{}
 	// Start with auth enabled
 	am.UpdateAuthConfig(&configstore.AuthConfig{
-		AdminUserName: "admin",
-		AdminPassword: "hashedpassword",
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     true,
 	})
 
@@ -728,8 +728,8 @@ func TestAuthMiddleware_UpdateAuthConfig_EnabledToDisabled(t *testing.T) {
 
 	// Now disable auth
 	am.UpdateAuthConfig(&configstore.AuthConfig{
-		AdminUserName: "admin",
-		AdminPassword: "hashedpassword",
+		AdminUserName: schemas.NewEnvVar("admin"),
+		AdminPassword: schemas.NewEnvVar("hashedpassword"),
 		IsEnabled:     false,
 	})
 

--- a/transports/bifrost-http/handlers/session.go
+++ b/transports/bifrost-http/handlers/session.go
@@ -99,11 +99,11 @@ func (h *SessionHandler) login(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Verify credentials
-	if payload.Username != authConfig.AdminUserName {
+	if payload.Username != authConfig.AdminUserName.GetValue() {
 		SendError(ctx, fasthttp.StatusUnauthorized, "Invalid username or password")
 		return
 	}
-	compare, err := encrypt.CompareHash(authConfig.AdminPassword, payload.Password)
+	compare, err := encrypt.CompareHash(authConfig.AdminPassword.GetValue(), payload.Password)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 		return

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -607,7 +607,7 @@ func (s *BifrostHTTPServer) UpdateAuthConfig(ctx context.Context, authConfig *co
 		return fmt.Errorf("config store not found")
 	}
 	// Allow disabling auth without credentials, but require them when enabling
-	if authConfig.IsEnabled && (authConfig.AdminUserName == "" || authConfig.AdminPassword == "") {
+	if authConfig.IsEnabled && (authConfig.AdminUserName == nil || authConfig.AdminUserName.GetValue() == "" || authConfig.AdminPassword == nil || authConfig.AdminPassword.GetValue() == "") {
 		return fmt.Errorf("username and password are required when auth is enabled")
 	}
 	// Update the config store

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -294,8 +294,8 @@ export interface FrameworkConfig {
 
 // Auth config
 export interface AuthConfig {
-	admin_username: string;
-	admin_password: string;
+	admin_username: EnvVar;
+	admin_password: EnvVar;
 	is_enabled: boolean;
 	disable_auth_on_inference?: boolean;
 }


### PR DESCRIPTION
## Summary

Enhance authentication configuration to support environment variables for username and password credentials, improving security and flexibility in deployment scenarios.

## Issues
Closes #1566 
Closes #1566

## Changes

- Updated `AuthConfig` to use `EnvVar` type for username and password fields, allowing values to be sourced from environment variables
- Added support for redacted password display in UI and API responses
- Modified auth config handling in HTTP handlers to properly handle environment variable references
- Updated Helm chart templates to support the new auth config structure
- Added environment variable resolution for auth credentials in config loading
- Enhanced password hashing logic to preserve environment variable references
- Added UI support for environment variable inputs in the security settings

## Type of change

- [x] Feature
- [x] Security enhancement

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)
- [x] Helm Charts

## How to test

```sh
# Test with direct values
go run ./cmd/bifrost --config examples/configs/withconfigstore/config.json

# Test with environment variables
export ADMIN=admin
export PASS=password
go run ./cmd/bifrost --config examples/configs/withconfigstore/config.json

# Verify UI
cd ui
pnpm i
pnpm dev
# Navigate to workspace/config/security and test auth settings
```

## Security considerations

This change improves security by:
- Allowing credentials to be sourced from environment variables instead of being hardcoded in config files
- Properly handling password redaction in API responses
- Preserving environment variable references when updating credentials
- Ensuring passwords are always properly hashed when stored

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)