### PR TITLE
feat: adds user-level governance to governance plugin

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -157,8 +157,10 @@ const (
 	BifrostContextKeyGovernanceTeamName                  BifrostContextKey = "bifrost-governance-team-name"         // string (to store the team name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernanceCustomerID                BifrostContextKey = "bifrost-governance-customer-id"       // string (to store the customer ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernanceCustomerName              BifrostContextKey = "bifrost-governance-customer-name"     // string (to store the customer name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceUserID                    BifrostContextKey = "bifrost-governance-user-id"           // string (to store the user ID (set by enterprise governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernanceRoutingRuleID             BifrostContextKey = "bifrost-governance-routing-rule-id"   // string (to store the routing rule ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernanceRoutingRuleName           BifrostContextKey = "bifrost-governance-routing-rule-name" // string (to store the routing rule name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceIncludeOnlyKeys           BifrostContextKey = "bf-governance-include-only-keys"      // []string (to store the include-only key IDs for provider config routing (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"            // int (to store the number of retries (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"               // int (to store the fallback index (set by bifrost - DO NOT SET THIS MANUALLY)) 0 for primary, 1 for first fallback, etc.
 	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
@@ -200,6 +202,7 @@ const (
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "user_id"
+	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
 )
 
 // RoutingEngine constants

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -351,7 +351,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*se
 	defer h.mu.RUnlock()
 
 	h.config.Mu.RLock()
-	enforceVK := h.config.ClientConfig.EnforceGovernanceHeader && h.config.ClientConfig.EnableGovernance
+	enforceVK := h.config.ClientConfig.EnforceAuthOnInference && h.config.ClientConfig.EnableGovernance
 	h.config.Mu.RUnlock()
 
 	vk := getVKFromRequest(ctx)

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -48,7 +48,7 @@ func (baseAccount *BaseAccount) GetKeysForProvider(ctx context.Context, provider
 	keys := config.Keys
 
 	if baseAccount.store.ClientConfig.EnableGovernance {
-		if v := ctx.Value(schemas.BifrostContextKey("bf-governance-include-only-keys")); v != nil {
+		if v := ctx.Value(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys); v != nil {
 			if includeOnlyKeys, ok := v.([]string); ok {
 				if len(includeOnlyKeys) == 0 {
 					// header present but empty means "no keys allowed"

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -172,7 +172,7 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	// 3. Governance (if enabled and not enterprise)
 	if s.Config.ClientConfig.EnableGovernance && ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil {
 		config := &governance.Config{
-			IsVkMandatory:   &s.Config.ClientConfig.EnforceGovernanceHeader,
+			IsVkMandatory:   &s.Config.ClientConfig.EnforceAuthOnInference,
 			RequiredHeaders: &s.Config.ClientConfig.RequiredHeaders,
 		}
 		s.registerPluginWithStatus(ctx, governance.PluginName, nil, config, false)


### PR DESCRIPTION
## Summary

Adds user-level budgets and rate limits to the governance plugin. This enables
enterprise deployments to set per-user spending limits and request rate
controls, evaluated after provider/model checks but before virtual key checks.

## Changes

- Added `BifrostContextKeyGovernanceUserID` context key to core schemas
- Added `UserGovernance` type with budget/rate-limit associations
- Added `GovernanceStore` interface methods for user governance CRUD,
  budget/rate-limit checks, and usage updates
- Implemented all user governance methods on `LocalGovernanceStore` (get,
  create, update, delete, check budget, check rate limit, update usage)
- Added `UserID` to `EvaluationRequest` and `UsageUpdate` structs
- Added `EvaluateUserRequest` method to the budget resolver
- Integrated user-level governance into `PreLLMHook` (evaluation) and
  `PostLLMHook` (usage tracking)
- Updated `DumpRateLimits` to include user rate limit IDs
- Updated `rebuildInMemoryStructures` to reset user governance map
- Updated budget/rate-limit reference update functions to include users

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Run governance plugin tests specifically:

```sh
go test ./plugins/governance/...
```

Verify user-level governance by configuring a user with a budget/rate-limit and
making requests with the `BifrostContextKeyGovernanceUserID` context key set.

## Screenshots/Recordings

N/A — backend-only changes.

## Breaking changes

- [ ] Yes
- [x] No

The `GovernanceStore` interface gains new methods, but all implementations
(`LocalGovernanceStore` and enterprise `GlobalGovernanceStore`) already
implement them.

## Security considerations

User-level governance enforces spending and rate limits per authenticated user.
No new secrets or PII handling is introduced — user IDs are passed via existing
context key mechanisms.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
