### PR TITLE
feat: docs for video gen

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
                   "providers/supported-providers/parasail",
                   "providers/supported-providers/perplexity",
                   "providers/supported-providers/replicate",
+                  "providers/supported-providers/runway",
                   "providers/supported-providers/sgl",
                   "providers/supported-providers/vertex",
                   "providers/supported-providers/vllm",

--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -365,6 +365,7 @@ The logging plugin captures all Bifrost request types:
 - Embeddings
 - Speech Generation (streaming and non-streaming)
 - Transcription (streaming and non-streaming)
+- Video Generation
 
 ---
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -75,6 +75,8 @@ tags:
     description: Text embedding generation
   - name: Images
     description: Image generations, editing, and variations
+  - name: Videos
+    description: Video generation and management
   - name: Audio
     description: Speech synthesis and transcription
   - name: Count Tokens
@@ -150,6 +152,14 @@ paths:
     $ref: './paths/inference/images.yaml#/image-edit'
   /v1/images/variations:
     $ref: './paths/inference/images.yaml#/image-variation'
+  /v1/videos:
+    $ref: './paths/inference/videos.yaml#/video-generation'
+  /v1/videos/{video_id}:
+    $ref: './paths/inference/videos.yaml#/video-by-id'
+  /v1/videos/{video_id}/content:
+    $ref: './paths/inference/videos.yaml#/video-download'
+  /v1/videos/{video_id}/remix:
+    $ref: './paths/inference/videos.yaml#/video-remix'
   /v1/count_tokens:
     $ref: './paths/inference/count-tokens.yaml#/count-tokens'
   /v1/batches:

--- a/docs/openapi/paths/inference/videos.yaml
+++ b/docs/openapi/paths/inference/videos.yaml
@@ -1,0 +1,268 @@
+# Video Generation Endpoints
+
+video-generation:
+  post:
+    operationId: videoGeneration
+    summary: Generate a video
+    description: |
+      Creates a video generation job from a text prompt. This is an asynchronous operation
+      that returns immediately with a job ID. Use the retrieve endpoint to check the status
+      and get the video URL when generation is complete.
+      
+      Request must be sent as multipart/form-data with at least `model` and `prompt`.
+    tags:
+      - Videos
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/videos.yaml#/VideoGenerationRequest'
+    responses:
+      '200':
+        description: |
+          Successful response. Returns a video generation job object with status information.
+          Poll the retrieve endpoint to check completion status.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/videos.yaml#/VideoGenerationResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+  get:
+    operationId: videoList
+    summary: List video generation jobs
+    description: |
+      Lists video generation jobs for a specific provider. Results are paginated
+      and can be filtered using query parameters.
+    tags:
+      - Videos
+    parameters:
+      - name: provider
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Provider name (e.g., "openai", "gemini")
+      - name: after
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Cursor for pagination - ID of the last item from the previous page
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+          default: 20
+        description: Maximum number of results to return
+      - name: order
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+            - "asc"
+            - "desc"
+          default: "desc"
+        description: Sort order by creation time
+    responses:
+      '200':
+        description: Successful response. Returns a paginated list of video generation jobs.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/videos.yaml#/VideoListResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+video-by-id:
+  get:
+    operationId: videoRetrieve
+    summary: Retrieve a video generation job
+    description: |
+      Retrieves the status and metadata for a video generation job.
+      Use this endpoint to poll for completion status after creating a video generation job.
+      When the status is "completed", the response will include a URL to download the video.
+    tags:
+      - Videos
+    parameters:
+      - name: video_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Video ID in format `provider:id` (e.g., `openai:video_abc123`)
+    responses:
+      '200':
+        description: Successful response. Returns the video generation job details.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/videos.yaml#/VideoGenerationResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Video not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+  delete:
+    operationId: videoDelete
+    summary: Delete a video generation job
+    description: |
+      Deletes a video generation job and its associated assets.
+      This operation cannot be undone.
+    tags:
+      - Videos
+    parameters:
+      - name: video_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Video ID in format `provider:id` (e.g., `openai:video_abc123`)
+    responses:
+      '200':
+        description: Successful response. Returns deletion confirmation.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/videos.yaml#/VideoDeleteResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Video not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+video-download:
+  get:
+    operationId: videoDownload
+    summary: Download video content
+    description: |
+      Downloads the binary content of a generated video.
+      The video must have a status of "completed" to be downloadable.
+      Returns the raw video file (typically MP4 format).
+    tags:
+      - Videos
+    parameters:
+      - name: video_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Video ID in format `provider:id` (e.g., `openai:video_abc123`)
+    responses:
+      '200':
+        description: Successful response. Returns the video file as binary content.
+        content:
+          video/mp4:
+            schema:
+              type: string
+              format: binary
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Video not found or not yet available
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+video-delete:
+  delete:
+    operationId: videoDelete
+    summary: Delete a video generation job
+    description: |
+      Deletes a video generation job and its associated assets.
+      This operation cannot be undone.
+    tags:
+      - Videos
+    parameters:
+      - name: video_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Video ID in format `provider:id` (e.g., `openai:video_abc123`)
+    responses:
+      '200':
+        description: Successful response. Returns deletion confirmation.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/videos.yaml#/VideoDeleteResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Video not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+video-remix:
+  post:
+    operationId: videoRemix
+    summary: Remix a video
+    description: |
+      Creates a new video generation job by remixing an existing video with a new prompt.
+      The source video must have a status of "completed" to be remixed.
+      Returns a new video generation job that can be polled for completion.
+    tags:
+      - Videos
+    parameters:
+      - name: video_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Video ID in format `provider:id` (e.g., `openai:video_abc123`)
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/videos.yaml#/VideoRemixRequest'
+    responses:
+      '200':
+        description: |
+          Successful response. Returns a new video generation job object.
+          Poll the retrieve endpoint to check completion status.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/videos.yaml#/VideoGenerationResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Source video not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/schemas/inference/videos.yaml
+++ b/docs/openapi/schemas/inference/videos.yaml
@@ -1,0 +1,246 @@
+# Video Generation Schemas
+
+VideoGenerationRequest:
+  type: object
+  required:
+    - model
+    - prompt
+  properties:
+    model:
+      type: string
+      description: Model identifier in format `provider/model`
+    prompt:
+      type: string
+      description: Text prompt describing the video to generate
+    input_reference:
+      type: string
+      description: Optional reference image for image-to-video (base64 data URL or plain URL)
+    seconds:
+      type: integer
+      minimum: 1
+      maximum: 60
+      description: Duration of the video in seconds
+    size:
+      type: string
+      description: Resolution of the generated video (e.g., `1280x720`, `720x1280`, `1920x1080`)
+    negative_prompt:
+      type: string
+      description: Text describing what to avoid in the generated video
+    seed:
+      type: integer
+      description: Seed for reproducible generation
+    video_uri:
+      type: string
+      description: Source video URI for video-to-video generation (provider-specific, e.g. GCS URI)
+    audio:
+      type: boolean
+      description: Enable audio generation in the video (supported by select providers/models)
+    fallbacks:
+      type: array
+      items:
+        $ref: './common.yaml#/Fallback'
+      description: Fallback models to try if primary model fails
+
+VideoGenerationResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: Unique identifier for the video generation job (format `provider:id`)
+    object:
+      type: string
+      enum:
+        - "video"
+      description: Object type, always "video"
+    model:
+      type: string
+      description: Model used for video generation
+    status:
+      $ref: '#/VideoStatus'
+    progress:
+      type: number
+      format: float
+      minimum: 0
+      maximum: 100
+      description: Approximate completion percentage (0-100)
+    prompt:
+      type: string
+      description: Prompt used to generate the video
+    remixed_from_video_id:
+      type: string
+      description: Source video ID if this is a remix
+    seconds:
+      type: integer
+      description: Duration of the generated video in seconds
+    size:
+      $ref: '#/VideoSize'
+    created_at:
+      type: integer
+      format: int64
+      description: Unix timestamp (seconds) when the job was created
+    completed_at:
+      type: integer
+      format: int64
+      description: Unix timestamp (seconds) when the job completed
+    expires_at:
+      type: integer
+      format: int64
+      description: Unix timestamp (seconds) when downloadable assets expire
+    videos:
+      type: array
+      description: Generated video outputs (only present when status is "completed")
+      items:
+        type: object
+        properties:
+          type:
+            type: string
+            enum:
+              - "url"
+              - "base64"
+            description: Output format of this video
+          url:
+            type: string
+            format: uri
+            description: URL to the generated video (present when type is "url")
+          base64:
+            type: string
+            description: Base64-encoded video content (present when type is "base64")
+          content_type:
+            type: string
+            description: MIME type of the video (e.g., "video/mp4")
+    error:
+      $ref: '#/VideoError'
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+VideoRemixRequest:
+  type: object
+  required:
+    - prompt
+  properties:
+    prompt:
+      type: string
+      description: Text prompt describing how to remix the video
+    fallbacks:
+      type: array
+      items:
+        $ref: './common.yaml#/Fallback'
+      description: Fallback models to try if primary model fails
+
+VideoListResponse:
+  type: object
+  properties:
+    object:
+      type: string
+      enum:
+        - "list"
+      description: Object type, always "list"
+    data:
+      type: array
+      items:
+        $ref: '#/VideoObject'
+      description: Array of video generation jobs
+    first_id:
+      type: string
+      description: ID of the first item in the list
+    last_id:
+      type: string
+      description: ID of the last item in the list
+    has_more:
+      type: boolean
+      description: Whether there are more results available
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+VideoObject:
+  type: object
+  properties:
+    id:
+      type: string
+      description: Unique identifier for the video (format `provider:id`)
+    object:
+      type: string
+      enum:
+        - "video"
+      description: Object type, always "video"
+    model:
+      type: string
+      description: Model used for generation
+    status:
+      $ref: '#/VideoStatus'
+    progress:
+      type: number
+      format: float
+      minimum: 0
+      maximum: 100
+      description: Approximate completion percentage (0-100)
+    prompt:
+      type: string
+      description: Prompt used to generate the video
+    remixed_from_video_id:
+      type: string
+      description: Source video ID if this is a remix
+    seconds:
+      type: integer
+      description: Duration of the video in seconds
+    size:
+      $ref: '#/VideoSize'
+    created_at:
+      type: integer
+      format: int64
+      description: Unix timestamp (seconds) when the job was created
+    completed_at:
+      type: integer
+      format: int64
+      description: Unix timestamp (seconds) when the job completed
+    expires_at:
+      type: integer
+      format: int64
+      description: Unix timestamp (seconds) when downloadable assets expire
+    error:
+      $ref: '#/VideoError'
+
+VideoDeleteResponse:
+  type: object
+  properties:
+    id:
+      type: string
+      description: ID of the deleted video
+    object:
+      type: string
+      enum:
+        - "video.deleted"
+      description: Object type, always "video.deleted"
+    deleted:
+      type: boolean
+      description: Whether the video was successfully deleted
+    extra_fields:
+      $ref: './common.yaml#/BifrostResponseExtraFields'
+
+VideoStatus:
+  type: string
+  enum:
+    - "queued"
+    - "in_progress"
+    - "completed"
+    - "failed"
+  description: |
+    Current lifecycle status of the video generation job:
+    - `queued`: Job is waiting to be processed
+    - `in_progress`: Video is currently being generated
+    - `completed`: Video generation completed successfully
+    - `failed`: Video generation failed
+
+VideoSize:
+  type: string
+  description: Resolution of the generated video (e.g., "1920x1080")
+
+VideoError:
+  type: object
+  properties:
+    code:
+      type: string
+      description: Error code
+    message:
+      type: string
+      description: Human-readable error message

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -26,6 +26,7 @@ Azure is a cloud provider offering access to OpenAI and Anthropic models through
 | List Models | ✅ | - | `/openai/v1/models` |
 | Image Generation | ✅ | ✅ | `/openai/v1/images/generations` |
 | Image Edit | ✅ | ✅ | `/openai/v1/images/edits` |
+| Video Generation | ✅ | - | `/openai/v1/videos` |
 | Image Variation | ❌ | ❌ | - |
 | Batch | ❌ | ❌ | - |
 | Text Completions | ❌ | ❌ | - |
@@ -513,6 +514,23 @@ Lists available models/deployments configured in the Azure key. Response include
 **Impact**: `gpt-4` and `gpt-4-turbo` can map to same deployment
 **Code**: `models.go:13-58`
 </Accordion>
+
+---
+
+# 8. Video Generation
+
+Azure routes video generation to OpenAI's Sora models via the Azure OpenAI-compatible endpoint. All parameters are identical to [OpenAI Video Generation](/providers/supported-providers/openai#video-generation).
+
+**Supported Operations**
+
+| Operation | Supported | Notes |
+|-----------|-----------|-------|
+| Generate | ✅ | `POST /v1/videos` |
+| Retrieve | ✅ | `GET /v1/videos/{id}` |
+| Download | ✅ | `GET /v1/videos/{id}/content` |
+| Delete | ✅ | `DELETE /v1/videos/{id}` |
+| List | ✅ | `GET /v1/videos` |
+| Remix | ❌ | Not supported |
 
 ---
 

--- a/docs/providers/supported-providers/gemini.mdx
+++ b/docs/providers/supported-providers/gemini.mdx
@@ -24,6 +24,7 @@ Google Gemini's API has different structure from OpenAI. Bifrost performs extens
 | Transcriptions (STT) | ✅ | ✅ | `/v1beta/models/{model}:generateContent` |
 | Image Generation | ✅ | - | `/v1beta/models/{model}:generateContent` or `/v1beta/models/{model}:predict` (Imagen) |
 | Image Edit | ✅ | - | `/v1beta/models/{model}:generateContent` or `/v1beta/models/{model}:predict` (Imagen) |
+| Video Generation | ✅ | - | `/v1beta/models/{model}:predictLongRunning` |
 | Image Variation | ❌ | - | Not supported |
 | Embeddings | ✅ | - | `/v1beta/models/{model}:embedContent` |
 | Files | ✅ | - | `/upload/storage/v1beta/files` |
@@ -741,6 +742,62 @@ Image variation is not supported by Gemini.
 - Context length = `inputTokenLimit + outputTokenLimit`
 
 **Pagination**: Token-based with `nextPageToken`
+
+---
+
+# 11. Video Generation
+
+<Note>
+Gemini video generation uses long-running operations. The response `id` is the operation name — use it to poll status. Video IDs use `gemini:{operation_name}` format.
+</Note>
+
+### Generate (`POST /v1/videos`)
+
+Requests use **JSON body (`application/json`)**.
+
+**Request Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `model` | string | ✅ | Veo model (e.g., `veo-3.1-generate-preview`) |
+| `prompt` | string | ✅ | Text description of the video |
+| `input_reference` | string | ❌ | Input image for image-to-video |
+| `seconds` | int | ❌ | Duration → `durationSeconds` |
+| `size` | string | ❌ | Resolution → aspect ratio (`1280x720` → `16:9`, `720x1280` → `9:16`) |
+| `negative_prompt` | string | ❌ | What to avoid in the video |
+| `seed` | int | ❌ | Seed for reproducibility |
+| `audio` | bool | ❌ | Enable audio generation → `generateAudio` |
+| `video_uri` | string | ❌ | GCS video URI for video extension |
+
+**Extra Params** (any unrecognized JSON field is forwarded as `extra_params`)
+
+| Key | Notes |
+|-----|-------|
+| `resolution` | Native Gemini resolution string |
+| `sampleCount` | Number of samples to generate |
+| `personGeneration` | Person generation policy |
+| `numberOfVideos` | Number of videos to generate |
+| `storageURI` | GCS bucket for output storage |
+| `compressionQuality` | Output compression quality |
+| `enhancePrompt` | Auto-enhance the prompt |
+| `resizeMode` | How to handle size mismatches |
+| `reference_images` | Style/asset reference image objects |
+| `lastFrame` | Last frame image object for interpolation |
+
+**Response**: [`BifrostVideoGenerationResponse`](https://github.com/maximhq/bifrost/blob/main/core/schemas/videos.go) — `id`, `status`, `videos[]`
+
+If Gemini filters content for safety, `status` is `failed` and `content_filter` describes the reason.
+
+**Job Statuses**: `in_progress` → `completed` / `failed`
+
+### Retrieve / Download
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| Get status | `GET /v1/videos/{id}` | Polls the long-running operation |
+| Download | `GET /v1/videos/{id}/content` | Downloads from GCS URI or decodes base64 video |
+
+Video Delete, List, and Remix are not supported.
 
 ---
 

--- a/docs/providers/supported-providers/openai.mdx
+++ b/docs/providers/supported-providers/openai.mdx
@@ -23,6 +23,7 @@ OpenAI is the **baseline schema** for Bifrost. When using OpenAI directly, param
 | Image Variation | ✅ | - | `/v1/images/variations` |
 | Files | ✅ | - | `/v1/files` |
 | Batch | ✅ | - | `/v1/batches` |
+| Video Generation | ✅ | - | `/v1/videos` |
 | List Models | ✅ | - | `/v1/models` |
 
 ---
@@ -458,6 +459,37 @@ Operations:
 # 12. List Models
 
 GET `/v1/models` - Lists available models with metadata. Model IDs in Bifrost responses are prefixed with `openai/` (e.g., `openai/gpt-4o`). Results are aggregated from all configured API keys. No request body or parameters required.
+
+---
+
+# 13. Video Generation
+
+## Generate (`POST /v1/videos`)
+
+
+**Request Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `model` | string | ✅ | e.g., `sora-2` |
+| `prompt` | string | ✅ | Text description of the video |
+| `input_reference` | string | ❌ | Input image for image-to-video |
+| `seconds` | int | ❌ | Duration in seconds |
+| `size` | string | ❌ | Resolution: `720x1280` (default), `1280x720`, `1024x1792`, `1792x1024` |
+
+**Response**: [`BifrostVideoGenerationResponse`](https://github.com/maximhq/bifrost/blob/main/core/schemas/videos.go) — `id`, `status`, `model`, `prompt`, `created_at`
+
+**Job Statuses**: `queued` → `in_progress` → `completed` / `failed`
+
+## Retrieve / Download / Delete / List / Remix
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| Get status | `GET /v1/videos/{id}` | Poll until `status: completed` |
+| Download | `GET /v1/videos/{id}/content` | Returns raw video bytes |
+| Delete | `DELETE /v1/videos/{id}` | Removes video job |
+| List jobs | `GET /v1/videos` | Query params: `after`, `limit`, `order` |
+| Remix | `POST /v1/videos/{id}/remix` | Body: `{"prompt": "..."}` |
 
 ---
 

--- a/docs/providers/supported-providers/replicate.mdx
+++ b/docs/providers/supported-providers/replicate.mdx
@@ -24,6 +24,7 @@ Replicate is architecturally different from other providers in Bifrost. It uses 
 | Text Completions | ✅ | ✅ | `/v1/predictions` |
 | Image Generation | ✅ | ✅ | `/v1/predictions` |
 | Image Edit | ✅ | ✅ | `/v1/predictions` |
+| Video Generation | ✅ | - | `/v1/predictions` |
 | Image Variation | ❌ | ❌ | - |
 | Files | ✅ | - | `/v1/files` |
 | List Models | ✅ | - | `/v1/deployments` |
@@ -721,6 +722,43 @@ Each Replicate model has unique parameters. To find available parameters:
 </Accordion>
 
 
+
+---
+
+## Video Generation
+
+### Generate (`POST /v1/videos`)
+
+**Request Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `model` | string | ✅ | Replicate model (owner/model or version ID) |
+| `prompt` | string | ✅ | Text description of the video |
+| `input_reference` | string | ❌ | Reference image (base64 data URL or URL) → mapped to `image` field; OpenAI-hosted models use `input_reference` |
+| `seconds` | int | ❌ | Duration → `duration` |
+| `seed` | int | ❌ | Seed for reproducibility |
+| `negative_prompt` | string | ❌ | What to avoid |
+
+**Extra Params**: Pass model-specific fields directly in the JSON body (unrecognized fields become `extra_params` and are flattened into the prediction input). `webhook` and `webhook_events_filter` are extracted automatically.
+
+
+**Response**: [`BifrostVideoGenerationResponse`](https://github.com/maximhq/bifrost/blob/main/core/schemas/videos.go) — `id`, `status`, `model`, `videos[]`
+
+**Job Statuses**: `queued` (starting) → `in_progress` (processing) → `completed` / `failed`
+
+### Retrieve / Download
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| Get status | `GET /v1/videos/{id}` | Maps to `/v1/predictions/{id}` |
+| Download | `GET /v1/videos/{id}/content` | Downloads from the prediction output URL |
+
+<Note>
+Video Delete, List, and Remix are not supported by Replicate.
+</Note>
+
+---
 
 ## Reference Links
 

--- a/docs/providers/supported-providers/runway.mdx
+++ b/docs/providers/supported-providers/runway.mdx
@@ -1,0 +1,118 @@
+---
+title: "Runway ML"
+description: "Runway ML API conversion guide - text-to-video, image-to-video, and video-to-video generation"
+icon: "film"
+---
+
+## Overview
+
+Runway ML provides video generation via an asynchronous task-based API. Bifrost maps the unified video schema to Runway's task API and polls until completion.
+
+### Supported Operations
+
+| Operation | Supported | Endpoint |
+|-----------|-----------|----------|
+| Video Generation | ✅ | `/v1/text_to_video`, `/v1/image_to_video`, `/v1/video_to_video` |
+| Video Retrieve | ✅ | `/v1/tasks/{task_id}` |
+| Video Download | ✅ | via Retrieve + URL download |
+| Video Delete | ✅ | `/v1/tasks/{task_id}` (cancel) |
+| Video List | ❌ | - |
+| Video Remix | ❌ | - |
+
+---
+
+# 1. Video Generation
+
+<Note>
+Video IDs in Bifrost use `runway:{task_id}` format. Pass the full prefixed ID to all retrieve/download/delete endpoints.
+</Note>
+
+## Generate (`POST /v1/videos`)
+
+**Request Parameters**
+
+| Parameter | Type | Required | Notes |
+|-----------|------|----------|-------|
+| `model` | string | ✅ | Runway model |
+| `prompt` | string | ✅ | Text description of the video |
+| `input_reference` | string | ❌ | Input image for image-to-video |
+| `seconds` | int | ❌ | Duration in seconds (default: `2`) |
+| `size` | string | ❌ | Resolution as `WxH` (e.g., `1280x720`; default: `1280x720`) — converted to `W:H` ratio |
+| `seed` | int | ❌ | **Gen models only** |
+| `audio` | bool | ❌ | Enable audio generation. **Veo models only** |
+| `video_uri` | string | ❌ | Source video URL for video-to-video. **gen4_aleph only** |
+
+**Extra Params**
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `references` | array | Video reference objects `[{"uri": "...", "tag": "..."}]` for video-to-video |
+| `content_moderation` | object | Content moderation config |
+| `reference_images` | array | Reference image objects for style/asset guidance |
+
+**Generation Modes** (auto-detected from inputs)
+
+- **Text-to-video**: `prompt` only
+- **Image-to-video**: `prompt` + `input_reference`
+- **Video-to-video**: `prompt` + `video_uri` — **gen4_aleph only**
+
+**Response**: [`BifrostVideoGenerationResponse`](https://github.com/maximhq/bifrost/blob/main/core/schemas/videos.go) with `id`, `status`, `videos[]`
+
+**Job Statuses**: `queued` → `in_progress` → `completed` / `failed`
+
+## Retrieve / Download / Delete
+
+| Operation | Endpoint | Notes |
+|-----------|----------|-------|
+| Get status | `GET /v1/videos/{id}` | Poll until `status: completed` |
+| Download content | `GET /v1/videos/{id}/content` | Returns raw video bytes (MP4) |
+| Cancel/Delete | `DELETE /v1/videos/{id}` | Cancels the running task |
+
+---
+
+## Configuration
+
+<Tabs>
+<Tab title="Gateway">
+
+```bash
+curl --location 'http://localhost:8080/api/providers' \
+--header 'Content-Type: application/json' \
+--data '{
+    "provider": "runway",
+    "keys": [
+        {
+            "name": "runway-key-1",
+            "value": "env.RUNWAY_API_KEY",
+            "models": [],
+            "weight": 1.0
+        }
+    ]
+}'
+```
+
+See **[Provider Configuration](../../quickstart/gateway/provider-configuration)** for full setup options.
+
+</Tab>
+<Tab title="Go SDK">
+
+```go
+case schemas.Runway:
+    return []schemas.Key{{
+        Value:  os.Getenv("RUNWAY_API_KEY"),
+        Models: []string{},
+        Weight: 1.0,
+    }}, nil
+```
+
+See **[Provider Configuration](../../quickstart/go-sdk/provider-configuration)** for full setup options.
+
+</Tab>
+</Tabs>
+
+---
+
+## Reference Links
+
+- [Runway ML API Documentation](https://docs.dev.runwayml.com/)
+- [Runway ML Models](https://runwayml.com/research/)

--- a/docs/providers/supported-providers/vertex.mdx
+++ b/docs/providers/supported-providers/vertex.mdx
@@ -24,6 +24,7 @@ Vertex AI is Google's unified ML platform providing access to Google's Gemini mo
 | Embeddings | ✅ | - | `/embeddings` |
 | Image Generation | ✅ | - | `/generateContent` or `/predict` (Imagen) |
 | Image Edit | ✅ | - | `/generateContent` or `/predict` (Imagen) |
+| Video Generation | ✅ | - | `/predictLongRunning` (Veo models only) |
 | Image Variation | ❌ | - | Not supported |
 | List Models | ✅ | - | `/models` |
 | Text Completions | ❌ | ❌ | - |
@@ -682,3 +683,24 @@ See **[Provider-Specific Authentication - Google Vertex](../../quickstart/go-sdk
 
 </Tab>
 </Tabs>
+
+---
+
+## Video Generation
+
+Vertex AI routes video generation through Gemini's Veo models using the `predictLongRunning` endpoint. All parameters are identical to [Gemini Video Generation](/providers/supported-providers/gemini#video-generation).
+
+<Note>
+Only Veo models are supported (e.g., `veo-2.0-generate-001`). Passing a non-Veo model name returns a configuration error.
+</Note>
+
+**Supported Operations**
+
+| Operation | Supported | Notes |
+|-----------|-----------|-------|
+| Generate | ✅ | `POST /v1/videos` |
+| Retrieve | ✅ | `GET /v1/videos/{id}` |
+| Download | ✅ | `GET /v1/videos/{id}/content` |
+| Delete | ❌ | Not supported |
+| List | ❌ | Not supported |
+| Remix | ❌ | Not supported |


### PR DESCRIPTION
## Summary

Added video generation API endpoints to the OpenAPI specification, enabling asynchronous video creation, retrieval, and management.

## Changes

- Added a new "Videos" tag to the API documentation
- Implemented four new video-related endpoints:
  - `/v1/videos` - POST to generate videos and GET to list existing videos
  - `/v1/videos/{video_id}` - Retrieve status and metadata for a specific video
  - `/v1/videos/{video_id}/content` - Download the generated video file
  - `/v1/videos/{video_id}/remix` - Create a new video based on an existing one
- Created comprehensive schemas for video generation requests and responses
- Added support for video generation parameters including duration, resolution, and reference images

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

The changes are to the OpenAPI specification only. To validate:

```sh
# Validate OpenAPI spec
npx @apidevtools/swagger-cli validate docs/openapi/openapi.yaml

# Generate documentation from spec
npx @redocly/cli build-docs docs/openapi/openapi.yaml -o api-docs.html
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No direct security implications as this is documentation only. The actual implementation will need to handle:
- Authentication for video generation and access
- Proper validation of user inputs
- Resource limits for video generation (duration, resolution)

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I updated documentation where needed
- [x] I verified the OpenAPI specification is valid