### PR TITLE
fixes arm builder

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -833,7 +833,7 @@ jobs:
         bifrost-http-release,
       ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped') && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
-    runs-on: ubuntu-latest-arm
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## Summary

Update the runner for Docker release job from `ubuntu-latest-arm` to `ubuntu-24.04-arm` in the release pipeline workflow.

## Changes

- Updated the GitHub Actions runner for the Docker release job from `ubuntu-latest-arm` to `ubuntu-24.04-arm` to use a specific Ubuntu version instead of the latest available

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)

## How to test

This change affects the CI pipeline only. To verify:

```sh
# Validate the GitHub workflow file syntax
gh workflow view .github/workflows/release-pipeline.yml
```

## Breaking changes

- [x] No

## Security considerations

No security implications as this is a CI infrastructure change only.

## Checklist

- [x] I verified the CI pipeline passes locally if applicable