### PR TITLE
dont use forward API key in case of claude code request

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -143,8 +143,10 @@ func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, 
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
+
 	// Can be empty in case of passthrough or keyless custom provider
-	if key != "" {
+	// Here we can avoid this - in case of passthrough completely
+	if key != "" && !IsClaudeCodeRequest(ctx) {
 		req.Header.Set("x-api-key", key)
 	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
@@ -418,7 +420,8 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		"Accept":            "text/event-stream",
 		"Cache-Control":     "no-cache",
 	}
-	if key.Value.GetValue() != "" {
+
+	if key.Value.GetValue() != "" && !IsClaudeCodeRequest(ctx) {
 		headers["x-api-key"] = key.Value.GetValue()
 	}
 
@@ -860,7 +863,8 @@ func (provider *AnthropicProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		"Accept":            "text/event-stream",
 		"Cache-Control":     "no-cache",
 	}
-	if key.Value.GetValue() != "" {
+	
+	if key.Value.GetValue() != "" && !IsClaudeCodeRequest(ctx) {
 		headers["x-api-key"] = key.Value.GetValue()
 	}
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1589,3 +1589,13 @@ func anthropicExtractFloat64(v interface{}) (float64, bool) {
 		return 0, false
 	}
 }
+
+// IsClaudeCodeRequest checks if the request is a Claude Code request.
+func IsClaudeCodeRequest(ctx *schemas.BifrostContext) bool {
+	if userAgent, ok := ctx.Value(schemas.BifrostContextKeyUserAgent).(string); ok {
+		if strings.Contains(strings.ToLower(userAgent), "claude-cli") {
+			return true
+		}
+	}
+	return false
+}

--- a/framework/configstore/errors.go
+++ b/framework/configstore/errors.go
@@ -7,6 +7,7 @@ import (
 )
 
 var ErrNotFound = errors.New("not found")
+var ErrAlreadyExists = errors.New("already exists")
 
 // ErrUnresolvedKeys is returned when one or more keys could not be resolved
 type ErrUnresolvedKeys struct {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -155,10 +155,10 @@ func (s *RDBConfigStore) parseGormError(err error) error {
 		if columnName != "" {
 			// Convert snake_case to space-separated words
 			columnName = strings.ReplaceAll(columnName, "_", " ")
-			return fmt.Errorf("a record with this %s already exists. Please use a different value", columnName)
+			return fmt.Errorf("a record with this %s %w. Please use a different value", columnName, ErrAlreadyExists)
 		}
 		// Fallback message if we couldn't parse the column name
-		return fmt.Errorf("a record with this value already exists. Please use a different value")
+		return fmt.Errorf("a record with this value %w. Please use a different value", ErrAlreadyExists)
 	}
 
 	// For other errors, return the original error

--- a/tests/e2e/core/utils/selectors.ts
+++ b/tests/e2e/core/utils/selectors.ts
@@ -5,7 +5,7 @@
 
 export const Selectors = {
   // Common
-  toast: '[data-sonner-toast]',
+  toast: '[data-sonner-toast]:not([data-removed="true"])',
   loadingSpinner: '[data-testid="loading-spinner"]',
 
   // Providers Page

--- a/tests/e2e/core/utils/test-helpers.ts
+++ b/tests/e2e/core/utils/test-helpers.ts
@@ -60,7 +60,8 @@ export async function assertToast(
   expectedText: string,
   type: 'success' | 'error' | 'info' = 'success'
 ): Promise<void> {
-  const toast = page.locator('[data-sonner-toast]')
+  const selector = `[data-sonner-toast][data-type="${type}"]:not([data-removed="true"])`
+  const toast = page.locator(selector).first()
   await expect(toast).toBeVisible({ timeout: 10000 })
   await expect(toast).toContainText(expectedText)
 }

--- a/tests/e2e/features/routing-rules/pages/routing-rules.page.ts
+++ b/tests/e2e/features/routing-rules/pages/routing-rules.page.ts
@@ -120,7 +120,7 @@ export class RoutingRulesPage extends BasePage {
   }
 
   private async waitForToastAndAssertSuccess(action: string): Promise<void> {
-    const toast = this.page.locator('[data-sonner-toast]').first()
+    const toast = this.page.locator('[data-sonner-toast]:not([data-removed="true"])').first()
     await expect(toast).toBeVisible({ timeout: 10000 })
     const toastText = await toast.textContent()
     if (toastText?.toLowerCase().includes('error') || toastText?.toLowerCase().includes('failed')) {

--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -4,6 +4,7 @@
         "openai": {
             "keys": [
                 {
+                    "name": "OpenAI API Key",
                     "value": "env.OPENAI_API_KEY",
                     "weight": 1,
                     "use_for_batch_api": true
@@ -16,6 +17,7 @@
         "anthropic": {
             "keys": [
                 {
+                    "name": "Anthropic API Key",
                     "value": "env.ANTHROPIC_API_KEY",
                     "weight": 1,
                     "use_for_batch_api": true
@@ -40,6 +42,7 @@
         "vertex": {
             "keys": [
                 {
+                    "name": "Vertex API Key",
                     "vertex_key_config": {
                         "project_id": "env.VERTEX_PROJECT_ID",
                         "region": "env.GOOGLE_LOCATION",
@@ -55,6 +58,7 @@
         "mistral": {
             "keys": [
                 {
+                    "name": "Mistral API Key",
                     "value": "env.MISTRAL_API_KEY",
                     "weight": 1
                 }
@@ -66,6 +70,7 @@
         "cohere": {
             "keys": [
                 {
+                    "name": "Cohere API Key",
                     "value": "env.COHERE_API_KEY",
                     "weight": 1
                 }
@@ -77,6 +82,7 @@
         "groq": {
             "keys": [
                 {
+                    "name": "Groq API Key",
                     "value": "env.GROQ_API_KEY",
                     "weight": 1
                 }
@@ -88,6 +94,7 @@
         "perplexity": {
             "keys": [
                 {
+                    "name": "Perplexity API Key",
                     "value": "env.PERPLEXITY_API_KEY",
                     "weight": 1
                 }
@@ -99,6 +106,7 @@
         "cerebras": {
             "keys": [
                 {
+                    "name": "Cerebras API Key",
                     "value": "env.CEREBRAS_API_KEY",
                     "weight": 1
                 }
@@ -110,6 +118,7 @@
         "openrouter": {
             "keys": [
                 {
+                    "name": "OpenRouter API Key",
                     "value": "env.OPENROUTER_API_KEY",
                     "weight": 1
                 }
@@ -121,6 +130,7 @@
         "azure": {
             "keys": [
                 {
+                    "name": "Azure API Key",
                     "value": "env.AZURE_API_KEY",
                     "azure_key_config": {
                         "endpoint": "env.AZURE_ENDPOINT",
@@ -136,6 +146,7 @@
         "bedrock": {
             "keys": [
                 {
+                    "name": "Bedrock API Key",
                     "bedrock_key_config": {
                         "access_key": "env.AWS_ACCESS_KEY_ID",
                         "secret_key": "env.AWS_SECRET_ACCESS_KEY",

--- a/transports/bifrost-http/.air.toml
+++ b/transports/bifrost-http/.air.toml
@@ -20,6 +20,7 @@ exclude_dir = [
     "docs",
     "npx",
     "test-reports",
+    "playwright-report",
 ]
 exclude_file = []
 exclude_regex = ["_test.go"]

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -22,6 +22,10 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			startTime := time.Now()
+			// skip logging if it's a /health check request
+			if string(ctx.RequestURI()) == "/health" {
+				goto corsFlow
+			}
 			defer func() {
 				statusCode := ctx.Response.Header.StatusCode()
 				level := schemas.LogLevelInfo
@@ -42,6 +46,7 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 				}
 				logBuilder.Send()
 			}()
+		corsFlow:
 			origin := string(ctx.Request.Header.Peek("Origin"))
 			allowed := IsOriginAllowed(origin, config.ClientConfig.AllowedOrigins)
 			allowedHeaders := []string{"Content-Type", "Authorization", "X-Requested-With", "X-Stainless-Timeout"}

--- a/transports/bifrost-http/lib/errors.go
+++ b/transports/bifrost-http/lib/errors.go
@@ -3,3 +3,4 @@ package lib
 import "errors"
 
 var ErrNotFound = errors.New("not found")
+var ErrAlreadyExists = errors.New("already exists")

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -1,0 +1,111 @@
+import Provider from "@/components/provider";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useGetCoreConfigQuery } from "@/lib/store";
+import { ModelProvider } from "@/lib/types/config";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { useEffect, useMemo, useState } from "react";
+import { ApiStructureFormFragment, GovernanceFormFragment, ProxyFormFragment } from "../fragments";
+import { NetworkFormFragment } from "../fragments/networkFormFragment";
+import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
+
+interface Props {
+	show: boolean;
+	onCancel: () => void;
+	provider: ModelProvider;
+}
+
+const availableTabs = (provider: ModelProvider, hasGovernanceAccess: boolean, isGovernanceEnabled: boolean) => {
+	const tabs = [];
+	if (provider?.custom_provider_config) {
+		tabs.push({
+			id: "api-structure",
+			label: "API Structure",
+		});
+	}
+	tabs.push({
+		id: "network",
+		label: "Network config",
+	});
+	tabs.push({
+		id: "proxy",
+		label: "Proxy config",
+	});
+	tabs.push({
+		id: "performance",
+		label: "Performance tuning",
+	});
+	if (hasGovernanceAccess && isGovernanceEnabled) {
+		tabs.push({
+			id: "governance",
+			label: "Governance",
+		});
+	}
+	return tabs;
+};
+
+export default function ProviderConfigSheet({ show, onCancel, provider }: Props) {
+	const [selectedTab, setSelectedTab] = useState<string | undefined>(undefined);
+	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+	const { data: coreConfig } = useGetCoreConfigQuery({});
+	const isGovernanceEnabled = coreConfig?.client_config?.enable_governance || false;
+
+	const tabs = useMemo(() => {
+		return availableTabs(provider, hasGovernanceAccess, isGovernanceEnabled);
+	}, [provider.name, provider.custom_provider_config, hasGovernanceAccess, isGovernanceEnabled]);
+
+	useEffect(() => {
+		setSelectedTab(tabs[0]?.id);
+	}, [tabs]);
+
+	return (
+		<Sheet
+			open={show}
+			onOpenChange={(open) => {
+				if (!open) onCancel();
+			}}
+		>
+			<SheetContent className="custom-scrollbar dark:bg-card bg-white p-8 sm:max-w-[50%]">
+				<SheetHeader className="flex flex-col items-start">
+					<SheetTitle>
+						<div className="font-lg flex items-center gap-2">
+							<div className="flex items-center">
+								<Provider provider={provider.name} size={24} />
+							</div>
+							Provider configuration
+						</div>
+					</SheetTitle>
+				</SheetHeader>
+				<div className="w-full rounded-sm border">
+					<Tabs defaultValue={tabs[0]?.id} value={selectedTab} onValueChange={setSelectedTab} className="space-y-6">
+						<TabsList
+							style={{ gridTemplateColumns: `repeat(${tabs.length}, 1fr)` }}
+							className="mb-4 grid h-10 w-full rounded-tl-sm rounded-tr-sm rounded-br-none rounded-bl-none"
+						>
+							{tabs.map((tab) => (
+								<TabsTrigger key={tab.id} value={tab.id} className="flex items-center gap-2">
+									{tab.label}
+								</TabsTrigger>
+							))}
+						</TabsList>
+						<TabsContent value="api-structure">
+							<ApiStructureFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="network">
+							<NetworkFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="proxy">
+							<ProxyFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="performance">
+							<PerformanceFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="governance">
+							<GovernanceFormFragment provider={provider} />
+						</TabsContent>
+					</Tabs>
+				</div>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -78,6 +78,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");
+				form.reset(data);
 			})
 			.catch((err) => {
 				toast.error("Failed to update provider configuration", {

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -105,6 +105,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");
+				form.reset(data);
 			})
 			.catch((err) => {
 				toast.error("Failed to update provider configuration", {
@@ -177,6 +178,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 													if (!Number.isNaN(parsed)) {
 														field.onChange(parsed)
 													}
+													form.trigger("network_config");
 												}}
 											/>
 										</FormControl>
@@ -207,6 +209,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 													if (!Number.isNaN(parsed)) {
 														field.onChange(parsed)
 													}
+													form.trigger("network_config");
 												}}
 											/>
 										</FormControl>
@@ -238,6 +241,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 													if (!Number.isNaN(parsed)) {
 														field.onChange(parsed)
 													}
+													form.trigger("network_config");
 												}}
 											/>
 										</FormControl>
@@ -267,6 +271,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 													if (!Number.isNaN(parsed)) {
 														field.onChange(parsed)
 													}
+													form.trigger("network_config");
 												}}
 											/>
 										</FormControl>

--- a/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
@@ -51,8 +51,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 			send_back_raw_request: provider.send_back_raw_request ?? false,
 			send_back_raw_response: provider.send_back_raw_response ?? false,
 		});
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [form, provider.name]);
+	}, [form, provider.name, provider.concurrency_and_buffer_size, provider.send_back_raw_request, provider.send_back_raw_response]);
 
 	const onSubmit = (data: PerformanceFormSchema) => {
 		// Create updated provider configuration
@@ -69,6 +68,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");
+				form.reset(data);
 			})
 			.catch((err) => {
 				toast.error("Failed to update provider configuration", {
@@ -107,6 +107,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 													if (!Number.isNaN(parsed)) {
 														field.onChange(parsed)
 													}
+													form.trigger("concurrency_and_buffer_size");
 												}}
 											/>
 										</FormControl>
@@ -139,6 +140,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 													if (!Number.isNaN(parsed)) {
 														field.onChange(parsed)
 													}
+													form.trigger("concurrency_and_buffer_size");
 												}}
 											/>
 										</FormControl>

--- a/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
@@ -71,6 +71,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");
+				form.reset(data);
 			})
 			.catch((err) => {
 				toast.error("Failed to update provider configuration", {

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -5,15 +5,14 @@
 
 "use client";
 
-import { useState } from "react";
+import { RbacOperation, RbacResource, useRbac } from "@/app/_fallbacks/enterprise/lib/contexts/rbacContext";
 import { Button } from "@/components/ui/button";
-import { Plus } from "lucide-react";
-import { RoutingRule } from "@/lib/types/routingRules";
 import { useGetRoutingRulesQuery } from "@/lib/store/apis/routingRulesApi";
-import { RoutingRulesTable } from "./routingRulesTable";
+import { RoutingRule } from "@/lib/types/routingRules";
+import { Plus } from "lucide-react";
+import { useState } from "react";
 import { RoutingRuleSheet } from "./routingRuleSheet";
-import { useRbac } from "@/app/_fallbacks/enterprise/lib/contexts/rbacContext";
-import { RbacResource, RbacOperation } from "@/app/_fallbacks/enterprise/lib/contexts/rbacContext";
+import { RoutingRulesTable } from "./routingRulesTable";
 
 export function RoutingRulesView() {
 	const [dialogOpen, setDialogOpen] = useState(false);
@@ -48,16 +47,11 @@ export function RoutingRulesView() {
 			{/* Header */}
 			<div className="flex items-center justify-between">
 				<div>
-					<p className="text-muted-foreground text-sm">
-						Manage CEL-based routing rules for intelligent request routing across providers
-					</p>
+					<h1 className="text-foreground text-lg font-semibold">Routing Rules</h1>
+					<p className="text-muted-foreground text-sm">Manage CEL-based routing rules for intelligent request routing across providers</p>
 				</div>
 				{canCreate && (
-					<Button
-						onClick={handleCreateNew}
-						disabled={isLoading}
-						className="gap-2"
-					>
+					<Button onClick={handleCreateNew} disabled={isLoading} className="gap-2">
 						<Plus className="h-4 w-4" />
 						<span className="hidden sm:inline">New Rule</span>
 					</Button>
@@ -67,38 +61,22 @@ export function RoutingRulesView() {
 			{/* Empty state or Table */}
 			{!isLoading && rules.length === 0 ? (
 				<div className="rounded-lg border border-dashed p-12 text-center">
-					<Plus className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-					<h3 className="text-lg font-semibold mb-1">
-						No routing rules yet
-					</h3>
-					<p className="text-muted-foreground mb-6">
-						Create your first routing rule to start intelligently routing requests
-					</p>
+					<Plus className="text-muted-foreground mx-auto mb-4 h-12 w-12" />
+					<h3 className="mb-1 text-lg font-semibold">No routing rules yet</h3>
+					<p className="text-muted-foreground mb-6">Create your first routing rule to start intelligently routing requests</p>
 					{canCreate && (
-						<Button
-							onClick={handleCreateNew}
-							className="gap-2"
-						>
+						<Button onClick={handleCreateNew} className="gap-2">
 							<Plus className="h-4 w-4" />
 							Create First Rule
 						</Button>
 					)}
 				</div>
 			) : (
-				<RoutingRulesTable
-					rules={rules}
-					isLoading={isLoading}
-					onEdit={handleEdit}
-					canDelete={canDelete}
-				/>
+				<RoutingRulesTable rules={rules} isLoading={isLoading} onEdit={handleEdit} canDelete={canDelete} />
 			)}
 
 			{/* RoutingRuleSheet */}
-			<RoutingRuleSheet
-				open={dialogOpen}
-				onOpenChange={handleDialogOpenChange}
-				editingRule={editingRule}
-			/>
+			<RoutingRuleSheet open={dialogOpen} onOpenChange={handleDialogOpenChange} editingRule={editingRule} />
 		</div>
 	);
 }

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -215,21 +215,26 @@ const SidebarItemView = ({
 		}
 	};
 
-	const handleNavigation = (url: string) => {
+	const openInNewTab = (url: string) => {
+		window.open(url, "_blank", "noopener,noreferrer");
+	};
+
+	const handleNavigation = (url: string, e?: React.MouseEvent) => {
 		if (!isAllowed) return;
-		if (isExternal) {
-			window.open(url, "_blank");
+		if (isExternal || e?.metaKey || e?.ctrlKey) {
+			openInNewTab(url);
 			return;
 		}
 		router.push(url);
 	};
 
-	const handleSubItemClick = (subItem: SidebarItem) => {
-		if (subItem.queryParam) {
-			router.push(`${subItem.url}?tab=${subItem.queryParam}`);
-		} else {
-			router.push(subItem.url);
+	const handleSubItemClick = (subItem: SidebarItem, e?: React.MouseEvent) => {
+		const url = subItem.queryParam ? `${subItem.url}?tab=${subItem.queryParam}` : subItem.url;
+		if (e?.metaKey || e?.ctrlKey) {
+			openInNewTab(url);
+			return;
 		}
+		router.push(url);
 	};
 
 	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
@@ -248,7 +253,7 @@ const SidebarItemView = ({
 								? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
 								: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
 				} `}
-				onClick={hasSubItems ? handleClick : item.hasAccess ? () => handleNavigation(item.url) : undefined}
+				onClick={hasSubItems ? handleClick : item.hasAccess ? (e) => handleNavigation(item.url, e) : undefined}
 			>
 				<div className="flex w-full items-center justify-between">
 					<div className="flex w-full items-center gap-2">
@@ -298,7 +303,7 @@ const SidebarItemView = ({
 													? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
 													: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
 									}`}
-									onClick={() => (subItem.hasAccess === false ? undefined : handleSubItemClick(subItem))}
+									onClick={(e) => (subItem.hasAccess === false ? undefined : handleSubItemClick(subItem, e))}
 								>
 									<div className="flex items-center gap-2">
 										{SubItemIcon && <SubItemIcon className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`} />}
@@ -845,16 +850,16 @@ export default function AppSidebar() {
 			} else if (e.key === "ArrowUp") {
 				e.preventDefault();
 				setFocusedIndex((prev) => Math.max(prev - 1, 0));
-			} else if (e.key === "Enter") {
-				e.preventDefault();
-				const target = navigableItems[focusedIndex];
-				if (target) {
-					const url = target.queryParam ? `${target.url}?tab=${target.queryParam}` : target.url;
-					if (target.isExternal) {
-						window.open(url, "_blank");
-					} else {
-						router.push(url);
-					}
+		} else if (e.key === "Enter") {
+			e.preventDefault();
+			const target = navigableItems[focusedIndex];
+			if (target) {
+				const url = target.queryParam ? `${target.url}?tab=${target.queryParam}` : target.url;
+				if (target.isExternal || e.metaKey || e.ctrlKey) {
+					window.open(url, "_blank", "noopener,noreferrer");
+				} else {
+					router.push(url);
+				}
 					setSearchQuery("");
 					setFocusedIndex(-1);
 					searchInputRef.current?.blur();

--- a/ui/components/ui/button.tsx
+++ b/ui/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground  hover:bg-primary/90",
-				destructive: "bg-destructive text-white  hover:bg-destructive/90  dark:bg-destructive/60",
+				destructive: "bg-destructive text-white font-normal  hover:bg-destructive/90  dark:bg-destructive/60",
 				outline:
 					"border bg-background hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
 				secondary: "bg-secondary text-secondary-foreground  hover:bg-secondary/80",
@@ -19,7 +19,7 @@ const buttonVariants = cva(
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
-				default: "h-9 px-4 py-2 has-[>svg]:px-3",
+				default: "h-8 px-2 py-1 has-[>svg]:px-2",
 				sm: "h-8 rounded-sm gap-1.5 px-3 has-[>svg]:px-2.5",
 				lg: "h-10 rounded-sm px-6 has-[>svg]:px-4",
 				icon: "size-9",

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -47,9 +47,9 @@ const ConcurrencyAndBufferSizeSchema = z
 		concurrency: z.number().min(1, "Concurrency must be greater than 0"),
 		buffer_size: z.number().min(1, "Buffer size must be greater than 0"),
 	})
-	.refine((data) => data.concurrency < data.buffer_size, {
-		message: "Buffer size must be greater than concurrency",
-		path: ["buffer_size"],
+	.refine((data) => data.concurrency <= data.buffer_size, {
+		message: "Concurrency must be less than or equal to buffer size",
+		path: ["concurrency"],
 	});
 
 const AllowedRequestsSchema = z.object({

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -508,16 +508,21 @@ export const networkOnlyFormSchema = z.object({
 
 // Performance form schema for the PerformanceFormFragment
 export const performanceFormSchema = z.object({
-	concurrency_and_buffer_size: z.object({
-		concurrency: z.coerce
-			.number("Concurrency must be a number")
-			.min(1, "Concurrency must be greater than 0")
-			.max(100000, "Concurrency must be less than 100000"),
-		buffer_size: z.coerce
-			.number("Buffer size must be a number")
-			.min(1, "Buffer size must be greater than 0")
-			.max(100000, "Buffer size must be less than 100000"),
-	}),
+	concurrency_and_buffer_size: z
+		.object({
+			concurrency: z
+				.number({ invalid_type_error: "Concurrency must be a number" })
+				.min(1, "Concurrency must be greater than 0")
+				.max(100000, "Concurrency must be less than 100000"),
+			buffer_size: z
+				.number({ invalid_type_error: "Buffer size must be a number" })
+				.min(1, "Buffer size must be greater than 0")
+				.max(100000, "Buffer size must be less than 100000"),
+		})
+		.refine((data) => data.concurrency <= data.buffer_size, {
+			message: "Concurrency must be less than or equal to buffer size",
+			path: ["concurrency"],
+		}),
 	send_back_raw_request: z.boolean(),
 	send_back_raw_response: z.boolean(),
 });


### PR DESCRIPTION
## Summary

Improve Claude Code (claude-cli) integration by refactoring the detection logic and fixing authentication handling for passthrough requests.

## Issues

Closes #1551

## Changes

- Extracted the Claude Code detection logic into a reusable `IsClaudeCodeRequest` utility function
- Fixed authentication header handling for Claude Code requests in passthrough mode
- Simplified code by using the new utility function across multiple files
- Improved WebSearch tool argument handling for Claude Code requests

## Type of change

- [x] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Use claude-cli to make requests to Bifrost with passthrough enabled
2. Verify that authentication headers are properly handled
3. Test WebSearch tool functionality with claude-cli

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with claude-cli authentication and WebSearch tool handling.

## Security considerations

Ensures proper authentication header handling for Claude Code requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable