### PR TITLE
fix: field conversion in helm chart from camelCase to snake_case

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.5
+version: 2.0.6
 appVersion: "1.4.3"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,13 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.5
+**Latest Version:** 2.0.6
 
 ## Changelog
+
+### v2.0.6
+
+- Fixes MCP client config template to convert camelCase Helm values to snake_case config format
 
 ### v2.0.5
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -376,4 +376,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-02-13T12:00:00.000000+00:00"
+generated: "2026-02-17T12:00:00.000000+00:00"

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.3
+    created: "2026-02-17T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.6.tgz
+    version: 2.0.6
+  - apiVersion: v2
+    appVersion: 1.4.3
     created: "2026-02-13T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers


### PR DESCRIPTION
## Summary

Adds missing camelCase to snake_case conversion for `mcp.clientConfig`.  

## Changes

Adds conversion login in `_helpers.tpl`, similar to what existed for other keys. 

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

Render latest version of helm chart with the following values:

```yaml
mcp:
  clientConfigs:
    - name: "myMCP"
      connectionType: "http"
      httpConfig:
        url: "http://my-mcp.svc.cluster.local/"
      headers:
        Authorization: "env.MY_MCP_AUTH"
      tools_to_execute: ["*"]
```

## Breaking changes

- [ ] Yes
- [x] No


## Related issues

Closes: https://github.com/maximhq/bifrost/issues/1668

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


