### PR TITLE
feat: add vllm rerank support with pricing and logging integration

### DIFF
--- a/core/providers/vllm/models.go
+++ b/core/providers/vllm/models.go
@@ -1,0 +1,17 @@
+package vllm
+
+// vLLMRerankRequest is the vLLM rerank request body.
+type vLLMRerankRequest struct {
+	Model           string                 `json:"model"`
+	Query           string                 `json:"query"`
+	Documents       []string               `json:"documents"`
+	TopN            *int                   `json:"top_n,omitempty"`
+	MaxTokensPerDoc *int                   `json:"max_tokens_per_doc,omitempty"`
+	Priority        *int                   `json:"priority,omitempty"`
+	ExtraParams     map[string]interface{} `json:"-"`
+}
+
+// GetExtraParams returns passthrough parameters for providerUtils.CheckContextAndGetRequestBody.
+func (r *vLLMRerankRequest) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}

--- a/core/providers/vllm/rerank.go
+++ b/core/providers/vllm/rerank.go
@@ -119,13 +119,17 @@ func parseVLLMUsage(rawUsage interface{}) (*schemas.BifrostLLMUsage, bool) {
 		return nil, false
 	}
 
-	promptTokens, _ := schemas.SafeExtractInt(usageMap["prompt_tokens"])
-	if promptTokens == 0 {
+	promptTokens := 0
+	if _, hasPromptTokens := usageMap["prompt_tokens"]; hasPromptTokens {
+		promptTokens, _ = schemas.SafeExtractInt(usageMap["prompt_tokens"])
+	} else {
 		promptTokens, _ = schemas.SafeExtractInt(usageMap["input_tokens"])
 	}
 
-	completionTokens, _ := schemas.SafeExtractInt(usageMap["completion_tokens"])
-	if completionTokens == 0 {
+	completionTokens := 0
+	if _, hasCompletionTokens := usageMap["completion_tokens"]; hasCompletionTokens {
+		completionTokens, _ = schemas.SafeExtractInt(usageMap["completion_tokens"])
+	} else {
 		completionTokens, _ = schemas.SafeExtractInt(usageMap["output_tokens"])
 	}
 

--- a/core/providers/vllm/rerank.go
+++ b/core/providers/vllm/rerank.go
@@ -1,0 +1,145 @@
+package vllm
+
+import (
+	"fmt"
+	"sort"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToVLLMRerankRequest converts a Bifrost rerank request to vLLM format.
+func ToVLLMRerankRequest(bifrostReq *schemas.BifrostRerankRequest) *vLLMRerankRequest {
+	if bifrostReq == nil {
+		return nil
+	}
+
+	vllmReq := &vLLMRerankRequest{
+		Model:     bifrostReq.Model,
+		Query:     bifrostReq.Query,
+		Documents: make([]string, len(bifrostReq.Documents)),
+	}
+
+	for i, doc := range bifrostReq.Documents {
+		vllmReq.Documents[i] = doc.Text
+	}
+
+	if bifrostReq.Params != nil {
+		vllmReq.TopN = bifrostReq.Params.TopN
+		vllmReq.MaxTokensPerDoc = bifrostReq.Params.MaxTokensPerDoc
+		vllmReq.Priority = bifrostReq.Params.Priority
+		vllmReq.ExtraParams = bifrostReq.Params.ExtraParams
+	}
+
+	return vllmReq
+}
+
+// ToBifrostRerankResponse converts a vLLM rerank response payload to Bifrost format.
+func ToBifrostRerankResponse(payload map[string]interface{}, documents []schemas.RerankDocument, returnDocuments bool) (*schemas.BifrostRerankResponse, error) {
+	if payload == nil {
+		return nil, fmt.Errorf("vllm rerank response is nil")
+	}
+
+	response := &schemas.BifrostRerankResponse{}
+
+	if id, ok := schemas.SafeExtractString(payload["id"]); ok {
+		response.ID = id
+	}
+	if model, ok := schemas.SafeExtractString(payload["model"]); ok {
+		response.Model = model
+	}
+	if usage, ok := parseVLLMUsage(payload["usage"]); ok {
+		response.Usage = usage
+	}
+
+	resultsRaw := payload["results"]
+	if resultsRaw == nil {
+		return nil, fmt.Errorf("invalid vllm rerank response: missing results")
+	}
+
+	resultItems, ok := resultsRaw.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid vllm rerank response: results must be an array")
+	}
+
+	seenIndices := make(map[int]struct{}, len(resultItems))
+	response.Results = make([]schemas.RerankResult, 0, len(resultItems))
+
+	for _, item := range resultItems {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid vllm rerank response: result item must be an object")
+		}
+
+		index, ok := schemas.SafeExtractInt(itemMap["index"])
+		if !ok {
+			return nil, fmt.Errorf("invalid vllm rerank response: result index is required")
+		}
+		if index < 0 || index >= len(documents) {
+			return nil, fmt.Errorf("invalid vllm rerank response: result index %d out of range", index)
+		}
+		if _, exists := seenIndices[index]; exists {
+			return nil, fmt.Errorf("invalid vllm rerank response: duplicate index %d", index)
+		}
+		seenIndices[index] = struct{}{}
+
+		relevanceScore, ok := schemas.SafeExtractFloat64(itemMap["relevance_score"])
+		if !ok {
+			relevanceScore, ok = schemas.SafeExtractFloat64(itemMap["score"])
+		}
+		if !ok {
+			return nil, fmt.Errorf("invalid vllm rerank response: relevance_score/score is required")
+		}
+
+		result := schemas.RerankResult{
+			Index:          index,
+			RelevanceScore: relevanceScore,
+		}
+
+		if returnDocuments {
+			doc := documents[index]
+			result.Document = &doc
+		}
+
+		response.Results = append(response.Results, result)
+	}
+
+	sort.SliceStable(response.Results, func(i, j int) bool {
+		if response.Results[i].RelevanceScore == response.Results[j].RelevanceScore {
+			return response.Results[i].Index < response.Results[j].Index
+		}
+		return response.Results[i].RelevanceScore > response.Results[j].RelevanceScore
+	})
+
+	return response, nil
+}
+
+func parseVLLMUsage(rawUsage interface{}) (*schemas.BifrostLLMUsage, bool) {
+	usageMap, ok := rawUsage.(map[string]interface{})
+	if !ok {
+		return nil, false
+	}
+
+	promptTokens, _ := schemas.SafeExtractInt(usageMap["prompt_tokens"])
+	if promptTokens == 0 {
+		promptTokens, _ = schemas.SafeExtractInt(usageMap["input_tokens"])
+	}
+
+	completionTokens, _ := schemas.SafeExtractInt(usageMap["completion_tokens"])
+	if completionTokens == 0 {
+		completionTokens, _ = schemas.SafeExtractInt(usageMap["output_tokens"])
+	}
+
+	totalTokens, ok := schemas.SafeExtractInt(usageMap["total_tokens"])
+	if !ok {
+		totalTokens = promptTokens + completionTokens
+	}
+	if promptTokens == 0 && completionTokens == 0 && totalTokens == 0 {
+		return nil, false
+	}
+
+	return &schemas.BifrostLLMUsage{
+		PromptTokens:     promptTokens,
+		CompletionTokens: completionTokens,
+		TotalTokens:      totalTokens,
+	}, true
+}

--- a/core/providers/vllm/rerank_test.go
+++ b/core/providers/vllm/rerank_test.go
@@ -1,0 +1,154 @@
+package vllm
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRerankToVLLMRerankRequestNil(t *testing.T) {
+	req := ToVLLMRerankRequest(nil)
+	assert.Nil(t, req)
+}
+
+func TestRerankToVLLMRerankRequest(t *testing.T) {
+	topN := 2
+	maxTokens := 128
+	priority := 5
+
+	req := ToVLLMRerankRequest(&schemas.BifrostRerankRequest{
+		Model: "BAAI/bge-reranker-v2-m3",
+		Query: "what is machine learning",
+		Documents: []schemas.RerankDocument{
+			{Text: "Machine learning is a subset of AI."},
+			{Text: "The weather is sunny."},
+		},
+		Params: &schemas.RerankParameters{
+			TopN:            &topN,
+			MaxTokensPerDoc: &maxTokens,
+			Priority:        &priority,
+			ExtraParams: map[string]interface{}{
+				"user": "test-user",
+			},
+		},
+	})
+
+	require.NotNil(t, req)
+	assert.Equal(t, "BAAI/bge-reranker-v2-m3", req.Model)
+	assert.Equal(t, "what is machine learning", req.Query)
+	assert.Equal(t, []string{"Machine learning is a subset of AI.", "The weather is sunny."}, req.Documents)
+	require.NotNil(t, req.TopN)
+	assert.Equal(t, 2, *req.TopN)
+	require.NotNil(t, req.MaxTokensPerDoc)
+	assert.Equal(t, 128, *req.MaxTokensPerDoc)
+	require.NotNil(t, req.Priority)
+	assert.Equal(t, 5, *req.Priority)
+	assert.Equal(t, "test-user", req.ExtraParams["user"])
+}
+
+func TestRerankToBifrostRerankResponse(t *testing.T) {
+	documents := []schemas.RerankDocument{
+		{Text: "doc-0"},
+		{Text: "doc-1"},
+		{Text: "doc-2"},
+	}
+
+	response, err := ToBifrostRerankResponse(map[string]interface{}{
+		"id":    "rerank-id",
+		"model": "BAAI/bge-reranker-v2-m3",
+		"usage": map[string]interface{}{
+			"prompt_tokens": 10,
+			"total_tokens":  10,
+		},
+		"results": []interface{}{
+			map[string]interface{}{"index": 1, "relevance_score": 0.1},
+			map[string]interface{}{"index": 0, "relevance_score": 0.9},
+		},
+	}, documents, true)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, "rerank-id", response.ID)
+	assert.Equal(t, "BAAI/bge-reranker-v2-m3", response.Model)
+	require.NotNil(t, response.Usage)
+	assert.Equal(t, 10, response.Usage.PromptTokens)
+	assert.Equal(t, 10, response.Usage.TotalTokens)
+	require.Len(t, response.Results, 2)
+	assert.Equal(t, 0, response.Results[0].Index)
+	assert.Equal(t, 0.9, response.Results[0].RelevanceScore)
+	require.NotNil(t, response.Results[0].Document)
+	assert.Equal(t, "doc-0", response.Results[0].Document.Text)
+	assert.Equal(t, 1, response.Results[1].Index)
+	assert.Equal(t, 0.1, response.Results[1].RelevanceScore)
+}
+
+func TestRerankToBifrostRerankResponseDuplicateIndices(t *testing.T) {
+	documents := []schemas.RerankDocument{
+		{Text: "doc-0"},
+		{Text: "doc-1"},
+	}
+
+	_, err := ToBifrostRerankResponse(map[string]interface{}{
+		"results": []interface{}{
+			map[string]interface{}{"index": 0, "relevance_score": 0.9},
+			map[string]interface{}{"index": 0, "relevance_score": 0.8},
+		},
+	}, documents, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate index")
+}
+
+func TestRerankToBifrostRerankResponseOutOfRangeIndex(t *testing.T) {
+	documents := []schemas.RerankDocument{
+		{Text: "doc-0"},
+	}
+
+	_, err := ToBifrostRerankResponse(map[string]interface{}{
+		"results": []interface{}{
+			map[string]interface{}{"index": 1, "relevance_score": 0.9},
+		},
+	}, documents, true)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
+func TestRerankToBifrostRerankResponseEmptyResults(t *testing.T) {
+	documents := []schemas.RerankDocument{
+		{Text: "doc-0"},
+	}
+
+	response, err := ToBifrostRerankResponse(map[string]interface{}{
+		"results": []interface{}{},
+	}, documents, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Len(t, response.Results, 0)
+}
+
+func TestRerankToBifrostRerankResponseZeroRelevanceScoreDoesNotFallback(t *testing.T) {
+	documents := []schemas.RerankDocument{
+		{Text: "doc-0"},
+	}
+
+	response, err := ToBifrostRerankResponse(map[string]interface{}{
+		"results": []interface{}{
+			map[string]interface{}{"index": 0, "relevance_score": 0.0, "score": 0.99},
+		},
+	}, documents, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.Len(t, response.Results, 1)
+	assert.Equal(t, 0.0, response.Results[0].RelevanceScore)
+}
+
+func TestRerankParseVLLMUsageZeroUsage(t *testing.T) {
+	usage, ok := parseVLLMUsage(map[string]interface{}{})
+	assert.False(t, ok)
+	assert.Nil(t, usage)
+}

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -284,7 +284,9 @@ func (provider *VLLMProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Ke
 
 	responsePayload, rawRequest, rawResponse, responseBody, statusCode, latency, bifrostErr := provider.callVLLMRerankEndpoint(ctx, key, request, resolvedPath, jsonData)
 	if bifrostErr != nil && !hasPathOverride && isRerankFallbackStatus(statusCode) {
-		responsePayload, rawRequest, rawResponse, responseBody, statusCode, latency, bifrostErr = provider.callVLLMRerankEndpoint(ctx, key, request, "/rerank", jsonData)
+		var fallbackLatency time.Duration
+		responsePayload, rawRequest, rawResponse, responseBody, statusCode, fallbackLatency, bifrostErr = provider.callVLLMRerankEndpoint(ctx, key, request, "/rerank", jsonData)
+		latency += fallbackLatency
 	}
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -200,9 +200,124 @@ func (provider *VLLMProvider) Speech(ctx *schemas.BifrostContext, key schemas.Ke
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
-// Rerank is not supported by the vLLM provider.
+func isRerankFallbackStatus(statusCode int) bool {
+	// vLLM deployments may return 501 for unimplemented routes.
+	// We fallback on 501 in addition to 404/405 for compatibility.
+	return statusCode == fasthttp.StatusNotFound ||
+		statusCode == fasthttp.StatusMethodNotAllowed ||
+		statusCode == fasthttp.StatusNotImplemented
+}
+
+func (provider *VLLMProvider) callVLLMRerankEndpoint(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	request *schemas.BifrostRerankRequest,
+	endpointPath string,
+	jsonData []byte,
+) (map[string]interface{}, interface{}, interface{}, []byte, int, time.Duration, *schemas.BifrostError) {
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + endpointPath)
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+	req.SetBody(jsonData)
+
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, nil, nil, nil, 0, latency, bifrostErr
+	}
+
+	statusCode := resp.StatusCode()
+	if statusCode != fasthttp.StatusOK {
+		return nil, nil, nil, nil, statusCode, latency, openai.ParseOpenAIError(resp, schemas.RerankRequest, provider.GetProviderKey(), request.Model)
+	}
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, nil, nil, nil, statusCode, latency, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, provider.GetProviderKey())
+	}
+
+	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
+	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
+
+	responsePayload := make(map[string]interface{})
+	rawRequest, rawResponse, bifrostErr := HandleVLLMResponse(body, &responsePayload, jsonData, sendBackRawRequest, sendBackRawResponse)
+	if bifrostErr != nil {
+		return nil, nil, nil, body, statusCode, latency, bifrostErr
+	}
+
+	return responsePayload, rawRequest, rawResponse, body, statusCode, latency, nil
+}
+
+// Rerank performs a rerank request to vLLM's API.
 func (provider *VLLMProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+	providerName := provider.GetProviderKey()
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToVLLMRerankRequest(request), nil
+		},
+		providerName,
+	)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	resolvedPath := providerUtils.GetPathFromContext(ctx, "")
+	hasPathOverride := resolvedPath != ""
+	if !hasPathOverride {
+		resolvedPath = "/v1/rerank"
+	} else if !strings.HasPrefix(resolvedPath, "/") {
+		resolvedPath = "/" + resolvedPath
+	}
+
+	responsePayload, rawRequest, rawResponse, responseBody, statusCode, latency, bifrostErr := provider.callVLLMRerankEndpoint(ctx, key, request, resolvedPath, jsonData)
+	if bifrostErr != nil && !hasPathOverride && isRerankFallbackStatus(statusCode) {
+		responsePayload, rawRequest, rawResponse, responseBody, statusCode, latency, bifrostErr = provider.callVLLMRerankEndpoint(ctx, key, request, "/rerank", jsonData)
+	}
+	if bifrostErr != nil {
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+	}
+
+	returnDocuments := request.Params != nil && request.Params.ReturnDocuments != nil && *request.Params.ReturnDocuments
+	bifrostResponse, err := ToBifrostRerankResponse(responsePayload, request.Documents, returnDocuments)
+	if err != nil {
+		return nil, providerUtils.EnrichError(
+			ctx,
+			providerUtils.NewBifrostOperationError("error converting rerank response", err, providerName),
+			jsonData,
+			responseBody,
+			provider.sendBackRawRequest,
+			provider.sendBackRawResponse,
+		)
+	}
+
+	// Keep requested model as the canonical model in Bifrost response.
+	bifrostResponse.Model = request.Model
+	bifrostResponse.ExtraFields.Provider = providerName
+	bifrostResponse.ExtraFields.ModelRequested = request.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.RerankRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		bifrostResponse.ExtraFields.RawRequest = rawRequest
+	}
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		bifrostResponse.ExtraFields.RawResponse = rawResponse
+	}
+
+	return bifrostResponse, nil
 }
 
 // SpeechStream is not supported by the vLLM provider.

--- a/core/providers/vllm/vllm_test.go
+++ b/core/providers/vllm/vllm_test.go
@@ -26,6 +26,7 @@ func TestVLLM(t *testing.T) {
 	textModel := getEnvWithDefault("VLLM_TEXT_MODEL", "Qwen/Qwen3-0.6B")
 	reasoningModel := getEnvWithDefault("VLLM_REASONING_MODEL", "Qwen/Qwen3-0.6B")
 	embeddingModel := getEnvWithDefault("VLLM_EMBEDDING_MODEL", "Qwen3-Embedding-0.6B")
+	rerankModel := strings.TrimSpace(os.Getenv("VLLM_RERANK_MODEL"))
 
 	testConfig := llmtests.ComprehensiveTestConfig{
 		Provider:       schemas.VLLM,
@@ -33,6 +34,7 @@ func TestVLLM(t *testing.T) {
 		TextModel:      textModel,
 		ReasoningModel: reasoningModel,
 		EmbeddingModel: embeddingModel,
+		RerankModel:    rerankModel,
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        true,
 			TextCompletionStream:  true,
@@ -49,6 +51,7 @@ func TestVLLM(t *testing.T) {
 			MultipleImages:        false,
 			CompleteEnd2End:       true,
 			Embedding:             true,
+			Rerank:                rerankModel != "",
 			ListModels:            true,
 			Reasoning:             true,
 			SpeechSynthesis:       false,

--- a/docs/providers/supported-providers/overview.mdx
+++ b/docs/providers/supported-providers/overview.mdx
@@ -56,6 +56,7 @@ Notes:
 - "Models" refers to the list models operation (`/v1/models`).
 - "Text" refers to the classic text completion interface (`/v1/completions`).
 - "Responses" refers to the OpenAI-style Responses API (`/v1/responses`). Non-OpenAI providers map this to their native chat API under the hood.
+- Reranking (`/v1/rerank`) is currently supported for Cohere, Bedrock, Vertex AI, and vLLM. See each provider page for model-specific requirements.
 - "Images" refers to the Image Generation API (`/v1/images/generations`).
 - "Image Edit" refers to the Image Edit API (`/v1/images/edits`).
 - "Image Variation" refers to the Image Variation API (`/v1/images/variations`).

--- a/docs/providers/supported-providers/vllm.mdx
+++ b/docs/providers/supported-providers/vllm.mdx
@@ -154,7 +154,9 @@ curl -X POST http://localhost:8080/v1/rerank \
       {"text": "Python is a programming language."},
       {"text": "Deep learning uses neural networks."}
     ],
-    "return_documents": true
+    "params": {
+      "return_documents": true
+    }
   }'
 ```
 

--- a/docs/providers/supported-providers/vllm.mdx
+++ b/docs/providers/supported-providers/vllm.mdx
@@ -1,13 +1,13 @@
 ---
 title: "vLLM"
-description: "vLLM API guide - OpenAI-compatible self-hosted inference, chat, text, embeddings, and streaming"
+description: "vLLM API guide - OpenAI-compatible self-hosted inference, chat, text, embeddings, rerank, and streaming"
 icon: "v"
 ---
 
 ## Overview
 
 vLLM is an **OpenAI-compatible provider** for self-hosted inference. Bifrost delegates to the shared OpenAI provider implementation. Key characteristics:
-- **OpenAI compatibility** - Chat, text completions, embeddings, and streaming
+- **OpenAI compatibility** - Chat, text completions, embeddings, rerank, and streaming
 - **Self-hosted** - Typically runs at `http://localhost:8000` or your own server
 - **Optional authentication** - API key often omitted for local instances
 - **Responses API** - Supported via chat completion fallback
@@ -20,6 +20,7 @@ vLLM is an **OpenAI-compatible provider** for self-hosted inference. Bifrost del
 | Responses API | ✅ | ✅ | `/v1/chat/completions` |
 | Text Completions | ✅ | ✅ | `/v1/completions` |
 | Embeddings | ✅ | - | `/v1/embeddings` |
+| Rerank | ✅ | - | `/v1/rerank` (fallback: `/rerank`) |
 | List Models | ✅ | - | `/v1/models` |
 | Image Generation | ❌ | ❌ | - |
 | Speech (TTS) | ❌ | ❌ | - |
@@ -135,6 +136,31 @@ vLLM supports `/v1/embeddings`. Use model IDs exposed by your vLLM server (e.g. 
 # 5. List Models
 
 Lists models from your vLLM instance via `/v1/models`. Available models depend on what is loaded on the server.
+
+---
+
+# 6. Rerank
+
+vLLM supports reranking for pooling/cross-encoder reranker models. Bifrost sends requests to `/v1/rerank` and automatically falls back to `/rerank` when required by your vLLM deployment.
+
+```bash
+curl -X POST http://localhost:8080/v1/rerank \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "vllm/BAAI/bge-reranker-v2-m3",
+    "query": "What is machine learning?",
+    "documents": [
+      {"text": "Machine learning is a subset of AI."},
+      {"text": "Python is a programming language."},
+      {"text": "Deep learning uses neural networks."}
+    ],
+    "return_documents": true
+  }'
+```
+
+<Note>
+Your upstream vLLM server must be started with a rerank-capable model (pooling/cross-encoder task support).
+</Note>
 
 ---
 

--- a/docs/quickstart/gateway/reranking.mdx
+++ b/docs/quickstart/gateway/reranking.mdx
@@ -6,6 +6,13 @@ icon: "book-open-cover"
 
 Use reranking to sort documents by relevance for search, retrieval, and context selection.
 
+## Provider Model Examples
+
+- Cohere: `cohere/rerank-v3.5`
+- vLLM: `vllm/BAAI/bge-reranker-v2-m3`
+- Bedrock: `bedrock/<rerank-model-or-arn>`
+- Vertex AI: `vertex/<ranking-model>`
+
 ## Basic Request
 
 ```bash
@@ -50,6 +57,10 @@ curl --location 'http://localhost:8080/v1/rerank' \
   ]
 }'
 ```
+
+## vLLM Endpoint Compatibility
+
+When using a `vllm/...` model, Bifrost sends rerank requests to `/v1/rerank` first and automatically retries `/rerank` when the upstream endpoint responds with `404`, `405`, or `501`.
 
 ## Response Shape
 

--- a/docs/quickstart/go-sdk/reranking.mdx
+++ b/docs/quickstart/go-sdk/reranking.mdx
@@ -6,6 +6,10 @@ icon: "book-open-cover"
 
 Use the Go SDK to rank candidate documents by relevance to a query.
 
+Provider/model examples:
+- Cohere: `Provider: schemas.Cohere`, `Model: "rerank-v3.5"`
+- vLLM: `Provider: schemas.VLLM`, `Model: "BAAI/bge-reranker-v2-m3"`
+
 ## Basic Example
 
 ```go
@@ -64,6 +68,8 @@ func main() {
 - `Params.Priority`: provider-dependent priority hint
 - `Params.ReturnDocuments`: include source document in each result
 - `Fallbacks`: fallback provider/model choices
+
+For vLLM, set `Provider` to `schemas.VLLM` and use the upstream model ID as `Model` (without the `vllm/` prefix that is used in Gateway HTTP requests).
 
 ## Response
 

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -133,6 +133,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddListModelsOutputColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddRerankOutputColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddRoutingEngineLogsColumn(ctx, db); err != nil {
 		return err
 	}
@@ -1183,6 +1186,39 @@ func migrationAddListModelsOutputColumn(ctx context.Context, db *gorm.DB) error 
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding list models output column: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddRerankOutputColumn(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_rerank_output_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "rerank_output") {
+				if err := migrator.AddColumn(&Log{}, "rerank_output"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&Log{}, "rerank_output") {
+				if err := migrator.DropColumn(&Log{}, "rerank_output"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding rerank output column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -249,6 +249,7 @@ func (mc *ModelCatalog) GetPricingEntryForModel(model string, provider schemas.M
 		schemas.ChatCompletionRequest,
 		schemas.ResponsesRequest,
 		schemas.EmbeddingRequest,
+		schemas.RerankRequest,
 		schemas.SpeechRequest,
 		schemas.TranscriptionRequest,
 	} {

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -41,6 +41,8 @@ func (mc *ModelCatalog) CalculateCost(result *schemas.BifrostResponse) float64 {
 		}
 	case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
 		usage = result.EmbeddingResponse.Usage
+	case result.RerankResponse != nil && result.RerankResponse.Usage != nil:
+		usage = result.RerankResponse.Usage
 	case result.SpeechResponse != nil:
 		if result.SpeechResponse.Usage != nil {
 			usage = &schemas.BifrostLLMUsage{

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -36,6 +36,8 @@ func normalizeRequestType(reqType schemas.RequestType) string {
 		baseType = "responses"
 	case schemas.EmbeddingRequest:
 		baseType = "embedding"
+	case schemas.RerankRequest:
+		baseType = "rerank"
 	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
 		baseType = "audio_speech"
 	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -337,6 +337,8 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 			initialData.Tools = tools
 		case schemas.EmbeddingRequest:
 			initialData.Params = req.EmbeddingRequest.Params
+		case schemas.RerankRequest:
+			initialData.Params = req.RerankRequest.Params
 		case schemas.SpeechRequest, schemas.SpeechStreamRequest:
 			initialData.Params = req.SpeechRequest.Params
 			initialData.SpeechInput = req.SpeechRequest.Input
@@ -638,6 +640,8 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 					usage = result.ResponsesResponse.Usage.ToBifrostLLMUsage()
 				case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
 					usage = result.EmbeddingResponse.Usage
+				case result.RerankResponse != nil && result.RerankResponse.Usage != nil:
+					usage = result.RerankResponse.Usage
 				case result.TranscriptionResponse != nil && result.TranscriptionResponse.Usage != nil:
 					usage = &schemas.BifrostLLMUsage{}
 					if result.TranscriptionResponse.Usage.InputTokens != nil {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -44,6 +44,7 @@ type UpdateLogData struct {
 	ChatOutput            *schemas.ChatMessage
 	ResponsesOutput       []schemas.ResponsesMessage
 	EmbeddingOutput       []schemas.EmbeddingData
+	RerankOutput          []schemas.RerankResult
 	ErrorDetails          *schemas.BifrostError
 	SpeechOutput          *schemas.BifrostSpeechResponse          // For non-streaming speech responses
 	TranscriptionOutput   *schemas.BifrostTranscriptionResponse   // For non-streaming transcription responses
@@ -706,6 +707,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 					}
 					if result.EmbeddingResponse != nil && len(result.EmbeddingResponse.Data) > 0 {
 						updateData.EmbeddingOutput = result.EmbeddingResponse.Data
+					}
+					if result.RerankResponse != nil {
+						updateData.RerankOutput = result.RerankResponse.Results
 					}
 					// Handle speech and transcription outputs for NON-streaming responses
 					if result.SpeechResponse != nil {

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -130,6 +130,15 @@ func (p *LoggerPlugin) updateLogEntry(
 			}
 		}
 
+		if data.RerankOutput != nil {
+			tempEntry.RerankOutputParsed = data.RerankOutput
+			if err := tempEntry.SerializeFields(); err != nil {
+				p.logger.Error("failed to serialize rerank output: %v", err)
+			} else {
+				updates["rerank_output"] = tempEntry.RerankOutput
+			}
+		}
+
 		if data.SpeechOutput != nil {
 			tempEntry.SpeechOutputParsed = data.SpeechOutput
 			if err := tempEntry.SerializeFields(); err != nil {

--- a/plugins/logging/pool.go
+++ b/plugins/logging/pool.go
@@ -42,6 +42,7 @@ func (p *LoggerPlugin) putUpdateLogData(data *UpdateLogData) {
 	data.SpeechOutput = nil
 	data.TranscriptionOutput = nil
 	data.EmbeddingOutput = nil
+	data.RerankOutput = nil
 	data.Cost = nil
 	data.ImageGenerationOutput = nil
 	data.RawRequest = nil

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -326,6 +326,17 @@ func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) ([]s
 			},
 		}, []schemas.ResponsesMessage{}
 	}
+	if request.RerankRequest != nil {
+		query := request.RerankRequest.Query
+		return []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: &query,
+				},
+			},
+		}, []schemas.ResponsesMessage{}
+	}
 	return []schemas.ChatMessage{}, []schemas.ResponsesMessage{}
 }
 

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -577,13 +577,12 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								/>
 							</>
 						)}
-						{log.rerank_output && !log.error_details?.error.message && (
-							<>
-								<div className="mt-4 w-full text-left text-sm font-medium">Rerank Output</div>
-								<CollapsibleBox
-									title={`Rerank Output (${log.rerank_output.length})`}
-									onCopy={() => JSON.stringify(log.rerank_output, null, 2)}
-								>
+							{log.rerank_output && !log.error_details?.error.message && (
+								<>
+									<CollapsibleBox
+										title={`Rerank Output (${log.rerank_output.length})`}
+										onCopy={() => JSON.stringify(log.rerank_output, null, 2)}
+									>
 									<CodeEditor
 										className="z-0 w-full"
 										shouldAdjustInitialHeight={true}

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -105,11 +105,11 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							<Badge variant="outline" className={`${StatusColors[log.status as Status]} uppercase`}>
 								{log.status}
 							</Badge>
-							{log.metadata?.isAsyncRequest ? (
-								<Badge variant="outline" className="bg-teal-100 text-teal-800 uppercase dark:bg-teal-900 dark:text-teal-200">
-									Async
-								</Badge>
-							) : null}
+								{log.metadata?.isAsyncRequest ? (
+									<Badge variant="outline" className="bg-teal-100 text-teal-800 uppercase dark:bg-teal-900 dark:text-teal-200">
+										Async
+									</Badge>
+								) : null}
 						</SheetTitle>
 					</div>
 					<AlertDialog>
@@ -575,6 +575,26 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 										),
 									}}
 								/>
+							</>
+						)}
+						{log.rerank_output && !log.error_details?.error.message && (
+							<>
+								<div className="mt-4 w-full text-left text-sm font-medium">Rerank Output</div>
+								<CollapsibleBox
+									title={`Rerank Output (${log.rerank_output.length})`}
+									onCopy={() => JSON.stringify(log.rerank_output, null, 2)}
+								>
+									<CodeEditor
+										className="z-0 w-full"
+										shouldAdjustInitialHeight={true}
+										maxHeight={450}
+										wrap={true}
+										code={JSON.stringify(log.rerank_output, null, 2)}
+										lang="json"
+										readonly={true}
+										options={{ scrollBeyondLastLine: false, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+									/>
+								</CollapsibleBox>
 							</>
 						)}
 						{log.raw_request && (

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -39,6 +39,7 @@ export const RequestTypes = [
 	"responses",
 	"responses_stream",
 	"embedding",
+	"rerank",
 	"speech",
 	"speech_stream",
 	"transcription",
@@ -134,6 +135,7 @@ export const RequestTypeLabels = {
 	responses_stream: "Responses Stream",
 
 	embedding: "Embedding",
+	rerank: "Rerank",
 
 	speech: "Speech",
 	speech_stream: "Speech Stream",
@@ -200,6 +202,7 @@ export const RequestTypeColors = {
 	responses_stream: "bg-violet-100 text-violet-800",
 
 	embedding: "bg-red-100 text-red-800",
+	rerank: "bg-fuchsia-100 text-fuchsia-800",
 
 	speech: "bg-purple-100 text-purple-800",
 	speech_stream: "bg-pink-100 text-pink-800",

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -198,6 +198,18 @@ export interface BifrostEmbedding {
 	embedding: string | number[] | number[][];
 }
 
+export interface RerankDocument {
+	text: string;
+	id?: string;
+	meta?: Record<string, unknown>;
+}
+
+export interface RerankResult {
+	index: number;
+	relevance_score: number;
+	document?: RerankDocument;
+}
+
 export interface BifrostImageGenerationData {
 	url?: string;
 	b64_json?: string;
@@ -367,6 +379,7 @@ export interface LogEntry {
 	output_message?: ChatMessage;
 	responses_output?: ResponsesMessage[];
 	embedding_output?: BifrostEmbedding[];
+	rerank_output?: RerankResult[];
 	image_generation_output?: BifrostImageGenerationOutput;
 	params?: ModelParameters;
 	speech_input?: SpeechInput;


### PR DESCRIPTION
## Summary

 Adds end-to-end rerank support for the vLLM provider and wires rerank into pricing/logging paths so requests are routed, parsed, costed, and visible in Logs UI.

 This supports vLLM deployments that expose either `/v1/rerank` or `/rerank`.

  ## What changed

  ### 1) vLLM provider rerank support
  - Added vLLM rerank request model and converters:
    - `core/providers/vllm/models.go`
    - `core/providers/vllm/rerank.go`
  - Implemented `VLLMProvider.Rerank(...)`:
    - primary endpoint: `/v1/rerank`
    - fallback endpoint: `/rerank`
    - fallback triggers only on `404/405/501`
    - fallback is skipped when request path override is explicitly provided
  - Added robust response parsing/validation:
    - missing/invalid `results` handling
    - duplicate index detection
    - out-of-range index detection
    - supports `relevance_score` and legacy `score`
    - avoids `score` fallback when `relevance_score: 0.0`
  - Added usage parsing support for:
    - `prompt_tokens` / `completion_tokens`
    - `input_tokens` / `output_tokens`
    - returns `nil` usage when all values are zero

  ### 2) Pricing integration for rerank
  - Added rerank normalization and lookup support:
    - `framework/modelcatalog/utils.go` (`normalizeRequestType -> "rerank"`)
    - `framework/modelcatalog/main.go` (`GetPricingEntryForModel` scan list includes rerank)
  - Added rerank usage cost path:
    - `framework/modelcatalog/pricing.go` (`CalculateCost` reads `result.RerankResponse.Usage`)
  - No DB schema changes required (existing `mode` column already supports this).

  ### 3) Logging integration for rerank
  - `PreLLMHook` now logs rerank params
  - `extractInputHistory` maps rerank query into `input_history` for log message rendering
  - `PostLLMHook` now captures rerank token usage when present
  - Logs UI supports rerank in type filter/badge mappings:
    - `ui/lib/constants/logs.ts` (`RequestTypes`, `RequestTypeLabels`, `RequestTypeColors`)

  ### 4) Tests
  - Added comprehensive rerank unit tests:
    - `core/providers/vllm/rerank_test.go`
      - nil request conversion
      - duplicate index / out-of-range validation
      - empty results
      - `relevance_score: 0.0` behavior
      - zero-usage parsing guard

  ## Type of change

  - [x] Feature
  - [ ] Bug fix
  - [ ] Breaking change
  - [ ] Refactor
  - [ ] Docs-only

  ## Affected areas

  - [x] Core (Go)
  - [x] Providers/Integrations
  - [x] Framework (modelcatalog pricing)
  - [x] Plugins (logging)
  - [x] UI (Logs constants)
  - [x] Docs

  ## Validation performed

  ```sh
  go test ./core/providers/vllm/... -run 'TestRerank|TestVLLM' -v
  go test ./framework/modelcatalog/... -v
  go test ./plugins/logging/... -v
  go vet ./core/providers/vllm/... ./framework/modelcatalog/... ./plugins/logging/...

  Notes:

  - TestVLLM is env-gated and skips when VLLM_BASE_URL is not set.
  - UI lint in this repo currently has an existing config issue (Cannot redefine plugin "import"), unrelated to this change.

  ## Manual verification

  1. Start vLLM with a rerank-capable model.
  2. Send rerank request through Bifrost:
      - POST /v1/rerank with model vllm/<upstream-model>
  3. Verify fallback behavior by deployment mode:
      - works against /v1/rerank
      - retries /rerank on 404/405/501
  4. Verify logs:
      - /api/logs?objects=rerank
      - request query appears in input_history
      - token_usage and cost populated when provider returns usage

  ## Breaking changes

  - [x] No

  ## Security considerations

  No new auth surface introduced. Reuses existing provider key handling and request validation paths.