### PR TITLE
feat: add large payload streaming context keys and provider utilities

### DIFF
--- a/core/providers/utils/large_response.go
+++ b/core/providers/utils/large_response.go
@@ -1,0 +1,326 @@
+package utils
+
+import (
+	"bytes"
+	"io"
+	"math"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// LargeResponseReader wraps an io.Reader and releases the fasthttp response on Close.
+// Used by providers to keep the response alive while the transport streams it to the client.
+type LargeResponseReader struct {
+	io.Reader
+	Resp     *fasthttp.Response
+	cleanup  func()
+	consumed bool // true after Read returns io.EOF — body fully consumed through Reader chain
+}
+
+// Read delegates to the wrapped Reader and tracks EOF so Close() can skip
+// a redundant (and potentially blocking) drain of the body stream.
+func (r *LargeResponseReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	if err == io.EOF {
+		r.consumed = true
+	}
+	return n, err
+}
+
+// Close drains any unconsumed body stream and releases the underlying fasthttp
+// response back to the pool. Draining prevents "whitespace in header" errors on
+// connection reuse when the client disconnects before the full response is consumed
+// (see: fasthttp#1743).
+//
+// When the body was already fully consumed through the Reader chain (consumed == true),
+// the drain is skipped. For identity-encoded responses (no Content-Length), the body
+// stream is a fasthttp closeReader that blocks until the TCP connection closes — which
+// can take minutes if the upstream server keeps the connection alive.
+func (r *LargeResponseReader) Close() error {
+	if r == nil || r.Resp == nil {
+		return nil
+	}
+	if !r.consumed {
+		if bodyStream := r.Resp.BodyStream(); bodyStream != nil {
+			_, _ = io.Copy(io.Discard, bodyStream)
+			if closer, ok := bodyStream.(io.Closer); ok {
+				_ = closer.Close()
+			}
+		}
+	}
+	if r.cleanup != nil {
+		r.cleanup()
+		r.cleanup = nil
+	}
+	fasthttp.ReleaseResponse(r.Resp)
+	r.Resp = nil
+	return nil
+}
+
+// BuildLargeResponseClient creates a streaming-enabled fasthttp client for large response detection.
+// The client caps buffering at the threshold and enables response body streaming.
+func BuildLargeResponseClient(base *fasthttp.Client, responseThreshold int64) *fasthttp.Client {
+	client := CloneFastHTTPClientConfig(base)
+	if responseThreshold > 0 && responseThreshold <= int64(math.MaxInt) {
+		client.MaxResponseBodySize = int(responseThreshold)
+	}
+	client.StreamResponseBody = true
+	return client
+}
+
+// PrepareResponseStreaming configures response body streaming when a large response
+// threshold is set in context. Returns the client to use for MakeRequestWithContext.
+// When threshold > 0: sets resp.StreamBody = true and returns a streaming-enabled client.
+// When threshold <= 0: returns the original client unchanged (no-op for feature-off path).
+func PrepareResponseStreaming(ctx *schemas.BifrostContext, client *fasthttp.Client, resp *fasthttp.Response) *fasthttp.Client {
+	responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64)
+	if responseThreshold <= 0 {
+		return client
+	}
+	resp.StreamBody = true
+	return BuildLargeResponseClient(client, responseThreshold)
+}
+
+// MaterializeStreamErrorBody reads a streamed error body into resp so that resp.Body()
+// returns the error payload for parsing. No-op when response streaming is not active.
+func MaterializeStreamErrorBody(ctx *schemas.BifrostContext, resp *fasthttp.Response) {
+	responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64)
+	if responseThreshold <= 0 {
+		return
+	}
+	if bodyStream := resp.BodyStream(); bodyStream != nil {
+		gz, reader, wasGzip := decompressBodyStreamIfGzip(resp, bodyStream)
+		if wasGzip {
+			defer ReleaseGzipReader(gz)
+		}
+		bodyBytes, readErr := io.ReadAll(io.LimitReader(reader, 512*1024)) // 512KB cap for error bodies
+		if readErr != nil {
+			return
+		}
+		resp.SetBody(bodyBytes)
+	}
+}
+
+// FinalizeResponseWithLargeDetection processes the response body with optional large response
+// detection. Takes ownership semantics: when isLargeResponse is true, the caller must NOT
+// release resp (it's wrapped in a reader stored in context). When false, resp is unchanged
+// and the caller should release as normal.
+//
+// Returns:
+//   - (body, false, nil) — normal path; body ready for parsing; resp NOT released.
+//   - (nil, true, nil) — large response detected; context keys set for streaming;
+//     caller must set respOwned = false.
+//   - (nil, false, err) — error; resp NOT released.
+func FinalizeResponseWithLargeDetection(
+	ctx *schemas.BifrostContext,
+	resp *fasthttp.Response,
+	providerName schemas.ModelProvider,
+	logger schemas.Logger,
+) ([]byte, bool, *schemas.BifrostError) {
+	responseThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargeResponseThreshold).(int64)
+
+	// No threshold — normal buffered read (feature-off path)
+	if responseThreshold <= 0 {
+		body, err := CheckAndDecodeBody(resp)
+		if err != nil {
+			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+		}
+		// Copy body before caller releases resp
+		return append([]byte(nil), body...), false, nil
+	}
+
+	contentLength := resp.Header.ContentLength()
+
+	// Known small response — read from stream, return body for normal parsing
+	if contentLength > 0 && int64(contentLength) <= responseThreshold {
+		if bodyStream := resp.BodyStream(); bodyStream != nil {
+			gz, reader, wasGzip := decompressBodyStreamIfGzip(resp, bodyStream)
+			if wasGzip {
+				defer ReleaseGzipReader(gz)
+			}
+			bodyBytes, readErr := io.ReadAll(reader)
+			if readErr != nil {
+				return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, readErr, providerName)
+			}
+			return bodyBytes, false, nil
+		}
+		// No stream — buffered fallback
+		body, err := CheckAndDecodeBody(resp)
+		if err != nil {
+			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+		}
+		return append([]byte(nil), body...), false, nil
+	}
+
+	// Unknown Content-Length (chunked transfer encoding) — buffer up to responseThreshold
+	// to determine if response is truly large. Responses within threshold are returned
+	// buffered for normal parsing/logging; only responses exceeding threshold are streamed.
+	if contentLength <= 0 {
+		if bodyStream := resp.BodyStream(); bodyStream != nil {
+			gz, reader, wasGzip := decompressBodyStreamIfGzip(resp, bodyStream)
+			releaseGzip := func() {}
+			if wasGzip {
+				releaseGzip = func() {
+					ReleaseGzipReader(gz)
+				}
+			}
+			bodyBytes, readErr := io.ReadAll(io.LimitReader(reader, responseThreshold+1))
+			if readErr != nil {
+				releaseGzip()
+				return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, readErr, providerName)
+			}
+			if int64(len(bodyBytes)) <= responseThreshold {
+				releaseGzip()
+				return bodyBytes, false, nil
+			}
+			// Exceeds threshold without Content-Length — set up large response streaming.
+			combinedReader := io.MultiReader(bytes.NewReader(bodyBytes), reader)
+			closableReader := &LargeResponseReader{
+				Reader:  combinedReader,
+				Resp:    resp,
+				cleanup: releaseGzip,
+			}
+			ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
+			ctx.SetValue(schemas.BifrostContextKeyLargeResponseReader, closableReader)
+			ctx.SetValue(schemas.BifrostContextKeyLargeResponseContentLength, contentLength)
+			if ct := string(resp.Header.ContentType()); ct != "" {
+				ctx.SetValue(schemas.BifrostContextKeyLargeResponseContentType, ct)
+			}
+			previewLen := min(len(bodyBytes), 1048576)
+			ctx.SetValue(schemas.BifrostContextKeyLargePayloadResponsePreview, string(bodyBytes[:previewLen]))
+			return nil, true, nil
+		}
+		// No stream — buffered fallback
+		body, err := CheckAndDecodeBody(resp)
+		if err != nil {
+			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+		}
+		return append([]byte(nil), body...), false, nil
+	}
+
+	// Known large response (Content-Length > threshold) — prefetch first 64KB for
+	// metadata extraction, then stream the rest without full materialization.
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		// No stream available — fall back to buffered read
+		if logger != nil {
+			logger.Warn("large-response fallback to buffered path: provider=%s content_length=%d threshold=%d body_stream_nil=true", providerName, contentLength, responseThreshold)
+		}
+		body, err := CheckAndDecodeBody(resp)
+		if err != nil {
+			return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, err, providerName)
+		}
+		return append([]byte(nil), body...), false, nil
+	}
+
+	// Decompress on-the-fly if provider returned gzip-encoded response.
+	// Clears Content-Encoding so the transport doesn't re-add it to the client response.
+	gz, decompressedStream, wasGzip := decompressBodyStreamIfGzip(resp, bodyStream)
+	if wasGzip {
+		contentLength = -1 // decompressed size unknown; transport will use chunked encoding
+	}
+
+	prefetchSize := 64 * 1024 // default
+	if ps, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadPrefetchSize).(int); ok && ps > 0 {
+		prefetchSize = ps
+	}
+	prefetchBuf := make([]byte, prefetchSize)
+	n, readErr := io.ReadFull(decompressedStream, prefetchBuf)
+	if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+		if wasGzip {
+			ReleaseGzipReader(gz)
+		}
+		return nil, false, NewBifrostOperationError(schemas.ErrProviderResponseDecode, readErr, providerName)
+	}
+	prefetchBuf = prefetchBuf[:n]
+
+	combinedReader := io.MultiReader(bytes.NewReader(prefetchBuf), decompressedStream)
+	closableReader := &LargeResponseReader{
+		Reader: combinedReader,
+		Resp:   resp,
+		cleanup: func() {
+			if wasGzip {
+				ReleaseGzipReader(gz)
+			}
+		},
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseReader, closableReader)
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseContentLength, contentLength)
+	if ct := string(resp.Header.ContentType()); ct != "" {
+		ctx.SetValue(schemas.BifrostContextKeyLargeResponseContentType, ct)
+	}
+	previewLen := min(n, 1048576)
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadResponsePreview, string(prefetchBuf[:previewLen]))
+
+	return nil, true, nil
+}
+
+// ParseOpenAIUsageFromBytes parses OpenAI-format usage from raw JSON bytes into BifrostLLMUsage.
+// Handles both Chat Completions (prompt_tokens/completion_tokens) and Responses API
+// (input_tokens/output_tokens) field names. Expects the "usage" object bytes directly,
+// not the full response body.
+func ParseOpenAIUsageFromBytes(data []byte) *schemas.BifrostLLMUsage {
+	var usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+		// Responses API uses different field names
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	}
+	if err := sonic.Unmarshal(data, &usage); err != nil {
+		return nil
+	}
+
+	result := &schemas.BifrostLLMUsage{}
+	if usage.PromptTokens > 0 {
+		result.PromptTokens = usage.PromptTokens
+	} else if usage.InputTokens > 0 {
+		result.PromptTokens = usage.InputTokens
+	}
+	if usage.CompletionTokens > 0 {
+		result.CompletionTokens = usage.CompletionTokens
+	} else if usage.OutputTokens > 0 {
+		result.CompletionTokens = usage.OutputTokens
+	}
+	if usage.TotalTokens > 0 {
+		result.TotalTokens = usage.TotalTokens
+	} else {
+		result.TotalTokens = result.PromptTokens + result.CompletionTokens
+	}
+
+	if result.TotalTokens == 0 {
+		return nil
+	}
+	return result
+}
+
+// SetupStreamingPassthrough configures large response passthrough for streaming
+// responses when large payload mode is active. Wraps the response body stream
+// in a LargeResponseReader and sets context keys for the transport layer.
+// Returns true if passthrough was set up. When true, the caller should return
+// a closed channel and must NOT release resp — it's owned by the reader in context.
+func SetupStreamingPassthrough(ctx *schemas.BifrostContext, resp *fasthttp.Response) bool {
+	isLargePayload, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadMode).(bool)
+	if !isLargePayload {
+		return false
+	}
+
+	reader, releaseGzip := DecompressStreamBody(resp)
+	closableReader := &LargeResponseReader{
+		Reader:  reader,
+		Resp:    resp,
+		cleanup: releaseGzip,
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseReader, closableReader)
+	if ct := string(resp.Header.ContentType()); ct != "" {
+		ctx.SetValue(schemas.BifrostContextKeyLargeResponseContentType, ct)
+	}
+	return true
+}

--- a/core/providers/utils/sse.go
+++ b/core/providers/utils/sse.go
@@ -1,0 +1,195 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const (
+	sseInitialBufSize = 8 * 1024        // 8KB — sufficient for >99.9% of SSE lines
+	sseMaxBufSize     = 10 * 1024 * 1024 // 10MB — allow large tokens (tool calls, audio)
+)
+
+// SSEDataReader reads SSE data-only events (Format A: OpenAI, Gemini, Cohere, etc.).
+// ReadDataLine returns the next SSE data payload, stripping the "data:" prefix.
+// Returns (nil, io.EOF) at end of stream or on "data: [DONE]".
+type SSEDataReader interface {
+	ReadDataLine() ([]byte, error)
+}
+
+// SSEEventReader reads SSE events with type and data (Format B: Anthropic, Replicate, etc.).
+// ReadEvent returns the complete event once an empty-line delimiter is encountered.
+// Multiple "data:" lines within one event are concatenated with newlines.
+// Returns ("", nil, io.EOF) at end of stream.
+type SSEEventReader interface {
+	ReadEvent() (eventType string, data []byte, err error)
+}
+
+// SSEReaderFactory creates SSE readers for streaming response processing.
+// Enterprise injects this via BifrostContextKeySSEReaderFactory to replace
+// the default bufio.Scanner-based implementations with streaming readers.
+type SSEReaderFactory struct {
+	NewDataReader  func(reader io.Reader) SSEDataReader
+	NewEventReader func(reader io.Reader) SSEEventReader
+}
+
+// GetSSEDataReader returns an SSEDataReader for the given reader.
+// If enterprise has injected an SSEReaderFactory via context, uses that.
+// Otherwise returns a default implementation wrapping bufio.NewScanner.
+func GetSSEDataReader(ctx *schemas.BifrostContext, reader io.Reader) SSEDataReader {
+	if ctx != nil {
+		if factory, ok := ctx.Value(schemas.BifrostContextKeySSEReaderFactory).(*SSEReaderFactory); ok && factory != nil && factory.NewDataReader != nil {
+			return factory.NewDataReader(reader)
+		}
+	}
+	return newDefaultSSEDataReader(reader)
+}
+
+// GetSSEEventReader returns an SSEEventReader for the given reader.
+// If enterprise has injected an SSEReaderFactory via context, uses that.
+// Otherwise returns a default implementation wrapping bufio.NewScanner.
+func GetSSEEventReader(ctx *schemas.BifrostContext, reader io.Reader) SSEEventReader {
+	if ctx != nil {
+		if factory, ok := ctx.Value(schemas.BifrostContextKeySSEReaderFactory).(*SSEReaderFactory); ok && factory != nil && factory.NewEventReader != nil {
+			return factory.NewEventReader(reader)
+		}
+	}
+	return newDefaultSSEEventReader(reader)
+}
+
+// Reusable byte prefixes for SSE field parsing.
+var (
+	sseDataPrefix  = []byte("data:")
+	sseDoneMarker  = []byte("[DONE]")
+	sseEventPrefix = []byte("event:")
+	sseIDPrefix    = []byte("id:")
+	sseRetryPrefix = []byte("retry:")
+)
+
+// defaultSSEDataReader implements SSEDataReader using bufio.NewScanner.
+// Handles Format A SSE streams (data-only: OpenAI, Gemini, Cohere, etc.).
+type defaultSSEDataReader struct {
+	scanner *bufio.Scanner
+}
+
+func newDefaultSSEDataReader(reader io.Reader) *defaultSSEDataReader {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, sseInitialBufSize), sseMaxBufSize)
+	return &defaultSSEDataReader{scanner: scanner}
+}
+
+func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
+		// Skip empty lines and comments
+		if len(line) == 0 || line[0] == ':' {
+			continue
+		}
+
+		// Parse "data:" lines
+		if bytes.HasPrefix(line, sseDataPrefix) {
+			data := line[5:] // len("data:") == 5
+			if len(data) > 0 && data[0] == ' ' {
+				data = data[1:]
+			}
+			if len(data) == 0 {
+				continue
+			}
+			if bytes.Equal(data, sseDoneMarker) {
+				return nil, io.EOF
+			}
+			// Copy to decouple from scanner's internal buffer
+			return append([]byte(nil), data...), nil
+		}
+
+		// Skip known SSE fields (event, id, retry)
+		if bytes.HasPrefix(line, sseEventPrefix) ||
+			bytes.HasPrefix(line, sseIDPrefix) ||
+			bytes.HasPrefix(line, sseRetryPrefix) {
+			continue
+		}
+
+		// Non-SSE line: return as-is (raw JSON error fallback, e.g. OpenAI)
+		return append([]byte(nil), line...), nil
+	}
+	if err := r.scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, io.EOF
+}
+
+// defaultSSEEventReader implements SSEEventReader using bufio.NewScanner.
+// Handles Format B SSE streams (event+data: Anthropic, Replicate, Mistral, etc.).
+// Events are delimited by empty lines; multiple "data:" lines are concatenated.
+type defaultSSEEventReader struct {
+	scanner   *bufio.Scanner
+	eventType string
+	eventData []byte
+}
+
+func newDefaultSSEEventReader(reader io.Reader) *defaultSSEEventReader {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, sseInitialBufSize), sseMaxBufSize)
+	return &defaultSSEEventReader{scanner: scanner}
+}
+
+func (r *defaultSSEEventReader) ReadEvent() (string, []byte, error) {
+	for r.scanner.Scan() {
+		line := r.scanner.Bytes()
+
+		// Skip comments
+		if len(line) > 0 && line[0] == ':' {
+			continue
+		}
+
+		// Empty line = event boundary
+		if len(line) == 0 {
+			if r.eventType == "" && len(r.eventData) == 0 {
+				continue
+			}
+			eventType := r.eventType
+			eventData := make([]byte, len(r.eventData))
+			copy(eventData, r.eventData)
+			r.eventType = ""
+			r.eventData = r.eventData[:0]
+			return eventType, eventData, nil
+		}
+
+		// Parse SSE fields
+		if bytes.HasPrefix(line, sseEventPrefix) {
+			field := line[6:] // len("event:") == 6
+			if len(field) > 0 && field[0] == ' ' {
+				field = field[1:]
+			}
+			r.eventType = string(field)
+		} else if bytes.HasPrefix(line, sseDataPrefix) {
+			data := line[5:] // len("data:") == 5
+			if len(data) > 0 && data[0] == ' ' {
+				data = data[1:]
+			}
+			if len(r.eventData) > 0 {
+				r.eventData = append(r.eventData, '\n')
+			}
+			r.eventData = append(r.eventData, data...)
+		}
+		// id:, retry:, and other fields are silently skipped
+	}
+
+	// Scanner done — return any accumulated event before EOF
+	if r.eventType != "" || len(r.eventData) > 0 {
+		eventType := r.eventType
+		eventData := make([]byte, len(r.eventData))
+		copy(eventData, r.eventData)
+		r.eventType = ""
+		r.eventData = r.eventData[:0]
+		return eventType, eventData, nil
+	}
+
+	if err := r.scanner.Err(); err != nil {
+		return "", nil, err
+	}
+	return "", nil, io.EOF
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
@@ -46,19 +45,6 @@ func MarshalSorted(v interface{}) ([]byte, error) {
 // MarshalSortedIndent marshals v to indented JSON with map keys sorted alphabetically.
 func MarshalSortedIndent(v interface{}, prefix, indent string) ([]byte, error) {
 	return sortedAPI.MarshalIndent(v, prefix, indent)
-}
-
-const (
-	sseInitialBufSize = 8 * 1024        // 8KB — sufficient for >99.9% of SSE lines
-	sseMaxBufSize     = 10 * 1024 * 1024 // 10MB — allow large tokens (tool calls, audio)
-)
-
-// NewSSEScanner creates a bufio.Scanner configured for SSE stream parsing.
-// Uses a small initial buffer (8KB) that auto-grows up to 10MB for rare large tokens.
-func NewSSEScanner(reader io.Reader) *bufio.Scanner {
-	scanner := bufio.NewScanner(reader)
-	scanner.Buffer(make([]byte, 0, sseInitialBufSize), sseMaxBufSize)
-	return scanner
 }
 
 // logger is the global logger for the provider utils (thread-safe via atomic.Pointer).
@@ -534,6 +520,341 @@ type RequestBodyWithExtraParams interface {
 
 type RequestBodyConverter func() (RequestBodyWithExtraParams, error)
 
+// IsLargePayloadPassthroughEnabled returns true when large payload mode has already
+// prepared an upstream body reader in context.
+func IsLargePayloadPassthroughEnabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	isLargePayload, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadMode).(bool)
+	if !ok || !isLargePayload {
+		return false
+	}
+	reader, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadReader).(io.Reader)
+	return ok && reader != nil
+}
+
+// ApplyLargePayloadRequestBody applies the request body reader from context to the
+// outgoing provider request. Returns true when a streaming body was applied.
+func ApplyLargePayloadRequestBody(ctx context.Context, req *fasthttp.Request) bool {
+	return ApplyLargePayloadRequestBodyWithModelNormalization(ctx, req, "")
+}
+
+const largePayloadModelRewriteScanBytes = 256 * 1024
+
+// ApplyLargePayloadRequestBodyWithModelNormalization applies the streaming body
+// reader from context and optionally rewrites prefixed model values for JSON
+// passthrough requests (for example "openai/gpt-5" -> "gpt-5").
+// This preserves low-memory streaming while keeping large-payload behavior
+// aligned with the normal parsed path that strips provider prefixes.
+func ApplyLargePayloadRequestBodyWithModelNormalization(
+	ctx context.Context,
+	req *fasthttp.Request,
+	defaultProvider schemas.ModelProvider,
+) bool {
+	if req == nil || !IsLargePayloadPassthroughEnabled(ctx) {
+		return false
+	}
+
+	bodyReader, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadReader).(io.Reader)
+	bodySize := -1
+	if contentLength, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadContentLength).(int); ok {
+		bodySize = contentLength
+	}
+
+	if contentType, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadContentType).(string); ok && contentType != "" {
+		ctLower := strings.ToLower(contentType)
+		if metadata, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadMetadata).(*schemas.LargePayloadMetadata); ok && metadata != nil {
+			if rawModel := strings.TrimSpace(metadata.Model); rawModel != "" && defaultProvider != "" {
+				_, normalizedModel := schemas.ParseModelString(rawModel, defaultProvider)
+				if normalizedModel != "" && normalizedModel != rawModel {
+					if strings.Contains(ctLower, "application/json") {
+						rewrittenReader, sizeDelta := RewriteLargePayloadModelInJSONPrefix(bodyReader, rawModel, normalizedModel)
+						bodyReader = rewrittenReader
+						if bodySize >= 0 {
+							bodySize += sizeDelta
+						}
+					} else if strings.Contains(ctLower, "multipart/form-data") {
+						rewrittenReader, sizeDelta := RewriteLargePayloadModelInMultipartPrefix(bodyReader, rawModel, normalizedModel)
+						bodyReader = rewrittenReader
+						if bodySize >= 0 {
+							bodySize += sizeDelta
+						}
+					}
+				}
+			}
+		}
+		req.Header.SetContentType(contentType)
+	}
+	req.SetBodyStream(bodyReader, bodySize)
+	return true
+}
+
+// RewriteLargePayloadModelInJSONPrefix reads the first 256KB of a streaming body,
+// rewrites the "model" JSON value from fromModel to toModel, and returns a
+// combined reader (rewritten prefix + remaining stream) with the size delta.
+func RewriteLargePayloadModelInJSONPrefix(reader io.Reader, fromModel, toModel string) (io.Reader, int) {
+	if reader == nil || fromModel == "" || toModel == "" || fromModel == toModel {
+		return reader, 0
+	}
+	prefix := make([]byte, largePayloadModelRewriteScanBytes)
+	n, err := io.ReadFull(reader, prefix)
+	if n == 0 && err != nil {
+		return reader, 0
+	}
+	prefix = prefix[:n]
+
+	rewrittenPrefix, changed := rewriteJSONModelValue(prefix, fromModel, toModel)
+	if !changed {
+		return io.MultiReader(bytes.NewReader(prefix), reader), 0
+	}
+	return io.MultiReader(bytes.NewReader(rewrittenPrefix), reader), len(rewrittenPrefix) - len(prefix)
+}
+
+func rewriteJSONModelValue(data []byte, fromModel, toModel string) ([]byte, bool) {
+	if len(data) == 0 || fromModel == "" || toModel == "" || fromModel == toModel {
+		return data, false
+	}
+	pattern := []byte(`"model"`)
+	searchFrom := 0
+	for {
+		match := bytes.Index(data[searchFrom:], pattern)
+		if match < 0 {
+			return data, false
+		}
+		idx := searchFrom + match + len(pattern)
+
+		for idx < len(data) && (data[idx] == ' ' || data[idx] == '\t' || data[idx] == '\r' || data[idx] == '\n') {
+			idx++
+		}
+		if idx >= len(data) || data[idx] != ':' {
+			searchFrom += match + len(pattern)
+			continue
+		}
+		idx++
+		for idx < len(data) && (data[idx] == ' ' || data[idx] == '\t' || data[idx] == '\r' || data[idx] == '\n') {
+			idx++
+		}
+		if idx >= len(data) || data[idx] != '"' {
+			searchFrom += match + len(pattern)
+			continue
+		}
+
+		valueStart := idx + 1
+		valueEnd := valueStart
+		escaped := false
+		for valueEnd < len(data) {
+			ch := data[valueEnd]
+			if escaped {
+				escaped = false
+				valueEnd++
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				valueEnd++
+				continue
+			}
+			if ch == '"' {
+				break
+			}
+			valueEnd++
+		}
+		if valueEnd >= len(data) {
+			return data, false
+		}
+
+		if string(data[valueStart:valueEnd]) != fromModel {
+			searchFrom = valueEnd + 1
+			continue
+		}
+
+		rewritten := make([]byte, 0, len(data)-len(fromModel)+len(toModel))
+		rewritten = append(rewritten, data[:valueStart]...)
+		rewritten = append(rewritten, toModel...)
+		rewritten = append(rewritten, data[valueEnd:]...)
+		return rewritten, true
+	}
+}
+
+// RewriteLargePayloadModelInMultipartPrefix reads the first 256KB of a streaming
+// multipart body, finds the model form field value, and rewrites it from fromModel
+// to toModel. The model field appears early in multipart bodies (typically the first
+// form field), so scanning the prefix is sufficient.
+func RewriteLargePayloadModelInMultipartPrefix(reader io.Reader, fromModel, toModel string) (io.Reader, int) {
+	if reader == nil || fromModel == "" || toModel == "" || fromModel == toModel {
+		return reader, 0
+	}
+	prefix := make([]byte, largePayloadModelRewriteScanBytes)
+	n, err := io.ReadFull(reader, prefix)
+	if n == 0 && err != nil {
+		return reader, 0
+	}
+	prefix = prefix[:n]
+
+	// In multipart, the model value appears as:
+	//   ...name="model"\r\n\r\nopenai/whisper-1\r\n--boundary...
+	// A direct byte replacement of fromModel→toModel in the prefix is safe because
+	// the model string (e.g. "openai/whisper-1") is unique within the form metadata.
+	from := []byte(fromModel)
+	to := []byte(toModel)
+	if idx := bytes.Index(prefix, from); idx >= 0 {
+		rewritten := make([]byte, 0, len(prefix)-len(from)+len(to))
+		rewritten = append(rewritten, prefix[:idx]...)
+		rewritten = append(rewritten, to...)
+		rewritten = append(rewritten, prefix[idx+len(from):]...)
+		return io.MultiReader(bytes.NewReader(rewritten), reader), len(rewritten) - len(prefix)
+	}
+	return io.MultiReader(bytes.NewReader(prefix), reader), 0
+}
+
+// DrainLargePayloadRemainder drains any unread bytes from the large payload reader.
+// This is useful for request types that may receive an upstream response before the
+// incoming client upload is fully consumed (for example, lightweight preflight APIs).
+// Example failure this prevents: fronting proxy returns 502/broken-pipe when backend
+// responds early while client is still uploading a large body.
+func DrainLargePayloadRemainder(ctx context.Context) {
+	if !IsLargePayloadPassthroughEnabled(ctx) {
+		return
+	}
+	bodyReader, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadReader).(io.Reader)
+	if bodyReader == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, bodyReader)
+}
+
+// CloneFastHTTPClientConfig creates a fresh fasthttp.Client by copying only
+// config fields from base.
+// Never copy fasthttp.Client by value: it contains internal pools and locks.
+// Example failure this prevents: parallel load regressions with unexpected buffering
+// behavior after `cloned := *base` copies of active clients.
+func CloneFastHTTPClientConfig(base *fasthttp.Client) *fasthttp.Client {
+	if base == nil {
+		return &fasthttp.Client{}
+	}
+
+	return &fasthttp.Client{
+		Transport:                     base.Transport,
+		DialTimeout:                   base.DialTimeout,
+		Dial:                          base.Dial,
+		TLSConfig:                     base.TLSConfig,
+		RetryIf:                       base.RetryIf, // nolint:staticcheck
+		RetryIfErr:                    base.RetryIfErr,
+		ConfigureClient:               base.ConfigureClient,
+		Name:                          base.Name,
+		MaxConnsPerHost:               base.MaxConnsPerHost,
+		MaxIdleConnDuration:           base.MaxIdleConnDuration,
+		MaxConnDuration:               base.MaxConnDuration,
+		MaxIdemponentCallAttempts:     base.MaxIdemponentCallAttempts,
+		ReadBufferSize:                base.ReadBufferSize,
+		WriteBufferSize:               base.WriteBufferSize,
+		ReadTimeout:                   base.ReadTimeout,
+		WriteTimeout:                  base.WriteTimeout,
+		MaxResponseBodySize:           base.MaxResponseBodySize,
+		MaxConnWaitTimeout:            base.MaxConnWaitTimeout,
+		ConnPoolStrategy:              base.ConnPoolStrategy,
+		NoDefaultUserAgentHeader:      base.NoDefaultUserAgentHeader,
+		DialDualStack:                 base.DialDualStack,
+		DisableHeaderNamesNormalizing: base.DisableHeaderNamesNormalizing,
+		DisablePathNormalizing:        base.DisablePathNormalizing,
+		StreamResponseBody:            base.StreamResponseBody,
+	}
+}
+
+// gzipReaderPool reuses gzip.Reader instances across requests to reduce GC pressure.
+var gzipReaderPool = sync.Pool{
+	New: func() any {
+		return &gzip.Reader{}
+	},
+}
+
+// AcquireGzipReader gets a gzip.Reader from the pool and resets it to read from r,
+// or creates a new one if the pool is empty or reset fails.
+func AcquireGzipReader(r io.Reader) (*gzip.Reader, error) {
+	if v := gzipReaderPool.Get(); v != nil {
+		gz := v.(*gzip.Reader)
+		if err := gz.Reset(r); err == nil {
+			return gz, nil
+		}
+		// Reset failed; close before re-pooling so we don't retain a partially
+		// initialized reader state between pool borrowers.
+		_ = gz.Close()
+		gzipReaderPool.Put(gz)
+	}
+	return gzip.NewReader(r)
+}
+
+// ReleaseGzipReader closes and returns a gzip.Reader to the pool.
+func ReleaseGzipReader(gz *gzip.Reader) {
+	if gz != nil {
+		_ = gz.Close()
+		gzipReaderPool.Put(gz)
+	}
+}
+
+// decompressBodyStreamIfGzip checks Content-Encoding for gzip and wraps the stream
+// with on-the-fly decompression using a pooled gzip.Reader. Clears Content-Encoding
+// header so downstream consumers don't double-decompress. Returns original reader
+// unchanged if not gzip-encoded or if gzip reader creation fails.
+func decompressBodyStreamIfGzip(resp *fasthttp.Response, stream io.Reader) (*gzip.Reader, io.Reader, bool) {
+	ce := strings.ToLower(strings.TrimSpace(string(resp.Header.Peek("Content-Encoding"))))
+	if !strings.Contains(ce, "gzip") {
+		return nil, stream, false
+	}
+	gz, err := AcquireGzipReader(stream)
+	if err != nil {
+		ReleaseGzipReader(gz)
+		return nil, stream, false
+	}
+	resp.Header.Del("Content-Encoding")
+	return gz, gz, true
+}
+
+// DecompressStreamBody returns a reader for consuming the response body, with
+// on-the-fly gzip decompression when Content-Encoding indicates gzip. The response
+// object is NOT modified (no SetBodyStream call), so the original requestStream
+// remains live for proper cleanup by ReleaseStreamingResponse. Clears the
+// Content-Encoding header to prevent double-decompression.
+//
+// Returns:
+//   - io.Reader: the reader to use for scanning (gzip reader if gzip-encoded,
+//     original body stream otherwise).
+//   - func(): cleanup function that releases the gzip reader back to the pool.
+//     Must be called (typically via defer) after streaming is complete.
+func DecompressStreamBody(resp *fasthttp.Response) (io.Reader, func()) {
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		// Return an empty reader instead of nil to prevent panics in callers
+		// that pass the reader to bufio.NewScanner without nil checks.
+		return bytes.NewReader(nil), func() {}
+	}
+	gz, decompressed, wasGzip := decompressBodyStreamIfGzip(resp, bodyStream)
+	if !wasGzip {
+		return bodyStream, func() {}
+	}
+	return decompressed, func() {
+		ReleaseGzipReader(gz)
+	}
+}
+
+// DrainNonSSEStreamResponse checks if the upstream response is a Server-Sent Events stream.
+// If not SSE, drains the body to io.Discard to prevent bufio.Scanner buffer bloat on
+// non-line-delimited data. Returns true if body was drained (caller should skip scanner).
+// We intentionally do not touch valid SSE bodies here: callers must continue reading from
+// the reader returned by DecompressStreamBody, and draining SSE in this helper would consume
+// the stream before the scanner/manual event loop starts.
+func DrainNonSSEStreamResponse(resp *fasthttp.Response) bool {
+	ct := strings.ToLower(string(resp.Header.ContentType()))
+	if strings.Contains(ct, "text/event-stream") {
+		return false
+	}
+	if bodyStream := resp.BodyStream(); bodyStream != nil {
+		_, _ = io.Copy(io.Discard, bodyStream)
+	}
+	return true
+}
+
 // MergeExtraParams merges extraParams into jsonMap, handling nested maps recursively.
 func MergeExtraParams(jsonMap map[string]interface{}, extraParams map[string]interface{}) {
 	for k, v := range extraParams {
@@ -661,6 +982,10 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 
 // CheckContextAndGetRequestBody checks if the raw request body should be used, and returns it if it exists.
 func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGetter, requestConverter RequestBodyConverter, providerType schemas.ModelProvider) ([]byte, *schemas.BifrostError) {
+	if IsLargePayloadPassthroughEnabled(ctx) {
+		return nil, nil
+	}
+
 	rawBody, ok := CheckAndGetRawRequestBody(ctx, request)
 	if !ok {
 		convertedBody, err := requestConverter()
@@ -2163,78 +2488,4 @@ func CheckAndSetDefaultProvider(ctx *schemas.BifrostContext, defaultProvider sch
 		return defaultProvider
 	}
 	return defaultProvider
-}
-
-// gzipReaderPool reuses gzip.Reader instances across requests to reduce GC pressure.
-var gzipReaderPool = sync.Pool{
-	New: func() any {
-		return &gzip.Reader{}
-	},
-}
-
-// AcquireGzipReader gets a gzip.Reader from the pool and resets it to read from r,
-// or creates a new one if the pool is empty or reset fails.
-func AcquireGzipReader(r io.Reader) (*gzip.Reader, error) {
-	if v := gzipReaderPool.Get(); v != nil {
-		gz := v.(*gzip.Reader)
-		if err := gz.Reset(r); err == nil {
-			return gz, nil
-		}
-		// Reset failed, return to pool to avoid leaking
-		gzipReaderPool.Put(gz)
-	}
-	return gzip.NewReader(r)
-}
-
-// ReleaseGzipReader closes and returns a gzip.Reader to the pool.
-func ReleaseGzipReader(gz *gzip.Reader) {
-	if gz != nil {
-		gz.Close()
-		gzipReaderPool.Put(gz)
-	}
-}
-
-// decompressBodyStreamIfGzip checks Content-Encoding for gzip and wraps the stream
-// with on-the-fly decompression using a pooled gzip.Reader. Clears Content-Encoding
-// header so downstream consumers don't double-decompress. Returns original reader
-// unchanged if not gzip-encoded or if gzip reader creation fails.
-func decompressBodyStreamIfGzip(resp *fasthttp.Response, stream io.Reader) (*gzip.Reader, io.Reader, bool) {
-	ce := strings.ToLower(strings.TrimSpace(string(resp.Header.Peek("Content-Encoding"))))
-	if !strings.Contains(ce, "gzip") {
-		return nil, stream, false
-	}
-	gz, err := AcquireGzipReader(stream)
-	if err != nil {
-		ReleaseGzipReader(gz)
-		return nil, stream, false
-	}
-	resp.Header.Del("Content-Encoding")
-	return gz, gz, true
-}
-
-// DecompressStreamBody returns a reader for consuming the response body, with
-// on-the-fly gzip decompression when Content-Encoding indicates gzip. The response
-// object is NOT modified (no SetBodyStream call), so the original requestStream
-// remains live for proper cleanup by ReleaseStreamingResponse. Clears the
-// Content-Encoding header to prevent double-decompression.
-//
-// Returns:
-//   - io.Reader: the reader to use for scanning (gzip reader if gzip-encoded,
-//     original body stream otherwise).
-//   - func(): cleanup function that releases the gzip reader back to the pool.
-//     Must be called (typically via defer) after streaming is complete.
-func DecompressStreamBody(resp *fasthttp.Response) (io.Reader, func()) {
-	bodyStream := resp.BodyStream()
-	if bodyStream == nil {
-		// Return an empty reader instead of nil to prevent panics in callers
-		// that pass the reader to bufio.NewScanner without nil checks.
-		return bytes.NewReader(nil), func() {}
-	}
-	gz, decompressed, wasGzip := decompressBodyStreamIfGzip(resp, bodyStream)
-	if !wasGzip {
-		return bodyStream, func() {}
-	}
-	return decompressed, func() {
-		ReleaseGzipReader(gz)
-	}
 }

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -15,6 +15,48 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+func TestRewriteJSONModelValue(t *testing.T) {
+	in := []byte(`{"model":"openai/gpt-5","messages":[{"role":"user","content":"x"}]}`)
+	out, changed := rewriteJSONModelValue(in, "openai/gpt-5", "gpt-5")
+	if !changed {
+		t.Fatal("expected model rewrite to occur")
+	}
+	if strings.Contains(string(out), `"model":"openai/gpt-5"`) {
+		t.Fatalf("expected prefixed model to be removed, got: %s", string(out))
+	}
+	if !strings.Contains(string(out), `"model":"gpt-5"`) {
+		t.Fatalf("expected rewritten model, got: %s", string(out))
+	}
+}
+
+func TestApplyLargePayloadRequestBodyWithModelNormalization(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	payload := `{"model":"openai/gpt-5","messages":[{"role":"user","content":"hello"}]}`
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
+	ctx.SetValue(
+		schemas.BifrostContextKeyLargePayloadReader,
+		strings.NewReader(payload),
+	)
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadContentLength, len(payload))
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadContentType, "application/json")
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMetadata, &schemas.LargePayloadMetadata{
+		Model: "openai/gpt-5",
+	})
+
+	req := &fasthttp.Request{}
+	if !ApplyLargePayloadRequestBodyWithModelNormalization(ctx, req, schemas.OpenAI) {
+		t.Fatal("expected large payload body to be applied")
+	}
+
+	body := string(req.Body())
+	if strings.Contains(body, "openai/gpt-5") {
+		t.Fatalf("expected rewritten model in body, got: %s", body)
+	}
+	if !strings.Contains(body, `"model":"gpt-5"`) {
+		t.Fatalf("expected normalized model in body, got: %s", body)
+	}
+}
+
 // TestHandleProviderAPIError_RawResponseIncluded verifies that HandleProviderAPIError
 // always includes the raw response body in BifrostError.ExtraFields.RawResponse
 func TestHandleProviderAPIError_RawResponseIncluded(t *testing.T) {
@@ -706,6 +748,77 @@ func TestCheckAndDecodeBody_Concurrent(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		<-done
+	}
+}
+
+func TestDrainNonSSEStreamResponse_SSEDoesNotDrain(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte("data: hello\n\n")
+	resp.Header.SetContentType("text/event-stream")
+	resp.SetBodyStream(bytes.NewReader(body), len(body))
+
+	drained := DrainNonSSEStreamResponse(resp)
+	if drained {
+		t.Fatal("expected SSE response to remain readable")
+	}
+
+	remaining, err := io.ReadAll(resp.BodyStream())
+	if err != nil {
+		t.Fatalf("failed to read SSE body after guard: %v", err)
+	}
+	if string(remaining) != string(body) {
+		t.Fatalf("expected SSE body to remain intact, got %q", string(remaining))
+	}
+}
+
+func TestDrainNonSSEStreamResponse_NonSSEDrains(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte(`{"error":"not stream"}`)
+	resp.Header.SetContentType("application/json")
+	resp.SetBodyStream(bytes.NewReader(body), len(body))
+
+	drained := DrainNonSSEStreamResponse(resp)
+	if !drained {
+		t.Fatal("expected non-SSE response to be drained")
+	}
+
+	remaining, err := io.ReadAll(resp.BodyStream())
+	if err != nil {
+		t.Fatalf("failed to read body after drain: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Fatalf("expected drained body to be empty, got %q", string(remaining))
+	}
+}
+
+func TestDrainNonSSEStreamResponse_GzipSSEStillReadable(t *testing.T) {
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	body := []byte("data: hello\n\ndata: [DONE]\n\n")
+	compressed := gzipCompress(body)
+	resp.Header.SetContentType("text/event-stream")
+	resp.Header.Set("Content-Encoding", "gzip")
+	resp.SetBodyStream(bytes.NewReader(compressed), len(compressed))
+
+	drained := DrainNonSSEStreamResponse(resp)
+	if drained {
+		t.Fatal("expected gzip SSE response to remain readable")
+	}
+
+	reader, releaseGzip := DecompressStreamBody(resp)
+	defer releaseGzip()
+
+	remaining, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("failed to read decompressed SSE body: %v", err)
+	}
+	if string(remaining) != string(body) {
+		t.Fatalf("expected decompressed SSE body %q, got %q", string(body), string(remaining))
 	}
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -211,10 +211,34 @@ const (
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "user_id"
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
-	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent"     // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
+	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
-	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"           // bool (triggers additional key validation during provider add/update)
-	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers" // map[string]string (set by provider handlers for response header forwarding)
+	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                      // bool (triggers additional key validation during provider add/update)
+	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"          // map[string]string (set by provider handlers for response header forwarding)
+	BifrostContextKeyLargePayloadMode                    BifrostContextKey = "bifrost-large-payload-mode"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large payload streaming mode is active
+	BifrostContextKeyLargePayloadReader                  BifrostContextKey = "bifrost-large-payload-reader"               // io.Reader (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large payloads
+	BifrostContextKeyLargePayloadContentLength           BifrostContextKey = "bifrost-large-payload-content-length"       // int (set by bifrost - DO NOT SET THIS MANUALLY)) content length for large payloads
+	BifrostContextKeyLargePayloadContentType             BifrostContextKey = "bifrost-large-payload-content-type"         // string (set by enterprise - DO NOT SET THIS MANUALLY)) original content type for large payload passthrough
+	BifrostContextKeyLargePayloadMetadata                BifrostContextKey = "bifrost-large-payload-metadata"             // *LargePayloadMetadata (set by bifrost - DO NOT SET THIS MANUALLY)) routing metadata for large payloads
+	BifrostContextKeyLargePayloadRequestThreshold        BifrostContextKey = "bifrost-large-payload-request-threshold"    // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) request threshold used by transport heuristics
+	BifrostContextKeyLargeResponseMode                   BifrostContextKey = "bifrost-large-response-mode"                // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large response streaming mode is active
+	BifrostContextKeyLargePayloadRequestPreview          BifrostContextKey = "bifrost-large-payload-request-preview"      // string (set by bifrost - DO NOT SET THIS MANUALLY)) truncated request body preview for logging
+	BifrostContextKeyLargePayloadResponsePreview         BifrostContextKey = "bifrost-large-payload-response-preview"     // string (set by bifrost - DO NOT SET THIS MANUALLY)) truncated response body preview for logging
+	BifrostContextKeyLargeResponseReader                 BifrostContextKey = "bifrost-large-response-reader"              // io.ReadCloser (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large responses
+	BifrostContextKeyLargeResponseContentLength          BifrostContextKey = "bifrost-large-response-content-length"      // int (set by bifrost - DO NOT SET THIS MANUALLY)) content length for large responses
+	BifrostContextKeyLargeResponseContentType            BifrostContextKey = "bifrost-large-response-content-type"        // string (set by bifrost - DO NOT SET THIS MANUALLY)) upstream content type for large responses
+	BifrostContextKeyLargeResponseContentDisposition     BifrostContextKey = "bifrost-large-response-content-disposition" // string (set by bifrost - DO NOT SET THIS MANUALLY)) downstream content disposition for large responses
+	BifrostContextKeyLargeResponseThreshold              BifrostContextKey = "bifrost-large-response-threshold"           // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) threshold for response streaming
+	BifrostContextKeyLargePayloadPrefetchSize            BifrostContextKey = "bifrost-large-payload-prefetch-size"        // int (set by enterprise - DO NOT SET THIS MANUALLY)) prefetch buffer size for metadata extraction from large responses
+	BifrostContextKeyDeferredUsage                       BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
+	BifrostContextKeyDeferredLargePayloadMetadata        BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
+	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                  // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
+)
+
+const (
+	// DefaultLargePayloadRequestThresholdBytes is the default request-size heuristic
+	// used by transport guards when no enterprise threshold is present on context.
+	DefaultLargePayloadRequestThresholdBytes = 10 * 1024 * 1024 // 10MB
 )
 
 // RoutingEngine constants
@@ -234,6 +258,16 @@ type RoutingEngineLogEntry struct {
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,
 // make sure to mark BifrostContextKeyStreamEndIndicator as true at the end of the stream.
+
+// LargePayloadMetadata holds routing-relevant metadata selectively extracted from large payloads.
+// This is used when the full request body is too large to parse (e.g., 400MB video upload).
+// Only small routing/observability fields are extracted; the body itself streams through unchanged.
+type LargePayloadMetadata struct {
+	ResponseModalities []string // e.g., ["AUDIO"] for speech, ["IMAGE"] for image generation
+	SpeechConfig       bool     // true if generationConfig.speechConfig is present
+	Model              string   // model extracted without full body parsing (openai/anthropic multipart/json)
+	StreamRequested    *bool    // stream flag when available in request payload metadata
+}
 
 //* Request Structs
 
@@ -891,4 +925,3 @@ type BifrostErrorExtraFields struct {
 	LiteLLMCompat  bool          `json:"litellm_compat,omitempty"`
 	KeyStatuses    []KeyStatus   `json:"key_statuses,omitempty"`
 }
-

--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -226,6 +226,8 @@ type HTTPTransportPlugin interface {
 	// Only invoked when using HTTP transport (bifrost-http), not when using Bifrost as a Go SDK directly.
 	// Works with both native .so plugins and WASM plugins due to serializable types.
 	// NOTE: This hook is NOT called for streaming responses. Use HTTPTransportStreamChunkHook instead.
+	// NOTE: For large streamed responses (non-streaming APIs that switch to body streaming for memory safety),
+	// resp.Body may be nil by design while StatusCode and Headers remain populated.
 	//
 	// Return values:
 	// - nil: Continue to next plugin/handler, response modifications are applied


### PR DESCRIPTION
## Summary

Add the foundational infrastructure for large payload streaming: context key
definitions, metadata types, engine validation bypass, and provider utility
functions for request/response body streaming without full materialization.

This is the base layer of the large payload optimization feature
(enterprise-only activation). All context keys, streaming utilities, and model
prefix rewriting logic are defined here for downstream providers, transport, and
plugins to consume.

## Changes

- Add 14 context keys to `core/schemas/bifrost.go` for request/response large
  payload state (`LargePayloadMode`, `LargePayloadReader`, `LargeResponseMode`,
  thresholds, previews, etc.)
- Add `LargePayloadMetadata` struct for selective metadata extraction (model,
  stream flag, modalities) without full body parse
- Add `DefaultLargePayloadRequestThresholdBytes` constant (10MB)
- Update `HTTPTransportPlugin` interface docs to note `resp.Body` may be nil
  under large streamed responses
- Add `isLargePayloadPassthrough()` helper to `core/bifrost.go` and skip
  nil-Input validation for all 15 request types when large payload mode is
  active
- Add request-side utilities: `IsLargePayloadPassthroughEnabled`,
  `ApplyLargePayloadRequestBody[WithModelNormalization]`,
  `RewriteLargePayloadModelInJSONPrefix`, `DrainLargePayloadRemainder`,
  `CloneFastHTTPClientConfig`
- Add early-exit path in `CheckContextAndGetRequestBody` when large payload
  passthrough is enabled
- Add `large_response.go` with response-side utilities: `LargeResponseReader`,
  `BuildLargeResponseClient`, `PrepareResponseStreaming`,
  `MaterializeStreamErrorBody`, `FinalizeResponseWithLargeDetection`
- Bump `golang.org/x/oauth2` v0.34→v0.35 across all modules

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
go version
go test ./core/providers/utils/...
```

The feature is gated by context keys that are only set by enterprise hook logic.
Without the hook, all large payload code paths are unreachable — normal request
flow is unchanged.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Part of the large payload optimization feature stack.

## Security considerations

- Model prefix rewriting scans only the first 256KB of the body to limit memory
  exposure
- Response prefetch is capped at 64KB for metadata extraction
- `DrainLargePayloadRemainder` prevents broken-pipe 502 errors on early provider
  responses

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
