### PR TITLE
feat(pricing): add provider-level per-model pricing overrides

### DIFF
--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -319,6 +319,62 @@ type CustomProviderConfig struct {
 	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider (not allowed for Bedrock)
 }
 
+type PricingOverrideMatchType string
+
+const (
+	PricingOverrideMatchExact    PricingOverrideMatchType = "exact"
+	PricingOverrideMatchWildcard PricingOverrideMatchType = "wildcard"
+	PricingOverrideMatchRegex    PricingOverrideMatchType = "regex"
+)
+
+// ProviderPricingOverride contains a partial pricing patch applied at lookup time.
+// Any nil field falls back to the base pricing data.
+type ProviderPricingOverride struct {
+	ModelPattern string                   `json:"model_pattern"`
+	MatchType    PricingOverrideMatchType `json:"match_type"`
+	RequestTypes []RequestType            `json:"request_types,omitempty"`
+
+	// Basic token pricing
+	InputCostPerToken  *float64 `json:"input_cost_per_token,omitempty"`
+	OutputCostPerToken *float64 `json:"output_cost_per_token,omitempty"`
+
+	// Additional pricing for media
+	InputCostPerVideoPerSecond *float64 `json:"input_cost_per_video_per_second,omitempty"`
+	InputCostPerAudioPerSecond *float64 `json:"input_cost_per_audio_per_second,omitempty"`
+
+	// Character-based pricing
+	InputCostPerCharacter  *float64 `json:"input_cost_per_character,omitempty"`
+	OutputCostPerCharacter *float64 `json:"output_cost_per_character,omitempty"`
+
+	// Pricing above 128k tokens
+	InputCostPerTokenAbove128kTokens          *float64 `json:"input_cost_per_token_above_128k_tokens,omitempty"`
+	InputCostPerCharacterAbove128kTokens      *float64 `json:"input_cost_per_character_above_128k_tokens,omitempty"`
+	InputCostPerImageAbove128kTokens          *float64 `json:"input_cost_per_image_above_128k_tokens,omitempty"`
+	InputCostPerVideoPerSecondAbove128kTokens *float64 `json:"input_cost_per_video_per_second_above_128k_tokens,omitempty"`
+	InputCostPerAudioPerSecondAbove128kTokens *float64 `json:"input_cost_per_audio_per_second_above_128k_tokens,omitempty"`
+	OutputCostPerTokenAbove128kTokens         *float64 `json:"output_cost_per_token_above_128k_tokens,omitempty"`
+	OutputCostPerCharacterAbove128kTokens     *float64 `json:"output_cost_per_character_above_128k_tokens,omitempty"`
+
+	// Pricing above 200k tokens
+	InputCostPerTokenAbove200kTokens           *float64 `json:"input_cost_per_token_above_200k_tokens,omitempty"`
+	OutputCostPerTokenAbove200kTokens          *float64 `json:"output_cost_per_token_above_200k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove200kTokens *float64 `json:"cache_creation_input_token_cost_above_200k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove200kTokens     *float64 `json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
+
+	// Cache and batch pricing
+	CacheReadInputTokenCost     *float64 `json:"cache_read_input_token_cost,omitempty"`
+	CacheCreationInputTokenCost *float64 `json:"cache_creation_input_token_cost,omitempty"`
+	InputCostPerTokenBatches    *float64 `json:"input_cost_per_token_batches,omitempty"`
+	OutputCostPerTokenBatches   *float64 `json:"output_cost_per_token_batches,omitempty"`
+
+	// Image generation pricing
+	InputCostPerImageToken       *float64 `json:"input_cost_per_image_token,omitempty"`
+	OutputCostPerImageToken      *float64 `json:"output_cost_per_image_token,omitempty"`
+	InputCostPerImage            *float64 `json:"input_cost_per_image,omitempty"`
+	OutputCostPerImage           *float64 `json:"output_cost_per_image,omitempty"`
+	CacheReadInputImageTokenCost *float64 `json:"cache_read_input_image_token_cost,omitempty"`
+}
+
 // IsOperationAllowed checks if a specific operation is allowed for this custom provider
 func (cpc *CustomProviderConfig) IsOperationAllowed(operation RequestType) bool {
 	if cpc == nil || cpc.AllowedRequests == nil {
@@ -334,11 +390,12 @@ type ProviderConfig struct {
 	NetworkConfig            NetworkConfig            `json:"network_config"`              // Network configuration
 	ConcurrencyAndBufferSize ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
-	Logger               Logger                `json:"-"`
-	ProxyConfig          *ProxyConfig          `json:"proxy_config,omitempty"` // Proxy configuration
-	SendBackRawRequest   bool                  `json:"send_back_raw_request"`  // Send raw request back in the bifrost response (default: false)
-	SendBackRawResponse  bool                  `json:"send_back_raw_response"` // Send raw response back in the bifrost response (default: false)
-	CustomProviderConfig *CustomProviderConfig `json:"custom_provider_config,omitempty"`
+	Logger               Logger                    `json:"-"`
+	ProxyConfig          *ProxyConfig              `json:"proxy_config,omitempty"` // Proxy configuration
+	SendBackRawRequest   bool                      `json:"send_back_raw_request"`  // Send raw request back in the bifrost response (default: false)
+	SendBackRawResponse  bool                      `json:"send_back_raw_response"` // Send raw response back in the bifrost response (default: false)
+	CustomProviderConfig *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
+	PricingOverrides     []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
 }
 
 func (config *ProviderConfig) CheckAndSetDefaults() {

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -256,6 +256,7 @@ type ProviderConfig struct {
 	SendBackRawRequest       bool                              `json:"send_back_raw_request"`                 // Include raw request in BifrostResponse
 	SendBackRawResponse      bool                              `json:"send_back_raw_response"`                // Include raw response in BifrostResponse
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
+	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`           // Provider-level pricing overrides
 	ConfigHash               string                            `json:"config_hash,omitempty"`                 // Hash of config.json version, used for change detection
 	Status                   string                            `json:"status,omitempty"`                      // Model discovery status for keyless providers
 	Description              string                            `json:"description,omitempty"`                 // Model discovery error message for keyless providers
@@ -270,6 +271,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		SendBackRawRequest:       p.SendBackRawRequest,
 		SendBackRawResponse:      p.SendBackRawResponse,
 		CustomProviderConfig:     p.CustomProviderConfig,
+		PricingOverrides:         p.PricingOverrides,
 		ConfigHash:               p.ConfigHash,
 		Status:                   p.Status,
 		Description:              p.Description,
@@ -415,6 +417,15 @@ func (p *ProviderConfig) GenerateConfigHash(providerName string) (string, error)
 	// Hash CustomProviderConfig
 	if p.CustomProviderConfig != nil {
 		data, err := sonic.Marshal(p.CustomProviderConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
+	// Hash PricingOverrides
+	if p.PricingOverrides != nil {
+		data, err := sonic.Marshal(p.PricingOverrides)
 		if err != nil {
 			return "", err
 		}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -249,6 +249,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			SendBackRawRequest:       providerConfig.SendBackRawRequest,
 			SendBackRawResponse:      providerConfig.SendBackRawResponse,
 			CustomProviderConfig:     providerConfig.CustomProviderConfig,
+			PricingOverrides:         providerConfig.PricingOverrides,
 			ConfigHash:               providerConfig.ConfigHash,
 			Status:                   providerConfig.Status,
 			Description:              providerConfig.Description,
@@ -412,6 +413,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 	dbProvider.SendBackRawRequest = configCopy.SendBackRawRequest
 	dbProvider.SendBackRawResponse = configCopy.SendBackRawResponse
 	dbProvider.CustomProviderConfig = configCopy.CustomProviderConfig
+	dbProvider.PricingOverrides = configCopy.PricingOverrides
 	dbProvider.ConfigHash = configCopy.ConfigHash
 
 	// Save the updated provider
@@ -549,6 +551,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		SendBackRawRequest:       configCopy.SendBackRawRequest,
 		SendBackRawResponse:      configCopy.SendBackRawResponse,
 		CustomProviderConfig:     configCopy.CustomProviderConfig,
+		PricingOverrides:         configCopy.PricingOverrides,
 		ConfigHash:               configCopy.ConfigHash,
 	}
 	// Create the provider
@@ -700,6 +703,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 			SendBackRawRequest:       dbProvider.SendBackRawRequest,
 			SendBackRawResponse:      dbProvider.SendBackRawResponse,
 			CustomProviderConfig:     dbProvider.CustomProviderConfig,
+			PricingOverrides:         dbProvider.PricingOverrides,
 			ConfigHash:               dbProvider.ConfigHash,
 			Status:                   dbProvider.Status,
 			Description:              dbProvider.Description,
@@ -746,6 +750,7 @@ func (s *RDBConfigStore) GetProviderConfig(ctx context.Context, provider schemas
 		SendBackRawRequest:       dbProvider.SendBackRawRequest,
 		SendBackRawResponse:      dbProvider.SendBackRawResponse,
 		CustomProviderConfig:     dbProvider.CustomProviderConfig,
+		PricingOverrides:         dbProvider.PricingOverrides,
 		ConfigHash:               dbProvider.ConfigHash,
 		Status:                   dbProvider.Status,
 		Description:              dbProvider.Description,

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -20,6 +20,7 @@ type TableProvider struct {
 	ConcurrencyBufferJSON    string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ConcurrencyAndBufferSize
 	ProxyConfigJSON          string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ProxyConfig
 	CustomProviderConfigJSON string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.CustomProviderConfig
+	PricingOverridesJSON     string    `gorm:"type:text" json:"-"`                                // JSON serialized []schemas.ProviderPricingOverride
 	SendBackRawRequest       bool      `json:"send_back_raw_request"`
 	SendBackRawResponse      bool      `json:"send_back_raw_response"`
 	CreatedAt                time.Time `gorm:"index;not null" json:"created_at"`
@@ -34,7 +35,8 @@ type TableProvider struct {
 	ProxyConfig              *schemas.ProxyConfig              `gorm:"-" json:"proxy_config,omitempty"`
 
 	// Custom provider fields
-	CustomProviderConfig *schemas.CustomProviderConfig `gorm:"-" json:"custom_provider_config,omitempty"`
+	CustomProviderConfig *schemas.CustomProviderConfig     `gorm:"-" json:"custom_provider_config,omitempty"`
+	PricingOverrides     []schemas.ProviderPricingOverride `gorm:"-" json:"pricing_overrides,omitempty"`
 
 	// Foreign keys
 	Models []TableModel `gorm:"foreignKey:ProviderID;constraint:OnDelete:CASCADE" json:"models"`
@@ -92,6 +94,15 @@ func (p *TableProvider) BeforeSave(tx *gorm.DB) error {
 		}
 		p.CustomProviderConfigJSON = string(data)
 	}
+	if p.PricingOverrides != nil {
+		data, err := json.Marshal(p.PricingOverrides)
+		if err != nil {
+			return err
+		}
+		p.PricingOverridesJSON = string(data)
+	} else {
+		p.PricingOverridesJSON = ""
+	}
 
 	// Validate governance fields
 	if p.BudgetID != nil && strings.TrimSpace(*p.BudgetID) == "" {
@@ -136,6 +147,14 @@ func (p *TableProvider) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 		p.CustomProviderConfig = &customConfig
+	}
+
+	if p.PricingOverridesJSON != "" {
+		var overrides []schemas.ProviderPricingOverride
+		if err := json.Unmarshal([]byte(p.PricingOverridesJSON), &overrides); err != nil {
+			return err
+		}
+		p.PricingOverrides = overrides
 	}
 
 	return nil

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -37,6 +37,11 @@ type ModelCatalog struct {
 	pricingData map[string]configstoreTables.TableModelPricing
 	mu          sync.RWMutex
 
+	// Provider-level pricing overrides are maintained separately to avoid contention
+	// with pricing cache rebuilds.
+	compiledOverrides map[schemas.ModelProvider][]compiledProviderPricingOverride
+	overridesMu       sync.RWMutex
+
 	modelPool      map[schemas.ModelProvider][]string
 	baseModelIndex map[string]string // model string → canonical base model name
 
@@ -112,6 +117,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		configStore:            configStore,
 		logger:                 logger,
 		pricingData:            make(map[string]configstoreTables.TableModelPricing),
+		compiledOverrides:      make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
 		modelPool:              make(map[schemas.ModelProvider][]string),
 		baseModelIndex:         make(map[string]string),
 		done:                   make(chan struct{}),

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -696,9 +696,10 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 		baseModelIndex = make(map[string]string)
 	}
 	return &ModelCatalog{
-		modelPool:      make(map[schemas.ModelProvider][]string),
-		baseModelIndex: baseModelIndex,
-		pricingData:    make(map[string]configstoreTables.TableModelPricing),
-		done:           make(chan struct{}),
+		modelPool:         make(map[schemas.ModelProvider][]string),
+		baseModelIndex:    baseModelIndex,
+		pricingData:       make(map[string]configstoreTables.TableModelPricing),
+		compiledOverrides: make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
+		done:              make(chan struct{}),
 	}
 }

--- a/framework/modelcatalog/main_test.go
+++ b/framework/modelcatalog/main_test.go
@@ -17,9 +17,10 @@ func newTestCatalog(modelPool map[schemas.ModelProvider][]string, baseModelIndex
 		baseModelIndex = make(map[string]string)
 	}
 	return &ModelCatalog{
-		modelPool:      modelPool,
-		baseModelIndex: baseModelIndex,
-		pricingData:    make(map[string]configstoreTables.TableModelPricing),
+		modelPool:         modelPool,
+		baseModelIndex:    baseModelIndex,
+		pricingData:       make(map[string]configstoreTables.TableModelPricing),
+		compiledOverrides: make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
 	}
 }
 

--- a/framework/modelcatalog/overrides.go
+++ b/framework/modelcatalog/overrides.go
@@ -1,0 +1,303 @@
+package modelcatalog
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+type compiledProviderPricingOverride struct {
+	override         schemas.ProviderPricingOverride
+	regex            *regexp.Regexp
+	requestModes     map[string]struct{}
+	hasRequestFilter bool
+	literalChars     int
+	order            int
+}
+
+func (mc *ModelCatalog) SetProviderPricingOverrides(provider schemas.ModelProvider, overrides []schemas.ProviderPricingOverride) error {
+	compiled := make([]compiledProviderPricingOverride, 0, len(overrides))
+	for i := range overrides {
+		item, err := compileProviderPricingOverride(i, overrides[i])
+		if err != nil {
+			return fmt.Errorf("invalid pricing override for provider %s at index %d: %w", provider, i, err)
+		}
+		compiled = append(compiled, item)
+	}
+
+	mc.overridesMu.Lock()
+	defer mc.overridesMu.Unlock()
+	if len(compiled) == 0 {
+		delete(mc.compiledOverrides, provider)
+		return nil
+	}
+	mc.compiledOverrides[provider] = compiled
+	return nil
+}
+
+func (mc *ModelCatalog) DeleteProviderPricingOverrides(provider schemas.ModelProvider) {
+	mc.overridesMu.Lock()
+	defer mc.overridesMu.Unlock()
+	delete(mc.compiledOverrides, provider)
+}
+
+func (mc *ModelCatalog) applyPricingOverrides(provider schemas.ModelProvider, model string, requestType schemas.RequestType, pricing configstoreTables.TableModelPricing) configstoreTables.TableModelPricing {
+	mc.overridesMu.RLock()
+	overrides := mc.compiledOverrides[provider]
+	mc.overridesMu.RUnlock()
+	if len(overrides) == 0 {
+		return pricing
+	}
+
+	modelCandidates := []string{model}
+	mode := normalizeRequestType(requestType)
+	best := selectBestOverride(overrides, modelCandidates, mode)
+	if best == nil {
+		return pricing
+	}
+
+	return patchPricing(pricing, best.override)
+}
+
+func compileProviderPricingOverride(order int, override schemas.ProviderPricingOverride) (compiledProviderPricingOverride, error) {
+	pattern := strings.TrimSpace(override.ModelPattern)
+	if pattern == "" {
+		return compiledProviderPricingOverride{}, fmt.Errorf("model_pattern cannot be empty")
+	}
+
+	result := compiledProviderPricingOverride{
+		override:     override,
+		requestModes: make(map[string]struct{}),
+		order:        order,
+	}
+	result.override.ModelPattern = pattern
+
+	switch override.MatchType {
+	case schemas.PricingOverrideMatchExact:
+		result.literalChars = len(pattern)
+	case schemas.PricingOverrideMatchWildcard:
+		if !strings.Contains(pattern, "*") {
+			return compiledProviderPricingOverride{}, fmt.Errorf("wildcard model_pattern must contain '*'")
+		}
+		result.literalChars = len(strings.ReplaceAll(pattern, "*", ""))
+	case schemas.PricingOverrideMatchRegex:
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return compiledProviderPricingOverride{}, fmt.Errorf("invalid regex model_pattern: %w", err)
+		}
+		result.regex = re
+		result.literalChars = len(pattern)
+	default:
+		return compiledProviderPricingOverride{}, fmt.Errorf("unsupported match_type: %s", override.MatchType)
+	}
+
+	if len(override.RequestTypes) > 0 {
+		result.hasRequestFilter = true
+		for _, requestType := range override.RequestTypes {
+			mode := normalizeRequestType(requestType)
+			if mode == "unknown" {
+				return compiledProviderPricingOverride{}, fmt.Errorf("unsupported request_type: %s", requestType)
+			}
+			result.requestModes[mode] = struct{}{}
+		}
+	}
+
+	return result, nil
+}
+
+func selectBestOverride(overrides []compiledProviderPricingOverride, modelCandidates []string, mode string) *compiledProviderPricingOverride {
+	var best *compiledProviderPricingOverride
+	for i := range overrides {
+		candidate := &overrides[i]
+		if candidate.hasRequestFilter {
+			if _, ok := candidate.requestModes[mode]; !ok {
+				continue
+			}
+		}
+		if !matchesAnyModel(candidate, modelCandidates) {
+			continue
+		}
+		if isBetterOverride(candidate, best) {
+			best = candidate
+		}
+	}
+	return best
+}
+
+func matchesAnyModel(override *compiledProviderPricingOverride, modelCandidates []string) bool {
+	for _, model := range modelCandidates {
+		if matchesModel(override, model) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesModel(override *compiledProviderPricingOverride, model string) bool {
+	switch override.override.MatchType {
+	case schemas.PricingOverrideMatchExact:
+		return model == override.override.ModelPattern
+	case schemas.PricingOverrideMatchWildcard:
+		return wildcardMatch(override.override.ModelPattern, model)
+	case schemas.PricingOverrideMatchRegex:
+		return override.regex != nil && override.regex.MatchString(model)
+	default:
+		return false
+	}
+}
+
+func overridePriority(matchType schemas.PricingOverrideMatchType) int {
+	switch matchType {
+	case schemas.PricingOverrideMatchExact:
+		return 0
+	case schemas.PricingOverrideMatchWildcard:
+		return 1
+	case schemas.PricingOverrideMatchRegex:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func isBetterOverride(candidate, best *compiledProviderPricingOverride) bool {
+	if best == nil {
+		return true
+	}
+
+	candidatePriority := overridePriority(candidate.override.MatchType)
+	bestPriority := overridePriority(best.override.MatchType)
+	if candidatePriority != bestPriority {
+		return candidatePriority < bestPriority
+	}
+
+	if candidate.hasRequestFilter != best.hasRequestFilter {
+		return candidate.hasRequestFilter
+	}
+
+	if candidate.literalChars != best.literalChars {
+		return candidate.literalChars > best.literalChars
+	}
+
+	return candidate.order < best.order
+}
+
+func wildcardMatch(pattern, model string) bool {
+	parts := strings.Split(pattern, "*")
+	if len(parts) == 1 {
+		return model == pattern
+	}
+
+	remaining := model
+	if parts[0] != "" {
+		if !strings.HasPrefix(remaining, parts[0]) {
+			return false
+		}
+		remaining = remaining[len(parts[0]):]
+	}
+
+	for i := 1; i < len(parts)-1; i++ {
+		part := parts[i]
+		if part == "" {
+			continue
+		}
+		index := strings.Index(remaining, part)
+		if index < 0 {
+			return false
+		}
+		remaining = remaining[index+len(part):]
+	}
+
+	last := parts[len(parts)-1]
+	if last == "" {
+		return true
+	}
+	return strings.HasSuffix(remaining, last)
+}
+
+func patchPricing(pricing configstoreTables.TableModelPricing, override schemas.ProviderPricingOverride) configstoreTables.TableModelPricing {
+	patched := pricing
+
+	if override.InputCostPerToken != nil {
+		patched.InputCostPerToken = *override.InputCostPerToken
+	}
+	if override.OutputCostPerToken != nil {
+		patched.OutputCostPerToken = *override.OutputCostPerToken
+	}
+	if override.InputCostPerVideoPerSecond != nil {
+		patched.InputCostPerVideoPerSecond = override.InputCostPerVideoPerSecond
+	}
+	if override.InputCostPerAudioPerSecond != nil {
+		patched.InputCostPerAudioPerSecond = override.InputCostPerAudioPerSecond
+	}
+	if override.InputCostPerCharacter != nil {
+		patched.InputCostPerCharacter = override.InputCostPerCharacter
+	}
+	if override.OutputCostPerCharacter != nil {
+		patched.OutputCostPerCharacter = override.OutputCostPerCharacter
+	}
+	if override.InputCostPerTokenAbove128kTokens != nil {
+		patched.InputCostPerTokenAbove128kTokens = override.InputCostPerTokenAbove128kTokens
+	}
+	if override.InputCostPerCharacterAbove128kTokens != nil {
+		patched.InputCostPerCharacterAbove128kTokens = override.InputCostPerCharacterAbove128kTokens
+	}
+	if override.InputCostPerImageAbove128kTokens != nil {
+		patched.InputCostPerImageAbove128kTokens = override.InputCostPerImageAbove128kTokens
+	}
+	if override.InputCostPerVideoPerSecondAbove128kTokens != nil {
+		patched.InputCostPerVideoPerSecondAbove128kTokens = override.InputCostPerVideoPerSecondAbove128kTokens
+	}
+	if override.InputCostPerAudioPerSecondAbove128kTokens != nil {
+		patched.InputCostPerAudioPerSecondAbove128kTokens = override.InputCostPerAudioPerSecondAbove128kTokens
+	}
+	if override.OutputCostPerTokenAbove128kTokens != nil {
+		patched.OutputCostPerTokenAbove128kTokens = override.OutputCostPerTokenAbove128kTokens
+	}
+	if override.OutputCostPerCharacterAbove128kTokens != nil {
+		patched.OutputCostPerCharacterAbove128kTokens = override.OutputCostPerCharacterAbove128kTokens
+	}
+	if override.InputCostPerTokenAbove200kTokens != nil {
+		patched.InputCostPerTokenAbove200kTokens = override.InputCostPerTokenAbove200kTokens
+	}
+	if override.OutputCostPerTokenAbove200kTokens != nil {
+		patched.OutputCostPerTokenAbove200kTokens = override.OutputCostPerTokenAbove200kTokens
+	}
+	if override.CacheCreationInputTokenCostAbove200kTokens != nil {
+		patched.CacheCreationInputTokenCostAbove200kTokens = override.CacheCreationInputTokenCostAbove200kTokens
+	}
+	if override.CacheReadInputTokenCostAbove200kTokens != nil {
+		patched.CacheReadInputTokenCostAbove200kTokens = override.CacheReadInputTokenCostAbove200kTokens
+	}
+	if override.CacheReadInputTokenCost != nil {
+		patched.CacheReadInputTokenCost = override.CacheReadInputTokenCost
+	}
+	if override.CacheCreationInputTokenCost != nil {
+		patched.CacheCreationInputTokenCost = override.CacheCreationInputTokenCost
+	}
+	if override.InputCostPerTokenBatches != nil {
+		patched.InputCostPerTokenBatches = override.InputCostPerTokenBatches
+	}
+	if override.OutputCostPerTokenBatches != nil {
+		patched.OutputCostPerTokenBatches = override.OutputCostPerTokenBatches
+	}
+	if override.InputCostPerImageToken != nil {
+		patched.InputCostPerImageToken = override.InputCostPerImageToken
+	}
+	if override.OutputCostPerImageToken != nil {
+		patched.OutputCostPerImageToken = override.OutputCostPerImageToken
+	}
+	if override.InputCostPerImage != nil {
+		patched.InputCostPerImage = override.InputCostPerImage
+	}
+	if override.OutputCostPerImage != nil {
+		patched.OutputCostPerImage = override.OutputCostPerImage
+	}
+	if override.CacheReadInputImageTokenCost != nil {
+		patched.CacheReadInputImageTokenCost = override.CacheReadInputImageTokenCost
+	}
+
+	return patched
+}

--- a/framework/modelcatalog/overrides_test.go
+++ b/framework/modelcatalog/overrides_test.go
@@ -22,10 +22,6 @@ func (noOpLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuild
 	return schemas.NoopLogEvent
 }
 
-func floatPtr(v float64) *float64 {
-	return &v
-}
-
 func TestSetProviderPricingOverrides_InvalidRegex(t *testing.T) {
 	mc := newTestCatalog(nil, nil)
 	err := mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
@@ -334,15 +330,15 @@ func TestPatchPricing_PartialPatchOnlyChangesSpecifiedFields(t *testing.T) {
 		CacheReadInputTokenCost:      &baseCacheRead,
 		InputCostPerImageToken:       &baseImageInput,
 		OutputCostPerImageToken:      &baseImageOutput,
-		CacheReadInputImageTokenCost: floatPtr(0.2),
+		CacheReadInputImageTokenCost: schemas.Ptr(0.2),
 	}
 
 	patched := patchPricing(base, schemas.ProviderPricingOverride{
 		ModelPattern:            "gpt-4o",
 		MatchType:               schemas.PricingOverrideMatchExact,
-		InputCostPerToken:       floatPtr(3),
-		CacheReadInputTokenCost: floatPtr(0.9),
-		OutputCostPerImageToken: floatPtr(1.2),
+		InputCostPerToken:       schemas.Ptr(3.0),
+		CacheReadInputTokenCost: schemas.Ptr(0.9),
+		OutputCostPerImageToken: schemas.Ptr(1.2),
 	})
 
 	// Changed fields

--- a/framework/modelcatalog/overrides_test.go
+++ b/framework/modelcatalog/overrides_test.go
@@ -1,0 +1,361 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type noOpLogger struct{}
+
+func (noOpLogger) Debug(string, ...any)                   {}
+func (noOpLogger) Info(string, ...any)                    {}
+func (noOpLogger) Warn(string, ...any)                    {}
+func (noOpLogger) Error(string, ...any)                   {}
+func (noOpLogger) Fatal(string, ...any)                   {}
+func (noOpLogger) SetLevel(schemas.LogLevel)              {}
+func (noOpLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (noOpLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func floatPtr(v float64) *float64 {
+	return &v
+}
+
+func TestSetProviderPricingOverrides_InvalidRegex(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	err := mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern: "[",
+			MatchType:    schemas.PricingOverrideMatchRegex,
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestGetPricing_OverridePrecedenceExactWildcardRegex(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	exact := 20.0
+	wildcard := 10.0
+	regex := 30.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &wildcard,
+		},
+		{
+			ModelPattern:      "^gpt-.*$",
+			MatchType:         schemas.PricingOverrideMatchRegex,
+			InputCostPerToken: &regex,
+		},
+		{
+			ModelPattern:      "gpt-4o",
+			MatchType:         schemas.PricingOverrideMatchExact,
+			InputCostPerToken: &exact,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 20.0, pricing.InputCostPerToken)
+	assert.Equal(t, 2.0, pricing.OutputCostPerToken)
+}
+
+func TestGetPricing_WildcardBeatsRegex(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o-mini", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o-mini",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	wildcard := 11.0
+	regex := 12.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "^gpt-4o.*$",
+			MatchType:         schemas.PricingOverrideMatchRegex,
+			InputCostPerToken: &regex,
+		},
+		{
+			ModelPattern:      "gpt-4o*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &wildcard,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o-mini", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 11.0, pricing.InputCostPerToken)
+}
+
+func TestGetPricing_RequestTypeSpecificOverrideBeatsGeneric(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o", "openai", "responses")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o",
+		Provider:           "openai",
+		Mode:               "responses",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	specific := 15.0
+	generic := 9.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-4o",
+			MatchType:         schemas.PricingOverrideMatchExact,
+			InputCostPerToken: &generic,
+		},
+		{
+			ModelPattern:      "gpt-4o",
+			MatchType:         schemas.PricingOverrideMatchExact,
+			RequestTypes:      []schemas.RequestType{schemas.ResponsesRequest},
+			InputCostPerToken: &specific,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o", "openai", schemas.ResponsesRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 15.0, pricing.InputCostPerToken)
+}
+
+func TestGetPricing_AppliesOverrideAfterFallbackResolution(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o", "vertex", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o",
+		Provider:           "vertex",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	override := 7.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.Gemini, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-4o",
+			MatchType:         schemas.PricingOverrideMatchExact,
+			InputCostPerToken: &override,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o", "gemini", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 7.0, pricing.InputCostPerToken)
+}
+
+func TestGetPricing_ExactOverrideDoesNotMatchProviderPrefixedModel(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("openai/gpt-4o", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "openai/gpt-4o",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	override := 19.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-4o",
+			MatchType:         schemas.PricingOverrideMatchExact,
+			InputCostPerToken: &override,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("openai/gpt-4o", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 1.0, pricing.InputCostPerToken)
+}
+
+func TestGetPricing_NoMatchingOverrideLeavesPricingUnchanged(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	baseCacheRead := 0.4
+	mc.pricingData[makeKey("gpt-4o", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:                   "gpt-4o",
+		Provider:                "openai",
+		Mode:                    "chat",
+		InputCostPerToken:       1,
+		OutputCostPerToken:      2,
+		CacheReadInputTokenCost: &baseCacheRead,
+	}
+
+	override := 9.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "claude-*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &override,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 1.0, pricing.InputCostPerToken)
+	assert.Equal(t, 2.0, pricing.OutputCostPerToken)
+	require.NotNil(t, pricing.CacheReadInputTokenCost)
+	assert.Equal(t, 0.4, *pricing.CacheReadInputTokenCost)
+}
+
+func TestDeleteProviderPricingOverrides_StopsApplying(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	override := 11.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-4o",
+			MatchType:         schemas.PricingOverrideMatchExact,
+			InputCostPerToken: &override,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 11.0, pricing.InputCostPerToken)
+
+	mc.DeleteProviderPricingOverrides(schemas.OpenAI)
+
+	pricing, ok = mc.getPricing("gpt-4o", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 1.0, pricing.InputCostPerToken)
+}
+
+func TestGetPricing_WildcardSpecificityLongerLiteralWins(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o-mini", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o-mini",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	generic := 5.0
+	specific := 6.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &generic,
+		},
+		{
+			ModelPattern:      "gpt-4o*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &specific,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o-mini", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 6.0, pricing.InputCostPerToken)
+}
+
+func TestGetPricing_ConfigOrderTiebreakFirstWinsWhenEqual(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+	mc.logger = noOpLogger{}
+	mc.pricingData[makeKey("gpt-4o-mini", "openai", "chat")] = configstoreTables.TableModelPricing{
+		Model:              "gpt-4o-mini",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	}
+
+	first := 8.0
+	second := 9.0
+	require.NoError(t, mc.SetProviderPricingOverrides(schemas.OpenAI, []schemas.ProviderPricingOverride{
+		{
+			ModelPattern:      "gpt-4o*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &first,
+		},
+		{
+			ModelPattern:      "gpt-4o*",
+			MatchType:         schemas.PricingOverrideMatchWildcard,
+			InputCostPerToken: &second,
+		},
+	}))
+
+	pricing, ok := mc.getPricing("gpt-4o-mini", "openai", schemas.ChatCompletionRequest)
+	require.True(t, ok)
+	require.NotNil(t, pricing)
+	assert.Equal(t, 8.0, pricing.InputCostPerToken)
+}
+
+func TestPatchPricing_PartialPatchOnlyChangesSpecifiedFields(t *testing.T) {
+	baseCacheRead := 0.4
+	baseImageInput := 0.7
+	baseImageOutput := 0.8
+	base := configstoreTables.TableModelPricing{
+		Model:                        "gpt-4o",
+		Provider:                     "openai",
+		Mode:                         "chat",
+		InputCostPerToken:            1,
+		OutputCostPerToken:           2,
+		CacheReadInputTokenCost:      &baseCacheRead,
+		InputCostPerImageToken:       &baseImageInput,
+		OutputCostPerImageToken:      &baseImageOutput,
+		CacheReadInputImageTokenCost: floatPtr(0.2),
+	}
+
+	patched := patchPricing(base, schemas.ProviderPricingOverride{
+		ModelPattern:            "gpt-4o",
+		MatchType:               schemas.PricingOverrideMatchExact,
+		InputCostPerToken:       floatPtr(3),
+		CacheReadInputTokenCost: floatPtr(0.9),
+		OutputCostPerImageToken: floatPtr(1.2),
+	})
+
+	// Changed fields
+	assert.Equal(t, 3.0, patched.InputCostPerToken)
+	require.NotNil(t, patched.CacheReadInputTokenCost)
+	assert.Equal(t, 0.9, *patched.CacheReadInputTokenCost)
+	require.NotNil(t, patched.OutputCostPerImageToken)
+	assert.Equal(t, 1.2, *patched.OutputCostPerImageToken)
+
+	// Unchanged fields
+	assert.Equal(t, 2.0, patched.OutputCostPerToken)
+	require.NotNil(t, patched.InputCostPerImageToken)
+	assert.Equal(t, 0.7, *patched.InputCostPerImageToken)
+	require.NotNil(t, patched.CacheReadInputImageTokenCost)
+	assert.Equal(t, 0.2, *patched.CacheReadInputImageTokenCost)
+}

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -449,7 +449,7 @@ func (mc *ModelCatalog) CalculateCostFromUsage(provider string, model string, de
 		outputCost = float64(completionTokens-cachedCompletionTokens) * pricing.OutputCostPerToken
 		if pricing.CacheCreationInputTokenCost != nil {
 			outputCost += float64(cachedCompletionTokens) * *pricing.CacheCreationInputTokenCost
-		}
+		} 
 	}
 
 	totalCost := inputCost + outputCost
@@ -460,79 +460,93 @@ func (mc *ModelCatalog) CalculateCostFromUsage(provider string, model string, de
 // getPricing returns pricing information for a model (thread-safe)
 func (mc *ModelCatalog) getPricing(model, provider string, requestType schemas.RequestType) (*configstoreTables.TableModelPricing, bool) {
 	mc.mu.RLock()
-	defer mc.mu.RUnlock()
-
-	pricing, ok := mc.pricingData[makeKey(model, provider, normalizeRequestType(requestType))]
+	pricing, ok := mc.resolvePricingEntryLocked(model, provider, requestType)
+	mc.mu.RUnlock()
 	if !ok {
-		// Lookup in vertex if gemini not found
-		if provider == string(schemas.Gemini) {
-			mc.logger.Debug("primary lookup failed, trying vertex provider for the same model")
-			pricing, ok = mc.pricingData[makeKey(model, "vertex", normalizeRequestType(requestType))]
+		return nil, false
+	}
+
+	patched := mc.applyPricingOverrides(schemas.ModelProvider(provider), model, requestType, pricing)
+	return &patched, true
+}
+
+// resolvePricingEntryLocked resolves pricing data from the base catalog including all existing fallback logic.
+// Caller must hold mc.mu read lock.
+func (mc *ModelCatalog) resolvePricingEntryLocked(model, provider string, requestType schemas.RequestType) (configstoreTables.TableModelPricing, bool) {
+	mode := normalizeRequestType(requestType)
+
+	pricing, ok := mc.pricingData[makeKey(model, provider, mode)]
+	if ok {
+		return pricing, true
+	}
+
+	// Lookup in vertex if gemini not found
+	if provider == string(schemas.Gemini) {
+		mc.logger.Debug("primary lookup failed, trying vertex provider for the same model")
+		pricing, ok = mc.pricingData[makeKey(model, "vertex", mode)]
+		if ok {
+			return pricing, true
+		}
+
+		// Lookup in chat if responses not found
+		if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
+			mc.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
+			pricing, ok = mc.pricingData[makeKey(model, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
 			if ok {
-				return &pricing, true
+				return pricing, true
+			}
+		}
+	}
+
+	if provider == string(schemas.Vertex) {
+		// Vertex models can be of the form "provider/model", so try to lookup the model without the provider prefix and keep the original provider
+		if strings.Contains(model, "/") {
+			modelWithoutProvider := strings.SplitN(model, "/", 2)[1]
+			mc.logger.Debug("primary lookup failed, trying vertex provider for the same model with provider/model format %s", modelWithoutProvider)
+			pricing, ok = mc.pricingData[makeKey(modelWithoutProvider, "vertex", mode)]
+			if ok {
+				return pricing, true
 			}
 
 			// Lookup in chat if responses not found
 			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
 				mc.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
-				pricing, ok = mc.pricingData[makeKey(model, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
+				pricing, ok = mc.pricingData[makeKey(modelWithoutProvider, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
 				if ok {
-					return &pricing, true
+					return pricing, true
 				}
 			}
 		}
-
-		if provider == string(schemas.Vertex) {
-			// Vertex models can be of the form "provider/model", so try to lookup the model without the provider prefix and keep the original provider
-			if strings.Contains(model, "/") {
-				modelWithoutProvider := strings.SplitN(model, "/", 2)[1]
-				mc.logger.Debug("primary lookup failed, trying vertex provider for the same model with provider/model format %s", modelWithoutProvider)
-				pricing, ok = mc.pricingData[makeKey(modelWithoutProvider, "vertex", normalizeRequestType(requestType))]
-				if ok {
-					return &pricing, true
-				}
-
-				// Lookup in chat if responses not found
-				if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
-					mc.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
-					pricing, ok = mc.pricingData[makeKey(modelWithoutProvider, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
-					if ok {
-						return &pricing, true
-					}
-				}
-			}
-		}
-
-		if provider == string(schemas.Bedrock) {
-			// If model is claude without "anthropic." prefix, try with "anthropic." prefix
-			if !strings.Contains(model, "anthropic.") && schemas.IsAnthropicModel(model) {
-				mc.logger.Debug("primary lookup failed, trying with anthropic. prefix for the same model")
-				pricing, ok = mc.pricingData[makeKey("anthropic."+model, provider, normalizeRequestType(requestType))]
-				if ok {
-					return &pricing, true
-				}
-
-				// Lookup in chat if responses not found
-				if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
-					mc.logger.Debug("secondary lookup failed, trying chat provider for the same model in chat completion")
-					pricing, ok = mc.pricingData[makeKey("anthropic."+model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
-					if ok {
-						return &pricing, true
-					}
-				}
-			}
-		}
-
-		// Lookup in chat if responses not found
-		if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
-			mc.logger.Debug("primary lookup failed, trying chat provider for the same model in chat completion")
-			pricing, ok = mc.pricingData[makeKey(model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
-			if ok {
-				return &pricing, true
-			}
-		}
-
-		return nil, false
 	}
-	return &pricing, true
+
+	if provider == string(schemas.Bedrock) {
+		// If model is claude without "anthropic." prefix, try with "anthropic." prefix
+		if !strings.Contains(model, "anthropic.") && schemas.IsAnthropicModel(model) {
+			mc.logger.Debug("primary lookup failed, trying with anthropic. prefix for the same model")
+			pricing, ok = mc.pricingData[makeKey("anthropic."+model, provider, mode)]
+			if ok {
+				return pricing, true
+			}
+
+			// Lookup in chat if responses not found
+			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
+				mc.logger.Debug("secondary lookup failed, trying chat provider for the same model in chat completion")
+				pricing, ok = mc.pricingData[makeKey("anthropic."+model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+				if ok {
+					return pricing, true
+				}
+			}
+		}
+	}
+
+	// Lookup in chat if responses not found
+	if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest {
+		mc.logger.Debug("primary lookup failed, trying chat provider for the same model in chat completion")
+		pricing, ok = mc.pricingData[makeKey(model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+		if ok {
+			return pricing, true
+		}
+	}
+
+	return configstoreTables.TableModelPricing{}, false
 }

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -58,18 +59,19 @@ const (
 
 // ProviderResponse represents the response for provider operations
 type ProviderResponse struct {
-	Name                     schemas.ModelProvider            `json:"name"`
-	Keys                     []schemas.Key                    `json:"keys"`                             // API keys for the provider
-	NetworkConfig            schemas.NetworkConfig            `json:"network_config"`                   // Network-related settings
-	ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"`      // Concurrency settings
-	ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config"`                     // Proxy configuration
-	SendBackRawRequest       bool                             `json:"send_back_raw_request"`            // Include raw request in BifrostResponse
-	SendBackRawResponse      bool                             `json:"send_back_raw_response"`           // Include raw response in BifrostResponse
-	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"` // Custom provider configuration
-	ProviderStatus           ProviderStatus                   `json:"provider_status"`                  // Health/initialization status of the provider
-	Status                   string                           `json:"status,omitempty"`                 // Operational status (e.g., list_models_failed)
-	Description              string                           `json:"description,omitempty"`            // Error/status description
-	ConfigHash               string                           `json:"config_hash,omitempty"`            // Hash of config.json version, used for change detection
+	Name                     schemas.ModelProvider             `json:"name"`
+	Keys                     []schemas.Key                     `json:"keys"`                             // API keys for the provider
+	NetworkConfig            schemas.NetworkConfig             `json:"network_config"`                   // Network-related settings
+	ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize  `json:"concurrency_and_buffer_size"`      // Concurrency settings
+	ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config"`                     // Proxy configuration
+	SendBackRawRequest       bool                              `json:"send_back_raw_request"`            // Include raw request in BifrostResponse
+	SendBackRawResponse      bool                              `json:"send_back_raw_response"`           // Include raw response in BifrostResponse
+	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"` // Custom provider configuration
+	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`      // Provider-level pricing overrides
+	ProviderStatus           ProviderStatus                    `json:"provider_status"`                  // Health/initialization status of the provider
+	Status                   string                            `json:"status,omitempty"`                 // Operational status (e.g., list_models_failed)
+	Description              string                            `json:"description,omitempty"`            // Error/status description
+	ConfigHash               string                            `json:"config_hash,omitempty"`            // Hash of config.json version, used for change detection
 }
 
 // ListProvidersResponse represents the response for listing all providers
@@ -181,6 +183,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		SendBackRawRequest       *bool                             `json:"send_back_raw_request,omitempty"`       // Include raw request in BifrostResponse
 		SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"`      // Include raw response in BifrostResponse
 		CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
+		PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`           // Provider-level pricing overrides
 	}{}
 	if err := json.Unmarshal(ctx.PostBody(), &payload); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid JSON: %v", err))
@@ -221,6 +224,10 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
+	if err := validatePricingOverrides(payload.PricingOverrides); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid pricing overrides: %v", err))
+		return
+	}
 	// Validate retry backoff values if NetworkConfig is provided
 	if payload.NetworkConfig != nil {
 		if err := validateRetryBackoff(payload.NetworkConfig); err != nil {
@@ -248,6 +255,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		SendBackRawRequest:       payload.SendBackRawRequest != nil && *payload.SendBackRawRequest,
 		SendBackRawResponse:      payload.SendBackRawResponse != nil && *payload.SendBackRawResponse,
 		CustomProviderConfig:     payload.CustomProviderConfig,
+		PricingOverrides:         payload.PricingOverrides,
 	}
 	// Validate custom provider configuration before persisting
 	if err := lib.ValidateCustomProvider(config, payload.Provider); err != nil {
@@ -259,6 +267,11 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		logger.Warn("Failed to add provider %s: %v", payload.Provider, err)
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to add provider: %v", err))
 		return
+	}
+	if h.inMemoryStore.ModelCatalog != nil {
+		if err := h.inMemoryStore.ModelCatalog.SetProviderPricingOverrides(payload.Provider, config.PricingOverrides); err != nil {
+			logger.Warn("Failed to set pricing overrides for provider %s: %v", payload.Provider, err)
+		}
 	}
 	logger.Info("Provider %s added successfully", payload.Provider)
 
@@ -281,6 +294,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			SendBackRawRequest:       config.SendBackRawRequest,
 			SendBackRawResponse:      config.SendBackRawResponse,
 			CustomProviderConfig:     config.CustomProviderConfig,
+			PricingOverrides:         config.PricingOverrides,
 			Status:                   config.Status,
 			Description:              config.Description,
 		}, ProviderStatusActive)
@@ -307,17 +321,22 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	}
 
 	var payload = struct {
-		Keys                     []schemas.Key                    `json:"keys"`                             // API keys for the provider
-		NetworkConfig            schemas.NetworkConfig            `json:"network_config"`                   // Network-related settings
-		ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"`      // Concurrency settings
-		ProxyConfig              *schemas.ProxyConfig             `json:"proxy_config,omitempty"`           // Proxy configuration
-		SendBackRawRequest       *bool                            `json:"send_back_raw_request,omitempty"`  // Include raw request in BifrostResponse
-		SendBackRawResponse      *bool                            `json:"send_back_raw_response,omitempty"` // Include raw response in BifrostResponse
-		CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"` // Custom provider configuration
+		Keys                     []schemas.Key                     `json:"keys"`                             // API keys for the provider
+		NetworkConfig            schemas.NetworkConfig             `json:"network_config"`                   // Network-related settings
+		ConcurrencyAndBufferSize schemas.ConcurrencyAndBufferSize  `json:"concurrency_and_buffer_size"`      // Concurrency settings
+		ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config,omitempty"`           // Proxy configuration
+		SendBackRawRequest       *bool                             `json:"send_back_raw_request,omitempty"`  // Include raw request in BifrostResponse
+		SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"` // Include raw response in BifrostResponse
+		CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"` // Custom provider configuration
+		PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`      // Provider-level pricing overrides
 	}{}
 
 	if err := sonic.Unmarshal(ctx.PostBody(), &payload); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid JSON: %v", err))
+		return
+	}
+	if err := validatePricingOverrides(payload.PricingOverrides); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid pricing overrides: %v", err))
 		return
 	}
 
@@ -355,6 +374,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		ConcurrencyAndBufferSize: oldConfigRaw.ConcurrencyAndBufferSize,
 		ProxyConfig:              oldConfigRaw.ProxyConfig,
 		CustomProviderConfig:     oldConfigRaw.CustomProviderConfig,
+		PricingOverrides:         oldConfigRaw.PricingOverrides,
 		Status:                   oldConfigRaw.Status,
 		Description:              oldConfigRaw.Description,
 	}
@@ -426,6 +446,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	config.NetworkConfig = &nc
 	config.ProxyConfig = payload.ProxyConfig
 	config.CustomProviderConfig = payload.CustomProviderConfig
+	config.PricingOverrides = payload.PricingOverrides
 	if payload.SendBackRawRequest != nil {
 		config.SendBackRawRequest = *payload.SendBackRawRequest
 	}
@@ -459,6 +480,11 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update provider: %v", err))
 		return
 	}
+	if h.inMemoryStore.ModelCatalog != nil {
+		if err := h.inMemoryStore.ModelCatalog.SetProviderPricingOverrides(provider, config.PricingOverrides); err != nil {
+			logger.Warn("Failed to set pricing overrides for provider %s: %v", provider, err)
+		}
+	}
 
 	// Attempt model discovery
 	err = h.attemptModelDiscovery(ctx, provider, payload.CustomProviderConfig)
@@ -479,6 +505,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 			SendBackRawRequest:       config.SendBackRawRequest,
 			SendBackRawResponse:      config.SendBackRawResponse,
 			CustomProviderConfig:     config.CustomProviderConfig,
+			PricingOverrides:         config.PricingOverrides,
 			Status:                   config.Status,
 			Description:              config.Description,
 		}, ProviderStatusActive)
@@ -955,11 +982,110 @@ func (h *ProviderHandler) getProviderResponseFromConfig(provider schemas.ModelPr
 		SendBackRawRequest:       config.SendBackRawRequest,
 		SendBackRawResponse:      config.SendBackRawResponse,
 		CustomProviderConfig:     config.CustomProviderConfig,
+		PricingOverrides:         config.PricingOverrides,
 		ProviderStatus:           status,
 		Status:                   config.Status,
 		Description:              config.Description,
 		ConfigHash:               config.ConfigHash,
 	}
+}
+
+func validatePricingOverrides(overrides []schemas.ProviderPricingOverride) error {
+	for i, override := range overrides {
+		if strings.TrimSpace(override.ModelPattern) == "" {
+			return fmt.Errorf("override[%d]: model_pattern is required", i)
+		}
+
+		switch override.MatchType {
+		case schemas.PricingOverrideMatchExact:
+			if strings.Contains(override.ModelPattern, "*") {
+				return fmt.Errorf("override[%d]: exact match_type cannot include '*'", i)
+			}
+		case schemas.PricingOverrideMatchWildcard:
+			if !strings.Contains(override.ModelPattern, "*") {
+				return fmt.Errorf("override[%d]: wildcard match_type requires '*' in model_pattern", i)
+			}
+		case schemas.PricingOverrideMatchRegex:
+			if _, err := regexp.Compile(override.ModelPattern); err != nil {
+				return fmt.Errorf("override[%d]: invalid regex pattern: %w", i, err)
+			}
+		default:
+			return fmt.Errorf("override[%d]: unsupported match_type %q", i, override.MatchType)
+		}
+
+		for _, requestType := range override.RequestTypes {
+			if !isSupportedOverrideRequestType(requestType) {
+				return fmt.Errorf("override[%d]: unsupported request_type %q", i, requestType)
+			}
+		}
+
+		if err := validatePricingOverrideNonNegativeFields(i, override); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func isSupportedOverrideRequestType(requestType schemas.RequestType) bool {
+	switch requestType {
+	case schemas.TextCompletionRequest,
+		schemas.TextCompletionStreamRequest,
+		schemas.ChatCompletionRequest,
+		schemas.ChatCompletionStreamRequest,
+		schemas.ResponsesRequest,
+		schemas.ResponsesStreamRequest,
+		schemas.EmbeddingRequest,
+		schemas.RerankRequest,
+		schemas.SpeechRequest,
+		schemas.SpeechStreamRequest,
+		schemas.TranscriptionRequest,
+		schemas.TranscriptionStreamRequest,
+		schemas.ImageGenerationRequest,
+		schemas.ImageGenerationStreamRequest:
+		return true
+	default:
+		return false
+	}
+}
+
+func validatePricingOverrideNonNegativeFields(index int, override schemas.ProviderPricingOverride) error {
+	optionalValues := map[string]*float64{
+		"input_cost_per_token":                              override.InputCostPerToken,
+		"output_cost_per_token":                             override.OutputCostPerToken,
+		"input_cost_per_video_per_second":                   override.InputCostPerVideoPerSecond,
+		"input_cost_per_audio_per_second":                   override.InputCostPerAudioPerSecond,
+		"input_cost_per_character":                          override.InputCostPerCharacter,
+		"output_cost_per_character":                         override.OutputCostPerCharacter,
+		"input_cost_per_token_above_128k_tokens":            override.InputCostPerTokenAbove128kTokens,
+		"input_cost_per_character_above_128k_tokens":        override.InputCostPerCharacterAbove128kTokens,
+		"input_cost_per_image_above_128k_tokens":            override.InputCostPerImageAbove128kTokens,
+		"input_cost_per_video_per_second_above_128k_tokens": override.InputCostPerVideoPerSecondAbove128kTokens,
+		"input_cost_per_audio_per_second_above_128k_tokens": override.InputCostPerAudioPerSecondAbove128kTokens,
+		"output_cost_per_token_above_128k_tokens":           override.OutputCostPerTokenAbove128kTokens,
+		"output_cost_per_character_above_128k_tokens":       override.OutputCostPerCharacterAbove128kTokens,
+		"input_cost_per_token_above_200k_tokens":            override.InputCostPerTokenAbove200kTokens,
+		"output_cost_per_token_above_200k_tokens":           override.OutputCostPerTokenAbove200kTokens,
+		"cache_creation_input_token_cost_above_200k_tokens": override.CacheCreationInputTokenCostAbove200kTokens,
+		"cache_read_input_token_cost_above_200k_tokens":     override.CacheReadInputTokenCostAbove200kTokens,
+		"cache_read_input_token_cost":                       override.CacheReadInputTokenCost,
+		"cache_creation_input_token_cost":                   override.CacheCreationInputTokenCost,
+		"input_cost_per_token_batches":                      override.InputCostPerTokenBatches,
+		"output_cost_per_token_batches":                     override.OutputCostPerTokenBatches,
+		"input_cost_per_image_token":                        override.InputCostPerImageToken,
+		"output_cost_per_image_token":                       override.OutputCostPerImageToken,
+		"input_cost_per_image":                              override.InputCostPerImage,
+		"output_cost_per_image":                             override.OutputCostPerImage,
+		"cache_read_input_image_token_cost":                 override.CacheReadInputImageTokenCost,
+	}
+
+	for fieldName, value := range optionalValues {
+		if value != nil && *value < 0 {
+			return fmt.Errorf("override[%d]: %s must be non-negative", index, fieldName)
+		}
+	}
+
+	return nil
 }
 
 func getProviderFromCtx(ctx *fasthttp.RequestCtx) (schemas.ModelProvider, error) {

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -225,7 +225,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	if err := validatePricingOverrides(payload.PricingOverrides); err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid pricing overrides: %v", err))
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid pricing overrides: %v", err))
 		return
 	}
 	// Validate retry backoff values if NetworkConfig is provided
@@ -336,7 +336,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if err := validatePricingOverrides(payload.PricingOverrides); err != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid pricing overrides: %v", err))
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid pricing overrides: %v", err))
 		return
 	}
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1804,6 +1804,7 @@ func initFrameworkConfigFromFile(ctx context.Context, config *Config, configData
 		logger.Error("failed to initialize pricing manager: %v", err)
 	} else {
 		config.ModelCatalog = pricingManager
+		applyProviderPricingOverrides(config.ModelCatalog, config.Providers)
 	}
 
 	// Initialize MCP catalog
@@ -2166,6 +2167,7 @@ func initDefaultFrameworkConfig(ctx context.Context, config *Config) error {
 		logger.Error("failed to initialize model catalog: %v", err)
 	} else {
 		config.ModelCatalog = modelCatalog
+		applyProviderPricingOverrides(config.ModelCatalog, config.Providers)
 	}
 
 	// Initialize MCP catalog
@@ -3480,4 +3482,15 @@ func DeepCopy[T any](in T) (T, error) {
 	}
 	err = sonic.Unmarshal(b, &out)
 	return out, err
+}
+
+func applyProviderPricingOverrides(catalog *modelcatalog.ModelCatalog, providers map[schemas.ModelProvider]configstore.ProviderConfig) {
+	if catalog == nil {
+		return
+	}
+	for provider, providerConfig := range providers {
+		if err := catalog.SetProviderPricingOverrides(provider, providerConfig.PricingOverrides); err != nil {
+			logger.Warn("failed to load pricing overrides for provider %s: %v", provider, err)
+		}
+	}
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -295,8 +295,8 @@ var DefaultClientConfig = configstore.ClientConfig{
 	InitialPoolSize:         schemas.DefaultInitialPoolSize,
 	EnableLogging:           true,
 	DisableContentLogging:   false,
-	EnableGovernance:       true,
-	EnforceAuthOnInference: false,
+	EnableGovernance:        true,
+	EnforceAuthOnInference:  false,
 	AllowDirectKeys:         false,
 	AllowedOrigins:          []string{"*"},
 	AllowedHeaders:          []string{},
@@ -1998,20 +1998,20 @@ func loadDefaultProviders(ctx context.Context, config *Config) error {
 			keys := make([]schemas.Key, len(dbProvider.Keys))
 			for i, dbKey := range dbProvider.Keys {
 				keys[i] = schemas.Key{
-					ID:               dbKey.ID,
-					Name:             dbKey.Name,
-					Value:            dbKey.Value,
-					Models:           dbKey.Models,
-					Weight:           dbKey.Weight,
-					Enabled:          dbKey.Enabled,
-					UseForBatchAPI:   dbKey.UseForBatchAPI,
-					AzureKeyConfig:   dbKey.AzureKeyConfig,
-					VertexKeyConfig:  dbKey.VertexKeyConfig,
-					BedrockKeyConfig: dbKey.BedrockKeyConfig,
+					ID:                 dbKey.ID,
+					Name:               dbKey.Name,
+					Value:              dbKey.Value,
+					Models:             dbKey.Models,
+					Weight:             dbKey.Weight,
+					Enabled:            dbKey.Enabled,
+					UseForBatchAPI:     dbKey.UseForBatchAPI,
+					AzureKeyConfig:     dbKey.AzureKeyConfig,
+					VertexKeyConfig:    dbKey.VertexKeyConfig,
+					BedrockKeyConfig:   dbKey.BedrockKeyConfig,
 					ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
-					ConfigHash:       dbKey.ConfigHash,
-					Status:           dbKey.Status,
-					Description:      dbKey.Description,
+					ConfigHash:         dbKey.ConfigHash,
+					Status:             dbKey.Status,
+					Description:        dbKey.Description,
 				}
 			}
 			providerConfig := configstore.ProviderConfig{
@@ -2022,6 +2022,7 @@ func loadDefaultProviders(ctx context.Context, config *Config) error {
 				SendBackRawRequest:       dbProvider.SendBackRawRequest,
 				SendBackRawResponse:      dbProvider.SendBackRawResponse,
 				CustomProviderConfig:     dbProvider.CustomProviderConfig,
+				PricingOverrides:         dbProvider.PricingOverrides,
 				ConfigHash:               dbProvider.ConfigHash,
 			}
 			if err := ValidateCustomProvider(providerConfig, provider); err != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1613,6 +1613,63 @@
       },
       "additionalProperties": false
     },
+    "pricing_override_match_type": {
+      "type": "string",
+      "enum": [
+        "exact",
+        "wildcard",
+        "regex"
+      ]
+    },
+    "provider_pricing_override": {
+      "type": "object",
+      "properties": {
+        "model_pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "match_type": {
+          "$ref": "#/$defs/pricing_override_match_type"
+        },
+        "request_types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "input_cost_per_token": { "type": "number", "minimum": 0 },
+        "output_cost_per_token": { "type": "number", "minimum": 0 },
+        "input_cost_per_video_per_second": { "type": "number", "minimum": 0 },
+        "input_cost_per_audio_per_second": { "type": "number", "minimum": 0 },
+        "input_cost_per_character": { "type": "number", "minimum": 0 },
+        "output_cost_per_character": { "type": "number", "minimum": 0 },
+        "input_cost_per_token_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_character_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_image_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_video_per_second_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_audio_per_second_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "output_cost_per_token_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "output_cost_per_character_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_token_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "output_cost_per_token_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "cache_creation_input_token_cost_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "cache_read_input_token_cost_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "cache_read_input_token_cost": { "type": "number", "minimum": 0 },
+        "cache_creation_input_token_cost": { "type": "number", "minimum": 0 },
+        "input_cost_per_token_batches": { "type": "number", "minimum": 0 },
+        "output_cost_per_token_batches": { "type": "number", "minimum": 0 },
+        "input_cost_per_image_token": { "type": "number", "minimum": 0 },
+        "output_cost_per_image_token": { "type": "number", "minimum": 0 },
+        "input_cost_per_image": { "type": "number", "minimum": 0 },
+        "output_cost_per_image": { "type": "number", "minimum": 0 },
+        "cache_read_input_image_token_cost": { "type": "number", "minimum": 0 }
+      },
+      "required": [
+        "model_pattern",
+        "match_type"
+      ],
+      "additionalProperties": false
+    },
     "network_config": {
       "type": "object",
       "properties": {
@@ -1857,6 +1914,13 @@
         "send_back_raw_response": {
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
       "required": [
@@ -1887,6 +1951,13 @@
         "send_back_raw_response": {
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
       "required": [
@@ -1917,6 +1988,13 @@
         "send_back_raw_response": {
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
       "required": [
@@ -1947,6 +2025,13 @@
         "send_back_raw_response": {
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
       "required": [

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1621,6 +1621,25 @@
         "regex"
       ]
     },
+    "pricing_override_request_type": {
+      "type": "string",
+      "enum": [
+        "text_completion",
+        "text_completion_stream",
+        "chat_completion",
+        "chat_completion_stream",
+        "responses",
+        "responses_stream",
+        "embedding",
+        "rerank",
+        "speech",
+        "speech_stream",
+        "transcription",
+        "transcription_stream",
+        "image_generation",
+        "image_generation_stream"
+      ]
+    },
     "provider_pricing_override": {
       "type": "object",
       "properties": {
@@ -1634,7 +1653,7 @@
         "request_types": {
           "type": "array",
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/pricing_override_request_type"
           }
         },
         "input_cost_per_token": { "type": "number", "minimum": 0 },

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -5,10 +5,14 @@ import { useGetCoreConfigQuery } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useMemo, useState } from "react";
-import { ApiStructureFormFragment, GovernanceFormFragment, ProxyFormFragment } from "../fragments";
-import { NetworkFormFragment } from "../fragments/networkFormFragment";
-import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
-import { PricingOverridesFormFragment } from "../fragments/pricingOverridesFormFragment";
+import {
+	ApiStructureFormFragment,
+	GovernanceFormFragment,
+	NetworkFormFragment,
+	PerformanceFormFragment,
+	PricingOverridesFormFragment,
+	ProxyFormFragment,
+} from "../fragments";
 
 interface Props {
 	show: boolean;
@@ -88,7 +92,7 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 							className="mb-4 grid h-10 w-full rounded-tl-sm rounded-tr-sm rounded-br-none rounded-bl-none"
 						>
 							{tabs.map((tab) => (
-								<TabsTrigger key={tab.id} value={tab.id} className="flex items-center gap-2">
+								<TabsTrigger key={tab.id} value={tab.id} data-testid={`provider-tab-${tab.id}`} className="flex items-center gap-2">
 									{tab.label}
 								</TabsTrigger>
 							))}

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ApiStructureFormFragment, GovernanceFormFragment, ProxyFormFragment } from "../fragments";
 import { NetworkFormFragment } from "../fragments/networkFormFragment";
 import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
+import { PricingOverridesFormFragment } from "../fragments/pricingOverridesFormFragment";
 
 interface Props {
 	show: boolean;
@@ -34,6 +35,10 @@ const availableTabs = (provider: ModelProvider, hasGovernanceAccess: boolean, is
 	tabs.push({
 		id: "performance",
 		label: "Performance tuning",
+	});
+	tabs.push({
+		id: "pricing-overrides",
+		label: "Pricing Overrides",
 	});
 	if (hasGovernanceAccess && isGovernanceEnabled) {
 		tabs.push({
@@ -99,6 +104,9 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 						</TabsContent>
 						<TabsContent value="performance">
 							<PerformanceFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="pricing-overrides">
+							<PricingOverridesFormFragment provider={provider} />
 						</TabsContent>
 						<TabsContent value="governance">
 							<GovernanceFormFragment provider={provider} />

--- a/ui/app/workspace/providers/fragments/index.ts
+++ b/ui/app/workspace/providers/fragments/index.ts
@@ -3,6 +3,7 @@ export { ApiKeyFormFragment } from "./apiKeysFormFragment";
 export { ApiStructureFormFragment } from "./apiStructureFormFragment";
 export { GovernanceFormFragment } from "./governanceFormFragment";
 export { NetworkFormFragment } from "./networkFormFragment";
+export { PerformanceFormFragment } from "./performanceFormFragment";
 export { PerformanceFormFragment as PerformanceTab } from "./performanceFormFragment";
 export { PricingOverridesFormFragment } from "./pricingOverridesFormFragment";
 export { ProxyFormFragment } from "./proxyFormFragment";

--- a/ui/app/workspace/providers/fragments/index.ts
+++ b/ui/app/workspace/providers/fragments/index.ts
@@ -4,4 +4,5 @@ export { ApiStructureFormFragment } from "./apiStructureFormFragment";
 export { GovernanceFormFragment } from "./governanceFormFragment";
 export { NetworkFormFragment } from "./networkFormFragment";
 export { PerformanceFormFragment as PerformanceTab } from "./performanceFormFragment";
+export { PricingOverridesFormFragment } from "./pricingOverridesFormFragment";
 export { ProxyFormFragment } from "./proxyFormFragment";

--- a/ui/app/workspace/providers/fragments/pricingOverridesFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/pricingOverridesFormFragment.tsx
@@ -30,12 +30,12 @@ export function PricingOverridesFormFragment({ provider }: PricingOverridesFormF
 	const isDirty = hasUserEdits && overridesJSON !== initialValue;
 
 	useEffect(() => {
-		if (hasUserEdits) {
+		if (isDirty) {
 			return;
 		}
 		setOverridesJSON(initialValue);
 		setValidationError("");
-	}, [hasUserEdits, initialValue, provider.name]);
+	}, [initialValue, isDirty, provider.name]);
 
 	useEffect(() => {
 		dispatch(setProviderFormDirtyState(isDirty));

--- a/ui/app/workspace/providers/fragments/pricingOverridesFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/pricingOverridesFormFragment.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
+import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
+import { ModelProvider } from "@/lib/types/config";
+import { providerPricingOverrideSchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+interface PricingOverridesFormFragmentProps {
+	provider: ModelProvider;
+}
+
+const pricingOverridesArraySchema = z.array(providerPricingOverrideSchema);
+
+const toPrettyJSON = (value: unknown) => JSON.stringify(value, null, 2);
+
+export function PricingOverridesFormFragment({ provider }: PricingOverridesFormFragmentProps) {
+	const dispatch = useAppDispatch();
+	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
+	const initialValue = useMemo(() => toPrettyJSON(provider.pricing_overrides ?? []), [provider.pricing_overrides]);
+	const [overridesJSON, setOverridesJSON] = useState(initialValue);
+	const [validationError, setValidationError] = useState<string>("");
+	const isDirty = overridesJSON !== initialValue;
+
+	useEffect(() => {
+		setOverridesJSON(initialValue);
+		setValidationError("");
+	}, [initialValue, provider.name]);
+
+	useEffect(() => {
+		dispatch(setProviderFormDirtyState(isDirty));
+	}, [dispatch, isDirty]);
+
+	const onReset = () => {
+		setOverridesJSON(initialValue);
+		setValidationError("");
+	};
+
+	const onSave = async () => {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(overridesJSON);
+		} catch {
+			setValidationError("Invalid JSON format.");
+			return;
+		}
+
+		const validated = pricingOverridesArraySchema.safeParse(parsed);
+		if (!validated.success) {
+			setValidationError(validated.error.issues[0]?.message || "Invalid pricing overrides configuration.");
+			return;
+		}
+
+		setValidationError("");
+
+		try {
+			await updateProvider({
+				...provider,
+				pricing_overrides: validated.data,
+			}).unwrap();
+			toast.success("Pricing overrides updated successfully");
+			setOverridesJSON(toPrettyJSON(validated.data));
+		} catch (err) {
+			toast.error("Failed to update pricing overrides", {
+				description: getErrorMessage(err),
+			});
+		}
+	};
+
+	return (
+		<div className="space-y-4 px-6 pb-6">
+			<div className="space-y-1">
+				<p className="text-sm font-medium">Provider Pricing Overrides</p>
+				<p className="text-muted-foreground text-xs">
+					Enter a JSON array of override objects. Match precedence is exact &gt; wildcard &gt; regex. Unspecified fields fall back to datasheet pricing.
+				</p>
+			</div>
+
+			<Textarea
+				data-testid="provider-pricing-overrides-json-input"
+				value={overridesJSON}
+				onChange={(event) => setOverridesJSON(event.target.value)}
+				rows={18}
+				className="font-mono text-xs"
+				disabled={!hasUpdateProviderAccess}
+				placeholder={`[
+  {
+    "model_pattern": "gpt-4o*",
+    "match_type": "wildcard",
+    "request_types": ["chat_completion"],
+    "input_cost_per_token": 0.000005,
+    "output_cost_per_token": 0.000015
+  }
+]`}
+			/>
+
+			{validationError ? <p className="text-destructive text-xs">{validationError}</p> : null}
+
+			<div className="flex justify-end gap-2">
+				<Button type="button" variant="outline" onClick={onReset} disabled={!hasUpdateProviderAccess || !isDirty}>
+					Reset
+				</Button>
+				<Button
+					type="button"
+					data-testid="provider-pricing-overrides-save-button"
+					onClick={onSave}
+					isLoading={isUpdatingProvider}
+					disabled={!hasUpdateProviderAccess || !isDirty}
+				>
+					Save Pricing Overrides
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -232,6 +232,40 @@ export interface CustomProviderConfig {
 	request_path_overrides?: Record<string, string>;
 }
 
+export type PricingOverrideMatchType = "exact" | "wildcard" | "regex";
+
+export interface ProviderPricingOverride {
+	model_pattern: string;
+	match_type: PricingOverrideMatchType;
+	request_types?: string[];
+	input_cost_per_token?: number;
+	output_cost_per_token?: number;
+	input_cost_per_video_per_second?: number;
+	input_cost_per_audio_per_second?: number;
+	input_cost_per_character?: number;
+	output_cost_per_character?: number;
+	input_cost_per_token_above_128k_tokens?: number;
+	input_cost_per_character_above_128k_tokens?: number;
+	input_cost_per_image_above_128k_tokens?: number;
+	input_cost_per_video_per_second_above_128k_tokens?: number;
+	input_cost_per_audio_per_second_above_128k_tokens?: number;
+	output_cost_per_token_above_128k_tokens?: number;
+	output_cost_per_character_above_128k_tokens?: number;
+	input_cost_per_token_above_200k_tokens?: number;
+	output_cost_per_token_above_200k_tokens?: number;
+	cache_creation_input_token_cost_above_200k_tokens?: number;
+	cache_read_input_token_cost_above_200k_tokens?: number;
+	cache_read_input_token_cost?: number;
+	cache_creation_input_token_cost?: number;
+	input_cost_per_token_batches?: number;
+	output_cost_per_token_batches?: number;
+	input_cost_per_image_token?: number;
+	output_cost_per_image_token?: number;
+	input_cost_per_image?: number;
+	output_cost_per_image?: number;
+	cache_read_input_image_token_cost?: number;
+}
+
 // ProviderConfig matching Go's lib.ProviderConfig
 export interface ModelProviderConfig {
 	keys: ModelProviderKey[];
@@ -241,6 +275,7 @@ export interface ModelProviderConfig {
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+	pricing_overrides?: ProviderPricingOverride[];
 	status?: "unknown" | "success" | "list_models_failed";
 	description?: string;
 }
@@ -268,6 +303,7 @@ export interface AddProviderRequest {
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+	pricing_overrides?: ProviderPricingOverride[];
 }
 
 // UpdateProviderRequest matching Go's UpdateProviderRequest
@@ -279,6 +315,7 @@ export interface UpdateProviderRequest {
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+	pricing_overrides?: ProviderPricingOverride[];
 }
 
 // BifrostErrorResponse matching Go's schemas.BifrostError

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -401,6 +401,86 @@ export const formCustomProviderConfigSchema = z
 			path: ["is_key_less"],
 		},
 	);
+
+export const providerPricingOverrideMatchTypeSchema = z.enum(["exact", "wildcard", "regex"]);
+
+export const providerPricingOverrideRequestTypeSchema = z.enum([
+	"text_completion",
+	"text_completion_stream",
+	"chat_completion",
+	"chat_completion_stream",
+	"responses",
+	"responses_stream",
+	"embedding",
+	"rerank",
+	"speech",
+	"speech_stream",
+	"transcription",
+	"transcription_stream",
+	"image_generation",
+	"image_generation_stream",
+]);
+
+export const providerPricingOverrideSchema = z
+	.object({
+		model_pattern: z.string().min(1, "Model pattern is required"),
+		match_type: providerPricingOverrideMatchTypeSchema,
+		request_types: z.array(providerPricingOverrideRequestTypeSchema).optional(),
+		input_cost_per_token: z.number().min(0).optional(),
+		output_cost_per_token: z.number().min(0).optional(),
+		input_cost_per_video_per_second: z.number().min(0).optional(),
+		input_cost_per_audio_per_second: z.number().min(0).optional(),
+		input_cost_per_character: z.number().min(0).optional(),
+		output_cost_per_character: z.number().min(0).optional(),
+		input_cost_per_token_above_128k_tokens: z.number().min(0).optional(),
+		input_cost_per_character_above_128k_tokens: z.number().min(0).optional(),
+		input_cost_per_image_above_128k_tokens: z.number().min(0).optional(),
+		input_cost_per_video_per_second_above_128k_tokens: z.number().min(0).optional(),
+		input_cost_per_audio_per_second_above_128k_tokens: z.number().min(0).optional(),
+		output_cost_per_token_above_128k_tokens: z.number().min(0).optional(),
+		output_cost_per_character_above_128k_tokens: z.number().min(0).optional(),
+		input_cost_per_token_above_200k_tokens: z.number().min(0).optional(),
+		output_cost_per_token_above_200k_tokens: z.number().min(0).optional(),
+		cache_creation_input_token_cost_above_200k_tokens: z.number().min(0).optional(),
+		cache_read_input_token_cost_above_200k_tokens: z.number().min(0).optional(),
+		cache_read_input_token_cost: z.number().min(0).optional(),
+		cache_creation_input_token_cost: z.number().min(0).optional(),
+		input_cost_per_token_batches: z.number().min(0).optional(),
+		output_cost_per_token_batches: z.number().min(0).optional(),
+		input_cost_per_image_token: z.number().min(0).optional(),
+		output_cost_per_image_token: z.number().min(0).optional(),
+		input_cost_per_image: z.number().min(0).optional(),
+		output_cost_per_image: z.number().min(0).optional(),
+		cache_read_input_image_token_cost: z.number().min(0).optional(),
+	})
+	.superRefine((data, ctx) => {
+		if (data.match_type === "exact" && data.model_pattern.includes("*")) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["model_pattern"],
+				message: "Exact match patterns cannot include '*'",
+			});
+		}
+		if (data.match_type === "wildcard" && !data.model_pattern.includes("*")) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["model_pattern"],
+				message: "Wildcard patterns must include '*'",
+			});
+		}
+		if (data.match_type === "regex") {
+			try {
+				new RegExp(data.model_pattern);
+			} catch {
+				ctx.addIssue({
+					code: "custom",
+					path: ["model_pattern"],
+					message: "Invalid regex pattern",
+				});
+			}
+		}
+	});
+
 // Full model provider config schema
 export const modelProviderConfigSchema = z.object({
 	keys: z.array(modelProviderKeySchema).min(1, "At least one key is required"),
@@ -410,6 +490,7 @@ export const modelProviderConfigSchema = z.object({
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
+	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
 
 // Model provider schema
@@ -426,6 +507,7 @@ export const formModelProviderConfigSchema = z.object({
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: formCustomProviderConfigSchema.optional(),
+	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
 
 // Flexible model provider schema for form data - allows any string for name
@@ -443,6 +525,7 @@ export const addProviderRequestSchema = z.object({
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
+	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
 
 // Update provider request schema
@@ -454,6 +537,7 @@ export const updateProviderRequestSchema = z.object({
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
+	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
 
 // Cache config schema


### PR DESCRIPTION
## Summary

Implements provider-level per-model pricing overrides with pattern-based matching and field-level patching over datasheet pricing.

Users can now define `pricing_overrides` under a provider and override selected pricing fields (token, cache, batch, image, tiered pricing, etc.) without changing remote datasheet sync or core cost formulas.

## What Changed

### 1. Schema & Config Support

- Added pricing override schema support in provider config:
  - `ProviderPricingOverride`
  - `PricingOverrideMatchType` (`exact`, `wildcard`, `regex`)
  - `pricing_overrides` in provider config

### 2. Configstore Persistence

- Added DB migration + column: `pricing_overrides_json`
- Added serialization/deserialization in provider table hooks
- Wired through create/update/get provider config flows

### 3. Override Engine (Model Catalog)

- Compile + validate rules
- Matching precedence:
  - `exact` > `wildcard` > `regex`
  - Request-type filtered overrides beat generic
  - Wildcard specificity tie-break
  - Config-order tie-break
- Partial patching:
  - Only specified fields override base pricing

### 4. Pricing Resolution Integration

- Applied after existing fallback resolution
- No changes to cost calculation formulas

### 5. Runtime Lifecycle Wiring

- Seed overrides on startup
- Refresh on provider reload/update
- Clear on provider delete

### 6. API Validation

- Match type and pattern validation
- Request type validation
- Non-negative pricing field validation

### 7. UI Support

- New **Pricing Overrides** tab in provider config
- JSON editor + validation

### 8. Tests Added / Expanded

- Precedence and tie-break behavior
- Fallback-order application
- No-match behavior
- Delete override behavior
- Partial patch behavior

---

## Type of Change

- [x] Feature

---

## Affected Areas

- [x] core (Go)
- [x] framework (configstore / modelcatalog)
- [x] transports (bifrost-http)
- [x] ui (Next.js)

---

## How to Test

### Automated Tests

```bash
# framework
cd framework
go test ./modelcatalog
go test ./configstore/...

# transports
cd ../transports
go test ./bifrost-http/server
go test ./bifrost-http/handlers

# ui typecheck
cd ../ui
pnpm exec tsc --noEmit --pretty false
```