### PR TITLE
feat: adds rate limits to customers and teams

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1812,7 +1812,7 @@ func (s *RDBConfigStore) DeleteVirtualKeyMCPConfig(ctx context.Context, id uint,
 // GetTeams retrieves all teams from the database.
 func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error) {
 	// Preload relationships for complete information
-	query := s.db.WithContext(ctx).Preload("Customer").Preload("Budget")
+	query := s.db.WithContext(ctx).Preload("Customer").Preload("Budget").Preload("RateLimit")
 	// Optional filtering by customer
 	if customerID != "" {
 		query = query.Where("customer_id = ?", customerID)
@@ -1827,7 +1827,7 @@ func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tab
 // GetTeam retrieves a specific team from the database.
 func (s *RDBConfigStore) GetTeam(ctx context.Context, id string) (*tables.TableTeam, error) {
 	var team tables.TableTeam
-	if err := s.db.WithContext(ctx).Preload("Customer").Preload("Budget").First(&team, "id = ?", id).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Customer").Preload("Budget").Preload("RateLimit").First(&team, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -1868,7 +1868,7 @@ func (s *RDBConfigStore) UpdateTeam(ctx context.Context, team *tables.TableTeam,
 func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var team tables.TableTeam
-		if err := tx.WithContext(ctx).Preload("Budget").First(&team, "id = ?", id).Error; err != nil {
+		if err := tx.WithContext(ctx).Preload("Budget").Preload("RateLimit").First(&team, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
@@ -1878,8 +1878,9 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 		if err := tx.WithContext(ctx).Model(&tables.TableVirtualKey{}).Where("team_id = ?", id).Update("team_id", nil).Error; err != nil {
 			return err
 		}
-		// Store the budget ID before deleting the team
+		// Store the budget and rate limit IDs before deleting the team
 		budgetID := team.BudgetID
+		rateLimitID := team.RateLimitID
 		// Delete the team first
 		if err := tx.WithContext(ctx).Delete(&tables.TableTeam{}, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -1890,6 +1891,12 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 		// Delete the team's budget if it exists
 		if budgetID != nil {
 			if err := tx.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *budgetID).Error; err != nil {
+				return err
+			}
+		}
+		// Delete the team's rate limit if it exists
+		if rateLimitID != nil {
+			if err := tx.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *rateLimitID).Error; err != nil {
 				return err
 			}
 		}
@@ -1906,7 +1913,7 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 // GetCustomers retrieves all customers from the database.
 func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustomer, error) {
 	var customers []tables.TableCustomer
-	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Order("created_at ASC").Find(&customers).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Preload("RateLimit").Order("created_at ASC").Find(&customers).Error; err != nil {
 		return nil, err
 	}
 	return customers, nil
@@ -1915,7 +1922,7 @@ func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustom
 // GetCustomer retrieves a specific customer from the database.
 func (s *RDBConfigStore) GetCustomer(ctx context.Context, id string) (*tables.TableCustomer, error) {
 	var customer tables.TableCustomer
-	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").First(&customer, "id = ?", id).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Preload("RateLimit").First(&customer, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -1956,7 +1963,7 @@ func (s *RDBConfigStore) UpdateCustomer(ctx context.Context, customer *tables.Ta
 func (s *RDBConfigStore) DeleteCustomer(ctx context.Context, id string) error {
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var customer tables.TableCustomer
-		if err := tx.WithContext(ctx).Preload("Budget").First(&customer, "id = ?", id).Error; err != nil {
+		if err := tx.WithContext(ctx).Preload("Budget").Preload("RateLimit").First(&customer, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
@@ -1970,8 +1977,9 @@ func (s *RDBConfigStore) DeleteCustomer(ctx context.Context, id string) error {
 		if err := tx.WithContext(ctx).Model(&tables.TableTeam{}).Where("customer_id = ?", id).Update("customer_id", nil).Error; err != nil {
 			return err
 		}
-		// Store the budget ID before deleting the customer
+		// Store the budget and rate limit IDs before deleting the customer
 		budgetID := customer.BudgetID
+		rateLimitID := customer.RateLimitID
 		// Delete the customer first
 		if err := tx.WithContext(ctx).Delete(&tables.TableCustomer{}, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -1982,6 +1990,12 @@ func (s *RDBConfigStore) DeleteCustomer(ctx context.Context, id string) error {
 		// Delete the customer's budget if it exists
 		if budgetID != nil {
 			if err := tx.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *budgetID).Error; err != nil {
+				return err
+			}
+		}
+		// Delete the customer's rate limit if it exists
+		if rateLimitID != nil {
+			if err := tx.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *rateLimitID).Error; err != nil {
 				return err
 			}
 		}
@@ -2005,9 +2019,15 @@ func (s *RDBConfigStore) GetRateLimits(ctx context.Context) ([]tables.TableRateL
 }
 
 // GetRateLimit retrieves a specific rate limit from the database.
-func (s *RDBConfigStore) GetRateLimit(ctx context.Context, id string) (*tables.TableRateLimit, error) {
+func (s *RDBConfigStore) GetRateLimit(ctx context.Context, id string, tx ...*gorm.DB) (*tables.TableRateLimit, error) {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.db
+	}
 	var rateLimit tables.TableRateLimit
-	if err := s.db.WithContext(ctx).First(&rateLimit, "id = ?", id).Error; err != nil {
+	if err := txDB.WithContext(ctx).First(&rateLimit, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -2056,6 +2076,20 @@ func (s *RDBConfigStore) UpdateRateLimits(ctx context.Context, rateLimits []*tab
 		if err := txDB.WithContext(ctx).Save(rl).Error; err != nil {
 			return s.parseGormError(err)
 		}
+	}
+	return nil
+}
+
+// DeleteRateLimit deletes a rate limit from the database.
+func (s *RDBConfigStore) DeleteRateLimit(ctx context.Context, id string, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.db
+	}
+	if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", id).Error; err != nil {
+		return s.parseGormError(err)
 	}
 	return nil
 }
@@ -2126,6 +2160,20 @@ func (s *RDBConfigStore) UpdateBudget(ctx context.Context, budget *tables.TableB
 		txDB = s.db
 	}
 	if err := txDB.WithContext(ctx).Save(budget).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
+
+// DeleteBudget deletes a budget from the database.
+func (s *RDBConfigStore) DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.db
+	}
+	if err := txDB.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", id).Error; err != nil {
 		return s.parseGormError(err)
 	}
 	return nil

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -102,10 +102,11 @@ type ConfigStore interface {
 
 	// Rate limit CRUD
 	GetRateLimits(ctx context.Context) ([]tables.TableRateLimit, error)
-	GetRateLimit(ctx context.Context, id string) (*tables.TableRateLimit, error)
+	GetRateLimit(ctx context.Context, id string, tx ...*gorm.DB) (*tables.TableRateLimit, error)
 	CreateRateLimit(ctx context.Context, rateLimit *tables.TableRateLimit, tx ...*gorm.DB) error
 	UpdateRateLimit(ctx context.Context, rateLimit *tables.TableRateLimit, tx ...*gorm.DB) error
 	UpdateRateLimits(ctx context.Context, rateLimits []*tables.TableRateLimit, tx ...*gorm.DB) error
+	DeleteRateLimit(ctx context.Context, id string, tx ...*gorm.DB) error
 
 	// Budget CRUD
 	GetBudgets(ctx context.Context) ([]tables.TableBudget, error)
@@ -113,6 +114,7 @@ type ConfigStore interface {
 	CreateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
 	UpdateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error
 	UpdateBudgets(ctx context.Context, budgets []*tables.TableBudget, tx ...*gorm.DB) error
+	DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error
 	UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64) error
 	UpdateRateLimitUsage(ctx context.Context, id string, tokenCurrentUsage int64, requestCurrentUsage int64) error
 

--- a/framework/configstore/tables/customer.go
+++ b/framework/configstore/tables/customer.go
@@ -2,14 +2,16 @@ package tables
 
 import "time"
 
-// TableCustomer represents a customer entity with budget
+// TableCustomer represents a customer entity with budget and rate limit
 type TableCustomer struct {
-	ID       string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
-	Name     string  `gorm:"type:varchar(255);not null" json:"name"`
-	BudgetID *string `gorm:"type:varchar(255);index" json:"budget_id,omitempty"`
+	ID          string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	Name        string  `gorm:"type:varchar(255);not null" json:"name"`
+	BudgetID    *string `gorm:"type:varchar(255);index" json:"budget_id,omitempty"`
+	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
 	// Relationships
 	Budget      *TableBudget      `gorm:"foreignKey:BudgetID" json:"budget,omitempty"`
+	RateLimit   *TableRateLimit   `gorm:"foreignKey:RateLimitID" json:"rate_limit,omitempty"`
 	Teams       []TableTeam       `gorm:"foreignKey:CustomerID" json:"teams"`
 	VirtualKeys []TableVirtualKey `gorm:"foreignKey:CustomerID" json:"virtual_keys"`
 

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -8,16 +8,18 @@ import (
 	"gorm.io/gorm"
 )
 
-// TableTeam represents a team entity with budget and customer association
+// TableTeam represents a team entity with budget, rate limit and customer association
 type TableTeam struct {
-	ID         string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
-	Name       string  `gorm:"type:varchar(255);not null" json:"name"`
-	CustomerID *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"` // A team can belong to a customer
-	BudgetID   *string `gorm:"type:varchar(255);index" json:"budget_id,omitempty"`
+	ID          string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	Name        string  `gorm:"type:varchar(255);not null" json:"name"`
+	CustomerID  *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"` // A team can belong to a customer
+	BudgetID    *string `gorm:"type:varchar(255);index" json:"budget_id,omitempty"`
+	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
 	// Relationships
 	Customer    *TableCustomer    `gorm:"foreignKey:CustomerID" json:"customer,omitempty"`
 	Budget      *TableBudget      `gorm:"foreignKey:BudgetID" json:"budget,omitempty"`
+	RateLimit   *TableRateLimit   `gorm:"foreignKey:RateLimitID" json:"rate_limit,omitempty"`
 	VirtualKeys []TableVirtualKey `gorm:"foreignKey:TeamID" json:"virtual_keys"`
 
 	Profile       *string                `gorm:"type:text" json:"-"`

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -109,8 +109,9 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 		return
 	}
 
-	// Update rate limit usage (both provider-level and VK-level) if applicable
-	if vk.RateLimit != nil || len(vk.ProviderConfigs) > 0 {
+	// Update rate limit usage (VK-level, provider-config-level, team-level, customer-level) if applicable
+	// Include TeamID and CustomerID checks since rate limits can be configured at those levels
+	if vk.RateLimit != nil || len(vk.ProviderConfigs) > 0 || vk.TeamID != nil || vk.CustomerID != nil {
 		if err := t.store.UpdateVirtualKeyRateLimitUsageInMemory(ctx, vk, update.Provider, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
 			t.logger.Error("failed to update rate limit usage for VK %s: %v", vk.ID, err)
 		}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -568,8 +568,36 @@ func (m *MockConfigStore) UpdateRateLimits(ctx context.Context, rateLimits []*ta
 	return nil
 }
 
-func (m *MockConfigStore) GetRateLimit(ctx context.Context, id string) (*tables.TableRateLimit, error) {
+func (m *MockConfigStore) GetRateLimit(ctx context.Context, id string, tx ...*gorm.DB) (*tables.TableRateLimit, error) {
 	return nil, nil
+}
+
+func (m *MockConfigStore) DeleteRateLimit(ctx context.Context, id string, tx ...*gorm.DB) error {
+	if m.governanceConfig == nil || len(m.governanceConfig.RateLimits) == 0 {
+		return nil
+	}
+	filtered := make([]tables.TableRateLimit, 0, len(m.governanceConfig.RateLimits))
+	for _, rl := range m.governanceConfig.RateLimits {
+		if rl.ID != id {
+			filtered = append(filtered, rl)
+		}
+	}
+	m.governanceConfig.RateLimits = filtered
+	return nil
+}
+
+func (m *MockConfigStore) DeleteBudget(ctx context.Context, id string, tx ...*gorm.DB) error {
+	if m.governanceConfig == nil || len(m.governanceConfig.Budgets) == 0 {
+		return nil
+	}
+	filtered := make([]tables.TableBudget, 0, len(m.governanceConfig.Budgets))
+	for _, b := range m.governanceConfig.Budgets {
+		if b.ID != id {
+			filtered = append(filtered, b)
+		}
+	}
+	m.governanceConfig.Budgets = filtered
+	return nil
 }
 
 func (m *MockConfigStore) GetRateLimits(ctx context.Context) ([]tables.TableRateLimit, error) {
@@ -14972,6 +15000,7 @@ var excludedGoFields = map[string]map[string]bool{
 		"created_at":   true,
 		"updated_at":   true,
 		"budget":       true, // GORM relation
+		"rate_limit":   true, // GORM relation
 		"teams":        true, // GORM relation
 		"virtual_keys": true, // GORM relation
 	},
@@ -14980,6 +15009,7 @@ var excludedGoFields = map[string]map[string]bool{
 		"created_at":   true,
 		"updated_at":   true,
 		"budget":       true, // GORM relation
+		"rate_limit":   true, // GORM relation
 		"customer":     true, // GORM relation
 		"virtual_keys": true, // GORM relation
 	},

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -296,6 +296,10 @@
               "budget_id": {
                 "type": "string",
                 "description": "Associated budget ID"
+              },
+              "rate_limit_id": {
+                "type": "string",
+                "description": "Associated rate limit ID"
               }
             },
             "required": [
@@ -326,6 +330,10 @@
               "budget_id": {
                 "type": "string",
                 "description": "Associated budget ID"
+              },
+              "rate_limit_id": {
+                "type": "string",
+                "description": "Associated rate limit ID"
               },
               "profile": {
                 "type": "object",

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -300,7 +300,7 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 												)}
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
-												<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+												<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
 													<TooltipProvider>
 														<Tooltip>
 															<TooltipTrigger asChild>

--- a/ui/app/workspace/user-groups/views/customerTable.tsx
+++ b/ui/app/workspace/user-groups/views/customerTable.tsx
@@ -13,17 +13,24 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { resetDurationLabels } from "@/lib/constants/governance";
 import { getErrorMessage, useDeleteCustomerMutation } from "@/lib/store";
 import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
-import { formatCurrency, parseResetPeriod } from "@/lib/utils/governance";
+import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Edit, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import CustomerDialog from "./customerDialog";
+
+// Helper to format reset duration for display
+const formatResetDuration = (duration: string) => {
+	return resetDurationLabels[duration] || duration;
+};
 
 interface CustomersTableProps {
 	customers: Customer[];
@@ -75,93 +82,219 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 
 	return (
 		<>
-			{showCustomerDialog && (
-				<CustomerDialog customer={editingCustomer} onSave={handleCustomerSaved} onCancel={() => setShowCustomerDialog(false)} />
-			)}
+			<TooltipProvider>
+				{showCustomerDialog && (
+					<CustomerDialog customer={editingCustomer} onSave={handleCustomerSaved} onCancel={() => setShowCustomerDialog(false)} />
+				)}
 
-			<div className="space-y-4">
-				<div className="flex items-center justify-between">
-					<div>
-						<p className="text-muted-foreground text-sm">Manage customer accounts with their own teams, budgets, and access controls.</p>
+				<div className="space-y-4">
+					<div className="flex items-center justify-between">
+						<div>
+							<p className="text-muted-foreground text-sm">Manage customer accounts with their own teams, budgets, and access controls.</p>
+						</div>
+						<Button data-testid="create-customer-btn" onClick={handleAddCustomer} disabled={!hasCreateAccess}>
+							<Plus className="h-4 w-4" />
+							Add Customer
+						</Button>
 					</div>
-					<Button data-testid="create-customer-btn" onClick={handleAddCustomer} disabled={!hasCreateAccess}>
-						<Plus className="h-4 w-4" />
-						Add Customer
-					</Button>
-				</div>
 
-				<div className="rounded-sm border" data-testid="customers-table">
-					<Table>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Name</TableHead>
-								<TableHead>Teams</TableHead>
-								<TableHead>Budget</TableHead>
-								<TableHead>Reset Period</TableHead>
-								<TableHead>Virtual Keys</TableHead>
-								<TableHead className="text-right"></TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{customers?.length === 0 ? (
+					<div className="rounded-sm border" data-testid="customers-table">
+						<Table>
+							<TableHeader>
 								<TableRow>
-									<TableCell colSpan={5} className="text-muted-foreground py-8 text-center">
-										No customers found. Create your first customer to get started.
-									</TableCell>
+									<TableHead>Name</TableHead>
+									<TableHead>Teams</TableHead>
+									<TableHead>Budget</TableHead>
+									<TableHead>Rate Limit</TableHead>
+									<TableHead>Virtual Keys</TableHead>
+									<TableHead className="text-right"></TableHead>
 								</TableRow>
-							) : (
-								customers?.map((customer) => {
-									const teams = getTeamsForCustomer(customer.id);
-									const vks = getVirtualKeysForCustomer(customer.id);
+							</TableHeader>
+							<TableBody>
+								{customers?.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={6} className="text-muted-foreground py-8 text-center">
+											No customers found. Create your first customer to get started.
+										</TableCell>
+									</TableRow>
+								) : (
+									customers?.map((customer) => {
+										const customerTeams = getTeamsForCustomer(customer.id);
+										const vks = getVirtualKeysForCustomer(customer.id);
 
-									return (
-										<TableRow key={customer.id}>
-											<TableCell className="max-w-[200px]">
-												<div className="truncate font-medium">{customer.name}</div>
-											</TableCell>
-											<TableCell>
-												{teams?.length > 0 ? (
-													<div className="flex items-center gap-2">
-														<TooltipProvider>
+										// Budget calculations
+										const isBudgetExhausted =
+											customer.budget?.max_limit && customer.budget.max_limit > 0 && customer.budget.current_usage >= customer.budget.max_limit;
+										const budgetPercentage =
+											customer.budget?.max_limit && customer.budget.max_limit > 0
+												? Math.min((customer.budget.current_usage / customer.budget.max_limit) * 100, 100)
+												: 0;
+
+										// Rate limit calculations
+										const isTokenLimitExhausted =
+											customer.rate_limit?.token_max_limit &&
+											customer.rate_limit.token_max_limit > 0 &&
+											customer.rate_limit.token_current_usage >= customer.rate_limit.token_max_limit;
+										const isRequestLimitExhausted =
+											customer.rate_limit?.request_max_limit &&
+											customer.rate_limit.request_max_limit > 0 &&
+											customer.rate_limit.request_current_usage >= customer.rate_limit.request_max_limit;
+										const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
+										const tokenPercentage =
+											customer.rate_limit?.token_max_limit && customer.rate_limit.token_max_limit > 0
+												? Math.min((customer.rate_limit.token_current_usage / customer.rate_limit.token_max_limit) * 100, 100)
+												: 0;
+										const requestPercentage =
+											customer.rate_limit?.request_max_limit && customer.rate_limit.request_max_limit > 0
+												? Math.min((customer.rate_limit.request_current_usage / customer.rate_limit.request_max_limit) * 100, 100)
+												: 0;
+
+										const isExhausted = isBudgetExhausted || isRateLimitExhausted;
+
+										return (
+											<TableRow key={customer.id} className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}>
+												<TableCell className="max-w-[200px] py-4">
+													<div className="flex flex-col gap-2">
+														<span className="truncate font-medium">{customer.name}</span>
+														{isExhausted && (
+															<Badge variant="destructive" className="w-fit text-xs">
+																Limit Reached
+															</Badge>
+														)}
+													</div>
+												</TableCell>
+												<TableCell>
+													{customerTeams?.length > 0 ? (
+														<div className="flex items-center gap-2">
 															<Tooltip>
 																<TooltipTrigger>
 																	<Badge variant="outline" className="text-xs">
-																		{teams.length} {teams.length === 1 ? "team" : "teams"}
+																		{customerTeams.length} {customerTeams.length === 1 ? "team" : "teams"}
 																	</Badge>
 																</TooltipTrigger>
-																<TooltipContent>{teams.map((team) => team.name).join(", ")}</TooltipContent>
+																<TooltipContent>{customerTeams.map((team) => team.name).join(", ")}</TooltipContent>
 															</Tooltip>
-														</TooltipProvider>
-													</div>
-												) : (
-													<span className="text-muted-foreground text-sm">-</span>
-												)}
-											</TableCell>
-											<TableCell>
-												{customer.budget ? (
-													<span
-														className={cn(
-															"font-mono text-sm",
-															customer.budget.current_usage >= customer.budget.max_limit && "text-destructive",
-														)}
-													>
-														{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
-													</span>
-												) : (
-													<span className="text-muted-foreground text-sm">-</span>
-												)}
-											</TableCell>
-											<TableCell>
-												{customer.budget ? (
-													parseResetPeriod(customer.budget.reset_duration)
-												) : (
-													<span className="text-muted-foreground text-sm">-</span>
-												)}
-											</TableCell>
-											<TableCell>
-												{vks?.length > 0 ? (
-													<div className="flex items-center gap-2">
-														<TooltipProvider>
+														</div>
+													) : (
+														<span className="text-muted-foreground text-sm">—</span>
+													)}
+												</TableCell>
+												<TableCell className="min-w-[180px]">
+													{customer.budget ? (
+														<Tooltip>
+															<TooltipTrigger asChild>
+																<div className="space-y-2">
+																	<div className="flex items-center justify-between gap-4">
+																		<span className="font-medium">{formatCurrency(customer.budget.max_limit)}</span>
+																		<span className="text-muted-foreground text-xs">
+																			{formatResetDuration(customer.budget.reset_duration)}
+																		</span>
+																	</div>
+																	<Progress
+																		value={budgetPercentage}
+																		className={cn(
+																			"bg-muted/70 dark:bg-muted/30 h-1.5",
+																			isBudgetExhausted
+																				? "[&>div]:bg-red-500/70"
+																				: budgetPercentage > 80
+																					? "[&>div]:bg-amber-500/70"
+																					: "[&>div]:bg-emerald-500/70",
+																		)}
+																	/>
+																</div>
+															</TooltipTrigger>
+															<TooltipContent>
+																<p className="font-medium">
+																	{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
+																</p>
+																<p className="text-primary-foreground/80 text-xs">
+																	Resets {formatResetDuration(customer.budget.reset_duration)}
+																</p>
+															</TooltipContent>
+														</Tooltip>
+													) : (
+														<span className="text-muted-foreground text-sm">—</span>
+													)}
+												</TableCell>
+												<TableCell className="min-w-[180px]">
+													{customer.rate_limit ? (
+														<div className="space-y-2.5">
+															{customer.rate_limit.token_max_limit && (
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<div className="space-y-1.5">
+																			<div className="flex items-center justify-between gap-4 text-xs">
+																				<span className="font-medium">{customer.rate_limit.token_max_limit.toLocaleString()} tokens</span>
+																				<span className="text-muted-foreground">
+																					{formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
+																				</span>
+																			</div>
+																			<Progress
+																				value={tokenPercentage}
+																				className={cn(
+																					"bg-muted/70 dark:bg-muted/30 h-1",
+																					isTokenLimitExhausted
+																						? "[&>div]:bg-red-500/70"
+																						: tokenPercentage > 80
+																							? "[&>div]:bg-amber-500/70"
+																							: "[&>div]:bg-emerald-500/70",
+																				)}
+																			/>
+																		</div>
+																	</TooltipTrigger>
+																	<TooltipContent>
+																		<p className="font-medium">
+																			{customer.rate_limit.token_current_usage.toLocaleString()} /{" "}
+																			{customer.rate_limit.token_max_limit.toLocaleString()} tokens
+																		</p>
+																		<p className="text-primary-foreground/80 text-xs">
+																			Resets {formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															)}
+															{customer.rate_limit.request_max_limit && (
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<div className="space-y-1.5">
+																			<div className="flex items-center justify-between gap-4 text-xs">
+																				<span className="font-medium">{customer.rate_limit.request_max_limit.toLocaleString()} req</span>
+																				<span className="text-muted-foreground">
+																					{formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
+																				</span>
+																			</div>
+																			<Progress
+																				value={requestPercentage}
+																				className={cn(
+																					"bg-muted/70 dark:bg-muted/30 h-1",
+																					isRequestLimitExhausted
+																						? "[&>div]:bg-red-500/70"
+																						: requestPercentage > 80
+																							? "[&>div]:bg-amber-500/70"
+																							: "[&>div]:bg-emerald-500/70",
+																				)}
+																			/>
+																		</div>
+																	</TooltipTrigger>
+																	<TooltipContent>
+																		<p className="font-medium">
+																			{customer.rate_limit.request_current_usage.toLocaleString()} /{" "}
+																			{customer.rate_limit.request_max_limit.toLocaleString()} requests
+																		</p>
+																		<p className="text-primary-foreground/80 text-xs">
+																			Resets {formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															)}
+														</div>
+													) : (
+														<span className="text-muted-foreground text-sm">—</span>
+													)}
+												</TableCell>
+												<TableCell>
+													{vks?.length > 0 ? (
+														<div className="flex items-center gap-2">
 															<Tooltip>
 																<TooltipTrigger>
 																	<Badge variant="outline" className="text-xs">
@@ -170,49 +303,74 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 																</TooltipTrigger>
 																<TooltipContent>{vks.map((vk) => vk.name).join(", ")}</TooltipContent>
 															</Tooltip>
-														</TooltipProvider>
+														</div>
+													) : (
+														<span className="text-muted-foreground text-sm">—</span>
+													)}
+												</TableCell>
+												<TableCell className="text-right">
+													<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+														<Tooltip>
+															<TooltipTrigger asChild>
+																<Button
+																	variant="ghost"
+																	size="icon"
+																	className="h-8 w-8"
+																	onClick={() => handleEditCustomer(customer)}
+																	disabled={!hasUpdateAccess}
+																>
+																	<Edit className="h-4 w-4" />
+																</Button>
+															</TooltipTrigger>
+															<TooltipContent>Edit</TooltipContent>
+														</Tooltip>
+														<AlertDialog>
+															<Tooltip>
+																<AlertDialogTrigger asChild>
+																	<TooltipTrigger asChild>
+																		<Button
+																			variant="ghost"
+																			size="icon"
+																			className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
+																			disabled={!hasDeleteAccess}
+																		>
+																			<Trash2 className="h-4 w-4" />
+																		</Button>
+																	</TooltipTrigger>
+																</AlertDialogTrigger>
+																<TooltipContent>Delete</TooltipContent>
+															</Tooltip>
+															<AlertDialogContent>
+																<AlertDialogHeader>
+																	<AlertDialogTitle>Delete Customer</AlertDialogTitle>
+																	<AlertDialogDescription>
+																		Are you sure you want to delete &quot;{customer.name}&quot;? This will also delete all associated teams
+																		and unassign any virtual keys. This action cannot be undone.
+																	</AlertDialogDescription>
+																</AlertDialogHeader>
+																<AlertDialogFooter>
+																	<AlertDialogCancel>Cancel</AlertDialogCancel>
+																	<AlertDialogAction
+																		onClick={() => handleDelete(customer.id)}
+																		disabled={isDeleting}
+																		className="bg-red-600 hover:bg-red-700"
+																	>
+																		{isDeleting ? "Deleting..." : "Delete"}
+																	</AlertDialogAction>
+																</AlertDialogFooter>
+															</AlertDialogContent>
+														</AlertDialog>
 													</div>
-												) : (
-													<span className="text-muted-foreground text-sm">-</span>
-												)}
-											</TableCell>
-											<TableCell className="text-right">
-												<div className="flex items-center justify-end gap-2">
-													<Button variant="ghost" size="sm" onClick={() => handleEditCustomer(customer)} disabled={!hasUpdateAccess}>
-														<Edit className="h-4 w-4" />
-													</Button>
-													<AlertDialog>
-														<AlertDialogTrigger asChild>
-															<Button variant="ghost" size="sm" disabled={!hasDeleteAccess}>
-																<Trash2 className="h-4 w-4" />
-															</Button>
-														</AlertDialogTrigger>
-														<AlertDialogContent>
-															<AlertDialogHeader>
-																<AlertDialogTitle>Delete Customer</AlertDialogTitle>
-																<AlertDialogDescription>
-																	Are you sure you want to delete &quot;{customer.name}&quot;? This will also delete all associated teams
-																	and unassign any virtual keys. This action cannot be undone.
-																</AlertDialogDescription>
-															</AlertDialogHeader>
-															<AlertDialogFooter>
-																<AlertDialogCancel>Cancel</AlertDialogCancel>
-																<AlertDialogAction onClick={() => handleDelete(customer.id)} disabled={isDeleting}>
-																	{isDeleting ? "Deleting..." : "Delete"}
-																</AlertDialogAction>
-															</AlertDialogFooter>
-														</AlertDialogContent>
-													</AlertDialog>
-												</div>
-											</TableCell>
-										</TableRow>
-									);
-								})
-							)}
-						</TableBody>
-					</Table>
+												</TableCell>
+											</TableRow>
+										);
+									})
+								)}
+							</TableBody>
+						</Table>
+					</div>
 				</div>
-			</div>
+			</TooltipProvider>
 		</>
 	);
 }

--- a/ui/components/formFooter.tsx
+++ b/ui/components/formFooter.tsx
@@ -24,7 +24,7 @@ export default function FormFooter({ validator, label, onCancel, isLoading, isEd
 
   return (
     <DialogFooter className="mt-4">
-      <Button variant="outline" onClick={onCancel} disabled={isLoading}>
+      <Button type="button" variant="outline" onClick={onCancel} disabled={isLoading}>
         Cancel
       </Button>
       <TooltipProvider>

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -29,18 +29,22 @@ export interface Team {
 	name: string;
 	customer_id?: string;
 	budget_id?: string;
+	rate_limit_id?: string;
 	// Populated relationships
 	customer?: Customer;
 	budget?: Budget;
+	rate_limit?: RateLimit;
 }
 
 export interface Customer {
 	id: string;
 	name: string;
 	budget_id?: string;
+	rate_limit_id?: string;
 	// Populated relationships
 	teams?: Team[];
 	budget?: Budget;
+	rate_limit?: RateLimit;
 }
 
 export interface DBKey {
@@ -172,22 +176,26 @@ export interface CreateTeamRequest {
 	name: string;
 	customer_id?: string;
 	budget?: CreateBudgetRequest;
+	rate_limit?: CreateRateLimitRequest;
 }
 
 export interface UpdateTeamRequest {
 	name?: string;
 	customer_id?: string;
 	budget?: UpdateBudgetRequest;
+	rate_limit?: UpdateRateLimitRequest;
 }
 
 export interface CreateCustomerRequest {
 	name: string;
 	budget?: CreateBudgetRequest;
+	rate_limit?: CreateRateLimitRequest;
 }
 
 export interface UpdateCustomerRequest {
 	name?: string;
 	budget?: UpdateBudgetRequest;
+	rate_limit?: UpdateRateLimitRequest;
 }
 
 export interface CreateBudgetRequest {


### PR DESCRIPTION
## Summary

Added rate limit support to teams and customers, allowing for hierarchical rate limiting at the organization level in addition to the existing virtual key level rate limits.

## Changes

- Added `rate_limit_id` column to both `governance_teams` and `governance_customers` tables
- Implemented database migration to add the new columns
- Updated CRUD operations for teams and customers to handle rate limits
- Enhanced the governance store to track and enforce rate limits at team and customer levels
- Updated UI components to display and manage rate limits for teams and customers
- Added proper cleanup of rate limits when teams or customers are deleted
- Implemented hierarchical rate limit checking that considers limits at VK, team, and customer levels

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (Next.js)

## How to test

1. Create a new team or customer with rate limits:
```sh
# Create a team with token and request rate limits
curl -X POST http://localhost:8000/api/governance/teams \
  -H "Content-Type: application/json" \
  -d '{"name":"Test Team","rate_limit":{"token_max_limit":1000,"token_reset_duration":"1h","request_max_limit":100,"request_reset_duration":"1h"}}'

# Create a customer with rate limits
curl -X POST http://localhost:8000/api/governance/customers \
  -H "Content-Type: application/json" \
  -d '{"name":"Test Customer","rate_limit":{"token_max_limit":5000,"token_reset_duration":"1d","request_max_limit":500,"request_reset_duration":"1d"}}'
```

2. Test rate limit enforcement by making requests through a virtual key associated with the team or customer
3. Verify rate limit usage is tracked and displayed correctly in the UI

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

Rate limits provide an additional layer of security by preventing abuse of the API.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
