### PR TITLE
fixes encryption tests for columns

### DIFF
--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -1690,12 +1690,11 @@ func TestEncryptedColumns_BedrockRegion_FitsAfterWidening(t *testing.T) {
 // Postgres-only: verify actual column types via information_schema
 // ============================================================================
 
-func TestPostgres_EncryptedColumns_AreVarchar255(t *testing.T) {
+func TestPostgres_EncryptedColumns_AreText(t *testing.T) {
 	db := setupTestPostgresDB(t) // skips if Postgres is unavailable
 
 	type colInfo struct {
-		DataType               string `gorm:"column:data_type"`
-		CharacterMaximumLength int    `gorm:"column:character_maximum_length"`
+		DataType string `gorm:"column:data_type"`
 	}
 
 	columns := []string{"azure_api_version", "vertex_region", "bedrock_region"}
@@ -1704,15 +1703,13 @@ func TestPostgres_EncryptedColumns_AreVarchar255(t *testing.T) {
 		t.Run(col, func(t *testing.T) {
 			var info colInfo
 			err := db.Raw(`
-				SELECT data_type, character_maximum_length
+				SELECT data_type
 				FROM information_schema.columns
 				WHERE table_name = 'config_keys' AND column_name = ?`, col).
 				Scan(&info).Error
 			require.NoError(t, err)
-			assert.Equal(t, "character varying", info.DataType,
-				"column %s should be character varying", col)
-			assert.Equal(t, 255, info.CharacterMaximumLength,
-				"column %s should have max length 255", col)
+			assert.Equal(t, "text", info.DataType,
+				"column %s should be text", col)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Updates the Postgres test to verify that encrypted columns use the `text` data type instead of `varchar(255)`. This reflects a change in the database schema where encrypted columns have been migrated from character varying with a 255 character limit to unlimited text fields.

## Changes

- Renamed test function from `TestPostgres_EncryptedColumns_AreVarchar255` to `TestPostgres_EncryptedColumns_AreText`
- Removed `CharacterMaximumLength` field from the `colInfo` struct since text columns don't have a maximum length constraint
- Updated SQL query to only select `data_type` from `information_schema.columns`
- Changed assertion to expect `"text"` instead of `"character varying"` data type
- Removed assertion for character maximum length of 255

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Run the specific test to verify encrypted columns are text type
go test ./framework/configstore/tables -run TestPostgres_EncryptedColumns_AreText

# Run all encryption tests
go test ./framework/configstore/tables -run TestEncryptedColumns
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change maintains the same level of security for encrypted data storage while allowing for larger encrypted values by removing the 255 character limit.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable