### PR TITLE
use GET in healthcheck instead of HEAD

### DIFF
--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -89,7 +89,7 @@ EXPOSE $APP_PORT
 
 # Health check for container status monitoring
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:${APP_PORT}/metrics || exit 1
+  CMD wget --no-verbose --tries=1 -O /dev/null http://127.0.0.1:${APP_PORT}/metrics || exit 1
 
 # Use entrypoint script that handles volume permissions and argument processing
 ENTRYPOINT ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary

Fix Docker healthcheck failing due to use of a HEAD request on the `/metrics` endpoint.

The existing healthcheck used `wget --spider`, which sends a HEAD request. Since `/metrics` only supports GET, this resulted in a `405` response and the container being marked unhealthy.

This change replaces `--spider` with `-O /dev/null` to send a GET request without storing the response body.


## Changes

* Replaced `wget --spider` with `wget -O /dev/null` in the Docker healthcheck


## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI


## Affected areas

* [ ] Core (Go)
* [x] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

## How to test

Build and run the container:

```sh
docker build -t bifrost-test .
docker run -p 8080:8080 bifrost-test
```

Expected behavior:

* Container reports `healthy`
* No `405` errors in logs

## Screenshots/Recordings

Not applicable (no UI changes).


## Breaking changes

* [ ] Yes
* [x] No


## Related issues


## Security considerations


## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [ ] I added/updated tests where appropriate (not applicable)
* [ ] I updated documentation where needed (not required)
* [x] I verified builds succeed (Go and UI)
* [ ] I verified the CI pipeline passes locally if applicable
