### PR TITLE
feat: add async rerank support

### DIFF
--- a/docs/features/async-inference.mdx
+++ b/docs/features/async-inference.mdx
@@ -50,6 +50,7 @@ Streaming is not supported on async endpoints.
 | Image generations | `/v1/async/images/generations` | `/v1/async/images/generations/{job_id}` |
 | Image edits | `/v1/async/images/edits` | `/v1/async/images/edits/{job_id}` |
 | Image variations | `/v1/async/images/variations` | `/v1/async/images/variations/{job_id}` |
+| Rerank | `/v1/async/rerank` | `/v1/async/rerank/{job_id}` |
 
 ## Submitting a Request
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
 - feat: add count tokens support for bedrock
+- feat: add async rerank support


### PR DESCRIPTION
## Summary

This PR adds async rerank support to the Bifrost HTTP transport, enabling users to submit rerank requests asynchronously and retrieve results later using job IDs.

## Changes

- Added async rerank endpoints (`/v1/async/rerank` for submission and `/v1/async/rerank/{job_id}` for retrieval)
- Extracted rerank request preparation logic into a shared `prepareRerankRequest` function to avoid code duplication between sync and async handlers
- Updated path-to-type mapping to include the new async rerank endpoint
- Added documentation for the new async rerank endpoints

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Test async rerank submission:
```sh
curl -X POST http://localhost:8080/v1/async/rerank \
  -H "Content-Type: application/json" \
  -d '{
    "model": "provider/model",
    "query": "search query",
    "documents": [{"text": "document 1"}, {"text": "document 2"}]
  }'
```

Test async rerank retrieval:
```sh
curl -X GET http://localhost:8080/v1/async/rerank/{job_id}
```

Run tests:
```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No additional security implications beyond existing async inference patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable