### PR TITLE
feat: add async job support for integration routes

### DIFF
--- a/core/schemas/async.go
+++ b/core/schemas/async.go
@@ -12,6 +12,15 @@ const (
 	AsyncJobStatusFailed     AsyncJobStatus = "failed"
 )
 
+const (
+	// AsyncHeaderResultTTL is the header containing the result TTL for async job retrieval.
+	AsyncHeaderResultTTL = "x-bf-async-job-result-ttl"
+	// AsyncHeaderCreate is the header that triggers async job creation on integration routes.
+	AsyncHeaderCreate = "x-bf-async"
+	// AsyncHeaderGetID is the header containing the job ID for async job retrieval on integration routes.
+	AsyncHeaderGetID = "x-bf-async-id"
+)
+
 // AsyncJobResponse is the JSON response returned when creating or polling an async job
 type AsyncJobResponse struct {
 	ID          string         `json:"id"`

--- a/docs/integrations/anthropic-sdk/overview.mdx
+++ b/docs/integrations/anthropic-sdk/overview.mdx
@@ -322,6 +322,111 @@ const openaiResponseWithHeader = await anthropic.messages.create({
 
 ---
 
+## Async Inference
+
+Submit inference requests asynchronously and poll for results later using the `x-bf-async` header. This is useful for long-running requests where you don't want to hold a connection open. See [Async Inference](../../features/async-inference) for full details.
+
+<Note>
+Async inference requires a [Logs Store](../../features/observability/default) to be configured and is not compatible with streaming.
+</Note>
+
+### Messages
+
+<Tabs group="anthropic-sdk">
+<Tab title="Python">
+
+```python
+import anthropic
+import time
+
+client = anthropic.Anthropic(
+    base_url="http://localhost:8080/anthropic",
+    api_key="dummy-key"
+)
+
+# Submit async request
+initial = client.messages.create(
+    model="anthropic/claude-sonnet-4-20250514",
+    max_tokens=256,
+    messages=[{"role": "user", "content": "Tell me a short story."}],
+    extra_headers={"x-bf-async": "true"}
+)
+
+# If content is present, the request completed synchronously
+if initial.content:
+    print(initial.content[0].text)
+else:
+    # Poll until completed
+    while True:
+        time.sleep(2)
+        poll = client.messages.create(
+            model="anthropic/claude-sonnet-4-20250514",
+            max_tokens=256,
+            messages=[{"role": "user", "content": "Tell me a short story."}],
+            extra_headers={"x-bf-async-id": initial.id}
+        )
+        if poll.content:
+            print(poll.content[0].text)
+            break
+```
+
+</Tab>
+<Tab title="JavaScript">
+
+```javascript
+import Anthropic from "@anthropic-ai/sdk";
+
+const anthropic = new Anthropic({
+  baseURL: "http://localhost:8080/anthropic",
+  apiKey: "dummy-key",
+});
+
+// Submit async request
+const initial = await anthropic.messages.create(
+  {
+    model: "anthropic/claude-sonnet-4-20250514",
+    max_tokens: 256,
+    messages: [{ role: "user", content: "Tell me a short story." }],
+  },
+  { headers: { "x-bf-async": "true" } }
+);
+
+// If content is present, the request completed synchronously
+if (initial.content?.length > 0) {
+  console.log(initial.content[0].text);
+} else {
+  // Poll until completed
+  while (true) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const poll = await anthropic.messages.create(
+      {
+        model: "anthropic/claude-sonnet-4-20250514",
+        max_tokens: 256,
+        messages: [{ role: "user", content: "Tell me a short story." }],
+      },
+      { headers: { "x-bf-async-id": initial.id } }
+    );
+    if (poll.content?.length > 0) {
+      console.log(poll.content[0].text);
+      break;
+    }
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+### Async Headers
+
+| Header | Description |
+|---|---|
+| `x-bf-async: true` | Submit the request as an async job. Returns immediately with a job ID. |
+| `x-bf-async-id: <job-id>` | Poll for results of a previously submitted async job. |
+| `x-bf-async-job-result-ttl: <seconds>` | Override the default result TTL (default: 3600s). |
+
+---
+
 ## Supported Features
 
 The Anthropic integration supports all features that are available in both the Anthropic SDK and Bifrost core functionality. If the Anthropic SDK supports a feature and Bifrost supports it, the integration will work seamlessly.

--- a/docs/integrations/openai-sdk/overview.mdx
+++ b/docs/integrations/openai-sdk/overview.mdx
@@ -369,6 +369,184 @@ console.log(azureResponse.choices[0].message.content);
 
 ---
 
+## Async Inference
+
+Submit inference requests asynchronously and poll for results later using the `x-bf-async` header. This is useful for long-running requests where you don't want to hold a connection open. See [Async Inference](../../features/async-inference) for full details.
+
+<Note>
+Async inference requires a [Logs Store](../../features/observability/default) to be configured and is not compatible with streaming.
+</Note>
+
+### Chat Completions
+
+<Tabs group="openai-sdk">
+<Tab title="Python">
+
+```python
+import openai
+import time
+
+client = openai.OpenAI(
+    base_url="http://localhost:8080/openai",
+    api_key="dummy-key"
+)
+
+# Submit async request
+initial = client.chat.completions.create(
+    model="openai/gpt-4o-mini",
+    messages=[{"role": "user", "content": "Tell me a short story."}],
+    extra_headers={"x-bf-async": "true"}
+)
+
+# If choices are present, the request completed synchronously
+if initial.choices:
+    print(initial.choices[0].message.content)
+else:
+    # Poll until completed
+    while True:
+        time.sleep(2)
+        poll = client.chat.completions.create(
+            model="openai/gpt-4o-mini",
+            messages=[{"role": "user", "content": "Tell me a short story."}],
+            extra_headers={"x-bf-async-id": initial.id}
+        )
+        if poll.choices:
+            print(poll.choices[0].message.content)
+            break
+```
+
+</Tab>
+<Tab title="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  baseURL: "http://localhost:8080/openai",
+  apiKey: "dummy-key",
+});
+
+// Submit async request
+const initial = await openai.chat.completions.create(
+  {
+    model: "openai/gpt-4o-mini",
+    messages: [{ role: "user", content: "Tell me a short story." }],
+  },
+  { headers: { "x-bf-async": "true" } }
+);
+
+// If choices are present, the request completed synchronously
+if (initial.choices?.length > 0) {
+  console.log(initial.choices[0].message.content);
+} else {
+  // Poll until completed
+  while (true) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const poll = await openai.chat.completions.create(
+      {
+        model: "openai/gpt-4o-mini",
+        messages: [{ role: "user", content: "Tell me a short story." }],
+      },
+      { headers: { "x-bf-async-id": initial.id } }
+    );
+    if (poll.choices?.length > 0) {
+      console.log(poll.choices[0].message.content);
+      break;
+    }
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+### Responses API
+
+<Tabs group="openai-sdk">
+<Tab title="Python">
+
+```python
+import openai
+import time
+
+client = openai.OpenAI(
+    base_url="http://localhost:8080/openai",
+    api_key="dummy-key"
+)
+
+# Submit async request
+initial = client.responses.create(
+    model="openai/gpt-4o-mini",
+    input="Tell me a short story.",
+    extra_headers={"x-bf-async": "true"}
+)
+
+# If status is "completed", the request completed synchronously
+if initial.status == "completed":
+    print(initial.output_text)
+else:
+    # Poll until completed
+    while True:
+        time.sleep(2)
+        poll = client.responses.create(
+            model="openai/gpt-4o-mini",
+            input="Tell me a short story.",
+            extra_headers={"x-bf-async-id": initial.id}
+        )
+        if poll.status == "completed":
+            print(poll.output_text)
+            break
+```
+
+</Tab>
+<Tab title="JavaScript">
+
+```javascript
+import OpenAI from "openai";
+
+const openai = new OpenAI({
+  baseURL: "http://localhost:8080/openai",
+  apiKey: "dummy-key",
+});
+
+// Submit async request
+const initial = await openai.responses.create(
+  { model: "openai/gpt-4o-mini", input: "Tell me a short story." },
+  { headers: { "x-bf-async": "true" } }
+);
+
+// If status is "completed", the request completed synchronously
+if (initial.status === "completed") {
+  console.log(initial.output_text);
+} else {
+  // Poll until completed
+  while (true) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const poll = await openai.responses.create(
+      { model: "openai/gpt-4o-mini", input: "Tell me a short story." },
+      { headers: { "x-bf-async-id": initial.id } }
+    );
+    if (poll.status === "completed") {
+      console.log(poll.output_text);
+      break;
+    }
+  }
+}
+```
+
+</Tab>
+</Tabs>
+
+### Async Headers
+
+| Header | Description |
+|---|---|
+| `x-bf-async: true` | Submit the request as an async job. Returns immediately with a job ID. |
+| `x-bf-async-id: <job-id>` | Poll for results of a previously submitted async job. |
+| `x-bf-async-job-result-ttl: <seconds>` | Override the default result TTL (default: 3600s). |
+
+---
+
 ## Supported Features
 
 The OpenAI integration supports all features that are available in both the OpenAI SDK and Bifrost core functionality. If the OpenAI SDK supports a feature and Bifrost supports it, the integration will work seamlessly.

--- a/docs/openapi/paths/integrations/anthropic/messages.yaml
+++ b/docs/openapi/paths/integrations/anthropic/messages.yaml
@@ -7,8 +7,31 @@ messages:
     description: |
       Creates a message using Anthropic Messages API format.
       Supports streaming via SSE.
+
+      **Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response will have an empty `content` array. When completed, `content` will contain the full result. See [Async Inference](/features/async-inference) for details.
     tags:
       - Anthropic Integration
+    parameters:
+      - name: x-bf-async
+        in: header
+        required: false
+        schema:
+          type: string
+          enum: ["true"]
+        description: Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming.
+      - name: x-bf-async-id
+        in: header
+        required: false
+        schema:
+          type: string
+        description: Poll for results of a previously submitted async job by providing the job ID returned from the initial async request.
+      - name: x-bf-async-job-result-ttl
+        in: header
+        required: false
+        schema:
+          type: integer
+          default: 3600
+        description: Override the default result TTL in seconds. Results expire after this duration from completion time.
     requestBody:
       required: true
       content:

--- a/docs/openapi/paths/integrations/openai/chat.yaml
+++ b/docs/openapi/paths/integrations/openai/chat.yaml
@@ -8,9 +8,32 @@ chat-completions:
       Creates a chat completion using OpenAI-compatible format.
       Supports streaming via SSE.
 
+      **Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response will have an empty `choices` array. When completed, `choices` will contain the full result. See [Async Inference](/features/async-inference) for details.
+
       **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/chat/completions`).
     tags:
       - OpenAI Integration
+    parameters:
+      - name: x-bf-async
+        in: header
+        required: false
+        schema:
+          type: string
+          enum: ["true"]
+        description: Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming.
+      - name: x-bf-async-id
+        in: header
+        required: false
+        schema:
+          type: string
+        description: Poll for results of a previously submitted async job by providing the job ID returned from the initial async request.
+      - name: x-bf-async-job-result-ttl
+        in: header
+        required: false
+        schema:
+          type: integer
+          default: 3600
+        description: Override the default result TTL in seconds. Results expire after this duration from completion time.
     requestBody:
       required: true
       content:

--- a/docs/openapi/paths/integrations/openai/responses.yaml
+++ b/docs/openapi/paths/integrations/openai/responses.yaml
@@ -8,9 +8,32 @@ responses:
       Creates a response using OpenAI Responses API format.
       Supports streaming via SSE.
 
+      **Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response `status` will not be `completed`. When completed, the full response with `output_text` will be returned. See [Async Inference](/features/async-inference) for details.
+
       **Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses`).
     tags:
       - OpenAI Integration
+    parameters:
+      - name: x-bf-async
+        in: header
+        required: false
+        schema:
+          type: string
+          enum: ["true"]
+        description: Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming.
+      - name: x-bf-async-id
+        in: header
+        required: false
+        schema:
+          type: string
+        description: Poll for results of a previously submitted async job by providing the job ID returned from the initial async request.
+      - name: x-bf-async-job-result-ttl
+        in: header
+        required: false
+        schema:
+          type: integer
+          default: 3600
+        description: Override the default result TTL in seconds. Results expire after this duration from completion time.
     requestBody:
       required: true
       content:

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -148,7 +148,7 @@ type Log struct {
 	ImageGenerationOutputParsed *schemas.BifrostImageGenerationResponse `gorm:"-" json:"image_generation_output,omitempty"`
 	CacheDebugParsed            *schemas.BifrostCacheDebug              `gorm:"-" json:"cache_debug,omitempty"`
 	ListModelsOutputParsed      []schemas.Model                         `gorm:"-" json:"list_models_output,omitempty"`
-	MetadataParsed              map[string]interface{}                   `gorm:"-" json:"metadata,omitempty"`
+	MetadataParsed              map[string]interface{}                  `gorm:"-" json:"metadata,omitempty"`
 	// Populated in handlers after find using the virtual key id and key id
 	VirtualKey  *tables.TableVirtualKey  `gorm:"-" json:"virtual_key,omitempty"`  // redacted
 	SelectedKey *schemas.Key             `gorm:"-" json:"selected_key,omitempty"` // redacted
@@ -646,9 +646,69 @@ func (j *AsyncJob) ToResponse() *schemas.AsyncJobResponse {
 	}
 
 	if j.Response != "" {
-		var result interface{}
-		if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
-			resp.Result = result
+		switch j.RequestType {
+		case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
+			var result schemas.BifrostResponsesResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+			var result schemas.BifrostChatResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
+			var result schemas.BifrostTextCompletionResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.EmbeddingRequest:
+			var result schemas.BifrostEmbeddingResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.SpeechRequest, schemas.SpeechStreamRequest:
+			var result schemas.BifrostSpeechResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
+			var result schemas.BifrostTranscriptionResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
+			var result schemas.BifrostImageGenerationResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.ImageEditRequest, schemas.ImageEditStreamRequest:
+			var result schemas.BifrostImageGenerationResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.ImageVariationRequest:
+			var result schemas.BifrostImageGenerationResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		case schemas.CountTokensRequest:
+			var result schemas.BifrostCountTokensResponse
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = &result
+			}
+		default:
+			var result interface{}
+			if err := sonic.Unmarshal([]byte(j.Response), &result); err == nil {
+				resp.Result = result
+			}
+		}
+		// Should never happen, but just in case
+		if resp.Result == nil {
+			var raw interface{}
+			if err := sonic.Unmarshal([]byte(j.Response), &raw); err == nil {
+				resp.Result = raw
+			}
 		}
 	}
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/bedrock"
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,14 @@ func (m *mockHandlerStore) GetAvailableProviders() []schemas.ModelProvider {
 
 func (m *mockHandlerStore) GetStreamChunkInterceptor() lib.StreamChunkInterceptor {
 	return nil
+}
+
+func (m *mockHandlerStore) GetAsyncJobExecutor() *logstore.AsyncJobExecutor {
+	return nil
+}
+
+func (m *mockHandlerStore) GetAsyncJobResultTTL() int {
+	return 3600
 }
 
 // Ensure mockHandlerStore implements lib.HandlerStore


### PR DESCRIPTION
## Summary

Adds asynchronous job processing capabilities to the Bifrost HTTP transport layer, allowing clients to submit long-running inference requests and retrieve results later using HTTP headers.

## Changes

- Added async job header constants (`AsyncHeaderResultTTL`, `AsyncHeaderCreate`, `AsyncHeaderGetID`) to the schemas package
- Enhanced `AsyncJob.ToResponse()` to properly type-cast responses based on request type instead of using generic interface{}
- Implemented async job creation and retrieval handlers in the integration router with support for chat completion and responses endpoints
- Added async response converters (`AsyncChatResponseConverter`, `AsyncResponsesResponseConverter`) to handle integration-specific formatting
- Integrated async job executor initialization in the server bootstrap process when both LogsStore and governance plugin are available
- Updated OpenAI and Anthropic integrations to support async operations with proper response conversion
- Modified success response handler to accept optional extra headers for async job metadata

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Test async job creation and retrieval:

```sh
# Create async job
curl -X POST /v1/chat/completions \
  -H "x-bf-async: true" \
  -H "x-bf-async-job-result-ttl: 7200" \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}'

# Retrieve job status/result
curl -X GET /v1/chat/completions \
  -H "x-bf-async-id: <job-id>"

# Run tests
go test ./transports/bifrost-http/...
go test ./framework/logstore/...
```

Requires LogsStore and governance plugin to be configured for async functionality.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Async jobs are scoped to virtual keys when governance is enabled, ensuring proper isolation between tenants. Job IDs must be provided via headers for retrieval, preventing unauthorized access to job results.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable