### PR TITLE
fix(vertex): use prefix matching for beta header filtering to handle version bumps

### DIFF
--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -29,6 +29,14 @@ const (
 	AnthropicCompactionBetaHeader = "compact-2026-01-12"
 	// AnthropicContextManagementBetaHeader is required for context management.
 	AnthropicContextManagementBetaHeader = "context-management-2025-06-27"
+
+	// Prefixes for Vertex-unsupported beta headers (version-bump proof).
+	// Use these with strings.HasPrefix when filtering headers for Vertex AI,
+	// so that future date bumps (e.g. structured-outputs-2025-12-15) are still matched.
+	AnthropicAdvancedToolUseBetaHeaderPrefix    = "advanced-tool-use-"
+	AnthropicStructuredOutputsBetaHeaderPrefix  = "structured-outputs-"
+	AnthropicPromptCachingScopeBetaHeaderPrefix = "prompt-caching-scope-"
+	AnthropicMCPClientBetaHeaderPrefix          = "mcp-client-"
 )
 
 // ==================== REQUEST TYPES ====================

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -201,11 +201,13 @@ func filterVertexUnsupportedBetaHeaders(headers map[string][]string) map[string]
 			// Split comma-separated beta headers
 			for beta := range strings.SplitSeq(headerValue, ",") {
 				beta = strings.TrimSpace(beta)
-				// Skip unsupported headers for Vertex
-				if beta == anthropic.AnthropicAdvancedToolUseBetaHeader ||
-					beta == anthropic.AnthropicStructuredOutputsBetaHeader ||
-					beta == anthropic.AnthropicPromptCachingScopeBetaHeader ||
-					beta == anthropic.AnthropicMCPClientBetaHeader {
+				// Skip unsupported headers for Vertex.
+				// Use prefix matching so that future date bumps
+				// (e.g. structured-outputs-2025-12-15) are still caught.
+				if strings.HasPrefix(beta, anthropic.AnthropicAdvancedToolUseBetaHeaderPrefix) ||
+					strings.HasPrefix(beta, anthropic.AnthropicStructuredOutputsBetaHeaderPrefix) ||
+					strings.HasPrefix(beta, anthropic.AnthropicPromptCachingScopeBetaHeaderPrefix) ||
+					strings.HasPrefix(beta, anthropic.AnthropicMCPClientBetaHeaderPrefix) {
 					continue
 				}
 				filteredBetas = append(filteredBetas, beta)

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -1,0 +1,87 @@
+package integrations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterVertexUnsupportedBetaHeaders(t *testing.T) {
+	t.Run("filters known exact header values", func(t *testing.T) {
+		headers := map[string][]string{
+			"anthropic-beta": {"advanced-tool-use-2025-11-20,structured-outputs-2025-11-13,mcp-client-2025-04-04,prompt-caching-scope-2026-01-05"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		_, ok := result["anthropic-beta"]
+		assert.False(t, ok, "all unsupported beta headers should be removed, leaving no anthropic-beta key")
+	})
+
+	t.Run("filters bumped date variants", func(t *testing.T) {
+		// Simulate Anthropic bumping version dates in the future
+		headers := map[string][]string{
+			"anthropic-beta": {"structured-outputs-2025-12-15,advanced-tool-use-2026-03-01,mcp-client-2026-01-01,prompt-caching-scope-2027-06-30"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		_, ok := result["anthropic-beta"]
+		assert.False(t, ok, "bumped-date variants of unsupported headers should also be filtered")
+	})
+
+	t.Run("passes through unrelated beta headers", func(t *testing.T) {
+		headers := map[string][]string{
+			"anthropic-beta": {"interleaved-thinking-2025-05-14,files-api-2025-04-14"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		vals, ok := result["anthropic-beta"]
+		assert.True(t, ok, "unrelated beta headers should be preserved")
+		assert.Equal(t, []string{"interleaved-thinking-2025-05-14,files-api-2025-04-14"}, vals)
+	})
+
+	t.Run("filters unsupported and keeps supported in mixed list", func(t *testing.T) {
+		headers := map[string][]string{
+			"anthropic-beta": {"interleaved-thinking-2025-05-14,structured-outputs-2025-11-13,files-api-2025-04-14,mcp-client-2025-04-04"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		vals, ok := result["anthropic-beta"]
+		assert.True(t, ok, "supported beta headers should be preserved")
+		assert.Equal(t, []string{"interleaved-thinking-2025-05-14,files-api-2025-04-14"}, vals)
+	})
+
+	t.Run("filters bumped unsupported mixed with supported", func(t *testing.T) {
+		// Future-proof: bumped dates should still be filtered
+		headers := map[string][]string{
+			"anthropic-beta": {"structured-outputs-2026-01-01,interleaved-thinking-2025-05-14,advanced-tool-use-2026-06-15"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		vals, ok := result["anthropic-beta"]
+		assert.True(t, ok, "supported beta headers should be preserved even when mixed with bumped unsupported ones")
+		assert.Equal(t, []string{"interleaved-thinking-2025-05-14"}, vals)
+	})
+
+	t.Run("returns headers unchanged when no anthropic-beta key present", func(t *testing.T) {
+		headers := map[string][]string{
+			"content-type": {"application/json"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		assert.Equal(t, headers, result)
+	})
+
+	t.Run("handles empty anthropic-beta value gracefully", func(t *testing.T) {
+		headers := map[string][]string{
+			"anthropic-beta": {""},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		// Empty string after trimming is not an unsupported header, but it is also empty — key should be removed
+		_, ok := result["anthropic-beta"]
+		assert.False(t, ok, "empty beta header list should result in key removal")
+	})
+
+	t.Run("case-insensitive key matching for Anthropic-Beta header", func(t *testing.T) {
+		headers := map[string][]string{
+			"Anthropic-Beta": {"structured-outputs-2025-11-13,interleaved-thinking-2025-05-14"},
+		}
+		result := filterVertexUnsupportedBetaHeaders(headers)
+		vals, ok := result["Anthropic-Beta"]
+		assert.True(t, ok, "header key casing should be preserved and matching should be case-insensitive")
+		assert.Equal(t, []string{"interleaved-thinking-2025-05-14"}, vals)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #1749.

When Anthropic ships a new version of a beta feature, the date suffix in the header changes (e.g. `structured-outputs-2025-11-13` becomes `structured-outputs-2025-12-15`). The previous implementation of `filterVertexUnsupportedBetaHeaders` used exact string equality against the known constants, so any date-bumped header would pass the filter unchanged and be forwarded to Vertex AI, which does not support those features and rejects the request.

## Root cause

`filterVertexUnsupportedBetaHeaders` in `transports/bifrost-http/integrations/anthropic.go` compared each beta header value with `==` against the four hardcoded constants:

```go
if beta == anthropic.AnthropicAdvancedToolUseBetaHeader ||
    beta == anthropic.AnthropicStructuredOutputsBetaHeader || ...
```

A bumped date (e.g. `structured-outputs-2025-12-15`) does not match `structured-outputs-2025-11-13`, so it slips through to Vertex and causes a 400.

## Fix

- Added four prefix constants to `core/providers/anthropic/types.go`:
  - `AnthropicAdvancedToolUseBetaHeaderPrefix = "advanced-tool-use-"`
  - `AnthropicStructuredOutputsBetaHeaderPrefix = "structured-outputs-"`
  - `AnthropicPromptCachingScopeBetaHeaderPrefix = "prompt-caching-scope-"`
  - `AnthropicMCPClientBetaHeaderPrefix = "mcp-client-"`

- Switched the filter conditions in `filterVertexUnsupportedBetaHeaders` to use `strings.HasPrefix` with these new constants, so any current or future date variant of each unsupported feature is reliably caught.

## Tests

New file: `transports/bifrost-http/integrations/anthropic_test.go`

- Known exact header values are filtered
- Bumped-date variants (simulating future Anthropic releases) are also filtered
- Unrelated headers (`interleaved-thinking-2025-05-14`, `files-api-2025-04-14`) pass through unchanged
- Mixed lists of supported and unsupported headers are handled correctly
- Case-insensitive `Anthropic-Beta` key matching is preserved
- Empty beta value is handled without a panic