### PR TITLE
fix: fixes vllm key redaction

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -43,7 +43,7 @@ type ClientConfig struct {
 	DisableContentLogging   bool                             `json:"disable_content_logging"` // Disable logging of content
 	DisableDBPingsInHealth  bool                             `json:"disable_db_pings_in_health"`
 	LogRetentionDays        int                              `json:"log_retention_days" validate:"min=1"` // Number of days to retain logs (minimum 1 day)
-	EnforceAuthOnInference  bool                             `json:"enforce_auth_on_inference"`            // Require auth (VK, API key, or user token) on inference endpoints
+	EnforceAuthOnInference  bool                             `json:"enforce_auth_on_inference"`           // Require auth (VK, API key, or user token) on inference endpoints
 	EnforceGovernanceHeader bool                             `json:"enforce_governance_header,omitempty"` // Deprecated: use EnforceAuthOnInference
 	EnforceSCIMAuth         bool                             `json:"enforce_scim_auth,omitempty"`         // Deprecated: use EnforceAuthOnInference
 	AllowDirectKeys         bool                             `json:"allow_direct_keys"`                   // Allow direct keys to be used for requests
@@ -57,8 +57,8 @@ type ClientConfig struct {
 	MCPToolSyncInterval     int                              `json:"mcp_tool_sync_interval"`              // Global tool sync interval in minutes (default: 10, 0 = disabled)
 	HeaderFilterConfig      *tables.GlobalHeaderFilterConfig `json:"header_filter_config,omitempty"`      // Global header filtering configuration for x-bf-eh-* headers
 	AsyncJobResultTTL       int                              `json:"async_job_result_ttl"`                // Default TTL for async job results in seconds (default: 3600 = 1 hour)
-	RequiredHeaders         []string                         `json:"required_headers,omitempty"`           // Headers that must be present on every request (case-insensitive)
-	LoggingHeaders          []string                         `json:"logging_headers,omitempty"`            // Headers to capture in log metadata
+	RequiredHeaders         []string                         `json:"required_headers,omitempty"`          // Headers that must be present on every request (case-insensitive)
+	LoggingHeaders          []string                         `json:"logging_headers,omitempty"`           // Headers to capture in log metadata
 	ConfigHash              string                           `json:"-"`                                   // Config hash for reconciliation (not serialized)
 }
 

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -933,6 +933,14 @@ func (h *ProviderHandler) mergeKeys(oldRawKeys []schemas.Key, oldRedactedKeys []
 				}
 			}
 
+			// Handle VLLM config redacted values
+			if updateKey.VLLMKeyConfig != nil && oldRedactedKey.VLLMKeyConfig != nil && oldRawKey.VLLMKeyConfig != nil {
+				if updateKey.VLLMKeyConfig.URL.IsRedacted() &&
+					updateKey.VLLMKeyConfig.URL.Equals(&oldRedactedKey.VLLMKeyConfig.URL) {
+					mergedKey.VLLMKeyConfig.URL = oldRawKey.VLLMKeyConfig.URL
+				}
+			}
+
 			// Preserve ConfigHash from old key (UI doesn't send it back)
 			mergedKey.ConfigHash = oldRawKey.ConfigHash
 


### PR DESCRIPTION
## Summary

Fixes handling of redacted VLLM configuration values during key updates and corrects code formatting inconsistencies.

## Changes

- Added proper handling for redacted VLLM URL values in the key merging logic to preserve original values when redacted placeholders are submitted
- Fixed whitespace alignment in ClientConfig struct field comments for consistent formatting

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test VLLM key configuration updates to ensure redacted URL values are properly preserved:

```sh
# Core/Transports
go version
go test ./...

# Test VLLM key update scenarios
# 1. Create a VLLM key with URL
# 2. Update the key through the API
# 3. Verify the original URL is preserved when redacted value is sent
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security by properly handling redacted sensitive values (URLs) in VLLM configurations, ensuring they are not inadvertently cleared during updates.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable