### PR TITLE
refactor: replaced ModelMatcher interface with ModelCatalog struct to avoid having to do to nil checks using reflect

### DIFF
--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -682,3 +682,17 @@ func (mc *ModelCatalog) Cleanup() error {
 
 	return nil
 }
+
+// NewTestCatalog creates a minimal ModelCatalog for testing purposes.
+// It does not start background sync workers or connect to external services.
+func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
+	if baseModelIndex == nil {
+		baseModelIndex = make(map[string]string)
+	}
+	return &ModelCatalog{
+		modelPool:      make(map[schemas.ModelProvider][]string),
+		baseModelIndex: baseModelIndex,
+		pricingData:    make(map[string]configstoreTables.TableModelPricing),
+		done:           make(chan struct{}),
+	}
+}

--- a/plugins/governance/model_provider_governance_test.go
+++ b/plugins/governance/model_provider_governance_test.go
@@ -1947,7 +1947,7 @@ func TestStore_CheckModelBudget_CrossProviderModelMatch(t *testing.T) {
 	budget := buildBudgetWithUsage("budget1", 100.0, 100.0, "1h") // At limit
 	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
 
-	mc := newMockModelMatcher(t)
+	mc := newTestModelCatalog(t)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
@@ -1967,7 +1967,7 @@ func TestStore_CheckModelBudget_CrossProviderModelMatch_WithinLimit(t *testing.T
 	budget := buildBudget("budget1", 100.0, "1h")
 	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
 
-	mc := newMockModelMatcher(t)
+	mc := newTestModelCatalog(t)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
@@ -1985,7 +1985,7 @@ func TestStore_CheckModelRateLimit_CrossProviderModelMatch(t *testing.T) {
 	rateLimit := buildRateLimitWithUsage("rl1", 10000, 10000, 1000, 0) // Token limit at max
 	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, nil, rateLimit)
 
-	mc := newMockModelMatcher(t)
+	mc := newTestModelCatalog(t)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
@@ -2005,7 +2005,7 @@ func TestStore_UpdateModelBudgetUsage_CrossProviderModelMatch(t *testing.T) {
 	budget := buildBudget("budget1", 100.0, "1h")
 	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, budget, nil)
 
-	mc := newMockModelMatcher(t)
+	mc := newTestModelCatalog(t)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},
@@ -2033,7 +2033,7 @@ func TestStore_UpdateModelRateLimitUsage_CrossProviderModelMatch(t *testing.T) {
 	rateLimit := buildRateLimitWithUsage("rl1", 100, 0, 1000, 0) // Low token limit
 	modelConfig := buildModelConfig("mc1", "gpt-4o", nil, nil, rateLimit)
 
-	mc := newMockModelMatcher(t)
+	mc := newTestModelCatalog(t)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		RateLimits:   []configstoreTables.TableRateLimit{*rateLimit},
@@ -2059,7 +2059,7 @@ func TestStore_CheckModelBudget_ModelWithProvider_ExactMatchOnly(t *testing.T) {
 	providerStr := "openai"
 	modelConfig := buildModelConfig("mc1", "gpt-4o", &providerStr, budget, nil)
 
-	mc := newMockModelMatcher(t)
+	mc := newTestModelCatalog(t)
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
 		ModelConfigs: []configstoreTables.TableModelConfig{*modelConfig},
 		Budgets:      []configstoreTables.TableBudget{*budget},


### PR DESCRIPTION
## Summary

replaced `ModelMatcher` interface with `ModelCatalog` struct to avoid having to
do to nil checks using reflect

## Changes

- Added `NewTestCatalog` function to create a minimal ModelCatalog for testing
  purposes
- Replaced the custom `mockModelMatcher` with the new `NewTestCatalog` function
  in governance tests
- Updated the governance store to use ModelCatalog directly instead of a
  ModelMatcher interface
- Renamed references from `modelMatcher` to `modelCatalog` throughout the
  codebase

## Type of change

- [x] Refactor
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

```sh
# Run the governance tests
go test ./plugins/governance/...

# Run the modelcatalog tests
go test ./framework/modelcatalog/...
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this is a testing utility.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)

