### PR TITLE
bifrost moves to go1.26

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -136,7 +136,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Docker Compose
         run: |
@@ -205,7 +205,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Docker Compose
         run: |
@@ -269,7 +269,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -313,7 +313,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -355,7 +355,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -419,7 +419,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -500,7 +500,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Configure Git
         run: |
@@ -594,7 +594,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -690,7 +690,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/scripts/load-test.sh
+++ b/.github/workflows/scripts/load-test.sh
@@ -1,0 +1,535 @@
+#!/bin/bash
+
+# Load Test Script for Bifrost
+# Runs a load test against bifrost-http with a mocker provider
+# Usage: ./load-test.sh
+#
+# This script:
+# 1. Builds bifrost-http locally if not present
+# 2. Creates a config.json with mocker provider (OpenAI-style)
+# 3. Starts the mocker server and bifrost-http
+# 4. Runs a load test at the configured RPS for 1 minute using Vegeta
+# 5. Prints the results
+
+set -e
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+BIFROST_HTTP_DIR="${REPO_ROOT}/transports/bifrost-http"
+TRANSPORTS_DIR="${REPO_ROOT}/transports"
+WORK_DIR="${SCRIPT_DIR}"
+MOCKER_DIR="${REPO_ROOT}/../bifrost-benchmarking/mocker"
+
+BIFROST_PORT=8080
+MOCKER_PORT=8000
+RATE=1000
+MAX_WORKERS=1000
+DURATION=60
+MOCKER_LATENCY_MS=10000  # 10 seconds base latency from mocker
+MAX_LATENCY_US=10000100  # 10 seconds + 100us base latency from mocker
+VEGETA_TO_BIFROST_DELAY_US=100
+BIFROST_TO_MOCKER_DELAY_US=100
+
+# Results storage for summary table
+RESULTS_FILE="${WORK_DIR}/load-test-results.md"
+RESULTS_JSON="${WORK_DIR}/load-test-results.json"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+  echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+  echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+  echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Cleanup function to kill background processes
+cleanup() {
+  log_info "Cleaning up..."
+  if [ -n "$BIFROST_PID" ] && kill -0 "$BIFROST_PID" 2>/dev/null; then
+    kill "$BIFROST_PID" 2>/dev/null || true
+    wait "$BIFROST_PID" 2>/dev/null || true
+  fi
+  if [ -n "$MOCKER_PID" ] && kill -0 "$MOCKER_PID" 2>/dev/null; then
+    kill "$MOCKER_PID" 2>/dev/null || true
+    wait "$MOCKER_PID" 2>/dev/null || true
+  fi
+  # Clean up temporary files (keep results files for artifact upload)
+  rm -f "${WORK_DIR}/config.json" "${WORK_DIR}/logs.db" "${WORK_DIR}/attack.bin" "${WORK_DIR}/bifrost.log" "${WORK_DIR}/vegeta-target.json" "${WORK_DIR}/vegeta-report.json" 2>/dev/null || true
+  log_info "Cleanup complete"
+}
+
+trap cleanup EXIT
+
+# Check for required tools
+check_dependencies() {
+  log_info "Checking dependencies..."
+
+  if ! command -v go &> /dev/null; then
+    log_error "Go is not installed. Please install Go 1.24.3 or later."
+    exit 1
+  fi
+
+  if ! command -v git &> /dev/null; then
+    log_error "Git is not installed. Please install Git."
+    exit 1
+  fi
+
+  log_success "All dependencies found"
+}
+
+# Kill any process running on a specific port
+kill_port() {
+  local port=$1
+  local pids=$(lsof -ti ":${port}" 2>/dev/null)
+  if [ -n "$pids" ]; then
+    log_warn "Killing existing process(es) on port ${port}: ${pids}"
+    echo "$pids" | xargs kill -9 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+# Kill processes on required ports before starting
+cleanup_ports() {
+  log_info "Checking for processes on required ports..."
+  kill_port ${MOCKER_PORT}
+  kill_port ${BIFROST_PORT}
+}
+
+# Install Vegeta if not present
+install_vegeta() {
+  if ! command -v vegeta &> /dev/null; then
+    log_info "Installing Vegeta load testing tool..."
+    go install github.com/tsenart/vegeta/v12@latest
+    export PATH="$PATH:$(go env GOPATH)/bin"
+    if ! command -v vegeta &> /dev/null; then
+      log_error "Failed to install Vegeta"
+      exit 1
+    fi
+    log_success "Vegeta installed"
+  else
+    log_success "Vegeta already installed"
+  fi
+}
+
+# Build bifrost-http if binary doesn't exist
+build_bifrost_http() {
+  if [ -f "${REPO_ROOT}/tmp/bifrost-http" ]; then
+    log_success "bifrost-http binary already exists at ${REPO_ROOT}/tmp/bifrost-http"
+    return 0
+  fi
+
+  log_info "Building bifrost-http..."
+  cd "${TRANSPORTS_DIR}"
+
+  # Build the binary
+  if go build -o ${REPO_ROOT}/tmp/bifrost-http .; then
+    log_success "bifrost-http built successfully"
+  else
+    log_error "Failed to build bifrost-http"
+    exit 1
+  fi
+
+  cd "${WORK_DIR}"
+}
+
+# Clone and setup mocker from bifrost-benchmarking
+setup_mocker() {
+  if [ -d "${REPO_ROOT}/../bifrost-benchmarking" ]; then
+    log_info "Updating bifrost-benchmarking repository..."
+    cd "${REPO_ROOT}/../bifrost-benchmarking"
+    git pull --quiet || true
+    cd "${WORK_DIR}"
+  else
+    log_info "Cloning bifrost-benchmarking repository..."
+    cd "${WORK_DIR}"
+    git clone --depth 1 https://github.com/maximhq/bifrost-benchmarking.git
+  fi
+
+  log_success "Mocker setup complete"
+}
+
+# Create config.json for bifrost with mocker provider
+create_config() {
+  log_info "Creating config.json..."
+
+  cat > "${WORK_DIR}/config.json" << 'EOF'
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "enable_logging": false,
+    "initial_pool_size": 10000,
+    "drop_excess_requests": false,
+    "enable_governance": false,
+    "allow_direct_keys": false
+  },
+  "config_store": {
+    "enabled": false
+  },
+  "logs_store": {
+    "enabled": false
+  },
+  "providers": {
+    "openai": {
+      "keys": [
+        {
+          "name": "mocker-key",
+          "value": "Bearer mocker-key",
+          "weight": 1
+        }
+      ],
+      "network_config": {
+        "base_url": "http://localhost:8000",
+        "default_request_timeout_in_seconds": 30
+      },
+      "concurrency_and_buffer_size": {
+        "concurrency": 2000,
+        "buffer_size": 2500
+      },
+      "custom_provider_config": {
+        "base_provider_type": "openai",
+        "allowed_requests": {
+          "list_models": false,
+          "chat_completion": true,
+          "chat_completion_stream": true
+        }
+      }
+    }
+  }
+}
+EOF
+
+  log_success "config.json created"
+}
+
+# Start the mocker server
+start_mocker() {
+  log_info "Starting mocker server on port ${MOCKER_PORT}..."
+
+  cd "${MOCKER_DIR}"
+  go run main.go -port ${MOCKER_PORT} -host 0.0.0.0 -latency ${MOCKER_LATENCY_MS}&
+  MOCKER_PID=$!
+  cd "${WORK_DIR}"
+
+  # Wait for mocker to be ready
+  local max_attempts=30
+  local attempt=0
+  while ! curl -s "http://localhost:${MOCKER_PORT}/v1/chat/completions" -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer mocker-key" \
+    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"test"}]}' > /dev/null 2>&1; do
+    sleep 1
+    attempt=$((attempt + 1))
+    if [ $attempt -ge $max_attempts ]; then
+      log_error "Mocker failed to start within ${max_attempts} seconds"
+      exit 1
+    fi
+  done
+
+  log_success "Mocker server started (PID: ${MOCKER_PID})"
+}
+
+# Start bifrost-http server
+start_bifrost() {
+  log_info "Starting bifrost-http on port ${BIFROST_PORT}..."
+
+  cd "${WORK_DIR}"
+  local bifrost_log="${WORK_DIR}/bifrost.log"
+  "${REPO_ROOT}/tmp/bifrost-http" -app-dir "${WORK_DIR}" -port "${BIFROST_PORT}" -host "0.0.0.0" -log-level "info" > "${bifrost_log}" 2>&1 &
+  BIFROST_PID=$!
+
+  # Wait for bifrost to be fully ready (look for "successfully started bifrost" message)
+  local max_attempts=60
+  local attempt=0
+  while ! grep -q "successfully started bifrost" "${bifrost_log}" 2>/dev/null; do
+    sleep 1
+    attempt=$((attempt + 1))
+    if [ $attempt -ge $max_attempts ]; then
+      log_error "Bifrost failed to start within ${max_attempts} seconds"
+      log_error "Bifrost log output:"
+      cat "${bifrost_log}" 2>/dev/null || true
+      exit 1
+    fi
+    # Check if process is still running
+    if ! kill -0 "$BIFROST_PID" 2>/dev/null; then
+      log_error "Bifrost process died unexpectedly"
+      log_error "Bifrost log output:"
+      cat "${bifrost_log}" 2>/dev/null || true
+      exit 1
+    fi
+  done
+
+  log_success "Bifrost-http started (PID: ${BIFROST_PID})"
+}
+
+# Initialize results file with header
+init_results_file() {
+  cat > "${RESULTS_FILE}" << 'EOF'
+# Bifrost Load Test Results
+
+## Latency Summary
+
+| Scenario | RPS | Duration | Success Rate | Min | Mean | P50 | P90 | P95 | P99 | Max |
+|----------|-----|----------|--------------|-----|------|-----|-----|-----|-----|-----|
+EOF
+
+  # Initialize JSON results
+  echo '{"scenarios": [], "timestamp": "'"$(date -u +"%Y-%m-%dT%H:%M:%SZ")"'"}' > "${RESULTS_JSON}"
+}
+
+# Parse vegeta output and record raw latencies
+# Arguments: $1 = scenario name, $2 = rate, $3 = duration
+parse_and_record_results() {
+  local scenario_name=$1
+  local rate=$2
+  local duration=$3
+
+  # Get JSON report from vegeta
+  local json_report_file="${WORK_DIR}/vegeta-report.json"
+  vegeta report -type=json < "${WORK_DIR}/attack.bin" > "${json_report_file}"
+
+  log_info "Parsing vegeta JSON report..."
+
+  # Check if jq is available for reliable JSON parsing
+  if command -v jq &> /dev/null; then
+    local latency_min=$(jq '.latencies.min // 0' "${json_report_file}")
+    local latency_mean=$(jq '.latencies.mean // 0' "${json_report_file}")
+    local latency_50=$(jq '.latencies["50th"] // 0' "${json_report_file}")
+    local latency_90=$(jq '.latencies["90th"] // 0' "${json_report_file}")
+    local latency_95=$(jq '.latencies["95th"] // 0' "${json_report_file}")
+    local latency_99=$(jq '.latencies["99th"] // 0' "${json_report_file}")
+    local latency_max=$(jq '.latencies.max // 0' "${json_report_file}")
+    local success_rate=$(jq '.success // 0' "${json_report_file}")
+  elif command -v python3 &> /dev/null; then
+    local latency_min=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('min', 0))")
+    local latency_mean=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('mean', 0))")
+    local latency_50=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('50th', 0))")
+    local latency_90=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('90th', 0))")
+    local latency_95=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('95th', 0))")
+    local latency_99=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('99th', 0))")
+    local latency_max=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('latencies', {}).get('max', 0))")
+    local success_rate=$(python3 -c "import json; d=json.load(open('${json_report_file}')); print(d.get('success', 0))")
+  else
+    log_error "Neither jq nor python3 found. Cannot parse JSON results."
+    return 1
+  fi
+
+  log_info "  Extracted latencies (ns): min=$latency_min, mean=$latency_mean, p50=$latency_50, p99=$latency_99, max=$latency_max"
+  log_info "  Success rate: $success_rate"
+
+  if [ -z "$latency_min" ] || [ "$latency_min" = "0" ] || [ "$latency_min" = "null" ]; then
+    log_warn "Failed to extract latency values from vegeta report"
+    log_info "Vegeta JSON report contents:"
+    cat "${json_report_file}"
+    return 1
+  fi
+
+  # Subtract network delay (vegeta->bifrost + bifrost->mocker) before converting to µs
+  local delay_ns=$(( (VEGETA_TO_BIFROST_DELAY_US + BIFROST_TO_MOCKER_DELAY_US) * 1000 ))
+  local us_min=$(printf "%.2f" $(echo "scale=4; ($latency_min - $delay_ns) / 1000" | bc))
+  local us_mean=$(printf "%.2f" $(echo "scale=4; ($latency_mean - $delay_ns) / 1000" | bc))
+  local us_50=$(printf "%.2f" $(echo "scale=4; ($latency_50 - $delay_ns) / 1000" | bc))
+  local us_90=$(printf "%.2f" $(echo "scale=4; ($latency_90 - $delay_ns) / 1000" | bc))
+  local us_95=$(printf "%.2f" $(echo "scale=4; ($latency_95 - $delay_ns) / 1000" | bc))
+  local us_99=$(printf "%.2f" $(echo "scale=4; ($latency_99 - $delay_ns) / 1000" | bc))
+  local us_max=$(printf "%.2f" $(echo "scale=4; ($latency_max - $delay_ns) / 1000" | bc))
+
+  # Convert success rate to percentage
+  local success_pct=$(printf "%.2f" $(echo "scale=4; $success_rate * 100" | bc))
+
+  # Append to markdown table
+  echo "| ${scenario_name} | ${rate} | ${duration}s | ${success_pct}% | ${us_min}µs | ${us_mean}µs | ${us_50}µs | ${us_90}µs | ${us_95}µs | ${us_99}µs | ${us_max}µs |" >> "${RESULTS_FILE}"
+
+  # Update JSON results
+  local tmp_json=$(mktemp)
+  cat "${RESULTS_JSON}" | sed 's/\("scenarios": \[\)/\1{"name": "'"${scenario_name}"'", "rate": '"${rate}"', "duration": '"${duration}"', "success_rate": '"${success_pct}"', "latency_us": {"min": '"${us_min}"', "mean": '"${us_mean}"', "p50": '"${us_50}"', "p90": '"${us_90}"', "p95": '"${us_95}"', "p99": '"${us_99}"', "max": '"${us_max}"'}},/' > "${tmp_json}"
+  mv "${tmp_json}" "${RESULTS_JSON}"
+
+  rm -f "${json_report_file}"
+
+  log_success "Results recorded for scenario: ${scenario_name}"
+  log_info "  Latency - Min: ${us_min}µs, Mean: ${us_mean}µs, P99: ${us_99}µs, Max: ${us_max}µs"
+
+  # Check if any adjusted latency exceeds the threshold
+  local failed=0
+  local delay_us=$(( VEGETA_TO_BIFROST_DELAY_US + BIFROST_TO_MOCKER_DELAY_US ))
+  local labels=("Min" "Mean" "P50" "P90" "P95" "P99" "Max")
+  local values=($latency_min $latency_mean $latency_50 $latency_90 $latency_95 $latency_99 $latency_max)
+  local extras=()
+
+  for i in "${!values[@]}"; do
+    local adjusted_us=$(( values[i] / 1000 - delay_us ))
+    if [ "$adjusted_us" -gt "$MAX_LATENCY_US" ]; then
+      extras+=("${labels[i]}:$(( adjusted_us - MAX_LATENCY_US ))")
+      failed=1
+    fi
+  done
+
+  if [ "$failed" -eq 1 ]; then
+    echo ""
+    log_error "FAILED: Latency exceeded ${MAX_LATENCY_US}µs threshold"
+    echo ""
+    echo -e "${RED}| Bucket | Extra Latency (µs) |${NC}"
+    echo -e "${RED}|--------|---------------------|${NC}"
+    for entry in "${extras[@]}"; do
+      local bucket="${entry%%:*}"
+      local extra="${entry##*:}"
+      echo -e "${RED}| ${bucket} | +${extra}µs |${NC}"
+    done
+    echo ""
+    exit 1
+  fi
+}
+
+# Finalize results file
+finalize_results() {
+  cat >> "${RESULTS_FILE}" << 'EOF'
+
+## Notes
+
+- All latency values are in microseconds (µs)
+- P50/P90/P95/P99 represent percentile latencies
+
+---
+*Generated by Bifrost Load Test Script*
+EOF
+
+  # Fix JSON (remove trailing comma in scenarios array)
+  sed -i.bak 's/},\]/}]/' "${RESULTS_JSON}" 2>/dev/null || sed -i '' 's/},\]/}]/' "${RESULTS_JSON}"
+  rm -f "${RESULTS_JSON}.bak"
+
+  log_success "Results saved to:"
+  log_info "  - Markdown: ${RESULTS_FILE}"
+  log_info "  - JSON: ${RESULTS_JSON}"
+
+  echo ""
+  echo "╔═══════════════════════════════════════════════════════════╗"
+  echo "║              Latency Summary Table                        ║"
+  echo "╚═══════════════════════════════════════════════════════════╝"
+  echo ""
+  cat "${RESULTS_FILE}"
+}
+
+# Run a single load test scenario
+# Arguments: $1 = scenario name, $2 = rate (optional), $3 = duration (optional)
+run_load_test() {
+  local scenario_name=${1:-"Default"}
+  local rate=${2:-$RATE}
+  local duration=${3:-$DURATION}
+
+  log_info "Running load test scenario '${scenario_name}': ${rate} RPS for ${duration} seconds..."
+  echo ""
+
+  # Create the target file for Vegeta
+  local target_url="http://localhost:${BIFROST_PORT}/v1/chat/completions"
+  local target_file="${WORK_DIR}/vegeta-target.json"
+  local payload='{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"Hello, how are you?"}]}'
+
+  # Write target in Vegeta JSON format
+  cat > "${target_file}" << EOF
+{"method": "POST", "url": "${target_url}", "header": {"Content-Type": ["application/json"]}, "body": "$(echo -n "${payload}" | base64)"}
+EOF
+
+  # Run Vegeta attack and save binary results to file
+  vegeta attack \
+    -format=json \
+    -targets="${target_file}" \
+    -rate="${rate}" \
+    -duration="${duration}s" \
+    -timeout="30s" \
+    -workers=500 \
+    -max-workers="${MAX_WORKERS}" > "${WORK_DIR}/attack.bin"
+
+  echo ""
+  log_info "Attack complete. Generating reports..."
+
+  echo ""
+  log_info "Summary report:"
+  vegeta report < "${WORK_DIR}/attack.bin"
+
+  echo ""
+  log_info "Latency histogram:"
+  vegeta report -type=hist[0,1ms,5ms,10ms,50ms,100ms,500ms,1s,5s,10s,15s] < "${WORK_DIR}/attack.bin" || log_warn "Histogram generation failed"
+
+  # Parse results and record to summary
+  parse_and_record_results "${scenario_name}" "${rate}" "${duration}"
+}
+
+# Run all test scenarios
+run_all_scenarios() {
+  # Initialize results file
+  init_results_file
+
+  echo ""
+  echo "╔═══════════════════════════════════════════════════════════╗"
+  echo "║                    Load Test Results                      ║"
+  echo "╚═══════════════════════════════════════════════════════════╝"
+  echo ""
+
+  run_load_test "Load Test (${RATE} RPS)" "${RATE}" "${DURATION}"
+
+  # Finalize and display summary
+  finalize_results
+}
+
+# Main execution
+main() {
+  echo ""
+  echo "╔═══════════════════════════════════════════════════════════╗"
+  echo "║              Bifrost Load Test Script                     ║"
+  echo "║           ${RATE} RPS for ${DURATION} seconds                         ║"
+  echo "╚═══════════════════════════════════════════════════════════╝"
+  echo ""
+
+  echo "Note: As the mocker may respond not exactly in 1000ms, there could be additional latency (+-10/20ms) between the mocker and the bifrost-http server."
+
+  check_dependencies
+  install_vegeta
+  build_bifrost_http
+  setup_mocker
+  create_config
+  cleanup_ports
+  start_mocker
+  start_bifrost
+
+  run_all_scenarios
+  cleanup_ports
+  echo ""
+  log_success "Load test completed successfully!"
+  log_info "Results files location:"
+  log_info "  - ${RESULTS_FILE}"
+  log_info "  - ${RESULTS_JSON}"
+
+  # Print final summary table to console
+  echo ""
+  echo "╔══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗"
+  echo "║                                                         FINAL RESULTS SUMMARY                                                                                    ║"
+  echo "╚══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝"
+  echo ""
+  echo "Mocker Latency: ${MOCKER_LATENCY_MS}ms"
+  echo ""
+  # Print just the table (header + separator + data rows)
+  grep -E "^\|" "${RESULTS_FILE}"
+  echo ""
+  echo "Notes:"
+  echo "  - All latency values are in microseconds (µs)"
+  echo "  - P50/P90/P95/P99 represent percentile latencies"
+  echo ""
+}
+
+main "$@"

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Install Snyk CLI
         uses: snyk/actions/setup@master
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.5"
+          go-version: "1.26"
 
       - name: Build
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.25.5-alpine3.22 \
+				golang:1.26-alpine3.22 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -X main.Version=v$(VERSION)' \
@@ -238,7 +238,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.25.5-alpine3.22 \
+				golang:1.26-alpine3.22 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -extldflags "-static" -X main.Version=v$(VERSION)' \

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/core
 
-go 1.25.5
+go 1.26
 
 require (
 	cloud.google.com/go v0.123.0
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0
 	github.com/aws/smithy-go v1.24.0
-	github.com/bytedance/sonic v1.14.2
+	github.com/bytedance/sonic v1.15.0
 	github.com/google/uuid v1.6.0
 	github.com/hajimehoshi/go-mp3 v0.3.4
 	github.com/mark3labs/mcp-go v0.43.2
@@ -45,7 +45,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -60,10 +60,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/examples/mcps/edge-case-server/go.mod
+++ b/examples/mcps/edge-case-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/edge-case-server
 
-go 1.23.0
+go 1.26
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/error-test-server/go.mod
+++ b/examples/mcps/error-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/error-test-server
 
-go 1.23.0
+go 1.26
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/go-test-server/go.mod
+++ b/examples/mcps/go-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/go-test-server
 
-go 1.23.2
+go 1.26
 
 require (
 	github.com/google/uuid v1.6.0

--- a/examples/mcps/http-no-ping-server/go.mod
+++ b/examples/mcps/http-no-ping-server/go.mod
@@ -1,6 +1,6 @@
 module http-no-ping-server
 
-go 1.23.0
+go 1.26
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/mcps/parallel-test-server/go.mod
+++ b/examples/mcps/parallel-test-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/mcps/parallel-test-server
 
-go 1.23.0
+go 1.26
 
 require github.com/mark3labs/mcp-go v0.43.2
 

--- a/examples/plugins/hello-world-wasm-go/go.mod
+++ b/examples/plugins/hello-world-wasm-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/hello-world-wasm
 
-go 1.25.5
+go 1.26
 
 require github.com/maximhq/bifrost/core v0.0.0-00010101000000-000000000000
 

--- a/examples/plugins/hello-world/Makefile
+++ b/examples/plugins/hello-world/Makefile
@@ -127,7 +127,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 			-e CGO_ENABLED=1 \
 			-e GOOS=$(TARGET_OS) \
 			-e GOARCH=$(TARGET_ARCH) \
-			golang:1.25.5-alpine3.22 \
+			golang:1.26-alpine3.22 \
 			sh -c "apk add --no-cache gcc musl-dev && \
 				go build -buildmode=plugin -ldflags='-w -s' -trimpath -o $(OUTPUT) main.go"; \
 		echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT) ($(TARGET_OS)/$(TARGET_ARCH))$(COLOR_RESET)"; \

--- a/examples/plugins/hello-world/go.mod
+++ b/examples/plugins/hello-world/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/hello-world
 
-go 1.25.5
+go 1.26
 
 require github.com/maximhq/bifrost/core v1.4.2
 

--- a/examples/plugins/http-transport-only/go.mod
+++ b/examples/plugins/http-transport-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/http-transport-only
 
-go 1.25.5
+go 1.26
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/llm-only/go.mod
+++ b/examples/plugins/llm-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/llm-only
 
-go 1.25.5
+go 1.26
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/mcp-only/go.mod
+++ b/examples/plugins/mcp-only/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/mcp-only
 
-go 1.25.5
+go 1.26
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/examples/plugins/multi-interface/go.mod
+++ b/examples/plugins/multi-interface/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/examples/plugins/multi-interface
 
-go 1.25.5
+go 1.26
 
 replace github.com/maximhq/bifrost/core => ../../../core
 

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/framework
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/google/uuid v1.6.0
@@ -30,7 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.94.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/swag/cmdutils v0.25.4 // indirect
@@ -83,7 +83,7 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/bytedance/sonic v1.14.2
+	github.com/bytedance/sonic v1.15.0
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -68,10 +68,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/plugins/governance/go.mod
+++ b/plugins/governance/go.mod
@@ -1,11 +1,11 @@
 module github.com/maximhq/bifrost/plugins/governance
 
-go 1.25.5
+go 1.26
 
 require gorm.io/gorm v1.31.1
 
 require (
-	github.com/bytedance/sonic v1.14.2
+	github.com/bytedance/sonic v1.15.0
 	github.com/google/cel-go v0.26.1
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.4.2
@@ -46,7 +46,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/governance/go.sum
+++ b/plugins/governance/go.sum
@@ -72,10 +72,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/plugins/jsonparser/go.mod
+++ b/plugins/jsonparser/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/jsonparser
 
-go 1.25.5
+go 1.26
 
 require github.com/maximhq/bifrost/core v1.4.2
 
@@ -34,8 +34,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/plugins/jsonparser/go.sum
+++ b/plugins/jsonparser/go.sum
@@ -60,10 +60,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/plugins/litellmcompat/go.mod
+++ b/plugins/litellmcompat/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/litellmcompat
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/maximhq/bifrost/core v1.4.2
@@ -38,8 +38,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/litellmcompat/go.sum
+++ b/plugins/litellmcompat/go.sum
@@ -68,10 +68,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/plugins/logging/go.mod
+++ b/plugins/logging/go.mod
@@ -1,9 +1,9 @@
 module github.com/maximhq/bifrost/plugins/logging
 
-go 1.25.5
+go 1.26
 
 require (
-	github.com/bytedance/sonic v1.14.2
+	github.com/bytedance/sonic v1.15.0
 	github.com/maximhq/bifrost/core v1.4.2
 	github.com/maximhq/bifrost/framework v1.2.20
 )
@@ -39,7 +39,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/logging/go.sum
+++ b/plugins/logging/go.sum
@@ -68,10 +68,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/plugins/maxim/go.mod
+++ b/plugins/maxim/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/maxim
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/maximhq/bifrost/core v1.4.2
@@ -41,8 +41,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/maxim/go.sum
+++ b/plugins/maxim/go.sum
@@ -68,10 +68,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/plugins/mocker/go.mod
+++ b/plugins/mocker/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/mocker
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/jaswdr/faker/v2 v2.8.0
@@ -37,8 +37,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/plugins/mocker/go.sum
+++ b/plugins/mocker/go.sum
@@ -60,10 +60,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/plugins/otel/go.mod
+++ b/plugins/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/otel
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/maximhq/bifrost/core v1.4.2
@@ -46,7 +46,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -128,7 +128,7 @@ require (
 )
 
 require (
-	github.com/bytedance/sonic v1.14.2
+	github.com/bytedance/sonic v1.15.0
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/plugins/otel/go.sum
+++ b/plugins/otel/go.sum
@@ -68,10 +68,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/semanticcache
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0
@@ -41,8 +41,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -68,10 +68,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/plugins/telemetry/go.mod
+++ b/plugins/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/plugins/telemetry
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/maximhq/bifrost/core v1.4.2
@@ -41,8 +41,8 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.14.2 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic v1.15.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/plugins/telemetry/go.sum
+++ b/plugins/telemetry/go.sum
@@ -70,10 +70,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=

--- a/tests/governance/go.mod
+++ b/tests/governance/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/governance
 
-go 1.25.5
+go 1.26

--- a/tests/scripts/1millogs/go.mod
+++ b/tests/scripts/1millogs/go.mod
@@ -1,6 +1,6 @@
 module github.com/maximhq/bifrost/tests/scripts/1millogs
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/maximhq/bifrost/core v1.2.37

--- a/tests/scripts/migration-checker/go.mod
+++ b/tests/scripts/migration-checker/go.mod
@@ -1,3 +1,3 @@
 module github.com/maximhq/bifrost/tests/scripts/migration-checker
 
-go 1.21
+go 1.26

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -15,7 +15,7 @@ RUN node scripts/fix-paths.js
 # Skip the copy-build step since we'll copy the files in the Go build stage
 
 # --- Go Build Stage: Compile the Go binary ---
-FROM golang:1.25.5-alpine3.22 AS builder
+FROM golang:1.26-alpine3.22 AS builder
 WORKDIR /app
 
 # Install dependencies including gcc for CGO and sqlite
@@ -38,11 +38,11 @@ COPY --from=ui-builder /app/out ./bifrost-http/ui
 ENV GOWORK=off
 ARG VERSION=unknown
 RUN go build \
-    -ldflags="-w -s -X main.Version=v${VERSION} -extldflags '-static'" \
-    -a -trimpath \
-    -tags "sqlite_static" \
-    -o /app/main \
-    ./bifrost-http
+  -ldflags="-w -s -X main.Version=v${VERSION} -extldflags '-static'" \
+  -a -trimpath \
+  -tags "sqlite_static" \
+  -o /app/main \
+  ./bifrost-http
 
 # Verify build succeeded
 RUN test -f /app/main || (echo "Build failed" && exit 1)
@@ -70,16 +70,16 @@ ARG ARG_APP_DIR=/app/data
 
 # Environment variables with defaults (can be overridden at runtime)
 ENV APP_PORT=$ARG_APP_PORT \
-    APP_HOST=$ARG_APP_HOST \
-    LOG_LEVEL=$ARG_LOG_LEVEL \
-    LOG_STYLE=$ARG_LOG_STYLE \
-    APP_DIR=$ARG_APP_DIR
+  APP_HOST=$ARG_APP_HOST \
+  LOG_LEVEL=$ARG_LOG_LEVEL \
+  LOG_STYLE=$ARG_LOG_STYLE \
+  APP_DIR=$ARG_APP_DIR
 
 
 RUN mkdir -p $APP_DIR/logs && \
-    adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app && \
-    chmod +x /app/docker-entrypoint.sh
+  adduser -D -s /bin/sh appuser && \
+  chown -R appuser:appuser /app && \
+  chmod +x /app/docker-entrypoint.sh
 USER appuser
 
 
@@ -89,7 +89,7 @@ EXPOSE $APP_PORT
 
 # Health check for container status monitoring
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${APP_PORT}/metrics || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${APP_PORT}/metrics || exit 1
 
 # Use entrypoint script that handles volume permissions and argument processing
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -1,10 +1,10 @@
 module github.com/maximhq/bifrost/transports
 
-go 1.25.5
+go 1.26
 
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4
-	github.com/bytedance/sonic v1.14.2
+	github.com/bytedance/sonic v1.15.0
 	github.com/fasthttp/router v1.5.4
 	github.com/fasthttp/websocket v1.5.12
 	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f
@@ -60,7 +60,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.4.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -74,10 +74,10 @@ github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMU
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.14.2 h1:k1twIoe97C1DtYUo+fZQy865IuHia4PR5RPiuGPPIIE=
-github.com/bytedance/sonic v1.14.2/go.mod h1:T80iDELeHiHKSc0C9tubFygiuXoGzrkjKzX2quAx980=
-github.com/bytedance/sonic/loader v0.4.0 h1:olZ7lEqcxtZygCK9EKYKADnpQoYkRQxaeY2NYzevs+o=
-github.com/bytedance/sonic/loader v0.4.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
+github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
+github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
+github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Upgrade Go version from 1.25.x to 1.26 across all GitHub workflows and project files.

## Changes

- Updated Go version from 1.25.5/1.25.7 to 1.26 in all GitHub workflow files
- Updated Go version in Dockerfile from 1.25.5 to 1.26
- Updated all go.mod files to specify Go 1.26
- Updated bytedance/sonic dependency from v1.14.2 to v1.15.0
- Updated bytedance/sonic/loader dependency from v0.4.0 to v0.5.0
- Added a new load test script for Bifrost in `.github/workflows/scripts/load-test.sh`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the project builds and tests pass with Go 1.26:

```sh
# Core/Transports
go version  # Should show go version go1.26 ...
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This update includes the latest Go version which may contain security improvements.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable