### PR TITLE
adds object to openai repsonses

### DIFF
--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1086,6 +1086,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesResponse() *BifrostResponsesRes
 	// Create new BifrostResponsesResponse from Chat fields
 	responsesResp := &BifrostResponsesResponse{
 		ID:            Ptr(cr.ID),
+		Object:        "response",
 		CreatedAt:     cr.Created,
 		Model:         cr.Model,
 		Citations:     cr.Citations,

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -43,7 +43,8 @@ func (r *BifrostResponsesRequest) GetRawRequestBody() []byte {
 }
 
 type BifrostResponsesResponse struct {
-	ID *string `json:"id,omitempty"` // used for internal conversions
+	ID     *string `json:"id,omitempty"` // used for internal conversions
+	Object string  `json:"object"`       // "response"
 
 	Background         *bool                               `json:"background,omitempty"`
 	Conversation       *ResponsesResponseConversation      `json:"conversation,omitempty"`
@@ -96,6 +97,13 @@ func (resp *BifrostResponsesResponse) WithDefaults() *BifrostResponsesResponse {
 		ID:        resp.ID,
 		CreatedAt: resp.CreatedAt,
 		Model:     resp.Model,
+	}
+
+	// Object - default: "response"
+	if resp.Object != "" {
+		result.Object = resp.Object
+	} else {
+		result.Object = "response"
 	}
 
 	result.Conversation = resp.Conversation


### PR DESCRIPTION
## Summary

Add `object` field with value "response" to the `BifrostResponsesResponse` struct to ensure consistent API response format.

## Issue

Closes #1638

## Changes

- Added `object` field to `BifrostResponsesResponse` struct with a fixed value of "response"
- Updated the `ToBifrostResponsesResponse` method to set the object field when converting from chat responses
- Added default handling for the object field in the `WithDefaults` method

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Verify that API responses now include the "object": "response" field in the JSON output.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Standardizes response format to match API conventions.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)