### PR TITLE
adds governance wrong virtual key check

### DIFF
--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -630,7 +630,7 @@ func (s *BifrostHTTPServer) ReloadClientConfigFromConfigStore(ctx context.Contex
 	config, err := s.Config.ConfigStore.GetClientConfig(context.Background())
 	if err != nil {
 		return fmt.Errorf("failed to get client config: %v", err)
-	}
+	}	
 	s.Config.ClientConfig = *config
 	// Reloading config in bifrost client
 	if s.Client != nil {


### PR DESCRIPTION
## Summary

Fixes virtual key validation logic in the governance plugin to properly check key existence in the store rather than just checking for empty strings, and improves authentication flow handling.

## Changes

- Updated `UpdateEnforceAuthOnInference` to use `bifrost.Ptr()` helper function instead of manual pointer creation
- Enhanced virtual key validation to check if the key actually exists in the store using `p.store.GetVirtualKey()`
- Modified authentication logic to validate virtual key existence before enforcing mandatory authentication requirements
- Added early return for cases where virtual key is invalid but not mandatory
- Minor whitespace formatting fix in server configuration reload

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test virtual key validation and authentication enforcement:

```sh
# Test with valid virtual key
curl -H "x-bf-vk: valid_key" http://localhost:8080/v1/inference

# Test with invalid virtual key when VK is mandatory
curl -H "x-bf-vk: invalid_key" http://localhost:8080/v1/inference

# Test without virtual key when VK is not mandatory
curl http://localhost:8080/v1/inference

# Run tests
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security by properly validating virtual keys against the actual store rather than just checking for non-empty strings. This prevents potential bypass scenarios where invalid keys could be accepted.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable