### PR TITLE
fix: tool sync interval in mcp catalog

### DIFF
--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -13,3 +13,4 @@
 - fix: errored request logs are now not counted in missing cost filter
 - feat: adds support for custom OAuth scopes when authenticating with Azure Entra ID
 - fix: if governance is disabled set enforce virtual key header to false
+- fix: tool sync interval in mcp catalog

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -30,6 +30,15 @@ interface MCPClientSheetProps {
 	onSubmitSuccess: () => void;
 }
 
+/** API sends tool_sync_interval as nanoseconds (Go time.Duration). Normalize to minutes for form/store. */
+function toolSyncIntervalToMinutes(v: number | undefined | null): number {
+	if (v === undefined || v === null) return 0;
+	const n = Number(v);
+	if (Number.isNaN(n)) return 0;
+	if (Math.abs(n) >= 1e9) return Math.round(n / 6e10);
+	return n;
+}
+
 export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: MCPClientSheetProps) {
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
 	const [updateMCPClient, { isLoading: isUpdating }] = useUpdateMCPClientMutation();
@@ -61,7 +70,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
-			tool_sync_interval: mcpClient.config.tool_sync_interval ?? 0,
+			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
 		},
 	});
 
@@ -75,7 +84,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
 			tool_pricing: mcpClient.config.tool_pricing || {},
-			tool_sync_interval: mcpClient.config.tool_sync_interval ?? 0,
+			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
 		});
 	}, [form, mcpClient]);
 
@@ -339,7 +348,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 														type="number"
 														className={`w-24 ${isUsingGlobal ? "text-muted-foreground" : ""}`}
 														placeholder={String(globalToolSyncInterval)}
-														value={field.value === 0 ? "" : (field.value ?? "")}
+														value={field.value === 0 || field.value === undefined ? "" : String(field.value)}
 														onChange={(e) => {
 															const val = e.target.value === "" ? undefined : parseInt(e.target.value);
 															field.onChange(val);


### PR DESCRIPTION
## Summary

Fix the tool sync interval display and conversion in the MCP client sheet to properly handle nanosecond values from the API.

## Changes

- Added a `toolSyncIntervalToMinutes` helper function to normalize tool sync interval values from nanoseconds (Go time.Duration) to minutes for the UI form
- Updated the form initialization to use this conversion function
- Fixed the form reset functionality to properly convert values
- Improved the input field value handling to better manage undefined values
- Added a changelog entry for the tool sync interval fix in MCP catalog

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Open the MCP client sheet in the UI
2. Verify that tool sync interval values display correctly in minutes
3. Test editing and saving the values to ensure they're properly converted

```sh
# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable