### PR TITLE
feat: update routing engine tracking to support multiple engines

### DIFF
--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -301,7 +301,7 @@ func (m *ToolsManager) ParseAndAddToolsToRequest(ctx context.Context, req *schem
 
 	// Get integration user agent for duplicate checking
 	var integrationUserAgentStr string
-	integrationUserAgent := ctx.Value(schemas.BifrostContextKey("integration-user-agent"))
+	integrationUserAgent := ctx.Value(schemas.BifrostContextKeyUserAgent)
 	if integrationUserAgent != nil {
 		if str, ok := integrationUserAgent.(string); ok {
 			integrationUserAgentStr = str

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -187,8 +187,15 @@ const (
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
-	BifrostContextKeyRoutingEngineUsed                   BifrostContextKey = "bifrost-routing-engine-used"                      // string (set by bifrost - DO NOT SET THIS MANUALLY) - either "routing-rule", "governance" or "loadbalancing"
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
+)
+
+// RoutingEngine constants
+const (
+	RoutingEngineGovernance    = "governance"
+	RoutingEngineRoutingRule   = "routing-rule"
+	RoutingEngineLoadbalancing = "loadbalancing"
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -220,7 +220,7 @@ func (bc *BifrostContext) Value(key any) any {
 func (bc *BifrostContext) SetValue(key, value any) {
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
-		// we silently drop writes for these reserved keys				
+		// we silently drop writes for these reserved keys
 		return
 	}
 	bc.valuesMu.Lock()
@@ -232,17 +232,17 @@ func (bc *BifrostContext) SetValue(key, value any) {
 }
 
 // GetAndSetValue gets a value from the internal userValues map and sets it
-func (bc *BifrostContext) GetAndSetValue(key any, value any) any {	
+func (bc *BifrostContext) GetAndSetValue(key any, value any) any {
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
-		// we silently drop writes for these reserved keys				
+		// we silently drop writes for these reserved keys
 		return bc.userValues[key]
 	}
 	if bc.userValues == nil {
 		bc.userValues = make(map[any]any)
-	}	
+	}
 	oldValue := bc.userValues[key]
 	bc.userValues[key] = value
 	return oldValue
@@ -280,4 +280,20 @@ func (bc *BifrostContext) GetParentCtxWithUserValues() context.Context {
 	}
 	bc.valuesMu.RUnlock()
 	return parentCtx
+}
+
+// AppendToContext appends a value to the context list value.
+// Parameters:
+//   - ctx: The Bifrost context
+//   - key: The key to append the value to
+//   - value: The value to append
+func AppendToContextList[T any](ctx *BifrostContext, key BifrostContextKey, value T) {
+	if ctx == nil {
+		return
+	}
+	existingValues, ok := ctx.Value(key).([]T)
+	if !ok {
+		existingValues = []T{}
+	}
+	ctx.SetValue(key, append(existingValues, value))
 }

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -62,7 +62,7 @@ Base Labels:
 - `method`: Request type (`chat`, `text`, `embedding`, `speech`, `transcription`)
 - `virtual_key_id`: Virtual key ID
 - `virtual_key_name`: Virtual key name
-- `routing_engine_used`: Routing engine used ("routing-rule", "governance", "loadbalancing")
+- `routing_engines_used`: Comma-separated routing engines used ("routing-rule", "governance", "loadbalancing")
 - `routing_rule_id`: Routing rule ID that matched the request
 - `routing_rule_name`: Routing rule name that matched the request
 - `selected_key_id`: Selected key ID

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -37,9 +37,11 @@ LogEntry:
     virtual_key_name:
       type: string
       nullable: true
-    routing_engine_used:
-      type: string
-      description: The routing engine used for this request (routing-rule, governance, or loadbalancing)
+    routing_engines_used:
+      type: array
+      items:
+        type: string
+      description: Array of routing engines used for this request (routing-rule, governance, or loadbalancing)
       nullable: true
     routing_rule_id:
       type: string

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- feat: rename routing_engine_used column to routing_engines_used for multi-engine tracking (parsed as comma-separated string)

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,3 +1,4 @@
+- feat: added multi level routing support for routing rules + vk based provider routing
 - feat: cross-provider model matching - budget/rate-limit configs for `gpt-4o` now apply to `openai/gpt-4o`, `gpt-4o-2024-08-06`, etc.
 - feat: expand GovernanceData with ModelConfigs and Providers for in-memory reads
 - feat: added routing rules for dynamic routing of requests based on predefined rules

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+- feat: support multiple routing engines in log entries with array-based tracking

--- a/plugins/telemetry/changelog.md
+++ b/plugins/telemetry/changelog.md
@@ -1,0 +1,1 @@
+- feat: support multiple routing engines in telemetry metrics with comma-separated label format

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -376,7 +377,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
 	fallbackIndex := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyFallbackIndex)
-	routingEngineUsed := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRoutingEngineUsed)
+	// Get routing engines array and join into comma-separated string
+	routingEngines := []string{}
+	if engines, ok := ctx.Value(schemas.BifrostContextKeyRoutingEnginesUsed).([]string); ok {
+		routingEngines = engines
+	}
+	routingEngineUsed := strings.Join(routingEngines, ",")
 
 	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
 	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+- feat: added multi level routing support for routing rules + vk based provider routing
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add key-level model discovery status tracking to improve visibility into API key health and model availability.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2274,6 +2274,10 @@
           "type": "boolean",
           "description": "Whether cluster mode is enabled"
         },
+        "region": {
+          "type": "string",
+          "description": "AWS region for cluster deployment (default: us-east-1)"
+        },
         "peers": {
           "type": "array",
           "description": "List of peer addresses",

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -636,7 +636,7 @@ export default function LogsPage() {
 			}
 		}
 		if (filters.routing_engine_used?.length) {
-			if (!log.routing_engine_used || !filters.routing_engine_used.includes(log.routing_engine_used)) {
+			if (!log.routing_engines_used || !log.routing_engines_used.some((engine) => filters.routing_engine_used!.includes(engine))) {
 				return false;
 			}
 		}

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -73,7 +73,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 	if (log.params?.tools) {
 		try {
 			toolsParameter = JSON.stringify(log.params.tools, null, 2);
-		} catch (ignored) {}
+		} catch (ignored) { }
 	}
 
 	// Extract audio format from request params
@@ -179,9 +179,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								label="Type"
 								value={
 									<div
-										className={`${
-											RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
-										} rounded-sm px-3 py-1`}
+										className={`${RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
+											} rounded-sm px-3 py-1`}
 									>
 										{RequestTypeLabels[log.object as keyof typeof RequestTypeLabels] ?? log.object ?? "unknown"}
 									</div>
@@ -193,27 +192,19 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							)}
 							{log.fallback_index > 0 && <LogEntryDetailsView className="w-full" label="Fallback Index" value={log.fallback_index} />}
 							{log.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={log.virtual_key.name} />}
-							{log.routing_engine_used && (
-								<LogEntryDetailsView
-									className="w-full"
-									label="Routing Engine Used"
-									value={
-										<Badge
-											className={
-												RoutingEngineUsedColors[log.routing_engine_used as keyof typeof RoutingEngineUsedColors] ??
-												"bg-gray-100 text-gray-800"
-											}
-										>
-											<div className="flex items-center gap-2">
-												{RoutingEngineUsedIcons[log.routing_engine_used as keyof typeof RoutingEngineUsedIcons]?.()}
-												<span>
-													{RoutingEngineUsedLabels[log.routing_engine_used as keyof typeof RoutingEngineUsedLabels] ??
-														log.routing_engine_used}
-												</span>
-											</div>
-										</Badge>
-									}
-								/>
+							{log.routing_engines_used && log.routing_engines_used.length > 0 && (
+								<LogEntryDetailsView className="w-full" label="Routing Engines Used" value={
+									<div className="flex flex-wrap gap-2">
+										{log.routing_engines_used.map((engine) => (
+											<Badge key={engine} className={RoutingEngineUsedColors[engine as keyof typeof RoutingEngineUsedColors] ?? "bg-gray-100 text-gray-800"}>
+												<div className="flex items-center gap-2">
+													{RoutingEngineUsedIcons[engine as keyof typeof RoutingEngineUsedIcons]?.()}
+													<span>{RoutingEngineUsedLabels[engine as keyof typeof RoutingEngineUsedLabels] ?? engine}</span>
+												</div>
+											</Badge>
+										))}
+									</div>
+								} />
 							)}
 							{log.routing_rule && <LogEntryDetailsView className="w-full" label="Routing Rule" value={log.routing_rule.name} />}
 

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -356,7 +356,7 @@ export interface LogEntry {
 	fallback_index: number;
 	selected_key_id: string;
 	virtual_key_id?: string;
-	routing_engine_used?: string;
+	routing_engines_used?: string[];
 	routing_rule_id?: string;
 	selected_key?: DBKey;
 	virtual_key?: VirtualKey;


### PR DESCRIPTION
## Summary

Enhance routing engine tracking by replacing the single routing engine field with an array-based approach to support multiple routing engines in a single request. This allows for more accurate tracking when requests pass through multiple routing components.

## Changes

- Renamed `BifrostContextKeyRoutingEngineUsed` to `BifrostContextKeyRoutingEnginesUsed` and changed its type from string to []string
- Added `AppendToContextList` utility function to easily add routing engines to the context
- Updated database schema to store multiple routing engines as a comma-separated string
- Modified the logging plugin to handle arrays of routing engines
- Updated telemetry plugin to join routing engines into a comma-separated label
- Updated UI to display multiple routing engines with appropriate badges
- Updated OpenAPI documentation to reflect the array-based approach

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

1. Set up a configuration with multiple routing components (e.g., routing rules and governance)
2. Make requests that pass through multiple routing engines
3. Verify logs show all routing engines used in the request
4. Check telemetry metrics include comma-separated routing engine labels

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

This change renames the context key from `routing_engine_used` to `routing_engines_used` and changes its type from string to []string. Any custom plugins that directly access this field will need to be updated.

Database migration is included to rename the column and maintain backward compatibility.

## Security considerations

No security implications. This change only affects telemetry and logging data structure.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable