### PR TITLE
fixed semanticcache tests by fixing ttl and caching wait times

### DIFF
--- a/plugins/semanticcache/plugin_embedding_test.go
+++ b/plugins/semanticcache/plugin_embedding_test.go
@@ -134,7 +134,7 @@ func TestEmbeddingRequestsCacheExpiration(t *testing.T) {
 	defer setup.Cleanup()
 
 	// Set very short TTL for testing
-	shortTTL := 2 * time.Second
+	shortTTL := 5 * time.Second
 	ctx := CreateContextWithCacheKeyAndTTL("test-embedding-ttl", shortTTL)
 
 	embeddingRequest := CreateEmbeddingRequest([]string{"TTL test embedding"})

--- a/plugins/semanticcache/plugin_responses_test.go
+++ b/plugins/semanticcache/plugin_responses_test.go
@@ -254,7 +254,7 @@ func TestResponsesAPICacheExpiration(t *testing.T) {
 	defer setup.Cleanup()
 
 	// Set very short TTL for testing
-	shortTTL := 1 * time.Second
+	shortTTL := 5 * time.Second
 	ctx := CreateContextWithCacheKeyAndTTL("test-responses-ttl", shortTTL)
 
 	responsesRequest := CreateBasicResponsesRequest("TTL test for Responses API", 0.5, 500)


### PR DESCRIPTION
## Summary

Increased the TTL values in semantic cache tests to improve test reliability.

## Changes

- Increased the TTL in `TestEmbeddingRequestsCacheExpiration` from 2 seconds to 5 seconds
- Increased the TTL in `TestResponsesAPICacheExpiration` from 1 second to 5 seconds

These changes help prevent flaky tests that might fail due to timing issues on slower CI environments.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache tests to verify they pass consistently:

```sh
go test ./plugins/semanticcache/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses test flakiness in CI pipelines.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable