### PR TITLE
fix(helm): correct semantic cache plugin name to match Go registry

### DIFF
--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -257,7 +257,7 @@ echo "------------------------------------------------------"
 # Verify semantic cache plugin renders with correct name ("semantic_cache", not "semanticcache")
 # Go registry: plugins/semanticcache/main.go defines PluginName = "semantic_cache"
 test_name="semanticCache plugin name matches Go registry (semantic_cache)"
-helm template bifrost ./helm-charts/bifrost \
+if helm template bifrost ./helm-charts/bifrost \
   --set image.tag=v1.0.0 \
   --set bifrost.plugins.semanticCache.enabled=true \
   --set bifrost.plugins.semanticCache.config.dimension=1536 \
@@ -265,8 +265,18 @@ helm template bifrost ./helm-charts/bifrost \
   --set 'bifrost.plugins.semanticCache.config.keys[0]=sk-test' \
   --set vectorStore.enabled=true \
   --set vectorStore.type=redis \
-  --set vectorStore.redis.enabled=true 2>/dev/null | grep -q '"name":"semantic_cache"'
-report_result "$test_name" $?
+  --set vectorStore.redis.enabled=true \
+  > /tmp/helm-template-output.yaml 2>&1; then
+  if grep -Eq '"name"[[:space:]]*:[[:space:]]*"semantic_cache"' /tmp/helm-template-output.yaml; then
+    report_result "$test_name" 0
+  else
+    report_result "$test_name" 1
+  fi
+else
+  report_result "$test_name" 1
+  echo -e "${YELLOW}  Error output:${NC}"
+  head -10 /tmp/helm-template-output.yaml | sed 's/^/    /'
+fi
 
 # Cleanup
 rm -f /tmp/helm-template-output.yaml

--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -249,6 +249,25 @@ test_template "production-like config" \
   --set 'ingress.hosts[0].paths[0].path=/' \
   --set 'ingress.hosts[0].paths[0].pathType=Prefix'
 
+# 4. Plugin Name Validation
+echo ""
+echo -e "${CYAN}🔌 4/4 - Validating Plugin Names Match Go Registry...${NC}"
+echo "------------------------------------------------------"
+
+# Verify semantic cache plugin renders with correct name ("semantic_cache", not "semanticcache")
+# Go registry: plugins/semanticcache/main.go defines PluginName = "semantic_cache"
+test_name="semanticCache plugin name matches Go registry (semantic_cache)"
+helm template bifrost ./helm-charts/bifrost \
+  --set image.tag=v1.0.0 \
+  --set bifrost.plugins.semanticCache.enabled=true \
+  --set bifrost.plugins.semanticCache.config.dimension=1536 \
+  --set bifrost.plugins.semanticCache.config.provider=openai \
+  --set 'bifrost.plugins.semanticCache.config.keys[0]=sk-test' \
+  --set vectorStore.enabled=true \
+  --set vectorStore.type=redis \
+  --set vectorStore.redis.enabled=true 2>/dev/null | grep -q '"name":"semantic_cache"'
+report_result "$test_name" $?
+
 # Cleanup
 rm -f /tmp/helm-template-output.yaml
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -749,7 +749,7 @@ false
 {{- if hasKey $inputConfig "cleanup_on_shutdown" }}
 {{- $_ := set $scConfig "cleanup_on_shutdown" $inputConfig.cleanup_on_shutdown }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "semanticcache" "config" $scConfig) }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "semantic_cache" "config" $scConfig) }}
 {{- end }}
 {{- if .Values.bifrost.plugins.otel.enabled }}
 {{- $otelConfig := dict }}


### PR DESCRIPTION
## Summary

The Helm chart renders the semantic cache plugin name as `"semanticcache"` in the generated config, but the Go plugin registry (`plugins/semanticcache/main.go`) defines `PluginName = "semantic_cache"` (with underscore). This causes a name mismatch at startup:

```
failed to load plugin semanticcache: unknown built-in plugin: semanticcache
plugin status: semanticcache - error
```

The server starts fine but semantic caching is silently broken.

## Changes

- `_helpers.tpl`: Changed plugin name from `"semanticcache"` to `"semantic_cache"` to match `semanticcache.PluginName` in Go
- `validate-helm-templates.sh`: Added a plugin name validation test that verifies the rendered name matches the Go registry constant

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the validation suite (includes new plugin name check)
bash .github/workflows/scripts/validate-helm-templates.sh

# Or verify directly:
helm template bifrost ./helm-charts/bifrost \
  --set image.tag=v1.4.7 \
  --set bifrost.plugins.semanticCache.enabled=true \
  --set bifrost.plugins.semanticCache.config.dimension=1536 \
  --set bifrost.plugins.semanticCache.config.provider=openai \
  --set 'bifrost.plugins.semanticCache.config.keys[0]=sk-test' \
  --set vectorStore.enabled=true \
  --set vectorStore.type=redis \
  --set vectorStore.redis.enabled=true | grep -o '"name":"semantic_cache"'
# Should output: "name":"semantic_cache"
```

## Breaking changes

- [ ] Yes
- [x] No

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable