### PR TITLE
fix: add bedrock integration routing rules and provider selection logic

### DIFF
--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+- fix: added missing routing rules and provider selection logic for bedrock integration cases in PreHTTPTransportHook

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -4,3 +4,4 @@
   <Warning>
     **Breaking change.** The count tokens route has moved from `/v1/count_tokens` to `/v1/responses/input_tokens`, and the request body field has been renamed from incorrect `messages` to `input`. Please update your clients accordingly.
   </Warning>
+- fix: added missing routing logic for bedrock integration


### PR DESCRIPTION
## Summary

This PR fixes missing routing rules and provider selection logic for Bedrock integration in the governance plugin's PreHTTPTransportHook. Previously, the governance plugin only handled model extraction and routing for standard OpenAI-style requests and Gemini integration, but lacked support for Bedrock's URL-based model parameter structure.

## Changes

- Added Bedrock path detection (`/bedrock`) alongside existing Gemini path detection
- Implemented model extraction from Bedrock's `modelId` URL parameter with proper URL decoding
- Added provider selection logic that sets the `modelId` context value for Bedrock requests
- Applied routing rules to update the `modelId` parameter when routing decisions are made
- Added `net/url` import for URL decoding functionality

The key design decision was to mirror the existing Gemini integration pattern while accounting for Bedrock's specific parameter naming (`modelId` instead of `model`) and the need for URL decoding of model identifiers.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Bedrock integration routing by sending requests through the governance plugin:

```sh
# Test Bedrock model routing
curl -X POST "https://your-instance/bedrock/model/anthropic%2Fclaude-3-5-sonnet/invoke" \
  -H "Authorization: Bearer your-key" \
  -d '{"messages": [{"role": "user", "content": "test"}]}'

# Verify governance plugin correctly extracts and routes the model
# Check logs for routing decisions and provider selection
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The change includes URL decoding of model IDs, which properly handles encoded characters in Bedrock model identifiers without introducing security vulnerabilities.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable