### PR TITLE
fix: adds support for handling custom providers to the known providers list so that `ParseModelString` works with custom providers as well

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -2578,6 +2578,7 @@ func (bifrost *Bifrost) RemoveProvider(providerKey schemas.ModelProvider) error 
 	}
 
 	bifrost.logger.Info("successfully removed provider %s", providerKey)
+	schemas.UnregisterKnownProvider(providerKey)
 	return nil
 }
 
@@ -3130,6 +3131,8 @@ func (bifrost *Bifrost) prepareProvider(providerKey schemas.ModelProvider, confi
 			break
 		}
 	}
+
+	schemas.RegisterKnownProvider(providerKey)
 
 	for range config.ConcurrencyAndBufferSize.Concurrency {
 		currentWaitGroup.Add(1)


### PR DESCRIPTION
## Summary

Added support for dynamic registration of custom model providers to improve
model string parsing. This allows the system to correctly identify custom
provider prefixes in model strings.

## Changes

- Added thread-safe registration and unregistration of custom model providers
- Implemented `RegisterKnownProvider`, `UnregisterKnownProvider`, and
  `IsKnownProvider` functions
- Updated the `knownProviders` map to be dynamically updatable at runtime
- Modified provider management in the HTTP transport to register/unregister
  providers when they are added or removed
- Added synchronization with a mutex to protect concurrent access to the
  providers map

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the registration and parsing of custom model providers:

```sh
# Core/Transports
go version
go test ./...

# Test with a custom provider
# 1. Add a custom provider via API
# 2. Verify that model strings with the custom provider prefix are correctly parsed
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves model string parsing for custom providers.

## Security considerations

No security implications as this is an internal API enhancement.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

