### PR TITLE
fix: duplicate 'not found' error on custom provider deletion --skip-pipeline

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -261,7 +261,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	logger.Info("Provider %s added successfully", payload.Provider)
-	
+
 	// Attempt model discovery
 	err := h.attemptModelDiscovery(ctx, payload.Provider, payload.CustomProviderConfig)
 
@@ -504,15 +504,6 @@ func (h *ProviderHandler) deleteProvider(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider not found: %v", err))
 		return
 	}
-
-	// Remove provider from store
-	if err := h.inMemoryStore.RemoveProvider(ctx, provider); err != nil {
-		logger.Warn("Failed to remove provider %s: %v", provider, err)
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to remove provider: %v", err))
-		return
-	}
-
-	logger.Info(fmt.Sprintf("Provider %s removed successfully", provider))
 
 	if err := h.modelsManager.RemoveProvider(ctx, provider); err != nil {
 		logger.Warn("Failed to delete models for provider %s: %v", provider, err)

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -12,3 +12,5 @@
 - chore: upgrade core to 1.4.3 and framework to 1.2.21
 - chore: fix CVE-2025-68121 by upgrading to Go 1.26.0
 - refactor: ListModelsRequest to use the common request handling pipeline instead of its own implementation
+- fix: add skip plugin pipeline flag to context for list models requests to avoid internal list models logs
+- fix: duplicate 'not found' error on custom provider deletion


### PR DESCRIPTION
## Summary

Fixed an issue with custom provider deletion that was causing duplicate 'not found' errors by reordering the deletion operations.

## Changes

- Reordered provider deletion operations in `RemoveProvider` to first remove from client, then from config store
- Improved error handling with more descriptive messages when config and client get out of sync
- Removed redundant provider removal code from the HTTP handler that was causing duplicate operations
- Updated changelog to include the fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

1. Add a custom provider through the API
2. Delete the custom provider
3. Verify that no duplicate 'not found' errors appear in the logs
4. Verify that the provider is properly removed from both the client and config store

```sh
# Core/Transports
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issue with duplicate 'not found' errors when deleting custom providers

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable