### PR TITLE
fix(redis): escape dots in RediSearch TAG field queries

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -816,6 +816,7 @@ func escapeSearchValue(value string) string {
 		"'", "\\'",
 		" ", "\\ ",
 		"-", "\\-",
+		".", "\\.",
 		",", "|",
 	)
 	return replacer.Replace(value)


### PR DESCRIPTION
## Summary

Dots (`.`) are special separator characters in RediSearch TAG fields. Model names containing dots (e.g. `gpt-4.1-mini`, `gpt-3.5-turbo`, `gpt-5.1`) cause the TAG query to parse incorrectly, resulting in zero matches even though the entry exists in Redis.

This caused semantic cache to silently miss for all models with dots in their names, while models without dots (`gpt-4o`, `gpt-5`, all Claude models) worked correctly.

The issue was in `escapeSearchValue` in `framework/vectorstore/redis.go` — it escapes many RediSearch special characters but was missing `.`.

## Reproduction

```bash
# Entry stored with model=gpt-4.1-mini exists in Redis, but:

# Without dot escaping (current) - 0 results:
redis-cli FT.SEARCH BifrostSemanticCachePlugin "@model:{gpt\-4.1\-mini}" RETURN 1 model LIMIT 0 3

# With dot escaping (fix) - finds the entry:
redis-cli FT.SEARCH BifrostSemanticCachePlugin "@model:{gpt\-4\.1\-mini}" RETURN 1 model LIMIT 0 3
```

Tested locally by building the transport with a `replace` directive pointing to the patched framework, and confirmed `gpt-4.1-mini` cache hits work with the fix.

## Affected models

All models with dots in their names:
- `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`
- `gpt-3.5-turbo` and variants
- `gpt-5.1`, `gpt-5.2` and variants

## Changes

- `framework/vectorstore/redis.go`: Added `".", "\\."` to `escapeSearchValue` replacer

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## Breaking changes

- [ ] Yes
- [x] No

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable