### PR TITLE
feat: add routing engine decision logs

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
+- feat: add routing engine decision logs to context

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -189,6 +189,7 @@ const (
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
+	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
 )
 
 // RoutingEngine constants
@@ -197,6 +198,14 @@ const (
 	RoutingEngineRoutingRule   = "routing-rule"
 	RoutingEngineLoadbalancing = "loadbalancing"
 )
+
+// RoutingEngineLogEntry represents a log entry from a routing engine
+// format: [timestamp] [engine] - message
+type RoutingEngineLogEntry struct {
+	Engine    string // e.g., "governance", "routing-rule", "openrouter"
+	Message   string // Human-readable decision/action message
+	Timestamp int64  // Unix milliseconds
+}
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,
 // make sure to mark BifrostContextKeyStreamEndIndicator as true at the end of the stream.

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -282,6 +282,35 @@ func (bc *BifrostContext) GetParentCtxWithUserValues() context.Context {
 	return parentCtx
 }
 
+// AppendRoutingEngineLog appends a routing engine log entry to the context.
+// Parameters:
+//   - ctx: The Bifrost context
+//   - engineName: Name of the routing engine (e.g., "governance", "routing-rule")
+//   - message: Human-readable log message describing the decision/action
+func (bc *BifrostContext) AppendRoutingEngineLog(engineName string, message string) {
+	entry := RoutingEngineLogEntry{
+		Engine:    engineName,
+		Message:   message,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	AppendToContextList(bc, BifrostContextKeyRoutingEngineLogs, entry)
+}
+
+// GetRoutingEngineLogs retrieves all routing engine logs from the context.
+// Parameters:
+//   - ctx: The Bifrost context
+//
+// Returns:
+//   - []RoutingEngineLogEntry: Slice of routing engine log entries (nil if none)
+func (bc *BifrostContext) GetRoutingEngineLogs() []RoutingEngineLogEntry {
+	if val := bc.Value(BifrostContextKeyRoutingEngineLogs); val != nil {
+		if logs, ok := val.([]RoutingEngineLogEntry); ok {
+			return logs
+		}
+	}
+	return nil
+}
+
 // AppendToContext appends a value to the context list value.
 // Parameters:
 //   - ctx: The Bifrost context

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,2 @@
 - feat: rename routing_engine_used column to routing_engines_used for multi-engine tracking (parsed as comma-separated string)
+- feat: add routing engine decision logs to logs table

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -116,8 +116,9 @@ type Log struct {
 	ErrorDetails          string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.BifrostError
 	Stream                bool      `gorm:"default:false" json:"stream"`                   // true if this was a streaming response
 	ContentSummary        string    `gorm:"type:text" json:"-"`
-	RawRequest            string    `gorm:"type:text" json:"raw_request"`  // Populated when `send-back-raw-request` is on
-	RawResponse           string    `gorm:"type:text" json:"raw_response"` // Populated when `send-back-raw-response` is on
+	RawRequest            string    `gorm:"type:text" json:"raw_request"`                   // Populated when `send-back-raw-request` is on
+	RawResponse           string    `gorm:"type:text" json:"raw_response"`                  // Populated when `send-back-raw-response` is on
+	RoutingEngineLogs     string    `gorm:"type:text" json:"routing_engine_logs,omitempty"` // Formatted routing engine decision logs
 
 	// Denormalized token fields for easier querying
 	PromptTokens     int `gorm:"default:0" json:"-"`

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -101,9 +101,9 @@ type VectorStore interface {
 	// Delete removes a vector from the vector store.
 	Delete(ctx context.Context, namespace string, id string) error
 	// DeleteAll deletes all vectors from the vector store.
-	DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error)	
+	DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error)
 	// Close closes the vector store.
-	Close(ctx context.Context, namespace string) error	
+	Close(ctx context.Context, namespace string) error
 }
 
 // Config represents the configuration for the vector store.

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -5,3 +5,4 @@
 - feat: add model and provider level governance - set budgets and rate limits on specific models or providers independent of virtual keys
 - feat: plugin now filters `/v1/models` responses based on virtual key configurations
 - chore: upgrade core to 1.4.1 and framework to 1.2.19
+- feat: add routing engine decision logs to context

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,1 +1,2 @@
 - feat: support multiple routing engines in log entries with array-based tracking
+- feat: add routing engine decision logs to log entries

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -61,6 +61,7 @@ func (p *LoggerPlugin) updateLogEntry(
 	routingRuleName string,
 	numberOfRetries int,
 	cacheDebug *schemas.BifrostCacheDebug,
+	routingEngineLogs string,
 	data *UpdateLogData,
 ) error {
 	updates := make(map[string]interface{})
@@ -84,6 +85,9 @@ func (p *LoggerPlugin) updateLogEntry(
 	}
 	if numberOfRetries != 0 {
 		updates["number_of_retries"] = numberOfRetries
+	}
+	if routingEngineLogs != "" {
+		updates["routing_engine_logs"] = routingEngineLogs
 	}
 	// Handle JSON fields by setting them on a temporary entry and serializing
 	tempEntry := &logstore.Log{}
@@ -222,6 +226,7 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	routingRuleName string,
 	numberOfRetries int,
 	cacheDebug *schemas.BifrostCacheDebug,
+	routingEngineLogs string,
 	streamResponse *streaming.ProcessedStreamResponse,
 	isFinalChunk bool,
 ) error {
@@ -243,6 +248,9 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	}
 	if numberOfRetries != 0 {
 		updates["number_of_retries"] = numberOfRetries
+	}
+	if routingEngineLogs != "" {
+		updates["routing_engine_logs"] = routingEngineLogs
 	}
 	// Handle error case first
 	if streamResponse.Data.ErrorDetails != nil {

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -395,3 +395,21 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 
 	return resp
 }
+
+// formatRoutingEngineLogs formats routing engine logs into a human-readable string.
+// Format: [timestamp] [engine] - message
+// Parameters:
+//   - logs: Slice of routing engine log entries
+//
+// Returns:
+//   - string: Formatted log string (empty string if no logs)
+func formatRoutingEngineLogs(logs []schemas.RoutingEngineLogEntry) string {
+	if len(logs) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, log := range logs {
+		sb.WriteString(fmt.Sprintf("[%d] [%s] - %s\n", log.Timestamp, log.Engine, log.Message))
+	}
+	return sb.String()
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1161,7 +1161,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 				if len(listModelsErr.ExtraFields.KeyStatuses) > 0 && s.Config.ConfigStore != nil {
 					s.updateKeyStatus(ctx, listModelsErr.ExtraFields.KeyStatuses)
 				}
-				logger.Error("failed to list models for provider %s: %v: falling back onto the static datasheet", provider, listModelsErr)
+				logger.Error("failed to list models for provider %s: %v: falling back onto the static datasheet", provider, bifrost.GetErrorMessage(listModelsErr))
 			}
 			allowedModels := make([]schemas.Model, 0)
 			for _, key := range providerConfig.Keys {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,3 +2,4 @@
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add key-level model discovery status tracking to improve visibility into API key health and model availability.
+- feat: add routing engine decision logs

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -138,7 +138,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 				</SheetHeader>
 				<div className="-mt-6 space-y-4 rounded-sm border px-6 py-4">
 					<div className="space-y-4">
-						<BlockHeader title="Timings" icon={<Timer className="h-5 w-5 text-gray-600" />} />
+						<BlockHeader title="Timings" />
 						<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 							<LogEntryDetailsView
 								className="w-full"
@@ -161,7 +161,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 					</div>
 					<DottedSeparator />
 					<div className="space-y-4">
-						<BlockHeader title="Request Details" icon={<FileText className="h-5 w-5 text-gray-600" />} />
+						<BlockHeader title="Request Details" />
 						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
 							<LogEntryDetailsView
 								className="w-full"
@@ -232,7 +232,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 						<>
 							<DottedSeparator />
 							<div className="space-y-4">
-								<BlockHeader title="Tokens" icon={<DollarSign className="h-5 w-5 text-gray-600" />} />
+								<BlockHeader title="Tokens" />
 								<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 									<LogEntryDetailsView className="w-full" label="Input Tokens" value={log.token_usage?.prompt_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Output Tokens" value={log.token_usage?.completion_tokens || "-"} />
@@ -299,7 +299,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									<>
 										<DottedSeparator />
 										<div className="space-y-4">
-											<BlockHeader title="Reasoning Parameters" icon={<FileText className="h-5 w-5 text-gray-600" />} />
+											<BlockHeader title="Reasoning Parameters" />
 											<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 												{reasoning.effort && (
 													<LogEntryDetailsView
@@ -346,7 +346,6 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									<div className="space-y-4">
 										<BlockHeader
 											title={`Caching Details (${log.cache_debug.cache_hit ? "Hit" : "Miss"})`}
-											icon={<DollarSign className="h-5 w-5 text-gray-600" />}
 										/>
 										<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 											{log.cache_debug.cache_hit ? (
@@ -425,6 +424,13 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 						</>
 					)}
 				</div>
+				{log.routing_engine_logs && (
+					<CollapsibleBox title="Routing Decision Logs" onCopy={() => log.routing_engine_logs || ""}>
+						<div className="custom-scrollbar max-h-[400px] overflow-y-auto px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap">
+							{log.routing_engine_logs}
+						</div>
+					</CollapsibleBox>
+				)}
 				{toolsParameter && (
 					<CollapsibleBox title={`Tools (${log.params?.tools?.length || 0})`} onCopy={() => toolsParameter}>
 						<CodeEditor

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -358,6 +358,7 @@ export interface LogEntry {
 	virtual_key_id?: string;
 	routing_engines_used?: string[];
 	routing_rule_id?: string;
+	routing_engine_logs?: string; // Human-readable routing decision logs
 	selected_key?: DBKey;
 	virtual_key?: VirtualKey;
 	routing_rule?: RoutingRule;


### PR DESCRIPTION
## Summary

Add routing engine decision logs to the context and store them in the logs table, providing visibility into routing decisions made by different engines (governance, routing rules, load balancing).

## Changes

- Added a new context key `BifrostContextKeyRoutingEngineLogs` to store routing engine log entries
- Created a `RoutingEngineLogEntry` struct to represent log entries with engine name, message, and timestamp
- Added helper functions to append and retrieve routing logs from context
- Modified the governance plugin to log key routing decisions
- Added routing engine logs to the database schema and UI
- Enhanced the logging plugin to format and store routing engine logs
- Updated the UI to display routing decision logs in the log details view

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Enable the governance plugin with routing rules
2. Make requests that trigger different routing decisions
3. Check the logs in the UI to see the routing decision logs
4. Verify that the logs show the decision-making process across different routing engines

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

The routing logs contain information about routing decisions but do not expose sensitive information like API keys.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable