### PR TITLE
fix logprobs JSON tag in chat completion response

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -866,7 +866,7 @@ type ChatAudioMessageAudio struct {
 type BifrostResponseChoice struct {
 	Index        int              `json:"index"`
 	FinishReason *string          `json:"finish_reason,omitempty"`
-	LogProbs     *BifrostLogProbs `json:"log_probs,omitempty"`
+	LogProbs     *BifrostLogProbs `json:"logprobs,omitempty"`
 
 	*TextCompletionResponseChoice
 	*ChatNonStreamResponseChoice


### PR DESCRIPTION
Fixes #1826.

The `BifrostResponseChoice` struct in `core/schemas/chatcompletions.go` had `json:"log_probs,omitempty"` but the OpenAI API spec uses `logprobs` (no underscore). This one-line change fixes the JSON tag to match the spec.