### PR TITLE
multiple profiles for otel

### DIFF
--- a/.github/workflows/configs/withobservability/config.json
+++ b/.github/workflows/configs/withobservability/config.json
@@ -19,10 +19,16 @@
         "enabled": true,
         "name": "otel",
         "config": {
-          "service_name": "bifrost",
-          "collector_url": "http://localhost:4318/v1/traces",
-          "trace_type": "otel",
-          "protocol": "http"
+          "profiles": [
+            {
+              "name": "default",
+              "enabled": true,
+              "service_name": "bifrost",
+              "collector_url": "http://localhost:4318/v1/traces",
+              "trace_type": "otel",
+              "protocol": "http"
+            }
+          ]
         }
       }
     ]

--- a/examples/configs/withobservability/config.json
+++ b/examples/configs/withobservability/config.json
@@ -27,10 +27,16 @@
         "enabled": true,
         "name": "otel",
         "config": {
-          "service_name": "bifrost",
-          "collector_url": "http://localhost:4318/v1/traces",
-          "trace_type": "otel",
-          "protocol": "http"
+          "profiles": [
+            {
+              "name": "default",
+              "enabled": true,
+              "service_name": "bifrost",
+              "collector_url": "http://localhost:4318/v1/traces",
+              "trace_type": "otel",
+              "protocol": "http"
+            }
+          ]
         }
       }
     ]

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -626,24 +626,61 @@
                 "config": {
                   "type": "object",
                   "properties": {
-                    "service_name": {
-                      "type": "string"
-                    },
-                    "collector_url": {
-                      "type": "string"
-                    },
-                    "trace_type": {
-                      "type": "string",
-                      "enum": [
-                        "otel"
-                      ]
-                    },
-                    "protocol": {
-                      "type": "string",
-                      "enum": [
-                        "http",
-                        "grpc"
-                      ]
+                    "profiles": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "service_name": {
+                            "type": "string"
+                          },
+                          "collector_url": {
+                            "type": "string"
+                          },
+                          "trace_type": {
+                            "type": "string",
+                            "enum": [
+                              "otel"
+                            ]
+                          },
+                          "protocol": {
+                            "type": "string",
+                            "enum": [
+                              "http",
+                              "grpc"
+                            ]
+                          },
+                          "headers": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "tls_ca_cert": {
+                            "type": "string"
+                          },
+                          "insecure": {
+                            "type": "boolean"
+                          },
+                          "metrics_enabled": {
+                            "type": "boolean"
+                          },
+                          "metrics_endpoint": {
+                            "type": "string"
+                          },
+                          "metrics_push_interval": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 300
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -659,9 +696,7 @@
                 "properties": {
                   "config": {
                     "required": [
-                      "collector_url",
-                      "trace_type",
-                      "protocol"
+                      "profiles"
                     ]
                   }
                 }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -262,10 +262,13 @@ bifrost:
     otel:
       enabled: false
       config:
-        service_name: "bifrost"
-        collector_url: ""
-        trace_type: "otel"
-        protocol: "grpc"
+        profiles:
+          - name: "default"
+            enabled: true
+            service_name: "bifrost"
+            collector_url: ""
+            trace_type: "otel"
+            protocol: "grpc"
 
     datadog:
       enabled: false

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -70,7 +70,7 @@ func hexToBytes(hexStr string, length int) []byte {
 }
 
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan
-func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
+func (p *otelProfile) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
 		otelSpans = append(otelSpans, p.convertSpanToOTELSpan(trace.TraceID, span))
@@ -81,14 +81,14 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 			Attributes: p.getResourceAttributes(),
 		},
 		ScopeSpans: []*ScopeSpan{{
-			Scope:  p.getInstrumentationScope(),
-			Spans:  otelSpans,
+			Scope: p.getInstrumentationScope(),
+			Spans: otelSpans,
 		}},
 	}
 }
 
 // convertSpanToOTELSpan converts a single Bifrost span to OTEL format
-func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
+func (p *otelProfile) convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
 	otelSpan := &Span{
 		TraceId:           hexToBytes(traceID, 16),
 		SpanId:            hexToBytes(span.SpanID, 8),
@@ -110,7 +110,7 @@ func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *
 }
 
 // getResourceAttributes returns the resource attributes for the OTEL span
-func (p *OtelPlugin) getResourceAttributes() []*KeyValue {
+func (p *otelProfile) getResourceAttributes() []*KeyValue {
 	attrs := []*KeyValue{
 		kvStr("service.name", p.serviceName),
 		kvStr("service.version", p.bifrostVersion),
@@ -123,7 +123,7 @@ func (p *OtelPlugin) getResourceAttributes() []*KeyValue {
 }
 
 // getInstrumentationScope returns the instrumentation scope for OTEL
-func (p *OtelPlugin) getInstrumentationScope() *commonpb.InstrumentationScope {
+func (p *otelProfile) getInstrumentationScope() *commonpb.InstrumentationScope {
 	return &commonpb.InstrumentationScope{
 		Name:    p.serviceName,
 		Version: p.bifrostVersion,

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -3,9 +3,11 @@ package otel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -43,7 +45,10 @@ const ProtocolHTTP Protocol = "http"
 // ProtocolGRPC is the second protocol
 const ProtocolGRPC Protocol = "grpc"
 
-type Config struct {
+// ProfileConfig represents the configuration for a single OTEL collector profile
+type ProfileConfig struct {
+	Name         string            `json:"name"`
+	Enabled      *bool             `json:"enabled,omitempty"` // nil defaults to true
 	ServiceName  string            `json:"service_name"`
 	CollectorURL string            `json:"collector_url"`
 	Headers      map[string]string `json:"headers"`
@@ -58,18 +63,16 @@ type Config struct {
 	MetricsPushInterval int    `json:"metrics_push_interval"` // in seconds, default 15
 }
 
-// OtelPlugin is the plugin for OpenTelemetry.
-// It implements the ObservabilityPlugin interface to receive completed traces
-// from the tracing middleware and forward them to an OTEL collector.
-type OtelPlugin struct {
-	ctx    context.Context
-	cancel context.CancelFunc
+// Config represents the configuration for the OTEL plugin with multiple profiles
+type Config struct {
+	Profiles []ProfileConfig `json:"profiles"`
+}
 
+// otelProfile holds runtime state for a single OTEL collector profile
+type otelProfile struct {
+	name        string
 	serviceName string
-	url         string
-	headers     map[string]string
 	traceType   TraceType
-	protocol    Protocol
 
 	bifrostVersion string
 
@@ -83,16 +86,18 @@ type OtelPlugin struct {
 	metricsExporter *MetricsExporter
 }
 
-// Init function for the OTEL plugin
-func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingManager *modelcatalog.ModelCatalog, bifrostVersion string) (*OtelPlugin, error) {
-	if config == nil {
-		return nil, fmt.Errorf("config is required")
-	}
-	logger = _logger
-	if pricingManager == nil {
-		logger.Warn("otel plugin requires model catalog to calculate cost, all cost calculations will be skipped.")
-	}
-	var err error
+// OtelPlugin is the plugin for OpenTelemetry.
+// It implements the ObservabilityPlugin interface to receive completed traces
+// from the tracing middleware and forward them to OTEL collectors.
+type OtelPlugin struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	profiles []*otelProfile
+}
+
+// initProfile initializes a single otelProfile from a ProfileConfig
+func initProfile(ctx context.Context, config *ProfileConfig, pricingManager *modelcatalog.ModelCatalog, bifrostVersion string) (*otelProfile, error) {
 	// If headers are present, and any of them start with env., we will replace the value with the environment variable
 	if config.Headers != nil {
 		for key, value := range config.Headers {
@@ -111,7 +116,6 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 	// Loading attributes from environment
 	attributesFromEnvironment := make([]*commonpb.KeyValue, 0)
 	if attributes, ok := os.LookupEnv(OTELResponseAttributesEnvKey); ok {
-		// We will split the attributes by , and then split each attribute by =
 		for attribute := range strings.SplitSeq(attributes, ",") {
 			attributeParts := strings.Split(strings.TrimSpace(attribute), "=")
 			if len(attributeParts) == 2 {
@@ -119,44 +123,45 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			}
 		}
 	}
-	// Preparing the plugin
-	p := &OtelPlugin{
+
+	profile := &otelProfile{
+		name:                      config.Name,
 		serviceName:               config.ServiceName,
-		url:                       config.CollectorURL,
 		traceType:                 config.TraceType,
-		headers:                   config.Headers,
-		protocol:                  config.Protocol,
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
 	}
-	p.ctx, p.cancel = context.WithCancel(ctx)
+
+	var err error
 	if config.Protocol == ProtocolGRPC {
-		p.client, err = NewOtelClientGRPC(config.CollectorURL, config.Headers, config.TLSCACert, config.Insecure)
+		profile.client, err = NewOtelClientGRPC(config.CollectorURL, config.Headers, config.TLSCACert, config.Insecure)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("profile %q: failed to create gRPC client: %w", config.Name, err)
 		}
 	}
 	if config.Protocol == ProtocolHTTP {
-		p.client, err = NewOtelClientHTTP(config.CollectorURL, config.Headers, config.TLSCACert, config.Insecure)
+		profile.client, err = NewOtelClientHTTP(config.CollectorURL, config.Headers, config.TLSCACert, config.Insecure)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("profile %q: failed to create HTTP client: %w", config.Name, err)
 		}
 	}
-	if p.client == nil {
-		return nil, fmt.Errorf("otel client is not initialized. invalid protocol type")
+	if profile.client == nil {
+		return nil, fmt.Errorf("profile %q: otel client is not initialized. invalid protocol type", config.Name)
 	}
 
 	// Initialize metrics exporter if enabled
 	if config.MetricsEnabled {
 		if config.MetricsEndpoint == "" {
-			return nil, fmt.Errorf("metrics_endpoint is required when metrics_enabled is true")
+			profile.client.Close()
+			return nil, fmt.Errorf("profile %q: metrics_endpoint is required when metrics_enabled is true", config.Name)
 		}
 		pushInterval := config.MetricsPushInterval
 		if pushInterval <= 0 {
 			pushInterval = 15 // default 15 seconds
 		} else if pushInterval > 300 {
-			return nil, fmt.Errorf("metrics_push_interval must be between 1 and 300 seconds, got %d", pushInterval)
+			profile.client.Close()
+			return nil, fmt.Errorf("profile %q: metrics_push_interval must be between 1 and 300 seconds, got %d", config.Name, pushInterval)
 		}
 		metricsConfig := &MetricsConfig{
 			ServiceName:  config.ServiceName,
@@ -167,16 +172,69 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			Insecure:     config.Insecure,
 			PushInterval: pushInterval,
 		}
-		p.metricsExporter, err = NewMetricsExporter(p.ctx, metricsConfig)
+		profile.metricsExporter, err = NewMetricsExporter(ctx, metricsConfig)
 		if err != nil {
-			// Clean up trace client if metrics exporter fails
-			if p.client != nil {
-				p.client.Close()
-			}
-			return nil, fmt.Errorf("failed to initialize metrics exporter: %w", err)
+			profile.client.Close()
+			return nil, fmt.Errorf("profile %q: failed to initialize metrics exporter: %w", config.Name, err)
 		}
-		logger.Info("OTEL metrics push enabled, pushing to %s every %d seconds", config.MetricsEndpoint, pushInterval)
+		logger.Info("OTEL metrics push enabled for profile %q, pushing to %s every %d seconds", config.Name, config.MetricsEndpoint, pushInterval)
 	}
+
+	return profile, nil
+}
+
+// cleanup shuts down a single profile's resources
+func (p *otelProfile) cleanup() error {
+	var errs []error
+	if p.metricsExporter != nil {
+		if err := p.metricsExporter.Shutdown(context.Background()); err != nil {
+			errs = append(errs, fmt.Errorf("profile %q: failed to shutdown metrics exporter: %w", p.name, err))
+		}
+	}
+	if p.client != nil {
+		if err := p.client.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("profile %q: failed to close client: %w", p.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// Init function for the OTEL plugin
+func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingManager *modelcatalog.ModelCatalog, bifrostVersion string) (*OtelPlugin, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config is required")
+	}
+	logger = _logger
+	if pricingManager == nil {
+		logger.Warn("otel plugin requires model catalog to calculate cost, all cost calculations will be skipped.")
+	}
+	if len(config.Profiles) == 0 {
+		logger.Warn("otel plugin has no profiles configured")
+	}
+
+	p := &OtelPlugin{}
+	p.ctx, p.cancel = context.WithCancel(ctx)
+
+	profiles := make([]*otelProfile, 0, len(config.Profiles))
+	for i := range config.Profiles {
+		// Skip disabled profiles
+		if config.Profiles[i].Enabled != nil && !*config.Profiles[i].Enabled {
+			logger.Info("OTEL profile %q is disabled, skipping", config.Profiles[i].Name)
+			continue
+		}
+		profile, err := initProfile(p.ctx, &config.Profiles[i], pricingManager, bifrostVersion)
+		if err != nil {
+			// Clean up already initialized profiles
+			for _, initialized := range profiles {
+				initialized.cleanup()
+			}
+			p.cancel()
+			return nil, err
+		}
+		profiles = append(profiles, profile)
+		logger.Info("OTEL profile %q initialized (collector: %s, protocol: %s)", config.Profiles[i].Name, config.Profiles[i].CollectorURL, config.Profiles[i].Protocol)
+	}
+	p.profiles = profiles
 
 	return p, nil
 }
@@ -203,36 +261,30 @@ func (p *OtelPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, r
 
 // ValidateConfig function for the OTEL plugin
 func (p *OtelPlugin) ValidateConfig(config any) (*Config, error) {
+	// Try to marshal from various input types to Config
 	var otelConfig Config
-	// Checking if its a string, then we will JSON parse and confirm
-	if configStr, ok := config.(string); ok {
-		if err := sonic.Unmarshal([]byte(configStr), &otelConfig); err != nil {
-			return nil, err
+	configBytes, err := marshalToBytes(config)
+	if err != nil {
+		return nil, err
+	}
+	if err := unmarshalFromBytes(configBytes, &otelConfig); err != nil {
+		return nil, err
+	}
+
+	for i, profile := range otelConfig.Profiles {
+		// Skip validation for disabled profiles
+		if profile.Enabled != nil && !*profile.Enabled {
+			continue
 		}
-	}
-	// Checking if its a map[string]any, then we will JSON parse and confirm
-	if configMap, ok := config.(map[string]any); ok {
-		configString, err := sonic.Marshal(configMap)
-		if err != nil {
-			return nil, err
+		if profile.CollectorURL == "" {
+			return nil, fmt.Errorf("profile[%d] (%s): collector url is required", i, profile.Name)
 		}
-		if err := sonic.Unmarshal([]byte(configString), &otelConfig); err != nil {
-			return nil, err
+		if profile.TraceType == "" {
+			return nil, fmt.Errorf("profile[%d] (%s): trace type is required", i, profile.Name)
 		}
-	}
-	// Checking if its a Config, then we will confirm
-	if config, ok := config.(*Config); ok {
-		otelConfig = *config
-	}
-	// Validating fields
-	if otelConfig.CollectorURL == "" {
-		return nil, fmt.Errorf("collector url is required")
-	}
-	if otelConfig.TraceType == "" {
-		return nil, fmt.Errorf("trace type is required")
-	}
-	if otelConfig.Protocol == "" {
-		return nil, fmt.Errorf("protocol is required")
+		if profile.Protocol == "" {
+			return nil, fmt.Errorf("profile[%d] (%s): protocol is required", i, profile.Name)
+		}
 	}
 	return &otelConfig, nil
 }
@@ -249,7 +301,7 @@ func (p *OtelPlugin) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.Bifros
 	return resp, bifrostErr, nil
 }
 
-// Inject receives a completed trace and sends it to the OTEL collector.
+// Inject receives a completed trace and sends it to all OTEL collector profiles.
 // Implements schemas.ObservabilityPlugin interface.
 // This method is called asynchronously by TracingMiddleware after the response
 // has been written to the client.
@@ -257,21 +309,27 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	if trace == nil {
 		return nil
 	}
-	if p.client == nil {
-		logger.Warn("otel client is not initialized")
-		return nil
+
+	errs := make([]error, len(p.profiles))
+	var wg sync.WaitGroup
+	for i, profile := range p.profiles {
+		if profile.client == nil {
+			logger.Warn("otel client is not initialized for profile %q", profile.name)
+			continue
+		}
+		wg.Add(1)
+		go func(idx int, prof *otelProfile) {
+			defer wg.Done()
+			resourceSpan := prof.convertTraceToResourceSpan(trace)
+			if err := prof.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
+				logger.Error("failed to emit trace %s to profile %q: %v", trace.TraceID, prof.name, err)
+				errs[idx] = err
+			}
+		}(i, profile)
 	}
+	wg.Wait()
 
-	// Convert schemas.Trace to OTEL ResourceSpan
-	resourceSpan := p.convertTraceToResourceSpan(trace)
-
-	// Emit to collector
-	if err := p.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
-		logger.Error("failed to emit trace %s: %v", trace.TraceID, err)
-		return err
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 // Cleanup function for the OTEL plugin
@@ -279,21 +337,40 @@ func (p *OtelPlugin) Cleanup() error {
 	if p.cancel != nil {
 		p.cancel()
 	}
-	// Shutdown metrics exporter first
-	if p.metricsExporter != nil {
-		if err := p.metricsExporter.Shutdown(context.Background()); err != nil {
-			logger.Error("failed to shutdown metrics exporter: %v", err)
+	var errs []error
+	for _, profile := range p.profiles {
+		if err := profile.cleanup(); err != nil {
+			errs = append(errs, err)
 		}
 	}
-	if p.client != nil {
-		return p.client.Close()
+	return errors.Join(errs...)
+}
+
+// GetMetricsExporter returns the first profile's metrics exporter for external use
+func (p *OtelPlugin) GetMetricsExporter() *MetricsExporter {
+	for _, profile := range p.profiles {
+		if profile.metricsExporter != nil {
+			return profile.metricsExporter
+		}
 	}
 	return nil
 }
 
-// GetMetricsExporter returns the metrics exporter for external use (e.g., by telemetry plugin)
-func (p *OtelPlugin) GetMetricsExporter() *MetricsExporter {
-	return p.metricsExporter
+// marshalToBytes converts any config input to JSON bytes
+func marshalToBytes(config any) ([]byte, error) {
+	switch v := config.(type) {
+	case string:
+		return []byte(v), nil
+	case []byte:
+		return v, nil
+	default:
+		return sonic.Marshal(v)
+	}
+}
+
+// unmarshalFromBytes unmarshals JSON bytes into the target
+func unmarshalFromBytes(data []byte, target any) error {
+	return sonic.Unmarshal(data, target)
 }
 
 // Compile-time check that OtelPlugin implements ObservabilityPlugin

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -406,7 +406,7 @@ func (h *PluginsHandler) deletePlugin(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
-	SendJSON(ctx, map[string]interface{}{
+	SendJSON(ctx, map[string]any{
 		"message": "Plugin deleted successfully",
 	})
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -495,7 +495,7 @@ func (s *BifrostHTTPServer) ReloadProvider(ctx context.Context, provider schemas
 		return nil, fmt.Errorf("failed to update provider model catalog: failed to get keys by provider: %s", err)
 	}
 	modelsInKeys := make([]schemas.Model, 0)
-	for _, key := range providerKeys {		
+	for _, key := range providerKeys {
 		for _, model := range key.Models {
 			modelsInKeys = append(modelsInKeys, schemas.Model{
 				ID: string(provider) + "/" + model,

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1050,71 +1050,199 @@
               "properties": {
                 "config": {
                   "type": "object",
-                  "description": "Configuration for the OpenTelemetry plugin",
-                  "properties": {
-                    "service_name": {
-                      "type": "string",
-                      "description": "Service name to be used for tracing",
-                      "default": "bifrost"
-                    },
-                    "collector_url": {
-                      "type": "string",
-                      "description": "URL of the OpenTelemetry collector",
-                      "oneOf": [
-                        {
-                          "format": "uri"
+                  "description": "Configuration for the OpenTelemetry plugin. Supports either a legacy single-collector config or a multi-profile config.",
+                  "oneOf": [
+                    {
+                      "description": "DEPRECATED: Legacy single-collector config. Use profiles[] instead.",
+                      "deprecated": true,
+                      "properties": {
+                        "service_name": {
+                          "type": "string",
+                          "description": "Service name to be used for tracing",
+                          "default": "bifrost"
                         },
-                        {
-                          "pattern": "^[^:\\s]+:\\d+$"
-                        }
-                      ]
-                    },
-                    "trace_type": {
-                      "type": "string",
-                      "description": "Type of trace to use for the OTEL collector",
-                      "enum": [
-                        "otel"
-                      ]
-                    },
-                    "protocol": {
-                      "type": "string",
-                      "description": "Protocol to use for the OTEL collector",
-                      "enum": [
-                        "http",
-                        "grpc"
-                      ]
-                    },
-                    "metrics_enabled": {
-                      "type": "boolean",
-                      "description": "Enable push-based metrics export via OTLP. Recommended for multi-node cluster deployments.",
-                      "default": false
-                    },
-                    "metrics_endpoint": {
-                      "type": "string",
-                      "description": "OTLP metrics endpoint URL (e.g., http://otel-collector:4318/v1/metrics for HTTP or otel-collector:4317 for gRPC)",
-                      "oneOf": [
-                        {
-                          "format": "uri"
+                        "collector_url": {
+                          "type": "string",
+                          "description": "URL of the OpenTelemetry collector",
+                          "oneOf": [
+                            {
+                              "format": "uri"
+                            },
+                            {
+                              "pattern": "^[^:\\s]+:\\d+$"
+                            }
+                          ]
                         },
-                        {
-                          "pattern": "^[^:\\s]+:\\d+$"
+                        "trace_type": {
+                          "type": "string",
+                          "description": "Type of trace to use for the OTEL collector",
+                          "enum": [
+                            "otel"
+                          ]
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "description": "Protocol to use for the OTEL collector",
+                          "enum": [
+                            "http",
+                            "grpc"
+                          ]
+                        },
+                        "headers": {
+                          "type": "object",
+                          "description": "Headers to send with requests. Values starting with 'env.' are resolved from environment variables.",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "tls_ca_cert": {
+                          "type": "string",
+                          "description": "Path to TLS CA certificate file"
+                        },
+                        "insecure": {
+                          "type": "boolean",
+                          "description": "Skip TLS verification",
+                          "default": true
+                        },
+                        "metrics_enabled": {
+                          "type": "boolean",
+                          "description": "Enable push-based metrics export via OTLP.",
+                          "default": false
+                        },
+                        "metrics_endpoint": {
+                          "type": "string",
+                          "description": "OTLP metrics endpoint URL",
+                          "oneOf": [
+                            {
+                              "format": "uri"
+                            },
+                            {
+                              "pattern": "^[^:\\s]+:\\d+$"
+                            }
+                          ]
+                        },
+                        "metrics_push_interval": {
+                          "type": "integer",
+                          "description": "Metrics push interval in seconds",
+                          "default": 15,
+                          "minimum": 1,
+                          "maximum": 300
                         }
-                      ]
+                      },
+                      "required": [
+                        "collector_url",
+                        "trace_type",
+                        "protocol"
+                      ],
+                      "additionalProperties": false
                     },
-                    "metrics_push_interval": {
-                      "type": "integer",
-                      "description": "Metrics push interval in seconds",
-                      "default": 15,
-                      "minimum": 1,
-                      "maximum": 300
+                    {
+                      "description": "Multi-profile config for pushing to multiple OTEL collectors in parallel.",
+                      "properties": {
+                        "profiles": {
+                          "type": "array",
+                          "description": "List of OTEL collector profiles. Each profile sends traces/metrics to a separate collector.",
+                          "minItems": 1,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Name of this profile (for identification in logs)"
+                              },
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Whether this profile is enabled",
+                                "default": true
+                              },
+                              "service_name": {
+                                "type": "string",
+                                "description": "Service name to be used for tracing",
+                                "default": "bifrost"
+                              },
+                              "collector_url": {
+                                "type": "string",
+                                "description": "URL of the OpenTelemetry collector",
+                                "oneOf": [
+                                  {
+                                    "format": "uri"
+                                  },
+                                  {
+                                    "pattern": "^[^:\\s]+:\\d+$"
+                                  }
+                                ]
+                              },
+                              "headers": {
+                                "type": "object",
+                                "description": "Headers to send with requests. Values starting with 'env.' are resolved from environment variables.",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "trace_type": {
+                                "type": "string",
+                                "description": "Type of trace to use for the OTEL collector",
+                                "enum": [
+                                  "otel"
+                                ]
+                              },
+                              "protocol": {
+                                "type": "string",
+                                "description": "Protocol to use for the OTEL collector",
+                                "enum": [
+                                  "http",
+                                  "grpc"
+                                ]
+                              },
+                              "tls_ca_cert": {
+                                "type": "string",
+                                "description": "Path to TLS CA certificate file"
+                              },
+                              "insecure": {
+                                "type": "boolean",
+                                "description": "Skip TLS verification",
+                                "default": true
+                              },
+                              "metrics_enabled": {
+                                "type": "boolean",
+                                "description": "Enable push-based metrics export via OTLP.",
+                                "default": false
+                              },
+                              "metrics_endpoint": {
+                                "type": "string",
+                                "description": "OTLP metrics endpoint URL",
+                                "oneOf": [
+                                  {
+                                    "format": "uri"
+                                  },
+                                  {
+                                    "pattern": "^[^:\\s]+:\\d+$"
+                                  }
+                                ]
+                              },
+                              "metrics_push_interval": {
+                                "type": "integer",
+                                "description": "Metrics push interval in seconds",
+                                "default": 15,
+                                "minimum": 1,
+                                "maximum": 300
+                              }
+                            },
+                            "required": [
+                              "collector_url",
+                              "trace_type",
+                              "protocol"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "profiles"
+                      ],
+                      "additionalProperties": false
                     }
-                  },
-                  "required": [
-                    "collector_url",
-                    "trace_type",
-                    "protocol"
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               }
             }

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/maximhq/bifrost/plugins/logging v1.4.19
 	github.com/maximhq/bifrost/plugins/maxim v1.5.18
 	github.com/maximhq/bifrost/plugins/otel v1.1.19
+	github.com/maximhq/bifrost/plugins/prometheus v0.0.0-00010101000000-000000000000
 	github.com/maximhq/bifrost/plugins/semanticcache v1.4.18
 	github.com/maximhq/bifrost/plugins/telemetry v1.4.20
 	github.com/prometheus/client_golang v1.23.2

--- a/ui/app/workspace/observability/dialogs/otelProfileSheet.tsx
+++ b/ui/app/workspace/observability/dialogs/otelProfileSheet.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Form } from "@/components/ui/form";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { getErrorMessage } from "@/lib/store";
+import { otelFormSchema, type OtelFormSchema, type OtelProfileConfigSchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { toast } from "sonner";
+import { OtelFormFragment } from "../fragments/otelFormFragment";
+
+interface OtelProfileSheetProps {
+	profile?: OtelProfileConfigSchema | null;
+	onSave: (profile: OtelProfileConfigSchema) => Promise<void>;
+	onCancel: () => void;
+}
+
+export default function OtelProfileSheet({ profile, onSave, onCancel }: OtelProfileSheetProps) {
+	const [isOpen, setIsOpen] = useState(true);
+	const isEditing = !!profile;
+	const hasAccess = useRbac(RbacResource.Observability, RbacOperation.Update);
+	const [isSaving, setIsSaving] = useState(false);
+
+	const form = useForm<OtelFormSchema, any, OtelFormSchema>({
+		resolver: zodResolver(otelFormSchema) as Resolver<OtelFormSchema, any, OtelFormSchema>,
+		mode: "onChange",
+		reValidateMode: "onChange",
+		defaultValues: {
+			otel_profile: profile
+				? { ...profile }
+				: {
+						name: "",
+						enabled: true,
+						service_name: "bifrost",
+						collector_url: "",
+						headers: {},
+						trace_type: "otel",
+						protocol: "http",
+						tls_ca_cert: "",
+						insecure: true,
+						metrics_enabled: false,
+						metrics_endpoint: "",
+						metrics_push_interval: 15,
+					},
+		},
+	});
+
+	const handleClose = () => {
+		setIsOpen(false);
+		setTimeout(() => {
+			onCancel();
+		}, 150);
+	};
+
+	const onSubmit = async (data: OtelFormSchema) => {
+		if (!hasAccess) {
+			toast.error("You don't have permission to perform this action");
+			return;
+		}
+		setIsSaving(true);
+		try {
+			await onSave(data.otel_profile);
+			toast.success(isEditing ? "Profile updated successfully" : "Profile created successfully");
+		} catch (error) {
+			toast.error(isEditing ? "Failed to update profile" : "Failed to create profile", {
+				description: getErrorMessage(error),
+			});
+		} finally {
+			setIsSaving(false);
+		}
+	};
+
+	return (
+		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+			<SheetContent
+				className="dark:bg-card flex w-full flex-col overflow-x-hidden overflow-y-auto bg-white p-8"
+				onInteractOutside={(e) => e.preventDefault()}
+				onEscapeKeyDown={(e) => e.preventDefault()}
+			>
+				<SheetHeader className="flex flex-col items-start">
+					<SheetTitle>{isEditing ? "Edit Profile" : "Add Profile"}</SheetTitle>
+					<SheetDescription>Configure an OpenTelemetry collector profile for sending traces and metrics.</SheetDescription>
+				</SheetHeader>
+
+				<Form {...form}>
+					<OtelFormFragment form={form} hasAccess={hasAccess} />
+
+					<div className="mt-auto flex justify-end gap-2 pt-6">
+						<Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
+							Cancel
+						</Button>
+						<TooltipProvider>
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span className="inline-block">
+										<Button
+											type="button"
+											disabled={!hasAccess || !form.formState.isDirty || !form.formState.isValid || isSaving}
+											isLoading={isSaving}
+											onClick={form.handleSubmit(onSubmit)}
+										>
+											{isEditing ? "Update" : "Create"}
+										</Button>
+									</span>
+								</TooltipTrigger>
+								{(!form.formState.isDirty || !form.formState.isValid) && (
+									<TooltipContent>
+										<p>
+											{!form.formState.isDirty && !form.formState.isValid
+												? "No changes made and validation errors present"
+												: !form.formState.isDirty
+													? "No changes made"
+													: "Please fix validation errors"}
+										</p>
+									</TooltipContent>
+								)}
+							</Tooltip>
+						</TooltipProvider>
+					</div>
+				</Form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/observability/views/plugins/otelView.tsx
+++ b/ui/app/workspace/observability/views/plugins/otelView.tsx
@@ -1,48 +1,222 @@
 "use client";
 
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { Button } from "@/components/ui/button";
+import { CardHeader, CardTitle } from "@/components/ui/card";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { Switch } from "@/components/ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { getErrorMessage, useAppSelector, useUpdatePluginMutation } from "@/lib/store";
-import { OtelConfigSchema, OtelFormSchema } from "@/lib/types/schemas";
-import { useMemo } from "react";
+import { OtelConfigSchema, OtelProfileConfigSchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { EllipsisIcon, PencilIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { OtelFormFragment } from "../../fragments/otelFormFragment";
+import OtelProfileSheet from "../../dialogs/otelProfileSheet";
+
+// normalizeOtelConfig converts legacy flat config to profiles-based config
+function normalizeOtelConfig(config: any): OtelConfigSchema {
+	if (!config) {
+		return { profiles: [] };
+	}
+	if (Array.isArray(config.profiles)) {
+		return { profiles: config.profiles };
+	}
+	// Legacy flat config: wrap in a single profile
+	const profile: OtelProfileConfigSchema = {
+		name: "default",
+		enabled: true,
+		...config,
+	};
+	return { profiles: [profile] };
+}
 
 export default function OtelView() {
 	const selectedPlugin = useAppSelector((state) => state.plugin.selectedPlugin);
-	const currentConfig = useMemo(
-		() => ({ ...((selectedPlugin?.config as OtelConfigSchema) ?? {}), enabled: selectedPlugin?.enabled }),
-		[selectedPlugin],
-	);
+	const config = useMemo(() => normalizeOtelConfig(selectedPlugin?.config), [selectedPlugin]);
 	const [updatePlugin, { isLoading: isUpdatingPlugin }] = useUpdatePluginMutation();
-	const baseUrl = `${window.location.protocol}//${window.location.host}`;
+	const hasUpdateAccess = useRbac(RbacResource.Observability, RbacOperation.Update);
 
-	const handleOtelConfigSave = (config: OtelFormSchema): Promise<void> => {
-		return new Promise((resolve, reject) => {
-			updatePlugin({
-				name: "otel",
-				data: {
-					enabled: config.enabled,
-					config: config.otel_config,
-				},
+	const [showSheet, setShowSheet] = useState(false);
+	const [editingIndex, setEditingIndex] = useState<number | null>(null);
+	const [showDeleteDialog, setShowDeleteDialog] = useState<{ show: boolean; index: number } | undefined>(undefined);
+
+	const editingProfile = useMemo(
+		() => (editingIndex !== null ? (config.profiles[editingIndex] ?? null) : null),
+		[editingIndex, config.profiles],
+	);
+
+	const saveProfiles = (profiles: OtelProfileConfigSchema[]) => {
+		return updatePlugin({
+			name: "otel",
+			data: {
+				enabled: true,
+				config: { profiles },
+			},
+		}).unwrap();
+	};
+
+	const handleAdd = () => {
+		setEditingIndex(null);
+		setShowSheet(true);
+	};
+
+	const handleEdit = (index: number) => {
+		setEditingIndex(index);
+		setShowSheet(true);
+	};
+
+	const handleSaved = () => {
+		setShowSheet(false);
+		setEditingIndex(null);
+	};
+
+	const handleToggleEnabled = (index: number, checked: boolean) => {
+		const updatedProfiles = config.profiles.map((p, i) => (i === index ? { ...p, enabled: checked } : p));
+		saveProfiles(updatedProfiles)
+			.then(() => {
+				toast.success(`Profile ${checked ? "enabled" : "disabled"} successfully`);
 			})
-				.unwrap()
-				.then(() => {
-					resolve();
-					toast.success("OTEL configuration updated successfully");
-				})
-				.catch((err) => {
-					toast.error("Failed to update OTEL configuration", {
-						description: getErrorMessage(err),
-					});
-					reject(err);
-				});
-		});
+			.catch((err) => {
+				toast.error("Failed to update profile", { description: getErrorMessage(err) });
+			});
+	};
+
+	const handleDelete = (index: number) => {
+		const updatedProfiles = config.profiles.filter((_, i) => i !== index);
+		saveProfiles(updatedProfiles)
+			.then(() => {
+				toast.success("Profile deleted successfully");
+				setShowDeleteDialog(undefined);
+			})
+			.catch((err) => {
+				toast.error("Failed to delete profile", { description: getErrorMessage(err) });
+			});
+	};
+
+	const handleProfileSave = (profile: OtelProfileConfigSchema) => {
+		let updatedProfiles: OtelProfileConfigSchema[];
+		if (editingIndex !== null) {
+			updatedProfiles = config.profiles.map((p, i) => (i === editingIndex ? profile : p));
+		} else {
+			updatedProfiles = [...config.profiles, profile];
+		}
+		return saveProfiles(updatedProfiles);
 	};
 
 	return (
 		<div className="flex w-full flex-col gap-4">
-			<div className="flex w-full flex-col gap-3">
-				<div className="text-muted-foreground mb-2 text-sm font-medium">Traces Configuration</div>
-				<OtelFormFragment onSave={handleOtelConfigSave} currentConfig={currentConfig} />
+			{showDeleteDialog && (
+				<AlertDialog open={showDeleteDialog.show}>
+					<AlertDialogContent onClick={(e) => e.stopPropagation()}>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Delete Profile</AlertDialogTitle>
+							<AlertDialogDescription>Are you sure you want to delete this profile? This action cannot be undone.</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter className="pt-4">
+							<AlertDialogCancel onClick={() => setShowDeleteDialog(undefined)} disabled={isUpdatingPlugin}>
+								Cancel
+							</AlertDialogCancel>
+							<AlertDialogAction disabled={isUpdatingPlugin || !hasUpdateAccess} onClick={() => handleDelete(showDeleteDialog.index)}>
+								Delete
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			)}
+			{showSheet && (
+				<OtelProfileSheet
+					profile={editingProfile}
+					onSave={async (profile: OtelProfileConfigSchema) => {
+						return handleProfileSave(profile).then(() => {
+							handleSaved();
+						});
+					}}
+					onCancel={() => {
+						setShowSheet(false);
+						setEditingIndex(null);
+					}}
+				/>
+			)}
+			<CardHeader className="px-0">
+				<CardTitle className="flex items-center justify-between">
+					<div className="flex items-center gap-2">OTEL Profiles</div>
+					<Button disabled={!hasUpdateAccess} onClick={handleAdd}>
+						<PlusIcon className="h-4 w-4" />
+						Add profile
+					</Button>
+				</CardTitle>
+			</CardHeader>
+			<div className="w-full rounded-sm border">
+				<Table className="w-full">
+					<TableHeader className="w-full">
+						<TableRow>
+							<TableHead>Name</TableHead>
+							<TableHead>Collector URL</TableHead>
+							<TableHead>Protocol</TableHead>
+							<TableHead>Enabled</TableHead>
+							<TableHead className="text-right"></TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{config.profiles.length === 0 && (
+							<TableRow>
+								<TableCell colSpan={5} className="py-6 text-center">
+									No profiles configured. Add a profile to start sending traces.
+								</TableCell>
+							</TableRow>
+						)}
+						{config.profiles.map((profile, index) => (
+							<TableRow key={index} className="text-sm transition-colors">
+								<TableCell>
+									<span className="font-mono text-sm">{profile.name || `Profile ${index + 1}`}</span>
+								</TableCell>
+								<TableCell>
+									<span className="text-muted-foreground font-mono text-sm">{profile.collector_url || "-"}</span>
+								</TableCell>
+								<TableCell>
+									<span className="text-sm uppercase">{profile.protocol || "-"}</span>
+								</TableCell>
+								<TableCell>
+									<Switch
+										checked={profile.enabled ?? true}
+										size="md"
+										disabled={!hasUpdateAccess}
+										onCheckedChange={(checked) => handleToggleEnabled(index, checked)}
+									/>
+								</TableCell>
+								<TableCell className="text-right">
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button onClick={(e) => e.stopPropagation()} variant="ghost">
+												<EllipsisIcon className="h-5 w-5" />
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent align="end">
+											<DropdownMenuItem onClick={() => handleEdit(index)} disabled={!hasUpdateAccess}>
+												<PencilIcon className="mr-1 h-4 w-4" />
+												Edit
+											</DropdownMenuItem>
+											<DropdownMenuItem onClick={() => setShowDeleteDialog({ show: true, index })} disabled={!hasUpdateAccess}>
+												<TrashIcon className="mr-1 h-4 w-4" />
+												Delete
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
 			</div>
 		</div>
 	);

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -527,9 +527,11 @@ export const performanceFormSchema = z.object({
 	send_back_raw_response: z.boolean(),
 });
 
-// OTEL Configuration Schema
-export const otelConfigSchema = z
+// OTEL Profile Configuration Schema (single profile)
+export const otelProfileConfigSchema = z
 	.object({
+		name: z.string().optional(),
+		enabled: z.boolean().default(true),
 		service_name: z.string().optional(),
 		collector_url: z.string().min(1, "Collector address is required"),
 		trace_type: z
@@ -632,10 +634,14 @@ export const otelConfigSchema = z
 		}
 	});
 
-// OTEL form schema for the OtelFormFragment
+// OTEL Configuration Schema (wraps multiple profiles)
+export const otelConfigSchema = z.object({
+	profiles: z.array(otelProfileConfigSchema),
+});
+
+// OTEL form schema for the OtelFormFragment (single profile editing)
 export const otelFormSchema = z.object({
-	enabled: z.boolean().default(false),
-	otel_config: otelConfigSchema,
+	otel_profile: otelProfileConfigSchema,
 });
 
 // Maxim Configuration Schema
@@ -873,6 +879,7 @@ export type NetworkFormConfigSchema = z.infer<typeof networkFormConfigSchema>;
 export type ProxyFormConfigSchema = z.infer<typeof proxyFormConfigSchema>;
 export type NetworkAndProxyFormSchema = z.infer<typeof networkAndProxyFormSchema>;
 export type ProxyOnlyFormSchema = z.infer<typeof proxyOnlyFormSchema>;
+export type OtelProfileConfigSchema = z.infer<typeof otelProfileConfigSchema>;
 export type OtelConfigSchema = z.infer<typeof otelConfigSchema>;
 export type OtelFormSchema = z.infer<typeof otelFormSchema>;
 export type MaximConfigSchema = z.infer<typeof maximConfigSchema>;


### PR DESCRIPTION
## Summary

This PR enhances the OpenTelemetry plugin to support multiple collector profiles, allowing Bifrost to send traces to multiple OTEL collectors simultaneously.

## Changes

- Restructured the OTEL plugin configuration to use a profiles-based approach
- Added support for sending traces to multiple collectors in parallel
- Updated the UI to support creating and managing multiple OTEL profiles
- Maintained backward compatibility with existing single-collector configurations
- Enhanced error handling with proper cleanup of resources when initialization fails
- Updated Helm charts, config schemas, and example configurations

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Plugins
- [x] UI (Next.js)

## How to test

1. Configure multiple OTEL profiles in your Bifrost config:

```json
{
  "plugins": [
    {
      "enabled": true,
      "name": "otel",
      "config": {
        "profiles": [
          {
            "name": "primary",
            "service_name": "bifrost",
            "collector_url": "http://otel-collector-1:4318/v1/traces",
            "trace_type": "otel",
            "protocol": "http"
          },
          {
            "name": "secondary",
            "service_name": "bifrost-backup",
            "collector_url": "http://otel-collector-2:4318/v1/traces",
            "trace_type": "otel",
            "protocol": "http"
          }
        ]
      }
    }
  ]
}
```

2. Start Bifrost and verify in logs that both profiles are initialized
3. Make requests and check that traces are sent to both collectors

## Breaking changes

- [x] No

The change is backward compatible. Existing single-collector configurations will be automatically converted to the new profiles-based format.

## Security considerations

This change doesn't introduce new security implications. The same security considerations for OTEL collectors (TLS, authentication headers) apply to each profile.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)