### PR TITLE
adds tags fetching back to migration tests

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 #   VERSIONS_TO_TEST  - Number of previous versions to test (default: 3)
 
 # Pull all the tags available
-#git fetch --tags
+git fetch --tags
 
 # Get the absolute path of the script directory
 if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Enables git tag fetching in the migration test script by uncommenting the `git fetch --tags` command. This ensures the script has access to all repository tags when determining which versions to test during migration testing.

## Changes

- Uncommented the `git fetch --tags` line in the migration test script
- This allows the script to pull all available tags from the repository, which is necessary for identifying previous versions to test against

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs
- [x] CI/Testing

## How to test

Run the migration test script to verify it can properly fetch and identify available versions:

```sh
# Run the migration test script
./.github/workflows/scripts/run-migration-tests.sh

# Verify tags are available
git tag --list
```

The script should now be able to access repository tags and determine which versions to test for migrations.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects the CI testing pipeline and does not impact runtime security.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable