### PR TITLE
adds pooling for response

### DIFF
--- a/core/internal/llmtests/automatic_function_calling.go
+++ b/core/internal/llmtests/automatic_function_calling.go
@@ -135,6 +135,14 @@ func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx 
 			}
 			t.Fatalf("❌ AutomaticFunctionCalling dual API test failed: %v", errors)
 		}
+		defer func() {
+			if result.ChatCompletionsResponse != nil {
+				result.ChatCompletionsResponse.Release()
+			}
+			if result.ResponsesAPIResponse != nil {
+				result.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Additional validation specific to automatic function calling using universal tool extraction
 		validateChatAutomaticToolCall := func(response *schemas.BifrostChatResponse, apiName string) {

--- a/core/internal/llmtests/chat_audio.go
+++ b/core/internal/llmtests/chat_audio.go
@@ -103,6 +103,7 @@ func RunChatAudioTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 		if chatResponse == nil {
 			t.Fatal("❌ Chat response should not be nil")
 		}
+		defer chatResponse.Release()
 
 		if len(chatResponse.Choices) == 0 {
 			t.Fatal("❌ Chat response should have at least one choice")

--- a/core/internal/llmtests/complete_end_to_end.go
+++ b/core/internal/llmtests/complete_end_to_end.go
@@ -102,6 +102,14 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			"CompleteEnd2End_Step1",
 			chatOperation1,
 			responsesOperation1)
+		defer func() {
+			if result1.ChatCompletionsResponse != nil {
+				result1.ChatCompletionsResponse.Release()
+			}
+			if result1.ResponsesAPIResponse != nil {
+				result1.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Validate both APIs succeeded
 		if !result1.BothSucceeded {
@@ -233,6 +241,14 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			"CompleteEnd2End_Step2",
 			chatOperation2,
 			responsesOperation2)
+		defer func() {
+			if result2.ChatCompletionsResponse != nil {
+				result2.ChatCompletionsResponse.Release()
+			}
+			if result2.ResponsesAPIResponse != nil {
+				result2.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Validate both APIs succeeded
 		if !result2.BothSucceeded {
@@ -371,6 +387,14 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			"CompleteEnd2End_Step3",
 			chatOperation3,
 			responsesOperation3)
+		defer func() {
+			if result3.ChatCompletionsResponse != nil {
+				result3.ChatCompletionsResponse.Release()
+			}
+			if result3.ResponsesAPIResponse != nil {
+				result3.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Validate both APIs succeeded
 		if !result3.BothSucceeded {

--- a/core/internal/llmtests/embedding.go
+++ b/core/internal/llmtests/embedding.go
@@ -106,6 +106,9 @@ func RunEmbeddingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 		if bifrostErr != nil {
 			t.Fatalf("❌ Embedding request failed after retries: %v", GetErrorMessage(bifrostErr))
 		}
+		if embeddingResponse != nil {
+			defer embeddingResponse.Release()
+		}
 
 		// Additional embedding-specific validation (complementary to the main validation)
 		validateEmbeddingSemantics(t, embeddingResponse, testTexts)

--- a/core/internal/llmtests/end_to_end_tool_calling.go
+++ b/core/internal/llmtests/end_to_end_tool_calling.go
@@ -93,6 +93,14 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			"End2EndToolCalling_Step1",
 			chatOperation,
 			responsesOperation)
+		defer func() {
+			if result1.ChatCompletionsResponse != nil {
+				result1.ChatCompletionsResponse.Release()
+			}
+			if result1.ResponsesAPIResponse != nil {
+				result1.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Validate both APIs succeeded
 		if !result1.BothSucceeded {
@@ -210,6 +218,14 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			"End2EndToolCalling_Step2",
 			chatOperation2,
 			responsesOperation2)
+		defer func() {
+			if result2.ChatCompletionsResponse != nil {
+				result2.ChatCompletionsResponse.Release()
+			}
+			if result2.ResponsesAPIResponse != nil {
+				result2.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Validate both APIs succeeded
 		if !result2.BothSucceeded {

--- a/core/internal/llmtests/file_base64.go
+++ b/core/internal/llmtests/file_base64.go
@@ -150,6 +150,7 @@ func RunFileBase64ChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx
 		if chatError != nil {
 			t.Fatalf("❌ FileBase64 Chat Completions test failed: %v", GetErrorMessage(chatError))
 		}
+		defer response.Release()
 
 		// Additional validation for PDF document processing
 		content := GetChatContent(response)
@@ -231,6 +232,7 @@ func RunFileBase64ResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 		if responsesError != nil {
 			t.Fatalf("❌ FileBase64 Responses test failed: %v", GetErrorMessage(responsesError))
 		}
+		defer response.Release()
 
 		// Additional validation for PDF document processing
 		content := GetResponsesContent(response)

--- a/core/internal/llmtests/file_url.go
+++ b/core/internal/llmtests/file_url.go
@@ -138,6 +138,9 @@ func RunFileURLChatCompletionsTest(t *testing.T, client *bifrost.Bifrost, ctx co
 			return client.ChatCompletionRequest(bfCtx, chatReq)
 		})
 
+		if response != nil {
+			defer response.Release()
+		}
 		if chatError != nil {
 			t.Fatalf("❌ FileURL Chat Completions test failed: %v", GetErrorMessage(chatError))
 		}
@@ -213,6 +216,9 @@ func RunFileURLResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx context.
 			return client.ResponsesRequest(bfCtx, responsesReq)
 		})
 
+		if response != nil {
+			defer response.Release()
+		}
 		if responsesError != nil {
 			t.Fatalf("❌ FileURL Responses test failed: %v", GetErrorMessage(responsesError))
 		}

--- a/core/internal/llmtests/image_base64.go
+++ b/core/internal/llmtests/image_base64.go
@@ -101,6 +101,14 @@ func RunImageBase64Test(t *testing.T, client *bifrost.Bifrost, ctx context.Conte
 			"ImageBase64",
 			chatOperation,
 			responsesOperation)
+		defer func() {
+			if result.ChatCompletionsResponse != nil {
+				result.ChatCompletionsResponse.Release()
+			}
+			if result.ResponsesAPIResponse != nil {
+				result.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Validate both APIs succeeded
 		if !result.BothSucceeded {

--- a/core/internal/llmtests/image_url.go
+++ b/core/internal/llmtests/image_url.go
@@ -107,6 +107,14 @@ func RunImageURLTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context,
 			}
 			t.Fatalf("❌ ImageURL dual API test failed: %v", errors)
 		}
+		defer func() {
+			if result.ChatCompletionsResponse != nil {
+				result.ChatCompletionsResponse.Release()
+			}
+			if result.ResponsesAPIResponse != nil {
+				result.ResponsesAPIResponse.Release()
+			}
+		}()
 
 		// Additional vision-specific validation using universal content extraction
 		validateChatImageProcessing := func(response *schemas.BifrostChatResponse, apiName string) {

--- a/core/internal/llmtests/multi_turn_conversation.go
+++ b/core/internal/llmtests/multi_turn_conversation.go
@@ -73,6 +73,7 @@ func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx con
 		if bifrostErr != nil {
 			t.Fatalf("❌ MultiTurnConversation_Step1 request failed after retries: %v", GetErrorMessage(bifrostErr))
 		}
+		defer response1.Release()
 
 		t.Logf("✅ First turn acknowledged: %s", GetChatContent(response1))
 
@@ -141,6 +142,7 @@ func RunMultiTurnConversationTest(t *testing.T, client *bifrost.Bifrost, ctx con
 	if bifrostErr != nil {
 		t.Fatalf("❌ MultiTurnConversation_Step2 request failed after retries: %v", GetErrorMessage(bifrostErr))
 	}
+	defer response2.Release()
 
 	// Validation already happened inside WithChatTestRetry via expectations2
 	// If we reach here, the model successfully remembered "Alice"

--- a/core/internal/llmtests/multiple_images.go
+++ b/core/internal/llmtests/multiple_images.go
@@ -125,6 +125,7 @@ func RunMultipleImagesTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 		if bifrostError != nil {
 			t.Fatalf("❌ Multiple images request failed after retries: %v", GetErrorMessage(bifrostError))
 		}
+		defer response.Release()
 
 		content := GetChatContent(response)
 

--- a/core/internal/llmtests/multiple_tool_calls.go
+++ b/core/internal/llmtests/multiple_tool_calls.go
@@ -109,6 +109,15 @@ func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx context
 			chatOperation,
 			responsesOperation)
 
+		defer func() {
+			if result.ChatCompletionsResponse != nil {
+				result.ChatCompletionsResponse.Release()
+			}
+			if result.ResponsesAPIResponse != nil {
+				result.ResponsesAPIResponse.Release()
+			}
+		}()
+
 		// Validate both APIs succeeded
 		if !result.BothSucceeded {
 			var errors []string

--- a/core/internal/llmtests/passthrough.go
+++ b/core/internal/llmtests/passthrough.go
@@ -72,6 +72,7 @@ func RunPassthroughExtraParamsTest(t *testing.T, client *bifrost.Bifrost, ctx co
 		if response == nil {
 			t.Fatalf("❌ Chat completion response is nil")
 		}
+		defer response.Release()
 
 		// Verify the response is valid
 		chatContent := GetChatContent(response)

--- a/core/internal/llmtests/prompt_caching.go
+++ b/core/internal/llmtests/prompt_caching.go
@@ -388,6 +388,7 @@ func RunPromptCachingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 
 				require.Nil(t, err, "Chat completion request should succeed: %v", err)
 				require.NotNil(t, response, "Response should not be nil")
+				defer response.Release()
 				require.NotNil(t, response.Usage, "Usage information should be present")
 
 				// Extract cached tokens

--- a/core/internal/llmtests/reasoning.go
+++ b/core/internal/llmtests/reasoning.go
@@ -96,6 +96,7 @@ func RunResponsesReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		if responsesError != nil {
 			t.Fatalf("❌ Reasoning test failed after retries: %v", GetErrorMessage(responsesError))
 		}
+		defer response.Release()
 
 		// Log the response content
 		responsesContent := GetResponsesContent(response)
@@ -290,6 +291,7 @@ func RunChatCompletionReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx c
 		if chatError != nil {
 			t.Fatalf("❌ Reasoning test failed after retries: %v", GetErrorMessage(chatError))
 		}
+		defer response.Release()
 
 		// Log the response content
 		chatContent := GetChatContent(response)
@@ -493,6 +495,7 @@ func RunMultiTurnReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		if chatError != nil {
 			t.Fatalf("Step 1 failed: %v", GetErrorMessage(chatError))
 		}
+		defer firstResponse.Release()
 
 		firstContent := GetChatContent(firstResponse)
 		if firstContent == "" {
@@ -562,6 +565,7 @@ func RunMultiTurnReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 		if chatError2 != nil {
 			t.Fatalf("Step 2 (multi-turn with reasoning passthrough) failed: %v", GetErrorMessage(chatError2))
 		}
+		defer secondResponse.Release()
 
 		secondContent := GetChatContent(secondResponse)
 		if secondContent == "" {

--- a/core/internal/llmtests/reasoning_opus.go
+++ b/core/internal/llmtests/reasoning_opus.go
@@ -146,6 +146,7 @@ func RunOpus45ReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			if responsesError != nil {
 				t.Fatalf("❌ Opus 4.5 Responses API reasoning test failed after retries: %v", GetErrorMessage(responsesError))
 			}
+			defer response.Release()
 
 			// Validate response has content
 			content := GetResponsesContent(response)
@@ -232,6 +233,7 @@ func RunOpus45ReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			if chatError != nil {
 				t.Fatalf("❌ Opus 4.5 Chat Completions API reasoning test failed after retries: %v", GetErrorMessage(chatError))
 			}
+			defer response.Release()
 
 			// Validate response has content
 			content := GetChatContent(response)
@@ -356,6 +358,7 @@ func RunOpus46ReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				if responsesError != nil {
 					t.Fatalf("❌ Opus 4.6 Responses API (effort=%s) reasoning test failed after retries: %v", effort, GetErrorMessage(responsesError))
 				}
+				defer response.Release()
 
 				// Validate response has content
 				content := GetResponsesContent(response)
@@ -443,6 +446,7 @@ func RunOpus46ReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			if chatError != nil {
 				t.Fatalf("❌ Opus 4.6 Chat Completions API reasoning test failed after retries: %v", GetErrorMessage(chatError))
 			}
+			defer response.Release()
 
 			// Validate response has content
 			content := GetChatContent(response)
@@ -545,6 +549,7 @@ func RunOpus46MultiTurnReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx 
 		if chatError != nil {
 			t.Fatalf("Step 1 failed: %v", GetErrorMessage(chatError))
 		}
+		defer firstResponse.Release()
 
 		firstContent := GetChatContent(firstResponse)
 		if firstContent == "" {
@@ -615,6 +620,7 @@ func RunOpus46MultiTurnReasoningTest(t *testing.T, client *bifrost.Bifrost, ctx 
 		if chatError2 != nil {
 			t.Fatalf("Step 2 (multi-turn with reasoning passthrough) failed: %v", GetErrorMessage(chatError2))
 		}
+		defer secondResponse.Release()
 
 		secondContent := GetChatContent(secondResponse)
 		if secondContent == "" {

--- a/core/internal/llmtests/simple_chat.go
+++ b/core/internal/llmtests/simple_chat.go
@@ -130,6 +130,8 @@ func RunSimpleChatTest(t *testing.T, client *bifrost.Bifrost, ctx context.Contex
 		if responsesError != nil {
 			t.Fatalf("❌ Responses API failed: %s", GetErrorMessage(responsesError))
 		}
+		defer chatResponse.Release()
+		defer responsesResponse.Release()
 
 		// Log results from both APIs
 		if chatResponse != nil {

--- a/core/internal/llmtests/structured_outputs.go
+++ b/core/internal/llmtests/structured_outputs.go
@@ -141,6 +141,7 @@ func testStructuredOutputChatWithValue(t *testing.T, client *bifrost.Bifrost, ct
 	if chatError != nil {
 		t.Fatalf("❌ Chat Completions API with structured output failed: %s", GetErrorMessage(chatError))
 	}
+	defer chatResponse.Release()
 
 	// Validate the response is valid JSON matching our schema
 	if chatResponse != nil {
@@ -477,6 +478,7 @@ func RunStructuredOutputResponsesTest(t *testing.T, client *bifrost.Bifrost, ctx
 		if responsesError != nil {
 			t.Fatalf("❌ Responses API with structured output failed: %s", GetErrorMessage(responsesError))
 		}
+		defer responsesResponse.Release()
 
 		// Validate the response is valid JSON matching our schema
 		if responsesResponse != nil {

--- a/core/internal/llmtests/text_completion.go
+++ b/core/internal/llmtests/text_completion.go
@@ -73,6 +73,7 @@ func RunTextCompletionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 		if bifrostErr != nil {
 			t.Fatalf("❌ TextCompletion request failed after retries: %v", GetErrorMessage(bifrostErr))
 		}
+		defer response.Release()
 
 		content := GetTextCompletionContent(response)
 		t.Logf("✅ Text completion result: %s", content)

--- a/core/internal/llmtests/tool_calls.go
+++ b/core/internal/llmtests/tool_calls.go
@@ -96,6 +96,15 @@ func RunToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context
 			chatOperation,
 			responsesOperation)
 
+		defer func() {
+			if result.ChatCompletionsResponse != nil {
+				result.ChatCompletionsResponse.Release()
+			}
+			if result.ResponsesAPIResponse != nil {
+				result.ResponsesAPIResponse.Release()
+			}
+		}()
+
 		// Validate both APIs succeeded
 		if !result.BothSucceeded {
 			var errors []string

--- a/core/internal/llmtests/web_search_tool.go
+++ b/core/internal/llmtests/web_search_tool.go
@@ -79,6 +79,9 @@ func RunWebSearchToolTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 		if err != nil {
 			t.Fatalf("❌ WebSearchTool test failed: %s", GetErrorMessage(err))
 		}
+		if response != nil {
+			defer response.Release()
+		}
 
 		require.NotNil(t, response, "Response should not be nil")
 
@@ -400,6 +403,9 @@ func RunWebSearchToolWithDomainsTest(t *testing.T, client *bifrost.Bifrost, ctx 
 		if err != nil {
 			t.Fatalf("❌ WebSearchToolWithDomains test failed: %s", GetErrorMessage(err))
 		}
+		if response != nil {
+			defer response.Release()
+		}
 
 		require.NotNil(t, response, "Response should not be nil")
 
@@ -504,6 +510,9 @@ func RunWebSearchToolContextSizesTest(t *testing.T, client *bifrost.Bifrost, ctx
 				if err != nil {
 					t.Fatalf("❌ WebSearchToolContextSize (%s) test failed: %s", size, GetErrorMessage(err))
 				}
+				if response != nil {
+					defer response.Release()
+				}
 
 				require.NotNil(t, response, "Response should not be nil")
 
@@ -598,6 +607,9 @@ func RunWebSearchToolMultiTurnTest(t *testing.T, client *bifrost.Bifrost, ctx co
 		if err != nil {
 			t.Fatalf("❌ First turn failed: %s", GetErrorMessage(err))
 		}
+		if firstResponse != nil {
+			defer firstResponse.Release()
+		}
 
 		require.NotNil(t, firstResponse, "First response should not be nil")
 
@@ -652,6 +664,9 @@ func RunWebSearchToolMultiTurnTest(t *testing.T, client *bifrost.Bifrost, ctx co
 
 		if err != nil {
 			t.Fatalf("❌ Second turn failed: %s", GetErrorMessage(err))
+		}
+		if secondResponse != nil {
+			defer secondResponse.Release()
 		}
 
 		require.NotNil(t, secondResponse, "Second response should not be nil")
@@ -740,6 +755,9 @@ func RunWebSearchToolMaxUsesTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 
 		if err != nil {
 			t.Fatalf("❌ WebSearchToolMaxUses test failed: %s", GetErrorMessage(err))
+		}
+		if response != nil {
+			defer response.Release()
 		}
 
 		require.NotNil(t, response, "Response should not be nil")

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -550,8 +550,9 @@ func HandleAnthropicChatCompletionStreaming(
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		chunkIndex := 0
 

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -686,27 +686,26 @@ func HandleAnthropicChatCompletionStreaming(
 					if event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeInputJSON && event.Delta.PartialJSON != nil {
 						// Convert tool use delta to content delta
 						content := *event.Delta.PartialJSON
-						response := &schemas.BifrostChatResponse{
-							ID:     messageID,
-							Object: "chat.completion.chunk",
-							Choices: []schemas.BifrostResponseChoice{
-								{
-									Index: 0,
-									ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
-										Delta: &schemas.ChatStreamResponseChoiceDelta{
-											Content: &content,
-										},
-									},
+					response := schemas.AcquireBifrostChatResponse()
+					response.ID = messageID
+					response.Object = "chat.completion.chunk"
+					response.Choices = []schemas.BifrostResponseChoice{
+						{
+							Index: 0,
+							ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+								Delta: &schemas.ChatStreamResponseChoiceDelta{
+									Content: &content,
 								},
 							},
-							ExtraFields: schemas.BifrostResponseExtraFields{
-								RequestType:    schemas.ChatCompletionStreamRequest,
-								Provider:       providerName,
-								ModelRequested: modelName,
-								ChunkIndex:     chunkIndex,
-								Latency:        time.Since(lastChunkTime).Milliseconds(),
-							},
-						}
+						},
+					}
+					response.ExtraFields = schemas.BifrostResponseExtraFields{
+						RequestType:    schemas.ChatCompletionStreamRequest,
+						Provider:       providerName,
+						ModelRequested: modelName,
+						ChunkIndex:     chunkIndex,
+						Latency:        time.Since(lastChunkTime).Milliseconds(),
+					}
 						lastChunkTime = time.Now()
 						chunkIndex++
 
@@ -1140,7 +1139,7 @@ func HandleAnthropicResponsesStream(
 
 					if isLastChunk && i == len(responses)-1 {
 						if response.Response == nil {
-							response.Response = &schemas.BifrostResponsesResponse{}
+							response.Response = schemas.AcquireBifrostResponsesResponse()
 						}
 						response.Response.Usage = usage
 						// Set raw request if enabled

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -375,7 +375,7 @@ func (provider *AzureProvider) TextCompletion(ctx *schemas.BifrostContext, key s
 		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostTextCompletionResponse{}
+	response := schemas.AcquireBifrostTextCompletionResponse()
 
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
 	if bifrostErr != nil {
@@ -505,7 +505,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostChatResponse{}
+	response := schemas.AcquireBifrostChatResponse()
 	var rawRequest interface{}
 	var rawResponse interface{}
 
@@ -697,7 +697,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostResponsesResponse{}
+	response := schemas.AcquireBifrostResponsesResponse()
 	var rawRequest interface{}
 	var rawResponse interface{}
 
@@ -856,7 +856,7 @@ func (provider *AzureProvider) Embedding(ctx *schemas.BifrostContext, key schema
 		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostEmbeddingResponse{}
+	response := schemas.AcquireBifrostEmbeddingResponse()
 
 	// Use enhanced response handler with pre-allocated response
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, response, jsonData, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -456,8 +456,9 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 		chunkIndex := 0
 		startTime := time.Now()
 		lastChunkTime := startTime
@@ -717,8 +718,9 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		chunkIndex := 0
 

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -805,7 +805,7 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 
 					if isLastChunk && i == len(responses)-1 {
 						if response.Response == nil {
-							response.Response = &schemas.BifrostResponsesResponse{}
+							response.Response = schemas.AcquireBifrostResponsesResponse()
 						}
 						// Set raw request if enabled
 						if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -418,8 +418,9 @@ func HandleGeminiChatCompletionStream(
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		chunkIndex := 0
 		startTime := time.Now()
@@ -758,8 +759,9 @@ func HandleGeminiResponsesStream(
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		chunkIndex := 0
 		sequenceNumber := 0 // Track sequence across all events
@@ -1193,9 +1195,9 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		// Increase buffer size to handle large chunks (especially for audio data)
-		buf := make([]byte, 0, 1024*1024) // 1MB initial buffer
-		scanner.Buffer(buf, 10*1024*1024) // Allow up to 10MB tokens
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 		chunkIndex := -1
 		usage := &schemas.SpeechUsage{}
 		startTime := time.Now()
@@ -1488,9 +1490,9 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		// Increase buffer size to handle large chunks (especially for audio data)
-		buf := make([]byte, 0, 1024*1024) // 1MB initial buffer
-		scanner.Buffer(buf, 10*1024*1024) // Allow up to 10MB tokens
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 		chunkIndex := -1
 		usage := &schemas.TranscriptionUsage{}
 		startTime := time.Now()

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -497,7 +497,7 @@ func (provider *HuggingFaceProvider) ChatCompletion(ctx *schemas.BifrostContext,
 		return nil, providerUtils.EnrichError(ctx, err, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	bifrostResponse := &schemas.BifrostChatResponse{}
+	bifrostResponse := schemas.AcquireBifrostChatResponse()
 
 	var rawResponse interface{}
 	var rawRequest interface{}

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -1175,8 +1175,9 @@ func HandleHuggingFaceImageGenerationStreaming(
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		lastChunkTime := startTime
 		chunkIndex := 0
@@ -1581,8 +1582,9 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		lastChunkTime := startTime
 		chunkIndex := 0

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -450,9 +450,9 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 		defer stopCancellation()
 
 		scanner := bufio.NewScanner(resp.BodyStream())
-		// Increase buffer size to handle large chunks
-		buf := make([]byte, 0, 64*1024) // 64KB initial buffer
-		scanner.Buffer(buf, 1024*1024)  // Allow up to 1MB tokens
+		bufPtr := providerUtils.AcquireScannerBuf()
+		scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+		defer providerUtils.ReleaseScannerBuf(bufPtr)
 		chunkIndex := -1
 
 		startTime := time.Now()

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -298,7 +298,7 @@ func HandleOpenAITextCompletionRequest(
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostTextCompletionResponse{}
+	response := schemas.AcquireBifrostTextCompletionResponse()
 
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
 	if bifrostErr != nil {
@@ -735,7 +735,7 @@ func HandleOpenAIChatCompletionRequest(
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
-	response := &schemas.BifrostChatResponse{}
+	response := schemas.AcquireBifrostChatResponse()
 	response.ExtraFields.ProviderResponseHeaders = providerUtils.ExtractProviderResponseHeaders(resp)
 
 	// Use enhanced response handler with pre-allocated response
@@ -1288,7 +1288,7 @@ func HandleOpenAIResponsesRequest(
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostResponsesResponse{}
+	response := schemas.AcquireBifrostResponsesResponse()
 
 	// Use enhanced response handler with pre-allocated response
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)
@@ -1673,7 +1673,7 @@ func HandleOpenAIEmbeddingRequest(
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName), jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
-	response := &schemas.BifrostEmbeddingResponse{}
+	response := schemas.AcquireBifrostEmbeddingResponse()
 
 	// Use enhanced response handler with pre-allocated response
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(body, response, jsonData, sendBackRawRequest, sendBackRawResponse)

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -562,29 +562,30 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 	go func() {
 		defer func() {
 			if ctx.Err() == context.Canceled {
-				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.TextCompletionStreamRequest, provider.logger)
-			} else if ctx.Err() == context.DeadlineExceeded {
-				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.TextCompletionStreamRequest, provider.logger)
-			}
-			close(responseChan)
-		}()
-		defer providerUtils.ReleaseStreamingResponse(resp)
+			providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.TextCompletionStreamRequest, provider.logger)
+		} else if ctx.Err() == context.DeadlineExceeded {
+			providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.TextCompletionStreamRequest, provider.logger)
+		}
+		close(responseChan)
+	}()
+	defer providerUtils.ReleaseStreamingResponse(resp)
 
-		// Setup cancellation handler
-		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
-		defer stopCancellation()
+	// Setup cancellation handler
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+	defer stopCancellation()
 
-		startTime := time.Now()
-		lastChunkTime := startTime
-		chunkIndex := 0
+	startTime := time.Now()
+	lastChunkTime := startTime
+	chunkIndex := 0
 
-		// Setup scanner to read SSE stream
-		scanner := bufio.NewScanner(bodyStream)
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+	// Setup scanner to read SSE stream
+	scanner := bufio.NewScanner(bodyStream)
+	bufPtr := providerUtils.AcquireScannerBuf()
+	scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+	defer providerUtils.ReleaseScannerBuf(bufPtr)
 
-		var currentEvent ReplicateSSEEvent
-		messageID := prediction.ID
+	var currentEvent ReplicateSSEEvent
+	messageID := prediction.ID
 
 		for scanner.Scan() {
 			// Check for context cancellation
@@ -941,29 +942,30 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 	go func() {
 		defer func() {
 			if ctx.Err() == context.Canceled {
-				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ChatCompletionStreamRequest, provider.logger)
-			} else if ctx.Err() == context.DeadlineExceeded {
-				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ChatCompletionStreamRequest, provider.logger)
-			}
-			close(responseChan)
-		}()
-		defer providerUtils.ReleaseStreamingResponse(resp)
+			providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ChatCompletionStreamRequest, provider.logger)
+		} else if ctx.Err() == context.DeadlineExceeded {
+			providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, provider.GetProviderKey(), request.Model, schemas.ChatCompletionStreamRequest, provider.logger)
+		}
+		close(responseChan)
+	}()
+	defer providerUtils.ReleaseStreamingResponse(resp)
 
-		// Setup cancellation handler
-		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
-		defer stopCancellation()
+	// Setup cancellation handler
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+	defer stopCancellation()
 
-		startTime := time.Now()
-		lastChunkTime := startTime
-		chunkIndex := 0
+	startTime := time.Now()
+	lastChunkTime := startTime
+	chunkIndex := 0
 
-		// Setup scanner to read SSE stream
-		scanner := bufio.NewScanner(bodyStream)
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+	// Setup scanner to read SSE stream
+	scanner := bufio.NewScanner(bodyStream)
+	bufPtr := providerUtils.AcquireScannerBuf()
+	scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+	defer providerUtils.ReleaseScannerBuf(bufPtr)
 
-		var currentEvent ReplicateSSEEvent
-		messageID := prediction.ID
+	var currentEvent ReplicateSSEEvent
+	messageID := prediction.ID
 
 		for scanner.Scan() {
 			// Check for context cancellation
@@ -1984,26 +1986,27 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 	go func() {
 		defer func() {
 			if ctx.Err() == context.Canceled {
-				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageGenerationStreamRequest, provider.logger)
-			} else if ctx.Err() == context.DeadlineExceeded {
-				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageGenerationStreamRequest, provider.logger)
-			}
-			close(responseChan)
-		}()
-		defer providerUtils.ReleaseStreamingResponse(resp)
+			providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageGenerationStreamRequest, provider.logger)
+		} else if ctx.Err() == context.DeadlineExceeded {
+			providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageGenerationStreamRequest, provider.logger)
+		}
+		close(responseChan)
+	}()
+	defer providerUtils.ReleaseStreamingResponse(resp)
 
-		// Setup cancellation handler
-		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
-		defer stopCancellation()
+	// Setup cancellation handler
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+	defer stopCancellation()
 
-		startTime := time.Now()
-		lastChunkTime := startTime
-		chunkIndex := 0
+	startTime := time.Now()
+	lastChunkTime := startTime
+	chunkIndex := 0
 
-		// Setup scanner to read SSE stream
-		scanner := bufio.NewScanner(bodyStream)
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+	// Setup scanner to read SSE stream
+	scanner := bufio.NewScanner(bodyStream)
+	bufPtr := providerUtils.AcquireScannerBuf()
+	scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+	defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		var currentEvent ReplicateSSEEvent
 		// Track last image data for final chunk
@@ -2421,26 +2424,27 @@ func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, 
 	go func() {
 		defer func() {
 			if ctx.Err() == context.Canceled {
-				providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageEditStreamRequest, provider.logger)
-			} else if ctx.Err() == context.DeadlineExceeded {
-				providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageEditStreamRequest, provider.logger)
-			}
-			close(responseChan)
-		}()
-		defer providerUtils.ReleaseStreamingResponse(resp)
+			providerUtils.HandleStreamCancellation(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageEditStreamRequest, provider.logger)
+		} else if ctx.Err() == context.DeadlineExceeded {
+			providerUtils.HandleStreamTimeout(ctx, postHookRunner, responseChan, providerName, request.Model, schemas.ImageEditStreamRequest, provider.logger)
+		}
+		close(responseChan)
+	}()
+	defer providerUtils.ReleaseStreamingResponse(resp)
 
-		// Setup cancellation handler
-		stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
-		defer stopCancellation()
+	// Setup cancellation handler
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+	defer stopCancellation()
 
-		startTime := time.Now()
-		lastChunkTime := startTime
-		chunkIndex := 0
+	startTime := time.Now()
+	lastChunkTime := startTime
+	chunkIndex := 0
 
-		// Setup scanner to read SSE stream
-		scanner := bufio.NewScanner(bodyStream)
-		buf := make([]byte, 0, 1024*1024)
-		scanner.Buffer(buf, 10*1024*1024)
+	// Setup scanner to read SSE stream
+	scanner := bufio.NewScanner(bodyStream)
+	bufPtr := providerUtils.AcquireScannerBuf()
+	scanner.Buffer((*bufPtr)[:0], 10*1024*1024)
+	defer providerUtils.ReleaseScannerBuf(bufPtr)
 
 		var currentEvent ReplicateSSEEvent
 		// Track last image data for final chunk

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1171,7 +1171,7 @@ func SendCreatedEventResponsesChunk(ctx *schemas.BifrostContext, postHookRunner 
 	firstChunk := &schemas.BifrostResponsesStreamResponse{
 		Type:           schemas.ResponsesStreamResponseTypeCreated,
 		SequenceNumber: 0,
-		Response:       &schemas.BifrostResponsesResponse{},
+		Response:       schemas.AcquireBifrostResponsesResponse(),
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType:    schemas.ResponsesStreamRequest,
 			Provider:       provider,
@@ -1190,7 +1190,7 @@ func SendInProgressEventResponsesChunk(ctx *schemas.BifrostContext, postHookRunn
 	chunk := &schemas.BifrostResponsesStreamResponse{
 		Type:           schemas.ResponsesStreamResponseTypeInProgress,
 		SequenceNumber: 1,
-		Response:       &schemas.BifrostResponsesResponse{},
+		Response:       schemas.AcquireBifrostResponsesResponse(),
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType:    schemas.ResponsesStreamRequest,
 			Provider:       provider,

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -534,7 +534,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 		return response, nil
 	} else {
-		response := &schemas.BifrostChatResponse{}
+		response := schemas.AcquireBifrostChatResponse()
 
 		// Use enhanced response handler with pre-allocated response
 		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(resp.Body(), response, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -818,6 +818,63 @@ func ReleaseBifrostError(err *BifrostError) {
 	}
 }
 
+// bifrostRequestPool provides a pool for BifrostRequest objects to reduce allocations.
+// BifrostRequest is a container struct with pointers to specific request types.
+var bifrostRequestPool = sync.Pool{
+	New: func() interface{} {
+		return &BifrostRequest{}
+	},
+}
+
+// AcquireBifrostRequest gets a BifrostRequest from the pool and resets it.
+func AcquireBifrostRequest() *BifrostRequest {
+	r := bifrostRequestPool.Get().(*BifrostRequest)
+	*r = BifrostRequest{}
+	return r
+}
+
+// Release returns a BifrostRequest to the pool after clearing all fields.
+// The caller must ensure no other goroutine holds a reference to this request.
+// Do NOT use the request after calling Release().
+func (br *BifrostRequest) Release() {
+	if br == nil {
+		return
+	}
+	// Nil all pointer fields to break references and allow GC of inner structs
+	br.RequestType = ""
+	br.ListModelsRequest = nil
+	br.TextCompletionRequest = nil
+	br.ChatRequest = nil
+	br.ResponsesRequest = nil
+	br.CountTokensRequest = nil
+	br.EmbeddingRequest = nil
+	br.SpeechRequest = nil
+	br.TranscriptionRequest = nil
+	br.ImageGenerationRequest = nil
+	br.ImageEditRequest = nil
+	br.ImageVariationRequest = nil
+	br.FileUploadRequest = nil
+	br.FileListRequest = nil
+	br.FileRetrieveRequest = nil
+	br.FileDeleteRequest = nil
+	br.FileContentRequest = nil
+	br.BatchCreateRequest = nil
+	br.BatchListRequest = nil
+	br.BatchRetrieveRequest = nil
+	br.BatchCancelRequest = nil
+	br.BatchResultsRequest = nil
+	br.ContainerCreateRequest = nil
+	br.ContainerListRequest = nil
+	br.ContainerRetrieveRequest = nil
+	br.ContainerDeleteRequest = nil
+	br.ContainerFileCreateRequest = nil
+	br.ContainerFileListRequest = nil
+	br.ContainerFileRetrieveRequest = nil
+	br.ContainerFileContentRequest = nil
+	br.ContainerFileDeleteRequest = nil
+	bifrostRequestPool.Put(br)
+}
+
 // bifrostResponsePool provides a pool for BifrostResponse wrapper objects to reduce
 // per-chunk allocations during streaming. The BifrostResponse is a temporary container
 // that wraps inner response pointers; it is no longer needed after the BifrostStreamChunk
@@ -837,10 +894,54 @@ func AcquireBifrostResponse() *BifrostResponse {
 
 // ReleaseBifrostResponse returns a BifrostResponse to the pool.
 // The caller must ensure no other goroutine holds a reference to this response.
+// Deprecated: Use r.Release() instead for consistency.
 func ReleaseBifrostResponse(r *BifrostResponse) {
 	if r != nil {
-		bifrostResponsePool.Put(r)
+		r.Release()
 	}
+}
+
+// Release returns a BifrostResponse to the pool after clearing all fields.
+// The caller must ensure no other goroutine holds a reference to this response.
+// Do NOT use the response after calling Release().
+func (r *BifrostResponse) Release() {
+	if r == nil {
+		return
+	}
+	// Nil all pointer fields to break references and allow GC of inner structs
+	r.ListModelsResponse = nil
+	r.TextCompletionResponse = nil
+	r.ChatResponse = nil
+	r.ResponsesResponse = nil
+	r.ResponsesStreamResponse = nil
+	r.CountTokensResponse = nil
+	r.EmbeddingResponse = nil
+	r.SpeechResponse = nil
+	r.SpeechStreamResponse = nil
+	r.TranscriptionResponse = nil
+	r.TranscriptionStreamResponse = nil
+	r.ImageGenerationResponse = nil
+	r.ImageGenerationStreamResponse = nil
+	r.FileUploadResponse = nil
+	r.FileListResponse = nil
+	r.FileRetrieveResponse = nil
+	r.FileDeleteResponse = nil
+	r.FileContentResponse = nil
+	r.BatchCreateResponse = nil
+	r.BatchListResponse = nil
+	r.BatchRetrieveResponse = nil
+	r.BatchCancelResponse = nil
+	r.BatchResultsResponse = nil
+	r.ContainerCreateResponse = nil
+	r.ContainerListResponse = nil
+	r.ContainerRetrieveResponse = nil
+	r.ContainerDeleteResponse = nil
+	r.ContainerFileCreateResponse = nil
+	r.ContainerFileListResponse = nil
+	r.ContainerFileRetrieveResponse = nil
+	r.ContainerFileContentResponse = nil
+	r.ContainerFileDeleteResponse = nil
+	bifrostResponsePool.Put(r)
 }
 
 // bifrostStreamChunkPool provides a pool for BifrostStreamChunk objects to reduce

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -817,3 +817,64 @@ func ReleaseBifrostError(err *BifrostError) {
 		bifrostErrorPool.Put(err)
 	}
 }
+
+// bifrostResponsePool provides a pool for BifrostResponse wrapper objects to reduce
+// per-chunk allocations during streaming. The BifrostResponse is a temporary container
+// that wraps inner response pointers; it is no longer needed after the BifrostStreamChunk
+// copies those pointers and is sent on the channel.
+var bifrostResponsePool = sync.Pool{
+	New: func() interface{} {
+		return &BifrostResponse{}
+	},
+}
+
+// AcquireBifrostResponse gets a BifrostResponse from the pool and resets it.
+func AcquireBifrostResponse() *BifrostResponse {
+	r := bifrostResponsePool.Get().(*BifrostResponse)
+	*r = BifrostResponse{}
+	return r
+}
+
+// ReleaseBifrostResponse returns a BifrostResponse to the pool.
+// The caller must ensure no other goroutine holds a reference to this response.
+func ReleaseBifrostResponse(r *BifrostResponse) {
+	if r != nil {
+		bifrostResponsePool.Put(r)
+	}
+}
+
+// bifrostStreamChunkPool provides a pool for BifrostStreamChunk objects to reduce
+// per-chunk allocations during streaming. Each chunk sent on the streaming channel
+// allocates a BifrostStreamChunk; pooling avoids this heap allocation.
+var bifrostStreamChunkPool = sync.Pool{
+	New: func() interface{} {
+		return &BifrostStreamChunk{}
+	},
+}
+
+// AcquireBifrostStreamChunk gets a BifrostStreamChunk from the pool and resets it.
+func AcquireBifrostStreamChunk() *BifrostStreamChunk {
+	c := bifrostStreamChunkPool.Get().(*BifrostStreamChunk)
+	*c = BifrostStreamChunk{}
+	return c
+}
+
+// ReleaseBifrostStreamChunk returns a BifrostStreamChunk to its pool.
+// NOTE: The inner BifrostChatResponse is NOT released here because post-hook
+// goroutines (e.g. PostLLMHook) may still hold a reference to it via the
+// original BifrostResponse. Releasing it while a goroutine reads it causes
+// a data race (nil-pointer panic on ChatResponse.Usage). The ChatResponse
+// is reclaimed by GC once all references are dropped.
+func ReleaseBifrostStreamChunk(c *BifrostStreamChunk) {
+	if c == nil {
+		return
+	}
+	c.BifrostChatResponse = nil
+	c.BifrostTextCompletionResponse = nil
+	c.BifrostResponsesStreamResponse = nil
+	c.BifrostSpeechStreamResponse = nil
+	c.BifrostTranscriptionStreamResponse = nil
+	c.BifrostImageGenerationStreamResponse = nil
+	c.BifrostError = nil
+	bifrostStreamChunkPool.Put(c)
+}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -65,10 +65,35 @@ func AcquireBifrostChatResponse() *BifrostChatResponse {
 
 // ReleaseBifrostChatResponse returns a BifrostChatResponse to the pool.
 // Do NOT release responses that are still referenced by other goroutines.
+// Deprecated: Use r.Release() instead for consistency.
 func ReleaseBifrostChatResponse(r *BifrostChatResponse) {
 	if r != nil {
-		bifrostChatResponsePool.Put(r)
+		r.Release()
 	}
+}
+
+// Release returns a BifrostChatResponse to the pool after clearing all fields.
+// The caller must ensure no other goroutine holds a reference to this response.
+// Do NOT use the response after calling Release().
+func (cr *BifrostChatResponse) Release() {
+	if cr == nil {
+		return
+	}
+	// Nil pointer and slice fields to break references and allow GC
+	cr.ID = ""
+	cr.Choices = nil
+	cr.Created = 0
+	cr.Model = ""
+	cr.Object = ""
+	cr.ServiceTier = nil
+	cr.SystemFingerprint = ""
+	cr.Usage = nil
+	cr.ExtraFields = BifrostResponseExtraFields{}
+	cr.ExtraParams = nil
+	cr.SearchResults = nil
+	cr.Videos = nil
+	cr.Citations = nil
+	bifrostChatResponsePool.Put(cr)
 }
 
 // ToTextCompletionResponse converts a BifrostChatResponse to a BifrostTextCompletionResponse

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 )
 
@@ -86,6 +87,71 @@ type BifrostResponsesResponse struct {
 	SearchResults []SearchResult `json:"search_results,omitempty"`
 	Videos        []VideoResult  `json:"videos,omitempty"`
 	Citations     []string       `json:"citations,omitempty"`
+}
+
+// bifrostResponsesResponsePool provides a pool for BifrostResponsesResponse objects.
+var bifrostResponsesResponsePool = sync.Pool{
+	New: func() interface{} {
+		return &BifrostResponsesResponse{}
+	},
+}
+
+// AcquireBifrostResponsesResponse gets a BifrostResponsesResponse from the pool and resets it.
+func AcquireBifrostResponsesResponse() *BifrostResponsesResponse {
+	r := bifrostResponsesResponsePool.Get().(*BifrostResponsesResponse)
+	*r = BifrostResponsesResponse{}
+	return r
+}
+
+// Release returns a BifrostResponsesResponse to the pool after clearing all fields.
+// The caller must ensure no other goroutine holds a reference to this response.
+// Do NOT use the response after calling Release().
+func (resp *BifrostResponsesResponse) Release() {
+	if resp == nil {
+		return
+	}
+	// Nil all pointer and slice fields to break references and allow GC
+	resp.ID = nil
+	resp.Object = ""
+	resp.Background = nil
+	resp.Conversation = nil
+	resp.CreatedAt = 0
+	resp.CompletedAt = nil
+	resp.Error = nil
+	resp.Include = nil
+	resp.IncompleteDetails = nil
+	resp.Instructions = nil
+	resp.MaxOutputTokens = nil
+	resp.MaxToolCalls = nil
+	resp.Metadata = nil
+	resp.Model = ""
+	resp.Output = nil
+	resp.ParallelToolCalls = nil
+	resp.PreviousResponseID = nil
+	resp.Prompt = nil
+	resp.PromptCacheKey = nil
+	resp.PresencePenalty = nil
+	resp.FrequencyPenalty = nil
+	resp.Reasoning = nil
+	resp.SafetyIdentifier = nil
+	resp.ServiceTier = nil
+	resp.Status = nil
+	resp.StreamOptions = nil
+	resp.StopReason = nil
+	resp.Store = nil
+	resp.Temperature = nil
+	resp.Text = nil
+	resp.TopLogProbs = nil
+	resp.TopP = nil
+	resp.ToolChoice = nil
+	resp.Tools = nil
+	resp.Truncation = nil
+	resp.Usage = nil
+	resp.ExtraFields = BifrostResponseExtraFields{}
+	resp.SearchResults = nil
+	resp.Videos = nil
+	resp.Citations = nil
+	bifrostResponsesResponsePool.Put(resp)
 }
 
 func (resp *BifrostResponsesResponse) WithDefaults() *BifrostResponsesResponse {

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -115,6 +115,18 @@ func (s *RDBLogStore) CreateIfNotExists(ctx context.Context, entry *Log) error {
 	}).Create(entry).Error
 }
 
+// BatchCreateIfNotExists inserts multiple log entries in a single transaction.
+// Uses ON CONFLICT DO NOTHING for idempotency.
+func (s *RDBLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*Log) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoNothing: true,
+	}).Create(&entries).Error
+}
+
 // Ping checks if the database is reachable.
 func (s *RDBLogStore) Ping(ctx context.Context) error {
 	return s.db.WithContext(ctx).Exec("SELECT 1").Error
@@ -846,6 +858,28 @@ func (s *RDBLogStore) Flush(ctx context.Context, since time.Time) error {
 func (s *RDBLogStore) FindAll(ctx context.Context, query any, fields ...string) ([]*Log, error) {
 	var logs []*Log
 	if err := s.db.WithContext(ctx).Select(fields).Where(query).Find(&logs).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []*Log{}, nil
+		}
+		return nil, err
+	}
+	return logs, nil
+}
+
+// FindAllDistinct finds all distinct log entries for the given fields.
+// Uses SQL DISTINCT to return only unique combinations, avoiding loading
+// all rows when only unique values are needed (e.g., for filter dropdowns).
+func (s *RDBLogStore) FindAllDistinct(ctx context.Context, query any, fields ...string) ([]*Log, error) {
+	var logs []*Log
+	db := s.db.WithContext(ctx).Where(query)
+	if len(fields) > 0 {
+		args := make([]interface{}, len(fields))
+		for i, f := range fields {
+			args[i] = f
+		}
+		db = db.Distinct(args...)
+	}
+	if err := db.Find(&logs).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return []*Log{}, nil
 		}

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -22,9 +22,11 @@ type LogStore interface {
 	Ping(ctx context.Context) error
 	Create(ctx context.Context, entry *Log) error
 	CreateIfNotExists(ctx context.Context, entry *Log) error
+	BatchCreateIfNotExists(ctx context.Context, entries []*Log) error
 	FindByID(ctx context.Context, id string) (*Log, error)
 	FindFirst(ctx context.Context, query any, fields ...string) (*Log, error)
 	FindAll(ctx context.Context, query any, fields ...string) ([]*Log, error)
+	FindAllDistinct(ctx context.Context, query any, fields ...string) ([]*Log, error)
 	HasLogs(ctx context.Context) (bool, error)
 	SearchLogs(ctx context.Context, filters SearchFilters, pagination PaginationOptions) (*SearchResult, error)
 	GetStats(ctx context.Context, filters SearchFilters) (*SearchStats, error)

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -172,19 +172,15 @@ func (mc *ModelCatalog) CalculateCostFromUsage(provider string, model string, de
 		return usage.Cost.TotalCost
 	}
 
-	mc.logger.Debug("looking up pricing for model %s and provider %s of request type %s", model, provider, normalizeRequestType(requestType))
 	// Get pricing for the model
 	pricing, exists := mc.getPricing(model, provider, requestType)
 	if !exists {
 		if deployment != "" {
-			mc.logger.Debug("pricing not found for model %s and provider %s of request type %s, trying with deployment %s", model, provider, normalizeRequestType(requestType), deployment)
 			pricing, exists = mc.getPricing(deployment, provider, requestType)
 			if !exists {
-				mc.logger.Debug("pricing not found for deployment %s and provider %s of request type %s, skipping cost calculation", deployment, provider, normalizeRequestType(requestType))
 				return 0.0
 			}
 		} else {
-			mc.logger.Debug("pricing not found for model %s and provider %s of request type %s, skipping cost calculation", model, provider, normalizeRequestType(requestType))
 			return 0.0
 		}
 	}

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -48,6 +48,8 @@ func (a *Accumulator) getChatStreamChunk() *ChatStreamChunk {
 // putChatStreamChunk returns a chat stream chunk to the pool
 func (a *Accumulator) putChatStreamChunk(chunk *ChatStreamChunk) {
 	chunk.Timestamp = time.Time{}
+	// Return the pooled delta struct before clearing the pointer
+	releaseChatStreamDelta(chunk.Delta)
 	chunk.Delta = nil
 	chunk.Cost = nil
 	chunk.SemanticCacheDebug = nil

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -895,6 +895,13 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
+	// For non-final streaming chunks, skip the goroutine entirely.
+	// postHookWorker only does work for non-streaming or final streaming chunks.
+	isStreaming := bifrost.IsStreamRequestType(requestType)
+	if isStreaming && !isFinalChunk {
+		return result, err, nil
+	}
+
 	// Always process usage tracking (with or without virtual key)
 	// If virtualKey is empty, it will be passed as empty string to postHookWorker
 	// The tracker will handle empty virtual keys gracefully by only updating provider-level and model-level usage

--- a/plugins/logging/batch_writer.go
+++ b/plugins/logging/batch_writer.go
@@ -1,0 +1,248 @@
+package logging
+
+import (
+	"time"
+
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+const (
+	// maxBatchSize is the maximum number of entries to collect before flushing
+	maxBatchSize = 100
+	// batchInterval is the maximum time to wait before flushing a partial batch
+	batchInterval = 50 * time.Millisecond
+	// writeQueueCapacity is the buffer size for the write queue channel
+	writeQueueCapacity = 10000
+	// pendingLogTTL is how long a pending log entry can stay in memory before cleanup
+	pendingLogTTL = 5 * time.Minute
+)
+
+// PendingLogData holds PreLLMHook input data until PostLLMHook fires.
+// Stored in pendingLogs sync.Map keyed by requestID.
+type PendingLogData struct {
+	RequestID         string
+	ParentRequestID   string
+	Timestamp         time.Time
+	FallbackIndex     int
+	RoutingEngineUsed string
+	InitialData       *InitialLogData
+	CreatedAt         time.Time // For cleanup of stale entries
+}
+
+// writeQueueEntry is an entry pushed to the batch write queue.
+type writeQueueEntry struct {
+	log      *logstore.Log            // Complete log entry ready for INSERT
+	callback func(entry *logstore.Log) // Post-commit callback receives the inserted entry (no DB re-read needed)
+}
+
+// batchWriter is the single writer goroutine that drains the write queue
+// and processes entries in batched transactions.
+func (p *LoggerPlugin) batchWriter() {
+	defer p.wg.Done()
+
+	batch := make([]*writeQueueEntry, 0, maxBatchSize)
+	timer := time.NewTimer(batchInterval)
+	timer.Stop()
+	timerRunning := false
+
+	for {
+		select {
+		case entry, ok := <-p.writeQueue:
+			if !ok {
+				// Channel closed - flush remaining batch and exit
+				if len(batch) > 0 {
+					p.processBatch(batch)
+				}
+				return
+			}
+			batch = append(batch, entry)
+			if len(batch) >= maxBatchSize {
+				if timerRunning {
+					timer.Stop()
+					timerRunning = false
+				}
+				p.processBatch(batch)
+				batch = batch[:0]
+			} else if !timerRunning {
+				timer.Reset(batchInterval)
+				timerRunning = true
+			}
+
+		case <-timer.C:
+			timerRunning = false
+			if len(batch) > 0 {
+				p.processBatch(batch)
+				batch = batch[:0]
+			}
+		}
+	}
+}
+
+// processBatch executes a batch of log entries in a single database transaction.
+func (p *LoggerPlugin) processBatch(batch []*writeQueueEntry) {
+	if len(batch) == 0 {
+		return
+	}
+
+	// Collect all log entries for batch insert
+	logs := make([]*logstore.Log, 0, len(batch))
+	for _, entry := range batch {
+		if entry.log != nil {
+			logs = append(logs, entry.log)
+		}
+	}
+
+	if len(logs) > 0 {
+		if err := p.store.BatchCreateIfNotExists(p.ctx, logs); err != nil {
+			p.logger.Warn("batch insert failed for %d log entries: %v", len(logs), err)
+			return
+		}
+	}
+
+	// Collect callbacks that need to fire, then run them in a single goroutine.
+	// This avoids blocking the batch writer (synchronous was causing 1+ second stalls
+	// during WebSocket broadcast) without creating a goroutine per entry (which caused
+	// goroutine explosion to 13K+).
+	type cbPair struct {
+		cb  func(*logstore.Log)
+		log *logstore.Log
+	}
+	var callbacks []cbPair
+	for _, entry := range batch {
+		if entry.callback != nil {
+			callbacks = append(callbacks, cbPair{cb: entry.callback, log: entry.log})
+		}
+	}
+	if len(callbacks) > 0 {
+		go func() {
+			for _, pair := range callbacks {
+				pair.cb(pair.log)
+			}
+		}()
+	}
+}
+
+// cleanupStalePendingLogs removes entries from pendingLogs that have been
+// waiting longer than pendingLogTTL. This handles cases where PostLLMHook
+// never fires for a request (e.g., request was cancelled before reaching the provider).
+func (p *LoggerPlugin) cleanupStalePendingLogs() {
+	cutoff := time.Now().Add(-pendingLogTTL)
+	p.pendingLogs.Range(func(key, value any) bool {
+		if pending, ok := value.(*PendingLogData); ok {
+			if pending.CreatedAt.Before(cutoff) {
+				p.pendingLogs.Delete(key)
+			}
+		}
+		return true
+	})
+}
+
+// enqueueLogEntry pushes a complete log entry to the write queue.
+// If the queue is full, it blocks until space is available (backpressure).
+func (p *LoggerPlugin) enqueueLogEntry(entry *logstore.Log, callback func(entry *logstore.Log)) {
+	if p.closed.Load() {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			// Channel was closed between the check and send; entry is dropped
+			p.droppedRequests.Add(1)
+		}
+	}()
+	select {
+	case p.writeQueue <- &writeQueueEntry{log: entry, callback: callback}:
+		// enqueued successfully
+	default:
+		// Fall through to blocking send
+		p.writeQueue <- &writeQueueEntry{log: entry, callback: callback}
+	}
+}
+
+// buildInitialLogEntry constructs a logstore.Log from PendingLogData (input)
+// without writing to the database. Used for the UI callback in PreLLMHook.
+func buildInitialLogEntry(pending *PendingLogData) *logstore.Log {
+	entry := &logstore.Log{
+		ID:                          pending.RequestID,
+		Timestamp:                   pending.Timestamp,
+		Object:                      pending.InitialData.Object,
+		Provider:                    pending.InitialData.Provider,
+		Model:                       pending.InitialData.Model,
+		FallbackIndex:               pending.FallbackIndex,
+		Status:                      "processing",
+		Stream:                      false,
+		CreatedAt:                   pending.Timestamp,
+		InputHistoryParsed:          pending.InitialData.InputHistory,
+		ResponsesInputHistoryParsed: pending.InitialData.ResponsesInputHistory,
+		ParamsParsed:                pending.InitialData.Params,
+		ToolsParsed:                 pending.InitialData.Tools,
+	}
+	if pending.ParentRequestID != "" {
+		entry.ParentRequestID = &pending.ParentRequestID
+	}
+	if pending.RoutingEngineUsed != "" {
+		entry.RoutingEngineUsed = &pending.RoutingEngineUsed
+	}
+	return entry
+}
+
+// buildCompleteLogEntryFromPending constructs a logstore.Log with both input (from PendingLogData)
+// and output fields fully populated. The caller provides a function to apply output-specific fields.
+func buildCompleteLogEntryFromPending(pending *PendingLogData) *logstore.Log {
+	entry := &logstore.Log{
+		ID:            pending.RequestID,
+		Timestamp:     pending.Timestamp,
+		Object:        pending.InitialData.Object,
+		Provider:      pending.InitialData.Provider,
+		Model:         pending.InitialData.Model,
+		FallbackIndex: pending.FallbackIndex,
+		Status:        "completed",
+		CreatedAt:     pending.Timestamp,
+		// Set parsed fields for serialization via GORM hooks
+		InputHistoryParsed:          pending.InitialData.InputHistory,
+		ResponsesInputHistoryParsed: pending.InitialData.ResponsesInputHistory,
+		ParamsParsed:                pending.InitialData.Params,
+		ToolsParsed:                 pending.InitialData.Tools,
+		SpeechInputParsed:           pending.InitialData.SpeechInput,
+		TranscriptionInputParsed:    pending.InitialData.TranscriptionInput,
+		ImageGenerationInputParsed:  pending.InitialData.ImageGenerationInput,
+	}
+	if pending.ParentRequestID != "" {
+		entry.ParentRequestID = &pending.ParentRequestID
+	}
+	if pending.RoutingEngineUsed != "" {
+		entry.RoutingEngineUsed = &pending.RoutingEngineUsed
+	}
+	return entry
+}
+
+// applyOutputFieldsToEntry sets common output fields on a log entry.
+func applyOutputFieldsToEntry(
+	entry *logstore.Log,
+	selectedKeyID, selectedKeyName string,
+	virtualKeyID, virtualKeyName string,
+	routingRuleID, routingRuleName string,
+	numberOfRetries int,
+	latency int64,
+) {
+	entry.SelectedKeyID = selectedKeyID
+	entry.SelectedKeyName = selectedKeyName
+	if virtualKeyID != "" {
+		entry.VirtualKeyID = &virtualKeyID
+	}
+	if virtualKeyName != "" {
+		entry.VirtualKeyName = &virtualKeyName
+	}
+	if routingRuleID != "" {
+		entry.RoutingRuleID = &routingRuleID
+	}
+	if routingRuleName != "" {
+		entry.RoutingRuleName = &routingRuleName
+	}
+	if numberOfRetries != 0 {
+		entry.NumberOfRetries = numberOfRetries
+	}
+	if latency != 0 {
+		latF := float64(latency)
+		entry.Latency = &latF
+	}
+}

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -124,6 +124,7 @@ type LoggerPlugin struct {
 	cleanupTicker         *time.Ticker // Ticker for cleaning up old processing logs
 	logMsgPool            sync.Pool    // Pool for reusing LogMessage structs
 	updateDataPool        sync.Pool    // Pool for reusing UpdateLogData structs
+	dbWriteSem            chan struct{} // Semaphore to limit concurrent DB write goroutines
 }
 
 // Init creates new logger plugin with given log store
@@ -149,6 +150,7 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, logsStore 
 		disableContentLogging: config.DisableContentLogging,
 		done:                  make(chan struct{}),
 		logger:                logger,
+		dbWriteSem:            make(chan struct{}, 64), // Cap concurrent DB write goroutines to prevent SQLite contention explosion
 		logMsgPool: sync.Pool{
 			New: func() interface{} {
 				return &LogMessage{}
@@ -329,6 +331,16 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	logMsg.RoutingEngineUsed = routingEngineUsed
 
 	go func(msg *LogMessage) {
+		// Acquire DB write semaphore to prevent goroutine explosion under high load
+		select {
+		case p.dbWriteSem <- struct{}{}:
+			// acquired
+		default:
+			// Semaphore full - drop this log write to prevent goroutine pile-up
+			p.putLogMessage(msg)
+			return
+		}
+		defer func() { <-p.dbWriteSem }()
 		defer p.putLogMessage(msg) // Return to pool when done
 		if err := p.insertInitialLogEntry(
 			p.ctx,
@@ -423,7 +435,27 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 	}
 
+	// For non-final streaming chunks, process the accumulator synchronously
+	// and skip the goroutine entirely. The accumulator work (ProcessStreamingChunk)
+	// is fast (mutex + append). Only final chunks, errors, and non-streaming
+	// responses need a goroutine for DB writes.
+	if bifrost.IsStreamRequestType(requestType) && !isFinalChunk && result != nil && bifrostErr == nil {
+		if tracer != nil && traceID != "" {
+			tracer.ProcessStreamingChunk(traceID, false, result, bifrostErr)
+		}
+		return result, bifrostErr, nil
+	}
+
 	go func() {
+		// Acquire DB write semaphore to prevent goroutine explosion under high load
+		select {
+		case p.dbWriteSem <- struct{}{}:
+			// acquired
+		default:
+			// Semaphore full - drop this log write to prevent goroutine pile-up
+			return
+		}
+		defer func() { <-p.dbWriteSem }()
 		// Queue the log update message (non-blocking) - use same pattern for both streaming and regular
 		logMsg := p.getLogMessage()
 		logMsg.RequestID = requestID
@@ -496,7 +528,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			return
 		}
 		if bifrost.IsStreamRequestType(requestType) {
-			p.logger.Debug("[logging] processing streaming response")
 
 			// Process streaming response via tracer's central accumulator
 			var streamResponse *streaming.ProcessedStreamResponse
@@ -505,12 +536,10 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				if accResult != nil {
 					streamResponse = convertToProcessedStreamResponse(accResult, requestType)
 				}
-			} else {
-				p.logger.Debug("tracer or traceID not available in streaming path for request %s, skipping stream processing", logMsg.RequestID)
 			}
 
 			if streamResponse == nil {
-				p.logger.Debug("failed to process streaming response: tracer or traceID not available")
+				// tracer or traceID not available, or accumulator returned nil
 			} else if isFinalChunk {
 				// Prepare final log data
 				logMsg.Operation = LogOperationStreamUpdate
@@ -547,7 +576,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				}
 				// Note: Stream accumulator cleanup is handled by the tracer
 				if tracer != nil && traceID != "" {
-					p.logger.Debug("cleaning up stream accumulator for trace ID: %s in logging plugin posthook", traceID)
 					tracer.CleanupStreamAccumulator(traceID)
 				}
 			}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -371,13 +371,196 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	return nil
 }
 
-// getLogEntry retrieves a log entry by ID using GORM
-func (p *LoggerPlugin) getLogEntry(ctx context.Context, requestID string) (*logstore.Log, error) {
-	entry, err := p.store.FindFirst(ctx, map[string]interface{}{"id": requestID})
-	if err != nil {
-		return nil, err
+// makePostWriteCallback creates a callback function for use after the batch writer commits.
+// It receives the already-inserted entry directly (no DB re-read needed).
+func (p *LoggerPlugin) makePostWriteCallback(enrichFn func(*logstore.Log)) func(entry *logstore.Log) {
+	return func(entry *logstore.Log) {
+		p.mu.Lock()
+		callback := p.logCallback
+		p.mu.Unlock()
+		if callback == nil {
+			return
+		}
+		if entry == nil {
+			return
+		}
+		if enrichFn != nil {
+			enrichFn(entry)
+		}
+		callback(p.ctx, entry)
 	}
-	return entry, nil
+}
+
+// applyStreamingOutputToEntry applies accumulated streaming data to a log entry.
+func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamResponse *streaming.ProcessedStreamResponse) {
+	// Handle error case first
+	if streamResponse.Data.ErrorDetails != nil {
+		entry.Status = "error"
+		entry.ErrorDetailsParsed = streamResponse.Data.ErrorDetails
+		latF := float64(streamResponse.Data.Latency)
+		entry.Latency = &latF
+		return
+	}
+
+	entry.Status = "success"
+	latF := float64(streamResponse.Data.Latency)
+	entry.Latency = &latF
+
+	// Update model if provided
+	if streamResponse.Data.Model != "" {
+		entry.Model = streamResponse.Data.Model
+	}
+
+	// Token usage
+	if streamResponse.Data.TokenUsage != nil {
+		entry.TokenUsageParsed = streamResponse.Data.TokenUsage
+		entry.PromptTokens = streamResponse.Data.TokenUsage.PromptTokens
+		entry.CompletionTokens = streamResponse.Data.TokenUsage.CompletionTokens
+		entry.TotalTokens = streamResponse.Data.TokenUsage.TotalTokens
+	}
+
+	// Cost
+	if streamResponse.Data.Cost != nil {
+		entry.Cost = streamResponse.Data.Cost
+	}
+
+	if p.disableContentLogging == nil || !*p.disableContentLogging {
+		// Transcription output
+		if streamResponse.Data.TranscriptionOutput != nil {
+			entry.TranscriptionOutputParsed = streamResponse.Data.TranscriptionOutput
+		}
+		// Speech output
+		if streamResponse.Data.AudioOutput != nil {
+			entry.SpeechOutputParsed = streamResponse.Data.AudioOutput
+		}
+		// Image generation output
+		if streamResponse.Data.ImageGenerationOutput != nil {
+			entry.ImageGenerationOutputParsed = streamResponse.Data.ImageGenerationOutput
+		}
+		// Cache debug
+		if streamResponse.Data.CacheDebug != nil {
+			entry.CacheDebugParsed = streamResponse.Data.CacheDebug
+		}
+		// Output message
+		if streamResponse.Data.OutputMessage != nil {
+			entry.OutputMessageParsed = streamResponse.Data.OutputMessage
+		}
+		// Responses output
+		if streamResponse.Data.OutputMessages != nil {
+			entry.ResponsesOutputParsed = streamResponse.Data.OutputMessages
+		}
+		// Raw request
+		if streamResponse.RawRequest != nil && *streamResponse.RawRequest != nil {
+			rawRequestBytes, err := sonic.Marshal(*streamResponse.RawRequest)
+			if err == nil {
+				entry.RawRequest = string(rawRequestBytes)
+			}
+		}
+		// Raw response
+		if streamResponse.Data.RawResponse != nil {
+			entry.RawResponse = *streamResponse.Data.RawResponse
+		}
+	}
+}
+
+// applyNonStreamingOutputToEntry applies non-streaming response data to a log entry.
+func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse) {
+	// Token usage
+	var usage *schemas.BifrostLLMUsage
+	switch {
+	case result.TextCompletionResponse != nil && result.TextCompletionResponse.Usage != nil:
+		usage = result.TextCompletionResponse.Usage
+	case result.ChatResponse != nil && result.ChatResponse.Usage != nil:
+		usage = result.ChatResponse.Usage
+	case result.ResponsesResponse != nil && result.ResponsesResponse.Usage != nil:
+		usage = result.ResponsesResponse.Usage.ToBifrostLLMUsage()
+	case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
+		usage = result.EmbeddingResponse.Usage
+	case result.TranscriptionResponse != nil && result.TranscriptionResponse.Usage != nil:
+		usage = &schemas.BifrostLLMUsage{}
+		if result.TranscriptionResponse.Usage.InputTokens != nil {
+			usage.PromptTokens = *result.TranscriptionResponse.Usage.InputTokens
+		}
+		if result.TranscriptionResponse.Usage.OutputTokens != nil {
+			usage.CompletionTokens = *result.TranscriptionResponse.Usage.OutputTokens
+		}
+		if result.TranscriptionResponse.Usage.TotalTokens != nil {
+			usage.TotalTokens = *result.TranscriptionResponse.Usage.TotalTokens
+		} else {
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		}
+	case result.ImageGenerationResponse != nil && result.ImageGenerationResponse.Usage != nil:
+		usage = &schemas.BifrostLLMUsage{}
+		usage.PromptTokens = result.ImageGenerationResponse.Usage.InputTokens
+		usage.CompletionTokens = result.ImageGenerationResponse.Usage.OutputTokens
+		if result.ImageGenerationResponse.Usage.TotalTokens > 0 {
+			usage.TotalTokens = result.ImageGenerationResponse.Usage.TotalTokens
+		} else {
+			usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+		}
+	}
+	if usage != nil {
+		entry.TokenUsageParsed = usage
+		entry.PromptTokens = usage.PromptTokens
+		entry.CompletionTokens = usage.CompletionTokens
+		entry.TotalTokens = usage.TotalTokens
+	}
+
+	// Extract raw request/response and output content
+	extraFields := result.GetExtraFields()
+	if p.disableContentLogging == nil || !*p.disableContentLogging {
+		if extraFields.RawRequest != nil {
+			rawRequestBytes, err := sonic.Marshal(extraFields.RawRequest)
+			if err == nil {
+				entry.RawRequest = string(rawRequestBytes)
+			}
+		}
+		if extraFields.RawResponse != nil {
+			rawRespBytes, err := sonic.Marshal(extraFields.RawResponse)
+			if err == nil {
+				entry.RawResponse = string(rawRespBytes)
+			}
+		}
+		if result.ListModelsResponse != nil && result.ListModelsResponse.Data != nil {
+			entry.ListModelsOutputParsed = result.ListModelsResponse.Data
+		}
+		if result.TextCompletionResponse != nil {
+			if len(result.TextCompletionResponse.Choices) > 0 {
+				choice := result.TextCompletionResponse.Choices[0]
+				if choice.TextCompletionResponseChoice != nil {
+					entry.OutputMessageParsed = &schemas.ChatMessage{
+						Role: schemas.ChatMessageRoleAssistant,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: choice.TextCompletionResponseChoice.Text,
+						},
+					}
+				}
+			}
+		}
+		if result.ChatResponse != nil {
+			if len(result.ChatResponse.Choices) > 0 {
+				choice := result.ChatResponse.Choices[0]
+				if choice.ChatNonStreamResponseChoice != nil {
+					entry.OutputMessageParsed = choice.ChatNonStreamResponseChoice.Message
+				}
+			}
+		}
+		if result.ResponsesResponse != nil {
+			entry.ResponsesOutputParsed = result.ResponsesResponse.Output
+		}
+		if result.EmbeddingResponse != nil && len(result.EmbeddingResponse.Data) > 0 {
+			entry.EmbeddingOutputParsed = result.EmbeddingResponse.Data
+		}
+		if result.SpeechResponse != nil {
+			entry.SpeechOutputParsed = result.SpeechResponse
+		}
+		if result.TranscriptionResponse != nil {
+			entry.TranscriptionOutputParsed = result.TranscriptionResponse
+		}
+		if result.ImageGenerationResponse != nil {
+			entry.ImageGenerationOutputParsed = result.ImageGenerationResponse
+		}
+	}
 }
 
 // SearchLogs searches logs with filters and pagination using GORM
@@ -421,9 +604,10 @@ func (p *LoggerPlugin) GetModelHistogram(ctx context.Context, filters logstore.S
 	return p.store.GetModelHistogram(ctx, filters, bucketSizeSeconds)
 }
 
-// GetAvailableModels returns all unique models from logs
+// GetAvailableModels returns all unique models from logs.
+// Uses DISTINCT to avoid loading all rows (28K+) when only unique values are needed.
 func (p *LoggerPlugin) GetAvailableModels(ctx context.Context) []string {
-	result, err := p.store.FindAll(ctx, "model IS NOT NULL AND model != ''", "model")
+	result, err := p.store.FindAllDistinct(ctx, "model IS NOT NULL AND model != ''", "model")
 	if err != nil {
 		p.logger.Error("failed to get available models: %w", err)
 		return []string{}
@@ -432,7 +616,7 @@ func (p *LoggerPlugin) GetAvailableModels(ctx context.Context) []string {
 }
 
 func (p *LoggerPlugin) GetAvailableSelectedKeys(ctx context.Context) []KeyPair {
-	result, err := p.store.FindAll(ctx, "selected_key_id IS NOT NULL AND selected_key_id != '' AND selected_key_name IS NOT NULL AND selected_key_name != ''", "selected_key_id, selected_key_name")
+	result, err := p.store.FindAllDistinct(ctx, "selected_key_id IS NOT NULL AND selected_key_id != '' AND selected_key_name IS NOT NULL AND selected_key_name != ''", "selected_key_id, selected_key_name")
 	if err != nil {
 		p.logger.Error("failed to get available selected keys: %w", err)
 		return []KeyPair{}
@@ -446,7 +630,7 @@ func (p *LoggerPlugin) GetAvailableSelectedKeys(ctx context.Context) []KeyPair {
 }
 
 func (p *LoggerPlugin) GetAvailableVirtualKeys(ctx context.Context) []KeyPair {
-	result, err := p.store.FindAll(ctx, "virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != ''", "virtual_key_id, virtual_key_name")
+	result, err := p.store.FindAllDistinct(ctx, "virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != ''", "virtual_key_id, virtual_key_name")
 	if err != nil {
 		p.logger.Error("failed to get available virtual keys: %w", err)
 		return []KeyPair{}
@@ -463,7 +647,7 @@ func (p *LoggerPlugin) GetAvailableVirtualKeys(ctx context.Context) []KeyPair {
 }
 
 func (p *LoggerPlugin) GetAvailableRoutingRules(ctx context.Context) []KeyPair {
-	result, err := p.store.FindAll(ctx, "routing_rule_id IS NOT NULL AND routing_rule_id != '' AND routing_rule_name IS NOT NULL AND routing_rule_name != ''", "routing_rule_id, routing_rule_name")
+	result, err := p.store.FindAllDistinct(ctx, "routing_rule_id IS NOT NULL AND routing_rule_id != '' AND routing_rule_name IS NOT NULL AND routing_rule_name != ''", "routing_rule_id, routing_rule_name")
 	if err != nil {
 		p.logger.Error("failed to get available routing rules: %w", err)
 		return []KeyPair{}
@@ -479,9 +663,10 @@ func (p *LoggerPlugin) GetAvailableRoutingRules(ctx context.Context) []KeyPair {
 	})
 }
 
-// GetAvailableRoutingEngines returns all unique routing engine types used in logs
+// GetAvailableRoutingEngines returns all unique routing engine types used in logs.
+// Uses DISTINCT to avoid loading all rows when only unique values are needed.
 func (p *LoggerPlugin) GetAvailableRoutingEngines(ctx context.Context) []string {
-	result, err := p.store.FindAll(ctx, "routing_engine_used IS NOT NULL AND routing_engine_used != ''", "routing_engine_used")
+	result, err := p.store.FindAllDistinct(ctx, "routing_engine_used IS NOT NULL AND routing_engine_used != ''", "routing_engine_used")
 	if err != nil {
 		p.logger.Error("failed to get available routing engines: %w", err)
 		return []string{}

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -419,25 +419,22 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	streamEndIndicatorValue := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator)
 	isFinalChunk, hasFinalChunkIndicator := streamEndIndicatorValue.(bool)
 
-	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
-	go func() {
-		// For streaming requests, handle per-token metrics for intermediate chunks
-		if bifrost.IsStreamRequestType(requestType) {
-			// For intermediate chunks, record per-token metrics and exit.
-			// The final chunk will fall through to record full request metrics.
-			if !hasFinalChunkIndicator || !isFinalChunk {
-				// Record metrics for the first token
-				if result != nil {
-					extraFields := result.GetExtraFields()
-					if extraFields.ChunkIndex == 0 {
-						p.StreamFirstTokenLatencySeconds.WithLabelValues(promLabelValues...).Observe(float64(extraFields.Latency) / 1000.0)
-					} else {
-						p.StreamInterTokenLatencySeconds.WithLabelValues(promLabelValues...).Observe(float64(extraFields.Latency) / 1000.0)
-					}
-				}
-				return // Exit goroutine for intermediate chunks
+	// For non-final streaming chunks, record per-token metrics synchronously and return.
+	// This avoids spawning a goroutine for each intermediate chunk.
+	if bifrost.IsStreamRequestType(requestType) && (!hasFinalChunkIndicator || !isFinalChunk) {
+		if result != nil {
+			extraFields := result.GetExtraFields()
+			if extraFields.ChunkIndex == 0 {
+				p.StreamFirstTokenLatencySeconds.WithLabelValues(promLabelValues...).Observe(float64(extraFields.Latency) / 1000.0)
+			} else {
+				p.StreamInterTokenLatencySeconds.WithLabelValues(promLabelValues...).Observe(float64(extraFields.Latency) / 1000.0)
 			}
 		}
+		return result, bifrostErr, nil
+	}
+
+	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
+	go func() {
 
 		cost := 0.0
 		if p.pricingManager != nil && result != nil {

--- a/transports/bifrost-http/handlers/devpprof.go
+++ b/transports/bifrost-http/handlers/devpprof.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"regexp"
 	"runtime"
@@ -24,8 +25,8 @@ const (
 	metricsCollectionInterval = 10 * time.Second
 	// Number of data points to keep (5 minutes / 10 seconds = 30 points)
 	historySize = 30
-	// Top allocations to return
-	topAllocationsCount = 5
+	// Top allocations to return (increased for better coverage with lower MemProfileRate)
+	topAllocationsCount = 20
 )
 
 // MemoryStats represents memory statistics at a point in time
@@ -35,6 +36,17 @@ type MemoryStats struct {
 	HeapInuse   uint64 `json:"heap_inuse"`
 	HeapObjects uint64 `json:"heap_objects"`
 	Sys         uint64 `json:"sys"`
+	// Detailed breakdown for memory diagnostics
+	HeapIdle     uint64 `json:"heap_idle"`     // Heap spans with no objects (available for reuse)
+	HeapReleased uint64 `json:"heap_released"` // Heap memory returned to OS
+	HeapSys      uint64 `json:"heap_sys"`      // Heap memory obtained from OS
+	StackInuse   uint64 `json:"stack_inuse"`   // Goroutine stack memory
+	StackSys     uint64 `json:"stack_sys"`     // Stack memory obtained from OS
+	MSpanInuse   uint64 `json:"mspan_inuse"`   // MSpan structure memory
+	MCacheInuse  uint64 `json:"mcache_inuse"`  // MCache structure memory
+	BuckHashSys  uint64 `json:"buck_hash_sys"` // Profiling bucket hash table
+	GCSys        uint64 `json:"gc_sys"`        // GC metadata memory
+	OtherSys     uint64 `json:"other_sys"`     // Other runtime allocations
 }
 
 // CPUStats represents CPU statistics
@@ -53,13 +65,21 @@ type RuntimeStats struct {
 	GOMAXPROCS   int    `json:"gomaxprocs"`
 }
 
-// AllocationInfo represents a single allocation site
-type AllocationInfo struct {
+// StackFrame represents a single frame in a call stack
+type StackFrame struct {
 	Function string `json:"function"`
 	File     string `json:"file"`
 	Line     int    `json:"line"`
-	Bytes    int64  `json:"bytes"`
-	Count    int64  `json:"count"`
+}
+
+// AllocationInfo represents a single allocation site with full call stack
+type AllocationInfo struct {
+	Function string       `json:"function"`
+	File     string       `json:"file"`
+	Line     int          `json:"line"`
+	Bytes    int64        `json:"bytes"`
+	Count    int64        `json:"count"`
+	Stack    []StackFrame `json:"stack"`
 }
 
 // GoroutineGroup represents a group of goroutines with the same stack trace
@@ -152,8 +172,12 @@ func getOrCreateCollector() *MetricsCollector {
 	return globalCollector
 }
 
-// NewDevPprofHandler creates a new dev pprof handler
+// NewDevPprofHandler creates a new dev pprof handler.
+// Sets a lower MemProfileRate for better heap profiling coverage
+// (1 sample per 64KB instead of default 1 per 512KB — 8x more coverage
+// without the huge overhead of 4KB sampling which caused 4GB+ peak memory).
 func NewDevPprofHandler() *DevPprofHandler {
+	runtime.MemProfileRate = 65536
 	return &DevPprofHandler{
 		collector: getOrCreateCollector(),
 	}
@@ -300,50 +324,91 @@ func getTopAllocations() []AllocationInfo {
 		return []AllocationInfo{}
 	}
 
-	// Find the indices for alloc_objects and alloc_space sample types
-	var allocObjectsIdx, allocSpaceIdx int
+	// Find the indices for inuse_objects and inuse_space sample types.
+	// Using inuse (current live) instead of alloc (cumulative) to show
+	// what is actually consuming memory right now.
+	var inuseObjectsIdx, inuseSpaceIdx int
 	for i, st := range p.SampleType {
 		switch st.Type {
-		case "alloc_objects":
-			allocObjectsIdx = i
-		case "alloc_space":
-			allocSpaceIdx = i
+		case "inuse_objects":
+			inuseObjectsIdx = i
+		case "inuse_space":
+			inuseSpaceIdx = i
 		}
 	}
 
-	// Aggregate allocations by function (top of stack = allocation site)
+	// Build allocation entries with full stack traces.
+	// Each unique stack trace is a separate entry so callers are visible.
 	allocMap := make(map[string]*AllocationInfo)
 
 	for _, sample := range p.Sample {
 		if len(sample.Location) == 0 {
 			continue
 		}
-		loc := sample.Location[0] // Top of stack = allocation site
-		if len(loc.Line) == 0 {
-			continue
-		}
-		line := loc.Line[0]
-		fn := line.Function
-		if fn == nil {
+
+		inuseBytes := sample.Value[inuseSpaceIdx]
+		inuseObjects := sample.Value[inuseObjectsIdx]
+		if inuseBytes == 0 && inuseObjects == 0 {
 			continue
 		}
 
-		// Skip allocations from the profiler itself
-		if isProfilerFunction(fn.Name, fn.Filename) {
+		// Build the full stack trace (innermost first)
+		var stack []StackFrame
+		var topFn StackFrame
+		hasTop := false
+		isProfiler := false
+		for _, loc := range sample.Location {
+			for _, line := range loc.Line {
+				fn := line.Function
+				if fn == nil {
+					continue
+				}
+				if isProfilerFunction(fn.Name, fn.Filename) {
+					isProfiler = true
+					break
+				}
+				frame := StackFrame{
+					Function: fn.Name,
+					File:     fn.Filename,
+					Line:     int(line.Line),
+				}
+				stack = append(stack, frame)
+				if !hasTop {
+					topFn = frame
+					hasTop = true
+				}
+			}
+			if isProfiler {
+				break
+			}
+		}
+		if isProfiler || !hasTop || len(stack) == 0 {
 			continue
 		}
 
-		key := fn.Name
+		// Build a key from the full stack to group identical call paths
+		var keyBuilder strings.Builder
+		for _, frame := range stack {
+			keyBuilder.WriteString(frame.File)
+			keyBuilder.WriteByte(':')
+			keyBuilder.WriteString(frame.Function)
+			keyBuilder.WriteByte(':')
+			keyBuilder.WriteString(fmt.Sprintf("%d", frame.Line))
+			keyBuilder.WriteByte(';')
+		}
+		key := keyBuilder.String()
+
 		if existing, ok := allocMap[key]; ok {
-			existing.Bytes += sample.Value[allocSpaceIdx]
-			existing.Count += sample.Value[allocObjectsIdx]
+			existing.Bytes += inuseBytes
+			existing.Count += inuseObjects
 		} else {
 			allocMap[key] = &AllocationInfo{
-				Function: fn.Name,
-				File:     fn.Filename,
-				Line:     int(line.Line),
-				Bytes:    sample.Value[allocSpaceIdx],
-				Count:    sample.Value[allocObjectsIdx],
+				Function: topFn.Function,
+				File:     topFn.File,
+				Line:     topFn.Line,
+				Bytes:    inuseBytes,
+				Count:    inuseObjects,
+				Stack:    stack,
 			}
 		}
 	}
@@ -384,11 +449,21 @@ func (h *DevPprofHandler) getPprof(ctx *fasthttp.RequestCtx) {
 	data := PprofData{
 		Timestamp: time.Now().Format(time.RFC3339),
 		Memory: MemoryStats{
-			Alloc:       memStats.Alloc,
-			TotalAlloc:  memStats.TotalAlloc,
-			HeapInuse:   memStats.HeapInuse,
-			HeapObjects: memStats.HeapObjects,
-			Sys:         memStats.Sys,
+			Alloc:        memStats.Alloc,
+			TotalAlloc:   memStats.TotalAlloc,
+			HeapInuse:    memStats.HeapInuse,
+			HeapObjects:  memStats.HeapObjects,
+			Sys:          memStats.Sys,
+			HeapIdle:     memStats.HeapIdle,
+			HeapReleased: memStats.HeapReleased,
+			HeapSys:      memStats.HeapSys,
+			StackInuse:   memStats.StackInuse,
+			StackSys:     memStats.StackSys,
+			MSpanInuse:   memStats.MSpanInuse,
+			MCacheInuse:  memStats.MCacheInuse,
+			BuckHashSys:  memStats.BuckHashSys,
+			GCSys:        memStats.GCSys,
+			OtherSys:     memStats.OtherSys,
 		},
 		CPU: h.collector.getCPUStats(),
 		Runtime: RuntimeStats{

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -787,6 +787,8 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 	forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
 	// Send successful response
 	SendJSON(ctx, resp)
+	// Release response back to pool for reuse
+	resp.Release()
 }
 
 // chatCompletion handles POST /v1/chat/completions - Process chat completion requests
@@ -879,6 +881,8 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 	forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
 	// Send successful response
 	SendJSON(ctx, resp)
+	// Release response back to pool for reuse
+	resp.Release()
 }
 
 // responses handles POST /v1/responses - Process responses requests
@@ -962,6 +966,8 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 	forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
 	// Send successful response
 	SendJSON(ctx, resp)
+	// Release response back to pool for reuse
+	resp.Release()
 }
 
 // embeddings handles POST /v1/embeddings - Process embeddings requests
@@ -1029,6 +1035,8 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 	forwardProviderHeaders(ctx, resp.ExtraFields.ProviderResponseHeaders)
 	// Send successful response
 	SendJSON(ctx, resp)
+	// Release response back to pool for reuse
+	resp.Release()
 }
 
 // speech handles POST /v1/audio/speech - Process speech completion requests

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1490,6 +1490,11 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 
 			// Convert response to JSON
 			chunkJSON, err := sonic.Marshal(chunk)
+
+			// Release the pooled stream chunk (and its inner BifrostChatResponse) back to the pool.
+			// The data has been serialized to chunkJSON; the original struct is no longer needed.
+			schemas.ReleaseBifrostStreamChunk(chunk)
+
 			if err != nil {
 				logger.Warn("Failed to marshal streaming response: %v", err)
 				continue

--- a/ui/app/pprof/page.tsx
+++ b/ui/app/pprof/page.tsx
@@ -16,7 +16,7 @@ import {
 	RotateCcw,
 	TrendingUp,
 } from "lucide-react";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 
 // ============================================================================
@@ -133,7 +133,7 @@ function StatCard({
 	);
 }
 
-// Allocation Table Component
+// Allocation Table Component with expandable stack traces
 function AllocationTable({
 	allocations,
 	sortField,
@@ -145,7 +145,20 @@ function AllocationTable({
 	sortDirection: SortDirection;
 	onSort: (field: AllocationSortField) => void;
 }) {
-	const SortIcon = sortDirection === "asc" ? ArrowUp : ArrowDown;
+	const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+	const SortIcon = sortDirection === "asc" ? ArrowUp : ArrowDown
+
+	const toggleRow = useCallback((index: number) => {
+		setExpandedRows(prev => {
+			const next = new Set(prev)
+			if (next.has(index)) {
+				next.delete(index)
+			} else {
+				next.add(index)
+			}
+			return next
+		})
+	}, [])
 
 	const SortHeader = ({ field, children }: { field: AllocationSortField; children: React.ReactNode }) => (
 		<th scope="col" className="px-4 py-3 text-left text-sm font-medium text-zinc-400">
@@ -154,13 +167,21 @@ function AllocationTable({
 				{sortField === field && <SortIcon className="h-3 w-3" />}
 			</button>
 		</th>
-	);
+	)
+
+	const shortFileName = (fullPath: string) => {
+		const parts = fullPath.split('/')
+		const idx = parts.findIndex(p => p === 'bifrost')
+		if (idx >= 0) return parts.slice(idx).join('/')
+		return parts.slice(-3).join('/')
+	}
 
 	return (
 		<div className="overflow-x-auto">
 			<table className="w-full">
 				<thead>
 					<tr className="border-b border-zinc-800">
+						<th className="w-8 px-2 py-3" />
 						<SortHeader field="function">Function</SortHeader>
 						<SortHeader field="file">File:Line</SortHeader>
 						<SortHeader field="bytes">Bytes</SortHeader>
@@ -168,35 +189,81 @@ function AllocationTable({
 					</tr>
 				</thead>
 				<tbody>
-					{allocations.map((alloc, i) => (
-						<tr key={`${alloc.function}-${alloc.line}-${i}`} className="border-b border-zinc-800/50 hover:bg-zinc-800/30">
-							<td className="px-4 py-3">
-								<code className="text-sm break-all text-zinc-200">{alloc.function}</code>
-							</td>
-							<td className="px-4 py-3">
-								<code className="text-sm text-zinc-400">
-									{alloc.file}:{alloc.line}
-								</code>
-							</td>
-							<td className="px-4 py-3">
-								<span className="font-mono text-sm text-rose-400">{formatBytes(alloc.bytes)}</span>
-							</td>
-							<td className="px-4 py-3">
-								<span className="font-mono text-sm text-zinc-300">{alloc.count.toLocaleString()}</span>
-							</td>
-						</tr>
-					))}
+					{allocations.map((alloc, i) => {
+						const isExpanded = expandedRows.has(i)
+						const hasStack = alloc.stack && alloc.stack.length > 1
+						return (
+							<Fragment key={`${alloc.function}-${alloc.line}-${i}`}>
+								<tr
+									className={`border-b border-zinc-800/50 hover:bg-zinc-800/30 ${hasStack ? 'cursor-pointer' : ''}`}
+									onClick={() => hasStack && toggleRow(i)}
+									role={hasStack ? "button" : undefined}
+									tabIndex={hasStack ? 0 : undefined}
+									aria-expanded={hasStack ? isExpanded : undefined}
+									onKeyDown={(e) => {
+										if (!hasStack) return
+										if (e.key === "Enter" || e.key === " ") {
+											e.preventDefault()
+											toggleRow(i)
+										}
+									}}
+								>
+									<td className="px-2 py-3 text-center">
+										{hasStack && (
+											isExpanded
+												? <ChevronDown className="inline h-4 w-4 text-zinc-500" />
+												: <ChevronRight className="inline h-4 w-4 text-zinc-500" />
+										)}
+									</td>
+									<td className="px-4 py-3">
+										<code className="text-sm break-all text-zinc-200">{alloc.function}</code>
+									</td>
+									<td className="px-4 py-3">
+										<code className="text-sm text-zinc-400">
+											{alloc.file}:{alloc.line}
+										</code>
+									</td>
+									<td className="px-4 py-3">
+										<span className="font-mono text-sm text-rose-400">{formatBytes(alloc.bytes)}</span>
+									</td>
+									<td className="px-4 py-3">
+										<span className="font-mono text-sm text-zinc-300">{alloc.count.toLocaleString()}</span>
+									</td>
+								</tr>
+								{isExpanded && hasStack && (
+									<tr className="border-b border-zinc-800/50 bg-zinc-900/50">
+										<td colSpan={5} className="px-6 py-3">
+											<div className="rounded border border-zinc-800 bg-zinc-950/50 p-3">
+												<div className="mb-2 text-xs font-medium text-zinc-500">Call Stack (innermost first)</div>
+												<div className="space-y-0.5">
+													{alloc.stack.map((frame, fi) => (
+														<div key={fi} className="flex items-start gap-2 font-mono text-xs">
+															<span className="mt-0.5 shrink-0 text-zinc-600">{fi === 0 ? '→' : ' '}</span>
+															<span className="text-zinc-300">{frame.function}</span>
+															<span className="shrink-0 text-zinc-600">
+																{shortFileName(frame.file)}:{frame.line}
+															</span>
+														</div>
+													))}
+												</div>
+											</div>
+										</td>
+									</tr>
+								)}
+							</Fragment>
+						)
+					})}
 					{allocations.length === 0 && (
 						<tr>
-							<td colSpan={4} className="px-4 py-8 text-center text-zinc-500">
-								No allocations data available
+							<td colSpan={5} className="px-4 py-8 text-center text-zinc-500">
+								No in-use memory data available
 							</td>
 						</tr>
 					)}
 				</tbody>
 			</table>
 		</div>
-	);
+	)
 }
 
 // Goroutine Group Component
@@ -483,6 +550,59 @@ export default function PprofPage() {
 						/>
 					</div>
 
+					{/* Memory Breakdown */}
+					<div className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+						<div className="mb-4 flex items-center gap-2">
+							<HardDrive className="h-4 w-4 text-purple-400" />
+							<span className="font-medium text-zinc-300">Memory Breakdown</span>
+							<span className="text-sm text-zinc-500">where {formatBytes(data.memory.sys)} system memory is used</span>
+						</div>
+						{(() => {
+							const m = data.memory
+							const goRuntime = m.mspan_inuse + m.mcache_inuse + m.buck_hash_sys + m.gc_sys + m.other_sys
+							const heapFrag = m.heap_idle - m.heap_released
+							const cgoEstimate = m.sys > (m.heap_sys + m.stack_sys + goRuntime)
+								? m.sys - m.heap_sys - m.stack_sys - goRuntime
+								: 0
+							const segments = [
+								{ label: 'Heap (live objects)', value: m.alloc, color: 'bg-cyan-500' },
+								{ label: 'Heap (idle, reclaimable)', value: heapFrag, color: 'bg-cyan-800' },
+								{ label: 'Heap (returned to OS)', value: m.heap_released, color: 'bg-zinc-700' },
+								{ label: 'Goroutine stacks', value: m.stack_inuse, color: 'bg-emerald-500' },
+								{ label: 'GC metadata', value: m.gc_sys, color: 'bg-amber-500' },
+								{ label: 'Runtime (mspan+mcache+other)', value: m.mspan_inuse + m.mcache_inuse + m.other_sys, color: 'bg-orange-500' },
+								{ label: 'Profiling overhead', value: m.buck_hash_sys, color: 'bg-rose-500' },
+								{ label: 'CGo / external (estimated)', value: cgoEstimate, color: 'bg-red-600' },
+							].filter(s => s.value > 0)
+							const total = segments.reduce((sum, s) => sum + s.value, 0)
+							return (
+								<div>
+									{/* Stacked bar */}
+									<div className="mb-4 flex h-6 overflow-hidden rounded-full">
+										{segments.map((seg, i) => (
+											<div
+												key={i}
+												className={`${seg.color} transition-all`}
+												style={{ width: `${(seg.value / total) * 100}%` }}
+												title={`${seg.label}: ${formatBytes(seg.value)}`}
+											/>
+										))}
+									</div>
+									{/* Legend */}
+									<div className="grid grid-cols-2 gap-x-6 gap-y-1.5 text-sm md:grid-cols-4">
+										{segments.map((seg, i) => (
+											<div key={i} className="flex items-center gap-2">
+												<span className={`h-2.5 w-2.5 shrink-0 rounded-sm ${seg.color}`} />
+												<span className="text-zinc-400">{seg.label}</span>
+												<span className="ml-auto font-mono text-zinc-200">{formatBytes(seg.value)}</span>
+											</div>
+										))}
+									</div>
+								</div>
+							)
+						})()}
+					</div>
+
 					{/* Charts */}
 					<div className="mb-8 grid gap-6 lg:grid-cols-2">
 						{/* CPU Chart */}
@@ -633,8 +753,8 @@ export default function PprofPage() {
 					<div className="mb-8 rounded-lg border border-zinc-800 bg-zinc-900">
 						<div className="flex items-center gap-2 border-b border-zinc-800 px-4 py-3">
 							<HardDrive className="h-4 w-4 text-rose-400" />
-							<span className="font-medium text-zinc-300">Memory Allocations</span>
-							<span className="text-sm text-zinc-500">({sortedAllocations.length} allocations)</span>
+							<span className="font-medium text-zinc-300">Memory In-Use</span>
+							<span className="text-sm text-zinc-500">({sortedAllocations.length} allocation sites)</span>
 						</div>
 						<AllocationTable
 							allocations={sortedAllocations}

--- a/ui/lib/store/apis/devApi.ts
+++ b/ui/lib/store/apis/devApi.ts
@@ -7,6 +7,17 @@ export interface MemoryStats {
   heap_inuse: number
   heap_objects: number
   sys: number
+  // Detailed breakdown
+  heap_idle: number
+  heap_released: number
+  heap_sys: number
+  stack_inuse: number
+  stack_sys: number
+  mspan_inuse: number
+  mcache_inuse: number
+  buck_hash_sys: number
+  gc_sys: number
+  other_sys: number
 }
 
 // CPU statistics
@@ -25,13 +36,21 @@ export interface RuntimeStats {
   gomaxprocs: number
 }
 
-// Allocation info for top allocations
+// Single frame in a call stack
+export interface StackFrame {
+  function: string
+  file: string
+  line: number
+}
+
+// Allocation info for top allocations with full call stack
 export interface AllocationInfo {
   function: string
   file: string
   line: number
   bytes: number
   count: number
+  stack: StackFrame[]
 }
 
 // Single point in the metrics history


### PR DESCRIPTION
## Summary

Implement object pooling for streaming response objects to reduce memory allocations and garbage collection pressure in high-throughput scenarios.

## Changes

- Added object pooling for scanner buffers used in SSE stream parsing across all providers
- Implemented pooling for `BifrostChatResponse`, `BifrostResponse`, and `BifrostStreamChunk` objects
- Added proper release mechanisms to return objects to their respective pools
- Optimized post-hook processing in plugins to avoid spawning goroutines for non-final streaming chunks
- Added semaphore to limit concurrent DB write goroutines in the logging plugin
- Reduced buffer sizes for scanner buffers where appropriate

## Type of change

- [x] Feature
- [x] Performance optimization

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins

## How to test

Run load tests with high concurrency to verify memory usage improvements:

```sh
# Core/Transports
go version
go test ./...

# Run load test with high concurrency
go run cmd/loadtest/main.go -concurrency=100 -duration=60s
```

## Breaking changes

- [x] No

## Related issues

Addresses performance issues with high-throughput streaming responses.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
- [x] I verified the CI pipeline passes locally