### PR TITLE
memory db inconsitency fixes

### DIFF
--- a/.github/workflows/scripts/test-e2e-ui.sh
+++ b/.github/workflows/scripts/test-e2e-ui.sh
@@ -129,7 +129,7 @@ npx playwright install --with-deps chromium
 
 # Run Playwright tests
 echo "🎭 Running Playwright E2E tests..."
-CI=true SKIP_WEB_SERVER=1 BASE_URL=http://localhost:18080 npx playwright test
+CI=true SKIP_WEB_SERVER=1 BASE_URL=http://localhost:18080 npx playwright test --workers=1
 PLAYWRIGHT_EXIT=$?
 
 cd ../..

--- a/tests/e2e/core/fixtures/base.fixture.ts
+++ b/tests/e2e/core/fixtures/base.fixture.ts
@@ -15,6 +15,7 @@ import { ConfigSettingsPage } from '../../features/config/pages/config-settings.
  * Custom test fixtures type
  */
 type BifrostFixtures = {
+  closeDevProfiler: void
   sidebarPage: SidebarPage
   providersPage: ProvidersPage
   virtualKeysPage: VirtualKeysPage
@@ -32,6 +33,18 @@ type BifrostFixtures = {
  * Extended test with Bifrost-specific fixtures
  */
 export const test = base.extend<BifrostFixtures>({
+  closeDevProfiler: [async ({ page }, use) => {
+    // Automatically dismiss the Dev Profiler overlay whenever it appears.
+    // Uses addLocatorHandler so it triggers before any test action if the profiler is visible.
+    await page.addLocatorHandler(
+      page.getByText('Dev Profiler', { exact: true }),
+      async () => {
+        await page.locator('button[title="Dismiss"]').click()
+      }
+    )
+    await use()
+  }, { auto: true }],
+
   sidebarPage: async ({ page }, use) => {
     await use(new SidebarPage(page))
   },

--- a/tests/e2e/core/pages/base.page.ts
+++ b/tests/e2e/core/pages/base.page.ts
@@ -132,6 +132,22 @@ export class BasePage {
   }
 
   /**
+   * Close the Dev Profiler overlay if it is visible.
+   * Clicks the dismiss (X) button on the profiler panel. Silently continues if not present.
+   */
+  async closeDevProfiler(): Promise<void> {
+    const profilerHeader = this.page.locator('text=Dev Profiler')
+    const isVisible = await profilerHeader.isVisible().catch(() => false)
+    if (isVisible) {
+      const dismissBtn = this.page.locator('button[title="Dismiss"]')
+      if (await dismissBtn.isVisible().catch(() => false)) {
+        await dismissBtn.click()
+        await profilerHeader.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {})
+      }
+    }
+  }
+
+  /**
    * Fill a form field by label
    */
   async fillByLabel(label: string, value: string): Promise<void> {


### PR DESCRIPTION
## Summary

Implement transaction safety for database and in-memory state operations to prevent inconsistencies when updates fail.

## Changes

- Added rollback capability for MCP client updates when in-memory updates fail
- Reordered operations in delete flows to ensure database operations happen before memory operations
- For MCP client updates, save the existing DB config before updates to enable rollback
- Modified provider removal to delete from DB first before removing from memory
- Reordered plugin creation to ensure DB entry is created before loading the plugin into memory

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the following scenarios to verify transaction safety:

```sh
# Test MCP client update with simulated memory update failure
# Verify DB state remains consistent with memory state

# Test plugin creation with simulated DB failure
# Verify no orphaned in-memory plugin state exists

# Test provider removal with simulated DB failure
# Verify provider remains in memory if DB delete fails
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change improves system stability by preventing inconsistent states between database and in-memory configurations, which could lead to unexpected behavior or security issues.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable