### PR TITLE
fix(azure): preserve OpenAI-compatible parameters for Azure provider

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -41,7 +41,7 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		openaiReq.ExtraParams = bifrostReq.Params.ExtraParams
 	}
 	switch bifrostReq.Provider {
-	case schemas.OpenAI:
+	case schemas.OpenAI, schemas.Azure:
 		return openaiReq
 	case schemas.XAI:
 		openaiReq.filterOpenAISpecificParameters()


### PR DESCRIPTION
## Summary
- Azure was falling into the `default` case in `ToOpenAIChatRequest`, which called `filterOpenAISpecificParameters()` and stripped `prompt_cache_key`, `prompt_cache_retention`, `prediction`, `verbosity`, `store`, and `web_search_options`
- Since Azure is API-compatible with OpenAI, it should be treated the same way -- preserving all OpenAI parameters rather than stripping them
- This fixes prompt caching not working when routing Chat Completion requests through Bifrost to Azure OpenAI

## Details

In `core/providers/openai/chat.go`, the `ToOpenAIChatRequest` function switches on provider. OpenAI has an explicit case that returns the request unmodified, but Azure had no case and fell into `default`, which strips OpenAI-specific fields. Adding `schemas.Azure` alongside `schemas.OpenAI` preserves the full parameter set.

Note: For the Responses API path, `prompt_cache_key` was already being preserved (no provider-specific filtering in `ToOpenAIResponsesRequest`), so only the Chat Completions path was affected.

## Test plan
- [x] Existing OpenAI provider tests pass
- [x] Existing Azure provider tests pass
- [ ] Verify prompt caching works end-to-end with Azure OpenAI Chat Completions

Made with [Cursor](https://cursor.com)