### PR TITLE
feat: add skip plugin pipeline flag

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add routing engine decision logs to context
+- feat: add skip plugin pipeline flag to context

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -187,9 +187,9 @@ const (
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
-	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
 	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
+	BifrostContextKeySkipPluginPipeline                  BifrostContextKey = "bifrost-skip-plugin-pipeline"                     // bool - skip plugin pipeline for the request
 )
 
 // RoutingEngine constants

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -487,7 +487,7 @@ func (s *BifrostHTTPServer) ReloadProvider(ctx context.Context, provider schemas
 	}
 
 	bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-	bfCtx.SetValue(schemas.BifrostContextKeySkipListModelsGovernanceFiltering, true)
+	bfCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
 	defer bfCtx.Cancel()
 
 	allModels, bifrostErr := s.Client.ListModelsRequest(bfCtx, &schemas.BifrostListModelsRequest{
@@ -721,7 +721,7 @@ func (s *BifrostHTTPServer) ForceReloadPricing(ctx context.Context) error {
 		// Based on allowed models we will set the data in the model catalog
 		for provider, providerConfig := range s.Config.Providers {
 			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-			bfCtx.SetValue(schemas.BifrostContextKeySkipListModelsGovernanceFiltering, true)
+			bfCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
 			modelData, listModelsErr := s.Client.ListModelsRequest(bfCtx, &schemas.BifrostListModelsRequest{
 				Provider: provider,
 			})
@@ -1149,7 +1149,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		// Based on allowed models we will set the data in the model catalog
 		for provider, providerConfig := range s.Config.Providers {
 			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-			bfCtx.SetValue(schemas.BifrostContextKeySkipListModelsGovernanceFiltering, true)
+			bfCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
 
 			modelData, listModelsErr := s.Client.ListModelsRequest(bfCtx, &schemas.BifrostListModelsRequest{
 				Provider: provider,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -3,3 +3,5 @@
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add key-level model discovery status tracking to improve visibility into API key health and model availability.
 - feat: add routing engine decision logs
+- fix: add skip plugin pipeline flag to context for list models requests to avoid internal list models logs
+- fix: add custom model support to routing rules UI

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -10,6 +10,9 @@ import { ArrowUpDown, Trash2 } from "lucide-react";
 import moment from "moment";
 
 function getMessage(log?: LogEntry) {
+	if (log?.object === "list_models") {
+		return "N/A";
+	}
 	if (log?.input_history && log.input_history.length > 0) {
 		let userMessageContent = log.input_history[log.input_history.length - 1].content;
 		if (userMessageContent == undefined) {
@@ -55,7 +58,7 @@ function getMessage(log?: LogEntry) {
 		return "Audio file";
 	} else if (log?.image_generation_input?.prompt) {
 		return log.image_generation_input.prompt;
-	} 
+	}
 	const obj = log?.object as string | undefined;
 	if (obj === "image_edit" || obj === "image_edit_stream" || obj === "image_variation") {
 		return "Image file";
@@ -126,7 +129,7 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 	{
 		accessorKey: "model",
 		header: "Model",
-		cell: ({ row }) => <div className="max-w-[120px] truncate font-mono text-xs font-normal">{row.original.model}</div>,
+		cell: ({ row }) => <div className="max-w-[120px] truncate font-mono text-xs font-normal">{row.original.model || "N/A"}</div>,
 	},
 	{
 		accessorKey: "latency",


### PR DESCRIPTION
## Summary

Introduced a new context flag `BifrostContextKeySkipPluginPipeline` to bypass the entire plugin pipeline when needed, replacing the more specific `BifrostContextKeySkipListModelsGovernanceFiltering`. Also renamed hook functions to be more descriptive of their purpose.

## Changes

- Renamed `RunPreHooks` to `RunLLMPreHooks` and `RunPostHooks` to `RunPostLLMHooks` for clarity
- Added a new context flag `BifrostContextKeySkipPluginPipeline` to skip the entire plugin pipeline
- Removed the more specific `BifrostContextKeySkipListModelsGovernanceFiltering` flag
- Updated all plugin hook functions to check for the new skip flag
- Modified UI logs view to handle list_models entries better by showing "N/A" for message and model fields

## Type of change

- [x] Refactor
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (Next.js)

## How to test

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

Verify that internal operations like bootstrap and provider reloading still work correctly with the new flag.

## Breaking changes

- [x] No

## Security considerations

This change improves code clarity and maintainability without introducing security implications. The ability to skip the plugin pipeline is only used internally for system operations.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)