### PR TITLE
feat: add unfiltered models support and backfill allowed models in list responses

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -386,9 +386,12 @@ func (bifrost *Bifrost) ListModelsRequest(ctx *schemas.BifrostContext, req *sche
 
 // ListAllModels lists all models from all configured providers.
 // It accumulates responses from all providers with a limit of 1000 per provider to get all results.
-func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	if request == nil {
-		request = &schemas.BifrostListModelsRequest{}
+func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	if req == nil {
+		req = &schemas.BifrostListModelsRequest{}
+	}
+	if ctx == nil {
+		ctx = bifrost.ctx
 	}
 
 	providerKeys, err := bifrost.GetConfiguredProviders()
@@ -434,8 +437,9 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, request *sche
 
 			// Create request for this provider with limit of 1000
 			providerRequest := &schemas.BifrostListModelsRequest{
-				Provider: providerKey,
-				PageSize: schemas.DefaultPageSize,
+				Provider:   providerKey,
+				PageSize:   schemas.DefaultPageSize,
+				Unfiltered: req.Unfiltered,
 			}
 
 			iterations := 0
@@ -540,7 +544,7 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, request *sche
 		},
 	}
 
-	response = response.ApplyPagination(request.PageSize, request.PageToken)
+	response = response.ApplyPagination(req.PageSize, req.PageToken)
 
 	return response, nil
 }

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,3 +2,6 @@
 - feat: added support for filtering /v1/models responses based on virtual key configurations in the governance plugin
 - feat: add vllm provider support
 - feat: support multiple credential types in vertex auth credentials
+- fix: added replicate and huggingface model allowlist on list models response
+- feat: added support for unfiltered list models response
+- fix: backfill allowed models that were not in the list models response

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -220,7 +220,7 @@ func (provider *AnthropicProvider) listModelsByKey(ctx *schemas.BifrostContext, 
 	}
 
 	// Create final response
-	response := anthropicResponse.ToBifrostListModelsResponse(provider.GetProviderKey(), key.Models)
+	response := anthropicResponse.ToBifrostListModelsResponse(provider.GetProviderKey(), key.Models, request.Unfiltered)
 	response.ExtraFields.Latency = latency.Milliseconds()
 
 	// Set raw request if enabled

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -302,7 +302,7 @@ func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key 
 	}
 
 	// Convert to Bifrost response
-	response := azureResponse.ToBifrostListModelsResponse(key.Models, key.AzureKeyConfig.Deployments)
+	response := azureResponse.ToBifrostListModelsResponse(key.Models, key.AzureKeyConfig.Deployments, request.Unfiltered)
 	if response == nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert Azure model list response", nil, schemas.Azure)
 	}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -597,7 +597,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	}
 
 	// Convert to Bifrost response
-	response := bedrockResponse.ToBifrostListModelsResponse(providerName, key.Models, config.Deployments)
+	response := bedrockResponse.ToBifrostListModelsResponse(providerName, key.Models, config.Deployments, request.Unfiltered)
 	if response == nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to convert Bedrock model list response", nil, providerName)
 	}

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -263,7 +263,7 @@ func (provider *CohereProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 	}
 
 	// Convert Cohere v2 response to Bifrost response
-	response := cohereResponse.ToBifrostListModelsResponse(providerName, key.Models)
+	response := cohereResponse.ToBifrostListModelsResponse(providerName, key.Models, request.Unfiltered)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -108,7 +108,7 @@ func (provider *ElevenlabsProvider) listModelsByKey(ctx *schemas.BifrostContext,
 		return nil, bifrostErr
 	}
 
-	response := elevenlabsResponse.ToBifrostListModelsResponse(providerName, key.Models)
+	response := elevenlabsResponse.ToBifrostListModelsResponse(providerName, key.Models, request.Unfiltered)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/elevenlabs/models.go
+++ b/core/providers/elevenlabs/models.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func (response *ElevenlabsListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string) *schemas.BifrostListModelsResponse {
+func (response *ElevenlabsListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string, unfiltered bool) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
 	}
@@ -15,14 +15,28 @@ func (response *ElevenlabsListModelsResponse) ToBifrostListModelsResponse(provid
 		Data: make([]schemas.Model, 0, len(*response)),
 	}
 
+	includedModels := make(map[string]bool)
 	for _, model := range *response {
-		if len(allowedModels) > 0 && !slices.Contains(allowedModels, model.ModelID) {
+		if !unfiltered && len(allowedModels) > 0 && !slices.Contains(allowedModels, model.ModelID) {
 			continue
 		}
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
 			ID:   string(providerKey) + "/" + model.ModelID,
 			Name: schemas.Ptr(model.Name),
 		})
+		includedModels[model.ModelID] = true
+	}
+
+	// Backfill allowed models that were not in the response
+	if !unfiltered && len(allowedModels) > 0 {
+		for _, allowedModel := range allowedModels {
+			if !includedModels[allowedModel] {
+				bifrostResponse.Data = append(bifrostResponse.Data, schemas.Model{
+					ID:   string(providerKey) + "/" + allowedModel,
+					Name: schemas.Ptr(allowedModel),
+				})
+			}
+		}
 	}
 
 	return bifrostResponse

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -173,7 +173,7 @@ func (provider *GeminiProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 		return nil, bifrostErr
 	}
 
-	response := geminiResponse.ToBifrostListModelsResponse(providerName, key.Models)
+	response := geminiResponse.ToBifrostListModelsResponse(providerName, key.Models, request.Unfiltered)
 
 	response.ExtraFields.Latency = latency.Milliseconds()
 

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -382,7 +382,7 @@ func (provider *HuggingFaceProvider) listModelsByKey(ctx *schemas.BifrostContext
 		}
 
 		if result.response != nil {
-			providerResponse := result.response.ToBifrostListModelsResponse(providerName, result.provider)
+			providerResponse := result.response.ToBifrostListModelsResponse(providerName, result.provider, key.Models, request.Unfiltered)
 			if providerResponse != nil {
 				aggregatedResponse.Data = append(aggregatedResponse.Data, providerResponse.Data...)
 				totalLatency += result.latency

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -97,6 +97,7 @@ func (provider *OpenAIProvider) ListModels(ctx *schemas.BifrostContext, keys []s
 				provider.client,
 				provider.buildRequestURL(ctx, "/v1/models", schemas.ListModelsRequest),
 				schemas.Key{},
+				request.Unfiltered,
 				provider.networkConfig.ExtraHeaders,
 				providerName,
 				providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -124,6 +125,7 @@ func listModelsByKey(
 	client *fasthttp.Client,
 	url string,
 	key schemas.Key,
+	unfiltered bool,
 	extraHeaders map[string]string,
 	providerName schemas.ModelProvider,
 	sendBackRawRequest bool,
@@ -169,7 +171,7 @@ func listModelsByKey(
 		return nil, bifrostErr
 	}
 
-	response := openaiResponse.ToBifrostListModelsResponse(providerName, key.Models)
+	response := openaiResponse.ToBifrostListModelsResponse(providerName, key.Models, unfiltered)
 
 	response.ExtraFields.Provider = providerName
 	response.ExtraFields.RequestType = schemas.ListModelsRequest
@@ -201,10 +203,10 @@ func HandleOpenAIListModelsRequest(
 	sendBackRawResponse bool,
 ) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	if len(keys) == 0 {
-		return listModelsByKey(ctx, client, url, schemas.Key{}, extraHeaders, providerName, sendBackRawRequest, sendBackRawResponse)
+		return listModelsByKey(ctx, client, url, schemas.Key{}, request.Unfiltered, extraHeaders, providerName, sendBackRawRequest, sendBackRawResponse)
 	}
 	listModelsByKeyWrapper := func(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-		return listModelsByKey(ctx, client, url, key, extraHeaders, providerName, sendBackRawRequest, sendBackRawResponse)
+		return listModelsByKey(ctx, client, url, key, request.Unfiltered, extraHeaders, providerName, sendBackRawRequest, sendBackRawResponse)
 	}
 	return providerUtils.HandleMultipleListModelsRequests(
 		ctx,

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -343,6 +343,8 @@ func (provider *ReplicateProvider) listDeploymentsByKey(ctx *schemas.BifrostCont
 	response := ToBifrostListModelsResponse(
 		deploymentsResponse,
 		providerName,
+		key.Models,
+		request.Unfiltered,
 	)
 
 	return response, nil

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -257,7 +257,7 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 	aggregatedResponse := &VertexListModelsResponse{
 		Models: allModels,
 	}
-	response := aggregatedResponse.ToBifrostListModelsResponse(key.Models, key.VertexKeyConfig.Deployments)
+	response := aggregatedResponse.ToBifrostListModelsResponse(key.Models, key.VertexKeyConfig.Deployments, request.Unfiltered)
 
 	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
 		response.ExtraFields.RawRequest = rawRequests

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -314,7 +314,7 @@ type ChatToolFunction struct {
 type ToolFunctionParameters struct {
 	Type                 string                      `json:"type"`                           // Type of the parameters
 	Description          *string                     `json:"description,omitempty"`          // Description of the parameters
-	Properties           *OrderedMap                 `json:"properties,omitempty"`           // Parameter properties
+	Properties           *OrderedMap                 `json:"properties"`                     // Parameter properties - always include even if empty (required by JSON Schema and some providers like OpenAI)
 	Required             []string                    `json:"required,omitempty"`             // Required parameter names
 	AdditionalProperties *AdditionalPropertiesStruct `json:"additionalProperties,omitempty"` // Whether to allow additional properties
 	Enum                 []string                    `json:"enum,omitempty"`                 // Enum values for the parameters
@@ -348,6 +348,16 @@ type ToolFunctionParameters struct {
 	Title    *string     `json:"title,omitempty"`    // Schema title
 	Default  interface{} `json:"default,omitempty"`  // Default value
 	Nullable *bool       `json:"nullable,omitempty"` // Nullable indicator (OpenAPI 3.0 style)
+}
+
+// MarshalJSON ensures properties is always an object, never null.
+func (t ToolFunctionParameters) MarshalJSON() ([]byte, error) {
+	type Alias ToolFunctionParameters
+	tmp := Alias(t)
+	if tmp.Properties == nil {
+		tmp.Properties = &OrderedMap{}
+	}
+	return Marshal(tmp)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ToolFunctionParameters.

--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -34,6 +34,9 @@ type BifrostListModelsRequest struct {
 	// PageToken: Token received from previous request to retrieve next page
 	PageToken string `json:"page_token"`
 
+	// Unfiltered: If true, the response will include all models for the provider, regardless of the allowed models (internal bifrost use only, not sent to the provider)
+	Unfiltered bool `json:"unfiltered"`
+
 	// ExtraParams: Additional provider-specific query parameters
 	// This allows for flexibility to pass any custom parameters that specific providers might support
 	ExtraParams map[string]interface{} `json:"-"`

--- a/docs/contributing/code-conventions.mdx
+++ b/docs/contributing/code-conventions.mdx
@@ -1,0 +1,358 @@
+---
+title: "Code Conventions"
+description: "Code style and convention guidelines for contributing to Bifrost."
+icon: "brush"
+---
+
+## Commit Message Format
+
+All commits to Bifrost should follow a standardized format. This ensures clear history and makes it easy to understand changes at a glance.
+
+### Format
+
+```
+[type]: description
+
+Optional body with more details
+```
+
+### Types
+
+- **feat** - New feature
+- **fix** - Bug fix
+- **refactor** - Code refactoring (no feature change, no bug fix)
+- **docs** - Documentation changes
+- **test** - Test changes
+- **chore** - Build, dependencies, tooling changes
+- **perf** - Performance improvements
+
+### Key Rule: Always List Affected Packages
+
+For every commit, **explicitly mention all packages/directories that were modified**. This is crucial for understanding the scope of changes.
+
+```
+[fix]: Handle null pointer in model response
+
+Affected packages:
+- core/providers/openai/
+- core/schemas/
+
+Impact: Fixes intermittent crashes when provider returns malformed response
+```
+
+### Examples
+
+**Good:**
+```
+[feat]: Add retry logic to MCP client manager
+
+Implements exponential backoff for transient errors (connection timeouts, network issues).
+Retries only for transient errors, fails immediately for permanent errors (auth, config).
+
+Affected packages:
+- core/mcp/clientmanager.go - Connection retry logic
+- core/mcp/utils.go - Retry executor and error classification
+- core/mcp/healthmonitor.go - Automatic reconnection
+
+Tests:
+- Added tests for retry backoff progression
+- Added tests for error classification
+```
+
+**Better (if changes are significant to multiple packages):**
+```
+[feat]: Add resilient MCP connection handling
+
+Commit 1: [feat]: MCP utils - Add retry executor with exponential backoff
+Commit 2: [fix]: MCP client - Use retry logic for connection establishment
+Commit 3: [feat]: MCP health monitor - Add automatic reconnection
+```
+
+## Go Code Conventions
+
+### Style Guidelines
+
+1. **Follow standard Go conventions**
+   - Use `gofmt` for formatting
+   - Run `make fmt` before committing
+
+2. **Naming**
+   - Use meaningful variable names
+   - Avoid single letters except in loops
+   - Use `camelCase` for variables and functions
+   - Use `PascalCase` for exported types
+
+3. **Comments**
+   - Comment exported functions and types
+   - Use clear, concise comments
+   - Explain *why*, not *what*
+
+4. **Error Handling**
+   - Always check and handle errors
+   - Provide context in error messages
+   - Don't ignore errors with `_`
+
+### Structure
+
+```go
+// Exported functions first
+func NewClient(config Config) (*Client, error) {
+    // implementation
+}
+
+// Exported methods
+func (c *Client) Do(ctx context.Context) error {
+    // implementation
+}
+
+// Unexported helper functions
+func (c *Client) validate() error {
+    // implementation
+}
+```
+
+### Documentation
+
+Each package should have:
+- A `package` comment
+- Exported function/type comments
+- Complex logic explanations
+
+```go
+// Package mcp provides Model Context Protocol integration
+// for connecting AI models to external tools and services.
+package mcp
+
+// Client manages connections to MCP servers.
+type Client struct {
+    // fields...
+}
+
+// Connect establishes a connection to the MCP server.
+// Returns an error if the connection fails.
+func (c *Client) Connect(ctx context.Context) error {
+    // implementation
+}
+```
+
+## TypeScript/React Code Conventions
+
+### Style Guidelines
+
+1. **Use TypeScript** - Avoid `any` types when possible
+2. **Use functional components** - No class components
+3. **Props interface**
+   ```typescript
+   interface ButtonProps {
+     onClick: () => void;
+     children: React.ReactNode;
+   }
+   ```
+
+4. **Naming**
+   - Components: `PascalCase`
+   - Functions/variables: `camelCase`
+   - Constants: `UPPER_SNAKE_CASE`
+
+### Structure
+
+```typescript
+// Imports
+import React from 'react';
+import { useContext } from 'react';
+
+// Types
+interface Props {
+  id: string;
+  onSubmit: (data: FormData) => Promise<void>;
+}
+
+// Component
+export const MyComponent: React.FC<Props> = ({ id, onSubmit }) => {
+  return (
+    <div>
+      {/* implementation */}
+    </div>
+  );
+};
+```
+
+## Testing Conventions
+
+### Go Tests
+
+1. **Test file naming**: `*_test.go`
+2. **Test function naming**: `Test<FunctionName>`
+3. **Table-driven tests for multiple cases**
+
+```go
+func TestProcessRequest(t *testing.T) {
+    tests := []struct {
+        name    string
+        input   string
+        want    string
+        wantErr bool
+    }{
+        {"valid input", "test", "result", false},
+        {"invalid input", "", "", true},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got, err := ProcessRequest(tt.input)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("unexpected error: %v", err)
+            }
+            if got != tt.want {
+                t.Errorf("got %s, want %s", got, tt.want)
+            }
+        })
+    }
+}
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+make test-all
+
+# Run specific test suite
+make test-core PROVIDER=openai
+
+# Run specific test case
+make test-core PROVIDER=openai TESTCASE=TestName/SubTest
+```
+
+## Documentation Conventions
+
+### MDX Files
+
+1. **Front matter**
+   ```mdx
+   ---
+   title: "Feature Name"
+   description: "Brief description of the feature"
+   icon: "icon-name"
+   ---
+   ```
+
+2. **Headings** - Use H2 (`##`) as top level in body
+3. **Code blocks** - Always include language: ` ```go`
+4. **Links** - Use relative paths: `/features/caching`
+
+### Examples
+
+```mdx
+---
+title: "Semantic Caching"
+description: "Intelligent response caching based on semantic similarity"
+icon: "database"
+---
+
+## Overview
+
+Semantic caching intelligently caches responses...
+
+## Configuration
+
+```yaml
+plugins:
+  semanticcache:
+    enabled: true
+```
+
+<Note>
+This is important information that needs highlighting.
+</Note>
+
+## Benefits
+
+- Reduces costs by 30-40%
+- Improves latency for similar queries
+```
+
+## Pull Request Conventions
+
+See [Raising a PR](/contributing/raising-a-pr) for detailed guidelines. Key points:
+
+1. **Commit messages**: Follow `[type]: description` format
+2. **Package listing**: Always mention affected packages
+3. **Changelog updates**: Update `changelog.md` for each affected package
+4. **Tests**: Ensure all tests pass before opening PR
+5. **Documentation**: Update docs if behavior changes
+
+## Changelog Format
+
+For each package you modify, update its `changelog.md` file at the top with:
+
+```
+[type]: description [@Your Name](https://github.com/yourname)
+```
+
+**Example:**
+```markdown
+[feat]: add semantic caching support for image generation [@prathammaxim](https://github.com/prathammaxim)
+[fix]: handle null pointer in response parsing [@username](https://github.com/username)
+[refactor]: simplify model caching logic [@username](https://github.com/username)
+```
+
+**File locations:**
+- `core/changelog.md`
+- `framework/changelog.md`
+- `transports/changelog.md`
+- `plugins/{plugin-name}/changelog.md`
+
+## Code Quality Standards
+
+Before submitting code:
+
+### Go Code
+```bash
+# Format code
+make fmt
+
+# Run linter
+make lint
+
+# Run tests
+make test-all
+```
+
+### TypeScript/React
+- Use ESLint configuration from project
+- Run Prettier for formatting
+- Ensure TypeScript compilation succeeds
+
+## Key Principles
+
+1. **Clarity** - Code should be easy to understand
+2. **Consistency** - Follow existing patterns in codebase
+3. **Testing** - All code should have tests
+4. **Documentation** - Document public APIs and complex logic
+5. **Simplicity** - Avoid over-engineering
+6. **Performance** - Consider performance implications of changes
+
+## Common Pitfalls
+
+❌ **Don't:**
+- Submit PRs without running tests
+- Use `fmt.Println` for logging (use logger)
+- Ignore error handling
+- Create huge functions (>100 lines)
+- Mix refactoring with feature changes
+- Forget to list affected packages in commit messages
+
+✅ **Do:**
+- Run `make test-all` before opening PR
+- Use structured logging
+- Handle all error cases
+- Keep functions focused and testable
+- Make logical, focused commits
+- Always mention affected packages and changes
+
+## Getting Help
+
+- See [Setting up the repository](/contributing/setting-up-repo) for development setup
+- Check [Architecture docs](/architecture) to understand the codebase
+- Ask in [Discord](https://discord.gg/exN5KAydbU) if you have questions

--- a/docs/contributing/raising-a-pr.mdx
+++ b/docs/contributing/raising-a-pr.mdx
@@ -1,0 +1,506 @@
+---
+title: "Raising a Pull Request"
+description: "Guidelines for submitting high-quality pull requests to Bifrost."
+icon: "code-pull-request"
+---
+
+## Before You Start
+
+1. **Create an issue first** (if one doesn't exist) - Discuss the change with the maintainers
+2. **Fork the repository** and create a feature branch
+3. **Set up your development environment** using [these instructions](/contributing/setting-up-repo)
+4. **Run tests locally** to ensure everything works
+
+## Commit Message Format
+
+All commits should follow a standardized format. **For each package/directory you modify, include a separate commit message line** describing the change in that package.
+
+### Format
+
+```
+[type]: description
+
+Additional details if needed (optional)
+```
+
+### Types
+
+- **feat** - New feature
+- **fix** - Bug fix
+- **refactor** - Code refactoring (no feature change, no bug fix)
+- **docs** - Documentation changes
+- **test** - Test changes
+- **chore** - Build, dependencies, tooling changes
+- **perf** - Performance improvements
+
+### Examples
+
+**Single Package Change:**
+```
+[fix]: handle connection timeout in MCP client manager
+```
+
+**Multiple Packages:**
+If your change affects multiple packages, include the package name or affected module in the description:
+
+```
+[fix]: MCP client - add retry logic to connection establishment
+
+This fixes intermittent connection failures by implementing exponential backoff.
+Affected packages:
+- core/mcp/clientmanager.go
+- core/mcp/healthmonitor.go
+```
+
+**Provider-Specific Changes:**
+```
+[fix]: OpenAI provider - handle streaming response errors
+[feat]: Anthropic provider - add support for batch API
+```
+
+**Multiple Commits for Multiple Packages:**
+If you're making significant changes to multiple packages, consider separate commits:
+
+```bash
+git commit -m "[feat]: Add retry mechanism to MCP core utilities"
+git commit -m "[fix]: Update OpenAI integration with retry support"
+git commit -m "[docs]: Document MCP resilience strategy"
+```
+
+### All Packages Modified Should Be Listed
+
+When creating a commit, always mention which packages/components are affected:
+
+```
+[feat]: Add semantic caching plugin
+
+Changes:
+- plugins/semanticcache/ - Core caching logic
+- core/bifrost.go - Plugin registration
+- transports/bifrost-http/server.go - Cache middleware integration
+
+Benefits:
+- Reduces API costs by 30-40%
+- Improves response latency for similar queries
+```
+
+<Tip>
+Use a structured format that makes it easy to understand at a glance what changed and where.
+</Tip>
+
+## Maintaining Changelogs
+
+For each package you modify, update the corresponding `changelog.md` file with your changes. Changelog entries are used to generate release notes and communicate changes to users.
+
+### Changelog File Locations
+
+Each package that receives updates should have a `changelog.md` file:
+
+- `core/changelog.md` - Core package changes
+- `framework/changelog.md` - Framework changes
+- `transports/changelog.md` - Transport layer changes
+- `plugins/{plugin-name}/changelog.md` - Specific plugin changes
+
+### Changelog Entry Format
+
+Each changelog entry follows this exact format:
+
+```
+[type]: description [@Your Name](https://github.com/yourname)
+```
+
+**Required Components:**
+- **Type**: One of `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, or `perf`
+- **Description**: Clear, concise description (under 100 characters)
+- **Author**: Your GitHub profile link (recommended)
+
+### Change Types Reference
+
+| Type | Usage | Example |
+|------|-------|---------|
+| **feat** | New feature | `[feat]: add exponential backoff retry mechanism` |
+| **fix** | Bug fix | `[fix]: handle connection timeout in MCP client` |
+| **refactor** | Code refactoring (no behavior change) | `[refactor]: simplify model caching` |
+| **docs** | Documentation updates | `[docs]: clarify semantic caching behavior` |
+| **test** | Test additions/modifications | `[test]: add regression tests for retry logic` |
+| **chore** | Build, dependencies, tooling | `[chore]: upgrade dependencies to latest versions` |
+| **perf** | Performance improvements | `[perf]: optimize model lookup to O(1)` |
+
+### Changelog Examples
+
+**Good Examples:**
+```markdown
+[feat]: add exponential backoff retry mechanism [@prathammaxim](https://github.com/prathammaxim)
+[fix]: handle null pointer in OpenAI response parsing [@contributor](https://github.com/contributor)
+[perf]: optimize model lookup with hash map [@contributor](https://github.com/contributor)
+```
+
+**Poor Examples (avoid):**
+```markdown
+- update stuff
+- minor changes
+- fix bug
+- added new thing
+```
+
+### How to Add Changelog Entries
+
+1. **Edit the `changelog.md`** file in the affected package
+2. **Add new entry at the TOP** of the file (most recent first)
+3. **Follow the exact format**: `[type]: description [@name](https://github.com/user)`
+4. **Include your author link** (optional but recommended)
+
+**Example: Before and After**
+
+**Before:**
+```markdown
+[feat]: added image generation request and response support
+[chore]: added case-insensitive helper methods
+```
+
+**After (with new entry at top):**
+```markdown
+[fix]: handle connection timeout in retry logic [@your-name](https://github.com/your-name)
+[feat]: add exponential backoff for transient errors [@your-name](https://github.com/your-name)
+[feat]: added image generation request and response support
+[chore]: added case-insensitive helper methods
+```
+
+### Multiple Package Changes
+
+When your PR affects multiple packages, **add entries to each package's `changelog.md`**:
+
+**Example Multi-Package Changelog:**
+
+**core/changelog.md:**
+```markdown
+[feat]: add retry executor with exponential backoff [@contributor](https://github.com/contributor)
+```
+
+**transports/changelog.md:**
+```markdown
+[fix]: apply retry logic to connection establishment [@contributor](https://github.com/contributor)
+```
+
+**plugins/governance/changelog.md:**
+```markdown
+[chore]: update core dependency to latest version
+```
+
+### What to Include in Changelog
+
+✅ **Do include:**
+- Bug fixes that affect users
+- New features
+- Breaking changes
+- Performance improvements
+- Significant refactoring
+- Documentation improvements
+
+❌ **Don't include:**
+- Internal code cleanup with no user impact
+- Typo fixes in comments only
+- Build system changes (unless significant)
+- Minor test-only changes
+
+### Changelog Best Practices
+
+1. **Add entries at the TOP** of the `changelog.md` file (most recent first)
+2. **One entry per logical change** - Don't combine unrelated changes
+3. **Keep descriptions concise** - Under 100 characters
+4. **Use consistent format** - `[type]: description`
+5. **Include your GitHub link** - Helps recognize contributors
+6. **Update all affected package changelogs** - Don't forget secondary packages
+7. **Add changelog entry with your commit** - Don't wait until the end
+
+### Format Consistency Rules
+
+**DO's:**
+- ✅ Use square brackets: `[feat]`
+- ✅ Use colon separator: `[feat]:`
+- ✅ Start with lowercase (unless proper noun)
+- ✅ Be specific and concise
+- ✅ Include GitHub profile link
+- ✅ Add new entries at the top
+
+**DON'Ts:**
+- ❌ Don't use parentheses: `(feat)` or braces `{feat}`
+- ❌ Don't use multiple spaces
+- ❌ Don't mix formats in the same file
+- ❌ Don't add entries at the bottom
+- ❌ Don't use vague descriptions
+
+### Complete PR Example with Changelogs
+
+If your PR adds retry logic to multiple packages:
+
+```
+Commit: [feat]: Add retry logic with exponential backoff
+
+Modified files:
+- core/mcp/utils.go ← add retry executor
+- core/mcp/clientmanager.go ← use retry logic
+
+Update changelogs:
+
+1. core/changelog.md:
+   [feat]: add exponential backoff retry mechanism [@your-name](https://github.com/your-name)
+
+2. transports/changelog.md:
+   [fix]: apply retry logic to connection establishment [@your-name](https://github.com/your-name)
+```
+
+### Changelog Review Checklist
+
+Before submitting a PR, verify:
+
+- [ ] All packages modified have changelog entries
+- [ ] Format is correct: `[type]: description [@name](https://github.com/user)`
+- [ ] Entries are added at TOP of the file
+- [ ] Author GitHub link is included
+- [ ] Description is clear and concise (under 100 chars)
+- [ ] Type is one of: feat, fix, refactor, docs, test, chore, perf
+- [ ] Entries are added with the commit (not after)
+
+## Pull Request Title
+
+Keep PR titles concise and descriptive, following the same pattern:
+
+```
+[type]: Brief description of the change
+```
+
+Examples:
+- `[feat]: Add rate limiting to governance plugin`
+- `[fix]: Resolve deadlock in MCP retry logic`
+- `[refactor]: Simplify model caching mechanism`
+- `[docs]: Update contribution guidelines for commit messages`
+
+## Pull Request Description
+
+Use the following template for your PR description:
+
+```markdown
+## Description
+
+Brief explanation of what this PR does and why it's needed.
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactoring
+
+## Affected Packages
+
+List all packages/directories modified:
+- core/providers/openai/
+- transports/bifrost-http/server/
+- plugins/governance/
+
+## Changes Made
+
+- Specific change 1
+- Specific change 2
+- Specific change 3
+
+## Testing
+
+Describe how you tested these changes:
+- [ ] Unit tests added/updated
+- [ ] Integration tests passed
+- [ ] Manual testing completed
+
+## Checklist
+
+- [ ] Code follows the project's code style
+- [ ] Tests are passing locally (`make test-all`)
+- [ ] Documentation is updated if needed
+- [ ] No breaking changes (or breaking changes are documented)
+- [ ] Commit messages follow the format: `[type]: description`
+- [ ] All affected packages are mentioned in commit messages
+
+## Related Issues
+
+Closes #123
+Relates to #456
+```
+
+## Best Practices
+
+### 1. Keep PRs Focused
+
+- One feature or fix per PR when possible
+- If multiple related changes, group them logically by package
+- Avoid mixing refactoring with feature changes
+
+### 2. Commit Messages Matter
+
+❌ **Bad:**
+```
+Update file
+```
+
+✅ **Good:**
+```
+[fix]: Handle null pointer in OpenAI response parsing
+```
+
+❌ **Bad:**
+```
+[feat]: Major update to semantic cache
+```
+
+✅ **Good:**
+```
+[feat]: Add semantic cache initialization with retry logic
+
+Changes:
+- plugins/semanticcache/ - Add retry mechanism
+- core/bifrost.go - Register cache handler
+- docs/ - Add usage documentation
+```
+
+### 3. Include All Affected Packages
+
+Always explicitly list which packages/directories are modified:
+
+```
+[fix]: Resolve SSE connection issues
+
+Affected components:
+- core/mcp/clientmanager.go - Add connection validation
+- core/mcp/healthmonitor.go - Improve health checks
+- core/mcp/utils.go - Fix retry context handling
+```
+
+### 4. Test Thoroughly
+
+Before opening a PR:
+
+```bash
+# Run all tests
+make test-all
+
+# Run specific test suite
+make test-core PROVIDER=openai
+
+# Format code
+make fmt
+
+# Lint code
+make lint
+```
+
+### 5. Small, Reviewable PRs
+
+- Aim for &lt;400 lines changed per PR
+- If larger, break into logical commits
+- Each commit should be independently reviewable
+
+### 6. Update Documentation
+
+- Update relevant `.mdx` files in `/docs`
+- Add comments for complex logic
+- Update README.md if behavior changes
+
+## Code Review Checklist
+
+Before requesting review, ensure:
+
+✅ All commits follow `[type]: description` format
+✅ All affected packages are explicitly mentioned
+✅ No merge conflicts
+✅ All tests pass (`make test-all`)
+✅ Code is properly formatted (`make fmt`)
+✅ No linting issues (`make lint`)
+✅ Documentation is updated
+✅ PR description is clear and complete
+
+## During Code Review
+
+- Respond to feedback promptly
+- Push new commits for requested changes (don't force-push to avoid confusion)
+- Mark conversations as resolved when addressed
+- Ask for clarification if feedback is unclear
+
+## Merging
+
+Once approved:
+- The maintainer will handle the merge
+- Your commits will be preserved in the history
+- Ensure your branch is up-to-date with `main` before final approval
+
+## Common Pitfalls to Avoid
+
+1. ❌ **Vague commit messages** - Always be specific about what changed
+2. ❌ **Missing package information** - Always list affected packages
+3. ❌ **Mixing concerns** - Keep commits focused
+4. ❌ **Not running tests** - Test locally before opening PR
+5. ❌ **Large PRs** - Break into smaller, reviewable chunks
+6. ❌ **Not updating docs** - If behavior changes, update documentation
+
+## Examples of Good Commits
+
+### Example 1: Provider Fix
+```
+[fix]: OpenAI provider - handle streaming response errors correctly
+
+Previously, streaming responses would sometimes fail with
+"context deadline exceeded" error when network latency exceeded
+timeout threshold.
+
+Changes:
+- core/providers/openai/openai.go - Add dynamic timeout
+- core/providers/anthropic/anthropic.go - Align timeout logic
+- tests/ - Add regression tests
+
+Affected packages:
+- core/providers/
+- core/bifrost.go (minor type update)
+```
+
+### Example 2: Plugin Development
+```
+[feat]: Add rate limiting to governance plugin
+
+Introduces token bucket algorithm for per-customer rate limiting.
+Allows fine-grained control over request throughput.
+
+Changes:
+- plugins/governance/ratelimit/ - New package with core logic
+- plugins/governance/main.go - Register rate limiter
+- transports/bifrost-http/middleware.go - Apply rate limit checks
+- docs/features/governance.mdx - Add usage documentation
+
+Benefits:
+- Prevents request storms
+- Fair resource allocation
+- Configurable per-customer
+```
+
+### Example 3: Core Refactoring
+```
+[refactor]: Simplify model caching to reduce complexity
+
+Consolidate three separate caching layers into unified approach.
+No behavior change - internal improvement only.
+
+Changes:
+- core/models.go - Unified cache implementation
+- core/cache/ - Remove legacy cache package
+- tests/ - Update cache tests
+
+Affected packages:
+- core/ (main change)
+- plugins/ (minor - cache API unchanged)
+```
+
+## Need Help?
+
+- 📚 See [Code Conventions](/contributing/code-conventions) for style guidelines
+- 🏗️ Check [Architecture Docs](/architecture) to understand the codebase structure
+- 💬 Ask in [Discord](https://discord.gg/exN5KAydbU) if unsure about the process
+- ❓ Refer to the [Changelog Review Checklist](#changelog-review-checklist) above before submitting

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -309,6 +309,8 @@
             "icon": "code",
             "pages": [
               "contributing/setting-up-repo",
+              "contributing/raising-a-pr",
+              "contributing/code-conventions",
               "contributing/adding-a-provider",
               "contributing/adding-a-configstore",
               "contributing/adding-a-logstore",

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,3 +1,4 @@
 - feat: added logging_headers config field and metadata column to MCP tool logs
 - feat: add tables for async job results
 - feat: added required_headers config field with DB persistence and migration
+- feat: added support for unfiltered models for provider in model catalog

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -42,8 +42,9 @@ type ModelCatalog struct {
 	compiledOverrides map[schemas.ModelProvider][]compiledProviderPricingOverride
 	overridesMu       sync.RWMutex
 
-	modelPool      map[schemas.ModelProvider][]string
-	baseModelIndex map[string]string // model string → canonical base model name
+	modelPool           map[schemas.ModelProvider][]string
+	unfilteredModelPool map[schemas.ModelProvider][]string // model pool without allowed models filtering
+	baseModelIndex      map[string]string                  // model string → canonical base model name
 
 	// Background sync worker
 	syncTicker *time.Ticker
@@ -122,6 +123,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		pricingData:            make(map[string]configstoreTables.TableModelPricing),
 		compiledOverrides:      make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
 		modelPool:              make(map[schemas.ModelProvider][]string),
+		unfilteredModelPool:    make(map[schemas.ModelProvider][]string),
 		baseModelIndex:         make(map[string]string),
 		done:                   make(chan struct{}),
 		shouldSyncPricingFunc:  shouldSyncPricingFunc,
@@ -277,6 +279,22 @@ func (mc *ModelCatalog) GetModelsForProvider(provider schemas.ModelProvider) []s
 	defer mc.mu.RUnlock()
 
 	models, exists := mc.modelPool[provider]
+	if !exists {
+		return []string{}
+	}
+
+	// Return a copy to prevent external modification
+	result := make([]string, len(models))
+	copy(result, models)
+	return result
+}
+
+// GetUnfilteredModelsForProvider returns all available models for a given provider (thread-safe)
+func (mc *ModelCatalog) GetUnfilteredModelsForProvider(provider schemas.ModelProvider) []string {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	models, exists := mc.unfilteredModelPool[provider]
 	if !exists {
 		return []string{}
 	}
@@ -493,6 +511,7 @@ func (mc *ModelCatalog) DeleteModelDataForProvider(provider schemas.ModelProvide
 	defer mc.mu.Unlock()
 
 	delete(mc.modelPool, provider)
+	delete(mc.unfilteredModelPool, provider)
 }
 
 // UpsertModelDataForProvider upserts model data for a given provider
@@ -568,6 +587,40 @@ func (mc *ModelCatalog) UpsertModelDataForProvider(provider schemas.ModelProvide
 	mc.modelPool[provider] = finalModelList
 }
 
+// UpsertUnfilteredModelDataForProvider upserts unfiltered model data for a given provider
+func (mc *ModelCatalog) UpsertUnfilteredModelDataForProvider(provider schemas.ModelProvider, modelData *schemas.BifrostListModelsResponse) {
+	if modelData == nil {
+		return
+	}
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	// Populating models from pricing data for the given provider
+	providerModels := []string{}
+	seenModels := make(map[string]bool)
+	for _, pricing := range mc.pricingData {
+		normalizedProvider := schemas.ModelProvider(normalizeProvider(pricing.Provider))
+		if normalizedProvider != provider {
+			continue
+		}
+		if !seenModels[pricing.Model] {
+			seenModels[pricing.Model] = true
+			providerModels = append(providerModels, pricing.Model)
+		}
+	}
+	for _, model := range modelData.Data {
+		parsedProvider, parsedModel := schemas.ParseModelString(model.ID, "")
+		if parsedProvider != provider {
+			continue
+		}
+		if !seenModels[parsedModel] {
+			seenModels[parsedModel] = true
+			providerModels = append(providerModels, parsedModel)
+		}
+	}
+	mc.unfilteredModelPool[provider] = providerModels
+}
+
 // RefineModelForProvider refines the model for a given provider by performing a lookup
 // in mc.modelPool and using schemas.ParseModelString to extract provider and model parts.
 // e.g. "gpt-oss-120b" for groq provider -> "openai/gpt-oss-120b"
@@ -633,6 +686,7 @@ func (mc *ModelCatalog) populateModelPoolFromPricingData() {
 
 	// Clear existing model pool and base model index
 	mc.modelPool = make(map[schemas.ModelProvider][]string)
+	mc.unfilteredModelPool = make(map[schemas.ModelProvider][]string)
 	mc.baseModelIndex = make(map[string]string)
 
 	// Map to track unique models per provider
@@ -664,6 +718,7 @@ func (mc *ModelCatalog) populateModelPoolFromPricingData() {
 			models = append(models, model)
 		}
 		mc.modelPool[provider] = models
+		mc.unfilteredModelPool[provider] = models
 	}
 
 	// Log the populated model pool for debugging
@@ -700,10 +755,11 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 		baseModelIndex = make(map[string]string)
 	}
 	return &ModelCatalog{
-		modelPool:         make(map[schemas.ModelProvider][]string),
-		baseModelIndex:    baseModelIndex,
-		pricingData:       make(map[string]configstoreTables.TableModelPricing),
-		compiledOverrides: make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
-		done:              make(chan struct{}),
+		modelPool:           make(map[schemas.ModelProvider][]string),
+		unfilteredModelPool: make(map[schemas.ModelProvider][]string),
+		baseModelIndex:      baseModelIndex,
+		pricingData:         make(map[string]configstoreTables.TableModelPricing),
+		compiledOverrides:   make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
+		done:                make(chan struct{}),
 	}
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -7,3 +7,6 @@
 - fix: azure openai sdk requests handling in openai integration
 - feat: support multiple credential types in vertex auth credentials
 - fix: semantic caching plugin initialization when configured using UI
+- fix: added replicate and huggingface model allowlist on list models response
+- fix: added support for unfiltered list models response when updating keys' allowed models field
+- fix: backfill allowed models that were not in the list models response

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -200,7 +200,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							</TooltipProvider>
 						</div>
 						<FormControl>
-							<ModelMultiselect provider={providerName} value={field.value || []} onChange={field.onChange} />
+							<ModelMultiselect provider={providerName} value={field.value || []} onChange={field.onChange} unfiltered={true} />
 						</FormControl>
 						<FormMessage />
 					</FormItem>
@@ -316,7 +316,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 													</TooltipTrigger>
 													<TooltipContent>
 														<p>Optional OAuth scopes for token requests. By default we use
-														https://cognitiveservices.azure.com/.default - add additional scopes here if your setup requires extra permissions.</p>
+															https://cognitiveservices.azure.com/.default - add additional scopes here if your setup requires extra permissions.</p>
 													</TooltipContent>
 												</Tooltip>
 											</TooltipProvider>
@@ -426,31 +426,31 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							Leave both API Key and Auth Credentials empty to use service account attached to your environment.
 						</AlertDescription>
 					</Alert>
-				<FormField
-					control={control}
-					name={`key.vertex_key_config.auth_credentials`}
-					render={({ field }) => (
-						<FormItem>
-							<FormLabel>Auth Credentials</FormLabel>
-							<FormDescription>Service account JSON object or env.VAR_NAME</FormDescription>
-							<FormControl>
-								<EnvVarInput
-									variant="textarea"
-									rows={4}
-									placeholder='{"type":"service_account","project_id":"your-gcp-project",...} or env.VERTEX_CREDENTIALS'
-									inputClassName="font-mono text-sm"
-									{...field}
-								/>
-							</FormControl>
-							{isRedacted(field.value?.value ?? "") && (
-								<div className="text-muted-foreground mt-1 flex items-center gap-1 text-xs">
-									<Info className="h-3 w-3" />
-									<span>Credentials are stored securely. Edit to update.</span>
-								</div>
-							)}
-						</FormItem>
-					)}
-				/>
+					<FormField
+						control={control}
+						name={`key.vertex_key_config.auth_credentials`}
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Auth Credentials</FormLabel>
+								<FormDescription>Service account JSON object or env.VAR_NAME</FormDescription>
+								<FormControl>
+									<EnvVarInput
+										variant="textarea"
+										rows={4}
+										placeholder='{"type":"service_account","project_id":"your-gcp-project",...} or env.VERTEX_CREDENTIALS'
+										inputClassName="font-mono text-sm"
+										{...field}
+									/>
+								</FormControl>
+								{isRedacted(field.value?.value ?? "") && (
+									<div className="text-muted-foreground mt-1 flex items-center gap-1 text-xs">
+										<Info className="h-3 w-3" />
+										<span>Credentials are stored securely. Edit to update.</span>
+									</div>
+								)}
+							</FormItem>
+						)}
+					/>
 					<FormField
 						control={control}
 						name={`key.vertex_key_config.deployments`}

--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -26,6 +26,7 @@ interface ModelMultiselectPropsBase {
 interface ModelMultiselectPropsSingle extends ModelMultiselectPropsBase {
 	/** Single select mode - value and onChange will be string instead of string[] */
 	isSingleSelect: true;
+	unfiltered?: boolean;
 	value: string;
 	onChange: (model: string) => void;
 }
@@ -33,6 +34,7 @@ interface ModelMultiselectPropsSingle extends ModelMultiselectPropsBase {
 interface ModelMultiselectPropsMulti extends ModelMultiselectPropsBase {
 	/** Multi select mode (default) - value and onChange will be string[] */
 	isSingleSelect?: false;
+	unfiltered?: boolean;
 	value: string[];
 	onChange: (models: string[]) => void;
 }
@@ -50,6 +52,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 		provider,
 		keys,
 		value,
+		unfiltered = false,
 		onChange,
 		placeholder = "Search models...",
 		disabled = false,
@@ -88,6 +91,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 				provider,
 				keys: keys && keys.length > 0 ? keys : undefined,
 				limit: 5,
+				unfiltered,
 			});
 		} else if (shouldUseBaseModels) {
 			getBaseModels({ limit: 20 });
@@ -95,6 +99,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 			getModels({
 				keys: keys && keys.length > 0 ? keys : undefined,
 				limit: 20,
+				unfiltered,
 			});
 		}
 	}, [provider, keys, getModels, getBaseModels, shouldLoadOnEmpty, shouldUseBaseModels]);
@@ -129,6 +134,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 					provider: provider || undefined,
 					keys: keys && keys.length > 0 ? keys : undefined,
 					limit: query ? 50 : shouldLoadOnEmpty && !provider ? 20 : 5,
+					unfiltered,
 				})
 					.unwrap()
 					.then((response) => {
@@ -166,6 +172,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 					provider,
 					keys: keys && keys.length > 0 ? keys : undefined,
 					limit: currentQuery ? 20 : 5,
+					unfiltered,
 				});
 			} else if (shouldUseBaseModels) {
 				getBaseModels({
@@ -177,6 +184,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 					query: currentQuery || undefined,
 					keys: keys && keys.length > 0 ? keys : undefined,
 					limit: currentQuery ? 20 : 5,
+					unfiltered,
 				});
 			}
 		},

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -2,11 +2,11 @@ import { AddProviderRequest, ListProvidersResponse, ModelProvider, ModelProvider
 import { DBKey } from "@/lib/types/governance";
 import { baseApi } from "./baseApi";
 
-function sortProviders (a: ModelProvider, b: ModelProvider) {
-	const aIsCustom = !!a.custom_provider_config
-	const bIsCustom = !!b.custom_provider_config
-	if (aIsCustom !== bIsCustom) return aIsCustom ? 1 : -1
-	return a.name.localeCompare(b.name)
+function sortProviders(a: ModelProvider, b: ModelProvider) {
+	const aIsCustom = !!a.custom_provider_config;
+	const bIsCustom = !!b.custom_provider_config;
+	if (aIsCustom !== bIsCustom) return aIsCustom ? 1 : -1;
+	return a.name.localeCompare(b.name);
 }
 
 // Types for models API
@@ -26,6 +26,7 @@ export interface GetModelsRequest {
 	provider?: string;
 	keys?: string[];
 	limit?: number;
+	unfiltered?: boolean;
 }
 
 export interface GetBaseModelsRequest {
@@ -67,7 +68,7 @@ export const providersApi = baseApi.injectEndpoints({
 						providersApi.util.updateQueryData("getProviders", undefined, (draft) => {
 							draft.push(newProvider);
 							draft.sort(sortProviders);
-						})
+						}),
 					);
 				} catch {}
 			},
@@ -89,7 +90,7 @@ export const providersApi = baseApi.injectEndpoints({
 							if (index !== -1) {
 								draft[index] = updatedProvider;
 							}
-						})
+						}),
 					);
 					dispatch(providersApi.util.updateQueryData("getProvider", arg.name, () => updatedProvider));
 				} catch {}
@@ -111,7 +112,7 @@ export const providersApi = baseApi.injectEndpoints({
 							if (index !== -1) {
 								draft.splice(index, 1);
 							}
-						})
+						}),
 					);
 				} catch {}
 			},
@@ -125,12 +126,13 @@ export const providersApi = baseApi.injectEndpoints({
 
 		// Get models with optional filtering
 		getModels: builder.query<ListModelsResponse, GetModelsRequest>({
-			query: ({ query, provider, keys, limit }) => {
+			query: ({ query, provider, keys, limit, unfiltered }) => {
 				const params = new URLSearchParams();
 				if (query) params.append("query", query);
 				if (provider) params.append("provider", provider);
 				if (keys && keys.length > 0) params.append("keys", keys.join(","));
 				if (limit !== undefined) params.append("limit", limit.toString());
+				if (unfiltered !== undefined) params.append("unfiltered", unfiltered.toString());
 				return `/models?${params.toString()}`;
 			},
 			providesTags: ["Models"],


### PR DESCRIPTION
## Summary

This PR adds support for unfiltered model listing and implements model backfilling to ensure allowed models are always included in list models responses, even when they're not returned by the provider's API.

## Changes

- Added `Unfiltered` field to `BifrostListModelsRequest` to bypass allowed model filtering
- Implemented model backfilling across all providers to include allowed models that weren't in the API response
- Updated `ListAllModels` function to pass through the unfiltered parameter to provider requests
- Added unfiltered model pool tracking in the model catalog for complete model visibility
- Updated UI model multiselect component to support unfiltered mode when editing API key configurations
- Fixed parameter naming consistency in `ListAllModels` function (request → req)
- Added required `properties` field to `ToolFunctionParameters` JSON schema

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test the unfiltered model listing functionality:

```sh
# Test unfiltered parameter in list models API
curl "http://localhost:8080/models?provider=openai&unfiltered=true"

# Test model backfilling by configuring a key with models not in provider response
# Then verify those models appear in the filtered response

# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that when editing API keys in the UI, the model selector shows all available models (unfiltered mode), and that allowed models are always included in responses even if the provider doesn't return them.

## Screenshots/Recordings

N/A - Backend functionality with minor UI parameter addition

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses model allowlist filtering issues for Replicate and HuggingFace providers, and ensures comprehensive model visibility in governance configurations.

## Security considerations

The unfiltered parameter is intended for internal Bifrost use and administrative interfaces. It bypasses model filtering but doesn't expose additional sensitive data beyond what's already available through provider APIs.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable