### PR TITLE
fix: reject providers which do not support embedding requests in semantic cache plugin

### DIFF
--- a/plugins/semanticcache/changelog.md
+++ b/plugins/semanticcache/changelog.md
@@ -1,0 +1,1 @@
+- fix: invalid providers which do not support embedding requests are rejected during initialization


### PR DESCRIPTION
## Summary

Adds validation to reject providers that don't support embedding operations during semantic cache initialization, preventing runtime errors when using incompatible providers.

## Changes

- Added a map `ProvidersWithEmbeddingSupport` that explicitly lists all providers supporting embedding operations
- Added validation during plugin initialization to check if the configured provider supports embeddings
- Returns a clear error message when an incompatible provider is specified
- Added comprehensive tests to verify both valid and invalid providers are handled correctly

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache plugin tests to verify provider validation:

```sh
cd plugins/semanticcache
go test -v ./...
```

The tests specifically check that:
1. Unsupported providers (Anthropic, Cerebras, Groq, etc.) are rejected with appropriate error messages
2. Supported providers (OpenAI, Azure, etc.) are accepted

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes an issue where the semantic cache plugin would fail at runtime when configured with providers that don't support embedding operations.

## Security considerations

No security implications.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable