### PR TITLE
review fixes 2

### DIFF
--- a/tests/e2e/core/utils/selectors.ts
+++ b/tests/e2e/core/utils/selectors.ts
@@ -78,7 +78,7 @@ export const Selectors = {
     teamsTable: '[data-testid="teams-table"]',
     customersTable: '[data-testid="customers-table"]',
     createTeamBtn: '[data-testid="create-team-btn"]',
-    createCustomerBtn: '[data-testid="create-customer-btn"]',
+    createCustomerBtn: '[data-testid="customer-button-create"]',
   },
 
   // Common form elements

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -312,6 +312,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 											href="https://docs.getbifrost.ai/mcp/code-mode"
 											target="_blank"
 											rel="noopener noreferrer"
+											data-testid="code-mode-link-help"
 											className="text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
 											aria-label="Learn more about Code Mode"
 										>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -445,6 +445,7 @@ export default function AppSidebar() {
 				url: "/workspace/prompt-repo",
 				icon: FolderGit,
 				description: "Prompt repository",
+				// Public access intentional — feature is "coming soon" with no sensitive data; RBAC will be added at GA
 				hasAccess: true,
 			},
 			{


### PR DESCRIPTION
## Summary

Updates test selectors and adds test identifiers to improve end-to-end test reliability and maintainability.

## Changes

- Updated `createCustomerBtn` selector from `create-customer-btn` to `customer-button-create` to match the actual UI implementation
- Added `data-testid="code-mode-link-help"` to the Code Mode documentation link in the MCP client form for better test targeting
- Added clarifying comment about intentional public access for the prompt repository feature, noting that RBAC will be implemented at general availability

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that end-to-end tests can properly locate UI elements with the updated selectors:

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build

# Run e2e tests to verify selectors work correctly
pnpm test:e2e || npm run test:e2e
```

## Screenshots/Recordings

N/A - Test infrastructure changes only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The comment addition clarifies that public access to the prompt repository is intentional for the preview feature, with proper RBAC to be implemented before general availability.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable