### PR TITLE
adds migration for missing columns

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -700,8 +700,10 @@ append_dynamic_columns_postgres() {
   echo "-- Dynamic column coverage for newer columns (generated based on schema)" >> "$output_file"
 
   # config_keys.azure_scopes (added in v1.4.5)
+  # Set to NULL for coverage - config sync resets this column on startup so non-null values
+  # would cause a snapshot comparison diff
   if column_exists_postgres "config_keys" "azure_scopes"; then
-    echo "UPDATE config_keys SET azure_scopes = '[\"https://cognitiveservices.azure.com/.default\"]' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    echo "UPDATE config_keys SET azure_scopes = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
   fi
 
   # governance_model_pricing.base_model (added in v1.4.5)
@@ -728,8 +730,9 @@ append_dynamic_columns_sqlite() {
 
   if [ -f "$config_db" ]; then
     # config_keys.azure_scopes (added in v1.4.5)
+    # Set to NULL for coverage - config sync resets this column on startup
     if column_exists_sqlite "$config_db" "config_keys" "azure_scopes"; then
-      echo "UPDATE config_keys SET azure_scopes = '[\"https://cognitiveservices.azure.com/.default\"]' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+      echo "UPDATE config_keys SET azure_scopes = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
     fi
 
     # governance_model_pricing.base_model (added in v1.4.5)


### PR DESCRIPTION
## Summary

Update migration tests to set `azure_scopes` to NULL instead of a specific value to prevent snapshot comparison diffs during config sync.

## Changes

- Modified the migration test scripts to set `azure_scopes` to NULL in both PostgreSQL and SQLite databases
- Added comments explaining that config sync resets this column on startup, so non-null values would cause snapshot comparison differences

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the migration tests to verify they complete successfully without snapshot comparison diffs:

```sh
# Run migration tests
./.github/workflows/scripts/run-migration-tests.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issues with migration test failures due to config sync resetting the `azure_scopes` column.

## Security considerations

No security implications as this only affects test data.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable