### PR TITLE
fixes ClaudeCodeMax mode vs ClaudeCode API mode forwarding

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -146,7 +146,7 @@ func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, 
 
 	// Can be empty in case of passthrough or keyless custom provider
 	// Here we can avoid this - in case of passthrough completely
-	if key != "" && !IsClaudeCodeRequest(ctx) {
+	if key != "" && !IsClaudeCodeMaxMode(ctx) {
 		req.Header.Set("x-api-key", key)
 	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
@@ -420,7 +420,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		"Cache-Control":     "no-cache",
 	}
 
-	if key.Value.GetValue() != "" && !IsClaudeCodeRequest(ctx) {
+	if key.Value.GetValue() != "" && !IsClaudeCodeMaxMode(ctx) {
 		headers["x-api-key"] = key.Value.GetValue()
 	}
 
@@ -862,8 +862,8 @@ func (provider *AnthropicProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		"Accept":            "text/event-stream",
 		"Cache-Control":     "no-cache",
 	}
-	
-	if key.Value.GetValue() != "" && !IsClaudeCodeRequest(ctx) {
+
+	if key.Value.GetValue() != "" && !IsClaudeCodeMaxMode(ctx) {
 		headers["x-api-key"] = key.Value.GetValue()
 	}
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -1590,12 +1590,18 @@ func anthropicExtractFloat64(v interface{}) (float64, bool) {
 	}
 }
 
+// IsClaudeCodeMaxMode checks if the request is a Claude Code max mode request.
+// In the max mode - we don't need to forward the key
+func IsClaudeCodeMaxMode(ctx *schemas.BifrostContext) bool {
+	userAgent, _ := ctx.Value(schemas.BifrostContextKeyUserAgent).(string)
+	skipKeySelection, _ := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool)
+	return strings.Contains(strings.ToLower(userAgent), "claude-cli") && skipKeySelection
+}
+
 // IsClaudeCodeRequest checks if the request is a Claude Code request.
 func IsClaudeCodeRequest(ctx *schemas.BifrostContext) bool {
 	if userAgent, ok := ctx.Value(schemas.BifrostContextKeyUserAgent).(string); ok {
-		if strings.Contains(strings.ToLower(userAgent), "claude-cli") {
-			return true
-		}
+		return strings.Contains(strings.ToLower(userAgent), "claude-cli")
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

Refine Claude Code integration by separating the concept of Claude CLI requests from the "max mode" where key selection should be skipped.

## Issues
Fixes #1610

## Changes

- Renamed `IsClaudeCodeRequest` function calls to `IsClaudeCodeMaxMode` in places where we're checking whether to skip API key inclusion
- Added a new `IsClaudeCodeMaxMode` function that checks both for Claude CLI user agent AND if key selection should be skipped
- Simplified the original `IsClaudeCodeRequest` function to only check for Claude CLI user agent
- Added clarifying comments about the relationship between `IsClaudeCodeMaxMode` and the `BifrostContextKeySkipKeySelection` context key
- Fixed indentation in the Anthropic messages route configuration

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Claude CLI requests in both modes:
1. With API key selection skipped (max mode)
2. With API key selection enabled (normal mode)

Verify that API keys are correctly included or omitted in the headers based on the mode.

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change ensures API keys are properly handled when using Claude CLI, preventing potential issues with key forwarding in different modes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable