### PR TITLE
fixes docker image tests

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -404,6 +404,11 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -430,6 +435,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/core/providers/cerebras/cerebras_test.go
+++ b/core/providers/cerebras/cerebras_test.go
@@ -24,7 +24,7 @@ func TestCerebras(t *testing.T) {
 
 	testConfig := llmtests.ComprehensiveTestConfig{
 		Provider:  schemas.Cerebras,
-		ChatModel: "llama-3.3-70b",
+		ChatModel: "llama3.1-8b",
 		Fallbacks: []schemas.Fallback{
 			{Provider: schemas.Cerebras, Model: "llama3.1-8b"},
 			{Provider: schemas.Cerebras, Model: "gpt-oss-120b"},


### PR DESCRIPTION
## Summary

Add Go setup steps to the release pipeline workflow to ensure the correct Go version (1.26) is available during the release process.

## Changes

- Added `actions/setup-go@v5` step to two jobs in the release pipeline workflow
- Specified Go version 1.26 for both setup steps
- Positioned the Go setup before the Node.js setup in both jobs

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)

## How to test

Verify that the GitHub Actions workflow runs successfully with the new Go setup steps:

```sh
# Core/Transports
go version  # Should show 1.26
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No security implications as this only affects the CI build environment.

## Checklist

- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable