### PR TITLE
adds metric push to otel

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4087,6 +4087,36 @@ func executeRequestWithRetries[T any](
 			tracer.SetAttribute(handle, "retry.count", attempts)
 		}
 
+		// Add context-related attributes (selected key, virtual key, team, customer, etc.)
+		if selectedKeyID, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string); ok && selectedKeyID != "" {
+			tracer.SetAttribute(handle, schemas.AttrSelectedKeyID, selectedKeyID)
+		}
+		if selectedKeyName, ok := ctx.Value(schemas.BifrostContextKeySelectedKeyName).(string); ok && selectedKeyName != "" {
+			tracer.SetAttribute(handle, schemas.AttrSelectedKeyName, selectedKeyName)
+		}
+		if virtualKeyID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); ok && virtualKeyID != "" {
+			tracer.SetAttribute(handle, schemas.AttrVirtualKeyID, virtualKeyID)
+		}
+		if virtualKeyName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyName).(string); ok && virtualKeyName != "" {
+			tracer.SetAttribute(handle, schemas.AttrVirtualKeyName, virtualKeyName)
+		}
+		if teamID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamID).(string); ok && teamID != "" {
+			tracer.SetAttribute(handle, schemas.AttrTeamID, teamID)
+		}
+		if teamName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamName).(string); ok && teamName != "" {
+			tracer.SetAttribute(handle, schemas.AttrTeamName, teamName)
+		}
+		if customerID, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerID).(string); ok && customerID != "" {
+			tracer.SetAttribute(handle, schemas.AttrCustomerID, customerID)
+		}
+		if customerName, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerName).(string); ok && customerName != "" {
+			tracer.SetAttribute(handle, schemas.AttrCustomerName, customerName)
+		}
+		if fallbackIndex, ok := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok {
+			tracer.SetAttribute(handle, schemas.AttrFallbackIndex, fallbackIndex)
+		}
+		tracer.SetAttribute(handle, schemas.AttrNumberOfRetries, attempts)
+
 		// Populate LLM request attributes (messages, parameters, etc.)
 		if req != nil {
 			tracer.PopulateLLMRequestAttributes(handle, req)

--- a/examples/configs/withprompushgateway/config.json
+++ b/examples/configs/withprompushgateway/config.json
@@ -179,7 +179,7 @@
       "enabled": true,
       "type": "sqlite",
       "config":{
-        "path": "./config.db"
+        "path": "../../examples/configs/withprompushgateway/config.db"
       }
     },
     "plugins": [

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -255,8 +255,18 @@
             },
             "allowedOrigins": {
               "type": "array",
+              "description": "CORS allowed origins (supports \"*\" or URI strings)",
               "items": {
-                "type": "string"
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "const": "*"
+                  },
+                  {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                ]
               }
             },
             "enableLogging": {
@@ -574,7 +584,17 @@
                       "maximum": 1
                     },
                     "ttl": {
-                      "type": "string"
+                      "description": "Time-to-live for cached responses (supports duration strings like '5m', '1h' or seconds as number, default: 5min)",
+                      "oneOf": [
+                        {
+                          "type": "string",
+                          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$"
+                        },
+                        {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      ]
                     },
                     "conversation_history_threshold": {
                       "type": "integer",
@@ -627,24 +647,55 @@
                   "type": "object",
                   "properties": {
                     "service_name": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Service name to be used for tracing",
+                      "default": "bifrost"
                     },
                     "collector_url": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "URL of the OpenTelemetry collector"
                     },
                     "trace_type": {
                       "type": "string",
                       "enum": [
                         "otel"
-                      ]
+                      ],
+                      "description": "Type of trace to use for the OTEL collector"
                     },
                     "protocol": {
                       "type": "string",
                       "enum": [
                         "http",
                         "grpc"
-                      ]
+                      ],
+                      "description": "Protocol to use for the OTEL collector"
+                    },
+                    "metrics_enabled": {
+                      "type": "boolean",
+                      "description": "Enable push-based metrics export via OTLP. Recommended for multi-node cluster deployments.",
+                      "default": false
+                    },
+                    "metrics_endpoint": {
+                      "type": "string",
+                      "description": "OTLP metrics endpoint URL (e.g., http://otel-collector:4318/v1/metrics for HTTP or otel-collector:4317 for gRPC)"
+                    },
+                    "metrics_push_interval": {
+                      "type": "integer",
+                      "description": "Metrics push interval in seconds",
+                      "default": 15,
+                      "minimum": 1,
+                      "maximum": 300
                     }
+                  },
+                  "if": {
+                    "properties": {
+                      "metrics_enabled": {
+                        "const": true
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": ["metrics_endpoint"]
                   }
                 }
               },
@@ -762,28 +813,55 @@
             },
             "rateLimits": {
               "type": "array",
+              "description": "Rate limit configurations",
               "items": {
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Rate limit ID"
                   },
                   "token_max_limit": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum tokens allowed"
                   },
                   "token_reset_duration": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Token reset duration (e.g., '30s', '5m', '1h', '1d', '1w', '1M', '1Y')"
+                  },
+                  "token_current_usage": {
+                    "type": "integer",
+                    "description": "Current token usage",
+                    "default": 0
+                  },
+                  "token_last_reset": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Last time token counter was reset"
                   },
                   "request_max_limit": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Maximum requests allowed"
                   },
                   "request_reset_duration": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Request reset duration (e.g., '30s', '5m', '1h', '1d', '1w', '1M', '1Y')"
+                  },
+                  "request_current_usage": {
+                    "type": "integer",
+                    "description": "Current request usage",
+                    "default": 0
+                  },
+                  "request_last_reset": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Last time request counter was reset"
                   }
                 },
                 "required": [
                   "id"
-                ]
+                ],
+                "additionalProperties": false
               }
             },
             "customers": {
@@ -1583,16 +1661,29 @@
                   ]
                 },
                 "host": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Weaviate server host (host:port)"
                 },
                 "apiKey": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "API key for Weaviate authentication"
                 },
                 "grpcHost": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Weaviate gRPC host (host:port)"
                 },
                 "grpcSecured": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether gRPC connection is secured"
+                },
+                "timeout": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Timeout for Weaviate operations (e.g., '5s')"
+                },
+                "className": {
+                  "type": "string",
+                  "description": "Class name for Weaviate vector store"
                 },
                 "existingSecret": {
                   "type": "string"
@@ -1646,19 +1737,74 @@
                   "type": "boolean"
                 },
                 "host": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Redis server host"
                 },
                 "port": {
                   "type": "integer",
                   "minimum": 1,
-                  "maximum": 65535
+                  "maximum": 65535,
+                  "description": "Redis server port"
+                },
+                "username": {
+                  "type": "string",
+                  "description": "Username for Redis AUTH"
                 },
                 "password": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Password for Redis AUTH"
                 },
                 "database": {
                   "type": "integer",
-                  "minimum": 0
+                  "minimum": 0,
+                  "default": 0,
+                  "description": "Redis database number"
+                },
+                "poolSize": {
+                  "type": "integer",
+                  "description": "Maximum number of socket connections"
+                },
+                "maxActiveConns": {
+                  "type": "integer",
+                  "description": "Maximum number of active connections"
+                },
+                "minIdleConns": {
+                  "type": "integer",
+                  "description": "Minimum number of idle connections"
+                },
+                "maxIdleConns": {
+                  "type": "integer",
+                  "description": "Maximum number of idle connections"
+                },
+                "connMaxLifetime": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Connection maximum lifetime (e.g., '30m')"
+                },
+                "connMaxIdleTime": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Connection maximum idle time (e.g., '5m')"
+                },
+                "dialTimeout": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Timeout for socket connection (e.g., '5s')"
+                },
+                "readTimeout": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Timeout for socket reads (e.g., '3s')"
+                },
+                "writeTimeout": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Timeout for socket writes (e.g., '3s')"
+                },
+                "contextTimeout": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "description": "Timeout for Redis operations (e.g., '10s')"
                 },
                 "existingSecret": {
                   "type": "string"
@@ -1707,18 +1853,24 @@
                   "type": "boolean"
                 },
                 "host": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Qdrant server host"
                 },
                 "port": {
                   "type": "integer",
                   "minimum": 1,
-                  "maximum": 65535
+                  "maximum": 65535,
+                  "default": 6334,
+                  "description": "Qdrant server port (default: 6334 for gRPC)"
                 },
                 "apiKey": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "API key for authentication"
                 },
                 "useTls": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Use TLS for connection"
                 },
                 "existingSecret": {
                   "type": "string"
@@ -1748,6 +1900,51 @@
             },
             "resources": {
               "type": "object"
+            }
+          }
+        },
+        "pinecone": {
+          "type": "object",
+          "description": "Pinecone configuration for vector store",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "external": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "apiKey": {
+                  "type": "string",
+                  "description": "Pinecone API key"
+                },
+                "indexHost": {
+                  "type": "string",
+                  "description": "Index host URL from Pinecone console (e.g., your-index.svc.environment.pinecone.io)"
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "description": "Name of existing secret containing Pinecone API key"
+                },
+                "apiKeyKey": {
+                  "type": "string",
+                  "description": "Key in the secret containing the API key"
+                }
+              },
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "then": {
+                "required": [
+                  "indexHost"
+                ]
+              }
             }
           }
         }
@@ -1877,74 +2074,138 @@
           "type": "object",
           "properties": {
             "endpoint": {
-              "type": "string"
+              "type": "string",
+              "description": "Azure endpoint (can use env. prefix)"
             },
             "deployments": {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
-              }
+              },
+              "description": "Model to deployment mappings"
             },
             "api_version": {
-              "type": "string"
+              "type": "string",
+              "description": "Azure API version"
             }
           },
           "required": [
             "endpoint",
             "api_version"
-          ]
+          ],
+          "additionalProperties": false
         },
         "vertex_key_config": {
           "type": "object",
           "properties": {
             "project_id": {
-              "type": "string"
+              "type": "string",
+              "description": "Google Cloud project ID (can use env. prefix)"
+            },
+            "project_number": {
+              "type": "string",
+              "description": "Google Cloud project number"
             },
             "region": {
-              "type": "string"
+              "type": "string",
+              "description": "Google Cloud region"
             },
             "auth_credentials": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "project_id",
-            "region"
-          ]
-        },
-        "bedrock_key_config": {
-          "type": "object",
-          "properties": {
-            "access_key": {
-              "type": "string"
-            },
-            "secret_key": {
-              "type": "string"
-            },
-            "session_token": {
-              "type": "string"
-            },
-            "region": {
-              "type": "string"
-            },
-            "arn": {
-              "type": "string"
+              "type": "string",
+              "description": "Authentication credentials (can use env. prefix)"
             },
             "deployments": {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
-              }
+              },
+              "description": "Model to deployment mappings"
+            }
+          },
+          "required": [
+            "project_id",
+            "region"
+          ],
+          "additionalProperties": false
+        },
+        "bedrock_key_config": {
+          "type": "object",
+          "properties": {
+            "access_key": {
+              "type": "string",
+              "description": "AWS access key (can use env. prefix)"
+            },
+            "secret_key": {
+              "type": "string",
+              "description": "AWS secret key (can use env. prefix)"
+            },
+            "session_token": {
+              "type": "string",
+              "description": "AWS session token (can use env. prefix)"
+            },
+            "region": {
+              "type": "string",
+              "description": "AWS region"
+            },
+            "arn": {
+              "type": "string",
+              "description": "AWS ARN"
+            },
+            "deployments": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Model to deployment mappings"
             }
           },
           "required": [
             "region"
-          ]
+          ],
+          "additionalProperties": false
         }
       },
       "required": [
         "name",
         "weight"
+      ],
+      "oneOf": [
+        {
+          "not": {
+            "anyOf": [
+              { "required": ["azure_key_config"] },
+              { "required": ["vertex_key_config"] },
+              { "required": ["bedrock_key_config"] }
+            ]
+          }
+        },
+        {
+          "required": ["azure_key_config"],
+          "not": {
+            "anyOf": [
+              { "required": ["vertex_key_config"] },
+              { "required": ["bedrock_key_config"] }
+            ]
+          }
+        },
+        {
+          "required": ["vertex_key_config"],
+          "not": {
+            "anyOf": [
+              { "required": ["azure_key_config"] },
+              { "required": ["bedrock_key_config"] }
+            ]
+          }
+        },
+        {
+          "required": ["bedrock_key_config"],
+          "not": {
+            "anyOf": [
+              { "required": ["azure_key_config"] },
+              { "required": ["vertex_key_config"] }
+            ]
+          }
+        }
       ]
     },
     "networkConfig": {
@@ -2138,41 +2399,207 @@
     },
     "virtualKeyProviderConfig": {
       "type": "object",
+      "description": "Provider configuration for a virtual key",
       "properties": {
         "id": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Provider config ID"
         },
         "virtual_key_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Associated virtual key ID"
         },
         "provider": {
-          "type": "string"
+          "type": "string",
+          "description": "Provider name"
         },
         "weight": {
-          "type": "number"
+          "type": "number",
+          "description": "Weight for load balancing",
+          "default": 1.0
         },
         "allowed_models": {
           "type": "array",
+          "description": "Allowed models for this provider config (empty means all models allowed)",
           "items": {
             "type": "string"
           }
         },
         "budget_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Associated budget ID"
         },
         "rate_limit_id": {
-          "type": "string"
+          "type": "string",
+          "description": "Associated rate limit ID"
         },
         "keys": {
           "type": "array",
+          "description": "Provider keys for this config (empty means all keys allowed for this provider)",
           "items": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Key database ID (auto-generated)"
+              },
+              "key_id": {
+                "type": "string",
+                "description": "Key UUID identifier"
+              },
+              "name": {
+                "type": "string",
+                "description": "Key name (must be unique)"
+              },
+              "value": {
+                "type": "string",
+                "description": "API key value (can use env. prefix)"
+              },
+              "models": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Supported models for this key"
+              },
+              "weight": {
+                "type": "number",
+                "minimum": 0,
+                "default": 1.0,
+                "description": "Weight for load balancing"
+              },
+              "azure_key_config": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "description": "Azure endpoint (can use env. prefix)"
+                  },
+                  "deployments": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Model to deployment mappings"
+                  },
+                  "api_version": {
+                    "type": "string",
+                    "description": "Azure API version"
+                  }
+                },
+                "required": ["endpoint", "api_version"],
+                "additionalProperties": false
+              },
+              "vertex_key_config": {
+                "type": "object",
+                "properties": {
+                  "project_id": {
+                    "type": "string",
+                    "description": "Google Cloud project ID (can use env. prefix)"
+                  },
+                  "project_number": {
+                    "type": "string",
+                    "description": "Google Cloud project number"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Google Cloud region"
+                  },
+                  "auth_credentials": {
+                    "type": "string",
+                    "description": "Authentication credentials (can use env. prefix)"
+                  },
+                  "deployments": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Model to deployment mappings"
+                  }
+                },
+                "required": ["project_id", "region"],
+                "additionalProperties": false
+              },
+              "bedrock_key_config": {
+                "type": "object",
+                "properties": {
+                  "access_key": {
+                    "type": "string",
+                    "description": "AWS access key (can use env. prefix)"
+                  },
+                  "secret_key": {
+                    "type": "string",
+                    "description": "AWS secret key (can use env. prefix)"
+                  },
+                  "session_token": {
+                    "type": "string",
+                    "description": "AWS session token (can use env. prefix)"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                  },
+                  "arn": {
+                    "type": "string",
+                    "description": "AWS ARN"
+                  },
+                  "deployments": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Model to deployment mappings"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "oneOf": [
+              {
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["vertex_key_config"] },
+                    { "required": ["bedrock_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["azure_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["vertex_key_config"] },
+                    { "required": ["bedrock_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["vertex_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["bedrock_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["bedrock_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["vertex_key_config"] }
+                  ]
+                }
+              }
+            ],
+            "required": ["key_id", "name", "value"]
           }
         }
       },
       "required": [
         "provider"
-      ]
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -257,21 +257,168 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	if trace == nil {
 		return nil
 	}
-	if p.client == nil {
-		logger.Warn("otel client is not initialized")
-		return nil
+
+	// Emit trace to collector if client is initialized
+	if p.client != nil {
+		// Convert schemas.Trace to OTEL ResourceSpan
+		resourceSpan := p.convertTraceToResourceSpan(trace)
+
+		// Emit to collector
+		if err := p.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
+			logger.Error("failed to emit trace %s: %v", trace.TraceID, err)
+		}
 	}
 
-	// Convert schemas.Trace to OTEL ResourceSpan
-	resourceSpan := p.convertTraceToResourceSpan(trace)
-
-	// Emit to collector
-	if err := p.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
-		logger.Error("failed to emit trace %s: %v", trace.TraceID, err)
-		return err
+	// Record metrics if metrics exporter is enabled
+	if p.metricsExporter != nil {
+		p.recordMetricsFromTrace(ctx, trace)
 	}
 
 	return nil
+}
+
+// Helper functions for type-safe attribute extraction from trace spans
+
+func getStringAttr(attrs map[string]any, key string) string {
+	if attrs == nil {
+		return ""
+	}
+	if v, ok := attrs[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func getIntAttr(attrs map[string]any, key string) int {
+	if attrs == nil {
+		return 0
+	}
+	switch v := attrs[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return 0
+}
+
+func getFloat64Attr(attrs map[string]any, key string) float64 {
+	if attrs == nil {
+		return 0
+	}
+	switch v := attrs[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	}
+	return 0
+}
+
+// recordMetricsFromTrace extracts metrics data from a completed trace and records them
+// via the OTEL metrics exporter. This is called from Inject after trace emission.
+func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.Trace) {
+	if trace == nil || p.metricsExporter == nil {
+		return
+	}
+
+	// Prefer the last attempt span (LLM call or retry) so metrics reflect the final outcome.
+	var llmSpan *schemas.Span
+	for _, span := range trace.Spans {
+		if span.Kind != schemas.SpanKindLLMCall && span.Kind != schemas.SpanKindRetry {
+			continue
+		}
+		if llmSpan == nil || span.EndTime.After(llmSpan.EndTime) {
+			llmSpan = span
+		}
+	}
+	if llmSpan == nil {
+		llmSpan = trace.RootSpan
+	}
+
+	if llmSpan == nil {
+		return
+	}
+
+	attrs := llmSpan.Attributes
+
+	// Extract all metric dimensions from span attributes
+	provider := getStringAttr(attrs, schemas.AttrProviderName)
+	model := getStringAttr(attrs, schemas.AttrRequestModel)
+	// Prefer request.type attribute to keep the method stable across retries
+	method := getStringAttr(attrs, "request.type")
+	if method == "" {
+		method = llmSpan.Name
+	}
+	virtualKeyID := getStringAttr(attrs, schemas.AttrVirtualKeyID)
+	virtualKeyName := getStringAttr(attrs, schemas.AttrVirtualKeyName)
+	selectedKeyID := getStringAttr(attrs, schemas.AttrSelectedKeyID)
+	selectedKeyName := getStringAttr(attrs, schemas.AttrSelectedKeyName)
+	numberOfRetries := getIntAttr(attrs, schemas.AttrNumberOfRetries)
+	fallbackIndex := getIntAttr(attrs, schemas.AttrFallbackIndex)
+	teamID := getStringAttr(attrs, schemas.AttrTeamID)
+	teamName := getStringAttr(attrs, schemas.AttrTeamName)
+	customerID := getStringAttr(attrs, schemas.AttrCustomerID)
+	customerName := getStringAttr(attrs, schemas.AttrCustomerName)
+
+	// Build common attributes for all metrics
+	otelAttrs := BuildBifrostAttributes(
+		provider, model, method,
+		virtualKeyID, virtualKeyName,
+		selectedKeyID, selectedKeyName,
+		numberOfRetries, fallbackIndex,
+		teamID, teamName, customerID, customerName,
+	)
+
+	// Record upstream request count
+	p.metricsExporter.RecordUpstreamRequest(ctx, otelAttrs...)
+
+	// Record latency (from span duration)
+	if !llmSpan.StartTime.IsZero() && !llmSpan.EndTime.IsZero() {
+		latencySeconds := llmSpan.EndTime.Sub(llmSpan.StartTime).Seconds()
+		p.metricsExporter.RecordUpstreamLatency(ctx, latencySeconds, otelAttrs...)
+	}
+
+	// Record success or error based on span status
+	if llmSpan.Status == schemas.SpanStatusError {
+		p.metricsExporter.RecordErrorRequest(ctx, otelAttrs...)
+	} else {
+		p.metricsExporter.RecordSuccessRequest(ctx, otelAttrs...)
+	}
+
+	// Record token usage - try both naming conventions
+	inputTokens := getIntAttr(attrs, schemas.AttrPromptTokens)
+	if inputTokens == 0 {
+		inputTokens = getIntAttr(attrs, schemas.AttrInputTokens)
+	}
+	if inputTokens > 0 {
+		p.metricsExporter.RecordInputTokens(ctx, int64(inputTokens), otelAttrs...)
+	}
+
+	outputTokens := getIntAttr(attrs, schemas.AttrCompletionTokens)
+	if outputTokens == 0 {
+		outputTokens = getIntAttr(attrs, schemas.AttrOutputTokens)
+	}
+	if outputTokens > 0 {
+		p.metricsExporter.RecordOutputTokens(ctx, int64(outputTokens), otelAttrs...)
+	}
+
+	// Record cost if available
+	cost := getFloat64Attr(attrs, schemas.AttrUsageCost)
+	if cost > 0 {
+		p.metricsExporter.RecordCost(ctx, cost, otelAttrs...)
+	}
+
+	// Record streaming latency metrics if available
+	ttft := getFloat64Attr(attrs, schemas.AttrTimeToFirstToken)
+	if ttft > 0 {
+		// Convert from milliseconds to seconds if needed (check the unit)
+		p.metricsExporter.RecordStreamFirstTokenLatency(ctx, ttft/1000.0, otelAttrs...)
+	}
 }
 
 // Cleanup function for the OTEL plugin

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1171,6 +1171,7 @@
 			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25"
@@ -3068,6 +3069,7 @@
 			"integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -3144,7 +3146,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
 			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"csstype": "^3.2.2"
 			}
@@ -3155,7 +3156,6 @@
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -3221,7 +3221,6 @@
 			"integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.41.0",
 				"@typescript-eslint/types": "8.41.0",
@@ -3722,6 +3721,7 @@
 			"integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.13.2",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -3732,21 +3732,24 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
 			"integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
 			"integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
 			"integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.13.2",
@@ -3754,6 +3757,7 @@
 			"integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.13.2",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -3765,7 +3769,8 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
 			"integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.14.1",
@@ -3773,6 +3778,7 @@
 			"integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -3786,6 +3792,7 @@
 			"integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -3796,6 +3803,7 @@
 			"integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -3805,7 +3813,8 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
 			"integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.14.1",
@@ -3813,6 +3822,7 @@
 			"integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -3830,6 +3840,7 @@
 			"integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -3844,6 +3855,7 @@
 			"integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-buffer": "1.14.1",
@@ -3857,6 +3869,7 @@
 			"integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@webassemblyjs/helper-api-error": "1.13.2",
@@ -3872,6 +3885,7 @@
 			"integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.14.1",
 				"@xtuc/long": "4.2.2"
@@ -3882,14 +3896,16 @@
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
 			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
 			"dev": true,
-			"license": "Apache-2.0"
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
@@ -3897,7 +3913,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3911,6 +3926,7 @@
 			"integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			},
@@ -3951,6 +3967,7 @@
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -3969,6 +3986,7 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -3985,7 +4003,8 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
@@ -4357,7 +4376,8 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
@@ -4470,6 +4490,7 @@
 			"integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6.0"
 			}
@@ -4554,7 +4575,8 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -4946,7 +4968,8 @@
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz",
 			"integrity": "sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/emoji-regex": {
 			"version": "9.2.2",
@@ -5108,7 +5131,8 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
 			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -5184,6 +5208,7 @@
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -5206,7 +5231,6 @@
 			"integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -5296,7 +5320,6 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -5398,7 +5421,6 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -5730,6 +5752,7 @@
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -5807,7 +5830,8 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.19.1",
@@ -6076,7 +6100,8 @@
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true,
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"peer": true
 		},
 		"node_modules/globals": {
 			"version": "14.0.0",
@@ -6754,6 +6779,7 @@
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -6769,6 +6795,7 @@
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -7171,6 +7198,7 @@
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -7271,7 +7299,8 @@
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -7377,8 +7406,7 @@
 			"version": "0.52.2",
 			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
 			"integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/monaco-editor-webpack-plugin": {
 			"version": "7.1.0",
@@ -7446,14 +7474,14 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/next": {
 			"version": "15.5.9",
 			"resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
 			"integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@next/env": "15.5.9",
 				"@swc/helpers": "0.5.15",
@@ -7544,7 +7572,8 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
 			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/numeric-quantity": {
 			"version": "2.1.0",
@@ -7921,7 +7950,6 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -8092,6 +8120,7 @@
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -8101,7 +8130,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
 			"integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8146,7 +8174,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -8159,7 +8186,6 @@
 			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
 			"integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			},
@@ -8252,7 +8278,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -8408,8 +8433,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -8470,6 +8494,7 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8593,7 +8618,8 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/safe-push-apply": {
 			"version": "1.0.0",
@@ -8642,6 +8668,7 @@
 			"integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
 				"ajv": "^8.9.0",
@@ -8680,6 +8707,7 @@
 			"integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3"
 			},
@@ -8692,7 +8720,8 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "7.7.2",
@@ -8713,6 +8742,7 @@
 			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -8924,6 +8954,7 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8943,6 +8974,7 @@
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -9231,6 +9263,7 @@
 			"integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.14.0",
@@ -9250,6 +9283,7 @@
 			"integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jest-worker": "^27.4.5",
@@ -9326,7 +9360,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -9499,7 +9532,6 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -9598,6 +9630,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"escalade": "^3.2.0",
 				"picocolors": "^1.1.1"
@@ -9726,6 +9759,7 @@
 			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -9740,6 +9774,7 @@
 			"integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -9789,6 +9824,7 @@
 			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -9799,6 +9835,7 @@
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^4.1.1"
@@ -9813,6 +9850,7 @@
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}


### PR DESCRIPTION
## Summary

Enhance tracing with context attributes and improve OpenTelemetry integration with metrics export capabilities.

## Changes

- Added context-related attributes to traces in `executeRequestWithRetries`:
  - Selected key ID and name
  - Virtual key ID and name
  - Team ID and name
  - Customer ID and name
  - Fallback index
  - Number of retries

- Enhanced the OpenTelemetry plugin with metrics export capabilities:
  - Added functionality to extract and record metrics from traces
  - Implemented metrics for request counts, latency, token usage, and costs
  - Updated to use latest OpenTelemetry semconv package (v1.39.0)

- Fixed database path in example configuration to use relative path
- Improved Helm chart schema with better descriptions and validation rules
- Enhanced plugin error status tracking in HTTP server

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# Test OpenTelemetry metrics export
# 1. Configure OTEL with metrics_enabled: true in config
# 2. Set metrics_endpoint to your collector
# 3. Verify metrics are being exported in your observability platform
```

## Breaking changes

- [x] No

## Security considerations

The OpenTelemetry metrics export feature sends operational metrics to configured collectors. Ensure your collector endpoints are properly secured and that you're not exposing sensitive information in metrics.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)