### PR TITLE
fix: move MCP server handler to inference routes for proper authentication

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -284,7 +284,7 @@ func (m *AuthMiddleware) UpdateAuthConfig(authConfig *configstore.AuthConfig) {
 	m.authConfig.Store(authConfig)
 }
 
-// InferenceMiddleware is for inference requests if authConfig is set, it will skip authentication if disableAuthOnInference is true.
+// InferenceMiddleware is for inference requests (including MCP routes) if authConfig is set, it will skip authentication if disableAuthOnInference is true.
 func (m *AuthMiddleware) InferenceMiddleware() schemas.BifrostHTTPMiddleware {
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		return authConfig.DisableAuthOnInference

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,3 @@
-feat: added support for replicate provider
-fix: fix embedContent in genai integration
+- fix: added mcp server handler to the inference routes registration
+- feat: added support for replicate provider
+- fix: fixed support for `:embedContent` in genai integration


### PR DESCRIPTION
## Summary

Fix MCP server handler registration by moving it to the inference routes, ensuring proper authentication handling for MCP routes.

## Changes

- Moved MCP server handler initialization and route registration from API routes to inference routes
- Updated middleware documentation to clarify that inference middleware also applies to MCP routes
- Updated bytedance/gopkg dependency to be indirect instead of direct
- Added changelog entry documenting the fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that MCP routes work correctly with authentication settings:

```sh
# Core/Transports
go version
go test ./...

# Test MCP routes with authentication disabled for inference
# The routes should be accessible without authentication
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where MCP server routes were not properly respecting the DisableAuthOnInference setting.

## Security considerations

This change ensures that MCP routes follow the same authentication rules as other inference routes, improving security consistency.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable