### PR TITLE
test fixes

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -1325,6 +1325,11 @@ EOF
   log_info "Building current version from Go workspace..."
   local current_binary="$TEMP_DIR/bifrost-http-current"
   cd "$REPO_ROOT"
+  # Ensure the embedded ui directory exists (it's gitignored, so it won't be present in CI)
+  if [ ! -d "$REPO_ROOT/transports/bifrost-http/ui" ]; then
+    mkdir -p "$REPO_ROOT/transports/bifrost-http/ui"
+    echo "placeholder" > "$REPO_ROOT/transports/bifrost-http/ui/.gitkeep"
+  fi
   if ! go build -o "$current_binary" ./transports/bifrost-http; then
     log_error "Failed to build current version"
     return 1
@@ -1513,6 +1518,11 @@ EOF
   log_info "Building current version from Go workspace..."
   local current_binary="$TEMP_DIR/bifrost-http-current"
   cd "$REPO_ROOT"
+  # Ensure the embedded ui directory exists (it's gitignored, so it won't be present in CI)
+  if [ ! -d "$REPO_ROOT/transports/bifrost-http/ui" ]; then
+    mkdir -p "$REPO_ROOT/transports/bifrost-http/ui"
+    echo "placeholder" > "$REPO_ROOT/transports/bifrost-http/ui/.gitkeep"
+  fi
   if ! go build -o "$current_binary" ./transports/bifrost-http; then
     log_error "Failed to build current version"
     return 1

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -843,8 +843,7 @@
                 },
                 "required": [
                   "id",
-                  "name",
-                  "value"
+                  "name"
                 ]
               }
             },
@@ -1833,7 +1832,6 @@
       },
       "required": [
         "name",
-        "value",
         "weight"
       ]
     },


### PR DESCRIPTION
## Summary

Fix migration tests and update JSON schema requirements for Bifrost Helm chart values.

## Changes

- Added code to create the `ui` directory for bifrost-http during migration tests if it doesn't exist
- This ensures the build process doesn't fail in CI environments where the gitignored directory is missing
- Removed unnecessary `value` requirement from the Helm chart values schema for both route parameters and routes

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the migration tests to verify they complete successfully:

```sh
./.github/workflows/scripts/run-migration-tests.sh
```

Validate that Helm chart values without the previously required `value` field are now accepted:

```sh
helm lint helm-charts/bifrost --values your-values.yaml
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes CI failures in migration tests due to missing UI directory.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable