### PR TITLE
support extra_params passthrough on /openai integration endpoint

### DIFF
--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -33,6 +33,11 @@ func (r *OpenAITextCompletionRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
 }
 
+func (r *OpenAITextCompletionRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.TextCompletionParameters.ExtraParams = params
+}
+
 // IsStreamingRequested implements the StreamingRequest interface
 func (r *OpenAITextCompletionRequest) IsStreamingRequested() bool {
 	return r.Stream != nil && *r.Stream
@@ -54,6 +59,11 @@ func (r *OpenAIEmbeddingRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
 }
 
+func (r *OpenAIEmbeddingRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.EmbeddingParameters.ExtraParams = params
+}
+
 // OpenAIChatRequest represents an OpenAI chat completion request
 type OpenAIChatRequest struct {
 	Model    string          `json:"model"`
@@ -73,6 +83,11 @@ type OpenAIChatRequest struct {
 
 func (r *OpenAIChatRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
+}
+
+func (r *OpenAIChatRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.ChatParameters.ExtraParams = params
 }
 
 type OpenAIMessage struct {
@@ -535,6 +550,11 @@ func (r *OpenAIResponsesRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
 }
 
+func (r *OpenAIResponsesRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.ResponsesParameters.ExtraParams = params
+}
+
 type OpenAIResponsesRequest struct {
 	Model string                      `json:"model"`
 	Input OpenAIResponsesRequestInput `json:"input"`
@@ -641,6 +661,11 @@ func (r *OpenAISpeechRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
 }
 
+func (r *OpenAISpeechRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.SpeechParameters.ExtraParams = params
+}
+
 // OpenAITranscriptionRequest represents an OpenAI transcription request
 // Note: This is used for JSON body parsing, actual form parsing is handled in the router
 type OpenAITranscriptionRequest struct {
@@ -700,6 +725,11 @@ func (r *OpenAIImageGenerationRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
 }
 
+func (r *OpenAIImageGenerationRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.ImageGenerationParameters.ExtraParams = params
+}
+
 // IsStreamingRequested implements the StreamingRequest interface
 func (r *OpenAIImageGenerationRequest) IsStreamingRequested() bool {
 	return r.Stream != nil && *r.Stream
@@ -743,6 +773,11 @@ func (r *OpenAIImageEditRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
 }
 
+func (r *OpenAIImageEditRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.ImageEditParameters.ExtraParams = params
+}
+
 // OpenAIImageVariationRequest is the struct for Image Variation requests in OpenAI format.
 type OpenAIImageVariationRequest struct {
 	Model string                       `json:"model"`
@@ -756,6 +791,11 @@ type OpenAIImageVariationRequest struct {
 
 func (r *OpenAIImageVariationRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
+}
+
+func (r *OpenAIImageVariationRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
+	r.ImageVariationParameters.ExtraParams = params
 }
 
 // IsStreamingRequested implements the StreamingRequest interface

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -48,13 +48,12 @@
 package integrations
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log"
 	"strconv"
 	"strings"
-
-	"bufio"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
 	"github.com/bytedance/sonic"
@@ -75,6 +74,14 @@ type ExtensionRouter interface {
 // StreamingRequest interface for requests that support streaming
 type StreamingRequest interface {
 	IsStreamingRequested() bool
+}
+
+// RequestWithSettableExtraParams is implemented by request types that accept
+// provider-specific extra parameters via the extra_params JSON key. The
+// integration router extracts extra_params from the raw request body and
+// passes them through so they propagate to the downstream provider.
+type RequestWithSettableExtraParams interface {
+	SetExtraParams(params map[string]interface{})
 }
 
 // BatchRequest wraps a Bifrost batch request with its type information.
@@ -520,6 +527,20 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 					if err := sonic.Unmarshal(rawBody, req); err != nil {
 						g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "Invalid JSON"))
 						return
+					}
+					// Extract the "extra_params" JSON key when passthrough is
+					// explicitly enabled via x-bf-passthrough-extra-params: true.
+					// Provider-specific fields (e.g. Bedrock guardrailConfig)
+					// must be nested under "extra_params" in the request body.
+					if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+						if rws, ok := req.(RequestWithSettableExtraParams); ok {
+							var wrapper struct {
+								ExtraParams map[string]interface{} `json:"extra_params"`
+							}
+							if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+								rws.SetExtraParams(wrapper.ExtraParams)
+							}
+						}
 					}
 				}
 			}

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -1,0 +1,353 @@
+package integrations
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestWithSettableExtraParams_OpenAIChatRequest(t *testing.T) {
+	t.Run("SetExtraParams populates both standalone and embedded ExtraParams", func(t *testing.T) {
+		req := &openai.OpenAIChatRequest{}
+		extra := map[string]interface{}{
+			"guardrailConfig": map[string]interface{}{
+				"guardrailIdentifier": "xxx",
+				"guardrailVersion":    "1",
+			},
+		}
+
+		rws, ok := interface{}(req).(RequestWithSettableExtraParams)
+		require.True(t, ok, "OpenAIChatRequest should implement RequestWithSettableExtraParams")
+
+		rws.SetExtraParams(extra)
+
+		assert.Equal(t, extra, req.GetExtraParams())
+		assert.Equal(t, extra, req.ChatParameters.ExtraParams, "embedded ChatParameters.ExtraParams should also be set")
+	})
+
+	t.Run("extra params propagate through ToBifrostChatRequest", func(t *testing.T) {
+		req := &openai.OpenAIChatRequest{
+			Model:    "bedrock/claude-4-5-sonnet-global",
+			Messages: []openai.OpenAIMessage{},
+		}
+		extra := map[string]interface{}{
+			"guardrailConfig": map[string]interface{}{
+				"guardrailIdentifier": "test-id",
+				"guardrailVersion":    "1",
+			},
+		}
+
+		rws := interface{}(req).(RequestWithSettableExtraParams)
+		rws.SetExtraParams(extra)
+
+		ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		bifrostReq := req.ToBifrostChatRequest(ctx)
+
+		require.NotNil(t, bifrostReq)
+		require.NotNil(t, bifrostReq.Params)
+		assert.Contains(t, bifrostReq.Params.ExtraParams, "guardrailConfig")
+	})
+}
+
+func TestRequestWithSettableExtraParams_AllOpenAIRequestTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		req  interface{}
+	}{
+		{"OpenAIChatRequest", &openai.OpenAIChatRequest{}},
+		{"OpenAITextCompletionRequest", &openai.OpenAITextCompletionRequest{}},
+		{"OpenAIResponsesRequest", &openai.OpenAIResponsesRequest{}},
+		{"OpenAIEmbeddingRequest", &openai.OpenAIEmbeddingRequest{}},
+		{"OpenAISpeechRequest", &openai.OpenAISpeechRequest{}},
+		{"OpenAIImageGenerationRequest", &openai.OpenAIImageGenerationRequest{}},
+		{"OpenAIImageEditRequest", &openai.OpenAIImageEditRequest{}},
+		{"OpenAIImageVariationRequest", &openai.OpenAIImageVariationRequest{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" implements RequestWithSettableExtraParams", func(t *testing.T) {
+			rws, ok := tt.req.(RequestWithSettableExtraParams)
+			require.True(t, ok, "%s should implement RequestWithSettableExtraParams", tt.name)
+
+			extra := map[string]interface{}{"test_key": "test_value"}
+			rws.SetExtraParams(extra)
+
+			getter, ok := tt.req.(interface{ GetExtraParams() map[string]interface{} })
+			require.True(t, ok, "%s should implement GetExtraParams", tt.name)
+			assert.Equal(t, extra, getter.GetExtraParams())
+		})
+	}
+}
+
+func TestExtraParamsRequiresPassthroughHeader(t *testing.T) {
+	handlerStore := &mockHandlerStore{allowDirectKeys: true}
+	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
+
+	var chatRoute *RouteConfig
+	for i := range routes {
+		if routes[i].Path == "/openai/v1/chat/completions" {
+			chatRoute = &routes[i]
+			break
+		}
+	}
+	require.NotNil(t, chatRoute, "should find /openai/v1/chat/completions route")
+
+	rawBody := []byte(`{
+		"model": "bedrock/claude-4-5-sonnet-global",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+		"extra_params": {
+			"guardrailConfig": {
+				"guardrailIdentifier": "my-guardrail",
+				"guardrailVersion": "1",
+				"trace": "disabled"
+			}
+		}
+	}`)
+
+	t.Run("extra_params NOT extracted without passthrough header", func(t *testing.T) {
+		req := chatRoute.GetRequestTypeInstance()
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		// Header not set -- simulate router logic
+		if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+			if rws, ok := req.(RequestWithSettableExtraParams); ok {
+				var wrapper struct {
+					ExtraParams map[string]interface{} `json:"extra_params"`
+				}
+				if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+					rws.SetExtraParams(wrapper.ExtraParams)
+				}
+				_ = rws
+			}
+		}
+
+		openaiReq, ok := req.(*openai.OpenAIChatRequest)
+		require.True(t, ok)
+		assert.Empty(t, openaiReq.ChatParameters.ExtraParams,
+			"ExtraParams should be empty when passthrough header is not set")
+	})
+
+	t.Run("extra_params extracted with passthrough header", func(t *testing.T) {
+		req := chatRoute.GetRequestTypeInstance()
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
+		if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+			if rws, ok := req.(RequestWithSettableExtraParams); ok {
+				var wrapper struct {
+					ExtraParams map[string]interface{} `json:"extra_params"`
+				}
+				if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+					rws.SetExtraParams(wrapper.ExtraParams)
+				}
+			}
+		}
+
+		openaiReq, ok := req.(*openai.OpenAIChatRequest)
+		require.True(t, ok)
+		require.Contains(t, openaiReq.ChatParameters.ExtraParams, "guardrailConfig",
+			"guardrailConfig should be in ExtraParams when passthrough header is set")
+
+		gc, ok := openaiReq.ChatParameters.ExtraParams["guardrailConfig"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "my-guardrail", gc["guardrailIdentifier"])
+		assert.Equal(t, "1", gc["guardrailVersion"])
+		assert.Equal(t, "disabled", gc["trace"])
+	})
+}
+
+func TestExtraParamsPassthrough_NestedStructures(t *testing.T) {
+	rawBody := []byte(`{
+		"model": "openai/gpt-4o-mini",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+		"extra_params": {
+			"custom_param": "value",
+			"another_param": 123,
+			"nested": {
+				"deep_field": "deep_value",
+				"deeper": {"level": 3}
+			}
+		}
+	}`)
+
+	req := &openai.OpenAIChatRequest{}
+	err := sonic.Unmarshal(rawBody, req)
+	require.NoError(t, err)
+
+	bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
+	if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+		if rws, ok := interface{}(req).(RequestWithSettableExtraParams); ok {
+			var wrapper struct {
+				ExtraParams map[string]interface{} `json:"extra_params"`
+			}
+			if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+				rws.SetExtraParams(wrapper.ExtraParams)
+			}
+		}
+	}
+
+	require.Len(t, req.ChatParameters.ExtraParams, 3)
+	assert.Equal(t, "value", req.ChatParameters.ExtraParams["custom_param"])
+	assert.Equal(t, float64(123), req.ChatParameters.ExtraParams["another_param"])
+
+	nested, ok := req.ChatParameters.ExtraParams["nested"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "deep_value", nested["deep_field"])
+}
+
+func TestExtraParamsPassthrough_EndToEnd(t *testing.T) {
+	rawJSON := []byte(`{
+		"model": "bedrock/claude-4-5-sonnet-global",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+		"stream": false,
+		"temperature": 0.7,
+		"extra_params": {
+			"guardrailConfig": {
+				"guardrailIdentifier": "my-guardrail",
+				"guardrailVersion": "1",
+				"trace": "disabled"
+			}
+		}
+	}`)
+
+	req := &openai.OpenAIChatRequest{}
+	err := sonic.Unmarshal(rawJSON, req)
+	require.NoError(t, err)
+	assert.Equal(t, "bedrock/claude-4-5-sonnet-global", req.Model)
+
+	bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
+	if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+		if rws, ok := interface{}(req).(RequestWithSettableExtraParams); ok {
+			var wrapper struct {
+				ExtraParams map[string]interface{} `json:"extra_params"`
+			}
+			if err := sonic.Unmarshal(rawJSON, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+				rws.SetExtraParams(wrapper.ExtraParams)
+			}
+		}
+	}
+
+	bifrostReq := req.ToBifrostChatRequest(bifrostCtx)
+
+	require.NotNil(t, bifrostReq)
+	require.NotNil(t, bifrostReq.Params)
+	require.Contains(t, bifrostReq.Params.ExtraParams, "guardrailConfig")
+
+	gc, ok := bifrostReq.Params.ExtraParams["guardrailConfig"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "my-guardrail", gc["guardrailIdentifier"])
+	assert.Equal(t, "1", gc["guardrailVersion"])
+	assert.Equal(t, "disabled", gc["trace"])
+
+	assert.NotContains(t, bifrostReq.Params.ExtraParams, "model")
+	assert.NotContains(t, bifrostReq.Params.ExtraParams, "messages")
+	assert.NotContains(t, bifrostReq.Params.ExtraParams, "stream")
+	assert.NotContains(t, bifrostReq.Params.ExtraParams, "temperature")
+}
+
+func TestExtraParamsPassthrough_NoExtraParamsKey(t *testing.T) {
+	rawBody := []byte(`{
+		"model": "openai/gpt-4o-mini",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}]
+	}`)
+
+	req := &openai.OpenAIChatRequest{}
+	err := sonic.Unmarshal(rawBody, req)
+	require.NoError(t, err)
+
+	bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
+	if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+		if rws, ok := interface{}(req).(RequestWithSettableExtraParams); ok {
+			var wrapper struct {
+				ExtraParams map[string]interface{} `json:"extra_params"`
+			}
+			if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+				rws.SetExtraParams(wrapper.ExtraParams)
+			}
+			_ = rws
+		}
+	}
+
+	assert.Empty(t, req.ChatParameters.ExtraParams,
+		"ExtraParams should be empty when extra_params key is absent from JSON")
+}
+
+// TestExtraParamsSetViaInterfaceMutatesOriginalReq verifies that setting extra
+// params through the RequestWithSettableExtraParams interface assertion mutates
+// the original req (interface{}) value. This matters because createHandler
+// passes req to config.RequestConverter after the extra params block -- both
+// variables must reference the same underlying struct via pointer semantics.
+func TestExtraParamsSetViaInterfaceMutatesOriginalReq(t *testing.T) {
+	handlerStore := &mockHandlerStore{allowDirectKeys: true}
+	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
+
+	var chatRoute *RouteConfig
+	for i := range routes {
+		if routes[i].Path == "/openai/v1/chat/completions" {
+			chatRoute = &routes[i]
+			break
+		}
+	}
+	require.NotNil(t, chatRoute)
+
+	rawBody := []byte(`{
+		"model": "bedrock/claude-4-5-sonnet-global",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+		"extra_params": {
+			"guardrailConfig": {
+				"guardrailIdentifier": "my-guardrail",
+				"guardrailVersion": "1"
+			}
+		}
+	}`)
+
+	// Simulate the exact flow in createHandler:
+	// 1. req is created via GetRequestTypeInstance (returns interface{})
+	// 2. JSON is unmarshalled into req
+	// 3. rws type assertion is used to call SetExtraParams
+	// 4. req (not rws) is passed to RequestConverter downstream
+	req := chatRoute.GetRequestTypeInstance() // returns interface{}
+	err := sonic.Unmarshal(rawBody, req)
+	require.NoError(t, err)
+
+	// Type-assert and set extra params (same as router code)
+	if rws, ok := req.(RequestWithSettableExtraParams); ok {
+		var wrapper struct {
+			ExtraParams map[string]interface{} `json:"extra_params"`
+		}
+		if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
+			rws.SetExtraParams(wrapper.ExtraParams)
+		}
+	}
+
+	// Verify that req (the original interface{} variable) was mutated
+	openaiReq, ok := req.(*openai.OpenAIChatRequest)
+	require.True(t, ok)
+	require.Contains(t, openaiReq.ChatParameters.ExtraParams, "guardrailConfig",
+		"original req should be mutated via pointer semantics")
+
+	// Verify the full downstream path: RequestConverter uses req
+	bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq, err := chatRoute.RequestConverter(bifrostCtx, req)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq)
+	require.NotNil(t, bifrostReq.ChatRequest)
+	require.NotNil(t, bifrostReq.ChatRequest.Params)
+	assert.Contains(t, bifrostReq.ChatRequest.Params.ExtraParams, "guardrailConfig",
+		"extra params should propagate through RequestConverter to BifrostChatRequest")
+}


### PR DESCRIPTION
## Summary

The `/openai` integration endpoint silently drops provider-specific extra parameters (e.g. AWS Bedrock `guardrailConfig`) because the integration router only performs a single-pass JSON unmarshal into typed request structs where `ExtraParams` has `json:"-"` tag.

This fix adds support for the `extra_params` JSON key on the `/openai` endpoint, gated behind the `x-bf-passthrough-extra-params: true` header, consistent with the [documented passthrough behavior](https://docs.getbifrost.ai/providers/request-options#passthrough-extra-parameters). Provider-specific fields must be nested under `"extra_params"` in the request body -- top-level unknown fields are intentionally not captured to preserve the OpenAI schema contract.

## Changes

- Added `RequestWithSettableExtraParams` interface to the integration router (`integrations/router.go`), following the existing `RequestBodyWithExtraParams` naming convention from `core/providers/utils`
- After JSON unmarshal in `GenericRouter.createHandler`, when `x-bf-passthrough-extra-params: true` is set, the `extra_params` JSON key is extracted from the raw body and passed to request types via `SetExtraParams`
- Added `SetExtraParams` methods on all OpenAI request types (`OpenAIChatRequest`, `OpenAITextCompletionRequest`, `OpenAIResponsesRequest`, `OpenAIEmbeddingRequest`, `OpenAISpeechRequest`, `OpenAIImageGenerationRequest`, `OpenAIImageEditRequest`, `OpenAIImageVariationRequest`) that set both the standalone and embedded parameter struct `ExtraParams` fields
- Added tests in `router_test.go` covering:
  - `RequestWithSettableExtraParams` interface compliance for all 8 OpenAI request types
  - Extra params propagation through `ToBifrostChatRequest`
  - Header gating: `extra_params` NOT extracted without passthrough header
  - Header gating: `extra_params` extracted with passthrough header
  - Nested structures inside `extra_params`
  - End-to-end flow: parse -> extract -> convert to BifrostRequest
  - No-op when `extra_params` key is absent

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Run integration router tests
go test ./transports/bifrost-http/integrations/... -v

# Run all handler tests
go test ./transports/bifrost-http/handlers/... -v

# Manual test: send request with extra_params to /openai endpoint
curl -X POST "http://bifrost/openai/v1/chat/completions" \
  -H "Content-Type: application/json" \
  -H "x-bf-passthrough-extra-params: true" \
  -d '{
    "model": "bedrock/claude-4-5-sonnet-global",
    "messages": [{"role": "user", "content": "hello"}],
    "extra_params": {
      "guardrailConfig": {
        "guardrailIdentifier": "xxx",
        "guardrailVersion": "1",
        "trace": "disabled"
      }
    }
  }'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #1540

## Security considerations

No security implications. Extra parameters are only extracted from the explicit `extra_params` JSON key when the user opts in via the `x-bf-passthrough-extra-params: true` header. Without the header, the `/openai` endpoint behavior is unchanged.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable