### PR TITLE
Persist DevProfiler visibility/expanded state in localStorage and fix sidebar search focus background

### DIFF
--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1036,7 +1036,7 @@ export default function AppSidebar() {
 							setFocusedIndex(-1);
 						}}
 						onKeyDown={handleSearchKeyDown}
-						className="border-input text-foreground placeholder:text-shadow-muted-foreground focus:ring-ring h-8 w-full rounded-sm border bg-transparent pr-14 pl-8 text-sm outline-none focus:bg-white"
+						className="border-input text-foreground placeholder:text-shadow-muted-foreground focus:ring-ring h-8 w-full rounded-sm border bg-transparent pr-14 pl-8 text-sm outline-none focus:bg-transparent"
 					/>
 					<kbd className="text-muted-foreground pointer-events-none absolute top-1/2 right-2 flex -translate-y-1/2 gap-0.5 text-[10px]">
 						<span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">⌘</span>


### PR DESCRIPTION
## Summary

Adds persistent state management to the DevProfiler component, allowing visibility and expansion states to be remembered across browser sessions. Also fixes a minor UI issue in the sidebar search input focus behavior.

## Changes

- Added localStorage persistence for DevProfiler visibility and expansion states using new storage utility functions
- Created reusable `loadBooleanFromStorage` and `saveBooleanToStorage` helper functions with proper error handling
- Modified DevProfiler state initialization to load from localStorage with sensible defaults
- Added useEffect hooks to automatically save state changes to localStorage
- Updated dismiss handler to persist visibility state when profiler is dismissed
- Fixed sidebar search input to maintain transparent background on focus instead of switching to white

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] UI (Next.js)

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```bash
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

1. Open the application in development mode
2. Toggle the DevProfiler visibility and expansion states
3. Refresh the page and verify the states are preserved
4. Dismiss the profiler and refresh - it should remain dismissed
5. Test the sidebar search input focus behavior to ensure background remains transparent

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

| Before | After |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/0c806020-69d4-4fbe-afa4-e26e46cf7870.png)<br> | ![image.png](https://app.graphite.com/user-attachments/assets/e298a8dd-46f8-48ff-9b62-b2141dc4566c.png) |
|  |  |
|  |  |

## Breaking changes

- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Uses localStorage for non-sensitive UI state persistence with proper error handling for storage failures.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable