### PR TITLE
adds message sanitization for huggingface messages

### DIFF
--- a/core/internal/llmtests/reasoning.go
+++ b/core/internal/llmtests/reasoning.go
@@ -40,7 +40,11 @@ func RunResponsesReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			Model:    testConfig.ReasoningModel,
 			Input:    responsesMessages,
 			Params: &schemas.ResponsesParameters{
-				MaxOutputTokens: bifrost.Ptr(1800),
+				// Reasoning models (o3, o4-mini) allocate tokens between reasoning and text output.
+				// Note: Older o1 models may not return message output via Responses API - use o3/o4-mini.
+				// OpenAI recommends reserving at least 25,000 tokens for reasoning and outputs.
+				// See: https://platform.openai.com/docs/guides/reasoning#allocating-space-for-reasoning
+				MaxOutputTokens: bifrost.Ptr(25000),
 				// Configure reasoning-specific parameters
 				Reasoning: &schemas.ResponsesParametersReasoning{
 					Effort: bifrost.Ptr("high"), // High effort for complex reasoning

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -37,7 +37,7 @@ func TestOpenAI(t *testing.T) {
 			{Provider: schemas.OpenAI, Model: "whisper-1"},
 		},
 		SpeechSynthesisModel: "gpt-4o-mini-tts",
-		ReasoningModel:       "o1",
+		ReasoningModel:       "o4-mini", // o4-mini properly returns both reasoning items and message output
 		ImageGenerationModel: "gpt-image-1",
 		ImageEditModel:       "gpt-image-1",
 		ImageVariationModel:  "dall-e-2",


### PR DESCRIPTION
## Summary

Improve reasoning model support by updating token allocation and sanitizing unsupported fields in HuggingFace provider.

## Changes

- Updated `MaxOutputTokens` from 1800 to 25000 in reasoning tests to follow OpenAI's recommendation for reasoning models
- Added detailed comments explaining token allocation for reasoning models (o3, o4-mini)
- Added sanitization function for HuggingFace messages to remove unsupported fields while preserving ToolCalls
- Changed test reasoning model from "o1" to "o4-mini" which properly returns both reasoning items and message output
- Added package documentation for the HuggingFace provider

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the reasoning tests with the updated token allocation:

```sh
# Core/Transports
go version
go test ./core/internal/llmtests -run TestResponsesReasoning
```

Test HuggingFace provider with messages containing unsupported fields to verify sanitization works correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable