### PR TITLE
feat: add asynchronous inference support

### DIFF
--- a/core/schemas/async.go
+++ b/core/schemas/async.go
@@ -1,0 +1,25 @@
+package schemas
+
+import "time"
+
+// AsyncJobStatus represents the status of an async job
+type AsyncJobStatus string
+
+const (
+	AsyncJobStatusPending    AsyncJobStatus = "pending"
+	AsyncJobStatusProcessing AsyncJobStatus = "processing"
+	AsyncJobStatusCompleted  AsyncJobStatus = "completed"
+	AsyncJobStatusFailed     AsyncJobStatus = "failed"
+)
+
+// AsyncJobResponse is the JSON response returned when creating or polling an async job
+type AsyncJobResponse struct {
+	ID          string         `json:"id"`
+	Status      AsyncJobStatus `json:"status"`
+	ExpiresAt   *time.Time     `json:"expires_at,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	CompletedAt *time.Time     `json:"completed_at,omitempty"`
+	StatusCode  int            `json:"status_code,omitempty"`
+	Result      interface{}    `json:"result,omitempty"`
+	Error       *BifrostError  `json:"error,omitempty"`
+}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -194,6 +194,7 @@ const (
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
 	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
 	BifrostContextKeySkipPluginPipeline                  BifrostContextKey = "bifrost-skip-plugin-pipeline"                     // bool - skip plugin pipeline for the request
+	BifrostIsAsyncRequest                                BifrostContextKey = "bifrost-is-async-request"                         // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
 )
 
 // RoutingEngine constants

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- feat: add tables for async job results

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -55,6 +55,7 @@ type ClientConfig struct {
 	MCPCodeModeBindingLevel string                           `json:"mcp_code_mode_binding_level"`         // Code mode binding level: "server" or "tool"
 	MCPToolSyncInterval     int                              `json:"mcp_tool_sync_interval"`              // Global tool sync interval in minutes (default: 10, 0 = disabled)
 	HeaderFilterConfig      *tables.GlobalHeaderFilterConfig `json:"header_filter_config,omitempty"`      // Global header filtering configuration for x-bf-eh-* headers
+	AsyncJobResultTTL       int                              `json:"async_job_result_ttl"`                // Default TTL for async job results in seconds (default: 3600 = 1 hour)
 	ConfigHash              string                           `json:"-"`                                   // Config hash for reconciliation (not serialized)
 }
 
@@ -134,6 +135,12 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 		hash.Write([]byte("mcpToolSyncInterval:" + strconv.Itoa(c.MCPToolSyncInterval)))
 	} else {
 		hash.Write([]byte("mcpToolSyncInterval:0"))
+	}
+
+	if c.AsyncJobResultTTL > 0 {
+		hash.Write([]byte("asyncJobResultTTL:" + strconv.Itoa(c.AsyncJobResultTTL)))
+	} else {
+		hash.Write([]byte("asyncJobResultTTL:0"))
 	}
 
 	// Hash integer fields

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -56,6 +56,7 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		MCPToolExecutionTimeout: config.MCPToolExecutionTimeout,
 		MCPCodeModeBindingLevel: config.MCPCodeModeBindingLevel,
 		MCPToolSyncInterval:     config.MCPToolSyncInterval,
+		AsyncJobResultTTL:       config.AsyncJobResultTTL,
 		HeaderFilterConfig:      config.HeaderFilterConfig,
 		ConfigHash:              config.ConfigHash,
 	}
@@ -217,6 +218,7 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		MCPToolExecutionTimeout: dbConfig.MCPToolExecutionTimeout,
 		MCPCodeModeBindingLevel: dbConfig.MCPCodeModeBindingLevel,
 		MCPToolSyncInterval:     dbConfig.MCPToolSyncInterval,
+		AsyncJobResultTTL:       dbConfig.AsyncJobResultTTL,
 		HeaderFilterConfig:      dbConfig.HeaderFilterConfig,
 		ConfigHash:              dbConfig.ConfigHash,
 	}, nil

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -28,6 +28,7 @@ type TableClientConfig struct {
 	MCPToolExecutionTimeout int    `gorm:"default:30" json:"mcp_tool_execution_timeout"`      // Timeout for individual tool execution in seconds (default: 30)
 	MCPCodeModeBindingLevel string `gorm:"default:server" json:"mcp_code_mode_binding_level"` // How tools are exposed in VFS: "server" or "tool"
 	MCPToolSyncInterval     int    `gorm:"default:10" json:"mcp_tool_sync_interval"`          // Global tool sync interval in minutes (default: 10, 0 = disabled)
+	AsyncJobResultTTL       int    `gorm:"default:3600" json:"async_job_result_ttl"`          // Default TTL for async job results in seconds (default: 3600 = 1 hour)
 
 	// LiteLLM fallback flag
 	EnableLiteLLMFallbacks bool `gorm:"column:enable_litellm_fallbacks;default:false" json:"enable_litellm_fallbacks"`

--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -1,0 +1,255 @@
+package logstore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	// DefaultAsyncJobResultTTL is the default TTL for async job results in seconds (1 hour).
+	DefaultAsyncJobResultTTL = 3600
+)
+
+const (
+	asyncJobCleanupInterval      = 1 * time.Minute
+	asyncJobCleanupTimeout       = 1 * time.Minute
+	asyncJobStaleProcessingHours = 24
+)
+
+// --- AsyncJobExecutor ---
+
+// AsyncOperation represents a function that can be executed asynchronously.
+// It returns the response and an optional BifrostError.
+type AsyncOperation func(ctx *schemas.BifrostContext) (interface{}, *schemas.BifrostError)
+
+// GovernanceStore is an interface that provides access to the governance store.
+type GovernanceStore interface {
+	GetVirtualKey(vkValue string) (*configstoreTables.TableVirtualKey, bool)
+}
+
+// AsyncJobExecutor manages async job creation and background execution.
+type AsyncJobExecutor struct {
+	logstore        LogStore
+	governanceStore GovernanceStore
+	logger          schemas.Logger
+}
+
+// NewAsyncJobExecutor creates a new AsyncJobExecutor.
+func NewAsyncJobExecutor(logstore LogStore, governanceStore GovernanceStore, logger schemas.Logger) *AsyncJobExecutor {
+	return &AsyncJobExecutor{
+		logstore:        logstore,
+		governanceStore: governanceStore,
+		logger:          logger,
+	}
+}
+
+// RetrieveJob retrieves a job by its ID.
+func (e *AsyncJobExecutor) RetrieveJob(ctx context.Context, jobID string, vkValue *string, operationType schemas.RequestType) (*AsyncJob, error) {
+	job, err := e.logstore.FindAsyncJobByID(ctx, jobID)
+	if err != nil {
+		return nil, err
+	}
+	if job.VirtualKeyID != nil {
+		if vkValue == nil {
+			return nil, fmt.Errorf("virtual key is required")
+		}
+		vk, ok := e.governanceStore.GetVirtualKey(*vkValue)
+		if !ok {
+			return nil, fmt.Errorf("virtual key not found")
+		}
+		if *job.VirtualKeyID != vk.ID {
+			return nil, fmt.Errorf("virtual key mismatch")
+		}
+	}
+	if job.RequestType != operationType {
+		return nil, fmt.Errorf("operation type mismatch")
+	}
+	return job, nil
+}
+
+// SubmitJob creates a pending job, starts background execution, and returns the job record.
+func (e *AsyncJobExecutor) SubmitJob(virtualKeyValue *string, resultTTL int, operation AsyncOperation, operationType schemas.RequestType) (*AsyncJob, error) {
+	if resultTTL <= 0 {
+		resultTTL = DefaultAsyncJobResultTTL
+	}
+
+	var virtualKeyID *string
+	if virtualKeyValue != nil {
+		vk, ok := e.governanceStore.GetVirtualKey(*virtualKeyValue)
+		if !ok {
+			return nil, fmt.Errorf("virtual key not found")
+		}
+		virtualKeyID = &vk.ID
+	}
+
+	now := time.Now().UTC()
+	job := &AsyncJob{
+		ID:           uuid.New().String(),
+		Status:       schemas.AsyncJobStatusPending,
+		RequestType:  operationType,
+		VirtualKeyID: virtualKeyID,
+		ResultTTL:    resultTTL,
+		CreatedAt:    now,
+	}
+
+	ctx := context.Background()
+	if err := e.logstore.CreateAsyncJob(ctx, job); err != nil {
+		return nil, fmt.Errorf("failed to create async job: %w", err)
+	}
+
+	go e.executeJob(job.ID, job.ResultTTL, operation)
+
+	return job, nil
+}
+
+// executeJob runs the operation in the background and updates the job record.
+func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation AsyncOperation) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	// Mark as processing
+	if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]interface{}{
+		"status": schemas.AsyncJobStatusProcessing,
+	}); err != nil {
+		e.logger.Warn("failed to update async job: %v", err)
+	}
+
+	ctx.SetValue(schemas.BifrostIsAsyncRequest, true)
+
+	// Execute the operation
+	resp, bifrostErr := operation(ctx)
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Duration(resultTTL) * time.Second)
+
+	if bifrostErr != nil {
+		errJSON, err := sonic.Marshal(bifrostErr)
+		if err != nil {
+			e.logger.Warn("failed to marshal bifrost error: %v", err)
+			return
+		}
+		statusCode := fasthttp.StatusInternalServerError
+		if bifrostErr.StatusCode != nil {
+			statusCode = *bifrostErr.StatusCode
+		}
+		if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]interface{}{
+			"status":       schemas.AsyncJobStatusFailed,
+			"status_code":  statusCode,
+			"error":        string(errJSON),
+			"completed_at": now,
+			"expires_at":   expiresAt,
+		}); err != nil {
+			e.logger.Warn("failed to update async job: %v", err)
+		}
+		return
+	}
+
+	respJSON, err := sonic.Marshal(resp)
+	if err != nil {
+		e.logger.Warn("failed to marshal result: %v", err)
+		return
+	}
+	if err := e.logstore.UpdateAsyncJob(ctx, jobID, map[string]interface{}{
+		"status":       schemas.AsyncJobStatusCompleted,
+		"status_code":  fasthttp.StatusOK,
+		"response":     string(respJSON),
+		"completed_at": now,
+		"expires_at":   expiresAt,
+	}); err != nil {
+		e.logger.Warn("failed to update async job: %v", err)
+	}
+}
+
+// --- Cleaner ---
+
+// AsyncJobCleaner manages the cleanup of expired async jobs.
+type AsyncJobCleaner struct {
+	store       LogStore
+	logger      schemas.Logger
+	stopCleanup chan struct{}
+	mu          sync.Mutex
+}
+
+// NewAsyncJobCleaner creates a new AsyncJobCleaner instance.
+func NewAsyncJobCleaner(store LogStore, logger schemas.Logger) *AsyncJobCleaner {
+	return &AsyncJobCleaner{
+		store:  store,
+		logger: logger,
+	}
+}
+
+// StartCleanupRoutine starts a goroutine that periodically cleans up expired async jobs.
+func (c *AsyncJobCleaner) StartCleanupRoutine() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stopCleanup != nil {
+		return
+	}
+
+	c.stopCleanup = make(chan struct{})
+	stopCh := c.stopCleanup
+
+	go func() {
+		// Run initial cleanup
+		ctx, cancel := context.WithTimeout(context.Background(), asyncJobCleanupTimeout)
+		c.cleanupExpiredJobs(ctx)
+		cancel()
+
+		ticker := time.NewTicker(asyncJobCleanupInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				ctx, cancel := context.WithTimeout(context.Background(), asyncJobCleanupTimeout)
+				c.cleanupExpiredJobs(ctx)
+				cancel()
+			case <-stopCh:
+				c.logger.Debug("async job cleanup routine stopped")
+				return
+			}
+		}
+	}()
+	c.logger.Debug("async job cleanup routine started (interval: %s)", asyncJobCleanupInterval)
+}
+
+// StopCleanupRoutine gracefully stops the cleanup goroutine.
+func (c *AsyncJobCleaner) StopCleanupRoutine() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stopCleanup == nil {
+		c.logger.Debug("async job cleanup routine already stopped")
+		return
+	}
+
+	close(c.stopCleanup)
+	c.stopCleanup = nil
+}
+
+// cleanupExpiredJobs deletes expired async jobs and stale processing jobs.
+func (c *AsyncJobCleaner) cleanupExpiredJobs(ctx context.Context) {
+	deleted, err := c.store.DeleteExpiredAsyncJobs(ctx)
+	if err != nil {
+		c.logger.Warn("failed to delete expired async jobs: %v", err)
+	} else if deleted > 0 {
+		c.logger.Debug("async job cleanup completed: deleted %d expired jobs", deleted)
+	}
+
+	// Clean up jobs stuck in "processing" for more than 24 hours
+	// This handles edge cases like marshal failures or server crashes
+	staleSince := time.Now().UTC().Add(-asyncJobStaleProcessingHours * time.Hour)
+	staleDeleted, err := c.store.DeleteStaleAsyncJobs(ctx, staleSince)
+	if err != nil {
+		c.logger.Warn("failed to delete stale processing async jobs: %v", err)
+	} else if staleDeleted > 0 {
+		c.logger.Warn("async job cleanup: deleted %d stale processing jobs (stuck > %dh)", staleDeleted, asyncJobStaleProcessingHours)
+	}
+}

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -52,6 +52,13 @@ type LogStore interface {
 	GetAvailableToolNames(ctx context.Context) ([]string, error)
 	GetAvailableServerLabels(ctx context.Context) ([]string, error)
 	GetAvailableMCPVirtualKeys(ctx context.Context) ([]MCPToolLog, error)
+
+	// Async Job methods
+	CreateAsyncJob(ctx context.Context, job *AsyncJob) error
+	FindAsyncJobByID(ctx context.Context, id string) (*AsyncJob, error)
+	UpdateAsyncJob(ctx context.Context, id string, updates map[string]interface{}) error
+	DeleteExpiredAsyncJobs(ctx context.Context) (int64, error)
+	DeleteStaleAsyncJobs(ctx context.Context, staleSince time.Time) (int64, error)
 }
 
 // NewLogStore creates a new log store based on the configuration.

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+- feat: add metadata column to logging table for async request tracking

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -41,6 +41,7 @@ func (p *LoggerPlugin) insertInitialLogEntry(
 		TranscriptionInputParsed:    data.TranscriptionInput,
 		ImageGenerationInputParsed:  data.ImageGenerationInput,
 		RoutingEnginesUsed:          routingEnginesUsed,
+		MetadataParsed:              data.Metadata,
 	}
 	if parentRequestID != "" {
 		entry.ParentRequestID = &parentRequestID

--- a/transports/bifrost-http/handlers/asyncinference.go
+++ b/transports/bifrost-http/handlers/asyncinference.go
@@ -1,0 +1,494 @@
+package handlers
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/fasthttp/router"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/plugins/governance"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// --- HTTP Handler ---
+
+// AsyncHandler handles async job HTTP endpoints.
+type AsyncHandler struct {
+	client       *bifrost.Bifrost
+	executor     *logstore.AsyncJobExecutor
+	handlerStore lib.HandlerStore
+	config       *lib.Config
+}
+
+// AsyncPathToTypeMapping maps exact paths to request types (only for non-parameterized paths)
+// Parameterized paths are set per-route in RegisterRoutes
+var AsyncPathToTypeMapping = map[string]schemas.RequestType{
+	"/v1/async/completions":          schemas.TextCompletionRequest,
+	"/v1/async/chat/completions":     schemas.ChatCompletionRequest,
+	"/v1/async/responses":            schemas.ResponsesRequest,
+	"/v1/async/embeddings":           schemas.EmbeddingRequest,
+	"/v1/async/audio/speech":         schemas.SpeechRequest,
+	"/v1/async/audio/transcriptions": schemas.TranscriptionRequest,
+	"/v1/async/images/generations":   schemas.ImageGenerationRequest,
+	"/v1/async/images/edits":         schemas.ImageEditRequest,
+	"/v1/async/images/variations":    schemas.ImageVariationRequest,
+}
+
+// RegisterAsyncRequestTypeMiddleware handles exact path matching for non-parameterized routes
+func RegisterAsyncRequestTypeMiddleware(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		path := string(ctx.Path())
+		if requestType, ok := AsyncPathToTypeMapping[path]; ok {
+			ctx.SetUserValue(schemas.BifrostContextKeyHTTPRequestType, requestType)
+		}
+		next(ctx)
+	}
+}
+
+// NewAsyncHandler creates a new AsyncHandler.
+func NewAsyncHandler(client *bifrost.Bifrost, config *lib.Config) (*AsyncHandler, error) {
+	if config.LogsStore == nil {
+		return nil, fmt.Errorf("logs store not found")
+	}
+	governancePlugin, err := lib.FindPluginAs[governance.BaseGovernancePlugin](config, governance.PluginName)
+	if err != nil {
+		return nil, fmt.Errorf("governance plugin not found: %v", err)
+	}
+	executor := logstore.NewAsyncJobExecutor(config.LogsStore, governancePlugin.GetGovernanceStore(), logger)
+	return &AsyncHandler{
+		client:       client,
+		executor:     executor,
+		handlerStore: config,
+		config:       config,
+	}, nil
+}
+
+// RegisterRoutes registers async job endpoints.
+func (h *AsyncHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	if h.executor == nil {
+		return // LogStore not configured, skip async routes
+	}
+
+	baseMiddlewares := append([]schemas.BifrostHTTPMiddleware{RegisterAsyncRequestTypeMiddleware}, middlewares...)
+
+	// Async submission endpoints (non-parameterized, request type set via AsyncPathToTypeMapping)
+	r.POST("/v1/async/completions", lib.ChainMiddlewares(h.asyncTextCompletion, baseMiddlewares...))
+	r.POST("/v1/async/chat/completions", lib.ChainMiddlewares(h.asyncChatCompletion, baseMiddlewares...))
+	r.POST("/v1/async/responses", lib.ChainMiddlewares(h.asyncResponses, baseMiddlewares...))
+	r.POST("/v1/async/embeddings", lib.ChainMiddlewares(h.asyncEmbeddings, baseMiddlewares...))
+	r.POST("/v1/async/audio/speech", lib.ChainMiddlewares(h.asyncSpeech, baseMiddlewares...))
+	r.POST("/v1/async/audio/transcriptions", lib.ChainMiddlewares(h.asyncTranscription, baseMiddlewares...))
+	r.POST("/v1/async/images/generations", lib.ChainMiddlewares(h.asyncImageGeneration, baseMiddlewares...))
+	r.POST("/v1/async/images/edits", lib.ChainMiddlewares(h.asyncImageEdit, baseMiddlewares...))
+	r.POST("/v1/async/images/variations", lib.ChainMiddlewares(h.asyncImageVariation, baseMiddlewares...))
+
+	// Async job retrieval endpoints
+	r.GET("/v1/async/completions/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.TextCompletionRequest), middlewares...))
+	r.GET("/v1/async/chat/completions/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.ChatCompletionRequest), middlewares...))
+	r.GET("/v1/async/responses/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.ResponsesRequest), middlewares...))
+	r.GET("/v1/async/embeddings/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.EmbeddingRequest), middlewares...))
+	r.GET("/v1/async/audio/speech/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.SpeechRequest), middlewares...))
+	r.GET("/v1/async/audio/transcriptions/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.TranscriptionRequest), middlewares...))
+	r.GET("/v1/async/images/generations/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.ImageGenerationRequest), middlewares...))
+	r.GET("/v1/async/images/edits/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.ImageEditRequest), middlewares...))
+	r.GET("/v1/async/images/variations/{job_id}", lib.ChainMiddlewares(h.getJob(schemas.ImageVariationRequest), middlewares...))
+}
+
+// --- Async submission handlers ---
+
+// asyncTextCompletion handles POST /v1/async/completions
+func (h *AsyncHandler) asyncTextCompletion(ctx *fasthttp.RequestCtx) {
+	req, bifrostTextReq, err := prepareTextCompletionRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Stream != nil && *req.Stream {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async text completions")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.TextCompletionRequest(bgCtx, bifrostTextReq)
+		},
+		schemas.TextCompletionRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncChatCompletion handles POST /v1/async/chat/completions
+func (h *AsyncHandler) asyncChatCompletion(ctx *fasthttp.RequestCtx) {
+	req, bifrostChatReq, err := prepareChatCompletionRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Stream != nil && *req.Stream {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async chat completions")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.ChatCompletionRequest(bgCtx, bifrostChatReq)
+		},
+		schemas.ChatCompletionRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncResponses handles POST /v1/async/responses
+func (h *AsyncHandler) asyncResponses(ctx *fasthttp.RequestCtx) {
+	req, bifrostResponsesReq, err := prepareResponsesRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Stream != nil && *req.Stream {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async responses")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.ResponsesRequest(bgCtx, bifrostResponsesReq)
+		},
+		schemas.ResponsesRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create async job: %v", err))
+		return
+	}
+
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncEmbeddings handles POST /v1/async/embeddings
+func (h *AsyncHandler) asyncEmbeddings(ctx *fasthttp.RequestCtx) {
+	_, bifrostEmbeddingReq, err := prepareEmbeddingRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.EmbeddingRequest(bgCtx, bifrostEmbeddingReq)
+		},
+		schemas.EmbeddingRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncSpeech handles POST /v1/async/audio/speech
+func (h *AsyncHandler) asyncSpeech(ctx *fasthttp.RequestCtx) {
+	req, bifrostSpeechReq, err := prepareSpeechRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.StreamFormat != nil && *req.StreamFormat == "sse" {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async speech")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.SpeechRequest(bgCtx, bifrostSpeechReq)
+		},
+		schemas.SpeechRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncTranscription handles POST /v1/async/audio/transcriptions
+func (h *AsyncHandler) asyncTranscription(ctx *fasthttp.RequestCtx) {
+	bifrostTranscriptionReq, stream, err := prepareTranscriptionRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if stream {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async transcriptions")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.TranscriptionRequest(bgCtx, bifrostTranscriptionReq)
+		},
+		schemas.TranscriptionRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncImageGeneration handles POST /v1/async/images/generations
+func (h *AsyncHandler) asyncImageGeneration(ctx *fasthttp.RequestCtx) {
+	req, bifrostReq, err := prepareImageGenerationRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.BifrostParams.Stream != nil && *req.BifrostParams.Stream {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async image generations")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.ImageGenerationRequest(bgCtx, bifrostReq)
+		},
+		schemas.ImageGenerationRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncImageEdit handles POST /v1/async/images/edits
+func (h *AsyncHandler) asyncImageEdit(ctx *fasthttp.RequestCtx) {
+	req, bifrostReq, err := prepareImageEditRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	if req.Stream != nil && *req.Stream {
+		SendError(ctx, fasthttp.StatusBadRequest, "stream is not supported for async image edits")
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.ImageEditRequest(bgCtx, bifrostReq)
+		},
+		schemas.ImageEditRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// asyncImageVariation handles POST /v1/async/images/variations
+func (h *AsyncHandler) asyncImageVariation(ctx *fasthttp.RequestCtx) {
+	bifrostReq, err := prepareImageVariationRequest(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+	if bifrostCtx == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+		return
+	}
+	defer cancel()
+
+	virtualKeyValue := getVirtualKeyFromContext(bifrostCtx)
+	resultTTL := getResultTTLFromHeaderWithDefault(ctx, h.config.ClientConfig.AsyncJobResultTTL)
+
+	job, err := h.executor.SubmitJob(
+		virtualKeyValue,
+		resultTTL,
+		func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
+			return h.client.ImageVariationRequest(bgCtx, bifrostReq)
+		},
+		schemas.ImageVariationRequest,
+	)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSONWithStatus(ctx, job.ToResponse(), fasthttp.StatusAccepted)
+}
+
+// --- Job retrieval handler ---
+
+// getJob handles GET /v1/async/{type}/{job_id}
+func (h *AsyncHandler) getJob(operationType schemas.RequestType) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		jobID, ok := ctx.UserValue("job_id").(string)
+		if !ok || jobID == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "job_id is required")
+			return
+		}
+
+		// Get the requesting user's VK for auth check
+		bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderFilterConfig())
+		if bifrostCtx == nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
+			return
+		}
+		defer cancel()
+
+		job, err := h.executor.RetrieveJob(bifrostCtx, jobID, getVirtualKeyFromContext(bifrostCtx), operationType)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusNotFound, "Job not found or expired")
+			return
+		}
+
+		resp := job.ToResponse()
+
+		// Return 202 for pending/processing, 200 for completed/failed
+		switch job.Status {
+		case schemas.AsyncJobStatusPending, schemas.AsyncJobStatusProcessing:
+			SendJSONWithStatus(ctx, resp, fasthttp.StatusAccepted)
+		default:
+			SendJSON(ctx, resp)
+		}
+	}
+}
+
+// --- Helper functions ---
+
+// getVirtualKeyFromContext extracts the virtual key value from context.
+// Returns nil if no VK is present (e.g., direct key mode or no governance).
+func getVirtualKeyFromContext(ctx *schemas.BifrostContext) *string {
+	vkValue := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyVirtualKey)
+	if vkValue == "" {
+		return nil
+	}
+	return &vkValue
+}
+
+func getResultTTLFromHeaderWithDefault(ctx *fasthttp.RequestCtx, defaultTTL int) int {
+	resultTTL := string(ctx.Request.Header.Peek("x-bf-async-job-result-ttl"))
+	if resultTTL == "" {
+		return defaultTTL
+	}
+	resultTTLInt, err := strconv.Atoi(resultTTL)
+	if err != nil || resultTTLInt < 0 {
+		return defaultTTL
+	}
+	return resultTTLInt
+}

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -382,6 +382,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		updatedConfig.MCPCodeModeBindingLevel = payload.ClientConfig.MCPCodeModeBindingLevel
 	}
 
+	// Only update AsyncJobResultTTL if explicitly provided (> 0) to avoid clearing stored value
+	if payload.ClientConfig.AsyncJobResultTTL > 0 {
+		updatedConfig.AsyncJobResultTTL = payload.ClientConfig.AsyncJobResultTTL
+	}
+
 	// Handle HeaderFilterConfig changes
 	if !headerFilterConfigEqual(payload.ClientConfig.HeaderFilterConfig, currentConfig.HeaderFilterConfig) {
 		// Validate that no security headers are in the allowlist or denylist

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- feat: add asynchronous inference support

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -114,6 +114,12 @@
             }
           },
           "additionalProperties": false
+        },
+        "async_job_result_ttl": {
+          "type": "integer",
+          "description": "Default TTL for async job results in seconds (default: 3600 = 1 hour)",
+          "default": 3600,
+          "minimum": 1
         }
       },
       "additionalProperties": false

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -77,6 +77,7 @@ export default function ClientSettingsView() {
 			localConfig.drop_excess_requests !== config.drop_excess_requests ||
 			localConfig.enable_litellm_fallbacks !== config.enable_litellm_fallbacks ||
 			localConfig.disable_db_pings_in_health !== config.disable_db_pings_in_health ||
+			localConfig.async_job_result_ttl !== config.async_job_result_ttl ||
 			!headerFilterConfigEqual(localConfig.header_filter_config, config.header_filter_config)
 		);
 	}, [config, localConfig]);
@@ -281,6 +282,27 @@ export default function ClientSettingsView() {
 						checked={localConfig.disable_db_pings_in_health}
 						onCheckedChange={(checked) => handleConfigChange("disable_db_pings_in_health", checked)}
 						disabled={!hasSettingsUpdateAccess}
+					/>
+				</div>
+				{/* Async Job Result TTL */}
+				<div className="flex items-center justify-between space-x-2">
+					<div className="space-y-0.5">
+						<label htmlFor="async-job-result-ttl" className="text-sm font-medium">
+							Async Job Result TTL (seconds)
+						</label>
+						<p className="text-muted-foreground text-sm">
+							Default time-to-live for async job results in seconds. Results are automatically cleaned up after expiry.
+						</p>
+					</div>
+					<Input
+						id="async-job-result-ttl"
+						type="number"
+						min={1}
+						className="w-32"
+						value={localConfig.async_job_result_ttl}
+						onChange={(e) => handleConfigChange("async_job_result_ttl", parseInt(e.target.value) || 0)}
+						disabled={!hasSettingsUpdateAccess}
+						data-testid="client-settings-async-job-result-ttl-input"
 					/>
 				</div>
 			</div>

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -99,6 +99,11 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							<Badge variant="outline" className={`${StatusColors[log.status as Status]} uppercase`}>
 								{log.status}
 							</Badge>
+							{log.metadata?.isAsyncRequest && (
+								<Badge variant="outline" className="bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200 uppercase">
+									Async
+								</Badge>
+							)}
 						</SheetTitle>
 					</div>
 					<AlertDialog>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -401,6 +401,7 @@ export interface CoreConfig {
 	mcp_tool_execution_timeout: number;
 	mcp_code_mode_binding_level?: string;
 	mcp_tool_sync_interval: number;
+	async_job_result_ttl: number;
 	header_filter_config?: GlobalHeaderFilterConfig;
 }
 
@@ -422,6 +423,7 @@ export const DefaultCoreConfig: CoreConfig = {
 	mcp_tool_execution_timeout: 30,
 	mcp_code_mode_binding_level: "server",
 	mcp_tool_sync_interval: 10,
+	async_job_result_ttl: 3600,
 	allowed_headers: [],
 };
 

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -387,6 +387,7 @@ export interface LogEntry {
 	created_at: string; // ISO string format from Go time.Time - when the log was first created
 	raw_request?: string; // Raw provider request
 	raw_response?: string; // Raw provider response
+	metadata?: Record<string, unknown>; // JSON metadata (e.g., isAsyncRequest)
 }
 
 export interface LogFilters {


### PR DESCRIPTION
## Summary

Add support for asynchronous API requests through a new `/v1/async/` endpoint family, allowing long-running operations to be executed in the background while clients poll for results.

## Changes

- Added new async job schema and database models to track job status and results
- Implemented AsyncJobExecutor to manage job creation, execution, and retrieval
- Created AsyncJobCleaner to automatically clean up expired job results
- Added new HTTP endpoints for submitting and retrieving async jobs
- Added configuration option for async job result TTL (default: 1 hour)
- Added UI support for configuring async job TTL
- Added metadata field to logs for tracking async operations

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Start Bifrost with the HTTP transport
2. Submit an async request to any of the new endpoints:
   ```sh
   curl -X POST http://localhost:8000/v1/async/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer YOUR_KEY" \
     -d '{
       "model": "provider/model",
       "messages": [{"role": "user", "content": "Hello"}]
     }'
   ```
3. Retrieve the job using the returned job ID:
   ```sh
   curl -X GET http://localhost:8000/v1/async/chat/completions/JOB_ID \
     -H "Authorization: Bearer YOUR_KEY"
   ```
4. Verify job TTL configuration in the UI under Client Settings

## Breaking changes

- [x] No
- [ ] Yes

## Related issues

N/A

## Security considerations

- Async jobs are associated with the virtual key that created them for proper access control
- Jobs automatically expire after the configured TTL to prevent data leakage
- Background processing uses the same authorization context as the original request

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable