### PR TITLE
fixed sidebar highlighting issue

### DIFF
--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -741,10 +741,6 @@ export default function AppSidebar() {
 		if (isAuditLogs && url === "/workspace/config") return true;
 		// User Provisioning is under Settings → highlight Settings when on scim
 		if ((path === "/workspace/scim" || path.startsWith("/workspace/scim/")) && url === "/workspace/config") return true;
-		// Guardrails Providers is accessed via Settings → highlight Settings, not Guardrails
-		const isGuardrailsProviders = path === "/workspace/guardrails/providers" || path.startsWith("/workspace/guardrails/providers/");
-		if (isGuardrailsProviders && url === "/workspace/config") return true;
-		if (isGuardrailsProviders && url === "/workspace/guardrails") return false;
 		if (url !== "/" && pathname.startsWith(url)) return true;
 		return false;
 	};


### PR DESCRIPTION
## Summary

Removes special navigation highlighting logic for Guardrails Providers pages in the sidebar component.

## Changes

- Removed conditional logic that highlighted the Settings menu item when navigating to guardrails providers pages
- Removed override that prevented highlighting the Guardrails menu item when on guardrails providers pages
- Guardrails providers navigation will now follow the default highlighting behavior

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the guardrails providers section and verify that sidebar highlighting works as expected with the default behavior.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable