### PR TITLE
fix: matched count tokens to openai spec

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -160,7 +160,7 @@ paths:
     $ref: './paths/inference/videos.yaml#/video-download'
   /v1/videos/{video_id}/remix:
     $ref: './paths/inference/videos.yaml#/video-remix'
-  /v1/count_tokens:
+  /v1/responses/input_tokens:
     $ref: './paths/inference/count-tokens.yaml#/count-tokens'
   /v1/batches:
     $ref: './paths/inference/batches.yaml#/batches'

--- a/docs/quickstart/gateway/reranking.mdx
+++ b/docs/quickstart/gateway/reranking.mdx
@@ -53,7 +53,7 @@ curl --location 'http://localhost:8080/v1/rerank' \
   "documents": [
     {"id": "a", "text": "Bifrost supports observability plugins like OTEL and Maxim."},
     {"id": "b", "text": "Bifrost can run in Kubernetes and ECS."},
-    {"id": "c", "text": "Token counting is available at /v1/count_tokens."}
+    {"id": "c", "text": "Token counting is available at /v1/responses/input_tokens."}
   ]
 }'
 ```
@@ -80,7 +80,7 @@ When using a `vllm/...` model, Bifrost sends rerank requests to `/v1/rerank` fir
       "relevance_score": 0.63,
       "document": {
         "id": "c",
-        "text": "Token counting is available at /v1/count_tokens."
+        "text": "Token counting is available at /v1/responses/input_tokens."
       }
     }
   ],

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+- fix: added missing count tokens support for usage field

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -692,6 +692,17 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 					} else {
 						usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
 					}
+				case result.CountTokensResponse != nil:
+					usage = &schemas.BifrostLLMUsage{}
+					usage.PromptTokens = result.CountTokensResponse.InputTokens
+					if result.CountTokensResponse.OutputTokens != nil {
+						usage.CompletionTokens = *result.CountTokensResponse.OutputTokens
+					}
+					if result.CountTokensResponse.TotalTokens != nil {
+						usage.TotalTokens = *result.CountTokensResponse.TotalTokens
+					} else {
+						usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+					}
 				}
 				updateData.TokenUsage = usage
 				// Extract raw response

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -337,6 +337,9 @@ func (p *LoggerPlugin) extractInputHistory(request *schemas.BifrostRequest) ([]s
 			},
 		}, []schemas.ResponsesMessage{}
 	}
+	if request.CountTokensRequest != nil && len(request.CountTokensRequest.Input) > 0 {
+		return []schemas.ChatMessage{}, request.CountTokensRequest.Input
+	}
 	return []schemas.ChatMessage{}, []schemas.ResponsesMessage{}
 }
 

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -445,47 +445,6 @@ type VideoRemixRequest struct {
 	ExtraParams map[string]any `json:"extra_params,omitempty"`
 }
 
-type CountTokensRequest struct {
-	Messages []schemas.ResponsesMessage `json:"messages"`
-	Tools    []schemas.ResponsesTool    `json:"tools,omitempty"`
-	BifrostParams
-	*schemas.ResponsesParameters
-}
-
-// UnmarshalJSON implements custom JSON unmarshalling for CountTokensRequest.
-// This is needed because ResponsesParameters has a custom UnmarshalJSON method,
-// which interferes with sonic's handling of the embedded BifrostParams struct.
-func (cr *CountTokensRequest) UnmarshalJSON(data []byte) error {
-	// First, unmarshal BifrostParams fields directly
-	type bifrostAlias BifrostParams
-	var bp bifrostAlias
-	if err := sonic.Unmarshal(data, &bp); err != nil {
-		return err
-	}
-	cr.BifrostParams = BifrostParams(bp)
-
-	// Unmarshal messages and tools
-	var msgStruct struct {
-		Messages []schemas.ResponsesMessage `json:"messages"`
-		Tools    []schemas.ResponsesTool    `json:"tools,omitempty"`
-	}
-	if err := sonic.Unmarshal(data, &msgStruct); err != nil {
-		return err
-	}
-	cr.Messages = msgStruct.Messages
-	cr.Tools = msgStruct.Tools
-
-	// Unmarshal ResponsesParameters (which has its own custom unmarshaller)
-	if cr.ResponsesParameters == nil {
-		cr.ResponsesParameters = &schemas.ResponsesParameters{}
-	}
-	if err := sonic.Unmarshal(data, cr.ResponsesParameters); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // BatchCreateRequest is a bifrost batch create request
 type BatchCreateRequest struct {
 	Model            string                     `json:"model"`                       // Model in "provider/model" format
@@ -581,18 +540,18 @@ const (
 // PathToTypeMapping maps exact paths to request types (only for non-parameterized paths)
 // Parameterized paths are set per-route in RegisterRoutes
 var PathToTypeMapping = map[string]schemas.RequestType{
-	"/v1/completions":          schemas.TextCompletionRequest,
-	"/v1/chat/completions":     schemas.ChatCompletionRequest,
-	"/v1/responses":            schemas.ResponsesRequest,
-	"/v1/embeddings":           schemas.EmbeddingRequest,
-	"/v1/rerank":               schemas.RerankRequest,
-	"/v1/audio/speech":         schemas.SpeechRequest,
-	"/v1/audio/transcriptions": schemas.TranscriptionRequest,
-	"/v1/images/generations":   schemas.ImageGenerationRequest,
-	"/v1/count_tokens":         schemas.CountTokensRequest,
-	"/v1/images/edits":         schemas.ImageEditRequest,
-	"/v1/images/variations":    schemas.ImageVariationRequest,
-	"/v1/models":               schemas.ListModelsRequest,
+	"/v1/completions":            schemas.TextCompletionRequest,
+	"/v1/chat/completions":       schemas.ChatCompletionRequest,
+	"/v1/responses":              schemas.ResponsesRequest,
+	"/v1/embeddings":             schemas.EmbeddingRequest,
+	"/v1/rerank":                 schemas.RerankRequest,
+	"/v1/audio/speech":           schemas.SpeechRequest,
+	"/v1/audio/transcriptions":   schemas.TranscriptionRequest,
+	"/v1/images/generations":     schemas.ImageGenerationRequest,
+	"/v1/responses/input_tokens": schemas.CountTokensRequest,
+	"/v1/images/edits":           schemas.ImageEditRequest,
+	"/v1/images/variations":      schemas.ImageVariationRequest,
+	"/v1/models":                 schemas.ListModelsRequest,
 }
 
 // createRequestTypeMiddleware creates a middleware that sets the request type for a specific route
@@ -633,7 +592,7 @@ func (h *CompletionHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 	r.POST("/v1/audio/speech", lib.ChainMiddlewares(h.speech, baseMiddlewares...))
 	r.POST("/v1/audio/transcriptions", lib.ChainMiddlewares(h.transcription, baseMiddlewares...))
 	r.POST("/v1/images/generations", lib.ChainMiddlewares(h.imageGeneration, baseMiddlewares...))
-	r.POST("/v1/count_tokens", lib.ChainMiddlewares(h.countTokens, baseMiddlewares...))
+	r.POST("/v1/responses/input_tokens", lib.ChainMiddlewares(h.countTokens, baseMiddlewares...))
 	r.POST("/v1/images/edits", lib.ChainMiddlewares(h.imageEdit, baseMiddlewares...))
 	r.POST("/v1/images/variations", lib.ChainMiddlewares(h.imageVariation, baseMiddlewares...))
 	r.POST("/v1/videos", lib.ChainMiddlewares(h.videoGeneration, baseMiddlewares...))
@@ -1371,50 +1330,9 @@ func (h *CompletionHandler) transcription(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, resp)
 }
 
-// prepareCountTokensRequest prepares a BifrostResponsesRequest from a CountTokensRequest
-func prepareCountTokensRequest(ctx *fasthttp.RequestCtx) (*CountTokensRequest, *schemas.BifrostResponsesRequest, error) {
-	req := CountTokensRequest{
-		ResponsesParameters: &schemas.ResponsesParameters{},
-	}
-	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
-		return nil, nil, fmt.Errorf("invalid request body: %v", err)
-	}
-	provider, modelName := schemas.ParseModelString(req.Model, "")
-	if provider == "" || modelName == "" {
-		return nil, nil, fmt.Errorf("model should be in provider/model format")
-	}
-	fallbacks, err := parseFallbacks(req.Fallbacks)
-	if err != nil {
-		return nil, nil, err
-	}
-	if req.ResponsesParameters == nil {
-		req.ResponsesParameters = &schemas.ResponsesParameters{}
-	}
-	extraParams, err := extractExtraParams(ctx.PostBody(), countTokensParamsKnownFields)
-	if err != nil {
-		logger.Warn("Failed to extract extra params: %v", err)
-	} else {
-		req.ResponsesParameters.ExtraParams = extraParams
-	}
-	if len(req.Tools) > 0 {
-		req.ResponsesParameters.Tools = req.Tools
-	}
-	if len(req.Messages) == 0 {
-		return nil, nil, fmt.Errorf("messages is required for count tokens")
-	}
-	bifrostReq := &schemas.BifrostResponsesRequest{
-		Provider:  schemas.ModelProvider(provider),
-		Model:     modelName,
-		Input:     req.Messages,
-		Params:    req.ResponsesParameters,
-		Fallbacks: fallbacks,
-	}
-	return &req, bifrostReq, nil
-}
-
-// countTokens handles POST /v1/count_tokens - Process count tokens requests
+// countTokens handles POST /v1/responses/input_tokens - Process count tokens requests
 func (h *CompletionHandler) countTokens(ctx *fasthttp.RequestCtx) {
-	_, bifrostReq, err := prepareCountTokensRequest(ctx)
+	_, bifrostResponsesReq, err := prepareResponsesRequest(ctx)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1427,7 +1345,7 @@ func (h *CompletionHandler) countTokens(ctx *fasthttp.RequestCtx) {
 	}
 	defer cancel()
 
-	response, bifrostErr := h.client.CountTokensRequest(bifrostCtx, bifrostReq)
+	response, bifrostErr := h.client.CountTokensRequest(bifrostCtx, bifrostResponsesReq)
 	if bifrostErr != nil {
 		SendBifrostError(ctx, bifrostErr)
 		return

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,6 @@
 - feat: add count tokens support for bedrock
 - feat: add async rerank support
+- fix: count tokens route fixed to match openai schema
+  <Warning>
+    **Breaking change.** The count tokens route has moved from `/v1/count_tokens` to `/v1/responses/input_tokens`, and the request body field has been renamed from incorrect `messages` to `input`. Please update your clients accordingly.
+  </Warning>

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -74,7 +74,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 	if (log.params?.tools) {
 		try {
 			toolsParameter = JSON.stringify(log.params.tools, null, 2);
-		} catch (ignored) {}
+		} catch (ignored) { }
 	}
 
 	// Extract audio format from request params
@@ -109,11 +109,11 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							<Badge variant="outline" className={`${StatusColors[log.status as Status]} uppercase`}>
 								{log.status}
 							</Badge>
-								{log.metadata?.isAsyncRequest ? (
-									<Badge variant="outline" className="bg-teal-100 text-teal-800 uppercase dark:bg-teal-900 dark:text-teal-200">
-										Async
-									</Badge>
-								) : null}
+							{log.metadata?.isAsyncRequest ? (
+								<Badge variant="outline" className="bg-teal-100 text-teal-800 uppercase dark:bg-teal-900 dark:text-teal-200">
+									Async
+								</Badge>
+							) : null}
 						</SheetTitle>
 					</div>
 					<AlertDialog>
@@ -194,9 +194,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								label="Type"
 								value={
 									<div
-										className={`${
-											RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
-										} rounded-sm px-3 py-1`}
+										className={`${RequestTypeColors[log.object as keyof typeof RequestTypeColors] ?? "bg-gray-100 text-gray-800"
+											} rounded-sm px-3 py-1`}
 									>
 										{RequestTypeLabels[log.object as keyof typeof RequestTypeLabels] ?? log.object ?? "unknown"}
 									</div>
@@ -590,12 +589,12 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								/>
 							</>
 						)}
-							{log.rerank_output && !log.error_details?.error.message && (
-								<>
-									<CollapsibleBox
-										title={`Rerank Output (${log.rerank_output.length})`}
-										onCopy={() => JSON.stringify(log.rerank_output, null, 2)}
-									>
+						{log.rerank_output && !log.error_details?.error.message && (
+							<>
+								<CollapsibleBox
+									title={`Rerank Output (${log.rerank_output.length})`}
+									onCopy={() => JSON.stringify(log.rerank_output, null, 2)}
+								>
 									<CodeEditor
 										className="z-0 w-full"
 										shouldAdjustInitialHeight={true}


### PR DESCRIPTION
## Summary

Migrates the count tokens endpoint from `/v1/count_tokens` to `/v1/responses/input_tokens` to align with OpenAI schema standards and consolidates request handling logic.

## Changes

- Moved count tokens endpoint from `/v1/count_tokens` to `/v1/responses/input_tokens`
- Removed duplicate `CountTokensRequest` struct and custom unmarshalling logic
- Updated count tokens handler to reuse existing `prepareResponsesRequest` function
- Updated OpenAPI specification and documentation examples to reflect new endpoint path
- Added changelog entry documenting the breaking change

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Test the new count tokens endpoint:

```sh
# Test the new endpoint
curl --location 'http://localhost:8080/v1/responses/input_tokens' \
--header 'Content-Type: application/json' \
--data '{
  "model": "provider/model",
  "input": [
    {"role": "user", "content": "Hello world"}
  ]
}'

# Verify old endpoint returns 404
curl --location 'http://localhost:8080/v1/count_tokens' \
--header 'Content-Type: application/json' \
--data '{}'

# Run tests
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

**Breaking change:** The count tokens route has moved from `/v1/count_tokens` to `/v1/responses/input_tokens`, and the request body field has been renamed from `messages` to `input`. Clients must update their endpoint URLs and request payloads accordingly.

## Related issues

N/A

## Security considerations

No security implications - this is an endpoint path change with no changes to authentication or data handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable