### PR TITLE
governance plugin multipart parsing bug fix

### DIFF
--- a/core/network/multipart.go
+++ b/core/network/multipart.go
@@ -1,0 +1,167 @@
+package network
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ParseMultipartFormFields extracts text form fields from a multipart/form-data body,
+// skipping file parts to avoid loading binary data into memory.
+func ParseMultipartFormFields(contentType string, body []byte) (map[string]any, error) {
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, err
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil, fmt.Errorf("no boundary in content-type")
+	}
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	payload := make(map[string]any)
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if part.FileName() != "" {
+			_ = part.Close()
+			continue
+		}
+		name := part.FormName()
+		if name != "" {
+			val, readErr := io.ReadAll(part)
+			if readErr != nil {
+				_ = part.Close()
+				return nil, readErr
+			}
+			payload[name] = string(val)
+		}
+		_ = part.Close()
+	}
+	return payload, nil
+}
+
+// ReconstructMultipartBody rebuilds a multipart/form-data body from the original,
+// replacing text field values with those from payload (e.g. updated "model") and
+// copying file parts byte-for-byte.
+func ReconstructMultipartBody(origContentType string, origBody []byte, payload map[string]any) ([]byte, string, error) {
+	_, params, err := mime.ParseMediaType(origContentType)
+	if err != nil {
+		return nil, "", err
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		return nil, "", fmt.Errorf("no boundary in content-type")
+	}
+	reader := multipart.NewReader(bytes.NewReader(origBody), boundary)
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writtenFields := make(map[string]bool)
+
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		name := part.FormName()
+		if part.FileName() != "" {
+			fw, createErr := writer.CreatePart(part.Header)
+			if createErr != nil {
+				_ = part.Close()
+				return nil, "", createErr
+			}
+			if _, copyErr := io.Copy(fw, part); copyErr != nil {
+				_ = part.Close()
+				return nil, "", copyErr
+			}
+		} else if name != "" {
+			if val, ok := payload[name]; ok {
+				if err := WriteMultipartField(writer, name, val); err != nil {
+					_ = part.Close()
+					return nil, "", err
+				}
+			} else {
+				origVal, readErr := io.ReadAll(part)
+				if readErr != nil {
+					_ = part.Close()
+					return nil, "", readErr
+				}
+				if err := writer.WriteField(name, string(origVal)); err != nil {
+					_ = part.Close()
+					return nil, "", err
+				}
+			}
+			writtenFields[name] = true
+		}
+		_ = part.Close()
+	}
+
+	for key, val := range payload {
+		if writtenFields[key] {
+			continue
+		}
+		if err := WriteMultipartField(writer, key, val); err != nil {
+			return nil, "", err
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), writer.FormDataContentType(), nil
+}
+
+// WriteMultipartField writes a single form field to the multipart writer,
+// handling string, []string, and other value types.
+func WriteMultipartField(writer *multipart.Writer, name string, val any) error {
+	switch v := val.(type) {
+	case string:
+		return writer.WriteField(name, v)
+	case []string:
+		encoded, err := sonic.Marshal(v)
+		if err != nil {
+			return err
+		}
+		return writer.WriteField(name, string(encoded))
+	default:
+		return writer.WriteField(name, fmt.Sprintf("%v", val))
+	}
+}
+
+// SerializePayloadToRequest writes the modified payload back to req.Body,
+// using multipart reconstruction for multipart/form-data or JSON for everything else.
+func SerializePayloadToRequest(req *schemas.HTTPRequest, payload map[string]any, isMultipart bool, origContentType string) error {
+	if isMultipart {
+		newBody, newCT, err := ReconstructMultipartBody(origContentType, req.Body, payload)
+		if err != nil {
+			return err
+		}
+		req.Body = newBody
+		for k := range req.Headers {
+			if strings.EqualFold(k, "content-type") {
+				delete(req.Headers, k)
+			}
+		}
+		req.Headers["Content-Type"] = newCT
+		return nil
+	}
+	body, err := sonic.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	req.Body = body
+	return nil
+}

--- a/core/network/multipart_test.go
+++ b/core/network/multipart_test.go
@@ -1,0 +1,271 @@
+package network
+
+import (
+	"bytes"
+	"mime/multipart"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// buildMultipartBody is a test helper that creates a multipart/form-data body
+// with the given text fields and optional file parts.
+func buildMultipartBody(t *testing.T, fields map[string]string, files map[string][]byte) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	for name, val := range fields {
+		if err := writer.WriteField(name, val); err != nil {
+			t.Fatalf("WriteField(%q): %v", name, err)
+		}
+	}
+	for name, data := range files {
+		fw, err := writer.CreateFormFile(name, name+".bin")
+		if err != nil {
+			t.Fatalf("CreateFormFile(%q): %v", name, err)
+		}
+		if _, err := fw.Write(data); err != nil {
+			t.Fatalf("Write file data: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close: %v", err)
+	}
+	return buf.Bytes(), writer.FormDataContentType()
+}
+
+func TestParseMultipartFormFields(t *testing.T) {
+	t.Run("extracts text fields and skips files", func(t *testing.T) {
+		body, ct := buildMultipartBody(t,
+			map[string]string{"model": "gpt-4", "prompt": "hello"},
+			map[string][]byte{"image": {0xFF, 0xD8, 0xFF}},
+		)
+		result, err := ParseMultipartFormFields(ct, body)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result["model"] != "gpt-4" {
+			t.Errorf("model = %v, want gpt-4", result["model"])
+		}
+		if result["prompt"] != "hello" {
+			t.Errorf("prompt = %v, want hello", result["prompt"])
+		}
+		if _, exists := result["image"]; exists {
+			t.Error("file part 'image' should have been skipped")
+		}
+	})
+
+	t.Run("returns error on missing boundary", func(t *testing.T) {
+		_, err := ParseMultipartFormFields("multipart/form-data", []byte("irrelevant"))
+		if err == nil {
+			t.Fatal("expected error for missing boundary")
+		}
+	})
+
+	t.Run("returns error on invalid content-type", func(t *testing.T) {
+		_, err := ParseMultipartFormFields(";;;invalid", []byte("irrelevant"))
+		if err == nil {
+			t.Fatal("expected error for invalid content-type")
+		}
+	})
+
+	t.Run("returns empty map for empty body", func(t *testing.T) {
+		// A valid multipart body with no parts (just the closing boundary).
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		ct := writer.FormDataContentType()
+		_ = writer.Close()
+
+		result, err := ParseMultipartFormFields(ct, buf.Bytes())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty map, got %v", result)
+		}
+	})
+}
+
+func TestReconstructMultipartBody(t *testing.T) {
+	t.Run("replaces text field value", func(t *testing.T) {
+		body, ct := buildMultipartBody(t,
+			map[string]string{"model": "gpt-3.5", "prompt": "hi"},
+			nil,
+		)
+		payload := map[string]any{"model": "gpt-4"}
+		newBody, newCT, err := ReconstructMultipartBody(ct, body, payload)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.HasPrefix(newCT, "multipart/form-data") {
+			t.Errorf("content-type = %v, want multipart/form-data prefix", newCT)
+		}
+		// Parse the reconstructed body and verify the value was replaced.
+		parsed, err := ParseMultipartFormFields(newCT, newBody)
+		if err != nil {
+			t.Fatalf("failed to parse reconstructed body: %v", err)
+		}
+		if parsed["model"] != "gpt-4" {
+			t.Errorf("model = %v, want gpt-4", parsed["model"])
+		}
+		if parsed["prompt"] != "hi" {
+			t.Errorf("prompt = %v, want hi (should be preserved)", parsed["prompt"])
+		}
+	})
+
+	t.Run("adds new fields from payload", func(t *testing.T) {
+		body, ct := buildMultipartBody(t,
+			map[string]string{"model": "gpt-4"},
+			nil,
+		)
+		payload := map[string]any{"model": "gpt-4", "temperature": "0.7"}
+		newBody, newCT, err := ReconstructMultipartBody(ct, body, payload)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		parsed, err := ParseMultipartFormFields(newCT, newBody)
+		if err != nil {
+			t.Fatalf("failed to parse: %v", err)
+		}
+		if parsed["temperature"] != "0.7" {
+			t.Errorf("temperature = %v, want 0.7", parsed["temperature"])
+		}
+	})
+
+	t.Run("returns error on missing boundary", func(t *testing.T) {
+		_, _, err := ReconstructMultipartBody("multipart/form-data", []byte("data"), map[string]any{})
+		if err == nil {
+			t.Fatal("expected error for missing boundary")
+		}
+	})
+}
+
+func TestWriteMultipartField(t *testing.T) {
+	t.Run("writes string value", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		if err := WriteMultipartField(writer, "key", "value"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_ = writer.Close()
+		parsed, err := ParseMultipartFormFields(writer.FormDataContentType(), buf.Bytes())
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if parsed["key"] != "value" {
+			t.Errorf("key = %v, want value", parsed["key"])
+		}
+	})
+
+	t.Run("writes []string as JSON array", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		if err := WriteMultipartField(writer, "tags", []string{"a", "b"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_ = writer.Close()
+		parsed, err := ParseMultipartFormFields(writer.FormDataContentType(), buf.Bytes())
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		val, ok := parsed["tags"].(string)
+		if !ok {
+			t.Fatalf("tags not a string, got %T", parsed["tags"])
+		}
+		var arr []string
+		if err := sonic.UnmarshalString(val, &arr); err != nil {
+			t.Fatalf("failed to unmarshal tags JSON: %v", err)
+		}
+		if len(arr) != 2 || arr[0] != "a" || arr[1] != "b" {
+			t.Errorf("tags = %v, want [a b]", arr)
+		}
+	})
+
+	t.Run("writes non-string with Sprintf", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		if err := WriteMultipartField(writer, "count", 42); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_ = writer.Close()
+		parsed, err := ParseMultipartFormFields(writer.FormDataContentType(), buf.Bytes())
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if parsed["count"] != "42" {
+			t.Errorf("count = %v, want 42", parsed["count"])
+		}
+	})
+}
+
+func TestSerializePayloadToRequest(t *testing.T) {
+	t.Run("JSON path", func(t *testing.T) {
+		req := &schemas.HTTPRequest{
+			Headers: map[string]string{"Content-Type": "application/json"},
+			Body:    []byte(`{"old":"data"}`),
+		}
+		payload := map[string]any{"model": "gpt-4", "prompt": "test"}
+		if err := SerializePayloadToRequest(req, payload, false, "application/json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var result map[string]any
+		if err := sonic.Unmarshal(req.Body, &result); err != nil {
+			t.Fatalf("failed to unmarshal result: %v", err)
+		}
+		if result["model"] != "gpt-4" {
+			t.Errorf("model = %v, want gpt-4", result["model"])
+		}
+	})
+
+	t.Run("multipart path", func(t *testing.T) {
+		body, ct := buildMultipartBody(t,
+			map[string]string{"model": "gpt-3.5"},
+			nil,
+		)
+		req := &schemas.HTTPRequest{
+			Headers: map[string]string{"Content-Type": ct},
+			Body:    body,
+		}
+		payload := map[string]any{"model": "gpt-4"}
+		if err := SerializePayloadToRequest(req, payload, true, ct); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Verify content-type was updated
+		newCT := req.Headers["Content-Type"]
+		if !strings.HasPrefix(newCT, "multipart/form-data") {
+			t.Errorf("content-type = %v, want multipart/form-data prefix", newCT)
+		}
+		// Verify the body contains the updated model
+		parsed, err := ParseMultipartFormFields(newCT, req.Body)
+		if err != nil {
+			t.Fatalf("parse error: %v", err)
+		}
+		if parsed["model"] != "gpt-4" {
+			t.Errorf("model = %v, want gpt-4", parsed["model"])
+		}
+	})
+
+	t.Run("multipart path removes old content-type header case-insensitively", func(t *testing.T) {
+		body, ct := buildMultipartBody(t,
+			map[string]string{"field": "val"},
+			nil,
+		)
+		req := &schemas.HTTPRequest{
+			Headers: map[string]string{"content-type": ct},
+			Body:    body,
+		}
+		payload := map[string]any{"field": "val"}
+		if err := SerializePayloadToRequest(req, payload, true, ct); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The old lowercase "content-type" should be gone, replaced by "Content-Type".
+		if _, exists := req.Headers["content-type"]; exists {
+			t.Error("old lowercase content-type header should have been removed")
+		}
+		if _, exists := req.Headers["Content-Type"]; !exists {
+			t.Error("new Content-Type header should be set")
+		}
+	})
+}

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -128,242 +128,247 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 							</TableHeader>
 							<TableBody>
 								{customers?.map((customer) => {
-										const customerTeams = getTeamsForCustomer(customer.id);
-										const vks = getVirtualKeysForCustomer(customer.id);
+									const customerTeams = getTeamsForCustomer(customer.id);
+									const vks = getVirtualKeysForCustomer(customer.id);
 
-										// Budget calculations
-										const isBudgetExhausted =
-											customer.budget?.max_limit && customer.budget.max_limit > 0 && customer.budget.current_usage >= customer.budget.max_limit;
-										const budgetPercentage =
-											customer.budget?.max_limit && customer.budget.max_limit > 0
-												? Math.min((customer.budget.current_usage / customer.budget.max_limit) * 100, 100)
-												: 0;
+									// Budget calculations
+									const isBudgetExhausted =
+										customer.budget?.max_limit &&
+										customer.budget.max_limit > 0 &&
+										customer.budget.current_usage >= customer.budget.max_limit;
+									const budgetPercentage =
+										customer.budget?.max_limit && customer.budget.max_limit > 0
+											? Math.min((customer.budget.current_usage / customer.budget.max_limit) * 100, 100)
+											: 0;
 
-										// Rate limit calculations
-										const isTokenLimitExhausted =
-											customer.rate_limit?.token_max_limit &&
-											customer.rate_limit.token_max_limit > 0 &&
-											customer.rate_limit.token_current_usage >= customer.rate_limit.token_max_limit;
-										const isRequestLimitExhausted =
-											customer.rate_limit?.request_max_limit &&
-											customer.rate_limit.request_max_limit > 0 &&
-											customer.rate_limit.request_current_usage >= customer.rate_limit.request_max_limit;
-										const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
-										const tokenPercentage =
-											customer.rate_limit?.token_max_limit && customer.rate_limit.token_max_limit > 0
-												? Math.min((customer.rate_limit.token_current_usage / customer.rate_limit.token_max_limit) * 100, 100)
-												: 0;
-										const requestPercentage =
-											customer.rate_limit?.request_max_limit && customer.rate_limit.request_max_limit > 0
-												? Math.min((customer.rate_limit.request_current_usage / customer.rate_limit.request_max_limit) * 100, 100)
-												: 0;
+									// Rate limit calculations
+									const isTokenLimitExhausted =
+										customer.rate_limit?.token_max_limit &&
+										customer.rate_limit.token_max_limit > 0 &&
+										customer.rate_limit.token_current_usage >= customer.rate_limit.token_max_limit;
+									const isRequestLimitExhausted =
+										customer.rate_limit?.request_max_limit &&
+										customer.rate_limit.request_max_limit > 0 &&
+										customer.rate_limit.request_current_usage >= customer.rate_limit.request_max_limit;
+									const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
+									const tokenPercentage =
+										customer.rate_limit?.token_max_limit && customer.rate_limit.token_max_limit > 0
+											? Math.min((customer.rate_limit.token_current_usage / customer.rate_limit.token_max_limit) * 100, 100)
+											: 0;
+									const requestPercentage =
+										customer.rate_limit?.request_max_limit && customer.rate_limit.request_max_limit > 0
+											? Math.min((customer.rate_limit.request_current_usage / customer.rate_limit.request_max_limit) * 100, 100)
+											: 0;
 
-										const isExhausted = isBudgetExhausted || isRateLimitExhausted;
+									const isExhausted = isBudgetExhausted || isRateLimitExhausted;
 
-										return (
-											<TableRow key={customer.id} className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}>
-												<TableCell className="max-w-[200px] py-4">
-													<div className="flex flex-col gap-2">
-														<span className="truncate font-medium">{customer.name}</span>
-														{isExhausted && (
-															<Badge variant="destructive" className="w-fit text-xs">
-																Limit Reached
-															</Badge>
+									return (
+										<TableRow
+											key={customer.id}
+											className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}
+										>
+											<TableCell className="max-w-[200px] py-4">
+												<div className="flex flex-col gap-2">
+													<span className="truncate font-medium">{customer.name}</span>
+													{isExhausted && (
+														<Badge variant="destructive" className="w-fit text-xs">
+															Limit Reached
+														</Badge>
+													)}
+												</div>
+											</TableCell>
+											<TableCell>
+												{customerTeams?.length > 0 ? (
+													<div className="flex items-center gap-2">
+														<Tooltip>
+															<TooltipTrigger>
+																<Badge variant="outline" className="text-xs">
+																	{customerTeams.length} {customerTeams.length === 1 ? "team" : "teams"}
+																</Badge>
+															</TooltipTrigger>
+															<TooltipContent>{customerTeams.map((team) => team.name).join(", ")}</TooltipContent>
+														</Tooltip>
+													</div>
+												) : (
+													<span className="text-muted-foreground text-sm">-</span>
+												)}
+											</TableCell>
+											<TableCell className="min-w-[180px]">
+												{customer.budget ? (
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<div className="space-y-2">
+																<div className="flex items-center justify-between gap-4">
+																	<span className="font-medium">{formatCurrency(customer.budget.max_limit)}</span>
+																	<span className="text-muted-foreground text-xs">
+																		{formatResetDuration(customer.budget.reset_duration)}
+																	</span>
+																</div>
+																<Progress
+																	value={budgetPercentage}
+																	className={cn(
+																		"bg-muted/70 dark:bg-muted/30 h-1.5",
+																		isBudgetExhausted
+																			? "[&>div]:bg-red-500/70"
+																			: budgetPercentage > 80
+																				? "[&>div]:bg-amber-500/70"
+																				: "[&>div]:bg-emerald-500/70",
+																	)}
+																/>
+															</div>
+														</TooltipTrigger>
+														<TooltipContent>
+															<p className="font-medium">
+																{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
+															</p>
+															<p className="text-primary-foreground/80 text-xs">
+																Resets {formatResetDuration(customer.budget.reset_duration)}
+															</p>
+														</TooltipContent>
+													</Tooltip>
+												) : (
+													<span className="text-muted-foreground text-sm">-</span>
+												)}
+											</TableCell>
+											<TableCell className="min-w-[180px]">
+												{customer.rate_limit ? (
+													<div className="space-y-2.5">
+														{customer.rate_limit.token_max_limit && (
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<div className="space-y-1.5">
+																		<div className="flex items-center justify-between gap-4 text-xs">
+																			<span className="font-medium">{customer.rate_limit.token_max_limit.toLocaleString()} tokens</span>
+																			<span className="text-muted-foreground">
+																				{formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
+																			</span>
+																		</div>
+																		<Progress
+																			value={tokenPercentage}
+																			className={cn(
+																				"bg-muted/70 dark:bg-muted/30 h-1",
+																				isTokenLimitExhausted
+																					? "[&>div]:bg-red-500/70"
+																					: tokenPercentage > 80
+																						? "[&>div]:bg-amber-500/70"
+																						: "[&>div]:bg-emerald-500/70",
+																			)}
+																		/>
+																	</div>
+																</TooltipTrigger>
+																<TooltipContent>
+																	<p className="font-medium">
+																		{customer.rate_limit.token_current_usage.toLocaleString()} /{" "}
+																		{customer.rate_limit.token_max_limit.toLocaleString()} tokens
+																	</p>
+																	<p className="text-primary-foreground/80 text-xs">
+																		Resets {formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
+																	</p>
+																</TooltipContent>
+															</Tooltip>
+														)}
+														{customer.rate_limit.request_max_limit && (
+															<Tooltip>
+																<TooltipTrigger asChild>
+																	<div className="space-y-1.5">
+																		<div className="flex items-center justify-between gap-4 text-xs">
+																			<span className="font-medium">{customer.rate_limit.request_max_limit.toLocaleString()} req</span>
+																			<span className="text-muted-foreground">
+																				{formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
+																			</span>
+																		</div>
+																		<Progress
+																			value={requestPercentage}
+																			className={cn(
+																				"bg-muted/70 dark:bg-muted/30 h-1",
+																				isRequestLimitExhausted
+																					? "[&>div]:bg-red-500/70"
+																					: requestPercentage > 80
+																						? "[&>div]:bg-amber-500/70"
+																						: "[&>div]:bg-emerald-500/70",
+																			)}
+																		/>
+																	</div>
+																</TooltipTrigger>
+																<TooltipContent>
+																	<p className="font-medium">
+																		{customer.rate_limit.request_current_usage.toLocaleString()} /{" "}
+																		{customer.rate_limit.request_max_limit.toLocaleString()} requests
+																	</p>
+																	<p className="text-primary-foreground/80 text-xs">
+																		Resets {formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
+																	</p>
+																</TooltipContent>
+															</Tooltip>
 														)}
 													</div>
-												</TableCell>
-												<TableCell>
-													{customerTeams?.length > 0 ? (
-														<div className="flex items-center gap-2">
-															<Tooltip>
-																<TooltipTrigger>
-																	<Badge variant="outline" className="text-xs">
-																		{customerTeams.length} {customerTeams.length === 1 ? "team" : "teams"}
-																	</Badge>
-																</TooltipTrigger>
-																<TooltipContent>{customerTeams.map((team) => team.name).join(", ")}</TooltipContent>
-															</Tooltip>
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell className="min-w-[180px]">
-													{customer.budget ? (
+												) : (
+													<span className="text-muted-foreground text-sm">-</span>
+												)}
+											</TableCell>
+											<TableCell>
+												{vks?.length > 0 ? (
+													<div className="flex items-center gap-2">
 														<Tooltip>
-															<TooltipTrigger asChild>
-																<div className="space-y-2">
-																	<div className="flex items-center justify-between gap-4">
-																		<span className="font-medium">{formatCurrency(customer.budget.max_limit)}</span>
-																		<span className="text-muted-foreground text-xs">
-																			{formatResetDuration(customer.budget.reset_duration)}
-																		</span>
-																	</div>
-																	<Progress
-																		value={budgetPercentage}
-																		className={cn(
-																			"bg-muted/70 dark:bg-muted/30 h-1.5",
-																			isBudgetExhausted
-																				? "[&>div]:bg-red-500/70"
-																				: budgetPercentage > 80
-																					? "[&>div]:bg-amber-500/70"
-																					: "[&>div]:bg-emerald-500/70",
-																		)}
-																	/>
-																</div>
+															<TooltipTrigger>
+																<Badge variant="outline" className="text-xs">
+																	{vks.length} {vks.length === 1 ? "key" : "keys"}
+																</Badge>
 															</TooltipTrigger>
-															<TooltipContent>
-																<p className="font-medium">
-																	{formatCurrency(customer.budget.current_usage)} / {formatCurrency(customer.budget.max_limit)}
-																</p>
-																<p className="text-primary-foreground/80 text-xs">
-																	Resets {formatResetDuration(customer.budget.reset_duration)}
-																</p>
-															</TooltipContent>
+															<TooltipContent>{vks.map((vk) => vk.name).join(", ")}</TooltipContent>
 														</Tooltip>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell className="min-w-[180px]">
-													{customer.rate_limit ? (
-														<div className="space-y-2.5">
-															{customer.rate_limit.token_max_limit && (
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<div className="space-y-1.5">
-																			<div className="flex items-center justify-between gap-4 text-xs">
-																				<span className="font-medium">{customer.rate_limit.token_max_limit.toLocaleString()} tokens</span>
-																				<span className="text-muted-foreground">
-																					{formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
-																				</span>
-																			</div>
-																			<Progress
-																				value={tokenPercentage}
-																				className={cn(
-																					"bg-muted/70 dark:bg-muted/30 h-1",
-																					isTokenLimitExhausted
-																						? "[&>div]:bg-red-500/70"
-																						: tokenPercentage > 80
-																							? "[&>div]:bg-amber-500/70"
-																							: "[&>div]:bg-emerald-500/70",
-																				)}
-																			/>
-																		</div>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		<p className="font-medium">
-																			{customer.rate_limit.token_current_usage.toLocaleString()} /{" "}
-																			{customer.rate_limit.token_max_limit.toLocaleString()} tokens
-																		</p>
-																		<p className="text-primary-foreground/80 text-xs">
-																			Resets {formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															)}
-															{customer.rate_limit.request_max_limit && (
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<div className="space-y-1.5">
-																			<div className="flex items-center justify-between gap-4 text-xs">
-																				<span className="font-medium">{customer.rate_limit.request_max_limit.toLocaleString()} req</span>
-																				<span className="text-muted-foreground">
-																					{formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
-																				</span>
-																			</div>
-																			<Progress
-																				value={requestPercentage}
-																				className={cn(
-																					"bg-muted/70 dark:bg-muted/30 h-1",
-																					isRequestLimitExhausted
-																						? "[&>div]:bg-red-500/70"
-																						: requestPercentage > 80
-																							? "[&>div]:bg-amber-500/70"
-																							: "[&>div]:bg-emerald-500/70",
-																				)}
-																			/>
-																		</div>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		<p className="font-medium">
-																			{customer.rate_limit.request_current_usage.toLocaleString()} /{" "}
-																			{customer.rate_limit.request_max_limit.toLocaleString()} requests
-																		</p>
-																		<p className="text-primary-foreground/80 text-xs">
-																			Resets {formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															)}
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell>
-													{vks?.length > 0 ? (
-														<div className="flex items-center gap-2">
-															<Tooltip>
-																<TooltipTrigger>
-																	<Badge variant="outline" className="text-xs">
-																		{vks.length} {vks.length === 1 ? "key" : "keys"}
-																	</Badge>
-																</TooltipTrigger>
-																<TooltipContent>{vks.map((vk) => vk.name).join(", ")}</TooltipContent>
-															</Tooltip>
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell className="text-right">
-													<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-														<Button
-															variant="ghost"
-															size="icon"
-															className="h-8 w-8"
-															onClick={() => handleEditCustomer(customer)}
-															disabled={!hasUpdateAccess}
-														>
-															<Edit className="h-4 w-4" />
-														</Button>
-														<AlertDialog>
-															<AlertDialogTrigger asChild>
-																<Button
-																	variant="ghost"
-																	size="icon"
-																	className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
-																	disabled={!hasDeleteAccess}
-																>
-																	<Trash2 className="h-4 w-4" />
-																</Button>
-															</AlertDialogTrigger>
-															<AlertDialogContent>
-																<AlertDialogHeader>
-																	<AlertDialogTitle>Delete Customer</AlertDialogTitle>
-																	<AlertDialogDescription>
-																		Are you sure you want to delete &quot;{customer.name}&quot;? This will also delete all associated teams
-																		and unassign any virtual keys. This action cannot be undone.
-																	</AlertDialogDescription>
-																</AlertDialogHeader>
-																<AlertDialogFooter>
-																	<AlertDialogCancel>Cancel</AlertDialogCancel>
-																	<AlertDialogAction
-																		onClick={() => handleDelete(customer.id)}
-																		disabled={isDeleting}
-																		className="bg-red-600 hover:bg-red-700"
-																	>
-																		{isDeleting ? "Deleting..." : "Delete"}
-																	</AlertDialogAction>
-																</AlertDialogFooter>
-															</AlertDialogContent>
-														</AlertDialog>
 													</div>
-												</TableCell>
-											</TableRow>
-										);
-									})}
+												) : (
+													<span className="text-muted-foreground text-sm">-</span>
+												)}
+											</TableCell>
+											<TableCell className="text-right">
+												<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+													<Button
+														variant="ghost"
+														size="icon"
+														className="h-8 w-8"
+														onClick={() => handleEditCustomer(customer)}
+														disabled={!hasUpdateAccess}
+													>
+														<Edit className="h-4 w-4" />
+													</Button>
+													<AlertDialog>
+														<AlertDialogTrigger asChild>
+															<Button
+																variant="ghost"
+																size="icon"
+																className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
+																disabled={!hasDeleteAccess}
+															>
+																<Trash2 className="h-4 w-4" />
+															</Button>
+														</AlertDialogTrigger>
+														<AlertDialogContent>
+															<AlertDialogHeader>
+																<AlertDialogTitle>Delete Customer</AlertDialogTitle>
+																<AlertDialogDescription>
+																	Are you sure you want to delete &quot;{customer.name}&quot;? This will also delete all associated teams
+																	and unassign any virtual keys. This action cannot be undone.
+																</AlertDialogDescription>
+															</AlertDialogHeader>
+															<AlertDialogFooter>
+																<AlertDialogCancel>Cancel</AlertDialogCancel>
+																<AlertDialogAction
+																	onClick={() => handleDelete(customer.id)}
+																	disabled={isDeleting}
+																	className="bg-red-600 hover:bg-red-700"
+																>
+																	{isDeleting ? "Deleting..." : "Delete"}
+																</AlertDialogAction>
+															</AlertDialogFooter>
+														</AlertDialogContent>
+													</AlertDialog>
+												</div>
+											</TableCell>
+										</TableRow>
+									);
+								})}
 							</TableBody>
 						</Table>
 					</div>


### PR DESCRIPTION
## Summary

Adds support for multipart/form-data requests in the governance plugin. Previously, the plugin only handled JSON payloads, which caused failures when processing file uploads or form submissions that use multipart encoding.

## Changes

- Added multipart/form-data parsing to extract text form fields while skipping file parts to avoid loading binary data into memory
- Implemented multipart body reconstruction that preserves file parts byte-for-byte while allowing text field modifications (like model routing)
- Added content-type detection to determine whether to use JSON or multipart parsing/serialization
- Refactored payload serialization into a dedicated function that handles both JSON and multipart formats
- Added proper content-type header management for reconstructed multipart requests

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with multipart/form-data requests that include both text fields and file uploads:

```sh
# Test multipart form handling
curl -X POST http://localhost:8080/api/endpoint \
  -H "Content-Type: multipart/form-data" \
  -F "model=gpt-4" \
  -F "temperature=0.7" \
  -F "file=@test.txt"

# Verify JSON requests still work
curl -X POST http://localhost:8080/api/endpoint \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-4", "temperature": 0.7}'

# Run tests
go test ./plugins/governance/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The implementation carefully avoids loading file contents into memory during parsing, only extracting text form fields for governance processing. File parts are copied byte-for-byte during reconstruction to prevent memory exhaustion attacks.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable