### PR TITLE
fix: add advisory locks to migrations to prevent cluster startup race conditions

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -34,6 +34,9 @@ fi
 # Repository root (3 levels up from .github/workflows/scripts)
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd -P)"
 
+# Setup Go workspace for CI (go.work is gitignored, must be regenerated)
+source "$SCRIPT_DIR/setup-go-workspace.sh"
+
 # Configuration
 DB_TYPE="${1:-all}"
 

--- a/.github/workflows/scripts/test-bifrost-http.sh
+++ b/.github/workflows/scripts/test-bifrost-http.sh
@@ -16,6 +16,19 @@ source "$(dirname "$0")/setup-go-workspace.sh"
 
 echo "🧪 Running bifrost-http tests..."
 
+# Validate that config.schema.json and values.schema.json are in sync
+echo "🔍 Validating schema consistency between config.schema.json and values.schema.json..."
+VALIDATE_SCHEMA_SCRIPT="$SCRIPT_DIR/validate-helm-schema.sh"
+if [ -f "$VALIDATE_SCHEMA_SCRIPT" ]; then
+  if ! "$VALIDATE_SCHEMA_SCRIPT"; then
+    echo "❌ Schema validation failed. The Helm chart values.schema.json is not in sync with config.schema.json"
+    exit 1
+  fi
+  echo "✅ Schema validation passed"
+else
+  echo "⚠️  Warning: validate-helm-schema.sh not found, skipping schema validation"
+fi
+
 # Cleanup function to ensure Docker services are stopped
 cleanup_docker() {
   echo "🧹 Cleaning up Docker services..."

--- a/.github/workflows/scripts/test-core.sh
+++ b/.github/workflows/scripts/test-core.sh
@@ -17,10 +17,14 @@ for mcp_dir in examples/mcps/*/; do
     if [ -f "$mcp_dir/go.mod" ]; then
       echo "  Building $mcp_name (Go)..."
       mkdir -p "$mcp_dir/bin"
-      cd "$mcp_dir" && go build -o "bin/$mcp_name" . && cd - > /dev/null
+      pushd "$mcp_dir" > /dev/null
+      GOWORK=off go build -o "bin/$mcp_name" .
+      popd > /dev/null
     elif [ -f "$mcp_dir/package.json" ]; then
       echo "  Building $mcp_name (TypeScript)..."
-      cd "$mcp_dir" && npm install --silent && npm run build && cd - > /dev/null
+      pushd "$mcp_dir" > /dev/null
+      npm install --silent && npm run build
+      popd > /dev/null
     fi
   fi
 done

--- a/.github/workflows/scripts/validate-helm-schema.sh
+++ b/.github/workflows/scripts/validate-helm-schema.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate that the Helm chart values.schema.json is in sync with config.schema.json
+# This script extracts required fields from both schemas and compares them
+
+# Get the repository root
+if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+fi
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+CONFIG_SCHEMA="$REPO_ROOT/transports/config.schema.json"
+HELM_SCHEMA="$REPO_ROOT/helm-charts/bifrost/values.schema.json"
+
+echo "📋 Comparing schemas:"
+echo "   Config schema: $CONFIG_SCHEMA"
+echo "   Helm schema:   $HELM_SCHEMA"
+
+# Check if files exist
+if [ ! -f "$CONFIG_SCHEMA" ]; then
+  echo "❌ Config schema not found: $CONFIG_SCHEMA"
+  exit 1
+fi
+
+if [ ! -f "$HELM_SCHEMA" ]; then
+  echo "❌ Helm schema not found: $HELM_SCHEMA"
+  exit 1
+fi
+
+# Check if jq is available
+if ! command -v jq &> /dev/null; then
+  echo "⚠️  jq not found, skipping detailed schema comparison"
+  echo "   Install jq for full schema validation"
+  exit 0
+fi
+
+ERRORS=0
+
+# Function to extract required fields from a schema definition
+extract_required_fields() {
+  local schema_file="$1"
+  local def_path="$2"
+  jq -r "$def_path.required // [] | .[]" "$schema_file" 2>/dev/null | sort
+}
+
+# Function to check if a definition exists in schema
+def_exists() {
+  local schema_file="$1"
+  local def_path="$2"
+  jq -e "$def_path" "$schema_file" > /dev/null 2>&1
+}
+
+echo ""
+echo "🔍 Checking required fields in governance entities..."
+
+# Check governance.budgets required fields
+CONFIG_BUDGET_REQUIRED=$(jq -r '.properties.governance.properties.budgets.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_BUDGET_REQUIRED=$(jq -r '.properties.bifrost.properties.governance.properties.budgets.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_BUDGET_REQUIRED" != "$HELM_BUDGET_REQUIRED" ]; then
+  echo "❌ Budget required fields mismatch:"
+  echo "   Config: [$CONFIG_BUDGET_REQUIRED]"
+  echo "   Helm:   [$HELM_BUDGET_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Budget required fields match: [$CONFIG_BUDGET_REQUIRED]"
+fi
+
+# Check governance.rate_limits required fields
+CONFIG_RATELIMIT_REQUIRED=$(jq -r '.properties.governance.properties.rate_limits.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_RATELIMIT_REQUIRED=$(jq -r '.properties.bifrost.properties.governance.properties.rateLimits.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_RATELIMIT_REQUIRED" != "$HELM_RATELIMIT_REQUIRED" ]; then
+  echo "❌ Rate limits required fields mismatch:"
+  echo "   Config: [$CONFIG_RATELIMIT_REQUIRED]"
+  echo "   Helm:   [$HELM_RATELIMIT_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Rate limits required fields match: [$CONFIG_RATELIMIT_REQUIRED]"
+fi
+
+# Check governance.customers required fields
+CONFIG_CUSTOMER_REQUIRED=$(jq -r '.properties.governance.properties.customers.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_CUSTOMER_REQUIRED=$(jq -r '.properties.bifrost.properties.governance.properties.customers.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_CUSTOMER_REQUIRED" != "$HELM_CUSTOMER_REQUIRED" ]; then
+  echo "❌ Customer required fields mismatch:"
+  echo "   Config: [$CONFIG_CUSTOMER_REQUIRED]"
+  echo "   Helm:   [$HELM_CUSTOMER_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Customer required fields match: [$CONFIG_CUSTOMER_REQUIRED]"
+fi
+
+# Check governance.teams required fields
+CONFIG_TEAM_REQUIRED=$(jq -r '.properties.governance.properties.teams.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_TEAM_REQUIRED=$(jq -r '.properties.bifrost.properties.governance.properties.teams.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_TEAM_REQUIRED" != "$HELM_TEAM_REQUIRED" ]; then
+  echo "❌ Team required fields mismatch:"
+  echo "   Config: [$CONFIG_TEAM_REQUIRED]"
+  echo "   Helm:   [$HELM_TEAM_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Team required fields match: [$CONFIG_TEAM_REQUIRED]"
+fi
+
+# Check governance.virtual_keys required fields
+CONFIG_VK_REQUIRED=$(jq -r '.properties.governance.properties.virtual_keys.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_VK_REQUIRED=$(jq -r '.properties.bifrost.properties.governance.properties.virtualKeys.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_VK_REQUIRED" != "$HELM_VK_REQUIRED" ]; then
+  echo "❌ Virtual key required fields mismatch:"
+  echo "   Config: [$CONFIG_VK_REQUIRED]"
+  echo "   Helm:   [$HELM_VK_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Virtual key required fields match: [$CONFIG_VK_REQUIRED]"
+fi
+
+echo ""
+echo '🔍 Checking required fields in $defs...'
+
+# Check base_key required fields
+CONFIG_BASEKEY_REQUIRED=$(jq -r '."$defs".base_key.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_BASEKEY_REQUIRED=$(jq -r '."$defs".providerKey.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_BASEKEY_REQUIRED" != "$HELM_BASEKEY_REQUIRED" ]; then
+  echo "❌ Provider key (base_key) required fields mismatch:"
+  echo "   Config: [$CONFIG_BASEKEY_REQUIRED]"
+  echo "   Helm:   [$HELM_BASEKEY_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Provider key required fields match: [$CONFIG_BASEKEY_REQUIRED]"
+fi
+
+# Check azure_key_config required fields
+CONFIG_AZURE_REQUIRED=$(jq -r '."$defs".azure_key.allOf[1].properties.azure_key_config.properties | keys | map(select(. as $k | ["endpoint", "api_version"] | index($k))) | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "endpoint,api_version")
+HELM_AZURE_REQUIRED=$(jq -r '."$defs".providerKey.properties.azure_key_config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+# Normalize the comparison (config schema uses allOf pattern)
+CONFIG_AZURE_REQ_NORM=$(jq -r '."$defs".azure_key.allOf[1].properties.azure_key_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+if [ -z "$CONFIG_AZURE_REQ_NORM" ]; then
+  # Try the direct path in $defs
+  CONFIG_AZURE_REQ_NORM=$(jq -r '."$defs".azure_key_config.required // ["endpoint", "api_version"] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "api_version,endpoint")
+fi
+
+if [ "$CONFIG_AZURE_REQ_NORM" != "$HELM_AZURE_REQUIRED" ]; then
+  echo "❌ Azure key config required fields mismatch:"
+  echo "   Config: [$CONFIG_AZURE_REQ_NORM]"
+  echo "   Helm:   [$HELM_AZURE_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Azure key config required fields match: [$HELM_AZURE_REQUIRED]"
+fi
+
+# Check vertex_key_config required fields
+CONFIG_VERTEX_REQUIRED=$(jq -r '."$defs".vertex_key.allOf[1].properties.vertex_key_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_VERTEX_REQUIRED=$(jq -r '."$defs".providerKey.properties.vertex_key_config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_VERTEX_REQUIRED" != "$HELM_VERTEX_REQUIRED" ]; then
+  echo "❌ Vertex key config required fields mismatch:"
+  echo "   Config: [$CONFIG_VERTEX_REQUIRED]"
+  echo "   Helm:   [$HELM_VERTEX_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Vertex key config required fields match: [$CONFIG_VERTEX_REQUIRED]"
+fi
+
+# Check bedrock_key_config required fields
+CONFIG_BEDROCK_REQUIRED=$(jq -r '."$defs".bedrock_key.allOf[1].properties.bedrock_key_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_BEDROCK_REQUIRED=$(jq -r '."$defs".providerKey.properties.bedrock_key_config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_BEDROCK_REQUIRED" != "$HELM_BEDROCK_REQUIRED" ]; then
+  echo "❌ Bedrock key config required fields mismatch:"
+  echo "   Config: [$CONFIG_BEDROCK_REQUIRED]"
+  echo "   Helm:   [$HELM_BEDROCK_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Bedrock key config required fields match: [$CONFIG_BEDROCK_REQUIRED]"
+fi
+
+# Check concurrency_config required fields
+CONFIG_CONCURRENCY_REQUIRED=$(jq -r '."$defs".concurrency_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_CONCURRENCY_REQUIRED=$(jq -r '."$defs".concurrencyConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_CONCURRENCY_REQUIRED" != "$HELM_CONCURRENCY_REQUIRED" ]; then
+  echo "❌ Concurrency config required fields mismatch:"
+  echo "   Config: [$CONFIG_CONCURRENCY_REQUIRED]"
+  echo "   Helm:   [$HELM_CONCURRENCY_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Concurrency config required fields match: [$CONFIG_CONCURRENCY_REQUIRED]"
+fi
+
+# Check proxy_config required fields
+CONFIG_PROXY_REQUIRED=$(jq -r '."$defs".proxy_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_PROXY_REQUIRED=$(jq -r '."$defs".proxyConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_PROXY_REQUIRED" != "$HELM_PROXY_REQUIRED" ]; then
+  echo "❌ Proxy config required fields mismatch:"
+  echo "   Config: [$CONFIG_PROXY_REQUIRED]"
+  echo "   Helm:   [$HELM_PROXY_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Proxy config required fields match: [$CONFIG_PROXY_REQUIRED]"
+fi
+
+# Check mcp_client_config required fields
+# Note: Config uses snake_case (connection_type), Helm uses camelCase (connectionType)
+CONFIG_MCP_REQUIRED=$(jq -r '."$defs".mcp_client_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_MCP_REQUIRED=$(jq -r '."$defs".mcpClientConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+# Normalize config snake_case to camelCase for comparison
+CONFIG_MCP_NORM=$(echo "$CONFIG_MCP_REQUIRED" | tr ',' '\n' | sed 's/connection_type/connectionType/' | sort | tr '\n' ',' | sed 's/,$//')
+
+if [ "$CONFIG_MCP_NORM" != "$HELM_MCP_REQUIRED" ]; then
+  echo "❌ MCP client config required fields mismatch:"
+  echo "   Config: [$CONFIG_MCP_REQUIRED] (normalized: [$CONFIG_MCP_NORM])"
+  echo "   Helm:   [$HELM_MCP_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ MCP client config required fields match: [$HELM_MCP_REQUIRED]"
+fi
+
+echo ""
+echo "🔍 Checking required fields in guardrails..."
+
+# Check guardrail_rules required fields
+CONFIG_GUARDRAIL_RULE_REQUIRED=$(jq -r '.properties.guardrails_config.properties.guardrail_rules.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+# Also check in $defs
+if [ -z "$CONFIG_GUARDRAIL_RULE_REQUIRED" ]; then
+  CONFIG_GUARDRAIL_RULE_REQUIRED=$(jq -r '."$defs".guardrails_config.properties.guardrail_rules.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+fi
+HELM_GUARDRAIL_RULE_REQUIRED=$(jq -r '.properties.bifrost.properties.guardrails.properties.rules.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_GUARDRAIL_RULE_REQUIRED" != "$HELM_GUARDRAIL_RULE_REQUIRED" ]; then
+  echo "❌ Guardrail rules required fields mismatch:"
+  echo "   Config: [$CONFIG_GUARDRAIL_RULE_REQUIRED]"
+  echo "   Helm:   [$HELM_GUARDRAIL_RULE_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Guardrail rules required fields match: [$CONFIG_GUARDRAIL_RULE_REQUIRED]"
+fi
+
+# Check guardrail_providers required fields
+CONFIG_GUARDRAIL_PROV_REQUIRED=$(jq -r '.properties.guardrails_config.properties.guardrail_providers.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+if [ -z "$CONFIG_GUARDRAIL_PROV_REQUIRED" ]; then
+  CONFIG_GUARDRAIL_PROV_REQUIRED=$(jq -r '."$defs".guardrails_config.properties.guardrail_providers.items.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+fi
+HELM_GUARDRAIL_PROV_REQUIRED=$(jq -r '.properties.bifrost.properties.guardrails.properties.providers.items.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_GUARDRAIL_PROV_REQUIRED" != "$HELM_GUARDRAIL_PROV_REQUIRED" ]; then
+  echo "❌ Guardrail providers required fields mismatch:"
+  echo "   Config: [$CONFIG_GUARDRAIL_PROV_REQUIRED]"
+  echo "   Helm:   [$HELM_GUARDRAIL_PROV_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Guardrail providers required fields match: [$CONFIG_GUARDRAIL_PROV_REQUIRED]"
+fi
+
+echo ""
+echo "🔍 Checking required fields in cluster config..."
+
+# Check cluster gossip config required fields
+CONFIG_GOSSIP_REQUIRED=$(jq -r '."$defs".cluster_config.properties.gossip.properties.config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_GOSSIP_REQUIRED=$(jq -r '.properties.bifrost.properties.cluster.properties.gossip.properties.config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+# Normalize field names (config uses snake_case, helm uses camelCase)
+CONFIG_GOSSIP_NORM=$(echo "$CONFIG_GOSSIP_REQUIRED" | tr ',' '\n' | sed 's/failure_threshold/failureThreshold/;s/success_threshold/successThreshold/;s/timeout_seconds/timeoutSeconds/' | sort | tr '\n' ',' | sed 's/,$//')
+
+if [ "$CONFIG_GOSSIP_NORM" != "$HELM_GOSSIP_REQUIRED" ]; then
+  echo "❌ Cluster gossip config required fields mismatch:"
+  echo "   Config: [$CONFIG_GOSSIP_REQUIRED] (normalized: [$CONFIG_GOSSIP_NORM])"
+  echo "   Helm:   [$HELM_GOSSIP_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Cluster gossip config required fields match: [$HELM_GOSSIP_REQUIRED]"
+fi
+
+echo ""
+echo "🔍 Checking required fields in virtual_key_provider_config..."
+
+# Check virtual_key_provider_config required fields
+CONFIG_VKPC_REQUIRED=$(jq -r '."$defs".virtual_key_provider_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_VKPC_REQUIRED=$(jq -r '."$defs".virtualKeyProviderConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_VKPC_REQUIRED" != "$HELM_VKPC_REQUIRED" ]; then
+  echo "❌ Virtual key provider config required fields mismatch:"
+  echo "   Config: [$CONFIG_VKPC_REQUIRED]"
+  echo "   Helm:   [$HELM_VKPC_REQUIRED]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Virtual key provider config required fields match: [$CONFIG_VKPC_REQUIRED]"
+fi
+
+echo ""
+if [ $ERRORS -gt 0 ]; then
+  echo "❌ Schema validation failed with $ERRORS error(s)"
+  echo ""
+  echo "To fix these errors, update helm-charts/bifrost/values.schema.json to match"
+  echo "the required fields in transports/config.schema.json"
+  exit 1
+fi
+
+echo "✅ All schema validations passed!"
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ target/
 go.work
 go.work.sum
 
+# Generated schema copy (created by go generate)
+transports/schema/config.schema.json
+
 # Sqlite DBs
 *.db
 *.db-shm

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -2,14 +2,77 @@ package logstore
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"github.com/maximhq/bifrost/framework/migrator"
 	"gorm.io/gorm"
 )
 
+const (
+	// migrationAdvisoryLockKey is used for PostgreSQL advisory locks
+	// to serialize migrations across cluster nodes.
+	// This is the SAME key used by configstore migrations to ensure
+	// all migrations are fully serialized.
+	migrationAdvisoryLockKey = 1000001
+)
+
+// migrationLock holds a dedicated connection for the advisory lock.
+// This ensures the lock is held on the same connection throughout migrations,
+// preventing race conditions caused by GORM's connection pooling.
+type migrationLock struct {
+	conn *sql.Conn
+}
+
+// acquireMigrationLock gets a dedicated connection and acquires an advisory lock.
+// For non-PostgreSQL databases, returns a no-op lock.
+func acquireMigrationLock(ctx context.Context, db *gorm.DB) (*migrationLock, error) {
+	if db.Dialector.Name() != "postgres" {
+		return &migrationLock{}, nil
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sql.DB: %w", err)
+	}
+
+	// Get a dedicated connection (not returned to pool until Close())
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dedicated connection: %w", err)
+	}
+
+	// Acquire advisory lock on this dedicated connection.
+	// This will BLOCK if another node holds the lock.
+	_, err = conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationAdvisoryLockKey)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+	}
+
+	return &migrationLock{conn: conn}, nil
+}
+
+// release unlocks and closes the dedicated connection
+func (l *migrationLock) release(ctx context.Context) {
+	if l.conn == nil {
+		return
+	}
+	// Release lock on the SAME connection that acquired it
+	_, _ = l.conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationAdvisoryLockKey)
+	l.conn.Close()
+}
+
 // Migrate performs the necessary database migrations.
 func triggerMigrations(ctx context.Context, db *gorm.DB) error {
+	// Acquire advisory lock to serialize migrations across cluster nodes.
+	// Uses the same key as configstore to ensure all migrations are serialized.
+	lock, err := acquireMigrationLock(ctx, db)
+	if err != nil {
+		return err
+	}
+	defer lock.release(ctx)
+
 	if err := migrationInit(ctx, db); err != nil {
 		return err
 	}

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.3
+version: 2.0.4
 appVersion: "1.4.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -5,6 +5,7 @@
 {{- if not .Values.image.tag }}
 {{- fail "ERROR: image.tag is required. Please specify the Bifrost image version (e.g., --set image.tag=v1.3.36). See available tags at https://hub.docker.com/r/maximhq/bifrost/tags" }}
 {{- end }}
+{{- include "bifrost.validate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -4,6 +4,7 @@
 {{- if not .Values.image.tag }}
 {{- fail "ERROR: image.tag is required. Please specify the Bifrost image version (e.g., --set image.tag=v1.3.36). See available tags at https://hub.docker.com/r/maximhq/bifrost/tags" }}
 {{- end }}
+{{- include "bifrost.validate" . }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1,0 +1,2068 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Bifrost Helm Chart Values",
+  "description": "Schema for Bifrost Helm chart values.yaml",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of Bifrost replicas"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ],
+          "description": "Image pull policy"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Image tag (required - validated at template render time)"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "deploymentAnnotations": {
+      "type": "object"
+    },
+    "deploymentLabels": {
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "annotations": {
+          "type": "object"
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": [
+                        "Prefix",
+                        "Exact",
+                        "ImplementationSpecific"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object"
+        },
+        "requests": {
+          "type": "object"
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object"
+    },
+    "readinessProbe": {
+      "type": "object"
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    },
+    "volumes": {
+      "type": "array"
+    },
+    "volumeMounts": {
+      "type": "array"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "bifrost": {
+      "type": "object",
+      "description": "Bifrost application configuration",
+      "properties": {
+        "appDir": {
+          "type": "string",
+          "description": "Application data directory"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "host": {
+          "type": "string"
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ]
+        },
+        "logStyle": {
+          "type": "string",
+          "enum": [
+            "json",
+            "text"
+          ]
+        },
+        "encryptionKey": {
+          "type": "string",
+          "description": "Encryption key for sensitive data"
+        },
+        "authConfig": {
+          "$ref": "#/$defs/authConfig"
+        },
+        "client": {
+          "type": "object",
+          "properties": {
+            "dropExcessRequests": {
+              "type": "boolean"
+            },
+            "initialPoolSize": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "allowedOrigins": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "enableLogging": {
+              "type": "boolean"
+            },
+            "disableContentLogging": {
+              "type": "boolean"
+            },
+            "disableDbPingsInHealth": {
+              "type": "boolean"
+            },
+            "logRetentionDays": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "enableGovernance": {
+              "type": "boolean"
+            },
+            "enforceGovernanceHeader": {
+              "type": "boolean"
+            },
+            "allowDirectKeys": {
+              "type": "boolean"
+            },
+            "maxRequestBodySizeMb": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "enableLitellmFallbacks": {
+              "type": "boolean"
+            },
+            "prometheusLabels": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "headerFilterConfig": {
+              "type": "object",
+              "properties": {
+                "allowlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "denylist": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "framework": {
+          "type": "object",
+          "properties": {
+            "pricing": {
+              "type": "object",
+              "properties": {
+                "pricingUrl": {
+                  "type": "string",
+                  "description": "Custom pricing URL (optional, can be empty)"
+                },
+                "pricingSyncInterval": {
+                  "type": "integer",
+                  "minimum": 3600
+                }
+              }
+            }
+          }
+        },
+        "providers": {
+          "type": "object",
+          "description": "AI provider configurations",
+          "additionalProperties": {
+            "$ref": "#/$defs/provider"
+          }
+        },
+        "providerSecrets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "existingSecret": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "envVar": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "mcp": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "clientConfigs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/mcpClientConfig"
+              }
+            },
+            "toolManagerConfig": {
+              "type": "object",
+              "properties": {
+                "toolExecutionTimeout": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "maxAgentDepth": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              }
+            }
+          }
+        },
+        "plugins": {
+          "type": "object",
+          "properties": {
+            "telemetry": {
+              "$ref": "#/$defs/pluginBase"
+            },
+            "logging": {
+              "$ref": "#/$defs/pluginBase"
+            },
+            "governance": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "is_vk_mandatory": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            },
+            "maxim": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "api_key": {
+                      "type": "string"
+                    },
+                    "log_repo_id": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "secretRef": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "key": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "config": {
+                        "required": [
+                          "api_key"
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "secretRef": {
+                        "required": [
+                          "name"
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "semanticCache": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "provider": {
+                      "type": "string",
+                      "enum": [
+                        "openai",
+                        "anthropic",
+                        "gemini",
+                        "bedrock",
+                        "azure",
+                        "cohere",
+                        "mistral",
+                        "groq",
+                        "ollama",
+                        "openrouter",
+                        "vertex",
+                        "cerebras",
+                        "parasail",
+                        "perplexity",
+                        "sgl",
+                        "huggingface"
+                      ]
+                    },
+                    "keys": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "API keys for embedding provider (required when enabled)"
+                    },
+                    "embedding_model": {
+                      "type": "string"
+                    },
+                    "dimension": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "threshold": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "ttl": {
+                      "type": "string"
+                    },
+                    "conversation_history_threshold": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "cache_by_model": {
+                      "type": "boolean"
+                    },
+                    "cache_by_provider": {
+                      "type": "boolean"
+                    },
+                    "exclude_system_prompt": {
+                      "type": "boolean"
+                    },
+                    "cleanup_on_shutdown": {
+                      "type": "boolean"
+                    },
+                    "vector_store_namespace": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "required": [
+                      "provider",
+                      "keys",
+                      "dimension"
+                    ]
+                  }
+                }
+              }
+            },
+            "otel": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "service_name": {
+                      "type": "string"
+                    },
+                    "collector_url": {
+                      "type": "string"
+                    },
+                    "trace_type": {
+                      "type": "string",
+                      "enum": [
+                        "otel"
+                      ]
+                    },
+                    "protocol": {
+                      "type": "string",
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ]
+                    }
+                  }
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "required": [
+                      "collector_url",
+                      "trace_type",
+                      "protocol"
+                    ]
+                  }
+                }
+              }
+            },
+            "datadog": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "service_name": {
+                      "type": "string"
+                    },
+                    "agent_addr": {
+                      "type": "string"
+                    },
+                    "env": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "string"
+                    },
+                    "custom_tags": {
+                      "type": "object"
+                    },
+                    "enable_traces": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            },
+            "custom": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "path": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "config": {
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "name",
+                  "enabled"
+                ]
+              }
+            }
+          }
+        },
+        "governance": {
+          "type": "object",
+          "properties": {
+            "budgets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "max_limit": {
+                    "type": "number"
+                  },
+                  "reset_duration": {
+                    "type": "string"
+                  },
+                  "current_usage": {
+                    "type": "number"
+                  },
+                  "last_reset": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "id",
+                  "max_limit",
+                  "reset_duration"
+                ]
+              }
+            },
+            "rateLimits": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "token_max_limit": {
+                    "type": "integer"
+                  },
+                  "token_reset_duration": {
+                    "type": "string"
+                  },
+                  "request_max_limit": {
+                    "type": "integer"
+                  },
+                  "request_reset_duration": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            },
+            "customers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "budget_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ]
+              }
+            },
+            "teams": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "customer_id": {
+                    "type": "string"
+                  },
+                  "budget_id": {
+                    "type": "string"
+                  },
+                  "profile": {
+                    "type": "object"
+                  },
+                  "config": {
+                    "type": "object"
+                  },
+                  "claims": {
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ]
+              }
+            },
+            "virtualKeys": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "is_active": {
+                    "type": "boolean"
+                  },
+                  "team_id": {
+                    "type": "string"
+                  },
+                  "customer_id": {
+                    "type": "string"
+                  },
+                  "budget_id": {
+                    "type": "string"
+                  },
+                  "rate_limit_id": {
+                    "type": "string"
+                  },
+                  "provider_configs": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/virtualKeyProviderConfig"
+                    }
+                  },
+                  "mcp_configs": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "mcp_client_id": {
+                          "type": "integer"
+                        },
+                        "tools_to_execute": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "mcp_client_id"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "value"
+                ]
+              }
+            },
+            "authConfig": {
+              "$ref": "#/$defs/authConfig"
+            }
+          }
+        },
+        "cluster": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "peers": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "gossip": {
+              "type": "object",
+              "properties": {
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "config": {
+                  "type": "object",
+                  "properties": {
+                    "timeoutSeconds": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "successThreshold": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "failureThreshold": {
+                      "type": "integer",
+                      "minimum": 1
+                    }
+                  },
+                  "required": [
+                    "timeoutSeconds",
+                    "successThreshold",
+                    "failureThreshold"
+                  ]
+                }
+              },
+              "required": [
+                "port",
+                "config"
+              ]
+            },
+            "discovery": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "kubernetes",
+                    "dns",
+                    "udp",
+                    "consul",
+                    "etcd",
+                    "mdns"
+                  ],
+                  "description": "Discovery type (empty when not configured)"
+                },
+                "allowedAddressSpace": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "k8sNamespace": {
+                  "type": "string"
+                },
+                "k8sLabelSelector": {
+                  "type": "string"
+                },
+                "dnsNames": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "udpBroadcastPort": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 65535,
+                  "description": "UDP broadcast port (0 means not configured)"
+                },
+                "consulAddress": {
+                  "type": "string"
+                },
+                "etcdEndpoints": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "mdnsService": {
+                  "type": "string"
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "type"
+                ]
+              }
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "gossip"
+            ]
+          }
+        },
+        "saml": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "",
+                "okta",
+                "entra"
+              ],
+              "description": "SAML provider type (empty when not configured)"
+            },
+            "config": {
+              "type": "object"
+            }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  },
+                  "provider": {
+                    "const": "okta"
+                  }
+                },
+                "required": [
+                  "enabled",
+                  "provider"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "properties": {
+                      "issuerUrl": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "clientId": {
+                        "type": "string"
+                      },
+                      "clientSecret": {
+                        "type": "string"
+                      },
+                      "audience": {
+                        "type": "string"
+                      },
+                      "userIdField": {
+                        "type": "string"
+                      },
+                      "teamIdsField": {
+                        "type": "string"
+                      },
+                      "rolesField": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "issuerUrl",
+                      "clientId"
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  },
+                  "provider": {
+                    "const": "entra"
+                  }
+                },
+                "required": [
+                  "enabled",
+                  "provider"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "properties": {
+                      "tenantId": {
+                        "type": "string"
+                      },
+                      "clientId": {
+                        "type": "string"
+                      },
+                      "clientSecret": {
+                        "type": "string"
+                      },
+                      "audience": {
+                        "type": "string"
+                      },
+                      "appIdUri": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "userIdField": {
+                        "type": "string"
+                      },
+                      "teamIdsField": {
+                        "type": "string"
+                      },
+                      "rolesField": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "tenantId",
+                      "clientId"
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "loadBalancer": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "trackerConfig": {
+              "type": "object"
+            },
+            "bootstrap": {
+              "type": "object"
+            }
+          }
+        },
+        "guardrails": {
+          "type": "object",
+          "properties": {
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "cel_expression": {
+                    "type": "string"
+                  },
+                  "apply_to": {
+                    "type": "string",
+                    "enum": [
+                      "input",
+                      "output",
+                      "both"
+                    ]
+                  },
+                  "sampling_rate": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 100
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "provider_config_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "enabled",
+                  "cel_expression",
+                  "apply_to"
+                ]
+              }
+            },
+            "providers": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "integer"
+                  },
+                  "provider_name": {
+                    "type": "string"
+                  },
+                  "policy_name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "config": {
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "provider_name",
+                  "policy_name",
+                  "enabled"
+                ]
+              }
+            }
+          }
+        },
+        "auditLogs": {
+          "type": "object",
+          "properties": {
+            "disabled": {
+              "type": "boolean"
+            },
+            "hmacKey": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "sqlite",
+            "postgres"
+          ]
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "storageClass": {
+              "type": "string"
+            },
+            "accessMode": {
+              "type": "string",
+              "enum": [
+                "ReadWriteOnce",
+                "ReadWriteMany",
+                "ReadOnlyMany"
+              ]
+            },
+            "size": {
+              "type": "string"
+            },
+            "existingClaim": {
+              "type": "string"
+            }
+          }
+        },
+        "configStore": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "",
+                "sqlite",
+                "postgres"
+              ]
+            },
+            "maxIdleConns": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "maxOpenConns": {
+              "type": "integer",
+              "minimum": 2
+            }
+          }
+        },
+        "logsStore": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "",
+                "sqlite",
+                "postgres"
+              ]
+            },
+            "maxIdleConns": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "maxOpenConns": {
+              "type": "integer",
+              "minimum": 2
+            }
+          }
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "external": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            "user": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "sslMode": {
+              "type": "string",
+              "enum": [
+                "disable",
+                "allow",
+                "prefer",
+                "require",
+                "verify-ca",
+                "verify-full"
+              ]
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "passwordKey": {
+              "type": "string"
+            }
+          },
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "host",
+              "port",
+              "user",
+              "database",
+              "sslMode"
+            ]
+          }
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+              ]
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            }
+          }
+        },
+        "primary": {
+          "type": "object",
+          "properties": {
+            "persistence": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "size": {
+                  "type": "string"
+                }
+              }
+            },
+            "resources": {
+              "type": "object"
+            }
+          }
+        },
+        "metrics": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "vectorStore": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "none",
+            "weaviate",
+            "redis",
+            "qdrant",
+            "pinecone"
+          ]
+        },
+        "weaviate": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "external": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "scheme": {
+                  "type": "string",
+                  "enum": [
+                    "http",
+                    "https"
+                  ]
+                },
+                "host": {
+                  "type": "string"
+                },
+                "apiKey": {
+                  "type": "string"
+                },
+                "grpcHost": {
+                  "type": "string"
+                },
+                "grpcSecured": {
+                  "type": "boolean"
+                },
+                "existingSecret": {
+                  "type": "string"
+                },
+                "apiKeyKey": {
+                  "type": "string"
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "scheme",
+                  "host"
+                ]
+              }
+            },
+            "replicas": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "image": {
+              "type": "object"
+            },
+            "persistence": {
+              "type": "object"
+            },
+            "resources": {
+              "type": "object"
+            },
+            "env": {
+              "type": "object"
+            }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "external": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "password": {
+                  "type": "string"
+                },
+                "database": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "existingSecret": {
+                  "type": "string"
+                },
+                "passwordKey": {
+                  "type": "string"
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "host"
+                ]
+              }
+            },
+            "image": {
+              "type": "object"
+            },
+            "auth": {
+              "type": "object"
+            },
+            "master": {
+              "type": "object"
+            },
+            "metrics": {
+              "type": "object"
+            }
+          }
+        },
+        "qdrant": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "external": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "apiKey": {
+                  "type": "string"
+                },
+                "useTls": {
+                  "type": "boolean"
+                },
+                "existingSecret": {
+                  "type": "string"
+                },
+                "apiKeyKey": {
+                  "type": "string"
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "host"
+                ]
+              }
+            },
+            "image": {
+              "type": "object"
+            },
+            "persistence": {
+              "type": "object"
+            },
+            "resources": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "valueFrom": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      }
+    },
+    "envFrom": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "$defs": {
+    "authConfig": {
+      "type": "object",
+      "properties": {
+        "adminUsername": {
+          "type": "string"
+        },
+        "adminPassword": {
+          "type": "string"
+        },
+        "isEnabled": {
+          "type": "boolean"
+        },
+        "disableAuthOnInference": {
+          "type": "boolean"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "usernameKey": {
+          "type": "string"
+        },
+        "passwordKey": {
+          "type": "string"
+        }
+      }
+    },
+    "pluginBase": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "config": {
+          "type": "object"
+        }
+      }
+    },
+    "provider": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/providerKey"
+          },
+          "minItems": 1
+        },
+        "network_config": {
+          "$ref": "#/$defs/networkConfig"
+        },
+        "concurrency_and_buffer_size": {
+          "$ref": "#/$defs/concurrencyConfig"
+        },
+        "proxy_config": {
+          "$ref": "#/$defs/proxyConfig"
+        },
+        "send_back_raw_response": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "keys"
+      ]
+    },
+    "providerKey": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        },
+        "models": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "weight": {
+          "type": "number",
+          "minimum": 0
+        },
+        "use_for_batch_api": {
+          "type": "boolean"
+        },
+        "azure_key_config": {
+          "type": "object",
+          "properties": {
+            "endpoint": {
+              "type": "string"
+            },
+            "deployments": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "api_version": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "endpoint",
+            "api_version"
+          ]
+        },
+        "vertex_key_config": {
+          "type": "object",
+          "properties": {
+            "project_id": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "auth_credentials": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "project_id",
+            "region"
+          ]
+        },
+        "bedrock_key_config": {
+          "type": "object",
+          "properties": {
+            "access_key": {
+              "type": "string"
+            },
+            "secret_key": {
+              "type": "string"
+            },
+            "session_token": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "arn": {
+              "type": "string"
+            },
+            "deployments": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "region"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "value",
+        "weight"
+      ]
+    },
+    "networkConfig": {
+      "type": "object",
+      "properties": {
+        "base_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "extra_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "default_request_timeout_in_seconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "retry_backoff_initial_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "retry_backoff_max_ms": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "concurrencyConfig": {
+      "type": "object",
+      "properties": {
+        "concurrency": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "buffer_size": {
+          "type": "integer",
+          "minimum": 1
+        }
+      },
+      "required": [
+        "concurrency",
+        "buffer_size"
+      ]
+    },
+    "proxyConfig": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "none",
+            "http",
+            "socks5",
+            "environment"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "username": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "ca_cert_pem": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "mcpClientConfig": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "connectionType": {
+          "type": "string",
+          "enum": [
+            "stdio",
+            "websocket",
+            "http"
+          ]
+        },
+        "stdioConfig": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string"
+            },
+            "args": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "envs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "command"
+          ]
+        },
+        "websocketConfig": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "required": [
+            "url"
+          ]
+        },
+        "httpConfig": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "required": [
+            "url"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "connectionType"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "connectionType": {
+                "const": "stdio"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "stdioConfig"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "connectionType": {
+                "const": "websocket"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "websocketConfig"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "connectionType": {
+                "const": "http"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "httpConfig"
+            ]
+          }
+        }
+      ]
+    },
+    "virtualKeyProviderConfig": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "virtual_key_id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "weight": {
+          "type": "number"
+        },
+        "allowed_models": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "budget_id": {
+          "type": "string"
+        },
+        "rate_limit_id": {
+          "type": "string"
+        },
+        "keys": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": [
+        "provider"
+      ]
+    }
+  }
+}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,28 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.3
+    created: "2026-02-10T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.4.tgz
+    version: 2.0.4
+  - apiVersion: v2
+    appVersion: 1.4.3
     created: "2026-02-05T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -311,4 +333,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-02-05T12:00:00.000000+00:00"
+generated: "2026-02-10T12:00:00.000000+00:00"

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -412,6 +412,10 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 		fmt.Println("")
 		logger.Warn("config file %s does not include \"$schema\":\"https://www.getbifrost.ai/schema\". Use our official schema file to avoid unexpected behavior.", absConfigFilePath)
 	}
+	// Validate config file against the schema - fatal on validation errors
+	if err := ValidateConfigSchema(data); err != nil {
+		logger.Error("config validation failed: %v. You can find the official schema at https://www.getbifrost.ai/schema. Some features may not work as expected unless you fix the config file.", err)
+	}
 	// If config file exists, we will use it to bootstrap config tables
 	logger.Info("loading configuration from: %s", absConfigFilePath)
 	return loadConfigFromFile(ctx, config, data)

--- a/transports/bifrost-http/lib/validator.go
+++ b/transports/bifrost-http/lib/validator.go
@@ -1,0 +1,64 @@
+// Package lib provides core functionality for the Bifrost HTTP service.
+// This file contains JSON schema validation for config files.
+package lib
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// ValidateConfigSchema validates config data against the JSON schema.
+// Returns nil if valid, or a formatted error describing all validation failures.
+func ValidateConfigSchema(data []byte) error {
+	// Pulling config.schema from https://www.getbifrost.ai/schema
+	configSchemaJSON, err := http.Get("https://www.getbifrost.ai/schema")
+	if err != nil {
+		return fmt.Errorf("failed to get config schema: %w", err)
+	}
+	defer configSchemaJSON.Body.Close()
+	configSchemaJSONBytes, err := io.ReadAll(configSchemaJSON.Body)
+	if err != nil {
+		logger.Warn("failed to download config schema: %v. running without config.json schema validation", err)
+		return nil
+	}
+	// Parse the schema JSON
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(configSchemaJSONBytes))
+	if err != nil {
+		return fmt.Errorf("failed to parse config schema JSON: %w", err)
+	}
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource("config.schema.json", schemaDoc); err != nil {
+		return fmt.Errorf("failed to add config schema resource: %w", err)
+	}
+	// Compile the schema
+	compiledSchema, err := c.Compile("config.schema.json")
+	if err != nil {
+		return fmt.Errorf("failed to compile config schema: %w", err)
+	}
+	var v any
+	if err := json.Unmarshal(data, &v); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	err = compiledSchema.Validate(v)
+	if err == nil {
+		return nil
+	}
+	// Format validation errors for better readability
+	return formatValidationError(err)
+}
+
+// formatValidationError converts jsonschema validation errors into user-friendly messages
+func formatValidationError(err error) error {
+	validationErr, ok := err.(*jsonschema.ValidationError)
+	if !ok {
+		return err
+	}
+
+	// Use the GoString format which provides detailed hierarchical output
+	return fmt.Errorf("schema validation failed:\n%s", validationErr.GoString())
+}

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1,0 +1,1418 @@
+package lib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateConfigSchema_ValidConfig(t *testing.T) {
+	// Minimal valid config matching the schema
+	validConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "default",
+						"value": "sk-test-key",
+						"weight": 1.0,
+						"models": ["gpt-4"]
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_EmptyObject(t *testing.T) {
+	// Empty object should be valid (all properties are optional)
+	emptyConfig := `{}`
+
+	err := ValidateConfigSchema([]byte(emptyConfig))
+	if err != nil {
+		t.Errorf("expected empty config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_InvalidJSON(t *testing.T) {
+	invalidJSON := `{invalid json`
+
+	err := ValidateConfigSchema([]byte(invalidJSON))
+	if err == nil {
+		t.Error("expected invalid JSON to fail validation")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Errorf("expected error to mention 'invalid JSON', got: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_InvalidType(t *testing.T) {
+	// client.initial_pool_size should be an integer, not a string
+	invalidConfig := `{
+		"client": {
+			"initial_pool_size": "not-a-number"
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config with wrong type to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_InvalidEnum(t *testing.T) {
+	// vector_store.type must be one of: weaviate, redis, qdrant, pinecone
+	invalidConfig := `{
+		"vector_store": {
+			"enabled": true,
+			"type": "invalid-store-type"
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config with invalid enum value to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MissingRequiredField(t *testing.T) {
+	// governance.budgets items require id, max_limit, and reset_duration
+	invalidConfig := `{
+		"governance": {
+			"budgets": [
+				{
+					"id": "budget-1"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing required fields to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_ValidGovernanceConfig(t *testing.T) {
+	validConfig := `{
+		"governance": {
+			"budgets": [
+				{
+					"id": "budget-1",
+					"max_limit": 100.0,
+					"reset_duration": "1d"
+				}
+			],
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Key",
+					"value": "vk_test123"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid governance config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_ValidClientConfig(t *testing.T) {
+	// allowed_origins with "*" or URI strings (but not both in same array according to oneOf)
+	validConfig := `{
+		"client": {
+			"initial_pool_size": 500,
+			"drop_excess_requests": true,
+			"enable_logging": true,
+			"log_retention_days": 30,
+			"allowed_origins": ["https://example.com"]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid client config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_InvalidMinimum(t *testing.T) {
+	// initial_pool_size has minimum: 1
+	invalidConfig := `{
+		"client": {
+			"initial_pool_size": 0
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config with value below minimum to fail validation")
+	}
+}
+
+// =============================================================================
+// Provider Key Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_ProviderKey_Valid(t *testing.T) {
+	// Valid provider key with all required fields: name, value, weight
+	validConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "my-key",
+						"value": "sk-test-key-12345",
+						"weight": 1.0
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid provider key config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_ProviderKey_MissingName(t *testing.T) {
+	// Missing required field: name
+	invalidConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"value": "sk-test-key-12345",
+						"weight": 1.0
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'name' in provider key to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_ProviderKey_MissingValue(t *testing.T) {
+	// Missing required field: value
+	invalidConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "my-key",
+						"weight": 1.0
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'value' in provider key to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_ProviderKey_MissingWeight(t *testing.T) {
+	// Missing required field: weight
+	invalidConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "my-key",
+						"value": "sk-test-key-12345"
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'weight' in provider key to fail validation")
+	}
+}
+
+// =============================================================================
+// Governance Budget Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_Budget_Valid(t *testing.T) {
+	// Valid budget with all required fields: id, max_limit, reset_duration
+	validConfig := `{
+		"governance": {
+			"budgets": [
+				{
+					"id": "budget-1",
+					"max_limit": 100.0,
+					"reset_duration": "30d"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid budget config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_Budget_MissingId(t *testing.T) {
+	// Missing required field: id
+	invalidConfig := `{
+		"governance": {
+			"budgets": [
+				{
+					"max_limit": 100.0,
+					"reset_duration": "30d"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'id' in budget to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_Budget_MissingMaxLimit(t *testing.T) {
+	// Missing required field: max_limit
+	invalidConfig := `{
+		"governance": {
+			"budgets": [
+				{
+					"id": "budget-1",
+					"reset_duration": "30d"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'max_limit' in budget to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_Budget_MissingResetDuration(t *testing.T) {
+	// Missing required field: reset_duration
+	invalidConfig := `{
+		"governance": {
+			"budgets": [
+				{
+					"id": "budget-1",
+					"max_limit": 100.0
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'reset_duration' in budget to fail validation")
+	}
+}
+
+// =============================================================================
+// Governance Rate Limit Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_RateLimit_Valid(t *testing.T) {
+	// Valid rate limit with required field: id
+	validConfig := `{
+		"governance": {
+			"rate_limits": [
+				{
+					"id": "rate-limit-1",
+					"token_max_limit": 10000,
+					"token_reset_duration": "1h"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid rate limit config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_RateLimit_MissingId(t *testing.T) {
+	// Missing required field: id
+	invalidConfig := `{
+		"governance": {
+			"rate_limits": [
+				{
+					"token_max_limit": 10000,
+					"token_reset_duration": "1h"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'id' in rate limit to fail validation")
+	}
+}
+
+// =============================================================================
+// Governance Customer Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_Customer_Valid(t *testing.T) {
+	// Valid customer with all required fields: id, name
+	validConfig := `{
+		"governance": {
+			"customers": [
+				{
+					"id": "customer-1",
+					"name": "Acme Corp"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid customer config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_Customer_MissingId(t *testing.T) {
+	// Missing required field: id
+	invalidConfig := `{
+		"governance": {
+			"customers": [
+				{
+					"name": "Acme Corp"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'id' in customer to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_Customer_MissingName(t *testing.T) {
+	// Missing required field: name
+	invalidConfig := `{
+		"governance": {
+			"customers": [
+				{
+					"id": "customer-1"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'name' in customer to fail validation")
+	}
+}
+
+// =============================================================================
+// Governance Team Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_Team_Valid(t *testing.T) {
+	// Valid team with all required fields: id, name
+	validConfig := `{
+		"governance": {
+			"teams": [
+				{
+					"id": "team-1",
+					"name": "Engineering"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid team config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_Team_MissingId(t *testing.T) {
+	// Missing required field: id
+	invalidConfig := `{
+		"governance": {
+			"teams": [
+				{
+					"name": "Engineering"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'id' in team to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_Team_MissingName(t *testing.T) {
+	// Missing required field: name
+	invalidConfig := `{
+		"governance": {
+			"teams": [
+				{
+					"id": "team-1"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'name' in team to fail validation")
+	}
+}
+
+// =============================================================================
+// Governance Virtual Key Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_VirtualKey_Valid(t *testing.T) {
+	// Valid virtual key with all required fields: id, name, value
+	validConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Virtual Key",
+					"value": "vk_test_123456"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid virtual key config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_VirtualKey_MissingId(t *testing.T) {
+	// Missing required field: id
+	invalidConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"name": "Test Virtual Key",
+					"value": "vk_test_123456"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'id' in virtual key to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_VirtualKey_MissingName(t *testing.T) {
+	// Missing required field: name
+	invalidConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"value": "vk_test_123456"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'name' in virtual key to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_VirtualKey_MissingValue(t *testing.T) {
+	// Missing required field: value
+	invalidConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Virtual Key"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'value' in virtual key to fail validation")
+	}
+}
+
+// =============================================================================
+// Virtual Key Provider Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_VirtualKeyProviderConfig_Valid(t *testing.T) {
+	// Valid virtual key provider config with required field: provider
+	validConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Virtual Key",
+					"value": "vk_test_123456",
+					"provider_configs": [
+						{
+							"provider": "openai"
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid virtual key provider config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_VirtualKeyProviderConfig_MissingProvider(t *testing.T) {
+	// Missing required field: provider
+	invalidConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Virtual Key",
+					"value": "vk_test_123456",
+					"provider_configs": [
+						{
+							"weight": 1.0
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'provider' in virtual key provider config to fail validation")
+	}
+}
+
+// =============================================================================
+// Virtual Key MCP Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_VirtualKeyMCPConfig_Valid(t *testing.T) {
+	// Valid virtual key MCP config with required field: mcp_client_id
+	validConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Virtual Key",
+					"value": "vk_test_123456",
+					"mcp_configs": [
+						{
+							"mcp_client_id": 1
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid virtual key MCP config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_VirtualKeyMCPConfig_MissingMCPClientId(t *testing.T) {
+	// Missing required field: mcp_client_id
+	invalidConfig := `{
+		"governance": {
+			"virtual_keys": [
+				{
+					"id": "vk-1",
+					"name": "Test Virtual Key",
+					"value": "vk_test_123456",
+					"mcp_configs": [
+						{
+							"tools_to_execute": ["tool1"]
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'mcp_client_id' in virtual key MCP config to fail validation")
+	}
+}
+
+// =============================================================================
+// MCP Client Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_MCPClientConfig_Valid_Stdio(t *testing.T) {
+	// Valid MCP client config with stdio connection type
+	validConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "stdio",
+					"stdio_config": {
+						"command": "/usr/bin/my-tool"
+					}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid MCP client config (stdio) to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_Valid_Websocket(t *testing.T) {
+	// Valid MCP client config with websocket connection type
+	validConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "websocket",
+					"websocket_config": {
+						"url": "ws://localhost:8080"
+					}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid MCP client config (websocket) to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_Valid_Http(t *testing.T) {
+	// Valid MCP client config with http connection type
+	validConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "http",
+					"http_config": {
+						"url": "http://localhost:8080"
+					}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid MCP client config (http) to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_MissingName(t *testing.T) {
+	// Missing required field: name
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"connection_type": "stdio",
+					"stdio_config": {
+						"command": "/usr/bin/my-tool"
+					}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'name' in MCP client config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_MissingConnectionType(t *testing.T) {
+	// Missing required field: connection_type
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"stdio_config": {
+						"command": "/usr/bin/my-tool"
+					}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'connection_type' in MCP client config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_MissingStdioConfig(t *testing.T) {
+	// Missing conditional required field: stdio_config when connection_type is stdio
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "stdio"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'stdio_config' for stdio connection type to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_MissingWebsocketConfig(t *testing.T) {
+	// Missing conditional required field: websocket_config when connection_type is websocket
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "websocket"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'websocket_config' for websocket connection type to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_MissingHttpConfig(t *testing.T) {
+	// Missing conditional required field: http_config when connection_type is http
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "http"
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'http_config' for http connection type to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_StdioConfig_MissingCommand(t *testing.T) {
+	// Missing required field in stdio_config: command
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "stdio",
+					"stdio_config": {
+						"args": ["--help"]
+					}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'command' in stdio_config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_WebsocketConfig_MissingUrl(t *testing.T) {
+	// Missing required field in websocket_config: url
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "websocket",
+					"websocket_config": {}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'url' in websocket_config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_MCPClientConfig_HttpConfig_MissingUrl(t *testing.T) {
+	// Missing required field in http_config: url
+	invalidConfig := `{
+		"mcp": {
+			"client_configs": [
+				{
+					"name": "my-mcp-client",
+					"connection_type": "http",
+					"http_config": {}
+				}
+			]
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'url' in http_config to fail validation")
+	}
+}
+
+// =============================================================================
+// Concurrency Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_ConcurrencyConfig_Valid(t *testing.T) {
+	// Valid concurrency config with all required fields: concurrency, buffer_size
+	validConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "my-key",
+						"value": "sk-test-key",
+						"weight": 1.0
+					}
+				],
+				"concurrency_and_buffer_size": {
+					"concurrency": 10,
+					"buffer_size": 100
+				}
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid concurrency config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_ConcurrencyConfig_MissingConcurrency(t *testing.T) {
+	// Missing required field: concurrency
+	invalidConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "my-key",
+						"value": "sk-test-key",
+						"weight": 1.0
+					}
+				],
+				"concurrency_and_buffer_size": {
+					"buffer_size": 100
+				}
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'concurrency' in concurrency config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_ConcurrencyConfig_MissingBufferSize(t *testing.T) {
+	// Missing required field: buffer_size
+	invalidConfig := `{
+		"providers": {
+			"openai": {
+				"keys": [
+					{
+						"name": "my-key",
+						"value": "sk-test-key",
+						"weight": 1.0
+					}
+				],
+				"concurrency_and_buffer_size": {
+					"concurrency": 10
+				}
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'buffer_size' in concurrency config to fail validation")
+	}
+}
+
+// =============================================================================
+// Plugin Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_Plugin_Valid(t *testing.T) {
+	// Valid plugin with all required fields: enabled, name, config
+	// Note: telemetry plugin requires config object
+	validConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "telemetry",
+				"config": {}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid plugin config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_Plugin_MissingEnabled(t *testing.T) {
+	// Missing required field: enabled
+	invalidConfig := `{
+		"plugins": [
+			{
+				"name": "telemetry"
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'enabled' in plugin to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_Plugin_MissingName(t *testing.T) {
+	// Missing required field: name
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'name' in plugin to fail validation")
+	}
+}
+
+// =============================================================================
+// Semantic Cache Plugin Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
+	// Valid semantic cache plugin with all required fields: provider, keys, dimension
+	validConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semanticcache",
+				"config": {
+					"provider": "openai",
+					"keys": ["sk-test-key"],
+					"dimension": 1536
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid semantic cache plugin config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_SemanticCachePlugin_MissingProvider(t *testing.T) {
+	// Missing required field: provider
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semanticcache",
+				"config": {
+					"keys": ["sk-test-key"],
+					"dimension": 1536
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'provider' in semantic cache plugin to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_SemanticCachePlugin_MissingKeys(t *testing.T) {
+	// Missing required field: keys
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semanticcache",
+				"config": {
+					"provider": "openai",
+					"dimension": 1536
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'keys' in semantic cache plugin to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_SemanticCachePlugin_MissingDimension(t *testing.T) {
+	// Missing required field: dimension
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semanticcache",
+				"config": {
+					"provider": "openai",
+					"keys": ["sk-test-key"]
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'dimension' in semantic cache plugin to fail validation")
+	}
+}
+
+// =============================================================================
+// OTEL Plugin Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_OtelPlugin_Valid(t *testing.T) {
+	// Valid OTEL plugin with all required fields: collector_url, trace_type, protocol
+	validConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "otel",
+				"config": {
+					"collector_url": "http://localhost:4318",
+					"trace_type": "otel",
+					"protocol": "http"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid OTEL plugin config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_OtelPlugin_MissingCollectorUrl(t *testing.T) {
+	// Missing required field: collector_url
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "otel",
+				"config": {
+					"trace_type": "otel",
+					"protocol": "http"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'collector_url' in OTEL plugin to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_OtelPlugin_MissingTraceType(t *testing.T) {
+	// Missing required field: trace_type
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "otel",
+				"config": {
+					"collector_url": "http://localhost:4318",
+					"protocol": "http"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'trace_type' in OTEL plugin to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_OtelPlugin_MissingProtocol(t *testing.T) {
+	// Missing required field: protocol
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "otel",
+				"config": {
+					"collector_url": "http://localhost:4318",
+					"trace_type": "otel"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'protocol' in OTEL plugin to fail validation")
+	}
+}
+
+// =============================================================================
+// Maxim Plugin Config Required Fields Tests
+// =============================================================================
+
+func TestValidateConfigSchema_MaximPlugin_Valid(t *testing.T) {
+	// Valid Maxim plugin with required field: api_key
+	validConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "maxim",
+				"config": {
+					"api_key": "maxim-api-key-12345"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig))
+	if err != nil {
+		t.Errorf("expected valid Maxim plugin config to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_MaximPlugin_MissingApiKey(t *testing.T) {
+	// Missing required field: api_key
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "maxim",
+				"config": {
+					"log_repo_id": "my-log-repo"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'api_key' in Maxim plugin to fail validation")
+	}
+}
+
+// =============================================================================
+// Azure Key Config Required Fields Tests
+// Note: Azure provider uses a special key schema that extends base_key
+// The azure_key_config is only valid within the azure provider's keys array
+// =============================================================================
+
+func TestValidateConfigSchema_AzureKeyConfig_MissingEndpoint(t *testing.T) {
+	// Missing required field: endpoint in azure_key_config
+	// This test validates that when azure_key_config is present, endpoint is required
+	invalidConfig := `{
+		"providers": {
+			"azure": {
+				"keys": [
+					{
+						"name": "azure-key",
+						"value": "azure-api-key",
+						"weight": 1.0,
+						"azure_key_config": {
+							"api_version": "2024-02-15-preview"
+						}
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'endpoint' in Azure key config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_AzureKeyConfig_MissingApiVersion(t *testing.T) {
+	// Missing required field: api_version in azure_key_config
+	invalidConfig := `{
+		"providers": {
+			"azure": {
+				"keys": [
+					{
+						"name": "azure-key",
+						"value": "azure-api-key",
+						"weight": 1.0,
+						"azure_key_config": {
+							"endpoint": "https://my-resource.openai.azure.com"
+						}
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'api_version' in Azure key config to fail validation")
+	}
+}
+
+// =============================================================================
+// Vertex Key Config Required Fields Tests
+// Note: Vertex provider uses a special key schema that extends base_key
+// =============================================================================
+
+func TestValidateConfigSchema_VertexKeyConfig_MissingProjectId(t *testing.T) {
+	// Missing required field: project_id in vertex_key_config
+	invalidConfig := `{
+		"providers": {
+			"vertex": {
+				"keys": [
+					{
+						"name": "vertex-key",
+						"value": "vertex-api-key",
+						"weight": 1.0,
+						"vertex_key_config": {
+							"region": "us-central1"
+						}
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'project_id' in Vertex key config to fail validation")
+	}
+}
+
+func TestValidateConfigSchema_VertexKeyConfig_MissingRegion(t *testing.T) {
+	// Missing required field: region in vertex_key_config
+	invalidConfig := `{
+		"providers": {
+			"vertex": {
+				"keys": [
+					{
+						"name": "vertex-key",
+						"value": "vertex-api-key",
+						"weight": 1.0,
+						"vertex_key_config": {
+							"project_id": "my-gcp-project"
+						}
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'region' in Vertex key config to fail validation")
+	}
+}
+
+// =============================================================================
+// Bedrock Key Config Required Fields Tests
+// Note: Bedrock provider uses a special key schema that extends base_key
+// =============================================================================
+
+func TestValidateConfigSchema_BedrockKeyConfig_MissingRegion(t *testing.T) {
+	// Missing required field: region in bedrock_key_config
+	invalidConfig := `{
+		"providers": {
+			"bedrock": {
+				"keys": [
+					{
+						"name": "bedrock-key",
+						"value": "bedrock-api-key",
+						"weight": 1.0,
+						"bedrock_key_config": {
+							"access_key": "AKIAIOSFODNN7EXAMPLE"
+						}
+					}
+				]
+			}
+		}
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig))
+	if err == nil {
+		t.Error("expected config missing 'region' in Bedrock key config to fail validation")
+	}
+}
+
+// =============================================================================
+// Guardrails Config Tests
+// Note: Guardrails is an enterprise feature. The guardrails_config schema
+// validation is tested but the detailed rules/providers validation is only
+// available in the enterprise version. The public schema validates that the
+// guardrails_config exists but doesn't expose detailed structure.
+// =============================================================================
+
+// Guardrails tests are skipped for the public schema as guardrails_config
+// is an enterprise feature with a different schema structure.
+// Enterprise-specific tests should be added to the enterprise test suite.

--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -69,6 +69,7 @@ import (
 //go:embed all:ui
 var uiContent embed.FS
 
+
 var Version string
 
 var logger = bifrost.NewDefaultLogger(schemas.LogLevelInfo)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -107,7 +107,7 @@ type BifrostHTTPServer struct {
 	LogsCleaner    *logstore.LogsCleaner
 
 	Client *bifrost.Bifrost
-	Config *lib.Config
+	Config *lib.Config	
 
 	Server *fasthttp.Server
 	Router *router.Router

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5,6 +5,11 @@
   "description": "Schema for Bifrost HTTP transport configuration",
   "type": "object",
   "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "The schema version. This should be set to \"https://www.getbifrost.ai/schema\"",
+      "const": "https://www.getbifrost.ai/schema"
+    },
     "encryption_key": {
       "type": "string",
       "description": "You can set the value as env.<ENV_VAR_NAME> to use an environment variable. We also read encryption key from BIFROST_ENCRYPTION_KEY environment variable. Note: once set, the encryption key cannot be changed unless you clean up the database. Accepts any string; a secure 32-byte AES-256 key will be derived using Argon2id KDF. If not provided, data will be saved in plain text. Recommended: use a passphrase of at least 16 bytes for better security"
@@ -402,8 +407,7 @@
             },
             "required": [
               "id",
-              "name",
-              "value"
+              "name"
             ],
             "additionalProperties": false
           }
@@ -1515,10 +1519,8 @@
       },
       "required": [
         "name",
-        "value",
         "weight"
-      ],
-      "additionalProperties": false
+      ]
     },
     "bedrock_key": {
       "allOf": [

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/maximhq/bifrost/plugins/semanticcache v1.4.17
 	github.com/maximhq/bifrost/plugins/telemetry v1.4.19
 	github.com/prometheus/client_golang v1.23.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fasthttp v1.68.0
 	gorm.io/driver/sqlite v1.6.0

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -89,6 +89,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/fasthttp/router v1.5.4 h1:oxdThbBwQgsDIYZ3wR1IavsNl6ZS9WdjKukeMikOnC8=
 github.com/fasthttp/router v1.5.4/go.mod h1:3/hysWq6cky7dTfzaaEPZGdptwjwx0qzTgFCKEWRjgc=
 github.com/fasthttp/websocket v1.5.12 h1:e4RGPpWW2HTbL3zV0Y/t7g0ub294LkiuXXUuTOUInlE=
@@ -263,6 +264,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 h1:qIQ0tWF9vxGtkJa24bR+2i53WBCz1nW/Pc47oVYauC4=
 github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287/go.mod h1:sM7Mt7uEoCeFSCBM+qBrqvEo+/9vdmj19wzp3yzUhmg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=


### PR DESCRIPTION
## Summary

Fixes a race condition that causes cluster startup failures when multiple nodes start simultaneously against a fresh PostgreSQL database. The error manifests as:
```
ERROR: duplicate key value violates unique constraint "pg_type_typname_nsp_index" (SQLSTATE 23505)
```

This occurs because both configstore and logstore migrations run in parallel across nodes, with each trying to create the same tables/types simultaneously.

## Changes

- Added PostgreSQL advisory lock to `configstore/migrations.go` to serialize migrations across cluster nodes
- Added the same advisory lock pattern to `logstore/migrations.go` using the same lock key (1000001) to ensure complete serialization of ALL migrations
- For non-PostgreSQL databases (SQLite), the lock is a no-op since they don't support clustering

Key design decisions:
- Uses `pg_advisory_lock` which blocks waiting nodes until the lock is released (vs `pg_try_advisory_lock` which would fail immediately)
- Uses a dedicated `sql.Conn` to hold the lock, preventing GORM's connection pooling from releasing it prematurely
- Both stores use the same lock key to ensure configstore and logstore migrations never run concurrently

### Database Agnostic

The fix is database agnostic - it only applies advisory locking for PostgreSQL and is a no-op for other databases:

```go
func acquireMigrationLock(ctx context.Context, db *gorm.DB) (*migrationLock, error) {
    if db.Dialector.Name() != "postgres" {
        return &migrationLock{}, nil  // No-op for non-PostgreSQL
    }
    // ... PostgreSQL advisory lock logic
}
```

- **PostgreSQL**: Uses `pg_advisory_lock` to serialize migrations across cluster nodes
- **SQLite/MySQL/Others**: Returns a no-op lock (migrations run normally without blocking)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Set up a fresh PostgreSQL database
2. Start 3 nodes simultaneously pointing to the same database:
   ```sh
   # Terminal 1, 2, 3 - run simultaneously
   ./bifrost-http --config config.json
   ```
3. All 3 nodes should start successfully without migration errors
4. Check logs - one node should complete migrations first, others wait then succeed

```sh
# Unit tests
go test ./framework/configstore/... -v
go test ./framework/logstore/... -v
```

## Screenshots/Recordings

N/A - backend change

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes cluster startup race condition in enterprise deployments.

## Security considerations

None - advisory locks are session-scoped and automatically released on disconnect.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable