### PR TITLE
fixes login page button size

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0
 	github.com/aws/smithy-go v1.24.0
-	github.com/bytedance/gopkg v0.1.3
 	github.com/bytedance/sonic v1.14.2
 	github.com/google/uuid v1.6.0
 	github.com/hajimehoshi/go-mp3 v0.3.4
@@ -45,6 +44,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.4.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -158,7 +158,7 @@ export default function LoginView() {
 							/>
 						</div>
 
-						<Button type="submit" className="w-full text-sm" isLoading={isLoading} disabled={isLoading}>
+						<Button type="submit" className="h-9 w-full text-sm" isLoading={isLoading} disabled={isLoading}>
 							{isLoading || isLoggingIn ? "Signing in..." : "Sign in"}
 						</Button>
 					</form>

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -174,6 +174,7 @@ export const baseApi = createApi({
 		"OAuth2Config",
 		"RoutingRules",
 		"MCPToolGroups",
+		"AuditLogs",
 	],
 	endpoints: () => ({}),
 });


### PR DESCRIPTION
## Summary

This PR updates the login button height for better UI consistency and moves the `bytedance/gopkg` dependency from direct to indirect in the Go module.

## Changes

- Added a fixed height (`h-9`) to the login button in the enterprise login view for better visual consistency
- Moved `github.com/bytedance/gopkg` from direct dependencies to indirect dependencies in `core/go.mod`

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify the login button has consistent height with other UI elements:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Navigate to the login page and verify the button height looks correct.

For Go dependency changes:
```sh
# Core
cd core
go mod tidy
go build ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is a UI styling change and dependency organization update.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable