### PR TITLE
fix: allow direct (hash-based) caching without embedding provider

### DIFF
--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -173,10 +173,40 @@ test_template "sqlite + qdrant" \
   --set vectorStore.type=qdrant \
   --set vectorStore.qdrant.enabled=true
 
-# 3. Special Configurations (4 tests)
+# 3. Special Configurations (7 tests)
 echo ""
-echo -e "${CYAN}⚙️  3/3 - Testing Special Configurations (4 tests)...${NC}"
+echo -e "${CYAN}⚙️  3/3 - Testing Special Configurations (7 tests)...${NC}"
 echo "-----------------------------------------------------"
+
+# semantic cache: direct mode (dimension: 1, no provider/keys)
+test_template "semanticCache: direct mode (dimension: 1)" \
+  --set bifrost.plugins.semanticCache.enabled=true \
+  --set bifrost.plugins.semanticCache.config.dimension=1 \
+  --set bifrost.plugins.semanticCache.config.ttl=30m \
+  --set vectorStore.enabled=true \
+  --set vectorStore.type=redis \
+  --set vectorStore.redis.enabled=true
+
+# semantic cache: semantic mode (dimension > 1, requires provider/keys)
+test_template "semanticCache: semantic mode (dimension: 1536)" \
+  --set bifrost.plugins.semanticCache.enabled=true \
+  --set bifrost.plugins.semanticCache.config.dimension=1536 \
+  --set bifrost.plugins.semanticCache.config.provider=openai \
+  --set 'bifrost.plugins.semanticCache.config.keys[0]=sk-test' \
+  --set vectorStore.enabled=true \
+  --set vectorStore.type=redis \
+  --set vectorStore.redis.enabled=true
+
+# semantic cache: direct mode with redis + postgres
+test_template "semanticCache: direct mode + postgres" \
+  --set bifrost.plugins.semanticCache.enabled=true \
+  --set bifrost.plugins.semanticCache.config.dimension=1 \
+  --set storage.mode=postgres \
+  --set postgresql.enabled=true \
+  --set postgresql.auth.password=testpass \
+  --set vectorStore.enabled=true \
+  --set vectorStore.type=redis \
+  --set vectorStore.redis.enabled=true
 
 # sqlite + persistence + autoscaling (StatefulSet HPA)
 test_template "sqlite + persistence + autoscaling (StatefulSet)" \

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -570,7 +570,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "description": "API keys for embedding provider (required when enabled)"
+                      "description": "API keys for embedding provider (required for semantic caching, not needed for direct caching with dimension: 1)"
                     },
                     "embedding_model": {
                       "type": "string"
@@ -630,8 +630,6 @@
                 "properties": {
                   "config": {
                     "required": [
-                      "provider",
-                      "keys",
                       "dimension"
                     ]
                   }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -310,6 +310,8 @@ bifrost:
     semanticCache:
       enabled: false
       config:
+        # Semantic caching mode (dimension > 1): requires provider, keys, and embedding_model
+        # Direct caching mode (dimension: 1): hash-based exact matching, no embedding provider needed
         provider: "openai"
         keys: []
         embedding_model: "text-embedding-3-small"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1001,11 +1001,10 @@
                     },
                     "keys": {
                       "type": "array",
-                      "description": "API keys for the embedding provider",
+                      "description": "API keys for the embedding provider (required for semantic caching, not needed for direct caching with dimension: 1)",
                       "items": {
                         "type": "string"
-                      },
-                      "minItems": 1
+                      }
                     },
                     "embedding_model": {
                       "type": "string",
@@ -1040,7 +1039,7 @@
                     },
                     "dimension": {
                       "type": "integer",
-                      "description": "Dimension for vector store embeddings",
+                      "description": "Dimension for vector store embeddings. Use 1 for direct (hash-based) caching without an embedding provider.",
                       "minimum": 1
                     },
                     "default_cache_key": {
@@ -1066,8 +1065,6 @@
                     }
                   },
                   "required": [
-                    "provider",
-                    "keys",
                     "dimension"
                   ],
                   "additionalProperties": false


### PR DESCRIPTION
## Summary

When semantic cache is enabled with `dimension: 1`, Bifrost uses direct hash-based caching that doesn't require an embedding provider. However, the Helm chart validation and config schema both unconditionally require `provider` and `keys` fields, making it impossible to configure direct-only caching without providing dummy values.

This follows up on #1728 (direct cache docs) and #1729 (default cache key) — the runtime already supports direct-only mode gracefully (`plugins/semanticcache/main.go` line 320), but the chart and schema block it.

## Changes

- Helm template validation (`_helpers.tpl`): `provider`/`keys` checks now only run when `dimension != 1`
- Helm config rendering (`_helpers.tpl`): `provider`/`keys`/`embedding_model` excluded from rendered config when `dimension == 1`, so the Go runtime sees empty provider and takes the direct-only path
- `values.schema.json`: only `dimension` required when enabled (was: provider + keys + dimension)
- `transports/config.schema.json`: same — only `dimension` required, removed `minItems: 1` from keys
- `values.yaml`: added comments documenting both modes
- `validate-helm-templates.sh`: added 3 test cases for direct cache mode (dimension: 1 without provider/keys, semantic mode with provider/keys, direct mode + postgres)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Helm template validation suite:
```sh
bash .github/workflows/scripts/validate-helm-templates.sh
```

This now includes 3 new test cases covering direct cache mode:
- `semanticCache: direct mode (dimension: 1)` — no provider/keys
- `semanticCache: semantic mode (dimension: 1536)` — with provider/keys
- `semanticCache: direct mode + postgres` — direct mode combined with postgres storage

Direct cache mode (should now work without provider/keys):
```yaml
bifrost:
  plugins:
    semanticCache:
      enabled: true
      config:
        dimension: 1
        ttl: "30m"
```

Semantic cache mode (should still require provider/keys):
```yaml
bifrost:
  plugins:
    semanticCache:
      enabled: true
      config:
        dimension: 1536
        # Omitting provider/keys should still fail validation
```

## Breaking changes

- [ ] Yes
- [x] No

Fully backwards compatible — existing semantic cache deployments (dimension > 1) still get the same provider/keys validation. `dimension` defaults to 1536 in the chart, so omitting it still requires provider/keys.

## Related issues

Follow-up to #1728 and #1729

## Security considerations

None — no auth, secrets, or PII changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
