### PR TITLE
refactor: shift last db usages to in memory structs

### DIFF
--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -21,9 +21,6 @@ type TableBudget struct {
 
 	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
-
-	// Virtual fields for runtime use (not stored in DB)
-	LastDBUsage float64 `gorm:"-" json:"-"`
 }
 
 // TableName sets the table name for each model
@@ -42,11 +39,5 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 		return fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)
 	}
 
-	return nil
-}
-
-// AfterFind hook for Budget to set the LastDBUsage virtual field
-func (b *TableBudget) AfterFind(tx *gorm.DB) error {
-	b.LastDBUsage = b.CurrentUsage
 	return nil
 }

--- a/framework/configstore/tables/ratelimit.go
+++ b/framework/configstore/tables/ratelimit.go
@@ -29,10 +29,6 @@ type TableRateLimit struct {
 
 	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
-
-	// Virtual fields for runtime use (not stored in DB)
-	LastDBTokenUsage   int64 `gorm:"-" json:"-"`
-	LastDBRequestUsage int64 `gorm:"-" json:"-"`
 }
 
 // TableName sets the table name for each model
@@ -77,12 +73,5 @@ func (rl *TableRateLimit) BeforeSave(tx *gorm.DB) error {
 		return fmt.Errorf("request_max_limit cannot be zero or negative: %d", *rl.RequestMaxLimit)
 	}
 
-	return nil
-}
-
-// AfterFind hook for RateLimit to set the LastDBTokenUsage and LastDBRequestUsage virtual fields
-func (rl *TableRateLimit) AfterFind(tx *gorm.DB) error {
-	rl.LastDBTokenUsage = rl.TokenCurrentUsage
-	rl.LastDBRequestUsage = rl.RequestCurrentUsage
 	return nil
 }


### PR DESCRIPTION
## Summary

Refactored the storage of last database usage values for budgets and rate limits by moving them from virtual fields in table structs to dedicated maps in the LocalGovernanceStore.

## Changes

- Removed virtual fields (`LastDBUsage`, `LastDBTokenUsage`, `LastDBRequestUsage`) from table structs
- Removed `AfterFind` hooks that were populating these virtual fields
- Added dedicated maps in LocalGovernanceStore to track last database usage values:
  - `LastDBUsagesBudgets` for budget usage
  - `LastDBUsagesRequestsRateLimits` for rate limit request usage
  - `LastDBUsagesTokensRateLimits` for rate limit token usage
- Added mutex locks to ensure thread-safe access to these maps
- Updated the code in `ResetExpiredBudgetsInMemory` and `ResetExpiredRateLimitsInMemory` to use the new maps
- Added initialization of these maps in `rebuildInMemoryStructures`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Verify that budget and rate limit tracking continues to work correctly after this refactoring.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change maintains the same security properties as before, just with an improved implementation approach for tracking usage data.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable