### PR TITLE
fix: replace dialect-specific upsert with find-then-create-or-update pattern

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
+- feat: add routing engine decision logs to context

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -301,7 +301,7 @@ func (m *ToolsManager) ParseAndAddToolsToRequest(ctx context.Context, req *schem
 
 	// Get integration user agent for duplicate checking
 	var integrationUserAgentStr string
-	integrationUserAgent := ctx.Value(schemas.BifrostContextKey("integration-user-agent"))
+	integrationUserAgent := ctx.Value(schemas.BifrostContextKeyUserAgent)
 	if integrationUserAgent != nil {
 		if str, ok := integrationUserAgent.(string); ok {
 			integrationUserAgentStr = str

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -189,6 +189,7 @@ const (
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
+	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
 )
 
 // RoutingEngine constants
@@ -197,6 +198,14 @@ const (
 	RoutingEngineRoutingRule   = "routing-rule"
 	RoutingEngineLoadbalancing = "loadbalancing"
 )
+
+// RoutingEngineLogEntry represents a log entry from a routing engine
+// format: [timestamp] [engine] - message
+type RoutingEngineLogEntry struct {
+	Engine    string // e.g., "governance", "routing-rule", "openrouter"
+	Message   string // Human-readable decision/action message
+	Timestamp int64  // Unix milliseconds
+}
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,
 // make sure to mark BifrostContextKeyStreamEndIndicator as true at the end of the stream.

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -187,8 +187,15 @@ const (
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
-	BifrostContextKeyRoutingEngineUsed                   BifrostContextKey = "bifrost-routing-engine-used"                      // string (set by bifrost - DO NOT SET THIS MANUALLY) - either "routing-rule", "governance" or "loadbalancing"
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
+)
+
+// RoutingEngine constants
+const (
+	RoutingEngineGovernance    = "governance"
+	RoutingEngineRoutingRule   = "routing-rule"
+	RoutingEngineLoadbalancing = "loadbalancing"
 )
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -220,7 +220,7 @@ func (bc *BifrostContext) Value(key any) any {
 func (bc *BifrostContext) SetValue(key, value any) {
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
-		// we silently drop writes for these reserved keys				
+		// we silently drop writes for these reserved keys
 		return
 	}
 	bc.valuesMu.Lock()
@@ -232,17 +232,17 @@ func (bc *BifrostContext) SetValue(key, value any) {
 }
 
 // GetAndSetValue gets a value from the internal userValues map and sets it
-func (bc *BifrostContext) GetAndSetValue(key any, value any) any {	
+func (bc *BifrostContext) GetAndSetValue(key any, value any) any {
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
-		// we silently drop writes for these reserved keys				
+		// we silently drop writes for these reserved keys
 		return bc.userValues[key]
 	}
 	if bc.userValues == nil {
 		bc.userValues = make(map[any]any)
-	}	
+	}
 	oldValue := bc.userValues[key]
 	bc.userValues[key] = value
 	return oldValue
@@ -280,4 +280,20 @@ func (bc *BifrostContext) GetParentCtxWithUserValues() context.Context {
 	}
 	bc.valuesMu.RUnlock()
 	return parentCtx
+}
+
+// AppendToContext appends a value to the context list value.
+// Parameters:
+//   - ctx: The Bifrost context
+//   - key: The key to append the value to
+//   - value: The value to append
+func AppendToContextList[T any](ctx *BifrostContext, key BifrostContextKey, value T) {
+	if ctx == nil {
+		return
+	}
+	existingValues, ok := ctx.Value(key).([]T)
+	if !ok {
+		existingValues = []T{}
+	}
+	ctx.SetValue(key, append(existingValues, value))
 }

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -282,6 +282,35 @@ func (bc *BifrostContext) GetParentCtxWithUserValues() context.Context {
 	return parentCtx
 }
 
+// AppendRoutingEngineLog appends a routing engine log entry to the context.
+// Parameters:
+//   - ctx: The Bifrost context
+//   - engineName: Name of the routing engine (e.g., "governance", "routing-rule")
+//   - message: Human-readable log message describing the decision/action
+func (bc *BifrostContext) AppendRoutingEngineLog(engineName string, message string) {
+	entry := RoutingEngineLogEntry{
+		Engine:    engineName,
+		Message:   message,
+		Timestamp: time.Now().UnixMilli(),
+	}
+	AppendToContextList(bc, BifrostContextKeyRoutingEngineLogs, entry)
+}
+
+// GetRoutingEngineLogs retrieves all routing engine logs from the context.
+// Parameters:
+//   - ctx: The Bifrost context
+//
+// Returns:
+//   - []RoutingEngineLogEntry: Slice of routing engine log entries (nil if none)
+func (bc *BifrostContext) GetRoutingEngineLogs() []RoutingEngineLogEntry {
+	if val := bc.Value(BifrostContextKeyRoutingEngineLogs); val != nil {
+		if logs, ok := val.([]RoutingEngineLogEntry); ok {
+			return logs
+		}
+	}
+	return nil
+}
+
 // AppendToContext appends a value to the context list value.
 // Parameters:
 //   - ctx: The Bifrost context

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -62,7 +62,7 @@ Base Labels:
 - `method`: Request type (`chat`, `text`, `embedding`, `speech`, `transcription`)
 - `virtual_key_id`: Virtual key ID
 - `virtual_key_name`: Virtual key name
-- `routing_engine_used`: Routing engine used ("routing-rule", "governance", "loadbalancing")
+- `routing_engines_used`: Comma-separated routing engines used ("routing-rule", "governance", "loadbalancing")
 - `routing_rule_id`: Routing rule ID that matched the request
 - `routing_rule_name`: Routing rule name that matched the request
 - `selected_key_id`: Selected key ID

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -37,9 +37,11 @@ LogEntry:
     virtual_key_name:
       type: string
       nullable: true
-    routing_engine_used:
-      type: string
-      description: The routing engine used for this request (routing-rule, governance, or loadbalancing)
+    routing_engines_used:
+      type: array
+      items:
+        type: string
+      description: Array of routing engines used for this request (routing-rule, governance, or loadbalancing)
       nullable: true
     routing_rule_id:
       type: string

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- feat: rename routing_engine_used column to routing_engines_used for multi-engine tracking (parsed as comma-separated string)

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,2 @@
 - feat: rename routing_engine_used column to routing_engines_used for multi-engine tracking (parsed as comma-separated string)
+- feat: add routing engine decision logs to logs table

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -116,8 +116,9 @@ type Log struct {
 	ErrorDetails          string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.BifrostError
 	Stream                bool      `gorm:"default:false" json:"stream"`                   // true if this was a streaming response
 	ContentSummary        string    `gorm:"type:text" json:"-"`
-	RawRequest            string    `gorm:"type:text" json:"raw_request"`  // Populated when `send-back-raw-request` is on
-	RawResponse           string    `gorm:"type:text" json:"raw_response"` // Populated when `send-back-raw-response` is on
+	RawRequest            string    `gorm:"type:text" json:"raw_request"`                   // Populated when `send-back-raw-request` is on
+	RawResponse           string    `gorm:"type:text" json:"raw_response"`                  // Populated when `send-back-raw-response` is on
+	RoutingEngineLogs     string    `gorm:"type:text" json:"routing_engine_logs,omitempty"` // Formatted routing engine decision logs
 
 	// Denormalized token fields for easier querying
 	PromptTokens     int `gorm:"default:0" json:"-"`

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -101,9 +101,9 @@ type VectorStore interface {
 	// Delete removes a vector from the vector store.
 	Delete(ctx context.Context, namespace string, id string) error
 	// DeleteAll deletes all vectors from the vector store.
-	DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error)	
+	DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error)
 	// Close closes the vector store.
-	Close(ctx context.Context, namespace string) error	
+	Close(ctx context.Context, namespace string) error
 }
 
 // Config represents the configuration for the vector store.

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -5,3 +5,4 @@
 - feat: add model and provider level governance - set budgets and rate limits on specific models or providers independent of virtual keys
 - feat: plugin now filters `/v1/models` responses based on virtual key configurations
 - chore: upgrade core to 1.4.1 and framework to 1.2.19
+- feat: add routing engine decision logs to context

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,3 +1,4 @@
+- feat: added multi level routing support for routing rules + vk based provider routing
 - feat: cross-provider model matching - budget/rate-limit configs for `gpt-4o` now apply to `openai/gpt-4o`, `gpt-4o-2024-08-06`, etc.
 - feat: expand GovernanceData with ModelConfigs and Providers for in-memory reads
 - feat: added routing rules for dynamic routing of requests based on predefined rules

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,1 +1,2 @@
 - feat: support multiple routing engines in log entries with array-based tracking
+- feat: add routing engine decision logs to log entries

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+- feat: support multiple routing engines in log entries with array-based tracking

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -61,6 +61,7 @@ func (p *LoggerPlugin) updateLogEntry(
 	routingRuleName string,
 	numberOfRetries int,
 	cacheDebug *schemas.BifrostCacheDebug,
+	routingEngineLogs string,
 	data *UpdateLogData,
 ) error {
 	updates := make(map[string]interface{})
@@ -84,6 +85,9 @@ func (p *LoggerPlugin) updateLogEntry(
 	}
 	if numberOfRetries != 0 {
 		updates["number_of_retries"] = numberOfRetries
+	}
+	if routingEngineLogs != "" {
+		updates["routing_engine_logs"] = routingEngineLogs
 	}
 	// Handle JSON fields by setting them on a temporary entry and serializing
 	tempEntry := &logstore.Log{}
@@ -222,6 +226,7 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	routingRuleName string,
 	numberOfRetries int,
 	cacheDebug *schemas.BifrostCacheDebug,
+	routingEngineLogs string,
 	streamResponse *streaming.ProcessedStreamResponse,
 	isFinalChunk bool,
 ) error {
@@ -243,6 +248,9 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	}
 	if numberOfRetries != 0 {
 		updates["number_of_retries"] = numberOfRetries
+	}
+	if routingEngineLogs != "" {
+		updates["routing_engine_logs"] = routingEngineLogs
 	}
 	// Handle error case first
 	if streamResponse.Data.ErrorDetails != nil {

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -395,3 +395,21 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 
 	return resp
 }
+
+// formatRoutingEngineLogs formats routing engine logs into a human-readable string.
+// Format: [timestamp] [engine] - message
+// Parameters:
+//   - logs: Slice of routing engine log entries
+//
+// Returns:
+//   - string: Formatted log string (empty string if no logs)
+func formatRoutingEngineLogs(logs []schemas.RoutingEngineLogEntry) string {
+	if len(logs) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, log := range logs {
+		sb.WriteString(fmt.Sprintf("[%d] [%s] - %s\n", log.Timestamp, log.Engine, log.Message))
+	}
+	return sb.String()
+}

--- a/plugins/telemetry/changelog.md
+++ b/plugins/telemetry/changelog.md
@@ -1,0 +1,1 @@
+- feat: support multiple routing engines in telemetry metrics with comma-separated label format

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -376,7 +377,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
 	fallbackIndex := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyFallbackIndex)
-	routingEngineUsed := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRoutingEngineUsed)
+	// Get routing engines array and join into comma-separated string
+	routingEngines := []string{}
+	if engines, ok := ctx.Value(schemas.BifrostContextKeyRoutingEnginesUsed).([]string); ok {
+		routingEngines = engines
+	}
+	routingEngineUsed := strings.Join(routingEngines, ",")
 
 	teamID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamID)
 	teamName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceTeamName)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1161,7 +1161,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 				if len(listModelsErr.ExtraFields.KeyStatuses) > 0 && s.Config.ConfigStore != nil {
 					s.updateKeyStatus(ctx, listModelsErr.ExtraFields.KeyStatuses)
 				}
-				logger.Error("failed to list models for provider %s: %v: falling back onto the static datasheet", provider, listModelsErr)
+				logger.Error("failed to list models for provider %s: %v: falling back onto the static datasheet", provider, bifrost.GetErrorMessage(listModelsErr))
 			}
 			allowedModels := make([]schemas.Model, 0)
 			for _, key := range providerConfig.Keys {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,3 +2,4 @@
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add key-level model discovery status tracking to improve visibility into API key health and model availability.
+- feat: add routing engine decision logs

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+- feat: added multi level routing support for routing rules + vk based provider routing
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add key-level model discovery status tracking to improve visibility into API key health and model availability.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2274,6 +2274,10 @@
           "type": "boolean",
           "description": "Whether cluster mode is enabled"
         },
+        "region": {
+          "type": "string",
+          "description": "AWS region for cluster deployment (default: us-east-1)"
+        },
         "peers": {
           "type": "array",
           "description": "List of peer addresses",

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -636,7 +636,7 @@ export default function LogsPage() {
 			}
 		}
 		if (filters.routing_engine_used?.length) {
-			if (!log.routing_engine_used || !filters.routing_engine_used.includes(log.routing_engine_used)) {
+			if (!log.routing_engines_used || !log.routing_engines_used.some((engine) => filters.routing_engine_used!.includes(engine))) {
 				return false;
 			}
 		}

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -73,7 +73,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 	if (log.params?.tools) {
 		try {
 			toolsParameter = JSON.stringify(log.params.tools, null, 2);
-		} catch (ignored) {}
+		} catch (ignored) { }
 	}
 
 	// Extract audio format from request params
@@ -179,9 +179,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								label="Type"
 								value={
 									<div
-										className={`${
-											RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
-										} rounded-sm px-3 py-1`}
+										className={`${RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
+											} rounded-sm px-3 py-1`}
 									>
 										{RequestTypeLabels[log.object as keyof typeof RequestTypeLabels] ?? log.object ?? "unknown"}
 									</div>
@@ -193,27 +192,19 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							)}
 							{log.fallback_index > 0 && <LogEntryDetailsView className="w-full" label="Fallback Index" value={log.fallback_index} />}
 							{log.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={log.virtual_key.name} />}
-							{log.routing_engine_used && (
-								<LogEntryDetailsView
-									className="w-full"
-									label="Routing Engine Used"
-									value={
-										<Badge
-											className={
-												RoutingEngineUsedColors[log.routing_engine_used as keyof typeof RoutingEngineUsedColors] ??
-												"bg-gray-100 text-gray-800"
-											}
-										>
-											<div className="flex items-center gap-2">
-												{RoutingEngineUsedIcons[log.routing_engine_used as keyof typeof RoutingEngineUsedIcons]?.()}
-												<span>
-													{RoutingEngineUsedLabels[log.routing_engine_used as keyof typeof RoutingEngineUsedLabels] ??
-														log.routing_engine_used}
-												</span>
-											</div>
-										</Badge>
-									}
-								/>
+							{log.routing_engines_used && log.routing_engines_used.length > 0 && (
+								<LogEntryDetailsView className="w-full" label="Routing Engines Used" value={
+									<div className="flex flex-wrap gap-2">
+										{log.routing_engines_used.map((engine) => (
+											<Badge key={engine} className={RoutingEngineUsedColors[engine as keyof typeof RoutingEngineUsedColors] ?? "bg-gray-100 text-gray-800"}>
+												<div className="flex items-center gap-2">
+													{RoutingEngineUsedIcons[engine as keyof typeof RoutingEngineUsedIcons]?.()}
+													<span>{RoutingEngineUsedLabels[engine as keyof typeof RoutingEngineUsedLabels] ?? engine}</span>
+												</div>
+											</Badge>
+										))}
+									</div>
+								} />
 							)}
 							{log.routing_rule && <LogEntryDetailsView className="w-full" label="Routing Rule" value={log.routing_rule.name} />}
 

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -138,7 +138,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 				</SheetHeader>
 				<div className="-mt-6 space-y-4 rounded-sm border px-6 py-4">
 					<div className="space-y-4">
-						<BlockHeader title="Timings" icon={<Timer className="h-5 w-5 text-gray-600" />} />
+						<BlockHeader title="Timings" />
 						<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 							<LogEntryDetailsView
 								className="w-full"
@@ -161,7 +161,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 					</div>
 					<DottedSeparator />
 					<div className="space-y-4">
-						<BlockHeader title="Request Details" icon={<FileText className="h-5 w-5 text-gray-600" />} />
+						<BlockHeader title="Request Details" />
 						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
 							<LogEntryDetailsView
 								className="w-full"
@@ -232,7 +232,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 						<>
 							<DottedSeparator />
 							<div className="space-y-4">
-								<BlockHeader title="Tokens" icon={<DollarSign className="h-5 w-5 text-gray-600" />} />
+								<BlockHeader title="Tokens" />
 								<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 									<LogEntryDetailsView className="w-full" label="Input Tokens" value={log.token_usage?.prompt_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Output Tokens" value={log.token_usage?.completion_tokens || "-"} />
@@ -299,7 +299,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									<>
 										<DottedSeparator />
 										<div className="space-y-4">
-											<BlockHeader title="Reasoning Parameters" icon={<FileText className="h-5 w-5 text-gray-600" />} />
+											<BlockHeader title="Reasoning Parameters" />
 											<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 												{reasoning.effort && (
 													<LogEntryDetailsView
@@ -346,7 +346,6 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									<div className="space-y-4">
 										<BlockHeader
 											title={`Caching Details (${log.cache_debug.cache_hit ? "Hit" : "Miss"})`}
-											icon={<DollarSign className="h-5 w-5 text-gray-600" />}
 										/>
 										<div className="grid w-full grid-cols-3 items-center justify-between gap-4">
 											{log.cache_debug.cache_hit ? (
@@ -425,6 +424,13 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 						</>
 					)}
 				</div>
+				{log.routing_engine_logs && (
+					<CollapsibleBox title="Routing Decision Logs" onCopy={() => log.routing_engine_logs || ""}>
+						<div className="custom-scrollbar max-h-[400px] overflow-y-auto px-6 py-2 font-mono text-xs break-words whitespace-pre-wrap">
+							{log.routing_engine_logs}
+						</div>
+					</CollapsibleBox>
+				)}
 				{toolsParameter && (
 					<CollapsibleBox title={`Tools (${log.params?.tools?.length || 0})`} onCopy={() => toolsParameter}>
 						<CodeEditor

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -356,7 +356,7 @@ export interface LogEntry {
 	fallback_index: number;
 	selected_key_id: string;
 	virtual_key_id?: string;
-	routing_engine_used?: string;
+	routing_engines_used?: string[];
 	routing_rule_id?: string;
 	selected_key?: DBKey;
 	virtual_key?: VirtualKey;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -358,6 +358,7 @@ export interface LogEntry {
 	virtual_key_id?: string;
 	routing_engines_used?: string[];
 	routing_rule_id?: string;
+	routing_engine_logs?: string; // Human-readable routing decision logs
 	selected_key?: DBKey;
 	virtual_key?: VirtualKey;
 	routing_rule?: RoutingRule;


### PR DESCRIPTION
## Summary

Refactored the `UpsertModelPrices` method in the RDB config store to use a find-then-create-or-update pattern instead of relying on database-specific upsert functionality.

## Changes

- Replaced the `clause.OnConflict` approach with a more portable implementation that first checks if a record exists
- If the record exists, updates it by setting the ID and using `Save()`
- If no record exists, creates a new one
- Added documentation explaining that this approach works across different database dialects (SQLite and PostgreSQL)

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./framework/configstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications as this is an internal database operation refactoring.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)