### PR TITLE
feat: support top-level cache_control for Anthropic automatic prompt caching

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2186,20 +2186,26 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				anthropicReq.ExtraParams[k] = v
 			}
 			if cacheControlRaw, exists := anthropicReq.ExtraParams["cache_control"]; exists {
+				parsed := false
 				switch v := cacheControlRaw.(type) {
 				case *schemas.CacheControl:
 					anthropicReq.CacheControl = v
+					parsed = true
 				case schemas.CacheControl:
 					anthropicReq.CacheControl = &v
+					parsed = true
 				default:
 					if data, err := json.Marshal(v); err == nil {
-						var parsed schemas.CacheControl
-						if json.Unmarshal(data, &parsed) == nil {
-							anthropicReq.CacheControl = &parsed
+						var cc schemas.CacheControl
+						if json.Unmarshal(data, &cc) == nil {
+							anthropicReq.CacheControl = &cc
+							parsed = true
 						}
 					}
 				}
-				delete(anthropicReq.ExtraParams, "cache_control")
+				if parsed {
+					delete(anthropicReq.ExtraParams, "cache_control")
+				}
 			}
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2181,8 +2181,11 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		anthropicReq.ServiceTier = bifrostReq.Params.ServiceTier
 
 		if bifrostReq.Params.ExtraParams != nil {
-			anthropicReq.ExtraParams = bifrostReq.Params.ExtraParams
-			if cacheControlRaw, exists := bifrostReq.Params.ExtraParams["cache_control"]; exists {
+			anthropicReq.ExtraParams = make(map[string]interface{}, len(bifrostReq.Params.ExtraParams))
+			for k, v := range bifrostReq.Params.ExtraParams {
+				anthropicReq.ExtraParams[k] = v
+			}
+			if cacheControlRaw, exists := anthropicReq.ExtraParams["cache_control"]; exists {
 				switch v := cacheControlRaw.(type) {
 				case *schemas.CacheControl:
 					anthropicReq.CacheControl = v
@@ -2196,7 +2199,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 						}
 					}
 				}
-				delete(bifrostReq.Params.ExtraParams, "cache_control")
+				delete(anthropicReq.ExtraParams, "cache_control")
 			}
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -81,6 +81,7 @@ type AnthropicMessageRequest struct {
 	Messages          []AnthropicMessage     `json:"messages"`
 	Metadata          *AnthropicMetaData     `json:"metadata,omitempty"`
 	System            *AnthropicContent      `json:"system,omitempty"`
+	CacheControl      *schemas.CacheControl  `json:"cache_control,omitempty"`
 	Temperature       *float64               `json:"temperature,omitempty"`
 	TopP              *float64               `json:"top_p,omitempty"`
 	TopK              *int                   `json:"top_k,omitempty"`
@@ -354,6 +355,7 @@ var anthropicMessageRequestKnownFields = map[string]bool{
 	"messages":           true,
 	"metadata":           true,
 	"system":             true,
+	"cache_control":      true,
 	"temperature":        true,
 	"top_p":              true,
 	"top_k":              true,

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -434,6 +434,13 @@ func (req *AnthropicMessageRequest) MarshalJSON() ([]byte, error) {
 		reqCopy := *req
 		reqCopy.stripCacheControlScope = false
 
+		// Strip scope from top-level cache_control
+		if reqCopy.CacheControl != nil && reqCopy.CacheControl.Scope != nil {
+			cc := *reqCopy.CacheControl
+			cc.Scope = nil
+			reqCopy.CacheControl = &cc
+		}
+
 		// Strip scope from tools
 		if len(reqCopy.Tools) > 0 {
 			toolsCopy := make([]AnthropicTool, len(reqCopy.Tools))

--- a/docs/openapi/schemas/integrations/anthropic/messages.yaml
+++ b/docs/openapi/schemas/integrations/anthropic/messages.yaml
@@ -22,6 +22,9 @@ AnthropicMessageRequest:
     system:
       $ref: '#/AnthropicContent'
       description: System prompt
+    cache_control:
+      $ref: '../../inference/common.yaml#/CacheControl'
+      description: Automatic caching directives for the whole request
     metadata:
       $ref: '#/AnthropicMetadata'
     stream:

--- a/docs/providers/supported-providers/anthropic.mdx
+++ b/docs/providers/supported-providers/anthropic.mdx
@@ -92,6 +92,8 @@ resp, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas
 </Tab>
 </Tabs>
 
+Anthropic also accepts a top-level `"cache_control": {"type": "ephemeral"}` object on `/anthropic/v1/messages` requests to enable automatic prompt caching, and Bifrost now forwards that directive through unchanged.
+
 ### Cache Control
 
 Cache directives can be added to system messages, user messages, and tool definitions to enable prompt caching:


### PR DESCRIPTION
## Summary
  Adds support for the top-level `cache_control` field on `/anthropic/v1/messages` requests, enabling Anthropic's automatic prompt caching.
  Previously this field was silently dropped.

  ## Changes
  - Added `CacheControl` field to `AnthropicMessageRequest` struct
  - Implemented bidirectional conversion through `ExtraParams` with type-safe handling
  - Updated OpenAPI schema and docs

  ## Type of change
  - [x] Feature

  ## Affected areas
  - [x] Core (Go)
  - [x] Providers/Integrations
  - [x] Docs

  ## Breaking changes
  - [x] No

  ## Related issues
  Closes #1746

  ## Checklist
  - [x] I read `docs/contributing/README.md` and followed the guidelines
  - [x] I updated documentation where needed
  - [x] I verified builds succeed (Go and UI)