### PR TITLE
feat: improve Docker build with local module support and workspace detection --skip-pipeline

### DIFF
--- a/.github/workflows/scripts/setup-go-workspace.sh
+++ b/.github/workflows/scripts/setup-go-workspace.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 # Usage: source setup-go-workspace.sh
 
 echo "🔧 Setting up Go workspace..."
+if [ -f "go.work" ]; then
+  echo "✅ Go workspace already exists, skipping init"
+  return 0 2>/dev/null || exit 0
+fi
 go work init
 go work use ./core
 go work use ./framework

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -1,3 +1,6 @@
+# Dockerfile.local - Uses local module sources via go workspace
+# For pre-release CI builds where module versions aren't published yet
+
 # --- UI Build Stage: Build the Next.js frontend ---
 FROM node:24-alpine3.22 AS ui-builder
 WORKDIR /app
@@ -14,9 +17,9 @@ RUN npx next build
 RUN node scripts/fix-paths.js
 # Skip the copy-build step since we'll copy the files in the Go build stage
 
-# --- Go Build Stage: Compile the Go binary ---
+# --- Go Build Stage: Compile the Go binary using local modules ---
 FROM golang:1.26-alpine3.22 AS builder
-WORKDIR /app
+WORKDIR /build
 
 # Install dependencies including gcc for CGO and sqlite
 RUN apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
@@ -24,25 +27,42 @@ RUN apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
 # Set environment for CGO-enabled build (required for go-sqlite3)
 ENV CGO_ENABLED=1 GOOS=linux
 
-COPY transports/go.mod transports/go.sum ./
-RUN ls
-RUN cat go.mod
-RUN go mod download
+# Copy all local modules
+COPY core/ ./core/
+COPY framework/ ./framework/
+COPY plugins/ ./plugins/
+COPY transports/ ./transports/
 
-# Copy source code and dependencies
-COPY transports/ ./
+# Set up go workspace to resolve local module dependencies
+RUN go work init && \
+  go work use ./core && \
+  go work use ./framework && \
+  go work use ./plugins/governance && \
+  go work use ./plugins/jsonparser && \
+  go work use ./plugins/litellmcompat && \
+  go work use ./plugins/logging && \
+  go work use ./plugins/maxim && \
+  go work use ./plugins/mocker && \
+  go work use ./plugins/otel && \
+  go work use ./plugins/semanticcache && \
+  go work use ./plugins/telemetry && \
+  go work use ./transports
 
-COPY --from=ui-builder /app/out ./bifrost-http/ui
+# Download external (non-local) dependencies
+RUN cd /build/transports && go mod download
+
+# Copy UI build output into transports
+COPY --from=ui-builder /app/out ./transports/bifrost-http/ui
 
 # Build the binary with CGO enabled and static SQLite linking
-ENV GOWORK=off
 ARG VERSION=unknown
-RUN go build \
-  -ldflags="-w -s -X main.Version=v${VERSION} -extldflags '-static'" \
-  -a -trimpath \
-  -tags "sqlite_static" \
-  -o /app/main \
-  ./bifrost-http
+RUN cd /build/transports && \
+  go build \
+    -ldflags="-w -s -X main.Version=v${VERSION} -extldflags '-static'" \
+    -a -trimpath \
+    -tags "sqlite_static" \
+    -o /app/main \
+    ./bifrost-http
 
 # Verify build succeeded
 RUN test -f /app/main || (echo "Build failed" && exit 1)
@@ -59,7 +79,7 @@ RUN apk add --no-cache musl libgcc ca-certificates wget
 
 # Create data directory and set up user
 COPY --from=builder /app/main .
-COPY --from=builder /app/docker-entrypoint.sh .
+COPY --from=builder /build/transports/docker-entrypoint.sh .
 
 # Getting arguments
 ARG ARG_APP_PORT=8080


### PR DESCRIPTION
## Summary

Improve Docker build process to support local module sources for pre-release CI builds and optimize the Go workspace setup script.

## Changes

- Added LOCAL build argument to Dockerfile that enables using local module sources via Go workspaces
- Restructured Dockerfile to properly handle both local and remote build modes
- Modified Docker build process to create a Go workspace when LOCAL=1 is specified
- Updated test-docker-image.sh to use LOCAL=1 when building test images
- Enhanced setup-go-workspace.sh to skip initialization if go.work already exists

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

Test the Docker image build with both modes:

```sh
# Test with remote dependencies (normal mode)
docker build -f transports/Dockerfile -t bifrost:test .

# Test with local module sources (CI mode)
docker build --build-arg LOCAL=1 -f transports/Dockerfile -t bifrost:test-local .

# Run the test script
.github/workflows/scripts/test-docker-image.sh
```

## Breaking changes

- [x] No

## Security considerations

No security implications. This change only affects the build process.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable