### PR TITLE
ordered map fixes

### DIFF
--- a/core/internal/llmtests/prompt_caching.go
+++ b/core/internal/llmtests/prompt_caching.go
@@ -40,12 +40,12 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Retrieve account information for a given account ID"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"account_id": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("account_id", map[string]interface{}{
 							"type":        "string",
 							"description": "The unique account identifier",
-						},
-					},
+						}),
+					),
 					Required: []string{"account_id"},
 				},
 			},
@@ -57,22 +57,22 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Calculate the cost for cloud resource usage based on service type and quantity"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"service_type": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("service_type", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"compute", "storage", "network", "database"},
 							"description": "The type of service being used",
-						},
-						"quantity": map[string]interface{}{
+						}),
+						schemas.KV("quantity", map[string]interface{}{
 							"type":        "number",
 							"description": "The quantity of resources used",
-						},
-						"unit": map[string]interface{}{
+						}),
+						schemas.KV("unit", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"hours", "GB", "requests", "GB-hours"},
 							"description": "The unit of measurement",
-						},
-					},
+						}),
+					),
 					Required: []string{"service_type", "quantity", "unit"},
 				},
 			},
@@ -84,12 +84,12 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Check the current status and health of the API service"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"endpoint": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("endpoint", map[string]interface{}{
 							"type":        "string",
 							"description": "Optional specific API endpoint to check",
-						},
-					},
+						}),
+					),
 					Required: []string{},
 				},
 			},
@@ -101,26 +101,26 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Create a new support ticket for a customer issue"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"subject": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("subject", map[string]interface{}{
 							"type":        "string",
 							"description": "Brief subject line for the ticket",
-						},
-						"description": map[string]interface{}{
+						}),
+						schemas.KV("description", map[string]interface{}{
 							"type":        "string",
 							"description": "Detailed description of the issue",
-						},
-						"priority": map[string]interface{}{
+						}),
+						schemas.KV("priority", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"low", "medium", "high", "urgent"},
 							"description": "Priority level of the ticket",
-						},
-						"category": map[string]interface{}{
+						}),
+						schemas.KV("category", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"technical", "billing", "account", "feature_request"},
 							"description": "Category of the support request",
-						},
-					},
+						}),
+					),
 					Required: []string{"subject", "description", "priority", "category"},
 				},
 			},
@@ -132,17 +132,17 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Retrieve documentation for a specific service or feature"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"service_name": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("service_name", map[string]interface{}{
 							"type":        "string",
 							"description": "Name of the service or feature",
-						},
-						"doc_type": map[string]interface{}{
+						}),
+						schemas.KV("doc_type", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"api", "guide", "tutorial", "reference"},
 							"description": "Type of documentation requested",
-						},
-					},
+						}),
+					),
 					Required: []string{"service_name"},
 				},
 			},
@@ -154,13 +154,13 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Get a list of available cloud regions for deployment"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"service_type": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("service_type", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"compute", "storage", "database", "all"},
 							"description": "Filter by service type or 'all' for all services",
-						},
-					},
+						}),
+					),
 					Required: []string{},
 				},
 			},
@@ -172,24 +172,24 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Estimate the monthly cost for a cloud deployment configuration"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"instance_type": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("instance_type", map[string]interface{}{
 							"type":        "string",
 							"description": "Type of compute instance",
-						},
-						"instance_count": map[string]interface{}{
+						}),
+						schemas.KV("instance_count", map[string]interface{}{
 							"type":        "integer",
 							"description": "Number of instances",
-						},
-						"storage_gb": map[string]interface{}{
+						}),
+						schemas.KV("storage_gb", map[string]interface{}{
 							"type":        "number",
 							"description": "Storage in GB",
-						},
-						"region": map[string]interface{}{
+						}),
+						schemas.KV("region", map[string]interface{}{
 							"type":        "string",
 							"description": "Deployment region",
-						},
-					},
+						}),
+					),
 					Required: []string{"instance_type", "instance_count", "storage_gb", "region"},
 				},
 			},
@@ -201,12 +201,12 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Validate an API key and return its permissions and status"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"api_key": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("api_key", map[string]interface{}{
 							"type":        "string",
 							"description": "The API key to validate",
-						},
-					},
+						}),
+					),
 					Required: []string{"api_key"},
 				},
 			},
@@ -218,25 +218,25 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Retrieve usage analytics and metrics for an account"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"account_id": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("account_id", map[string]interface{}{
 							"type":        "string",
 							"description": "Account ID to get analytics for",
-						},
-						"start_date": map[string]interface{}{
+						}),
+						schemas.KV("start_date", map[string]interface{}{
 							"type":        "string",
 							"description": "Start date in YYYY-MM-DD format",
-						},
-						"end_date": map[string]interface{}{
+						}),
+						schemas.KV("end_date", map[string]interface{}{
 							"type":        "string",
 							"description": "End date in YYYY-MM-DD format",
-						},
-						"metric_type": map[string]interface{}{
+						}),
+						schemas.KV("metric_type", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"requests", "cost", "latency", "errors", "all"},
 							"description": "Type of metrics to retrieve",
-						},
-					},
+						}),
+					),
 					Required: []string{"account_id", "start_date", "end_date"},
 				},
 			},
@@ -248,17 +248,17 @@ func GetPromptCachingTools() []schemas.ChatTool {
 				Description: bifrost.Ptr("Check compliance status and certifications for security and regulatory requirements"),
 				Parameters: &schemas.ToolFunctionParameters{
 					Type: "object",
-					Properties: &schemas.OrderedMap{
-						"compliance_type": map[string]interface{}{
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("compliance_type", map[string]interface{}{
 							"type":        "string",
 							"enum":        []string{"SOC2", "ISO27001", "GDPR", "HIPAA", "all"},
 							"description": "Type of compliance to check",
-						},
-						"region": map[string]interface{}{
+						}),
+						schemas.KV("region", map[string]interface{}{
 							"type":        "string",
 							"description": "Optional region to check compliance for",
-						},
-					},
+						}),
+					),
 					Required: []string{},
 				},
 			},

--- a/core/internal/llmtests/responses_stream.go
+++ b/core/internal/llmtests/responses_stream.go
@@ -316,16 +316,16 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				ResponsesToolFunction: &schemas.ResponsesToolFunction{
 					Parameters: &schemas.ToolFunctionParameters{
 						Type: "object",
-						Properties: &schemas.OrderedMap{
-							"location": map[string]interface{}{
+						Properties: schemas.NewOrderedMapFromPairs(
+							schemas.KV("location", map[string]interface{}{
 								"type":        "string",
 								"description": "The city and state, e.g. San Francisco, CA",
-							},
-							"unit": map[string]interface{}{
+							}),
+							schemas.KV("unit", map[string]interface{}{
 								"type": "string",
 								"enum": []string{"celsius", "fahrenheit"},
-							},
-						},
+							}),
+						),
 						Required: []string{"location"},
 					},
 				},

--- a/core/internal/llmtests/utils.go
+++ b/core/internal/llmtests/utils.go
@@ -109,16 +109,16 @@ var sampleToolDescriptions = map[SampleToolType]string{
 var WeatherToolFunction = &schemas.ChatToolFunction{
 	Parameters: &schemas.ToolFunctionParameters{
 		Type: "object",
-		Properties: &schemas.OrderedMap{
-			"location": map[string]interface{}{
+		Properties: schemas.NewOrderedMapFromPairs(
+			schemas.KV("location", map[string]interface{}{
 				"type":        "string",
 				"description": "The city and state, e.g. San Francisco, CA",
-			},
-			"unit": map[string]interface{}{
+			}),
+			schemas.KV("unit", map[string]interface{}{
 				"type": "string",
 				"enum": []string{"celsius", "fahrenheit"},
-			},
-		},
+			}),
+		),
 		Required: []string{"location"},
 	},
 }
@@ -126,12 +126,12 @@ var WeatherToolFunction = &schemas.ChatToolFunction{
 var CalculatorToolFunction = &schemas.ChatToolFunction{
 	Parameters: &schemas.ToolFunctionParameters{
 		Type: "object",
-		Properties: &schemas.OrderedMap{
-			"expression": map[string]interface{}{
+		Properties: schemas.NewOrderedMapFromPairs(
+			schemas.KV("expression", map[string]interface{}{
 				"type":        "string",
 				"description": "The mathematical expression to evaluate, e.g. '2 + 3' or '10 * 5'",
-			},
-		},
+			}),
+		),
 		Required: []string{"expression"},
 	},
 }
@@ -139,12 +139,12 @@ var CalculatorToolFunction = &schemas.ChatToolFunction{
 var TimeToolFunction = &schemas.ChatToolFunction{
 	Parameters: &schemas.ToolFunctionParameters{
 		Type: "object",
-		Properties: &schemas.OrderedMap{
-			"timezone": map[string]interface{}{
+		Properties: schemas.NewOrderedMapFromPairs(
+			schemas.KV("timezone", map[string]interface{}{
 				"type":        "string",
 				"description": "The timezone identifier, e.g. 'America/New_York' or 'UTC'",
-			},
-		},
+			}),
+		),
 		Required: []string{"timezone"},
 	},
 }

--- a/core/internal/mcptests/agent_limits_test.go
+++ b/core/internal/mcptests/agent_limits_test.go
@@ -536,7 +536,7 @@ func TestAgent_Timeout(t *testing.T) {
 			Description: schemas.Ptr("A tool that takes a long time"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type:       "object",
-				Properties: &schemas.OrderedMap{},
+				Properties: schemas.NewOrderedMap(),
 			},
 		},
 	}
@@ -613,7 +613,7 @@ func TestAgent_TimeoutDuringExecution(t *testing.T) {
 			Description: schemas.Ptr("A tool that takes 1 full second"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type:       "object",
-				Properties: &schemas.OrderedMap{},
+				Properties: schemas.NewOrderedMap(),
 			},
 		},
 	}
@@ -675,7 +675,7 @@ func TestAgent_Timeout_ChatFormat(t *testing.T) {
 		Function: &schemas.ChatToolFunction{
 			Name:        "slow_chat_tool",
 			Description: schemas.Ptr("Tool for chat format timeout test"),
-			Parameters:  &schemas.ToolFunctionParameters{Type: "object", Properties: &schemas.OrderedMap{}},
+			Parameters:  &schemas.ToolFunctionParameters{Type: "object", Properties: schemas.NewOrderedMap()},
 		},
 	}
 
@@ -723,7 +723,7 @@ func TestAgent_Timeout_ResponsesFormat(t *testing.T) {
 		Function: &schemas.ChatToolFunction{
 			Name:        "slow_responses_tool",
 			Description: schemas.Ptr("Tool for responses format timeout test"),
-			Parameters:  &schemas.ToolFunctionParameters{Type: "object", Properties: &schemas.OrderedMap{}},
+			Parameters:  &schemas.ToolFunctionParameters{Type: "object", Properties: schemas.NewOrderedMap()},
 		},
 	}
 

--- a/core/internal/mcptests/concurrency_advanced_test.go
+++ b/core/internal/mcptests/concurrency_advanced_test.go
@@ -382,7 +382,7 @@ func TestConcurrent_ToolRegistration(t *testing.T) {
 					Description: schemas.Ptr(fmt.Sprintf("Test tool %d", id)),
 					Parameters: &schemas.ToolFunctionParameters{
 						Type:       "object",
-						Properties: &schemas.OrderedMap{},
+						Properties: schemas.NewOrderedMap(),
 					},
 				},
 			}

--- a/core/internal/mcptests/connection_test.go
+++ b/core/internal/mcptests/connection_test.go
@@ -192,12 +192,12 @@ func TestInProcessConnection(t *testing.T) {
 			Description: schemas.Ptr("A test tool for in-process execution"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"message": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("message", map[string]interface{}{
 						"type":        "string",
 						"description": "The message to process",
-					},
-				},
+					}),
+				),
 				Required: []string{"message"},
 			},
 		},
@@ -244,11 +244,11 @@ func TestInProcessToolExecution(t *testing.T) {
 			Description: schemas.Ptr("Echoes the input"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"text": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("text", map[string]interface{}{
 						"type": "string",
-					},
-				},
+					}),
+				),
 			},
 		},
 	}

--- a/core/internal/mcptests/context_propagation_test.go
+++ b/core/internal/mcptests/context_propagation_test.go
@@ -200,9 +200,9 @@ func TestContext_ValueIsolation(t *testing.T) {
 			Description: schemas.Ptr("Handles context values"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"value": map[string]interface{}{"type": "string"},
-				},
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("value", map[string]interface{}{"type": "string"}),
+				),
 			},
 		},
 	}

--- a/core/internal/mcptests/fixtures.go
+++ b/core/internal/mcptests/fixtures.go
@@ -77,21 +77,21 @@ func GetSampleCalculatorTool() schemas.ChatTool {
 			Description: schemas.Ptr("Performs basic arithmetic operations (add, subtract, multiply, divide)"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"operation": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("operation", map[string]interface{}{
 						"type":        "string",
 						"description": "The operation to perform",
 						"enum":        []string{"add", "subtract", "multiply", "divide"},
-					},
-					"x": map[string]interface{}{
+					}),
+					schemas.KV("x", map[string]interface{}{
 						"type":        "number",
 						"description": "First number",
-					},
-					"y": map[string]interface{}{
+					}),
+					schemas.KV("y", map[string]interface{}{
 						"type":        "number",
 						"description": "Second number",
-					},
-				},
+					}),
+				),
 				Required: []string{"operation", "x", "y"},
 			},
 		},
@@ -107,12 +107,12 @@ func GetSampleEchoTool() schemas.ChatTool {
 			Description: schemas.Ptr("Echoes back the input message"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"message": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("message", map[string]interface{}{
 						"type":        "string",
 						"description": "The message to echo",
-					},
-				},
+					}),
+				),
 				Required: []string{"message"},
 			},
 		},
@@ -128,17 +128,17 @@ func GetSampleWeatherTool() schemas.ChatTool {
 			Description: schemas.Ptr("Gets the current weather for a location"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"location": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("location", map[string]interface{}{
 						"type":        "string",
 						"description": "The location to get weather for",
-					},
-					"units": map[string]interface{}{
+					}),
+					schemas.KV("units", map[string]interface{}{
 						"type":        "string",
 						"description": "Temperature units (celsius or fahrenheit)",
 						"enum":        []string{"celsius", "fahrenheit"},
-					},
-				},
+					}),
+				),
 				Required: []string{"location"},
 			},
 		},
@@ -154,12 +154,12 @@ func GetSampleDelayTool() schemas.ChatTool {
 			Description: schemas.Ptr("Delays execution for a specified number of seconds"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"seconds": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("seconds", map[string]interface{}{
 						"type":        "number",
 						"description": "Number of seconds to delay",
-					},
-				},
+					}),
+				),
 				Required: []string{"seconds"},
 			},
 		},
@@ -175,12 +175,12 @@ func GetSampleErrorTool() schemas.ChatTool {
 			Description: schemas.Ptr("Throws an error for testing error handling"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"error_message": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("error_message", map[string]interface{}{
 						"type":        "string",
 						"description": "The error message to throw",
-					},
-				},
+					}),
+				),
 				Required: []string{"error_message"},
 			},
 		},
@@ -320,12 +320,12 @@ func RegisterEchoTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Echoes back the input message"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"message": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("message", map[string]interface{}{
 						"type":        "string",
 						"description": "The message to echo back",
-					},
-				},
+					}),
+				),
 				Required: []string{"message"},
 			},
 		},
@@ -362,21 +362,21 @@ func RegisterCalculatorTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Performs basic arithmetic operations"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"operation": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("operation", map[string]interface{}{
 						"type":        "string",
 						"description": "The operation to perform (add, subtract, multiply, divide)",
 						"enum":        []string{"add", "subtract", "multiply", "divide"},
-					},
-					"x": map[string]interface{}{
+					}),
+					schemas.KV("x", map[string]interface{}{
 						"type":        "number",
 						"description": "First number",
-					},
-					"y": map[string]interface{}{
+					}),
+					schemas.KV("y", map[string]interface{}{
 						"type":        "number",
 						"description": "Second number",
-					},
-				},
+					}),
+				),
 				Required: []string{"operation", "x", "y"},
 			},
 		},
@@ -442,17 +442,17 @@ func RegisterWeatherTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Gets the current weather for a location"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"location": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("location", map[string]interface{}{
 						"type":        "string",
 						"description": "The city and state, e.g. San Francisco, CA",
-					},
-					"units": map[string]interface{}{
+					}),
+					schemas.KV("units", map[string]interface{}{
 						"type":        "string",
 						"description": "The temperature unit (celsius or fahrenheit)",
 						"enum":        []string{"celsius", "fahrenheit"},
-					},
-				},
+					}),
+				),
 				Required: []string{"location"},
 			},
 		},
@@ -500,16 +500,16 @@ func RegisterSearchTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Searches for information on a topic"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"query": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("query", map[string]interface{}{
 						"type":        "string",
 						"description": "The search query",
-					},
-					"max_results": map[string]interface{}{
+					}),
+					schemas.KV("max_results", map[string]interface{}{
 						"type":        "number",
 						"description": "Maximum number of results to return",
-					},
-				},
+					}),
+				),
 				Required: []string{"query"},
 			},
 		},
@@ -556,12 +556,12 @@ func RegisterGetTemperatureTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Get the current temperature for a popular city"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"location": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("location", map[string]interface{}{
 						"type":        "string",
 						"description": "The name of the city (e.g., 'New York', 'London', 'Tokyo')",
-					},
-				},
+					}),
+				),
 				Required: []string{"location"},
 			},
 		},
@@ -605,12 +605,12 @@ func RegisterGetTimeTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Gets the current date and time"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"timezone": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("timezone", map[string]interface{}{
 						"type":        "string",
 						"description": "The timezone (e.g., UTC, America/New_York)",
-					},
-				},
+					}),
+				),
 			},
 		},
 	}
@@ -649,12 +649,12 @@ func RegisterReadFileTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Reads the contents of a file"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"path": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("path", map[string]interface{}{
 						"type":        "string",
 						"description": "The file path to read",
-					},
-				},
+					}),
+				),
 				Required: []string{"path"},
 			},
 		},
@@ -696,12 +696,12 @@ func RegisterDelayTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Delays execution for specified seconds"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"seconds": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("seconds", map[string]interface{}{
 						"type":        "number",
 						"description": "Number of seconds to delay",
-					},
-				},
+					}),
+				),
 				Required: []string{"seconds"},
 			},
 		},
@@ -744,12 +744,12 @@ func RegisterThrowErrorTool(manager *mcp.MCPManager) error {
 			Description: schemas.Ptr("Throws an error with specified message"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"error_message": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("error_message", map[string]interface{}{
 						"type":        "string",
 						"description": "The error message to throw",
-					},
-				},
+					}),
+				),
 				Required: []string{"error_message"},
 			},
 		},

--- a/core/internal/mcptests/tool_conflicts_test.go
+++ b/core/internal/mcptests/tool_conflicts_test.go
@@ -228,12 +228,12 @@ func TestMultipleSameNameTools_DifferentImplementations(t *testing.T) {
 			Description: schemas.Ptr("Custom data processor"),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type: "object",
-				Properties: &schemas.OrderedMap{
-					"data": map[string]interface{}{
+				Properties: schemas.NewOrderedMapFromPairs(
+					schemas.KV("data", map[string]interface{}{
 						"type":        "string",
 						"description": "Data to process",
-					},
-				},
+					}),
+				),
 				Required: []string{"data"},
 			},
 		},

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -49,12 +49,12 @@ type ExecutionEnvironment struct {
 // createExecuteToolCodeTool creates the executeToolCode tool definition for code mode.
 // This tool allows executing Python (Starlark) code in a sandboxed interpreter with access to MCP server tools.
 func (s *StarlarkCodeMode) createExecuteToolCodeTool() schemas.ChatTool {
-	executeToolCodeProps := schemas.OrderedMap{
-		"code": map[string]interface{}{
+	executeToolCodeProps := schemas.NewOrderedMapFromPairs(
+		schemas.KV("code", map[string]interface{}{
 			"type":        "string",
 			"description": "Python code to execute. The code runs in a Starlark interpreter (Python subset). Tool calls are synchronous - no async/await needed. For loops/conditionals, wrap in a function. Use print() for logging. ALWAYS retry if code fails. Example: def main():\n  items = server.list_items()\n  for item in items:\n    print(item)\nresult = main()",
-		},
-	}
+		}),
+	)
 	return schemas.ChatTool{
 		Type: schemas.ChatToolTypeFunction,
 		Function: &schemas.ChatToolFunction{
@@ -94,7 +94,7 @@ func (s *StarlarkCodeMode) createExecuteToolCodeTool() schemas.ChatTool {
 
 			Parameters: &schemas.ToolFunctionParameters{
 				Type:       "object",
-				Properties: &executeToolCodeProps,
+				Properties: executeToolCodeProps,
 				Required:   []string{"code"},
 			},
 		},

--- a/core/mcp/codemode/starlark/listfiles.go
+++ b/core/mcp/codemode/starlark/listfiles.go
@@ -45,7 +45,7 @@ func (s *StarlarkCodeMode) createListToolFilesTool() schemas.ChatTool {
 			Description: schemas.Ptr(description),
 			Parameters: &schemas.ToolFunctionParameters{
 				Type:       "object",
-				Properties: &schemas.OrderedMap{},
+				Properties: schemas.NewOrderedMap(),
 				Required:   []string{},
 			},
 		},

--- a/core/mcp/utils_test.go
+++ b/core/mcp/utils_test.go
@@ -39,8 +39,8 @@ func TestConvertMCPToolToBifrostSchema_EmptyParameters(t *testing.T) {
 	}
 
 	// Verify it's an empty map
-	if bifrostTool.Function.Parameters.Properties != nil && len(*bifrostTool.Function.Parameters.Properties) != 0 {
-		t.Errorf("Expected empty properties map, got %d properties", len(*bifrostTool.Function.Parameters.Properties))
+	if bifrostTool.Function.Parameters.Properties != nil && bifrostTool.Function.Parameters.Properties.Len() != 0 {
+		t.Errorf("Expected empty properties map, got %d properties", bifrostTool.Function.Parameters.Properties.Len())
 	}
 
 	// Verify the type is preserved
@@ -90,8 +90,8 @@ func TestConvertMCPToolToBifrostSchema_WithParameters(t *testing.T) {
 	}
 
 	// Verify the correct number of properties
-	if len(*bifrostTool.Function.Parameters.Properties) != 2 {
-		t.Errorf("Expected 2 properties, got %d", len(*bifrostTool.Function.Parameters.Properties))
+	if bifrostTool.Function.Parameters.Properties.Len() != 2 {
+		t.Errorf("Expected 2 properties, got %d", bifrostTool.Function.Parameters.Properties.Len())
 	}
 
 	// Verify required fields

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -397,28 +397,28 @@ func convertJSONSchemaToToolParameters(schema *schemas.ResponsesTextConfigFormat
 	// Convert map[string]any to OrderedMap for Properties
 	if schema.Properties != nil {
 		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Properties); ok {
-			params.Properties = &orderedMap
+			params.Properties = orderedMap
 		}
 	}
 
 	// Convert map[string]any to OrderedMap for Defs
 	if schema.Defs != nil {
 		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Defs); ok {
-			params.Defs = &orderedMap
+			params.Defs = orderedMap
 		}
 	}
 
 	// Convert map[string]any to OrderedMap for Definitions
 	if schema.Definitions != nil {
 		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Definitions); ok {
-			params.Definitions = &orderedMap
+			params.Definitions = orderedMap
 		}
 	}
 
 	// Convert map[string]any to OrderedMap for Items
 	if schema.Items != nil {
 		if orderedMap, ok := schemas.SafeExtractOrderedMap(*schema.Items); ok {
-			params.Items = &orderedMap
+			params.Items = orderedMap
 		}
 	}
 
@@ -427,7 +427,7 @@ func convertJSONSchemaToToolParameters(schema *schemas.ResponsesTextConfigFormat
 		params.AnyOf = make([]schemas.OrderedMap, 0, len(schema.AnyOf))
 		for _, item := range schema.AnyOf {
 			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
-				params.AnyOf = append(params.AnyOf, orderedMap)
+				params.AnyOf = append(params.AnyOf, *orderedMap)
 			}
 		}
 	}
@@ -436,7 +436,7 @@ func convertJSONSchemaToToolParameters(schema *schemas.ResponsesTextConfigFormat
 		params.OneOf = make([]schemas.OrderedMap, 0, len(schema.OneOf))
 		for _, item := range schema.OneOf {
 			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
-				params.OneOf = append(params.OneOf, orderedMap)
+				params.OneOf = append(params.OneOf, *orderedMap)
 			}
 		}
 	}
@@ -445,7 +445,7 @@ func convertJSONSchemaToToolParameters(schema *schemas.ResponsesTextConfigFormat
 		params.AllOf = make([]schemas.OrderedMap, 0, len(schema.AllOf))
 		for _, item := range schema.AllOf {
 			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
-				params.AllOf = append(params.AllOf, orderedMap)
+				params.AllOf = append(params.AllOf, *orderedMap)
 			}
 		}
 	}
@@ -464,7 +464,7 @@ func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolF
 		params.Description = &desc
 	}
 	if props, ok := schemas.SafeExtractOrderedMap(m["properties"]); ok {
-		params.Properties = &props
+		params.Properties = props
 	}
 	if req, ok := m["required"].([]interface{}); ok {
 		required := make([]string, 0, len(req))
@@ -482,21 +482,21 @@ func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolF
 			}
 		} else if addPropsMap, ok := schemas.SafeExtractOrderedMap(addProps); ok {
 			params.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
-				AdditionalPropertiesMap: &addPropsMap,
+				AdditionalPropertiesMap: addPropsMap,
 			}
 		}
 	}
 	if defs, ok := schemas.SafeExtractOrderedMap(m["$defs"]); ok {
-		params.Defs = &defs
+		params.Defs = defs
 	}
 	if definitions, ok := schemas.SafeExtractOrderedMap(m["definitions"]); ok {
-		params.Definitions = &definitions
+		params.Definitions = definitions
 	}
 	if ref, ok := m["$ref"].(string); ok {
 		params.Ref = &ref
 	}
 	if items, ok := schemas.SafeExtractOrderedMap(m["items"]); ok {
-		params.Items = &items
+		params.Items = items
 	}
 	if minItems, ok := anthropicExtractInt64(m["minItems"]); ok {
 		params.MinItems = schemas.Ptr(minItems)
@@ -508,7 +508,7 @@ func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolF
 		anyOfMaps := make([]schemas.OrderedMap, 0, len(anyOf))
 		for _, item := range anyOf {
 			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
-				anyOfMaps = append(anyOfMaps, orderedMap)
+				anyOfMaps = append(anyOfMaps, *orderedMap)
 			}
 		}
 		if len(anyOfMaps) > 0 {
@@ -519,7 +519,7 @@ func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolF
 		oneOfMaps := make([]schemas.OrderedMap, 0, len(oneOf))
 		for _, item := range oneOf {
 			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
-				oneOfMaps = append(oneOfMaps, orderedMap)
+				oneOfMaps = append(oneOfMaps, *orderedMap)
 			}
 		}
 		if len(oneOfMaps) > 0 {
@@ -530,7 +530,7 @@ func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolF
 		allOfMaps := make([]schemas.OrderedMap, 0, len(allOf))
 		for _, item := range allOf {
 			if orderedMap, ok := schemas.SafeExtractOrderedMap(item); ok {
-				allOfMaps = append(allOfMaps, orderedMap)
+				allOfMaps = append(allOfMaps, *orderedMap)
 			}
 		}
 		if len(allOfMaps) > 0 {
@@ -1297,7 +1297,7 @@ func convertAnthropicOutputFormatToResponsesTextConfig(outputFormat interface{})
 
 		if additionalProps, ok := schemas.SafeExtractOrderedMap(schemaMap["additionalProperties"]); ok {
 			jsonSchema.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
-				AdditionalPropertiesMap: &additionalProps,
+				AdditionalPropertiesMap: additionalProps,
 			}
 		}
 

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -65,7 +65,7 @@ type BedrockConverseRequest struct {
 	InferenceConfig                   *BedrockInferenceConfig          `json:"inferenceConfig,omitempty"`                   // Inference parameters
 	ToolConfig                        *BedrockToolConfig               `json:"toolConfig,omitempty"`                        // Tool configuration
 	GuardrailConfig                   *BedrockGuardrailConfig          `json:"guardrailConfig,omitempty"`                   // Guardrail configuration
-	AdditionalModelRequestFields      schemas.OrderedMap               `json:"additionalModelRequestFields,omitempty"`      // Model-specific parameters (untyped)
+	AdditionalModelRequestFields      *schemas.OrderedMap              `json:"additionalModelRequestFields,omitempty"`      // Model-specific parameters (untyped)
 	AdditionalModelResponseFieldPaths []string                         `json:"additionalModelResponseFieldPaths,omitempty"` // Additional response field paths
 	PerformanceConfig                 *BedrockPerformanceConfig        `json:"performanceConfig,omitempty"`                 // Performance configuration
 	PromptVariables                   map[string]BedrockPromptVariable `json:"promptVariables,omitempty"`                   // Prompt variables for prompt management

--- a/core/providers/cohere/utils.go
+++ b/core/providers/cohere/utils.go
@@ -58,7 +58,7 @@ func convertInterfaceToToolFunctionParameters(params interface{}) *schemas.ToolF
 
 	// Extract properties
 	if orderedProps, ok := schemas.SafeExtractOrderedMap(paramsMap["properties"]); ok {
-		result.Properties = &orderedProps
+		result.Properties = orderedProps
 	}
 
 	// Extract enum
@@ -81,18 +81,18 @@ func convertInterfaceToToolFunctionParameters(params interface{}) *schemas.ToolF
 
 	if addPropsVal, ok := schemas.SafeExtractOrderedMap(paramsMap["additionalProperties"]); ok {
 		result.AdditionalProperties = &schemas.AdditionalPropertiesStruct{
-			AdditionalPropertiesMap: &addPropsVal,
+			AdditionalPropertiesMap: addPropsVal,
 		}
 	}
 
 	// Extract $defs (JSON Schema draft 2019-09+)
 	if defsVal, ok := schemas.SafeExtractOrderedMap(paramsMap["$defs"]); ok {
-		result.Defs = &defsVal
+		result.Defs = defsVal
 	}
 
 	// Extract definitions (legacy JSON Schema draft-07)
 	if defsVal, ok := schemas.SafeExtractOrderedMap(paramsMap["definitions"]); ok {
-		result.Definitions = &defsVal
+		result.Definitions = defsVal
 	}
 
 	// Extract $ref
@@ -102,7 +102,7 @@ func convertInterfaceToToolFunctionParameters(params interface{}) *schemas.ToolF
 
 	// Extract items (array element schema)
 	if itemsVal, ok := schemas.SafeExtractOrderedMap(paramsMap["items"]); ok {
-		result.Items = &itemsVal
+		result.Items = itemsVal
 	}
 
 	// Extract minItems
@@ -120,7 +120,7 @@ func convertInterfaceToToolFunctionParameters(params interface{}) *schemas.ToolF
 		anyOf := make([]schemas.OrderedMap, 0, len(anyOfVal))
 		for _, v := range anyOfVal {
 			if m, ok := schemas.SafeExtractOrderedMap(v); ok {
-				anyOf = append(anyOf, m)
+				anyOf = append(anyOf, *m)
 			}
 		}
 		result.AnyOf = anyOf
@@ -131,7 +131,7 @@ func convertInterfaceToToolFunctionParameters(params interface{}) *schemas.ToolF
 		oneOf := make([]schemas.OrderedMap, 0, len(oneOfVal))
 		for _, v := range oneOfVal {
 			if m, ok := schemas.SafeExtractOrderedMap(v); ok {
-				oneOf = append(oneOf, m)
+				oneOf = append(oneOf, *m)
 			}
 		}
 		result.OneOf = oneOf
@@ -142,7 +142,7 @@ func convertInterfaceToToolFunctionParameters(params interface{}) *schemas.ToolF
 		allOf := make([]schemas.OrderedMap, 0, len(allOfVal))
 		for _, v := range allOfVal {
 			if m, ok := schemas.SafeExtractOrderedMap(v); ok {
-				allOf = append(allOf, m)
+				allOf = append(allOf, *m)
 			}
 		}
 		result.AllOf = allOf

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -355,25 +355,25 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Description: schemas.Ptr("Search for products with filters"),
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"query": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("query", map[string]interface{}{
 											"type":        "string",
 											"description": "Search query",
-										},
-										"category": map[string]interface{}{
+										}),
+										schemas.KV("category", map[string]interface{}{
 											"type":        "string",
 											"description": "Product category",
 											"enum":        []interface{}{"electronics", "books", "clothing"},
-										},
-										"tags": map[string]interface{}{
+										}),
+										schemas.KV("tags", map[string]interface{}{
 											"type":        "array",
 											"description": "Filter tags",
 											"items": map[string]interface{}{
 												"type":        "string",
 												"description": "A tag",
 											},
-										},
-									},
+										}),
+									),
 									Required: []string{"query"},
 								},
 							},
@@ -427,8 +427,8 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Description: schemas.Ptr("Process customer order"),
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"customer": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("customer", map[string]interface{}{
 											"type": "object",
 											"properties": map[string]interface{}{
 												"name": map[string]interface{}{
@@ -439,8 +439,8 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 												},
 											},
 											"required": []string{"name", "email"},
-										},
-										"items": map[string]interface{}{
+										}),
+										schemas.KV("items", map[string]interface{}{
 											"type": "array",
 											"items": map[string]interface{}{
 												"type": "object",
@@ -454,8 +454,8 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 												},
 												"required": []string{"product_id", "quantity"},
 											},
-										},
-									},
+										}),
+									),
 									Required: []string{"customer", "items"},
 								},
 							},
@@ -504,12 +504,12 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Name: "test_tool",
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"data": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("data", map[string]interface{}{
 											"type":  "array",
 											"items": map[string]interface{}{}, // Empty items object
-										},
-									},
+										}),
+									),
 								},
 							},
 						},
@@ -545,28 +545,28 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Description: schemas.Ptr("Validate input with constraints"),
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"username": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("username", map[string]interface{}{
 											"type":        "string",
 											"description": "Username with length constraints",
 											"minLength":   float64(3),
 											"maxLength":   float64(20),
 											"pattern":     "^[a-zA-Z0-9_]+$",
-										},
-										"age": map[string]interface{}{
+										}),
+										schemas.KV("age", map[string]interface{}{
 											"type":    "integer",
 											"minimum": float64(0),
 											"maximum": float64(150),
-										},
-										"tags": map[string]interface{}{
+										}),
+										schemas.KV("tags", map[string]interface{}{
 											"type":     "array",
 											"minItems": float64(1),
 											"maxItems": float64(5),
 											"items": map[string]interface{}{
 												"type": "string",
 											},
-										},
-									},
+										}),
+									),
 									Required: []string{"username"},
 								},
 							},
@@ -625,15 +625,15 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Description: schemas.Ptr("Process ID that can be string or number"),
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"id": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("id", map[string]interface{}{
 											"anyOf": []interface{}{
 												map[string]interface{}{"type": "string"},
 												map[string]interface{}{"type": "integer"},
 											},
 											"description": "ID that can be string or integer",
-										},
-									},
+										}),
+									),
 									Required: []string{"id"},
 								},
 							},
@@ -674,10 +674,10 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Description: schemas.Ptr("Process a list of items"),
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "array",
-									Items: &schemas.OrderedMap{
-										"type":        "string",
-										"description": "Item in the list",
-									},
+									Items: schemas.NewOrderedMapFromPairs(
+										schemas.KV("type", "string"),
+										schemas.KV("description", "Item in the list"),
+									),
 									MinItems: schemas.Ptr(int64(1)),
 									MaxItems: schemas.Ptr(int64(10)),
 								},
@@ -722,18 +722,18 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 								Parameters: &schemas.ToolFunctionParameters{
 									Type:  "object",
 									Title: schemas.Ptr("ConfigParameters"),
-									Properties: &schemas.OrderedMap{
-										"enabled": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("enabled", map[string]interface{}{
 											"type":     "boolean",
 											"default":  true,
 											"nullable": true,
 											"title":    "Enabled Flag",
-										},
-										"format_type": map[string]interface{}{
+										}),
+										schemas.KV("format_type", map[string]interface{}{
 											"type":   "string",
 											"format": "email",
-										},
-									},
+										}),
+									),
 								},
 							},
 						},
@@ -1700,20 +1700,20 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 							ResponsesToolFunction: &schemas.ResponsesToolFunction{
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"filters": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("filters", map[string]interface{}{
 											"type":        "array",
 											"description": "List of filters",
 											"items": map[string]interface{}{
 												"type":        "string",
 												"description": "Filter criterion",
 											},
-										},
-										"sort_order": map[string]interface{}{
+										}),
+										schemas.KV("sort_order", map[string]interface{}{
 											"type": "string",
 											"enum": []interface{}{"asc", "desc"},
-										},
-									},
+										}),
+									),
 									Required: []string{"filters"},
 								},
 							},
@@ -1763,8 +1763,8 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 							ResponsesToolFunction: &schemas.ResponsesToolFunction{
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"updates": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("updates", map[string]interface{}{
 											"type": "array",
 											"items": map[string]interface{}{
 												"type": "object",
@@ -1787,8 +1787,8 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 												},
 												"required": []string{"id", "fields"},
 											},
-										},
-									},
+										}),
+									),
 									Required: []string{"updates"},
 								},
 							},
@@ -1843,12 +1843,12 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 							ResponsesToolFunction: &schemas.ResponsesToolFunction{
 								Parameters: &schemas.ToolFunctionParameters{
 									Type: "object",
-									Properties: &schemas.OrderedMap{
-										"any_array": map[string]interface{}{
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("any_array", map[string]interface{}{
 											"type":  "array",
 											"items": map[string]interface{}{}, // Empty items
-										},
-									},
+										}),
+									),
 								},
 							},
 						},

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -1,0 +1,382 @@
+package schemas
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// OrderedMap is a map that preserves insertion order of keys.
+// It stores key-value pairs and maintains the order in which keys were first inserted.
+// It is NOT safe for concurrent use.
+type OrderedMap struct {
+	keys   []string
+	values map[string]interface{}
+}
+
+// Pair is a key-value pair for constructing OrderedMaps with order preserved.
+type Pair struct {
+	Key   string
+	Value interface{}
+}
+
+// KV is a shorthand constructor for Pair.
+func KV(key string, value interface{}) Pair {
+	return Pair{Key: key, Value: value}
+}
+
+// NewOrderedMap creates a new empty OrderedMap.
+func NewOrderedMap() *OrderedMap {
+	return &OrderedMap{
+		values: make(map[string]interface{}),
+	}
+}
+
+// NewOrderedMapWithCapacity creates a new empty OrderedMap with preallocated capacity.
+func NewOrderedMapWithCapacity(cap int) *OrderedMap {
+	return &OrderedMap{
+		keys:   make([]string, 0, cap),
+		values: make(map[string]interface{}, cap),
+	}
+}
+
+// NewOrderedMapFromPairs creates an OrderedMap from key-value pairs, preserving the given order.
+func NewOrderedMapFromPairs(pairs ...Pair) *OrderedMap {
+	om := &OrderedMap{
+		keys:   make([]string, 0, len(pairs)),
+		values: make(map[string]interface{}, len(pairs)),
+	}
+	for _, p := range pairs {
+		om.Set(p.Key, p.Value)
+	}
+	return om
+}
+
+// OrderedMapFromMap creates an OrderedMap from a plain map.
+// Key order is NOT guaranteed since Go maps have undefined iteration order.
+// Use this only when insertion order doesn't matter (e.g., for hashing).
+func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
+	if m == nil {
+		return nil
+	}
+	om := &OrderedMap{
+		keys:   make([]string, 0, len(m)),
+		values: make(map[string]interface{}, len(m)),
+	}
+	for k, v := range m {
+		om.keys = append(om.keys, k)
+		om.values[k] = v
+	}
+	return om
+}
+
+// Get returns the value associated with the key and whether the key exists.
+func (om *OrderedMap) Get(key string) (interface{}, bool) {
+	if om == nil {
+		return nil, false
+	}
+	v, ok := om.values[key]
+	return v, ok
+}
+
+// Set sets the value for a key. If the key is new, it is appended to the end.
+// If the key already exists, its value is updated in place without changing order.
+func (om *OrderedMap) Set(key string, value interface{}) {
+	if om.values == nil {
+		om.values = make(map[string]interface{})
+	}
+	if _, exists := om.values[key]; !exists {
+		om.keys = append(om.keys, key)
+	}
+	om.values[key] = value
+}
+
+// Delete removes a key and its value. The key is also removed from the ordered keys list.
+func (om *OrderedMap) Delete(key string) {
+	if om == nil {
+		return
+	}
+	if _, exists := om.values[key]; !exists {
+		return
+	}
+	delete(om.values, key)
+	for i, k := range om.keys {
+		if k == key {
+			om.keys = append(om.keys[:i], om.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+// Len returns the number of key-value pairs.
+func (om *OrderedMap) Len() int {
+	if om == nil {
+		return 0
+	}
+	return len(om.keys)
+}
+
+// Keys returns the keys in insertion order. The returned slice is a copy.
+func (om *OrderedMap) Keys() []string {
+	if om == nil {
+		return nil
+	}
+	out := make([]string, len(om.keys))
+	copy(out, om.keys)
+	return out
+}
+
+// Range iterates over key-value pairs in insertion order.
+// If fn returns false, iteration stops.
+func (om *OrderedMap) Range(fn func(key string, value interface{}) bool) {
+	if om == nil {
+		return
+	}
+	for _, k := range om.keys {
+		if !fn(k, om.values[k]) {
+			break
+		}
+	}
+}
+
+// Clone creates a shallow copy of the OrderedMap (keys and top-level values are copied,
+// but nested values share references).
+func (om *OrderedMap) Clone() *OrderedMap {
+	if om == nil {
+		return nil
+	}
+	clone := &OrderedMap{
+		keys:   make([]string, len(om.keys)),
+		values: make(map[string]interface{}, len(om.values)),
+	}
+	copy(clone.keys, om.keys)
+	for k, v := range om.values {
+		clone.values[k] = v
+	}
+	return clone
+}
+
+// ToMap returns a plain map[string]interface{} with the same key-value pairs.
+// The returned map does not preserve insertion order.
+func (om *OrderedMap) ToMap() map[string]interface{} {
+	if om == nil {
+		return nil
+	}
+	m := make(map[string]interface{}, len(om.values))
+	for k, v := range om.values {
+		m[k] = v
+	}
+	return m
+}
+
+// MarshalJSON serializes the OrderedMap to JSON, preserving insertion order of keys.
+// Uses a value receiver so that both OrderedMap and *OrderedMap invoke this method
+// (critical for []OrderedMap slices like AnyOf/OneOf/AllOf in ToolFunctionParameters).
+func (om OrderedMap) MarshalJSON() ([]byte, error) {
+	if om.values == nil {
+		return []byte("null"), nil
+	}
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+
+	for i, k := range om.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+
+		// key
+		keyBytes, err := Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyBytes)
+		buf.WriteByte(':')
+
+		// value — nested *OrderedMap values will use their own MarshalJSON
+		valBytes, err := Marshal(om.values[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valBytes)
+	}
+
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// MarshalSorted serializes the OrderedMap to JSON with keys sorted alphabetically.
+// Use this when deterministic output is needed regardless of insertion order (e.g., hashing).
+func (om *OrderedMap) MarshalSorted() ([]byte, error) {
+	if om == nil {
+		return []byte("null"), nil
+	}
+
+	keys := make([]string, len(om.keys))
+	copy(keys, om.keys)
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+
+	for i, k := range keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+
+		keyBytes, err := Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyBytes)
+		buf.WriteByte(':')
+
+		valBytes, err := Marshal(om.values[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valBytes)
+	}
+
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON deserializes JSON into the OrderedMap, preserving the key order
+// from the JSON document. Nested objects are also deserialized as *OrderedMap.
+// Note: uses encoding/json.Decoder (not sonic) because token-by-token decoding
+// is required to preserve key order from the JSON document.
+func (om *OrderedMap) UnmarshalJSON(data []byte) error {
+	// Handle null
+	trimmed := bytes.TrimSpace(data)
+	if bytes.Equal(trimmed, []byte("null")) {
+		om.keys = nil
+		om.values = nil
+		return nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+
+	// Read opening brace
+	t, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("orderedmap: expected '{': %w", err)
+	}
+	delim, ok := t.(json.Delim)
+	if !ok || delim != '{' {
+		return fmt.Errorf("orderedmap: expected '{', got %v", t)
+	}
+
+	om.keys = om.keys[:0]
+	if om.values == nil {
+		om.values = make(map[string]interface{})
+	} else {
+		for k := range om.values {
+			delete(om.values, k)
+		}
+	}
+
+	for dec.More() {
+		// Read key
+		keyToken, err := dec.Token()
+		if err != nil {
+			return fmt.Errorf("orderedmap: reading key: %w", err)
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return fmt.Errorf("orderedmap: expected string key, got %T", keyToken)
+		}
+
+		// Read value, preserving nested object order
+		value, err := decodeOrderedValue(dec)
+		if err != nil {
+			return fmt.Errorf("orderedmap: reading value for key %q: %w", key, err)
+		}
+
+		om.Set(key, value)
+	}
+
+	// Read closing brace
+	if _, err := dec.Token(); err != nil {
+		return fmt.Errorf("orderedmap: expected '}': %w", err)
+	}
+
+	return nil
+}
+
+// decodeOrderedValue reads a single JSON value from the decoder.
+// Objects are decoded as *OrderedMap (preserving key order).
+// Arrays are decoded as []interface{} with each element recursively decoded.
+// Primitives are returned as their Go equivalents.
+func decodeOrderedValue(dec *json.Decoder) (interface{}, error) {
+	t, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	switch v := t.(type) {
+	case json.Delim:
+		if v == '{' {
+			// Recursively parse nested object as *OrderedMap
+			nested := NewOrderedMap()
+			for dec.More() {
+				keyToken, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected string key, got %T", keyToken)
+				}
+				val, err := decodeOrderedValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				nested.Set(key, val)
+			}
+			// Consume closing '}'
+			if _, err := dec.Token(); err != nil {
+				return nil, err
+			}
+			return nested, nil
+		}
+		if v == '[' {
+			// Parse array elements recursively
+			var arr []interface{}
+			for dec.More() {
+				val, err := decodeOrderedValue(dec)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, val)
+			}
+			// Consume closing ']'
+			if _, err := dec.Token(); err != nil {
+				return nil, err
+			}
+			if arr == nil {
+				arr = []interface{}{}
+			}
+			return arr, nil
+		}
+		return nil, fmt.Errorf("unexpected delimiter: %v", v)
+
+	case string:
+		return v, nil
+	case float64:
+		return v, nil
+	case bool:
+		return v, nil
+	case nil:
+		return nil, nil
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return v.String(), nil
+		}
+		return f, nil
+	default:
+		return v, nil
+	}
+}

--- a/core/schemas/orderedmap_test.go
+++ b/core/schemas/orderedmap_test.go
@@ -1,0 +1,331 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOrderedMap(t *testing.T) {
+	om := NewOrderedMap()
+	assert.NotNil(t, om)
+	assert.Equal(t, 0, om.Len())
+	assert.Empty(t, om.Keys())
+}
+
+func TestNewOrderedMapFromPairs(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("b", 2),
+		KV("a", 1),
+		KV("c", 3),
+	)
+	assert.Equal(t, 3, om.Len())
+	assert.Equal(t, []string{"b", "a", "c"}, om.Keys())
+
+	v, ok := om.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, 1, v)
+}
+
+func TestOrderedMap_SetPreservesInsertionOrder(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("z", 1)
+	om.Set("a", 2)
+	om.Set("m", 3)
+
+	assert.Equal(t, []string{"z", "a", "m"}, om.Keys())
+}
+
+func TestOrderedMap_SetUpdateInPlace(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("a", 1)
+	om.Set("b", 2)
+	om.Set("a", 10) // update, not re-append
+
+	assert.Equal(t, []string{"a", "b"}, om.Keys())
+	v, ok := om.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, 10, v)
+}
+
+func TestOrderedMap_Delete(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("a", 1),
+		KV("b", 2),
+		KV("c", 3),
+	)
+	om.Delete("b")
+
+	assert.Equal(t, 2, om.Len())
+	assert.Equal(t, []string{"a", "c"}, om.Keys())
+
+	_, ok := om.Get("b")
+	assert.False(t, ok)
+}
+
+func TestOrderedMap_DeleteNonExistent(t *testing.T) {
+	om := NewOrderedMapFromPairs(KV("a", 1))
+	om.Delete("b") // should not panic
+	assert.Equal(t, 1, om.Len())
+}
+
+func TestOrderedMap_Range(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("x", 1),
+		KV("y", 2),
+		KV("z", 3),
+	)
+
+	var keys []string
+	var vals []interface{}
+	om.Range(func(key string, value interface{}) bool {
+		keys = append(keys, key)
+		vals = append(vals, value)
+		return true
+	})
+
+	assert.Equal(t, []string{"x", "y", "z"}, keys)
+	assert.Equal(t, []interface{}{1, 2, 3}, vals)
+}
+
+func TestOrderedMap_RangeEarlyStop(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("a", 1),
+		KV("b", 2),
+		KV("c", 3),
+	)
+
+	var keys []string
+	om.Range(func(key string, _ interface{}) bool {
+		keys = append(keys, key)
+		return key != "b" // stop after "b"
+	})
+
+	assert.Equal(t, []string{"a", "b"}, keys)
+}
+
+func TestOrderedMap_Clone(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("a", 1),
+		KV("b", 2),
+	)
+
+	clone := om.Clone()
+	assert.Equal(t, om.Keys(), clone.Keys())
+
+	// Modifying clone doesn't affect original
+	clone.Set("c", 3)
+	assert.Equal(t, 2, om.Len())
+	assert.Equal(t, 3, clone.Len())
+}
+
+func TestOrderedMap_ToMap(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("a", 1),
+		KV("b", "hello"),
+	)
+
+	m := om.ToMap()
+	assert.Equal(t, map[string]interface{}{"a": 1, "b": "hello"}, m)
+}
+
+func TestOrderedMap_NilSafety(t *testing.T) {
+	var om *OrderedMap
+
+	assert.Equal(t, 0, om.Len())
+	assert.Nil(t, om.Keys())
+	assert.Nil(t, om.Clone())
+	assert.Nil(t, om.ToMap())
+
+	v, ok := om.Get("key")
+	assert.Nil(t, v)
+	assert.False(t, ok)
+
+	// Range on nil should not panic
+	om.Range(func(key string, value interface{}) bool {
+		t.Fatal("should not be called")
+		return true
+	})
+
+	// Delete on nil should not panic
+	om.Delete("key")
+}
+
+func TestOrderedMap_MarshalJSON_PreservesOrder(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("z_last", 1),
+		KV("a_first", 2),
+		KV("m_middle", 3),
+	)
+
+	data, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, `{"z_last":1,"a_first":2,"m_middle":3}`, string(data))
+}
+
+func TestOrderedMap_MarshalJSON_Empty(t *testing.T) {
+	om := NewOrderedMap()
+	data, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, string(data))
+}
+
+func TestOrderedMap_MarshalJSON_NilValues(t *testing.T) {
+	om := OrderedMap{} // zero value, values is nil
+	data, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, `null`, string(data))
+}
+
+func TestOrderedMap_UnmarshalJSON_PreservesOrder(t *testing.T) {
+	input := `{"z_last":1,"a_first":"two","m_middle":true}`
+
+	var om OrderedMap
+	err := json.Unmarshal([]byte(input), &om)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"z_last", "a_first", "m_middle"}, om.Keys())
+
+	v, ok := om.Get("z_last")
+	assert.True(t, ok)
+	assert.Equal(t, float64(1), v) // JSON numbers are float64
+
+	v, ok = om.Get("a_first")
+	assert.True(t, ok)
+	assert.Equal(t, "two", v)
+
+	v, ok = om.Get("m_middle")
+	assert.True(t, ok)
+	assert.Equal(t, true, v)
+}
+
+func TestOrderedMap_UnmarshalJSON_NestedObjects(t *testing.T) {
+	input := `{"outer_b":{"inner_z":1,"inner_a":2},"outer_a":"simple"}`
+
+	var om OrderedMap
+	err := json.Unmarshal([]byte(input), &om)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"outer_b", "outer_a"}, om.Keys())
+
+	nested, ok := om.Get("outer_b")
+	assert.True(t, ok)
+
+	nestedOM, ok := nested.(*OrderedMap)
+	require.True(t, ok, "nested object should be *OrderedMap, got %T", nested)
+	assert.Equal(t, []string{"inner_z", "inner_a"}, nestedOM.Keys())
+}
+
+func TestOrderedMap_UnmarshalJSON_Null(t *testing.T) {
+	var om OrderedMap
+	err := json.Unmarshal([]byte("null"), &om)
+	require.NoError(t, err)
+	assert.Equal(t, 0, om.Len())
+}
+
+func TestOrderedMap_JSONRoundTrip(t *testing.T) {
+	original := NewOrderedMapFromPairs(
+		KV("answer", map[string]interface{}{
+			"type":        "string",
+			"description": "The answer to the question",
+		}),
+		KV("chain_of_thought", map[string]interface{}{
+			"type":        "string",
+			"description": "Reasoning chain",
+		}),
+		KV("citations", map[string]interface{}{
+			"type":        "array",
+			"description": "Sources",
+		}),
+	)
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var restored OrderedMap
+	err = json.Unmarshal(data, &restored)
+	require.NoError(t, err)
+
+	assert.Equal(t, original.Keys(), restored.Keys())
+}
+
+func TestOrderedMap_MarshalSorted(t *testing.T) {
+	om := NewOrderedMapFromPairs(
+		KV("z", 1),
+		KV("a", 2),
+		KV("m", 3),
+	)
+
+	data, err := om.MarshalSorted()
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":2,"m":3,"z":1}`, string(data))
+}
+
+func TestOrderedMap_MarshalSorted_Nil(t *testing.T) {
+	var om *OrderedMap
+	data, err := om.MarshalSorted()
+	require.NoError(t, err)
+	assert.Equal(t, `null`, string(data))
+}
+
+func TestOrderedMapFromMap(t *testing.T) {
+	m := map[string]interface{}{"a": 1, "b": 2}
+	om := OrderedMapFromMap(m)
+	assert.Equal(t, 2, om.Len())
+
+	v, ok := om.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, 1, v)
+}
+
+func TestOrderedMapFromMap_Nil(t *testing.T) {
+	om := OrderedMapFromMap(nil)
+	assert.Nil(t, om)
+}
+
+func TestOrderedMap_NestedOrderedMapMarshal(t *testing.T) {
+	inner := NewOrderedMapFromPairs(
+		KV("z_prop", "last"),
+		KV("a_prop", "first"),
+	)
+	outer := NewOrderedMapFromPairs(
+		KV("properties", inner),
+		KV("type", "object"),
+	)
+
+	data, err := json.Marshal(outer)
+	require.NoError(t, err)
+	assert.Equal(t, `{"properties":{"z_prop":"last","a_prop":"first"},"type":"object"}`, string(data))
+}
+
+func TestOrderedMap_UnmarshalThenMarshalPreservesOrder(t *testing.T) {
+	// This is the core use case: JSON comes in with a specific order,
+	// we deserialize, then re-serialize and the order is preserved.
+	input := `{"answer":"string","chain_of_thought":"string","citations":"array","is_unanswered":"boolean"}`
+
+	var om OrderedMap
+	err := json.Unmarshal([]byte(input), &om)
+	require.NoError(t, err)
+
+	output, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, input, string(output))
+}
+
+func TestOrderedMap_EmptyArray(t *testing.T) {
+	input := `{"items":[],"name":"test"}`
+
+	var om OrderedMap
+	err := json.Unmarshal([]byte(input), &om)
+	require.NoError(t, err)
+
+	v, ok := om.Get("items")
+	assert.True(t, ok)
+	assert.Equal(t, []interface{}{}, v)
+
+	output, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, input, string(output))
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -810,9 +810,9 @@ func GenerateRoutingRuleHash(r tables.TableRoutingRule) (string, error) {
 	if r.Query != nil {
 		hash.Write([]byte(*r.Query))
 	} else if len(r.ParsedQuery) > 0 {
-		// Convert map to OrderedMap which has deterministic JSON marshalling with sorted keys
-		orderedMap := schemas.OrderedMap(r.ParsedQuery)
-		data, err := sonic.Marshal(orderedMap)
+		// Convert map to OrderedMap and use sorted marshalling for deterministic hashes
+		orderedMap := schemas.OrderedMapFromMap(r.ParsedQuery)
+		data, err := orderedMap.MarshalSorted()
 		if err != nil {
 			return "", err
 		}

--- a/plugins/semanticcache/plugin_edge_cases_test.go
+++ b/plugins/semanticcache/plugin_edge_cases_test.go
@@ -126,12 +126,12 @@ func TestToolVariations(t *testing.T) {
 						Description: bifrost.Ptr("Get the current weather"),
 						Parameters: &schemas.ToolFunctionParameters{
 							Type: "object",
-							Properties: &schemas.OrderedMap{
-								"location": map[string]interface{}{
+							Properties: schemas.NewOrderedMapFromPairs(
+								schemas.KV("location", map[string]interface{}{
 									"type":        "string",
 									"description": "The city and state",
-								},
-							},
+								}),
+							),
 						},
 						Strict: bifrost.Ptr(false),
 					},
@@ -163,12 +163,12 @@ func TestToolVariations(t *testing.T) {
 						Description: bifrost.Ptr("Get current weather information"),
 						Parameters: &schemas.ToolFunctionParameters{
 							Type: "object",
-							Properties: &schemas.OrderedMap{
-								"city": map[string]interface{}{ // Different parameter name
+							Properties: schemas.NewOrderedMapFromPairs(
+								schemas.KV("city", map[string]interface{}{ // Different parameter name
 									"type":        "string",
 									"description": "The city name",
-								},
-							},
+								}),
+							),
 						},
 						Strict: bifrost.Ptr(false),
 					},

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -281,9 +281,10 @@ func (h *MCPServerHandler) syncServer(server *server.MCPServer, availableTools [
 			if tool.Function.Parameters.Properties != nil {
 				// Convert *map[string]interface{} to map[string]any
 				props := make(map[string]any)
-				for k, v := range *tool.Function.Parameters.Properties {
-					props[k] = v
-				}
+				tool.Function.Parameters.Properties.Range(func(key string, value interface{}) bool {
+					props[key] = value
+					return true
+				})
 				inputSchema.Properties = props
 			}
 			if tool.Function.Parameters.Required != nil {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1139,9 +1139,11 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 			}
 			allowedModels := make([]schemas.Model, 0)
 			for _, key := range providerConfig.Keys {
-				allowedModels = append(allowedModels, schemas.Model{
-					ID: string(provider) + "/" + key.ID,
-				})
+				for _, model := range key.Models {
+					allowedModels = append(allowedModels, schemas.Model{
+						ID: string(provider) + "/" + model,
+					})
+				}
 			}
 			s.Config.ModelCatalog.UpsertModelDataForProvider(provider, modelData, allowedModels)
 		}


### PR DESCRIPTION
## Summary

Refactored the `OrderedMap` type to use a proper struct with explicit ordering instead of a map alias, improving JSON serialization consistency and providing better type safety.

## Changes

- Replaced `type OrderedMap map[string]interface{}` with a proper struct that maintains insertion order
- Added methods for creating, accessing, and manipulating ordered maps
- Updated all tool function parameters to use the new `OrderedMap` implementation
- Added helper functions like `NewOrderedMapFromPairs()` and `KV()` for more readable map construction
- Implemented proper JSON marshaling/unmarshaling that preserves key order
- Added tests for the new `OrderedMap` implementation

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the core tests to verify the refactored code works correctly:

```sh
# Core/Transports
go version
go test ./core/schemas/...
go test ./core/providers/...
go test ./core/internal/llmtests/...
go test ./core/internal/mcptests/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves JSON serialization consistency for tool parameters.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable