### PR TITLE
fix: filter openrouter list models response based on allowed models on key

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: filter openrouter list models response based on allowed models on key

--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -35,7 +35,7 @@ type BifrostListModelsRequest struct {
 	PageToken string `json:"page_token"`
 
 	// Unfiltered: If true, the response will include all models for the provider, regardless of the allowed models (internal bifrost use only, not sent to the provider)
-	Unfiltered bool `json:"unfiltered"`
+	Unfiltered bool `json:"-"`
 
 	// ExtraParams: Additional provider-specific query parameters
 	// This allows for flexibility to pass any custom parameters that specific providers might support

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: filter openrouter list models response based on allowed models on key


### PR DESCRIPTION
## Summary

Fixed OpenRouter list models endpoint to properly filter the response based on the allowed models configured on the API key, ensuring users only see models they have access to.

closes #1793

## Changes

- Added filtering logic in `listModelsByKey` to check if models are included in the key's allowed models list
- Implemented backfill functionality to include allowed models that aren't present in the OpenRouter API response
- Added support for both raw model IDs and provider-prefixed model IDs when checking allowed models
- Only applies filtering when `request.Unfiltered` is false and allowed models are configured

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the OpenRouter list models endpoint with API keys that have restricted model access:

```sh
# Core/Transports
go version
go test ./...

# Test with restricted API key
curl -X GET "http://localhost:8080/v1/models" \
  -H "Authorization: Bearer your-restricted-openrouter-key"

# Verify only allowed models are returned
# Test with unfiltered request
curl -X GET "http://localhost:8080/v1/models?unfiltered=true" \
  -H "Authorization: Bearer your-restricted-openrouter-key"
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security by ensuring users cannot see or access models they don't have permissions for based on their API key configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable