### PR TITLE
fix: added supported req types for replicate in config.ts

### DIFF
--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -145,6 +145,18 @@ export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 		"image_edit",
 		"image_variation",
 	],
+	replicate: [
+		"list_models",
+		"text_completion",
+		"chat_completion",
+		"chat_completion_stream",
+		"responses",
+		"responses_stream",
+		"image_generation",
+		"image_generation_stream",
+		"image_edit",
+		"image_edit_stream",
+	],
 };
 
 export const IS_ENTERPRISE = process.env.NEXT_PUBLIC_IS_ENTERPRISE === "true";


### PR DESCRIPTION
## Summary

Added Replicate to the list of supported providers with its corresponding supported request types.

## Changes

- Added the `replicate` provider to the `PROVIDER_SUPPORTED_REQUESTS` object with a list of supported request types including text completion, chat completion, image generation, and image editing capabilities

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that Replicate appears as a supported provider in the UI and that the listed request types are available:

```sh
# UI
cd ui
pnpm i
pnpm dev
```

Navigate to the providers section and confirm Replicate is available with the supported request types.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only adds supported request types for a provider.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable