### PR TITLE
feat/added eye toggle button for hide and see password

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { getErrorMessage, setAuthToken, useIsAuthEnabledQuery, useLoginMutation } from "@/lib/store/apis";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
+import { Eye, EyeOff } from "lucide-react";
 import { useTheme } from "next-themes";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -34,6 +35,7 @@ export default function LoginView() {
 	const [mounted, setMounted] = useState(false);
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");
+	const [showPassword, setShowPassword] = useState(false);
 	const [errorMessage, setErrorMessage] = useState("");
 	const [isCheckingAuth, setIsCheckingAuth] = useState(true);
 	const router = useRouter();
@@ -146,16 +148,30 @@ export default function LoginView() {
 							<Label htmlFor="password" className="text-sm font-medium">
 								Password
 							</Label>
-							<Input
-								id="password"
-								type="password"
-								placeholder="Enter your password"
-								value={password}
-								onChange={(e) => setPassword(e.target.value)}
-								required
-								className="text-sm"
-								autoComplete="current-password"
-							/>
+							<div className="relative">
+								<Input
+									id="password"
+									type={showPassword ? "text" : "password"}
+									placeholder="Enter your password"
+									value={password}
+									onChange={(e) => setPassword(e.target.value)}
+									required
+									className="text-sm pr-10"
+									autoComplete="current-password"
+								/>
+								<button
+									type="button"
+									onClick={() => setShowPassword(!showPassword)}
+									className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+									aria-label={showPassword ? "Hide password" : "Show password"}
+								>
+									{showPassword ? (
+										<EyeOff className="h-4 w-4" />
+									) : (
+										<Eye className="h-4 w-4" />
+									)}
+								</button>
+							</div>
 						</div>
 
 						<Button type="submit" className="h-9 w-full text-sm" isLoading={isLoading} disabled={isLoading}>


### PR DESCRIPTION
## Summary

Adds a show/hide (eye) toggle to the password input on the login page to improve usability and reduce input errors.

## Changes

- Added an eye icon toggle to switch the password field between masked and visible states
- Improves user experience when entering passwords, especially on first-time or complex passwords
- No changes to authentication logic or API behavior

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## Screenshot
Before:
<img width="1920" height="1199" alt="Screenshot from 2026-02-17 23-26-45" src="https://github.com/user-attachments/assets/71f83f45-f381-4d2f-a0ae-50bbb68b1aef" />

After:
[Screencast from 2026-02-17 23-32-38.webm](https://github.com/user-attachments/assets/334fef70-d2b3-4bd0-83fc-2a537387f102)
