### PR TITLE
semantic cache test case fix

### DIFF
--- a/plugins/semanticcache/plugin_edge_cases_test.go
+++ b/plugins/semanticcache/plugin_edge_cases_test.go
@@ -204,7 +204,7 @@ func TestToolVariations(t *testing.T) {
 		t.Fatalf("Second request with tools failed: %v", err3)
 	}
 
-	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, string(CacheTypeDirect))
+	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, "")
 
 	// Test 4: Request with different tools (should NOT cache hit)
 	t.Log("Making request with different tools...")

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -495,12 +495,7 @@ func (s *BifrostHTTPServer) ReloadProvider(ctx context.Context, provider schemas
 		return nil, fmt.Errorf("failed to update provider model catalog: failed to get keys by provider: %s", err)
 	}
 	modelsInKeys := make([]schemas.Model, 0)
-	for _, key := range providerKeys {
-		if len(key.Models) == 0 {
-			// Clean up
-			modelsInKeys = make([]schemas.Model, 0)
-			break
-		}
+	for _, key := range providerKeys {		
 		for _, model := range key.Models {
 			modelsInKeys = append(modelsInKeys, schemas.Model{
 				ID: string(provider) + "/" + model,
@@ -715,9 +710,11 @@ func (s *BifrostHTTPServer) ForceReloadPricing(ctx context.Context) error {
 			}
 			allowedModels := make([]schemas.Model, 0)
 			for _, key := range providerConfig.Keys {
-				allowedModels = append(allowedModels, schemas.Model{
-					ID: string(provider) + "/" + key.ID,
-				})
+				for _, model := range key.Models {
+					allowedModels = append(allowedModels, schemas.Model{
+						ID: string(provider) + "/" + model,
+					})
+				}
 			}
 			s.Config.ModelCatalog.UpsertModelDataForProvider(provider, modelData, allowedModels)
 		}


### PR DESCRIPTION
## Summary

Fixed two issues: corrected a semantic cache test assertion and fixed model catalog handling in the HTTP server.

## Changes

- Fixed the semantic cache test by updating the `AssertCacheHit` call to use an empty string instead of a specific cache type
- Fixed model catalog handling in `ReloadProvider` by removing the logic that was clearing the models list when a key had no models
- Corrected the `ForceReloadPricing` method to properly handle models within keys instead of treating the key ID as the model ID

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Test semantic cache functionality
go test ./plugins/semanticcache/...

# Test HTTP server model catalog handling
go test ./transports/bifrost-http/server/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with semantic cache testing and model catalog handling in the HTTP server.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable