### PR TITLE
Allow configuring a default cache key at the plugin level

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -728,6 +728,9 @@ false
 {{- if $inputConfig.vector_store_namespace }}
 {{- $_ := set $scConfig "vector_store_namespace" $inputConfig.vector_store_namespace }}
 {{- end }}
+{{- if $inputConfig.default_cache_key }}
+{{- $_ := set $scConfig "default_cache_key" $inputConfig.default_cache_key }}
+{{- end }}
 {{- if hasKey $inputConfig "conversation_history_threshold" }}
 {{- $_ := set $scConfig "conversation_history_threshold" $inputConfig.conversation_history_threshold }}
 {{- end }}

--- a/plugins/semanticcache/plugin_default_cache_key_test.go
+++ b/plugins/semanticcache/plugin_default_cache_key_test.go
@@ -1,0 +1,122 @@
+package semanticcache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestDefaultCacheKey_CachesWithoutPerRequestKey verifies that when DefaultCacheKey
+// is configured, requests without an explicit cache key are cached automatically.
+func TestDefaultCacheKey_CachesWithoutPerRequestKey(t *testing.T) {
+	config := getDefaultTestConfig()
+	config.DefaultCacheKey = "test-default-key"
+
+	setup := NewTestSetupWithConfig(t, config)
+	defer setup.Cleanup()
+
+	// Context with NO per-request cache key
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	testRequest := CreateBasicChatRequest("What is Bifrost? Answer in one short sentence.", 0.7, 50)
+
+	t.Log("Making first request without per-request cache key (should use default and be cached)...")
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx, testRequest)
+	if err1 != nil {
+		return
+	}
+
+	if response1 == nil || len(response1.Choices) == 0 || response1.Choices[0].Message.Content.ContentStr == nil {
+		t.Fatal("First response is invalid")
+	}
+
+	// First request should NOT be a cache hit
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
+
+	WaitForCache()
+
+	t.Log("Making second identical request without per-request cache key (should hit cache)...")
+	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
+	if err2 != nil {
+		if err2.Error != nil {
+			t.Fatalf("Second request failed: %v", err2.Error.Message)
+		}
+		t.Fatalf("Second request failed: %v", err2)
+	}
+
+	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, string(CacheTypeDirect))
+	t.Log("Default cache key correctly enabled caching without per-request key")
+}
+
+// TestDefaultCacheKey_PerRequestKeyOverridesDefault verifies that an explicit
+// per-request cache key takes precedence over the configured default.
+func TestDefaultCacheKey_PerRequestKeyOverridesDefault(t *testing.T) {
+	config := getDefaultTestConfig()
+	config.DefaultCacheKey = "test-default-key"
+
+	setup := NewTestSetupWithConfig(t, config)
+	defer setup.Cleanup()
+
+	testRequest := CreateBasicChatRequest("What is the capital of France?", 0.5, 50)
+
+	// Cache with the default key (no per-request key)
+	ctx1 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	_, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
+	if err1 != nil {
+		return
+	}
+
+	WaitForCache()
+
+	// Same request but with a DIFFERENT per-request key — should miss
+	ctx2 := CreateContextWithCacheKey("override-key")
+	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
+	if err2 != nil {
+		if err2.Error != nil {
+			t.Fatalf("Second request failed: %v", err2.Error.Message)
+		}
+		t.Fatalf("Second request failed: %v", err2)
+	}
+
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2})
+	t.Log("Per-request cache key correctly overrides default (different namespace = cache miss)")
+}
+
+// TestDefaultCacheKey_EmptyDefault_NoCaching verifies that when DefaultCacheKey
+// is empty (default zero value), requests without a per-request key bypass caching.
+func TestDefaultCacheKey_EmptyDefault_NoCaching(t *testing.T) {
+	config := getDefaultTestConfig()
+	// DefaultCacheKey is intentionally left empty (zero value)
+
+	setup := NewTestSetupWithConfig(t, config)
+	defer setup.Cleanup()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	testRequest := CreateBasicChatRequest("What is deep learning", 0.7, 50)
+
+	t.Log("Making first request without any cache key and no default (should not cache)...")
+	response1, err1 := setup.Client.ChatCompletionRequest(ctx, testRequest)
+	if err1 != nil {
+		return
+	}
+
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
+
+	WaitForCache()
+
+	t.Log("Making second identical request (should still not cache)...")
+	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
+	if err2 != nil {
+		if err2.Error != nil {
+			t.Fatalf("Second request failed: %v", err2.Error.Message)
+		}
+		t.Fatalf("Second request failed: %v", err2)
+	}
+
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2})
+	t.Log("Empty default cache key correctly preserves opt-in behavior")
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1043,6 +1043,10 @@
                       "description": "Dimension for vector store embeddings",
                       "minimum": 1
                     },
+                    "default_cache_key": {
+                      "type": "string",
+                      "description": "Default cache key used when no per-request key is provided. When set, all requests without an explicit x-bf-cache-key header will use this value and be cached automatically."
+                    },
                     "conversation_history_threshold": {
                       "type": "integer",
                       "description": "Skip caching for requests with more than this number of messages in conversation history (default: 3)",


### PR DESCRIPTION
## Summary
Enable default caching
- Right now, requests without an explicit x-bf-cache-key header are not automatically cached. 
- Setting default_cache_key alters the behavior
- When default_cache_key is unset (empty string), existing behavior is preserved: caching is opt-in per request.

## Changes

- Add a default_cache_key, which can be set via

```
{
  "plugins": [
    {
      "enabled": true,
      "name": "semantic_cache",
      "config": {
        "default_cache_key": "global",
        "dimension": 1536,
        "provider": "openai",
        "embedding_model": "text-embedding-3-small"
      }
    }
  ]
}
```

```
bifrost:
  plugins:
    semanticCache:
      enabled: true
      config:
        default_cache_key: "global"
        dimension: 1536
        provider: "openai"
        embedding_model: "text-embedding-3-small"
```

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [X] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Set default_cache_key
```
{
  "plugins": [
    {
      "enabled": true,
      "name": "semantic_cache",
      "config": {
        "default_cache_key": "global",
        "dimension": 1536,
        "provider": "openai",
        "embedding_model": "text-embedding-3-small"
      }
    }
  ]
}
```
## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [X] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [X] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


