### PR TITLE
fix: tool choice struct empty fields on json marshal

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -8,3 +8,4 @@
 - feat: support for video generation requests
 - feat: add runway provider support
 - feat: support for preserving JSON key order in tool function parameters
+- fix: empty json marshalling fixes for tool choice struct

--- a/core/internal/llmtests/automatic_function_calling.go
+++ b/core/internal/llmtests/automatic_function_calling.go
@@ -77,7 +77,7 @@ func RunAutomaticFunctionCallingTest(t *testing.T, client *bifrost.Bifrost, ctx 
 					ToolChoice: &schemas.ChatToolChoice{
 						ChatToolChoiceStruct: &schemas.ChatToolChoiceStruct{
 							Type: schemas.ChatToolChoiceTypeFunction,
-							Function: schemas.ChatToolChoiceFunction{
+							Function: &schemas.ChatToolChoiceFunction{
 								Name: string(SampleToolTypeTime),
 							},
 						},

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -160,7 +160,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 				switch bifrostReq.Params.ToolChoice.ChatToolChoiceStruct.Type {
 				case schemas.ChatToolChoiceTypeFunction:
 					toolChoice.Type = "tool"
-					toolChoice.Name = bifrostReq.Params.ToolChoice.ChatToolChoiceStruct.Function.Name
+					if bifrostReq.Params.ToolChoice.ChatToolChoiceStruct.Function != nil {
+						toolChoice.Name = bifrostReq.Params.ToolChoice.ChatToolChoiceStruct.Function.Name
+					}
 				case schemas.ChatToolChoiceTypeAllowedTools:
 					toolChoice.Type = "any"
 				case schemas.ChatToolChoiceTypeCustom:

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1102,7 +1102,10 @@ func convertToolChoice(toolChoice schemas.ChatToolChoice) *BedrockToolChoice {
 	if toolChoice.ChatToolChoiceStruct != nil {
 		switch toolChoice.ChatToolChoiceStruct.Type {
 		case schemas.ChatToolChoiceTypeFunction:
-			name := toolChoice.ChatToolChoiceStruct.Function.Name
+			name := ""
+			if toolChoice.ChatToolChoiceStruct.Function != nil {
+				name = toolChoice.ChatToolChoiceStruct.Function.Name
+			}
 			if name != "" {
 				return &BedrockToolChoice{
 					Tool: &BedrockToolChoiceTool{Name: name},

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1380,7 +1380,7 @@ func convertToolChoiceToToolConfig(toolChoice *schemas.ChatToolChoice) ToolConfi
 		}
 
 		// Handle specific function selection
-		if toolChoice.ChatToolChoiceStruct.Function.Name != "" {
+		if toolChoice.ChatToolChoiceStruct.Function != nil && toolChoice.ChatToolChoiceStruct.Function.Name != "" {
 			functionCallingConfig.AllowedFunctionNames = []string{toolChoice.ChatToolChoiceStruct.Function.Name}
 		}
 	}

--- a/core/providers/huggingface/chat.go
+++ b/core/providers/huggingface/chat.go
@@ -115,7 +115,7 @@ func ToHuggingFaceChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) 
 					hfToolChoice.EnumValue = &required
 				}
 			} else if params.ToolChoice.ChatToolChoiceStruct != nil {
-				if params.ToolChoice.ChatToolChoiceStruct.Type == schemas.ChatToolChoiceTypeFunction {
+				if params.ToolChoice.ChatToolChoiceStruct.Type == schemas.ChatToolChoiceTypeFunction && params.ToolChoice.ChatToolChoiceStruct.Function != nil {
 					hfToolChoice.Function = &schemas.ChatToolChoiceFunction{
 						Name: params.ToolChoice.ChatToolChoiceStruct.Function.Name,
 					}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -495,10 +495,10 @@ const (
 
 // ChatToolChoiceStruct represents a tool choice.
 type ChatToolChoiceStruct struct {
-	Type         ChatToolChoiceType         `json:"type"`                    // Type of tool choice
-	Function     ChatToolChoiceFunction     `json:"function,omitempty"`      // Function to call if type is ToolChoiceTypeFunction
-	Custom       ChatToolChoiceCustom       `json:"custom,omitempty"`        // Custom tool to call if type is ToolChoiceTypeCustom
-	AllowedTools ChatToolChoiceAllowedTools `json:"allowed_tools,omitempty"` // Allowed tools to call if type is ToolChoiceTypeAllowedTools
+	Type         ChatToolChoiceType          `json:"type"`                    // Type of tool choice
+	Function     *ChatToolChoiceFunction     `json:"function,omitempty"`      // Function to call if type is ToolChoiceTypeFunction
+	Custom       *ChatToolChoiceCustom       `json:"custom,omitempty"`        // Custom tool to call if type is ToolChoiceTypeCustom
+	AllowedTools *ChatToolChoiceAllowedTools `json:"allowed_tools,omitempty"` // Allowed tools to call if type is ToolChoiceTypeAllowedTools
 }
 
 type ChatToolChoice struct {

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -269,13 +269,13 @@ func (ctc *ChatToolChoice) ToResponsesToolChoice() *ResponsesToolChoice {
 
 		case ChatToolChoiceTypeFunction:
 			// Map function choice
-			if ctc.ChatToolChoiceStruct.Function.Name != "" {
+			if ctc.ChatToolChoiceStruct.Function != nil && ctc.ChatToolChoiceStruct.Function.Name != "" {
 				rtc.ResponsesToolChoiceStruct.Name = &ctc.ChatToolChoiceStruct.Function.Name
 			}
 
 		case ChatToolChoiceTypeAllowedTools:
 			// Map allowed tools
-			if len(ctc.ChatToolChoiceStruct.AllowedTools.Tools) > 0 {
+			if ctc.ChatToolChoiceStruct.AllowedTools != nil && len(ctc.ChatToolChoiceStruct.AllowedTools.Tools) > 0 {
 				tools := make([]ResponsesToolChoiceAllowedToolDef, len(ctc.ChatToolChoiceStruct.AllowedTools.Tools))
 				for i, tool := range ctc.ChatToolChoiceStruct.AllowedTools.Tools {
 					tools[i] = ResponsesToolChoiceAllowedToolDef{
@@ -289,14 +289,14 @@ func (ctc *ChatToolChoice) ToResponsesToolChoice() *ResponsesToolChoice {
 				rtc.ResponsesToolChoiceStruct.Tools = tools
 			}
 			// Copy the mode (e.g., "auto", "required")
-			if ctc.ChatToolChoiceStruct.AllowedTools.Mode != "" {
+			if ctc.ChatToolChoiceStruct.AllowedTools != nil && ctc.ChatToolChoiceStruct.AllowedTools.Mode != "" {
 				mode := ctc.ChatToolChoiceStruct.AllowedTools.Mode
 				rtc.ResponsesToolChoiceStruct.Mode = &mode
 			}
 
 		case ChatToolChoiceTypeCustom:
 			// Map custom choice
-			if ctc.ChatToolChoiceStruct.Custom.Name != "" {
+			if ctc.ChatToolChoiceStruct.Custom != nil && ctc.ChatToolChoiceStruct.Custom.Name != "" {
 				rtc.ResponsesToolChoiceStruct.Name = &ctc.ChatToolChoiceStruct.Custom.Name
 			}
 		}
@@ -339,14 +339,14 @@ func (tc *ResponsesToolChoice) ToChatToolChoice() *ChatToolChoice {
 
 		// Handle function choice
 		if tc.ResponsesToolChoiceStruct.Type == ResponsesToolChoiceTypeFunction && tc.ResponsesToolChoiceStruct.Name != nil {
-			ctc.ChatToolChoiceStruct.Function = ChatToolChoiceFunction{
+			ctc.ChatToolChoiceStruct.Function = &ChatToolChoiceFunction{
 				Name: *tc.ResponsesToolChoiceStruct.Name,
 			}
 		}
 
 		// Handle custom choice
 		if tc.ResponsesToolChoiceStruct.Type == ResponsesToolChoiceTypeCustom && tc.ResponsesToolChoiceStruct.Name != nil {
-			ctc.ChatToolChoiceStruct.Custom = ChatToolChoiceCustom{
+			ctc.ChatToolChoiceStruct.Custom = &ChatToolChoiceCustom{
 				Name: *tc.ResponsesToolChoiceStruct.Name,
 			}
 		}
@@ -368,7 +368,7 @@ func (tc *ResponsesToolChoice) ToChatToolChoice() *ChatToolChoice {
 			if tc.ResponsesToolChoiceStruct.Mode != nil && *tc.ResponsesToolChoiceStruct.Mode != "" {
 				mode = *tc.ResponsesToolChoiceStruct.Mode
 			}
-			ctc.ChatToolChoiceStruct.AllowedTools = ChatToolChoiceAllowedTools{
+			ctc.ChatToolChoiceStruct.AllowedTools = &ChatToolChoiceAllowedTools{
 				Mode:  mode,
 				Tools: tools,
 			}

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -651,7 +651,7 @@ func (plugin *Plugin) extractChatParametersToMetadata(params *schemas.ChatParame
 	if params.ToolChoice != nil {
 		if params.ToolChoice.ChatToolChoiceStr != nil {
 			metadata["tool_choice"] = *params.ToolChoice.ChatToolChoiceStr
-		} else if params.ToolChoice.ChatToolChoiceStruct != nil && params.ToolChoice.ChatToolChoiceStruct.Function.Name != "" {
+		} else if params.ToolChoice.ChatToolChoiceStruct != nil && params.ToolChoice.ChatToolChoiceStruct.Function != nil && params.ToolChoice.ChatToolChoiceStruct.Function.Name != "" {
 			metadata["tool_choice"] = params.ToolChoice.ChatToolChoiceStruct.Function.Name
 		}
 	}


### PR DESCRIPTION
## Summary

Fixed JSON marshalling issues for tool choice struct by converting nested fields from value types to pointer types, preventing empty objects from being serialized when fields are unset.

## Changes

- Changed `Function`, `Custom`, and `AllowedTools` fields in `ChatToolChoiceStruct` from value types to pointer types
- Added nil checks throughout the codebase before accessing these pointer fields
- Updated test code to use pointer syntax when creating tool choice structs
- Added changelog entry documenting the fix

The change ensures that when tool choice fields are not set, they serialize as `null` or are omitted entirely rather than appearing as empty objects in JSON output.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that tool choice structs serialize correctly and don't produce empty objects:

```sh
# Core/Transports
go version
go test ./...

# Test specific function calling scenarios
go test ./core/internal/llmtests -run TestAutomaticFunctionCalling
```

Test with various providers (Anthropic, Bedrock, Gemini, HuggingFace) to ensure tool choice handling works correctly with the pointer changes.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a JSON serialization fix.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable