### PR TITLE
emits marshalling error for anthropic sdk

### DIFF
--- a/transports/bifrost-http/integrations/langchain.go
+++ b/transports/bifrost-http/integrations/langchain.go
@@ -22,7 +22,7 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	routes = append(routes, CreateOpenAIRouteConfigs("/langchain", handlerStore)...)
 
 	// Add Anthropic routes to LangChain for Anthropic API compatibility
-	routes = append(routes, CreateAnthropicRouteConfigs("/langchain")...)
+	routes = append(routes, CreateAnthropicRouteConfigs("/langchain", logger)...)
 
 	// Add Anthropic count tokens route for LangChain to ensure token counting uses the dedicated endpoint
 	routes = append(routes, CreateAnthropicCountTokensRouteConfigs("/langchain", handlerStore)...)

--- a/transports/bifrost-http/integrations/litellm.go
+++ b/transports/bifrost-http/integrations/litellm.go
@@ -22,7 +22,7 @@ func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, lo
 	routes = append(routes, CreateOpenAIRouteConfigs("/litellm", handlerStore)...)
 
 	// Add Anthropic routes to LiteLLM for Anthropic API compatibility
-	routes = append(routes, CreateAnthropicRouteConfigs("/litellm")...)
+	routes = append(routes, CreateAnthropicRouteConfigs("/litellm", logger)...)
 
 	// Add GenAI routes to LiteLLM for Vertex AI compatibility
 	routes = append(routes, CreateGenAIRouteConfigs("/litellm")...)

--- a/transports/bifrost-http/integrations/pydanticai.go
+++ b/transports/bifrost-http/integrations/pydanticai.go
@@ -22,7 +22,7 @@ func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore,
 	routes = append(routes, CreateOpenAIRouteConfigs("/pydanticai", handlerStore)...)
 	// Add Anthropic routes to Pydantic AI for Anthropic API compatibility
 	// Supports: messages API (Claude models)
-	routes = append(routes, CreateAnthropicRouteConfigs("/pydanticai")...)
+	routes = append(routes, CreateAnthropicRouteConfigs("/pydanticai", logger)...)
 	// Add GenAI routes to Pydantic AI for Google Gemini API compatibility
 	// Supports: generateContent, streamGenerateContent, embedContent
 	routes = append(routes, CreateGenAIRouteConfigs("/pydanticai")...)


### PR DESCRIPTION
## Summary

Improve Anthropic integration by adding proper error logging and optimizing string concatenation in streaming responses.

## Issue
Closes #1622

## Changes

- Added logger parameter to `CreateAnthropicRouteConfigs` and `createAnthropicMessagesRouteConfig` functions to enable error logging
- Added explicit error logging when marshaling Anthropic streaming messages fails
- Replaced string concatenation with `strings.Builder` for more efficient handling of streaming responses
- Updated function calls to pass the logger parameter through the call chain

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Anthropic streaming responses with high volume to verify improved performance:

```sh
# Core/Transports
go version
go test ./transports/bifrost-http/integrations/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves error handling and performance for Anthropic streaming responses

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable