### PR TITLE
feat: force enable governance

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -1990,7 +1990,7 @@ func migrationAddAdditionalConfigHashColumns(ctx context.Context, db *gorm.DB) e
 							EnableLogging:           cc.EnableLogging,
 							DisableContentLogging:   cc.DisableContentLogging,
 							LogRetentionDays:        cc.LogRetentionDays,
-							EnableGovernance:        cc.EnableGovernance,
+							EnableGovernance:        true,
 							EnforceGovernanceHeader: cc.EnforceGovernanceHeader,
 							AllowDirectKeys:         cc.AllowDirectKeys,
 							AllowedOrigins:          cc.AllowedOrigins,


### PR DESCRIPTION
## Summary

Enable governance by default in the client configuration to ensure all deployments have governance features activated.

## Changes

- Modified the `EnableGovernance` field to always be set to `true` in three locations:
  - In the migration function `migrationAddAdditionalConfigHashColumns`
  - In the `UpdateClientConfig` method of `RDBConfigStore`
  - In the `GetClientConfig` method of `RDBConfigStore`
- Updated the `TableClientConfig` struct to set `default:true` for the `EnableGovernance` field in the GORM tag

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)

## How to test

```sh
# Core/Transports
go version
go test ./framework/configstore/...

# Verify that governance is enabled by default in new deployments
# Verify that existing deployments have governance enabled after migration
```

## Breaking changes

- [x] No

## Security considerations

This change improves security by ensuring governance features are always enabled, providing better tracking and control over API usage.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)