### PR TITLE
allow deleting all providers

### DIFF
--- a/ui/app/workspace/providers/views/modelProviderConfig.tsx
+++ b/ui/app/workspace/providers/views/modelProviderConfig.tsx
@@ -17,7 +17,6 @@ export default function ModelProviderConfig({ provider, onRequestDelete }: Props
 	const [showConfigSheet, setShowConfigSheet] = useState(false);
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 	const hasDeleteProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
-	const isCustomProvider = !!provider.custom_provider_config;
 
 	const showApiKeys = useMemo(() => {
 		if (provider.custom_provider_config) {
@@ -28,7 +27,7 @@ export default function ModelProviderConfig({ provider, onRequestDelete }: Props
 
 	const editConfigButton = (
 		<div className="flex items-center gap-2">
-			{isCustomProvider && onRequestDelete && hasDeleteProviderAccess && (
+			{onRequestDelete && hasDeleteProviderAccess && (
 				<Button variant="outline" onClick={onRequestDelete} className="text-destructive hover:bg-destructive/10 hover:text-destructive" aria-label="Delete provider" data-testid="provider-delete-btn">
 					<Trash className="h-4 w-4" />
 				</Button>


### PR DESCRIPTION
## Summary

Enable delete functionality for all model providers by removing the restriction that limited deletion to only custom providers.

## Issues

Closes #1802

## Changes

- Removed the `isCustomProvider` variable and its associated check
- Modified the delete button visibility condition to show for all providers when the user has delete permissions
- The delete button now appears for both built-in and custom providers, controlled only by RBAC permissions

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the workspace providers configuration page
2. Verify that the delete button appears for all provider types (not just custom ones)
3. Confirm that the delete button only shows when the user has appropriate RBAC permissions
4. Test the delete functionality works for both built-in and custom providers

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The change maintains existing RBAC permission checks, ensuring only authorized users can delete providers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable