### PR TITLE
ignore health and pprof in logs

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -17,13 +17,17 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+var loggingSkipPaths = []string{"/health", "/_next","/api/dev"}
+
 // CorsMiddleware handles CORS headers for localhost and configured allowed origins
 func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			startTime := time.Now()
 			// skip logging if it's a /health check request
-			if string(ctx.RequestURI()) == "/health" {
+			if slices.IndexFunc(loggingSkipPaths, func(path string) bool {
+				return strings.HasPrefix(string(ctx.RequestURI()), path)
+			}) != -1 {
 				goto corsFlow
 			}
 			defer func() {


### PR DESCRIPTION
## Summary

Extend the logging skip paths in the HTTP middleware to include `/_next` and `/api/dev` paths in addition to the existing `/health` path.

## Changes

- Modified the `CorsMiddleware` to skip logging for additional paths: `/_next` and `/api/dev`
- Created a global `loggingSkipPaths` variable to store all paths that should skip logging
- Replaced the direct string comparison with a more flexible prefix-based check using `strings.HasPrefix` and `slices.IndexFunc`

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that requests to `/health`, `/_next/*`, and `/api/dev*` paths don't generate log entries:

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# Make requests to these paths and verify no logs are generated
curl http://localhost:8080/health
curl http://localhost:8080/_next/static/chunks/main.js
curl http://localhost:8080/api/dev/status
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves logging performance by reducing noise from health checks, Next.js asset requests, and development API endpoints.

## Security considerations

No security implications as this only affects logging behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable