### PR TITLE
adds proper status check for openrouter keys

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3782,6 +3782,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 				ModelRequested: model,
 				RawRequest:     primaryErr.ExtraFields.RawRequest,
 				RawResponse:    primaryErr.ExtraFields.RawResponse,
+				KeyStatuses:    primaryErr.ExtraFields.KeyStatuses,
 			}
 		}
 		return primaryResult, primaryErr
@@ -3831,6 +3832,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 				ModelRequested: fallback.Model,
 				RawRequest:     fallbackErr.ExtraFields.RawRequest,
 				RawResponse:    fallbackErr.ExtraFields.RawResponse,
+				KeyStatuses:    fallbackErr.ExtraFields.KeyStatuses,
 			}
 			return nil, fallbackErr
 		}
@@ -3843,6 +3845,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 			ModelRequested: model,
 			RawRequest:     primaryErr.ExtraFields.RawRequest,
 			RawResponse:    primaryErr.ExtraFields.RawResponse,
+			KeyStatuses:    primaryErr.ExtraFields.KeyStatuses,
 		}
 	}
 
@@ -3893,6 +3896,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				ModelRequested: model,
 				RawRequest:     primaryErr.ExtraFields.RawRequest,
 				RawResponse:    primaryErr.ExtraFields.RawResponse,
+				KeyStatuses:    primaryErr.ExtraFields.KeyStatuses,
 			}
 		}
 		return primaryResult, primaryErr
@@ -3940,6 +3944,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				ModelRequested: fallback.Model,
 				RawRequest:     fallbackErr.ExtraFields.RawRequest,
 				RawResponse:    fallbackErr.ExtraFields.RawResponse,
+				KeyStatuses:    fallbackErr.ExtraFields.KeyStatuses,
 			}
 			return nil, fallbackErr
 		}
@@ -3952,6 +3957,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 			ModelRequested: model,
 			RawRequest:     primaryErr.ExtraFields.RawRequest,
 			RawResponse:    primaryErr.ExtraFields.RawResponse,
+			KeyStatuses:    primaryErr.ExtraFields.KeyStatuses,
 		}
 	}
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -211,8 +211,9 @@ const (
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "user_id"
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
-	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
+	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent"     // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
+	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"           // bool (triggers additional key validation during provider add/update)
 )
 
 // RoutingEngine constants

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -637,6 +637,7 @@ func (s *RDBConfigStore) DeleteProvider(ctx context.Context, provider schemas.Mo
 	// Store the budget and rate limit IDs before deleting
 	budgetID := dbProvider.BudgetID
 	rateLimitID := dbProvider.RateLimitID
+	
 	// Delete the provider first (keys will be deleted due to CASCADE constraint)
 	if err := txDB.WithContext(ctx).Delete(&dbProvider).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -498,6 +498,7 @@ func (s *BifrostHTTPServer) ReloadProvider(ctx context.Context, provider schemas
 
 	bfCtx := schemas.NewBifrostContext(ctx, time.Now().Add(15*time.Second))
 	bfCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
+	bfCtx.SetValue(schemas.BifrostContextKeyValidateKeys, true) // Validate keys during provider add/update
 	defer bfCtx.Cancel()
 
 	allModels, bifrostErr := s.Client.ListModelsRequest(bfCtx, &schemas.BifrostListModelsRequest{

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -146,12 +146,21 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										<TableCell>
 											<div className="flex items-center space-x-2">
 												{key.status === "success" && (
-													<CheckCircle2 className="text-green-600 h-4 w-4 flex-shrink-0" />
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<button type="button" aria-label="Key status: list models working" data-testid={`key-status-success-${key.name}`} className="inline-flex">
+																<CheckCircle2 aria-hidden className="text-green-600 h-4 w-4 flex-shrink-0" />
+															</button>
+														</TooltipTrigger>
+														<TooltipContent>List models working</TooltipContent>
+													</Tooltip>
 												)}
 												{key.status === "list_models_failed" && (
 													<Tooltip>
-														<TooltipTrigger>
-															<AlertCircle className="text-destructive h-4 w-4 flex-shrink-0" />
+														<TooltipTrigger asChild>
+															<button type="button" aria-label="Key status: list models failed" data-testid={`key-status-error-${key.name}`} className="inline-flex">
+																<AlertCircle aria-hidden className="text-destructive h-4 w-4 flex-shrink-0" />
+															</button>
 														</TooltipTrigger>
 														<TooltipContent className="max-w-xs break-words">
 															{key.description || "Model discovery failed for this key"}


### PR DESCRIPTION
## Summary

Adds key validation for OpenRouter provider during provider add/update operations. OpenRouter's `/v1/models` endpoint doesn't require authentication, so invalid API keys would appear to work when adding a provider. This change adds a minimal chat completion request to verify keys are actually valid.

## Issues
closes #1761

## Changes

- Added `validateKey` method to OpenRouter provider that makes a minimal chat completion request using a free model (`meta-llama/llama-3.2-1b-instruct:free`) to verify API key validity
- Added `BifrostContextKeyValidateKeys` context key to trigger validation during provider add/update operations
- Set validation context flag in `ReloadProvider` method to enable key validation
- Added `KeyStatuses` field to error handling in both regular and streaming request handlers
- Simplified provider list logic in UI to only show actually configured providers instead of mixing configured and unconfigured providers
- Added tooltip to success status icon in provider keys table

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

1. Test OpenRouter provider key validation:
```sh
# Add an OpenRouter provider with an invalid API key
# The system should now reject the invalid key instead of accepting it

# Add an OpenRouter provider with a valid API key
# The system should accept it and show success status
```

2. Test that existing functionality still works:
```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

3. Verify error handling includes key status information in responses

## Screenshots/Recordings

N/A - Backend validation improvement with minor UI simplification

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- The validation uses a minimal request with `max_tokens=1` to minimize API usage during validation
- Uses a free model to avoid charges during key validation
- Properly handles authentication errors (401/403) to detect invalid keys

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable