### PR TITLE
chore: add changelog entry for vertex beta header prefix matching fix

### DIFF
--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+- fix: vertex provider now uses prefix matching for beta header filtering to correctly handle version bumps
 - feat: added support for logging headers to capture request headers into log metadata
 - fix: OAuth callback URL now respects X-Forwarded-Proto header for correct HTTPS scheme behind reverse proxies
 - feat: add asynchronous inference support


### PR DESCRIPTION
Adds the missing changelog entry in `transports/changelog.md` for the vertex beta header prefix matching fix that was merged in #1753.

Forgot to include this in the original PR — following up on the request from @Pratham-Mishra04.