### PR TITLE
fixes bedrock test

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -3405,9 +3405,9 @@ func TestDocumentFormatResponseMapping(t *testing.T) {
 		{"HTML", "html", "text/html"},
 		{"CSV", "csv", "text/csv"},
 		{"DOC", "doc", "application/msword"},
-		{"DOCX", "docx", "application/msword"},
+		{"DOCX", "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
 		{"XLS", "xls", "application/vnd.ms-excel"},
-		{"XLSX", "xlsx", "application/vnd.ms-excel"},
+		{"XLSX", "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
 		{"Unknown", "xyz", "application/pdf"},
 	}
 

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -657,6 +657,12 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	return res, nil, nil
 }
 
+// WaitForPendingOperations blocks until all pending cache operations (goroutines) complete.
+// This is useful in tests to ensure cache entries are stored before checking for cache hits.
+func (plugin *Plugin) WaitForPendingOperations() {
+	plugin.waitGroup.Wait()
+}
+
 // Cleanup performs cleanup operations for the semantic cache plugin.
 // It removes all cached entries created by this plugin from the VectorStore only if CleanUpOnShutdown is true.
 // Identifies cache entries by the presence of semantic cache-specific fields (request_hash, cache_key).

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -540,7 +540,7 @@ func AssertNoCacheHit(t *testing.T, response *schemas.BifrostResponse) {
 
 // WaitForCache waits for async cache operations to complete
 func WaitForCache() {
-	time.Sleep(1 * time.Second)
+	time.Sleep(2 * time.Second)
 }
 
 // CreateEmbeddingRequest creates an embedding request for testing


### PR DESCRIPTION
## Summary

This PR updates MIME type mappings for DOCX and XLSX files to use their correct OpenXML format identifiers and adds a new method to the semantic cache plugin to wait for pending operations, which is useful for testing.

## Changes

- Updated MIME type for DOCX files from "application/msword" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
- Updated MIME type for XLSX files from "application/vnd.ms-excel" to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
- Added a new `WaitForPendingOperations()` method to the semantic cache plugin to properly wait for background operations to complete in tests
- Increased the wait time in `WaitForCache()` from 1 second to 2 seconds to ensure more reliable test behavior

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Bedrock provider tests and semantic cache plugin tests to verify the changes:

```sh
# Test Bedrock provider
go test ./core/providers/bedrock/...

# Test semantic cache plugin
go test ./plugins/semanticcache/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes incorrect MIME type mappings for modern Office document formats and improves test reliability for the semantic cache plugin.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable