### PR TITLE
Add direct cache docs

### DIFF
--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -266,7 +266,7 @@ bifrost:
   "plugins": [
     {
       "enabled": true,
-      "name": "semanticcache",
+      "name": "semantic_cache",
       "config": {
         "dimension": 1,
         "ttl": "5m",
@@ -289,6 +289,10 @@ When initialized this way, all requests automatically use direct hash matching r
 
 **Redis** is recommended for direct hash mode. It does not require vectors for metadata-only entries, and all cache fields are indexed as RediSearch TAG fields for fast exact-match lookups.
 
+<Warning>
+Redis requires the [RediSearch](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/) module. The Helm chart's built-in Redis subchart (`redis:7-alpine`) does **not** include RediSearch and will fail at startup. Use an external Redis Stack instance or override the image to one that includes the module (e.g., `redis/redis-stack-server` or Redis 8+).
+</Warning>
+
 <Tabs group="direct-hash-redis">
 
 <Tab title="Helm">
@@ -298,16 +302,11 @@ vectorStore:
   enabled: true
   type: redis
   redis:
-    enabled: true
-    auth:
+    external:
       enabled: true
+      host: "redis-stack.example.com"
+      port: 6379
       password: "your-redis-password"
-    # Or use an external Redis instance:
-    # external:
-    #   enabled: true
-    #   host: "redis.example.com"
-    #   port: 6379
-    #   password: "your-redis-password"
 ```
 
 </Tab>

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -290,7 +290,7 @@ When initialized this way, all requests automatically use direct hash matching r
 **Redis** is recommended for direct hash mode. It does not require vectors for metadata-only entries, and all cache fields are indexed as RediSearch TAG fields for fast exact-match lookups.
 
 <Warning>
-Redis requires the [RediSearch](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/) module. The Helm chart's built-in Redis subchart (`redis:7-alpine`) does **not** include RediSearch and will fail at startup. Use an external Redis Stack instance or override the image to one that includes the module (e.g., `redis/redis-stack-server` or Redis 8+).
+Qdrant and Pinecone are not compatible with direct hash mode when no embedding provider is configured. These stores require a vector for every entry; the plugin's zero-vector placeholder codepath requires an initialised embedding client, so storage will fail if no provider is set. Weaviate requires a vector per entry as well and is therefore also not recommended for direct-only mode.
 </Warning>
 
 <Tabs group="direct-hash-redis">

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -202,7 +202,7 @@ bifrostConfig := schemas.BifrostConfig{
 
 ## Direct Hash Mode (Embedding-Free)
 
-Direct hash mode provides exact-match caching using [xxhash](https://github.com/cespare/xxhash) without requiring an embedding provider. Each request is hashed deterministically based on its normalized input, parameters, and stream flag. Identical requests produce cache hits; different wording is a cache miss.
+Direct hash mode provides exact-match caching without requiring an embedding provider. Each request is hashed deterministically based on its normalized input, parameters, and stream flag. Identical requests produce cache hits; different wording is a cache miss.
 
 **When to use direct hash mode:**
 - You only need exact-match deduplication (no fuzzy/semantic matching)
@@ -270,18 +270,11 @@ When initialized this way, all requests automatically use direct hash matching r
 
 ### Recommended Vector Store
 
-**Redis is the recommended vector store for direct hash mode.** Here's why:
+**Redis** is recommended for direct hash mode. It does not require vectors for metadata-only entries, and all cache fields are indexed as RediSearch TAG fields for fast exact-match lookups.
 
-| Vector Store | Requires Vectors? | Index Type | Direct Hash Performance |
-|---|---|---|---|
-| **Redis** | No | RediSearch TAG (inverted index) | **Best** -- O(1) exact-match lookups, no vector overhead |
-| Weaviate | Yes | Built-in inverted index | Usable, but stores zero-vector placeholders and maintains an HNSW index unnecessarily |
-| Qdrant | Yes | Payload index | Requires vectors for all entries -- not ideal |
-| Pinecone | Yes | Metadata filtering | Requires vectors for all entries -- not ideal |
-
-Redis stores all metadata fields (`request_hash`, `cache_key`, `params_hash`, `provider`, `model`) as RediSearch TAG fields with inverted indices. Direct hash lookups execute as `FT.SEARCH` queries against these indices, providing O(1) exact-match performance with no vector storage overhead.
-
-**Minimal Redis setup for direct hash mode:**
+<Warning>
+Qdrant and Pinecone are not compatible with direct hash mode when no embedding provider is configured. These stores require vectors for all entries, and without an embedding provider, no vectors are generated, causing storage to fail. Weaviate may work but is not recommended for this use case.
+</Warning>
 
 ```json
 {
@@ -296,7 +289,7 @@ Redis stores all metadata fields (`request_hash`, `cache_key`, `params_hash`, `p
 ```
 
 <Info>
-Redis requires the [RediSearch module](https://redis.io/docs/stack/search/) (included in Redis Stack). Without it, the plugin will return an error on startup.
+Redis requires the RediSearch module (included in [Redis Stack](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)). Without it, the plugin will return an error on startup.
 </Info>
 
 ### Per-Request Cache Type Override

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -242,6 +242,23 @@ plugin, err := semanticcache.Init(ctx, cacheConfig, logger, store)
 
 </Tab>
 
+<Tab title="Helm">
+
+```yaml
+bifrost:
+  plugins:
+    semanticCache:
+      enabled: true
+      config:
+        dimension: 1
+        ttl: "5m"
+        cleanup_on_shutdown: true
+        cache_by_model: true
+        cache_by_provider: true
+```
+
+</Tab>
+
 <Tab title="config.json">
 
 ```json
@@ -249,7 +266,7 @@ plugin, err := semanticcache.Init(ctx, cacheConfig, logger, store)
   "plugins": [
     {
       "enabled": true,
-      "name": "semantic_cache",
+      "name": "semanticcache",
       "config": {
         "dimension": 1,
         "ttl": "5m",
@@ -276,6 +293,31 @@ When initialized this way, all requests automatically use direct hash matching r
 Qdrant and Pinecone are not compatible with direct hash mode when no embedding provider is configured. These stores require vectors for all entries, and without an embedding provider, no vectors are generated, causing storage to fail. Weaviate may work but is not recommended for this use case.
 </Warning>
 
+<Tabs group="direct-hash-redis">
+
+<Tab title="Helm">
+
+```yaml
+vectorStore:
+  enabled: true
+  type: redis
+  redis:
+    enabled: true
+    auth:
+      enabled: true
+      password: "your-redis-password"
+    # Or use an external Redis instance:
+    # external:
+    #   enabled: true
+    #   host: "redis.example.com"
+    #   port: 6379
+    #   password: "your-redis-password"
+```
+
+</Tab>
+
+<Tab title="config.json">
+
 ```json
 {
   "vector_store": {
@@ -288,9 +330,9 @@ Qdrant and Pinecone are not compatible with direct hash mode when no embedding p
 }
 ```
 
-<Info>
-Redis requires the RediSearch module (included in [Redis Stack](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)). Without it, the plugin will return an error on startup.
-</Info>
+</Tab>
+
+</Tabs>
 
 ### Per-Request Cache Type Override
 

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -103,7 +103,7 @@ import (
 )
 
 // Configure semantic cache plugin
-cacheConfig := semanticcache.Config{
+cacheConfig := &semanticcache.Config{
     // Embedding model configuration (Required)
     Provider:       schemas.OpenAI,
     Keys:          []schemas.Key{{Value: "sk-..."}},
@@ -212,7 +212,7 @@ Direct hash mode provides exact-match caching without requiring an embedding pro
 
 ### Setup
 
-To enable direct-only mode globally, omit the `provider`, `keys`, and `embedding_model` fields from the plugin config. The plugin will automatically fall back to direct search only.
+To enable direct-only mode globally, omit the `provider` and `keys` fields from the plugin config. The plugin will automatically fall back to direct search only.
 
 <Warning>
 A vector store is still required as the storage backend, even in direct hash mode. See [Recommended Vector Store](#recommended-vector-store) below for the best choice.
@@ -288,10 +288,6 @@ When initialized this way, all requests automatically use direct hash matching r
 ### Recommended Vector Store
 
 **Redis** is recommended for direct hash mode. It does not require vectors for metadata-only entries, and all cache fields are indexed as RediSearch TAG fields for fast exact-match lookups.
-
-<Warning>
-Qdrant and Pinecone are not compatible with direct hash mode when no embedding provider is configured. These stores require vectors for all entries, and without an embedding provider, no vectors are generated, causing storage to fail. Weaviate may work but is not recommended for this use case.
-</Warning>
 
 <Tabs group="direct-hash-redis">
 

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -200,6 +200,113 @@ bifrostConfig := schemas.BifrostConfig{
 
 ---
 
+## Direct Hash Mode (Embedding-Free)
+
+Direct hash mode provides exact-match caching using [xxhash](https://github.com/cespare/xxhash) without requiring an embedding provider. Each request is hashed deterministically based on its normalized input, parameters, and stream flag. Identical requests produce cache hits; different wording is a cache miss.
+
+**When to use direct hash mode:**
+- You only need exact-match deduplication (no fuzzy/semantic matching)
+- You cannot or do not want to call an external embedding API
+- You want the lowest possible latency with zero embedding overhead
+- Cost-sensitive environments where embedding API calls add up
+
+### Setup
+
+To enable direct-only mode globally, omit the `provider`, `keys`, and `embedding_model` fields from the plugin config. The plugin will automatically fall back to direct search only.
+
+<Warning>
+A vector store is still required as the storage backend, even in direct hash mode. See [Recommended Vector Store](#recommended-vector-store) below for the best choice.
+</Warning>
+
+<Tabs group="direct-hash-setup">
+
+<Tab title="Go SDK">
+
+```go
+import (
+    "github.com/maximhq/bifrost/plugins/semanticcache"
+)
+
+cacheConfig := &semanticcache.Config{
+    // No Provider, Keys, or EmbeddingModel -- direct hash mode only
+    Dimension: 1, // Minimal value; no real vectors are stored
+
+    TTL:               5 * time.Minute,
+    CleanUpOnShutdown: true,
+    CacheByModel:      bifrost.Ptr(true),
+    CacheByProvider:   bifrost.Ptr(true),
+}
+
+plugin, err := semanticcache.Init(ctx, cacheConfig, logger, store)
+```
+
+</Tab>
+
+<Tab title="config.json">
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "semantic_cache",
+      "config": {
+        "dimension": 1,
+        "ttl": "5m",
+        "cleanup_on_shutdown": true,
+        "cache_by_model": true,
+        "cache_by_provider": true
+      }
+    }
+  ]
+}
+```
+
+</Tab>
+
+</Tabs>
+
+When initialized this way, all requests automatically use direct hash matching regardless of the `x-bf-cache-type` header. No embeddings are generated, and no embedding provider credentials are needed.
+
+### Recommended Vector Store
+
+**Redis is the recommended vector store for direct hash mode.** Here's why:
+
+| Vector Store | Requires Vectors? | Index Type | Direct Hash Performance |
+|---|---|---|---|
+| **Redis** | No | RediSearch TAG (inverted index) | **Best** -- O(1) exact-match lookups, no vector overhead |
+| Weaviate | Yes | Built-in inverted index | Usable, but stores zero-vector placeholders and maintains an HNSW index unnecessarily |
+| Qdrant | Yes | Payload index | Requires vectors for all entries -- not ideal |
+| Pinecone | Yes | Metadata filtering | Requires vectors for all entries -- not ideal |
+
+Redis stores all metadata fields (`request_hash`, `cache_key`, `params_hash`, `provider`, `model`) as RediSearch TAG fields with inverted indices. Direct hash lookups execute as `FT.SEARCH` queries against these indices, providing O(1) exact-match performance with no vector storage overhead.
+
+**Minimal Redis setup for direct hash mode:**
+
+```json
+{
+  "vector_store": {
+    "enabled": true,
+    "type": "redis",
+    "config": {
+      "addr": "localhost:6379"
+    }
+  }
+}
+```
+
+<Info>
+Redis requires the [RediSearch module](https://redis.io/docs/stack/search/) (included in Redis Stack). Without it, the plugin will return an error on startup.
+</Info>
+
+### Per-Request Cache Type Override
+
+When the plugin is initialized **without** an embedding provider (direct-only mode), all requests use direct hash matching automatically. The `x-bf-cache-type` header has no effect.
+
+When the plugin is initialized **with** an embedding provider (dual-layer mode), you can force direct-only matching on specific requests using the `x-bf-cache-type: direct` header. See [Cache Type Control](#cache-type-control) for details.
+
+---
+
 ## Cache Triggering
 
 <Warning>

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -229,7 +229,7 @@ import (
 
 cacheConfig := &semanticcache.Config{
     // No Provider, Keys, or EmbeddingModel -- direct hash mode only
-    Dimension: 1, // Minimal value; no real vectors are stored
+    Dimension: 1, // Placeholder; entries are stored as metadata-only (no embedding vectors). Change dimension before switching to dual-layer mode to avoid mixed-dimension issues.
 
     TTL:               5 * time.Minute,
     CleanUpOnShutdown: true,


### PR DESCRIPTION
## Summary

Documents the existing direct hash mode (embedding-free) for the semantic cache plugin. Users looking for simple exact-match caching without the cost/complexity of an embedding provider had no way to discover this capability from the docs.

## Changes

- Added a new "Direct Hash Mode (Embedding-Free)" section to `docs/features/semantic-caching.mdx` covering setup (omit `provider`/`keys`/`embedding_model` from config), recommended vector store (Redis), and per-request cache type override behavior.
- Included a warning that Qdrant and Pinecone are not compatible with this mode when no embedding provider is configured, since the zero-vector placeholder codepath requires `plugin.client != nil`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

- Verify the new section renders correctly on the Mintlify docs site (PR preview or `npx mintlify dev`)
- Confirm anchor links (`#direct-hash-mode-embedding-free`, `#recommended-vector-store`, `#cache-type-control`) resolve correctly
- Validate the Go SDK and config.json examples match actual plugin behavior (omitting `provider`/`keys` triggers direct-only fallback per `main.go` lines 319-321)

## Screenshots/Recordings

N/A -- docs-only change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
