### PR TITLE
feat: extend e2e ui tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   push:
-    branches: ["02-11-fix_fix_mcp_and_virtual-key_tests"]
+    branches: ["02-27-feat_extend_e2e_ui_tests"]
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/scripts/test-e2e-ui.sh
+++ b/.github/workflows/scripts/test-e2e-ui.sh
@@ -131,7 +131,7 @@ npx playwright install --with-deps chromium
 # Forward MCP_SSE_HEADERS so the mcp-registry SSE test can use it (set in workflow env).
 echo "🎭 Running Playwright E2E tests..."
 CI=true SKIP_WEB_SERVER=1 BASE_URL=http://localhost:18080 BIFROST_BASE_URL=http://localhost:18080 \
-  MCP_SSE_HEADERS=${MCP_SSE_HEADERS:-} \
+  MCP_SSE_HEADERS="${MCP_SSE_HEADERS:-}" \
   npx playwright test --workers=4
 PLAYWRIGHT_EXIT=$?
 

--- a/tests/e2e/core/fixtures/base.fixture.ts
+++ b/tests/e2e/core/fixtures/base.fixture.ts
@@ -10,6 +10,11 @@ import { MCPRegistryPage } from '../../features/mcp-registry/pages/mcp-registry.
 import { PluginsPage } from '../../features/plugins/pages/plugins.page'
 import { ObservabilityPage } from '../../features/observability/pages/observability.page'
 import { ConfigSettingsPage } from '../../features/config/pages/config-settings.page'
+import { GovernancePage } from '../../features/governance/pages/governance.page'
+import { MCPAuthConfigPage } from '../../features/mcp-auth-config/pages/mcp-auth-config.page'
+import { MCPSettingsPage } from '../../features/mcp-settings/pages/mcp-settings.page'
+import { MCPToolGroupsPage } from '../../features/mcp-tool-groups/pages/mcp-tool-groups.page'
+import { ModelLimitsPage } from '../../features/model-limits/pages/model-limits.page'
 
 /**
  * Custom test fixtures type
@@ -27,6 +32,11 @@ type BifrostFixtures = {
   pluginsPage: PluginsPage
   observabilityPage: ObservabilityPage
   configSettingsPage: ConfigSettingsPage
+  governancePage: GovernancePage
+  modelLimitsPage: ModelLimitsPage
+  mcpSettingsPage: MCPSettingsPage
+  mcpToolGroupsPage: MCPToolGroupsPage
+  mcpAuthConfigPage: MCPAuthConfigPage
 }
 
 /**
@@ -87,6 +97,26 @@ export const test = base.extend<BifrostFixtures>({
 
   configSettingsPage: async ({ page }, use) => {
     await use(new ConfigSettingsPage(page))
+  },
+
+  governancePage: async ({ page }, use) => {
+    await use(new GovernancePage(page))
+  },
+
+  modelLimitsPage: async ({ page }, use) => {
+    await use(new ModelLimitsPage(page))
+  },
+
+  mcpSettingsPage: async ({ page }, use) => {
+    await use(new MCPSettingsPage(page))
+  },
+
+  mcpToolGroupsPage: async ({ page }, use) => {
+    await use(new MCPToolGroupsPage(page))
+  },
+
+  mcpAuthConfigPage: async ({ page }, use) => {
+    await use(new MCPAuthConfigPage(page))
   },
 })
 

--- a/tests/e2e/core/utils/selectors.ts
+++ b/tests/e2e/core/utils/selectors.ts
@@ -14,7 +14,9 @@ export const Selectors = {
     providerList: '[data-testid="provider-list"]',
     providerItem: (name: string) => `[data-testid="provider-item-${name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}"]`,
     addProviderBtn: '[data-testid="add-provider-btn"]',
-    
+    /** Add New Provider dropdown > Custom provider... (opens custom provider sheet) */
+    addProviderOptionCustom: '[data-testid="add-provider-option-custom"]',
+
     // Provider config
     providerConfig: '[data-testid="provider-config"]',
     addKeyBtn: '[data-testid="add-key-btn"]',

--- a/tests/e2e/features/config/config.spec.ts
+++ b/tests/e2e/features/config/config.spec.ts
@@ -42,6 +42,97 @@ test.describe('Config Settings', () => {
       await expect(configSettingsPage.saveBtn).toBeVisible()
       await expect(configSettingsPage.page.getByRole('heading', { name: /Pricing/i })).toBeVisible()
     })
+
+    test('should navigate to MCP settings', async ({ configSettingsPage }) => {
+      await configSettingsPage.goto('mcp-gateway')
+      await expect(configSettingsPage.page.getByTestId('mcp-settings-view')).toBeVisible()
+      await expect(configSettingsPage.page.getByTestId('mcp-agent-depth-input')).toBeVisible()
+      await expect(configSettingsPage.page.getByTestId('mcp-tool-timeout-input')).toBeVisible()
+    })
+  })
+
+  test.describe('MCP Settings', () => {
+    test('should display MCP settings form', async ({ configSettingsPage }) => {
+      await configSettingsPage.goto('mcp-gateway')
+
+      await expect(configSettingsPage.page.getByTestId('mcp-settings-view')).toBeVisible()
+      await expect(configSettingsPage.page.getByTestId('mcp-agent-depth-input')).toBeVisible()
+      await expect(configSettingsPage.page.getByTestId('mcp-tool-timeout-input')).toBeVisible()
+      await expect(configSettingsPage.page.getByTestId('mcp-binding-level')).toBeVisible()
+    })
+
+    test('should have save button disabled when no changes', async ({ configSettingsPage }) => {
+      await configSettingsPage.goto('mcp-gateway')
+
+      const saveBtn = configSettingsPage.page.getByTestId('mcp-settings-save-btn')
+      await expect(saveBtn).toBeVisible()
+      await expect(saveBtn).toBeDisabled()
+    })
+  })
+
+  test.describe('Pricing Config', () => {
+    let originalPricingUrl: string | null = null
+
+    test.beforeEach(async ({ configSettingsPage }) => {
+      await configSettingsPage.goto('pricing-config')
+      originalPricingUrl = await configSettingsPage.pricingDatasheetUrlInput.inputValue()
+    })
+
+    test.afterEach(async ({ configSettingsPage }) => {
+      await configSettingsPage.goto('pricing-config')
+      const canEdit = await configSettingsPage.pricingDatasheetUrlInput.isEditable().catch(() => false)
+      if (!canEdit || originalPricingUrl === null) return
+      await configSettingsPage.setPricingDatasheetUrl(originalPricingUrl)
+      const isSaveEnabled = await configSettingsPage.pricingSaveBtn.isDisabled().then((d) => !d)
+      if (isSaveEnabled) {
+        await configSettingsPage.savePricingConfig()
+        await configSettingsPage.dismissToasts()
+      }
+    })
+
+    test('should display pricing config view', async ({ configSettingsPage }) => {
+      await expect(configSettingsPage.pricingConfigView).toBeVisible()
+      await expect(configSettingsPage.pricingDatasheetUrlInput).toBeVisible()
+      await expect(configSettingsPage.pricingForceSyncBtn).toBeVisible()
+      await expect(configSettingsPage.pricingSaveBtn).toBeVisible()
+    })
+
+    test('should set and save datasheet URL', async ({ configSettingsPage }) => {
+      const testUrl = 'https://example.com/pricing.json'
+      await configSettingsPage.setPricingDatasheetUrl(testUrl)
+
+      const isSaveEnabled = await configSettingsPage.pricingSaveBtn.isDisabled().then((d) => !d)
+      if (!isSaveEnabled) {
+        test.skip(true, 'Save button disabled (no changes detected or RBAC)')
+        return
+      }
+
+      await configSettingsPage.savePricingConfig()
+      await configSettingsPage.dismissToasts()
+    })
+
+    test('should trigger force sync', async ({ configSettingsPage }) => {
+      const isForceSyncEnabled = await configSettingsPage.pricingForceSyncBtn.isDisabled().then((d) => !d)
+      if (!isForceSyncEnabled) {
+        test.skip(true, 'Force sync button disabled (RBAC or no datasheet URL)')
+        return
+      }
+
+      await configSettingsPage.triggerForceSync()
+      await configSettingsPage.dismissToasts()
+    })
+
+    test('should validate URL format', async ({ configSettingsPage }) => {
+      await configSettingsPage.pricingDatasheetUrlInput.fill('invalid-url-no-http')
+      const canSave = await configSettingsPage.pricingSaveBtn.isDisabled().then((d) => !d)
+      if (!canSave) {
+        test.skip(true, 'Save button disabled (RBAC)')
+        return
+      }
+      await configSettingsPage.pricingSaveBtn.click()
+
+      await expect(configSettingsPage.page.getByText(/URL must start with http|valid URL/i)).toBeVisible()
+    })
   })
 
   test.describe('Client Settings', () => {
@@ -65,6 +156,15 @@ test.describe('Config Settings', () => {
       await expect(configSettingsPage.dropExcessRequestsSwitch).toBeVisible()
       await expect(configSettingsPage.enableLiteLLMFallbacksSwitch).toBeVisible()
       await expect(configSettingsPage.disableDBPingsSwitch).toBeVisible()
+    })
+
+    test('should display async job result TTL input when available', async ({ configSettingsPage }) => {
+      const isVisible = await configSettingsPage.asyncJobResultTtlInput.isVisible().catch(() => false)
+      if (isVisible) {
+        await expect(configSettingsPage.asyncJobResultTtlInput).toBeVisible()
+      } else {
+        test.skip(true, 'Async job result TTL not available')
+      }
     })
 
     test('should toggle drop excess requests', async ({ configSettingsPage }) => {
@@ -162,6 +262,15 @@ test.describe('Config Settings', () => {
       // Check for main logging controls
       await expect(configSettingsPage.page.getByText(/Enable Logs/i)).toBeVisible()
       await expect(configSettingsPage.page.getByText(/Log Retention/i)).toBeVisible()
+    })
+
+    test('should display workspace logging headers textarea when available', async ({ configSettingsPage }) => {
+      const isVisible = await configSettingsPage.workspaceLoggingHeadersTextarea.isVisible().catch(() => false)
+      if (isVisible) {
+        await expect(configSettingsPage.workspaceLoggingHeadersTextarea).toBeVisible()
+      } else {
+        test.skip(true, 'Workspace logging headers not available (depends on log connector)')
+      }
     })
 
     test('should toggle content logging when available', async ({ configSettingsPage }) => {
@@ -272,9 +381,42 @@ test.describe('Config Settings', () => {
       await expect(configSettingsPage.saveBtn).toBeVisible()
     })
 
+    test('should display enforce auth on inference switch', async ({ configSettingsPage }) => {
+      const isVisible = await configSettingsPage.enforceAuthOnInferenceSwitch.isVisible().catch(() => false)
+      if (!isVisible) {
+        test.skip(true, 'Enforce auth on inference not available')
+        return
+      }
+      await expect(configSettingsPage.enforceAuthOnInferenceSwitch).toBeVisible()
+    })
+
+    test('should toggle enforce auth on inference', async ({ configSettingsPage }) => {
+      const isVisible = await configSettingsPage.enforceAuthOnInferenceSwitch.isVisible().catch(() => false)
+      if (!isVisible) {
+        test.skip(true, 'Enforce auth on inference not available')
+        return
+      }
+      const initialState = await configSettingsPage.getSwitchState(configSettingsPage.enforceAuthOnInferenceSwitch)
+      await configSettingsPage.toggleEnforceAuthOnInference()
+      const newState = await configSettingsPage.getSwitchState(configSettingsPage.enforceAuthOnInferenceSwitch)
+      expect(newState).toBe(!initialState)
+      await configSettingsPage.toggleEnforceAuthOnInference()
+      if (await configSettingsPage.hasPendingChanges()) {
+        await configSettingsPage.saveSettings()
+      }
+    })
+
+    test('should display required headers textarea', async ({ configSettingsPage }) => {
+      const isVisible = await configSettingsPage.requiredHeadersTextarea.isVisible().catch(() => false)
+      if (!isVisible) {
+        test.skip(true, 'Required headers control not available')
+        return
+      }
+      await expect(configSettingsPage.requiredHeadersTextarea).toBeVisible()
+    })
+
     test('should display rate limiting section', async ({ configSettingsPage }) => {
       const isVisible = await configSettingsPage.isRateLimitingSectionVisible()
-      // Rate limiting section should exist
       expect(isVisible).toBeDefined()
     })
   })

--- a/tests/e2e/features/config/pages/config-settings.page.ts
+++ b/tests/e2e/features/config/pages/config-settings.page.ts
@@ -18,14 +18,18 @@ export class ConfigSettingsPage extends BasePage {
   readonly dropExcessRequestsSwitch: Locator
   readonly enableLiteLLMFallbacksSwitch: Locator
   readonly disableDBPingsSwitch: Locator
+  readonly asyncJobResultTtlInput: Locator
 
   // Logging Settings
   readonly enableLoggingSwitch: Locator
   readonly disableContentLoggingSwitch: Locator
   readonly logRetentionDaysInput: Locator
+  readonly workspaceLoggingHeadersTextarea: Locator
 
   // Security Settings
   readonly rateLimitingSection: Locator
+  readonly enforceAuthOnInferenceSwitch: Locator
+  readonly requiredHeadersTextarea: Locator
 
   // Performance Tuning Settings
   readonly workerPoolSizeInput: Locator
@@ -33,6 +37,12 @@ export class ConfigSettingsPage extends BasePage {
 
   // Observability Settings
   readonly observabilityToggles: Locator
+
+  // Pricing Config
+  readonly pricingConfigView: Locator
+  readonly pricingDatasheetUrlInput: Locator
+  readonly pricingForceSyncBtn: Locator
+  readonly pricingSaveBtn: Locator
 
   constructor(page: Page) {
     super(page)
@@ -42,6 +52,7 @@ export class ConfigSettingsPage extends BasePage {
     this.dropExcessRequestsSwitch = page.locator('#drop-excess-requests')
     this.enableLiteLLMFallbacksSwitch = page.locator('#enable-litellm-fallbacks')
     this.disableDBPingsSwitch = page.locator('#disable-db-pings-in-health')
+    this.asyncJobResultTtlInput = page.getByTestId('client-settings-async-job-result-ttl-input')
 
     // Logging Settings locators
     this.enableLoggingSwitch = page.locator('#enable-logging')
@@ -49,9 +60,12 @@ export class ConfigSettingsPage extends BasePage {
     this.logRetentionDaysInput = page.getByLabel(/Log Retention Days/i).or(
       page.locator('#log-n-days')
     )
+    this.workspaceLoggingHeadersTextarea = page.getByTestId('workspace-logging-headers-textarea')
 
     // Security Settings locators
     this.rateLimitingSection = page.locator('text=Rate Limiting').locator('..')
+    this.enforceAuthOnInferenceSwitch = page.getByTestId('enforce-auth-on-inference-switch')
+    this.requiredHeadersTextarea = page.getByTestId('required-headers-textarea')
 
     // Performance Tuning locators
     this.workerPoolSizeInput = page.getByLabel(/Worker Pool Size/i)
@@ -59,6 +73,12 @@ export class ConfigSettingsPage extends BasePage {
 
     // Observability locators
     this.observabilityToggles = page.locator('button[role="switch"]')
+
+    // Pricing Config locators
+    this.pricingConfigView = page.getByTestId('pricing-config-view')
+    this.pricingDatasheetUrlInput = page.getByTestId('pricing-datasheet-url-input')
+    this.pricingForceSyncBtn = page.getByTestId('pricing-force-sync-btn')
+    this.pricingSaveBtn = page.getByTestId('pricing-save-btn')
   }
 
   async goto(path: string): Promise<void> {
@@ -258,6 +278,25 @@ export class ConfigSettingsPage extends BasePage {
     return await this.page.getByText(/Rate Limiting/i).isVisible()
   }
 
+  async toggleEnforceAuthOnInference(): Promise<void> {
+    await this.enforceAuthOnInferenceSwitch.click()
+  }
+
+  async setRequiredHeaders(value: string): Promise<void> {
+    await this.requiredHeadersTextarea.clear()
+    await this.requiredHeadersTextarea.fill(value)
+  }
+
+  async setWorkspaceLoggingHeaders(value: string): Promise<void> {
+    await this.workspaceLoggingHeadersTextarea.clear()
+    await this.workspaceLoggingHeadersTextarea.fill(value)
+  }
+
+  async setAsyncJobResultTtl(value: string): Promise<void> {
+    await this.asyncJobResultTtlInput.clear()
+    await this.asyncJobResultTtlInput.fill(value)
+  }
+
   // === Observability Settings Methods ===
 
   async getObservabilityConnectors(): Promise<string[]> {
@@ -277,5 +316,22 @@ export class ConfigSettingsPage extends BasePage {
     const connectorSection = this.page.locator('div').filter({ hasText: new RegExp(connectorName, 'i') }).first()
     const toggleSwitch = connectorSection.locator('button[role="switch"]').first()
     await toggleSwitch.click()
+  }
+
+  // === Pricing Config Methods ===
+
+  async setPricingDatasheetUrl(url: string): Promise<void> {
+    await this.pricingDatasheetUrlInput.clear()
+    await this.pricingDatasheetUrlInput.fill(url)
+  }
+
+  async triggerForceSync(): Promise<void> {
+    await this.pricingForceSyncBtn.click()
+    await this.waitForSuccessToast()
+  }
+
+  async savePricingConfig(): Promise<void> {
+    await this.pricingSaveBtn.click()
+    await this.waitForSuccessToast()
   }
 }

--- a/tests/e2e/features/dashboard/dashboard.spec.ts
+++ b/tests/e2e/features/dashboard/dashboard.spec.ts
@@ -211,14 +211,11 @@ test.describe('Dashboard', () => {
       await waitForNetworkIdle(dashboardPage.page)
       await dashboardPage.waitForChartsToLoad()
 
-      // Verify page loaded with correct state
+      // Verify page loaded with correct state from URL
       const url = dashboardPage.page.url()
       expect(url).toContain('period=7d')
-      // Chart state may be in URL or DOM - check both
-      const hasChartInUrl = url.includes('volume_chart=')
-      const toggleState = await dashboardPage.getChartToggleState(dashboardPage.volumeChartToggle)
-      // Either URL contains chart state OR DOM has toggle state
-      expect(hasChartInUrl || toggleState).toBeTruthy()
+      // volume_chart=line was in the URL - verify exact value persisted
+      expect(url).toContain('volume_chart=line')
     })
   })
 
@@ -227,20 +224,23 @@ test.describe('Dashboard', () => {
       // Wait for charts to load
       await dashboardPage.waitForChartsToLoad()
 
-      // Check that each chart card has a canvas or SVG element (chart content)
-      const volumeChartContent = dashboardPage.logVolumeChart.locator('canvas, svg')
-      const tokenChartContent = dashboardPage.tokenUsageChart.locator('canvas, svg')
-      const costChartContent = dashboardPage.costChart.locator('canvas, svg')
-      const modelChartContent = dashboardPage.modelUsageChart.locator('canvas, svg')
+      // Check that each chart card has a canvas or chart surface SVG (recharts-surface = actual chart, not icons)
+      const volumeChartContent = dashboardPage.logVolumeChart.locator('canvas, svg.recharts-surface')
+      const tokenChartContent = dashboardPage.tokenUsageChart.locator('canvas, svg.recharts-surface')
+      const costChartContent = dashboardPage.costChart.locator('canvas, svg.recharts-surface')
+      const modelChartContent = dashboardPage.modelUsageChart.locator('canvas, svg.recharts-surface')
 
-      // At least one of these should be visible (depends on data availability)
-      const hasVolumeChart = await volumeChartContent.count() > 0
-      const hasTokenChart = await tokenChartContent.count() > 0
-      const hasCostChart = await costChartContent.count() > 0
-      const hasModelChart = await modelChartContent.count() > 0
+      // Each chart card should have canvas or SVG content (chart library renders into these)
+      const volumeCount = await volumeChartContent.count()
+      const tokenCount = await tokenChartContent.count()
+      const costCount = await costChartContent.count()
+      const modelCount = await modelChartContent.count()
 
-      // All charts should have rendered content
-      expect(hasVolumeChart || hasTokenChart || hasCostChart || hasModelChart).toBe(true)
+      // All four chart cards should have rendered content (count > 0)
+      expect(volumeCount).toBeGreaterThan(0)
+      expect(tokenCount).toBeGreaterThan(0)
+      expect(costCount).toBeGreaterThan(0)
+      expect(modelCount).toBeGreaterThan(0)
     })
 
     test('should show chart legends', async ({ dashboardPage }) => {

--- a/tests/e2e/features/governance/governance.data.ts
+++ b/tests/e2e/features/governance/governance.data.ts
@@ -1,0 +1,19 @@
+import { CustomerConfig, TeamConfig } from './pages/governance.page'
+
+export function createTeamData(overrides: Partial<TeamConfig> = {}): TeamConfig {
+  const timestamp = Date.now()
+  return {
+    name: `E2E Team ${timestamp}`,
+    budget: { maxLimit: 100, resetDuration: '1M' },
+    ...overrides,
+  }
+}
+
+export function createCustomerData(overrides: Partial<CustomerConfig> = {}): CustomerConfig {
+  const timestamp = Date.now()
+  return {
+    name: `E2E Customer ${timestamp}`,
+    budget: { maxLimit: 50, resetDuration: '1d' },
+    ...overrides,
+  }
+}

--- a/tests/e2e/features/governance/governance.spec.ts
+++ b/tests/e2e/features/governance/governance.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+import { createCustomerData, createTeamData } from './governance.data'
+
+const createdTeams: string[] = []
+const createdCustomers: string[] = []
+
+test.describe('Governance - Teams', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.beforeEach(async ({ governancePage }) => {
+    await governancePage.gotoTeams()
+  })
+
+  test.afterEach(async ({ governancePage }) => {
+    await governancePage.closeTeamDialog()
+    for (const name of [...createdTeams]) {
+      try {
+        const exists = await governancePage.teamExists(name)
+        if (exists) {
+          await governancePage.deleteTeam(name)
+        }
+      } catch (e) {
+        console.error(`[CLEANUP] Failed to delete team ${name}:`, e)
+      }
+    }
+    createdTeams.length = 0
+    for (const name of [...createdCustomers]) {
+      try {
+        await governancePage.gotoCustomers()
+        const exists = await governancePage.customerExists(name)
+        if (exists) {
+          await governancePage.deleteCustomer(name)
+        }
+      } catch (e) {
+        console.error(`[CLEANUP] Failed to delete customer ${name}:`, e)
+      }
+    }
+    createdCustomers.length = 0
+  })
+
+  test('should display create team button or empty state', async ({ governancePage }) => {
+    const createVisible = await governancePage.teamsCreateBtn.isVisible().catch(() => false)
+    const emptyAddVisible = await governancePage.page.getByTestId('team-button-add').isVisible().catch(() => false)
+    expect(createVisible || emptyAddVisible).toBe(true)
+  })
+
+  test('should create a team', async ({ governancePage }) => {
+    const teamData = createTeamData({ name: `E2E Test Team ${Date.now()}` })
+    createdTeams.push(teamData.name)
+
+    await governancePage.createTeam(teamData)
+
+    const exists = await governancePage.teamExists(teamData.name)
+    expect(exists).toBe(true)
+  })
+
+  test('should edit a team', async ({ governancePage }) => {
+    const teamData = createTeamData({ name: `E2E Edit Team ${Date.now()}` })
+    createdTeams.push(teamData.name)
+    await governancePage.createTeam(teamData)
+
+    await governancePage.editTeam(teamData.name, { budget: { maxLimit: 129 } })
+
+    const exists = await governancePage.teamExists(teamData.name)
+    expect(exists).toBe(true)
+  })
+
+  test('should create team with customer assignment', async ({ governancePage }) => {
+    // 1. Create a customer (UI)
+    const customerData = createCustomerData({ name: `E2E Customer For Team ${Date.now()}` })
+    createdCustomers.push(customerData.name)
+    await governancePage.gotoCustomers()
+    await governancePage.createCustomer(customerData)
+
+    // 2. Go to Teams and create a team, assign the customer from the create-team dropdown (UI)
+    await governancePage.gotoTeams()
+    const teamData = createTeamData({
+      name: `E2E Team With Customer ${Date.now()}`,
+      customerName: customerData.name,
+    })
+    createdTeams.push(teamData.name)
+    await governancePage.createTeam(teamData)
+
+    // 3. Validate in UI that the customer was assigned (via data-testid)
+    const exists = await governancePage.teamExists(teamData.name)
+    expect(exists).toBe(true)
+    const customerCell = governancePage.getTeamRowCustomerCell(teamData.name)
+    await expect(customerCell).toContainText(customerData.name)
+  })
+
+  test('should delete a team', async ({ governancePage }) => {
+    const teamData = createTeamData({ name: `E2E Delete Team ${Date.now()}` })
+    createdTeams.push(teamData.name)
+    await governancePage.createTeam(teamData)
+
+    let exists = await governancePage.teamExists(teamData.name)
+    expect(exists).toBe(true)
+
+    await governancePage.deleteTeam(teamData.name)
+    const idx = createdTeams.indexOf(teamData.name)
+    if (idx >= 0) createdTeams.splice(idx, 1)
+
+    exists = await governancePage.teamExists(teamData.name)
+    expect(exists).toBe(false)
+  })
+})
+
+test.describe('Governance - Customers', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.beforeEach(async ({ governancePage }) => {
+    await governancePage.gotoCustomers()
+  })
+
+  test.afterEach(async ({ governancePage }) => {
+    for (const name of [...createdCustomers]) {
+      try {
+        const exists = await governancePage.customerExists(name)
+        if (exists) {
+          await governancePage.deleteCustomer(name)
+        }
+      } catch (e) {
+        console.error(`[CLEANUP] Failed to delete customer ${name}:`, e)
+      }
+    }
+    createdCustomers.length = 0
+  })
+
+  test('should display create customer button or empty state', async ({ governancePage }) => {
+    const createVisible = await governancePage.customersCreateBtn.isVisible().catch(() => false)
+    const emptyCreateVisible = await governancePage.page.getByTestId('customer-button-create').isVisible().catch(() => false)
+    expect(createVisible || emptyCreateVisible).toBe(true)
+  })
+
+  test('should create a customer', async ({ governancePage }) => {
+    const customerData = createCustomerData({ name: `E2E Test Customer ${Date.now()}` })
+    createdCustomers.push(customerData.name)
+
+    await governancePage.createCustomer(customerData)
+
+    const exists = await governancePage.customerExists(customerData.name)
+    expect(exists).toBe(true)
+  })
+
+  test('should edit a customer', async ({ governancePage }) => {
+    const customerData = createCustomerData({ name: `E2E Edit Customer ${Date.now()}` })
+    createdCustomers.push(customerData.name)
+    await governancePage.createCustomer(customerData)
+
+    const newName = `E2E Edited Customer ${Date.now()}`
+    createdCustomers[createdCustomers.length - 1] = newName
+    await governancePage.editCustomer(customerData.name, { name: newName })
+
+    const oldExists = await governancePage.customerExists(customerData.name)
+    const newExists = await governancePage.customerExists(newName)
+    expect(oldExists).toBe(false)
+    expect(newExists).toBe(true)
+  })
+
+  test('should delete a customer', async ({ governancePage }) => {
+    const customerData = createCustomerData({ name: `E2E Delete Customer ${Date.now()}` })
+    createdCustomers.push(customerData.name)
+    await governancePage.createCustomer(customerData)
+
+    let exists = await governancePage.customerExists(customerData.name)
+    expect(exists).toBe(true)
+
+    await governancePage.deleteCustomer(customerData.name)
+    const idx = createdCustomers.indexOf(customerData.name)
+    if (idx >= 0) createdCustomers.splice(idx, 1)
+
+    exists = await governancePage.customerExists(customerData.name)
+    expect(exists).toBe(false)
+  })
+})

--- a/tests/e2e/features/governance/pages/governance.page.ts
+++ b/tests/e2e/features/governance/pages/governance.page.ts
@@ -1,0 +1,229 @@
+import { Locator, Page } from '@playwright/test'
+import { expect } from '../../../core/fixtures/base.fixture'
+import { BasePage } from '../../../core/pages/base.page'
+import { fillSelect, waitForNetworkIdle } from '../../../core/utils/test-helpers'
+
+export interface TeamConfig {
+  name: string
+  /** Assign by customer id (from API). Prefer customerName for UI-only flow. */
+  customerId?: string
+  /** Assign by customer name in the create-team dropdown (UI-only, no API). */
+  customerName?: string
+  budget?: { maxLimit: number; resetDuration?: string }
+  rateLimit?: {
+    tokenMaxLimit?: number
+    tokenResetDuration?: string
+    requestMaxLimit?: number
+    requestResetDuration?: string
+  }
+}
+
+export interface CustomerConfig {
+  name: string
+  budget?: { maxLimit: number; resetDuration?: string }
+  rateLimit?: {
+    tokenMaxLimit?: number
+    tokenResetDuration?: string
+    requestMaxLimit?: number
+    requestResetDuration?: string
+  }
+}
+
+export class GovernancePage extends BasePage {
+  // Teams
+  readonly teamsCreateBtn: Locator
+  readonly teamsTable: Locator
+  readonly teamDialog: Locator
+  readonly teamNameInput: Locator
+
+  // Customers
+  readonly customersCreateBtn: Locator
+  readonly customersTable: Locator
+  readonly customerDialog: Locator
+  readonly customerNameInput: Locator
+
+  constructor(page: Page) {
+    super(page)
+
+    this.teamsCreateBtn = page.getByTestId('create-team-btn').or(page.getByTestId('team-button-add'))
+    this.teamsTable = page.getByTestId('teams-table')
+    this.teamDialog = page.getByTestId('team-dialog-content')
+    this.teamNameInput = page.getByTestId('team-name-input')
+
+    this.customersCreateBtn = page.getByTestId('customer-button-create')
+    this.customersTable = page.getByTestId('customer-table-container')
+    this.customerDialog = page.getByTestId('customer-dialog-content')
+    this.customerNameInput = page.getByTestId('customer-name-input')
+  }
+
+  async gotoTeams(): Promise<void> {
+    await this.page.goto('/workspace/governance/teams')
+    await waitForNetworkIdle(this.page)
+  }
+
+  async gotoCustomers(): Promise<void> {
+    await this.page.goto('/workspace/governance/customers')
+    await waitForNetworkIdle(this.page)
+  }
+
+  getTeamRow(name: string): Locator {
+    return this.page.getByTestId(`team-row-${name}`)
+  }
+
+  /** Customer cell for a team row (use for asserting assigned customer in UI). */
+  getTeamRowCustomerCell(teamName: string): Locator {
+    return this.page.getByTestId(`team-row-${teamName}-customer`)
+  }
+
+  async teamExists(name: string): Promise<boolean> {
+    const row = this.getTeamRow(name)
+    return (await row.count()) > 0
+  }
+
+  async createTeam(config: TeamConfig): Promise<void> {
+    await this.teamsCreateBtn.click()
+    await expect(this.teamDialog).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+
+    await this.teamNameInput.fill(config.name)
+
+    if (config.customerId !== undefined || config.customerName !== undefined) {
+      const trigger = this.page.getByTestId('team-customer-select-trigger')
+      await trigger.click()
+      if (config.customerId === '') {
+        await this.page.getByTestId('team-customer-option-none').click()
+      } else if (config.customerName !== undefined) {
+        const customerOption = this.page
+          .locator('[data-testid^="team-customer-option-"]')
+          .filter({ hasText: config.customerName })
+        await customerOption.waitFor({ state: 'visible', timeout: 5000 })
+        await customerOption.click()
+      } else if (config.customerId !== undefined && config.customerId !== '') {
+        const customerOption = this.page.getByTestId(`team-customer-option-${config.customerId}`)
+        await customerOption.waitFor({ state: 'visible', timeout: 5000 })
+        await customerOption.click()
+      }
+    }
+
+    if (config.budget?.maxLimit !== undefined) {
+      const budgetInput = this.page.getByTestId('budget-max-limit-input')
+      await budgetInput.fill(String(config.budget.maxLimit))
+    }
+
+    const saveBtn = this.teamDialog.getByRole('button', { name: /Create Team/i })
+    await expect(saveBtn).toBeEnabled()
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+    await expect(this.teamDialog).not.toBeVisible({ timeout: 10000 })
+  }
+
+  async deleteTeam(name: string): Promise<void> {
+    const deleteBtn = this.page.getByTestId(`team-delete-btn-${name}`)
+    await deleteBtn.click()
+
+    const confirmDialog = this.page.locator('[role="alertdialog"]')
+    await confirmDialog.getByRole('button', { name: /Delete/i }).click()
+    await this.waitForSuccessToast()
+    await expect.poll(() => this.teamExists(name), { timeout: 10000 }).toBe(false)
+  }
+
+  async closeTeamDialog(): Promise<void> {
+    if (await this.teamDialog.isVisible().catch(() => false)) {
+      await this.teamDialog.getByRole('button', { name: /Cancel/i }).click()
+      await expect(this.teamDialog).not.toBeVisible({ timeout: 10000 })
+    }
+  }
+
+  getCustomerRow(name: string): Locator {
+    return this.customersTable.getByTestId(`customer-row-${name}`)
+  }
+
+  async customerExists(name: string): Promise<boolean> {
+    const row = this.getCustomerRow(name)
+    return (await row.count()) > 0
+  }
+
+  async createCustomer(config: CustomerConfig): Promise<void> {
+    await this.customersCreateBtn.click()
+    await expect(this.customerDialog).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+
+    await this.customerNameInput.fill(config.name)
+
+    if (config.budget?.maxLimit !== undefined) {
+      const budgetInput = this.page.getByTestId('budget-max-limit-input')
+      await budgetInput.fill(String(config.budget.maxLimit))
+    }
+
+    const saveBtn = this.customerDialog.getByRole('button', { name: /Create Customer/i })
+    await expect(saveBtn).toBeEnabled()
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+    await expect(this.customerDialog).not.toBeVisible({ timeout: 10000 })
+  }
+
+  async deleteCustomer(name: string): Promise<void> {
+    const row = this.getCustomerRow(name)
+    const deleteBtn = row.locator('[data-testid^="customer-button-delete-"]')
+    await deleteBtn.click()
+
+    const confirmBtn = this.page.getByTestId('customer-button-delete-confirm')
+    await confirmBtn.waitFor({ state: 'visible', timeout: 5000 })
+    await confirmBtn.click()
+    await this.waitForSuccessToast()
+    await expect.poll(() => this.customerExists(name), { timeout: 10000 }).toBe(false)
+  }
+
+  async editTeam(name: string, updates: Partial<TeamConfig>): Promise<void> {
+    const editBtn = this.page.getByTestId(`team-edit-btn-${name}`)
+    await editBtn.click()
+    await expect(this.teamDialog).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+
+    if (updates.name) {
+      await this.teamNameInput.clear()
+      await this.teamNameInput.fill(updates.name)
+    }
+
+    if (updates.customerId !== undefined) {
+      const trigger = this.page.getByTestId('team-customer-select-trigger')
+      await trigger.click()
+      if (updates.customerId === '') {
+        await this.page.getByTestId('team-customer-option-none').click()
+      } else {
+        await this.page.getByTestId(`team-customer-option-${updates.customerId}`).click()
+      }
+    }
+
+    if (updates.budget?.maxLimit !== undefined) {
+      const budgetInput = this.page.getByTestId('budget-max-limit-input')
+      await budgetInput.clear()
+      await budgetInput.fill(String(updates.budget.maxLimit))
+    }
+
+    const saveBtn = this.teamDialog.getByRole('button', { name: /Save|Update/i })
+    await expect(saveBtn).toBeEnabled()
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+    await expect(this.teamDialog).not.toBeVisible({ timeout: 10000 })
+  }
+
+  async editCustomer(name: string, updates: Partial<CustomerConfig>): Promise<void> {
+    const row = this.getCustomerRow(name)
+    const editBtn = row.locator('[data-testid^="customer-button-edit-"]')
+    await editBtn.click()
+    await expect(this.customerDialog).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+
+    if (updates.name) {
+      await this.customerNameInput.clear()
+      await this.customerNameInput.fill(updates.name)
+    }
+
+    const saveBtn = this.customerDialog.getByRole('button', { name: /Save|Update/i })
+    await expect(saveBtn).toBeEnabled()
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+    await expect(this.customerDialog).not.toBeVisible({ timeout: 10000 })
+  }
+}

--- a/tests/e2e/features/mcp-auth-config/mcp-auth-config.spec.ts
+++ b/tests/e2e/features/mcp-auth-config/mcp-auth-config.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+
+// MCP Auth Config routes to @enterprise components not present in OSS.
+// Tests only verify URL routing; do not add UI assertions for enterprise-only content.
+test.describe('MCP Auth Config', () => {
+  test.beforeEach(async ({ mcpAuthConfigPage }) => {
+    await mcpAuthConfigPage.goto()
+  })
+
+  test('should load MCP auth config page', async ({ mcpAuthConfigPage }) => {
+    await expect(mcpAuthConfigPage.page).toHaveURL(/mcp-auth-config/)
+  })
+})

--- a/tests/e2e/features/mcp-auth-config/pages/mcp-auth-config.page.ts
+++ b/tests/e2e/features/mcp-auth-config/pages/mcp-auth-config.page.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test'
+import { BasePage } from '../../../core/pages/base.page'
+import { waitForNetworkIdle } from '../../../core/utils/test-helpers'
+
+export class MCPAuthConfigPage extends BasePage {
+  constructor(page: Page) {
+    super(page)
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/workspace/mcp-auth-config')
+    await waitForNetworkIdle(this.page)
+  }
+}

--- a/tests/e2e/features/mcp-registry/mcp-registry.spec.ts
+++ b/tests/e2e/features/mcp-registry/mcp-registry.spec.ts
@@ -6,6 +6,8 @@ import {
     createSTDIOClientData
 } from './mcp-registry.data'
 
+const hasSSEHeaders = Boolean(process.env.MCP_SSE_HEADERS)
+
 // Track created clients for cleanup
 const createdClients: string[] = []
 
@@ -39,10 +41,10 @@ test.describe('MCP Registry', () => {
       const isEmptyStateVisible = await mcpRegistryPage.isEmptyStateVisible()
 
       if (count === 0) {
-        // Empty state or empty table
-        expect(isEmptyStateVisible || count === 0).toBe(true)
+        expect(isEmptyStateVisible).toBe(true)
       } else {
         expect(count).toBeGreaterThan(0)
+        expect(isEmptyStateVisible).toBe(false)
       }
     })
   })
@@ -66,9 +68,14 @@ test.describe('MCP Registry', () => {
       createdClients.push(clientData.name)
       const exists = await mcpRegistryPage.clientExists(clientData.name)
       expect(exists).toBe(true)
+
+      // Verify connection type displayed correctly
+      const connectionType = await mcpRegistryPage.getClientConnectionType(clientData.name)
+      expect(connectionType).toBe('HTTP')
     })
 
     test('should create SSE client', async ({ mcpRegistryPage }) => {
+      test.skip(!hasSSEHeaders, 'Requires MCP_SSE_HEADERS for authenticated SSE MCP endpoint')
       const clientData = createSSEClientData({
         name: `sse_test_${Date.now()}`,
       })
@@ -79,6 +86,10 @@ test.describe('MCP Registry', () => {
       createdClients.push(clientData.name)
       const exists = await mcpRegistryPage.clientExists(clientData.name)
       expect(exists).toBe(true)
+
+      // Verify connection type displayed correctly
+      const connectionType = await mcpRegistryPage.getClientConnectionType(clientData.name)
+      expect(connectionType).toBe('SSE')
     })
 
     test('should create STDIO client with command', async ({ mcpRegistryPage }) => {
@@ -151,6 +162,7 @@ test.describe('MCP Registry', () => {
     })
 
     test('should connect to SSE server and list tools', async ({ mcpRegistryPage }) => {
+      test.skip(!hasSSEHeaders, 'Requires MCP_SSE_HEADERS for authenticated SSE MCP endpoint')
       const clientData = createSSEClientData({
         name: `sse_validation_${Date.now()}`,
       })
@@ -264,13 +276,15 @@ test.describe('MCP Registry', () => {
       expect(created).toBe(true) // Client creation must succeed for this test
       createdClients.push(clientData.name)
 
-      // Reconnect - this should succeed even if connection fails
-      // The button click and toast are the main verification
+      // Reconnect - method waits for success toast
       await mcpRegistryPage.reconnectClient(clientData.name)
 
-      // Client should still exist
+      // Verify client still exists and has a status (reconnect completed)
       const exists = await mcpRegistryPage.clientExists(clientData.name)
       expect(exists).toBe(true)
+      const status = await mcpRegistryPage.getClientStatus(clientData.name)
+      expect(status).toBeTruthy()
+      expect(['connected', 'disconnected', 'connecting']).toContain(status.toLowerCase())
     })
   })
 

--- a/tests/e2e/features/mcp-registry/pages/mcp-registry.page.ts
+++ b/tests/e2e/features/mcp-registry/pages/mcp-registry.page.ts
@@ -596,6 +596,22 @@ export class MCPRegistryPage extends BasePage {
   }
 
   /**
+   * Get connection type displayed in the table (HTTP, SSE, STDIO)
+   */
+  async getClientConnectionType(name: string): Promise<string> {
+    const row = this.getClientRow(name)
+    const typeCell = row.getByTestId('mcp-client-connection-type')
+    if ((await typeCell.count()) > 0) {
+      return (await typeCell.first().textContent())?.trim() ?? ''
+    }
+    const cells = row.locator('td')
+    if ((await cells.count()) >= 2) {
+      return (await cells.nth(1).textContent())?.trim() ?? ''
+    }
+    return ''
+  }
+
+  /**
    * Get tools count from the client details sheet
    * Assumes the detail sheet is already open
    */

--- a/tests/e2e/features/mcp-settings/mcp-settings.spec.ts
+++ b/tests/e2e/features/mcp-settings/mcp-settings.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+
+test.describe('MCP Settings', () => {
+  test.beforeEach(async ({ mcpSettingsPage }) => {
+    await mcpSettingsPage.goto()
+  })
+
+  test('should display MCP settings page', async ({ mcpSettingsPage }) => {
+    await expect(mcpSettingsPage.mcpSettingsView).toBeVisible()
+  })
+
+  test('should display MCP settings form fields', async ({ mcpSettingsPage }) => {
+    await expect(mcpSettingsPage.page.getByLabel('Max Agent Depth')).toBeVisible()
+    await expect(mcpSettingsPage.page.getByLabel('Tool Execution Timeout (seconds)')).toBeVisible()
+  })
+
+  test('should have save button disabled when no changes', async ({ mcpSettingsPage }) => {
+    await expect(mcpSettingsPage.saveBtn).toBeVisible()
+    await expect(mcpSettingsPage.saveBtn).toBeDisabled()
+  })
+})

--- a/tests/e2e/features/mcp-settings/pages/mcp-settings.page.ts
+++ b/tests/e2e/features/mcp-settings/pages/mcp-settings.page.ts
@@ -1,0 +1,24 @@
+import { Locator, Page } from '@playwright/test'
+import { BasePage } from '../../../core/pages/base.page'
+import { waitForNetworkIdle } from '../../../core/utils/test-helpers'
+
+export class MCPSettingsPage extends BasePage {
+  readonly mcpSettingsView: Locator
+  readonly saveBtn: Locator
+  readonly maxAgentDepthInput: Locator
+  readonly toolTimeoutInput: Locator
+
+  constructor(page: Page) {
+    super(page)
+
+    this.mcpSettingsView = page.getByTestId('mcp-settings-view')
+    this.saveBtn = page.getByTestId('mcp-settings-save-btn')
+    this.maxAgentDepthInput = page.getByTestId('mcp-agent-depth-input').or(page.locator('#mcp-agent-depth'))
+    this.toolTimeoutInput = page.getByTestId('mcp-tool-timeout-input').or(page.locator('#mcp-tool-execution-timeout'))
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/workspace/mcp-settings')
+    await waitForNetworkIdle(this.page)
+  }
+}

--- a/tests/e2e/features/mcp-tool-groups/mcp-tool-groups.spec.ts
+++ b/tests/e2e/features/mcp-tool-groups/mcp-tool-groups.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+
+// MCP Tool Groups routes to @enterprise components not present in OSS.
+// Tests only verify URL routing; do not add UI assertions for enterprise-only content.
+test.describe('MCP Tool Groups', () => {
+  test.beforeEach(async ({ mcpToolGroupsPage }) => {
+    await mcpToolGroupsPage.goto()
+  })
+
+  test('should load MCP tool groups page', async ({ mcpToolGroupsPage }) => {
+    await expect(mcpToolGroupsPage.page).toHaveURL(/mcp-tool-groups/)
+  })
+})

--- a/tests/e2e/features/mcp-tool-groups/pages/mcp-tool-groups.page.ts
+++ b/tests/e2e/features/mcp-tool-groups/pages/mcp-tool-groups.page.ts
@@ -1,0 +1,14 @@
+import { Page } from '@playwright/test'
+import { BasePage } from '../../../core/pages/base.page'
+import { waitForNetworkIdle } from '../../../core/utils/test-helpers'
+
+export class MCPToolGroupsPage extends BasePage {
+  constructor(page: Page) {
+    super(page)
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/workspace/mcp-tool-groups')
+    await waitForNetworkIdle(this.page)
+  }
+}

--- a/tests/e2e/features/model-limits/model-limits.data.ts
+++ b/tests/e2e/features/model-limits/model-limits.data.ts
@@ -1,0 +1,11 @@
+import { ModelLimitConfig } from './pages/model-limits.page'
+
+export function createModelLimitData(overrides: Partial<ModelLimitConfig> = {}): ModelLimitConfig {
+  return {
+    provider: 'openai',
+    modelName: 'gpt-4o-mini',
+    budget: { maxLimit: 10, resetDuration: '1M' },
+    rateLimit: { tokenMaxLimit: 1000, requestMaxLimit: 50 },
+    ...overrides,
+  }
+}

--- a/tests/e2e/features/model-limits/model-limits.spec.ts
+++ b/tests/e2e/features/model-limits/model-limits.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+import { createModelLimitData } from './model-limits.data'
+
+const createdLimits: { modelName: string; provider: string }[] = []
+
+test.describe('Model Limits', () => {
+  test.beforeEach(async ({ modelLimitsPage }) => {
+    await modelLimitsPage.goto()
+  })
+
+  test.afterEach(async ({ modelLimitsPage }) => {
+    await modelLimitsPage.closeSheet()
+    for (const { modelName, provider } of [...createdLimits]) {
+      try {
+        const exists = await modelLimitsPage.modelLimitExists(modelName, provider)
+        if (exists) {
+          await modelLimitsPage.deleteModelLimit(modelName, provider)
+        }
+      } catch (e) {
+        console.error(`[CLEANUP] Failed to delete model limit ${modelName}:`, e)
+      }
+    }
+    createdLimits.length = 0
+  })
+
+  test('should display create button or empty state', async ({ modelLimitsPage }) => {
+    const createVisible = await modelLimitsPage.createBtn.isVisible().catch(() => false)
+    expect(createVisible).toBe(true)
+  })
+
+  test('should create a model limit with budget and rate limit', async ({ modelLimitsPage }) => {
+    const limitData = createModelLimitData({
+      provider: 'openai',
+      budget: { maxLimit: 5, resetDuration: '1M' },
+      rateLimit: { tokenMaxLimit: 500, requestMaxLimit: 20 },
+    })
+
+    const modelName = await modelLimitsPage.createModelLimit(limitData)
+    createdLimits.push({ modelName, provider: limitData.provider })
+
+    const exists = await modelLimitsPage.modelLimitExists(modelName, limitData.provider)
+    expect(exists).toBe(true)
+  })
+
+  test('should edit a model limit budget and rate limit', async ({ modelLimitsPage }) => {
+    const limitData = createModelLimitData({ provider: 'openai' })
+
+    const modelName = await modelLimitsPage.createModelLimit(limitData)
+    createdLimits.push({ modelName, provider: limitData.provider })
+
+    await modelLimitsPage.editModelLimit(modelName, limitData.provider, {
+      budget: { maxLimit: 20 },
+      rateLimit: { tokenMaxLimit: 2000, requestMaxLimit: 100 },
+    })
+
+    const exists = await modelLimitsPage.modelLimitExists(modelName, limitData.provider)
+    expect(exists).toBe(true)
+  })
+
+  test('should delete a model limit', async ({ modelLimitsPage }) => {
+    const limitData = createModelLimitData({
+      provider: 'openai',
+      budget: { maxLimit: 5 },
+    })
+
+    const modelName = await modelLimitsPage.createModelLimit(limitData)
+    createdLimits.push({ modelName, provider: limitData.provider })
+
+    let exists = await modelLimitsPage.modelLimitExists(modelName, limitData.provider)
+    expect(exists).toBe(true)
+
+    await modelLimitsPage.deleteModelLimit(modelName, limitData.provider)
+    const idx = createdLimits.findIndex(
+      (limit) => limit.modelName === modelName && limit.provider === limitData.provider
+    )
+    if (idx >= 0) createdLimits.splice(idx, 1)
+
+    exists = await modelLimitsPage.modelLimitExists(modelName, limitData.provider)
+    expect(exists).toBe(false)
+  })
+})

--- a/tests/e2e/features/model-limits/pages/model-limits.page.ts
+++ b/tests/e2e/features/model-limits/pages/model-limits.page.ts
@@ -1,0 +1,138 @@
+import type { Locator, Page } from '@playwright/test'
+import { expect } from '../../../core/fixtures/base.fixture'
+import { BasePage } from '../../../core/pages/base.page'
+import { fillSelect, waitForNetworkIdle } from '../../../core/utils/test-helpers'
+
+export interface ModelLimitConfig {
+  provider: string
+  modelName: string
+  budget?: { maxLimit: number; resetDuration?: string }
+  rateLimit?: {
+    tokenMaxLimit?: number
+    requestMaxLimit?: number
+  }
+}
+
+function toTestIdPart(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+}
+
+export class ModelLimitsPage extends BasePage {
+  readonly createBtn: Locator
+  readonly table: Locator
+  readonly sheet: Locator
+
+  constructor(page: Page) {
+    super(page)
+
+    this.createBtn = page.getByTestId('model-limits-button-create')
+    this.table = page.getByTestId('model-limits-table')
+    this.sheet = page.getByTestId('model-limit-sheet')
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/workspace/model-limits')
+    await waitForNetworkIdle(this.page)
+  }
+
+  getModelLimitRow(modelName: string, provider: string = 'all'): Locator {
+    return this.page.getByTestId(`model-limit-row-${toTestIdPart(modelName)}-${toTestIdPart(provider)}`)
+  }
+
+  async modelLimitExists(modelName: string, provider: string = 'all'): Promise<boolean> {
+    const row = this.getModelLimitRow(modelName, provider)
+    return (await row.count()) > 0
+  }
+
+  /**
+   * Create a model limit via the sheet: selects provider, selects the requested
+   * model (config.modelName) in the search dropdown, fills budget and rate
+   * limit, then saves. Returns the selected model name for use in exists/edit/delete.
+   */
+  async createModelLimit(config: ModelLimitConfig): Promise<string> {
+    await this.createBtn.click()
+    await expect(this.sheet).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+
+    // Select provider (stable testid; sheet is the only one open)
+    await fillSelect(
+      this.page,
+      '[data-testid="model-limit-provider-select"]',
+      config.provider === 'all' ? 'All Providers' : config.provider
+    )
+
+    // Model multiselect - search and select requested model deterministically
+    const modelSelectContainer = this.sheet.getByTestId('model-limit-model-select')
+    const modelInput = modelSelectContainer.locator('input')
+    await modelInput.fill(config.modelName)
+    await this.page.waitForSelector('[role="option"]', { timeout: 10000 })
+    const targetOption = this.page.getByRole('option', { name: config.modelName, exact: true })
+    await expect(targetOption).toBeVisible({ timeout: 10000 })
+    await targetOption.click()
+    const selectedModelName = config.modelName
+
+    if (config.budget?.maxLimit !== undefined) {
+      const budgetInput = this.page.locator('#modelBudgetMaxLimit')
+      await budgetInput.fill(String(config.budget.maxLimit))
+    }
+
+    if (config.rateLimit?.tokenMaxLimit !== undefined) {
+      await this.page.locator('#modelTokenMaxLimit').fill(String(config.rateLimit.tokenMaxLimit))
+    }
+    if (config.rateLimit?.requestMaxLimit !== undefined) {
+      await this.page.locator('#modelRequestMaxLimit').fill(String(config.rateLimit.requestMaxLimit))
+    }
+
+    const saveBtn = this.page.getByRole('button', { name: /Create Limit/i })
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+    await expect(this.sheet).not.toBeVisible({ timeout: 10000 })
+    return selectedModelName
+  }
+
+  async editModelLimit(modelName: string, provider: string, updates: Partial<ModelLimitConfig>): Promise<void> {
+    const editBtn = this.page.getByTestId(`model-limit-button-edit-${toTestIdPart(modelName)}-${toTestIdPart(provider)}`)
+    await editBtn.click()
+    await expect(this.sheet).toBeVisible({ timeout: 5000 })
+    await this.waitForSheetAnimation()
+
+    if (updates.budget?.maxLimit !== undefined) {
+      const budgetInput = this.page.locator('#modelBudgetMaxLimit')
+      await budgetInput.clear()
+      await budgetInput.fill(String(updates.budget.maxLimit))
+    }
+
+    if (updates.rateLimit?.tokenMaxLimit !== undefined) {
+      const tokenInput = this.page.locator('#modelTokenMaxLimit')
+      await tokenInput.clear()
+      await tokenInput.fill(String(updates.rateLimit.tokenMaxLimit))
+    }
+    if (updates.rateLimit?.requestMaxLimit !== undefined) {
+      const requestInput = this.page.locator('#modelRequestMaxLimit')
+      await requestInput.clear()
+      await requestInput.fill(String(updates.rateLimit.requestMaxLimit))
+    }
+
+    const saveBtn = this.page.getByRole('button', { name: /Save Changes|Create Limit/i })
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+    await expect(this.sheet).not.toBeVisible({ timeout: 10000 })
+  }
+
+  async deleteModelLimit(modelName: string, provider: string = 'all'): Promise<void> {
+    const deleteBtn = this.page.getByTestId(`model-limit-button-delete-${toTestIdPart(modelName)}-${toTestIdPart(provider)}`)
+    await deleteBtn.click()
+
+    const confirmDialog = this.page.locator('[role="alertdialog"]')
+    await confirmDialog.getByRole('button', { name: /Delete/i }).click()
+    await this.waitForSuccessToast()
+    await this.page.waitForTimeout(1000)
+  }
+
+  async closeSheet(): Promise<void> {
+    if (await this.sheet.isVisible().catch(() => false)) {
+      await this.page.keyboard.press('Escape')
+      await expect(this.sheet).not.toBeVisible({ timeout: 5000 }).catch(() => {})
+    }
+  }
+}

--- a/tests/e2e/features/observability/observability.spec.ts
+++ b/tests/e2e/features/observability/observability.spec.ts
@@ -23,15 +23,15 @@ test.describe('Observability', () => {
     })
 
     test('should display OTel connector tab', async ({ observabilityPage }) => {
-      await expect(observabilityPage.otelTab).toBeVisible()
+      await expect(observabilityPage.getConnectorTab('otel')).toBeVisible()
     })
 
     test('should display Maxim connector tab', async ({ observabilityPage }) => {
-      await expect(observabilityPage.maximTab).toBeVisible()
+      await expect(observabilityPage.getConnectorTab('maxim')).toBeVisible()
     })
 
     test('should display Datadog connector tab', async ({ observabilityPage }) => {
-      await expect(observabilityPage.datadogTab).toBeVisible()
+      await expect(observabilityPage.getConnectorTab('datadog')).toBeVisible()
     })
   })
 
@@ -62,20 +62,36 @@ test.describe('Observability', () => {
       await observabilityPage.selectConnector('otel')
 
       // Check if toggle is enabled (not disabled)
-      const isToggleEnabled = await observabilityPage.isToggleEnabled()
+      const isToggleEnabled = await observabilityPage.isToggleEnabled('otel')
 
       if (!isToggleEnabled) {
         test.skip(true, 'OTel toggle is disabled (requires configuration)')
         return
       }
 
-      const initialState = await observabilityPage.isConnectorEnabled()
+      const initialState = await observabilityPage.isConnectorEnabled('otel')
 
-      const toggled = await observabilityPage.toggleConnector()
+      const toggled = await observabilityPage.toggleConnector('otel')
       expect(toggled).toBe(true)
 
-      const newState = await observabilityPage.isConnectorEnabled()
-      expect(newState).toBe(!initialState)
+      // Verify toggle state flipped; poll briefly in case UI updates async (form can reset from refetch)
+      await expect
+        .poll(async () => observabilityPage.isConnectorEnabled('otel'), { timeout: 3000 })
+        .toBe(!initialState)
+    })
+
+    test('should display OTel delete button when connector is configured', async ({ observabilityPage }) => {
+      await observabilityPage.selectConnector('otel')
+
+      const deleteBtn = observabilityPage.getConnectorDeleteBtn('otel')
+      const isVisible = await deleteBtn.isVisible().catch(() => false)
+
+      if (!isVisible) {
+        test.skip(true, 'OTel delete button not visible (connector may not be configured)')
+        return
+      }
+
+      await expect(deleteBtn).toBeVisible()
     })
 
     test('should configure OTel endpoint', async ({ observabilityPage }) => {
@@ -113,19 +129,19 @@ test.describe('Observability', () => {
       await observabilityPage.selectConnector('maxim')
 
       // Check if toggle is enabled
-      const isToggleEnabled = await observabilityPage.isToggleEnabled()
+      const isToggleEnabled = await observabilityPage.isToggleEnabled('maxim')
 
       if (!isToggleEnabled) {
         test.skip(true, 'Maxim toggle is disabled (requires configuration)')
         return
       }
 
-      const initialState = await observabilityPage.isConnectorEnabled()
+      const initialState = await observabilityPage.isConnectorEnabled('maxim')
 
-      const toggled = await observabilityPage.toggleConnector()
+      const toggled = await observabilityPage.toggleConnector('maxim')
       expect(toggled).toBe(true)
 
-      const newState = await observabilityPage.isConnectorEnabled()
+      const newState = await observabilityPage.isConnectorEnabled('maxim')
       expect(newState).toBe(!initialState)
     })
 
@@ -144,6 +160,99 @@ test.describe('Observability', () => {
         const inputsVisible = await observabilityPage.page.locator('input').first().isVisible().catch(() => false)
         expect(inputsVisible).toBe(true)
       }
+    })
+  })
+
+  test.describe('Prometheus Connector', () => {
+    test('should select Prometheus connector', async ({ observabilityPage }) => {
+      const isAvailable = await observabilityPage.isConnectorAvailable('prometheus')
+
+      if (!isAvailable) {
+        test.skip(true, 'Prometheus connector not available')
+        return
+      }
+
+      await observabilityPage.selectConnector('prometheus')
+
+      const selected = await observabilityPage.getSelectedConnector()
+      expect(selected).toContain('Prometheus')
+    })
+
+    test('should display Prometheus configuration when available', async ({ observabilityPage }) => {
+      const isAvailable = await observabilityPage.isConnectorAvailable('prometheus')
+
+      if (!isAvailable) {
+        test.skip(true, 'Prometheus connector not available')
+        return
+      }
+
+      await observabilityPage.selectConnector('prometheus')
+
+      const toggle = observabilityPage.getConnectorToggle('prometheus')
+      const isVisible = await toggle.isVisible().catch(() => false)
+      expect(isVisible).toBe(true)
+    })
+
+    test('should toggle Prometheus connector when available', async ({ observabilityPage }) => {
+      const isAvailable = await observabilityPage.isConnectorAvailable('prometheus')
+
+      if (!isAvailable) {
+        test.skip(true, 'Prometheus connector not available')
+        return
+      }
+
+      await observabilityPage.selectConnector('prometheus')
+
+      const isToggleEnabled = await observabilityPage.isToggleEnabled('prometheus')
+
+      if (!isToggleEnabled) {
+        test.skip(true, 'Prometheus toggle is disabled')
+        return
+      }
+
+      const initialState = await observabilityPage.isConnectorEnabled('prometheus')
+      const toggled = await observabilityPage.toggleConnector('prometheus')
+      expect(toggled).toBe(true)
+
+      const newState = await observabilityPage.isConnectorEnabled('prometheus')
+      expect(newState).toBe(!initialState)
+    })
+
+    test('should display Prometheus delete button when connector is configured', async ({ observabilityPage }) => {
+      const isAvailable = await observabilityPage.isConnectorAvailable('prometheus')
+
+      if (!isAvailable) {
+        test.skip(true, 'Prometheus connector not available')
+        return
+      }
+
+      await observabilityPage.selectConnector('prometheus')
+
+      const deleteBtn = observabilityPage.getConnectorDeleteBtn('prometheus')
+      const isVisible = await deleteBtn.isVisible().catch(() => false)
+
+      if (!isVisible) {
+        test.skip(true, 'Prometheus delete button not visible (connector may not be configured)')
+        return
+      }
+
+      await expect(deleteBtn).toBeVisible()
+    })
+  })
+
+  test.describe('BigQuery Connector', () => {
+    test('should select BigQuery connector', async ({ observabilityPage }) => {
+      const isAvailable = await observabilityPage.isConnectorAvailable('bigquery')
+
+      if (!isAvailable) {
+        test.skip(true, 'BigQuery connector not available')
+        return
+      }
+
+      await observabilityPage.selectConnector('bigquery')
+
+      const selected = await observabilityPage.getSelectedConnector()
+      expect(selected).toContain('BigQuery')
     })
   })
 
@@ -173,22 +282,22 @@ test.describe('Observability', () => {
 
       await observabilityPage.selectConnector('datadog')
 
-      const isToggleEnabled = await observabilityPage.isToggleEnabled()
+      const isToggleEnabled = await observabilityPage.isToggleEnabled('datadog')
 
       if (!isToggleEnabled) {
         test.skip(true, 'Datadog toggle is disabled')
         return
       }
 
-      const initialState = await observabilityPage.isConnectorEnabled()
-      const toggled = await observabilityPage.toggleConnector()
+      const initialState = await observabilityPage.isConnectorEnabled('datadog')
+      const toggled = await observabilityPage.toggleConnector('datadog')
 
       if (!toggled) {
         test.skip(true, 'Datadog toggle could not be toggled')
         return
       }
 
-      const newState = await observabilityPage.isConnectorEnabled()
+      const newState = await observabilityPage.isConnectorEnabled('datadog')
       expect(newState).toBe(!initialState)
     })
   })

--- a/tests/e2e/features/observability/pages/observability.page.ts
+++ b/tests/e2e/features/observability/pages/observability.page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator, expect } from '@playwright/test'
+import { Page, Locator } from '@playwright/test'
 import { BasePage } from '../../../core/pages/base.page'
 import { waitForNetworkIdle } from '../../../core/utils/test-helpers'
 
@@ -7,50 +7,59 @@ import { waitForNetworkIdle } from '../../../core/utils/test-helpers'
  */
 export interface ObservabilityState {
   otelEnabled: boolean
+  prometheusEnabled: boolean
   maximEnabled: boolean
   datadogEnabled: boolean
+  bigqueryEnabled: boolean
   newRelicEnabled: boolean
 }
 
+export type ObservabilityConnector = 'otel' | 'prometheus' | 'maxim' | 'datadog' | 'bigquery' | 'newrelic'
+
 export class ObservabilityPage extends BasePage {
-  // Connector tabs/buttons - using exact names from the UI
-  readonly otelTab: Locator
-  readonly maximTab: Locator
-  readonly datadogTab: Locator
-  readonly newRelicTab: Locator
-  
   // Save button (within the active view)
   readonly saveBtn: Locator
-  
-  // OTel form elements
-  readonly otelToggle: Locator
-  readonly otelEndpointInput: Locator
-  readonly otelHeadersTable: Locator
-  
-  // Maxim form elements
-  readonly maximToggle: Locator
-  readonly maximApiKeyInput: Locator
 
   constructor(page: Page) {
     super(page)
-    
-    // Connector tabs - using text content to find the exact button
-    this.otelTab = page.locator('button:has-text("Open Telemetry")')
-    this.maximTab = page.locator('button:has-text("Maxim"):not(:has-text("Save"))')
-    this.datadogTab = page.locator('button:has-text("Datadog"):not(:has-text("Save"))')
-    this.newRelicTab = page.locator('button:has-text("New Relic")')
-    
+
     // Save button
     this.saveBtn = page.getByRole('button', { name: /Save/i })
-    
-    // OTel elements
-    this.otelToggle = page.locator('button[role="switch"]').first()
-    this.otelEndpointInput = page.getByPlaceholder(/otel-collector/i)
-    this.otelHeadersTable = page.locator('[data-testid="headers-table"]')
-    
-    // Maxim elements
-    this.maximToggle = page.locator('button[role="switch"]').first()
-    this.maximApiKeyInput = page.getByPlaceholder(/API Key/i)
+  }
+
+  /** Map of connector -> data-testid for enable toggle (otel/prometheus have specific testids) */
+  private static readonly CONNECTOR_TOGGLE_TESTIDS: Partial<Record<ObservabilityConnector, string>> = {
+    otel: 'otel-connector-enable-toggle',
+    prometheus: 'prometheus-connector-enable-toggle',
+  }
+
+  /** Map of connector -> data-testid for delete button (otel/prometheus have specific testids) */
+  private static readonly CONNECTOR_DELETE_TESTIDS: Partial<Record<ObservabilityConnector, string>> = {
+    otel: 'otel-connector-delete-btn',
+    prometheus: 'prometheus-connector-delete-btn',
+  }
+
+  /**
+   * Get connector tab locator by data-testid
+   */
+  getConnectorTab(connector: ObservabilityConnector): Locator {
+    return this.page.getByTestId(`observability-provider-btn-${connector}`)
+  }
+
+  /**
+   * Get connector enable toggle locator. Uses specific data-testid for otel/prometheus.
+   */
+  getConnectorToggle(connector: ObservabilityConnector): Locator {
+    const testId = ObservabilityPage.CONNECTOR_TOGGLE_TESTIDS[connector]
+    return testId ? this.page.getByTestId(testId) : this.page.locator('button[role="switch"]').first()
+  }
+
+  /**
+   * Get connector delete button locator. Returns locator for otel/prometheus; for others returns a no-match locator.
+   */
+  getConnectorDeleteBtn(connector: ObservabilityConnector): Locator {
+    const testId = ObservabilityPage.CONNECTOR_DELETE_TESTIDS[connector]
+    return testId ? this.page.getByTestId(testId) : this.page.locator('[data-testid="connector-delete-unused"]')
   }
 
   async goto(): Promise<void> {
@@ -61,22 +70,14 @@ export class ObservabilityPage extends BasePage {
   /**
    * Select a connector tab
    */
-  async selectConnector(connector: 'otel' | 'maxim' | 'datadog' | 'newrelic'): Promise<void> {
-    const tabs = {
-      'otel': this.otelTab,
-      'maxim': this.maximTab,
-      'datadog': this.datadogTab,
-      'newrelic': this.newRelicTab,
-    }
-    
-    const tab = tabs[connector]
-    
+  async selectConnector(connector: ObservabilityConnector): Promise<void> {
+    const tab = this.getConnectorTab(connector)
+
     // Wait for tab to be visible first
     await tab.waitFor({ state: 'visible', timeout: 10000 })
-    
-    const isDisabled = await tab.getAttribute('aria-disabled') === 'true' || 
-                       await tab.isDisabled()
-    
+
+    const isDisabled = (await tab.getAttribute('aria-disabled')) === 'true' || (await tab.isDisabled())
+
     if (!isDisabled) {
       await tab.click()
       await waitForNetworkIdle(this.page)
@@ -86,29 +87,21 @@ export class ObservabilityPage extends BasePage {
   /**
    * Check if a connector tab is available (not disabled)
    */
-  async isConnectorAvailable(connector: 'otel' | 'maxim' | 'datadog' | 'newrelic'): Promise<boolean> {
-    const tabs = {
-      'otel': this.otelTab,
-      'maxim': this.maximTab,
-      'datadog': this.datadogTab,
-      'newrelic': this.newRelicTab,
-    }
-    
-    const tab = tabs[connector]
+  async isConnectorAvailable(connector: ObservabilityConnector): Promise<boolean> {
+    const tab = this.getConnectorTab(connector)
     const isVisible = await tab.isVisible().catch(() => false)
     if (!isVisible) return false
-    
-    const isDisabled = await tab.getAttribute('aria-disabled') === 'true' ||
-                       await tab.isDisabled()
+
+    const isDisabled = (await tab.getAttribute('aria-disabled')) === 'true' || (await tab.isDisabled())
     return !isDisabled
   }
 
   /**
-   * Get the currently selected connector
+   * Get the currently selected connector (display name)
    */
   async getSelectedConnector(): Promise<string | null> {
-    // The selected connector has aria-current="page"
-    const selected = this.page.locator('button[aria-current="page"]')
+    // Observability view uses plain buttons with aria-current="page" for the selected tab
+    const selected = this.page.locator('[data-testid^="observability-provider-btn-"][aria-current="page"]')
     const isVisible = await selected.isVisible().catch(() => false)
     if (!isVisible) return null
     return await selected.textContent()
@@ -117,8 +110,8 @@ export class ObservabilityPage extends BasePage {
   /**
    * Check if a connector is enabled (toggle is checked)
    */
-  async isConnectorEnabled(): Promise<boolean> {
-    const toggle = this.page.locator('button[role="switch"]').first()
+  async isConnectorEnabled(connector: ObservabilityConnector): Promise<boolean> {
+    const toggle = this.getConnectorToggle(connector)
     const isVisible = await toggle.isVisible().catch(() => false)
     if (!isVisible) return false
     const state = await toggle.getAttribute('data-state')
@@ -128,8 +121,8 @@ export class ObservabilityPage extends BasePage {
   /**
    * Check if the toggle is clickable (not disabled)
    */
-  async isToggleEnabled(): Promise<boolean> {
-    const toggle = this.page.locator('button[role="switch"]').first()
+  async isToggleEnabled(connector: ObservabilityConnector): Promise<boolean> {
+    const toggle = this.getConnectorToggle(connector)
     const isVisible = await toggle.isVisible().catch(() => false)
     if (!isVisible) return false
     const isDisabled = await toggle.isDisabled()
@@ -137,17 +130,21 @@ export class ObservabilityPage extends BasePage {
   }
 
   /**
-   * Toggle the current connector enabled state (only if toggle is enabled)
+   * Toggle the current connector enabled state (only if toggle is enabled).
+   * Waits for data-state to transition after click to avoid race with subsequent assertions.
    */
-  async toggleConnector(): Promise<boolean> {
-    const toggle = this.page.locator('button[role="switch"]').first()
+  async toggleConnector(connector: ObservabilityConnector): Promise<boolean> {
+    const toggle = this.getConnectorToggle(connector)
     const isVisible = await toggle.isVisible().catch(() => false)
     if (!isVisible) return false
-    
+
     const isDisabled = await toggle.isDisabled()
     if (isDisabled) return false
-    
+
+    const previousState = await toggle.getAttribute('data-state')
     await toggle.click()
+    const expectedState = previousState === 'checked' ? 'unchecked' : 'checked'
+    await this.waitForStateChange(toggle, 'data-state', expectedState, 5000)
     return true
   }
 
@@ -233,27 +230,25 @@ export class ObservabilityPage extends BasePage {
   async getCurrentState(): Promise<ObservabilityState> {
     const state: ObservabilityState = {
       otelEnabled: false,
+      prometheusEnabled: false,
       maximEnabled: false,
       datadogEnabled: false,
+      bigqueryEnabled: false,
       newRelicEnabled: false,
     }
 
-    // Check OTel
-    if (await this.isConnectorAvailable('otel')) {
-      await this.selectConnector('otel')
-      state.otelEnabled = await this.isConnectorEnabled()
-    }
-
-    // Check Maxim
-    if (await this.isConnectorAvailable('maxim')) {
-      await this.selectConnector('maxim')
-      state.maximEnabled = await this.isConnectorEnabled()
-    }
-
-    // Datadog might require enterprise
-    if (await this.isConnectorAvailable('datadog')) {
-      await this.selectConnector('datadog')
-      state.datadogEnabled = await this.isConnectorEnabled()
+    const connectors: ObservabilityConnector[] = ['otel', 'prometheus', 'maxim', 'datadog', 'bigquery', 'newrelic']
+    for (const connector of connectors) {
+      if (await this.isConnectorAvailable(connector)) {
+        await this.selectConnector(connector)
+        const enabled = await this.isConnectorEnabled(connector)
+        if (connector === 'otel') state.otelEnabled = enabled
+        else if (connector === 'prometheus') state.prometheusEnabled = enabled
+        else if (connector === 'maxim') state.maximEnabled = enabled
+        else if (connector === 'datadog') state.datadogEnabled = enabled
+        else if (connector === 'bigquery') state.bigqueryEnabled = enabled
+        else if (connector === 'newrelic') state.newRelicEnabled = enabled
+      }
     }
 
     return state
@@ -263,43 +258,29 @@ export class ObservabilityPage extends BasePage {
    * Disable all connectors
    */
   async disableAllConnectors(): Promise<void> {
-    // Disable OTel
-    if (await this.isConnectorAvailable('otel')) {
-      try {
-        await this.selectConnector('otel')
-        if (await this.isConnectorEnabled() && await this.isToggleEnabled()) {
-          await this.toggleConnector()
-          await this.saveConfiguration().catch(() => {})
+    const cleanupErrors: string[] = []
+    const connectors: ObservabilityConnector[] = ['otel', 'prometheus', 'maxim', 'datadog', 'bigquery', 'newrelic']
+    for (const connector of connectors) {
+      if (await this.isConnectorAvailable(connector)) {
+        try {
+          await this.selectConnector(connector)
+          if ((await this.isConnectorEnabled(connector)) && (await this.isToggleEnabled(connector))) {
+            await this.toggleConnector(connector)
+            // If Save is disabled there is nothing to persist (connector is already off in UI)
+            const saveEnabled = await this.saveBtn.isEnabled().catch(() => false)
+            if (saveEnabled) {
+              await this.saveConfiguration().catch((e) => {
+                cleanupErrors.push(`${connector} save: ${e instanceof Error ? e.message : String(e)}`)
+              })
+            }
+          }
+        } catch (error) {
+          cleanupErrors.push(`${connector}: ${error instanceof Error ? error.message : String(error)}`)
         }
-      } catch {
-        // Ignore errors
       }
     }
-
-    // Disable Maxim
-    if (await this.isConnectorAvailable('maxim')) {
-      try {
-        await this.selectConnector('maxim')
-        if (await this.isConnectorEnabled() && await this.isToggleEnabled()) {
-          await this.toggleConnector()
-          await this.saveConfiguration().catch(() => {})
-        }
-      } catch {
-        // Ignore errors
-      }
-    }
-
-    // Disable Datadog (enterprise)
-    if (await this.isConnectorAvailable('datadog')) {
-      try {
-        await this.selectConnector('datadog')
-        if (await this.isConnectorEnabled() && await this.isToggleEnabled()) {
-          await this.toggleConnector()
-          await this.saveConfiguration().catch(() => {})
-        }
-      } catch {
-        // Ignore errors - might be enterprise only
-      }
+    if (cleanupErrors.length > 0) {
+      throw new Error(`disableAllConnectors failed for: ${cleanupErrors.join('; ')}`)
     }
   }
 

--- a/tests/e2e/features/placeholders/placeholders.spec.ts
+++ b/tests/e2e/features/placeholders/placeholders.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+
+test.describe('Placeholder and Enterprise Pages', () => {
+  test('should load prompt-repo coming soon page', async ({ page }) => {
+    await page.goto('/workspace/prompt-repo')
+    await expect(page.getByText(/Prompt repository is coming soon/i)).toBeVisible({ timeout: 10000 })
+  })
+
+  test('should load alert-channels page', async ({ page }) => {
+    await page.goto('/workspace/alert-channels')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Unlock alert channels for better observability')).toBeVisible()
+    const readMore = page.getByRole('button', { name: /Read more/i })
+    await expect(readMore).toBeVisible()
+    const [popup] = await Promise.all([page.waitForEvent('popup'), readMore.click()])
+    await expect(popup).toHaveURL(/^https:\/\/docs\.getbifrost\.ai\/enterprise\/alert-channels(\?|$)/)
+    await popup.close()
+  })
+
+  test('should load guardrails page', async ({ page }) => {
+    await page.goto('/workspace/guardrails')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/guardrails(?:\?.*)?$/)
+  })
+
+  test('should load audit-logs page', async ({ page }) => {
+    await page.goto('/workspace/audit-logs')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/audit-logs(?:\?.*)?$/)
+  })
+
+  test('should load cluster page', async ({ page }) => {
+    await page.goto('/workspace/cluster')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/cluster(?:\?.*)?$/)
+  })
+
+  test('should load custom-pricing page', async ({ page }) => {
+    await page.goto('/workspace/custom-pricing')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/custom-pricing(?:\?.*)?$/)
+  })
+
+  test('should load rbac page', async ({ page }) => {
+    await page.goto('/workspace/rbac')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/governance\/rbac(?:\?.*)?$/)
+  })
+
+  test('should load scim page', async ({ page }) => {
+    await page.goto('/workspace/scim')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/scim(?:\?.*)?$/)
+  })
+
+  test('should load adaptive-routing page', async ({ page }) => {
+    await page.goto('/workspace/adaptive-routing')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Unlock adaptive routing for better performance')).toBeVisible()
+    const readMore = page.getByRole('button', { name: /Read more/i })
+    await expect(readMore).toBeVisible()
+    const [popup] = await Promise.all([page.waitForEvent('popup'), readMore.click()])
+    await expect(popup).toHaveURL(/^https:\/\/docs\.getbifrost\.ai\/enterprise\/adaptive-load-balancing(\?|$)/)
+    await popup.close()
+  })
+
+  test('should load guardrails configuration page', async ({ page }) => {
+    await page.goto('/workspace/guardrails/configuration')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/guardrails\/configuration(?:\?.*)?$/)
+  })
+
+  test('should load guardrails providers page', async ({ page }) => {
+    await page.goto('/workspace/guardrails/providers')
+    await page.waitForLoadState('networkidle')
+    await expect(page).toHaveURL(/\/workspace\/guardrails\/providers(?:\?.*)?$/)
+  })
+})

--- a/tests/e2e/features/plugins/pages/plugins.page.ts
+++ b/tests/e2e/features/plugins/pages/plugins.page.ts
@@ -54,7 +54,8 @@ export class PluginsPage extends BasePage {
     await waitForNetworkIdle(this.page)
     // Wait for create button or empty state to be visible (indicates page loaded).
     // Use .first() so the locator resolves to one element when both are visible (strict mode).
-    await this.createBtn.or(this.page.getByText(/No plugins installed/i))
+    await this.page.getByTestId('plugins-create-button')
+      .or(this.page.getByTestId('plugins-empty-state'))
       .first()
       .waitFor({ state: 'visible', timeout: 10000 })
     // Ensure sheet is closed (in case it was left open from previous test)
@@ -113,15 +114,15 @@ export class PluginsPage extends BasePage {
    * Get the count of plugins in the sidebar
    */
   async getPluginCount(): Promise<number> {
-    const buttons = this.pluginList
-    const count = await buttons.count()
-
-    // Check if it's empty state
-    const emptyMessage = this.page.getByText(/No plugins installed/i)
-    const isEmptyVisible = await emptyMessage.isVisible().catch(() => false)
+    // Check if it's empty state (no plugin list, only empty state is shown)
+    const emptyState = this.page.getByTestId('plugins-empty-state')
+    const isEmptyVisible = await emptyState.isVisible().catch(() => false)
     if (isEmptyVisible) {
       return 0
     }
+
+    const buttons = this.page.getByTestId('plugin-list-item')
+    const count = await buttons.count()
 
     return count
   }

--- a/tests/e2e/features/plugins/plugins.spec.ts
+++ b/tests/e2e/features/plugins/plugins.spec.ts
@@ -30,6 +30,17 @@ test.describe('Plugins', () => {
 
   test.describe('Plugin Display', () => {
     test('should display plugins table', async ({ pluginsPage }) => {
+      // Ensure at least one plugin exists so the table (sidebar) is shown
+      const count = await pluginsPage.getPluginCount()
+      if (count === 0) {
+        const pluginData = createPluginData({ name: `e2e-display-table-${Date.now()}` })
+        const created = await pluginsPage.createPlugin(pluginData)
+        if (!created) {
+          test.skip(true, 'Backend rejected plugin creation (failed to load .so)')
+          return
+        }
+        createdPlugins.push(pluginData.name)
+      }
       // Plugins page has a sidebar (aliased as table), not a traditional table
       await expect(pluginsPage.table).toBeVisible()
     })
@@ -40,8 +51,8 @@ test.describe('Plugins', () => {
 
     test('should show empty state or plugin list', async ({ pluginsPage }) => {
       const count = await pluginsPage.getPluginCount()
-      const emptyMessage = pluginsPage.page.getByText(/No plugins/i)
-      const isEmptyStateVisible = await emptyMessage.isVisible().catch(() => false)
+      const emptyState = pluginsPage.page.getByTestId('plugins-empty-state')
+      const isEmptyStateVisible = await emptyState.isVisible().catch(() => false)
 
       if (count === 0) {
         expect(isEmptyStateVisible).toBe(true)
@@ -237,16 +248,18 @@ test.describe('Plugins', () => {
       await sheetPathInput.fill(ensureTestPluginExists()) // Path is required; use same path as build
       await pluginsPage.saveBtn.click()
 
-      // Either sheet stays open with error OR error toast appears
-      const sheetVisible = await pluginsPage.sheet.isVisible()
-      const hasError = await pluginsPage.page.locator('[role="alert"], .text-destructive, [data-sonner-toast]').count() > 0
+      // Duplicate creation should be rejected: either sheet stays open with error OR error toast appears
+      const inlineError = pluginsPage.sheet.locator('[role="alert"], .text-destructive').first()
+      const errorToast = pluginsPage.page.locator('[data-sonner-toast][data-type="error"]').first()
+      await inlineError.or(errorToast).waitFor({ state: 'visible', timeout: 10000 })
+      const hasInlineError = await inlineError.isVisible().catch(() => false)
 
-      // At least one of these should be true
-      expect(sheetVisible || hasError).toBe(true)
-
-      // Cancel if sheet is still open
-      if (sheetVisible) {
+      if (hasInlineError) {
+        await expect(pluginsPage.sheet).toBeVisible()
+        await expect(inlineError).toBeVisible()
         await pluginsPage.cancelPlugin()
+      } else {
+        await expect(errorToast).toBeVisible()
       }
     })
   })
@@ -336,15 +349,18 @@ test.describe('Plugins', () => {
       // Wait for response
       await pluginsPage.page.waitForTimeout(1000)
 
-      // Sheet may close with error toast or stay open with error
-      const sheetVisible = await pluginsPage.sheet.isVisible()
-      const hasErrorToast = await pluginsPage.page.locator('[data-sonner-toast][data-type="error"]').count() > 0
+      // Invalid path: sheet may close with error toast or stay open with error
+      const inlineError = pluginsPage.sheet.locator('[role="alert"], .text-destructive').first()
+      const errorToast = pluginsPage.page.locator('[data-sonner-toast][data-type="error"]').first()
+      await inlineError.or(errorToast).waitFor({ state: 'visible', timeout: 10000 })
+      const hasInlineError = await inlineError.isVisible().catch(() => false)
 
-      // Expect either the sheet to remain open OR an error toast
-      expect(sheetVisible || hasErrorToast).toBe(true)
-
-      if (sheetVisible) {
+      if (hasInlineError) {
+        await expect(pluginsPage.sheet).toBeVisible()
+        await expect(inlineError).toBeVisible()
         await pluginsPage.cancelPlugin()
+      } else {
+        await expect(errorToast).toBeVisible()
       }
     })
   })

--- a/tests/e2e/features/providers/pages/providers.page.ts
+++ b/tests/e2e/features/providers/pages/providers.page.ts
@@ -13,6 +13,8 @@ export class ProvidersPage extends BasePage {
   // Locators
   readonly providerList: Locator
   readonly addProviderBtn: Locator
+  /** Add New Provider dropdown > "Custom provider..." menu item */
+  readonly addProviderOptionCustom: Locator
   readonly addKeyBtn: Locator
   readonly keysTable: Locator
 
@@ -23,6 +25,9 @@ export class ProvidersPage extends BasePage {
   readonly baseUrlInput: Locator
   readonly customProviderSaveBtn: Locator
   readonly customProviderCancelBtn: Locator
+
+  // Keys table empty state (when provider has no keys)
+  readonly keysTableEmptyState: Locator
 
   // Key form
   readonly keyForm: Locator
@@ -35,6 +40,7 @@ export class ProvidersPage extends BasePage {
     // Provider list
     this.providerList = page.locator(Selectors.providers.providerList)
     this.addProviderBtn = page.getByTestId('add-provider-btn')
+    this.addProviderOptionCustom = page.getByTestId('add-provider-option-custom')
 
     // Keys table
     this.addKeyBtn = page.getByTestId('add-key-btn')
@@ -47,6 +53,9 @@ export class ProvidersPage extends BasePage {
     this.baseUrlInput = page.getByTestId('base-url-input')
     this.customProviderSaveBtn = page.getByTestId('custom-provider-save-btn')
     this.customProviderCancelBtn = page.getByTestId('custom-provider-cancel-btn')
+
+    // Keys table empty state
+    this.keysTableEmptyState = page.getByTestId('keys-table-empty-state')
 
     // Key form
     this.keyForm = page.getByTestId('key-form')
@@ -125,14 +134,32 @@ export class ProvidersPage extends BasePage {
   }
 
   /**
+   * Add a known provider from the "Add provider" dropdown (e.g. Nebius, OpenAI).
+   * Opens the dropdown and clicks the option with data-testid add-provider-option-{name}.
+   */
+  async addKnownProviderFromDropdown(providerName: string): Promise<void> {
+    await this.addProviderBtn.click()
+    const option = this.page.getByTestId(`add-provider-option-${providerName}`)
+    await option.waitFor({ state: 'visible', timeout: 5000 })
+    await option.click()
+    await waitForNetworkIdle(this.page)
+  }
+
+  /**
+   * Open the custom provider sheet via Add New Provider > Custom provider...
+   */
+  async openCustomProviderSheet(): Promise<void> {
+    await this.addProviderBtn.click()
+    await this.addProviderOptionCustom.waitFor({ state: 'visible', timeout: 5000 })
+    await this.addProviderOptionCustom.click()
+    await expect(this.customProviderSheet).toBeVisible({ timeout: 5000 })
+  }
+
+  /**
    * Create a custom provider
    */
   async createProvider(config: CustomProviderConfig): Promise<void> {
-    // Click add provider button
-    await this.addProviderBtn.click()
-
-    // Wait for custom provider sheet to appear
-    await expect(this.customProviderSheet).toBeVisible()
+    await this.openCustomProviderSheet()
 
     // Fill in provider name
     await this.customProviderNameInput.fill(config.name)
@@ -164,14 +191,12 @@ export class ProvidersPage extends BasePage {
    * @param options.skipToastWait - If true, do not wait for success toast (e.g. for cleanup); avoids cleanup failures when toast is missing or already gone.
    */
   async deleteProvider(name: string, options?: { skipToastWait?: boolean }): Promise<void> {
-    // First select the provider
+    // First select the provider (config panel shows with delete button)
     await this.selectProvider(name)
 
-    // Find and click the delete button
-    const providerItem = this.getProviderItem(name)
-    await providerItem.hover()
-
-    const deleteBtn = providerItem.locator('svg.lucide-trash')
+    // Click the delete button in the config panel
+    const deleteBtn = this.page.getByTestId('provider-delete-btn')
+    await deleteBtn.waitFor({ state: 'visible', timeout: 5000 })
     await deleteBtn.click()
 
     // Confirm deletion in dialog
@@ -195,6 +220,24 @@ export class ProvidersPage extends BasePage {
     return this.page.getByTestId(`key-row-${name}`).or(
       this.page.locator('tr, [role="row"]').filter({ hasText: name })
     )
+  }
+
+  /**
+   * Get the displayed weight for a key
+   */
+  async getKeyWeight(name: string): Promise<string> {
+    const keyRow = this.getKeyRow(name)
+    return (await keyRow.getByTestId('key-weight-value').textContent()) ?? ''
+  }
+
+  /**
+   * Get the enabled state of a key (switch checked or not)
+   */
+  async getKeyEnabledState(name: string): Promise<boolean> {
+    const keyRow = this.getKeyRow(name)
+    const switchEl = keyRow.getByTestId('key-enabled-switch')
+    const checked = await switchEl.getAttribute('data-state')
+    return checked === 'checked'
   }
 
   /**
@@ -289,7 +332,7 @@ export class ProvidersPage extends BasePage {
    */
   async toggleKeyEnabled(keyName: string): Promise<void> {
     const keyRow = this.getKeyRow(keyName)
-    const switchEl = keyRow.locator('button[role="switch"]')
+    const switchEl = keyRow.getByTestId('key-enabled-switch')
     await switchEl.click()
     await this.waitForSuccessToast()
   }
@@ -352,17 +395,10 @@ export class ProvidersPage extends BasePage {
   /**
    * Select a configuration tab
    */
-  async selectConfigTab(tabName: 'network' | 'proxy' | 'performance' | 'governance'): Promise<void> {
+  async selectConfigTab(tabName: 'network' | 'proxy' | 'performance' | 'governance' | 'debugging'): Promise<void> {
     await this.openConfigSheet()
 
-    const tabLabels: Record<string, string> = {
-      network: 'Network config',
-      proxy: 'Proxy config',
-      performance: 'Performance tuning',
-      governance: 'Governance',
-    }
-
-    const tab = this.page.getByRole('tab', { name: tabLabels[tabName] })
+    const tab = this.page.getByTestId(`provider-tab-${tabName}`)
     await tab.click()
     await this.page.waitForTimeout(300)
   }
@@ -370,12 +406,13 @@ export class ProvidersPage extends BasePage {
   /**
    * Get the save button for the current config tab
    */
-  getConfigSaveBtn(configType: 'network' | 'proxy' | 'performance' | 'governance'): Locator {
+  getConfigSaveBtn(configType: 'network' | 'proxy' | 'performance' | 'governance' | 'debugging'): Locator {
     const buttonNames: Record<string, string> = {
       network: 'Save Network Configuration',
       proxy: 'Save Proxy Configuration',
       performance: 'Save Performance Configuration',
       governance: 'Save Governance Configuration',
+      debugging: 'Save Debugging Configuration',
     }
     return this.page.getByRole('button', { name: buttonNames[configType] })
   }
@@ -399,17 +436,17 @@ export class ProvidersPage extends BasePage {
   }
 
   /**
-   * Get raw request switch
+   * Get raw request switch (Debugging tab: "Send Back Raw Request")
    */
   getRawRequestSwitch(): Locator {
-    return this.page.getByLabel('Include Raw Request').locator('..').locator('button[role="switch"]')
+    return this.page.getByLabel('Send Back Raw Request').locator('..').locator('button[role="switch"]')
   }
 
   /**
-   * Get raw response switch
+   * Get raw response switch (Debugging tab: "Send Back Raw Response")
    */
   getRawResponseSwitch(): Locator {
-    return this.page.getByLabel('Include Raw Response').locator('..').locator('button[role="switch"]')
+    return this.page.getByLabel('Send Back Raw Response').locator('..').locator('button[role="switch"]')
   }
 
   /**
@@ -444,13 +481,21 @@ export class ProvidersPage extends BasePage {
   }
 
   /**
-   * Set performance configuration
+   * Save debugging configuration and wait for success toast
+   */
+  async saveDebuggingConfig(): Promise<void> {
+    const saveBtn = this.getConfigSaveBtn('debugging')
+    await saveBtn.click()
+    await this.waitForSuccessToast()
+  }
+
+  /**
+   * Set performance configuration (concurrency, buffer size only).
+   * For raw request/response toggles use setDebuggingConfig.
    */
   async setPerformanceConfig(config: {
     concurrency?: number
     bufferSize?: number
-    rawRequest?: boolean
-    rawResponse?: boolean
   }): Promise<void> {
     await this.selectConfigTab('performance')
 
@@ -463,10 +508,17 @@ export class ProvidersPage extends BasePage {
       const input = this.getBufferSizeInput()
       await this.fillNumberInput(input, String(config.bufferSize))
     }
+  }
+
+  /**
+   * Set debugging configuration (raw request/response toggles).
+   */
+  async setDebuggingConfig(config: { rawRequest?: boolean; rawResponse?: boolean }): Promise<void> {
+    await this.selectConfigTab('debugging')
 
     if (config.rawRequest !== undefined) {
       const switchEl = this.getRawRequestSwitch()
-      const isChecked = await switchEl.getAttribute('data-state') === 'checked'
+      const isChecked = (await switchEl.getAttribute('data-state')) === 'checked'
       if (isChecked !== config.rawRequest) {
         await switchEl.click()
       }
@@ -474,7 +526,7 @@ export class ProvidersPage extends BasePage {
 
     if (config.rawResponse !== undefined) {
       const switchEl = this.getRawResponseSwitch()
-      const isChecked = await switchEl.getAttribute('data-state') === 'checked'
+      const isChecked = (await switchEl.getAttribute('data-state')) === 'checked'
       if (isChecked !== config.rawResponse) {
         await switchEl.click()
       }
@@ -607,7 +659,8 @@ export class ProvidersPage extends BasePage {
    */
   async isGovernanceTabVisible(): Promise<boolean> {
     await this.openConfigSheet()
-    const tab = this.page.getByRole('tab', { name: 'Governance' })
+    const tab = this.page.getByTestId('provider-tab-governance')
     return await tab.isVisible().catch(() => false)
   }
+
 }

--- a/tests/e2e/features/providers/providers.spec.ts
+++ b/tests/e2e/features/providers/providers.spec.ts
@@ -111,32 +111,26 @@ test.describe('Providers', () => {
     })
 
     test('should display empty state when no keys configured', async ({ providersPage }) => {
-      // Select a provider that typically has no keys in fresh install
-      await providersPage.selectProvider('groq')
-      // Get key count
-      const keyCount = await providersPage.getKeyCount()
-
-      // Check for empty state message
-      const emptyMessage = providersPage.page.getByText('No keys found')
-      const isEmptyStateVisible = await emptyMessage.isVisible().catch(() => false)
-
-      // Deterministic assertion: either empty state is shown OR there are keys
-      if (keyCount === 0) {
-        // When no keys, empty state should be shown
-        expect(isEmptyStateVisible).toBe(true)
-      } else {
-        // When keys exist, empty state should NOT be shown
-        expect(isEmptyStateVisible).toBe(false)
+      // Add Nebius from the dropdown if not already in sidebar (created with no keys)
+      if (!(await providersPage.providerExists('nebius'))) {
+        await providersPage.addKnownProviderFromDropdown('nebius')
+        createdProviders.push('nebius')
       }
+      // Select Nebius (it has zero keys)
+      const providerItem = providersPage.getProviderItem('nebius')
+      await expect(providerItem).toBeVisible({ timeout: 15000 })
+      await providersPage.selectProvider('nebius')
+      const keyCount = await providersPage.getKeyCount()
+      expect(keyCount).toBe(0)
+
+      // Empty state row should be visible
+      await expect(providersPage.keysTableEmptyState).toBeVisible()
     })
   })
 
   test.describe('Custom Providers', () => {
     test('should open custom provider creation sheet', async ({ providersPage }) => {
-      await providersPage.addProviderBtn.click()
-
-      // Verify sheet is visible
-      await expect(providersPage.customProviderSheet).toBeVisible()
+      await providersPage.openCustomProviderSheet()
 
       // Verify form fields are present
       await expect(providersPage.customProviderNameInput).toBeVisible()
@@ -179,8 +173,7 @@ test.describe('Providers', () => {
     })
 
     test('should cancel custom provider creation', async ({ providersPage }) => {
-      await providersPage.addProviderBtn.click()
-      await expect(providersPage.customProviderSheet).toBeVisible()
+      await providersPage.openCustomProviderSheet()
 
       // Fill some data
       await providersPage.customProviderNameInput.fill('cancelled-provider')
@@ -195,12 +188,33 @@ test.describe('Providers', () => {
       const providerExists = await providersPage.providerExists('cancelled-provider')
       expect(providerExists).toBe(false)
     })
+
+    test('should delete custom provider and update UI', async ({ providersPage }) => {
+      const providerData = createCustomProviderData({
+        name: `delete-test-${Date.now()}`,
+        baseProviderType: 'openai',
+        baseUrl: 'https://api.delete-test.com/v1',
+      })
+      createdProviders.push(providerData.name)
+
+      await providersPage.createProvider(providerData)
+
+      const providerItem = providersPage.getProviderItem(providerData.name)
+      await expect(providerItem).toBeVisible({ timeout: 15000 })
+
+      await providersPage.deleteProvider(providerData.name, { skipToastWait: true })
+
+      const idx = createdProviders.indexOf(providerData.name)
+      if (idx >= 0) createdProviders.splice(idx, 1)
+
+      // Assert provider is no longer in the configured providers list (do not rely on toast)
+      await expect(providerItem).not.toBeVisible({ timeout: 5000 })
+    })
   })
 
   test.describe('Form Validation', () => {
     test('should require name for custom provider', async ({ providersPage }) => {
-      await providersPage.addProviderBtn.click()
-      await expect(providersPage.customProviderSheet).toBeVisible()
+      await providersPage.openCustomProviderSheet()
 
       // Try to save without name
       await providersPage.baseUrlInput.fill('https://api.example.com')
@@ -214,8 +228,7 @@ test.describe('Providers', () => {
     })
 
     test('should require base URL for custom provider', async ({ providersPage }) => {
-      await providersPage.addProviderBtn.click()
-      await expect(providersPage.customProviderSheet).toBeVisible()
+      await providersPage.openCustomProviderSheet()
 
       // Fill only name
       await providersPage.customProviderNameInput.fill('test-provider')
@@ -268,14 +281,14 @@ test.describe('Provider Key Management', () => {
 
     await providersPage.addKey(keyData)
 
-    // Now edit it
+    // Now edit it - set weight to 0.7
     await providersPage.editKey(keyData.name, {
       weight: 0.7,
     })
 
-    // Key should still exist
-    const keyExists = await providersPage.keyExists(keyData.name)
-    expect(keyExists).toBe(true)
+    // Verify weight was saved and displayed (wait for table to refresh after save)
+    const keyRow = providersPage.getKeyRow(keyData.name)
+    await expect(keyRow.getByTestId('key-weight-value')).toContainText('0.7', { timeout: 10000 })
   })
 
   test('should delete a key', async ({ providersPage }) => {
@@ -313,12 +326,15 @@ test.describe('Provider Key Management', () => {
 
     await providersPage.addKey(keyData)
 
-    // Toggle the key
-    await providersPage.toggleKeyEnabled(keyData.name)
+    // Key starts enabled
+    let isEnabled = await providersPage.getKeyEnabledState(keyData.name)
+    expect(isEnabled).toBe(true)
 
-    // Key should still exist
-    const keyExists = await providersPage.keyExists(keyData.name)
-    expect(keyExists).toBe(true)
+    // Toggle to disabled
+    await providersPage.toggleKeyEnabled(keyData.name)
+    await providersPage.page.waitForTimeout(9000)
+    isEnabled = await providersPage.getKeyEnabledState(keyData.name)
+    expect(isEnabled).toBe(false)
   })
 })
 
@@ -342,12 +358,9 @@ test.describe('Provider Configuration', () => {
     // Select OpenAI provider
     await providersPage.selectProvider('openai')
 
-    // Check for models section or tab
+    // Models section should be visible for selected provider
     const modelsSection = providersPage.page.getByText(/Models/i).first()
-    const modelsVisible = await modelsSection.isVisible().catch(() => false)
-
-    // Either models are shown directly or there's no models section
-    expect(modelsVisible !== undefined).toBe(true)
+    await expect(modelsSection).toBeVisible()
   })
 })
 
@@ -366,11 +379,11 @@ test.describe('Performance Tuning', () => {
   })
 
   test('should display raw request/response toggles', async ({ providersPage }) => {
-    await providersPage.selectConfigTab('performance')
+    await providersPage.selectConfigTab('debugging')
 
-    // Should see raw request and response toggles
-    const rawRequestLabel = providersPage.page.getByText('Include Raw Request')
-    const rawResponseLabel = providersPage.page.getByText('Include Raw Response')
+    // Should see raw request and response toggles (Debugging tab labels)
+    const rawRequestLabel = providersPage.page.getByText('Send Back Raw Request')
+    const rawResponseLabel = providersPage.page.getByText('Send Back Raw Response')
 
     await expect(rawRequestLabel).toBeVisible()
     await expect(rawResponseLabel).toBeVisible()
@@ -401,6 +414,10 @@ test.describe('Performance Tuning', () => {
     const saveBtn = providersPage.getConfigSaveBtn('performance')
     await expect(saveBtn).toBeEnabled()
     await providersPage.savePerformanceConfig()
+
+    // Verify value persisted after save (reload would be ideal but we restore instead)
+    const afterSaveValue = await concurrencyInput.inputValue()
+    expect(afterSaveValue).toBe(newValue)
 
     // Restore original value
     await providersPage.fillNumberInput(concurrencyInput, originalValue)
@@ -445,7 +462,7 @@ test.describe('Performance Tuning', () => {
   })
 
   test('should toggle and save raw request/response', async ({ providersPage }) => {
-    await providersPage.selectConfigTab('performance')
+    await providersPage.selectConfigTab('debugging')
 
     const rawRequestSwitch = providersPage.getRawRequestSwitch()
     const rawResponseSwitch = providersPage.getRawResponseSwitch()
@@ -459,9 +476,9 @@ test.describe('Performance Tuning', () => {
     await rawResponseSwitch.click()
 
     // Save and verify success
-    const saveBtn = providersPage.getConfigSaveBtn('performance')
+    const saveBtn = providersPage.getConfigSaveBtn('debugging')
     await expect(saveBtn).toBeEnabled()
-    await providersPage.savePerformanceConfig()
+    await providersPage.saveDebuggingConfig()
 
     // Restore original states
     const currentRawRequest = await rawRequestSwitch.getAttribute('data-state') === 'checked'
@@ -474,7 +491,7 @@ test.describe('Performance Tuning', () => {
       await rawResponseSwitch.click()
     }
 
-    await providersPage.savePerformanceConfig()
+    await providersPage.saveDebuggingConfig()
   })
 })
 
@@ -710,5 +727,59 @@ test.describe('Governance (Budget & Rate Limits)', () => {
       expect(await tokenInput.inputValue()).toBe('100000')
       expect(await requestInput.inputValue()).toBe('1000')
     }
+  })
+})
+
+test.describe('Debugging Tab', () => {
+  test.beforeEach(async ({ providersPage }) => {
+    await providersPage.goto()
+    await providersPage.selectProvider('openai')
+  })
+
+  test('should display debugging tab', async ({ providersPage }) => {
+    await providersPage.openConfigSheet()
+    const debuggingTab = providersPage.page.getByTestId('provider-tab-debugging')
+    await expect(debuggingTab).toBeVisible()
+  })
+
+  test('should navigate to debugging tab', async ({ providersPage }) => {
+    await providersPage.selectConfigTab('debugging')
+
+    const debuggingTab = providersPage.page.getByTestId('provider-tab-debugging')
+    await expect(debuggingTab).toHaveAttribute('data-state', 'active')
+    const debuggingContent = providersPage.page.getByTestId('provider-config-debugging-content')
+    await expect(debuggingContent).toBeVisible()
+  })
+})
+
+test.describe('vLLM Provider', () => {
+  test.beforeEach(async ({ providersPage }) => {
+    await providersPage.goto()
+  })
+
+  test('should display vLLM-specific key fields when adding key to vLLM provider', async ({ providersPage }) => {
+    const vllmAvailable = await providersPage.providerExists('vllm')
+    if (!vllmAvailable) {
+      test.skip(true, 'vLLM provider not in sidebar (add from dropdown first)')
+      return
+    }
+
+    await providersPage.selectProvider('vllm')
+    await providersPage.addKeyBtn.click()
+
+    const vllmUrlInput = providersPage.page.getByTestId('key-input-vllm-url')
+    const vllmModelInput = providersPage.page.getByTestId('key-input-vllm-model-name')
+
+    const urlVisible = await vllmUrlInput.isVisible().catch(() => false)
+    const modelVisible = await vllmModelInput.isVisible().catch(() => false)
+
+    if (!urlVisible && !modelVisible) {
+      test.skip(true, 'vLLM key form fields not shown (provider may use standard key form)')
+      return
+    }
+    await expect(vllmUrlInput).toBeVisible()
+    await expect(vllmModelInput).toBeVisible()
+
+    await providersPage.keyCancelBtn.click()
   })
 })

--- a/tests/e2e/features/routing-rules/pages/routing-rules.page.ts
+++ b/tests/e2e/features/routing-rules/pages/routing-rules.page.ts
@@ -57,7 +57,7 @@ export class RoutingRulesPage extends BasePage {
     this.table = page.locator('table').filter({
       has: page.locator('th').filter({ hasText: /^Priority$/ })
     }).first()
-    this.emptyState = page.getByText(/No routing rules yet/i)
+    this.emptyState = page.getByTestId('routing-rules-empty-state')
     // Use .first() to handle both "New Rule" and "Create First Rule" buttons
     this.createBtn = page.locator('[data-testid="create-routing-rule-btn"]').or(
       page.getByRole('button', { name: /New Rule|Create First Rule/i }).first()
@@ -585,6 +585,17 @@ export class RoutingRulesPage extends BasePage {
   async reorderRuleByPriority(name: string, newPriority: number): Promise<void> {
     // Edit the rule and change its priority
     await this.editRoutingRule(name, { priority: newPriority })
+  }
+
+  /**
+   * Get rule's description from the table (first column contains name + description)
+   */
+  async getRuleDescription(name: string): Promise<string> {
+    const row = this.getRuleRow(name)
+    const descEl = row.getByTestId('routing-rule-description')
+    const count = await descEl.count()
+    if (count === 0) return ''
+    return (await descEl.textContent()) ?? ''
   }
 
   /**

--- a/tests/e2e/features/routing-rules/routing-rules.spec.ts
+++ b/tests/e2e/features/routing-rules/routing-rules.spec.ts
@@ -21,7 +21,6 @@ test.describe('Routing Rules', () => {
         // Ignore cleanup errors
       }
     }
-    // Clear the array
     createdRules.length = 0
   })
 
@@ -101,14 +100,14 @@ test.describe('Routing Rules', () => {
 
       await routingRulesPage.createRoutingRule(ruleData)
 
-      // Edit it
+      // Edit it - change description
       await routingRulesPage.editRoutingRule(ruleData.name, {
         description: 'Updated description',
       })
 
-      // Verify it still exists
-      const exists = await routingRulesPage.ruleExists(ruleData.name)
-      expect(exists).toBe(true)
+      // Verify description was saved and displayed in table
+      const description = await routingRulesPage.getRuleDescription(ruleData.name)
+      expect(description).toContain('Updated description')
     })
 
     test('should delete routing rule', async ({ routingRulesPage }) => {
@@ -169,9 +168,14 @@ test.describe('Routing Rules', () => {
   test.describe('Table Display', () => {
     test('should display routing rules table', async ({ routingRulesPage }) => {
       // With 0 rules the view shows empty state (no table); with 1+ rules it shows the table
-      const tableVisible = await routingRulesPage.table.isVisible().catch(() => false)
-      const emptyVisible = await routingRulesPage.emptyState.isVisible().catch(() => false)
-      expect(tableVisible || emptyVisible).toBe(true)
+      const count = await routingRulesPage.getRuleCount()
+      if (count === 0) {
+        await expect(routingRulesPage.emptyState).toBeVisible()
+        await expect(routingRulesPage.table).not.toBeVisible()
+      } else {
+        await expect(routingRulesPage.table).toBeVisible()
+        await expect(routingRulesPage.emptyState).not.toBeVisible()
+      }
     })
 
     test('should show empty state when no rules', async ({ routingRulesPage }) => {
@@ -224,9 +228,9 @@ test.describe('Routing Rules', () => {
       const newPriority = (rule1.priority! + 100) % 901
       await routingRulesPage.editRoutingRule(rule1.name, { priority: newPriority })
 
-      // Verify rules still exist
-      expect(await routingRulesPage.ruleExists(rule1.name)).toBe(true)
-      expect(await routingRulesPage.ruleExists(rule2.name)).toBe(true)
+      // Verify priority was saved and displayed
+      const displayedPriority = await routingRulesPage.getRulePriority(rule1.name)
+      expect(displayedPriority).toBe(newPriority)
     })
 
     test('should create rule with virtual key scope', async ({ routingRulesPage }) => {

--- a/tests/e2e/features/virtual-keys/pages/virtual-keys.page.ts
+++ b/tests/e2e/features/virtual-keys/pages/virtual-keys.page.ts
@@ -86,6 +86,7 @@ export class VirtualKeysPage extends BasePage {
   // Main page elements
   readonly createBtn: Locator
   readonly table: Locator
+  readonly emptyState: Locator
 
   // Virtual key sheet elements
   readonly sheet: Locator
@@ -102,6 +103,7 @@ export class VirtualKeysPage extends BasePage {
     // Main page elements
     this.createBtn = page.getByTestId('create-vk-btn')
     this.table = page.getByTestId('vk-table')
+    this.emptyState = page.getByTestId('virtual-keys-empty-state')
 
     // Virtual key sheet elements
     this.sheet = page.getByTestId('vk-sheet')
@@ -136,6 +138,19 @@ export class VirtualKeysPage extends BasePage {
     // Use count() to check if element exists in DOM (doesn't require visibility)
     const count = await row.count()
     return count > 0
+  }
+
+  /**
+   * Check if the key value is revealed (visible) or masked in the table.
+   * When masked, the display shows bullets (•); when revealed, it shows the full key.
+   */
+  async isKeyRevealed(name: string): Promise<boolean> {
+    const row = this.getVirtualKeyRow(name)
+    const keyCell = row.getByTestId('vk-key-value')
+    await keyCell.waitFor({ state: 'visible', timeout: 5000 })
+    const text = (await keyCell.textContent())?.trim() ?? ''
+    // Masked keys contain bullet character; revealed keys do not
+    return text.length > 0 && !text.includes('•')
   }
 
   /**

--- a/tests/e2e/features/virtual-keys/virtual-keys.spec.ts
+++ b/tests/e2e/features/virtual-keys/virtual-keys.spec.ts
@@ -114,6 +114,13 @@ test.describe('Virtual Keys', () => {
 
       const vkExists = await virtualKeysPage.virtualKeyExists(vkData.name)
       expect(vkExists).toBe(true)
+
+      // Verify budget was saved correctly
+      await virtualKeysPage.viewVirtualKey(vkData.name)
+      await virtualKeysPage.waitForSheetAnimation()
+      const budgetInput = virtualKeysPage.page.locator('#budgetMaxLimit')
+      await expect(budgetInput).toHaveValue(String(SAMPLE_BUDGETS.small.maxLimit))
+      await virtualKeysPage.closeSheet()
     })
 
     test('should create virtual key with medium budget', async ({ virtualKeysPage }) => {
@@ -152,6 +159,13 @@ test.describe('Virtual Keys', () => {
 
       const vkExists = await virtualKeysPage.virtualKeyExists(vkData.name)
       expect(vkExists).toBe(true)
+
+      // Verify rate limit was saved correctly
+      await virtualKeysPage.viewVirtualKey(vkData.name)
+      await virtualKeysPage.waitForSheetAnimation()
+      const tokenLimitInput = virtualKeysPage.page.locator('#tokenMaxLimit')
+      await expect(tokenLimitInput).toHaveValue(String(SAMPLE_RATE_LIMITS.tokenOnly.tokenMaxLimit))
+      await virtualKeysPage.closeSheet()
     })
 
     test('should create virtual key with request rate limit', async ({ virtualKeysPage }) => {
@@ -320,8 +334,10 @@ test.describe('Virtual Key Management', () => {
     // Click to view details
     await virtualKeysPage.viewVirtualKey(vkName)
 
-    // Detail sheet should be visible
+    // Detail sheet should be visible with correct content
     await expect(virtualKeysPage.sheet).toBeVisible()
+    await expect(virtualKeysPage.nameInput).toHaveValue(vkName)
+    await expect(virtualKeysPage.descriptionInput).toHaveValue('Detailed description for viewing')
 
     // Close the sheet (will be handled by afterEach if not)
     await virtualKeysPage.closeSheet()
@@ -334,10 +350,12 @@ test.describe('Virtual Key Management', () => {
     managementVKs.push(vkName)
     await virtualKeysPage.createVirtualKey(vkData)
 
-    // Copy the key value
+    // Copy the key value - method waits for success toast
     await virtualKeysPage.copyVirtualKeyValue(vkName)
 
-    // Should show success toast (assertion in the method)
+    // Verify copy succeeded: row still exists and key is intact
+    const vkExists = await virtualKeysPage.virtualKeyExists(vkName)
+    expect(vkExists).toBe(true)
   })
 
   test('should toggle key visibility', async ({ virtualKeysPage }) => {
@@ -347,39 +365,62 @@ test.describe('Virtual Key Management', () => {
     managementVKs.push(vkName)
     await virtualKeysPage.createVirtualKey(vkData)
 
+    // Initially key is masked
+    let isRevealed = await virtualKeysPage.isKeyRevealed(vkName)
+    expect(isRevealed).toBe(false)
+
     // Toggle visibility (show key)
     await virtualKeysPage.toggleKeyVisibility(vkName)
+    isRevealed = await virtualKeysPage.isKeyRevealed(vkName)
+    expect(isRevealed).toBe(true)
 
     // Toggle again (hide key)
     await virtualKeysPage.toggleKeyVisibility(vkName)
-
-    // Virtual key should still exist
-    const vkExists = await virtualKeysPage.virtualKeyExists(vkName)
-    expect(vkExists).toBe(true)
+    isRevealed = await virtualKeysPage.isKeyRevealed(vkName)
+    expect(isRevealed).toBe(false)
   })
 })
+
+// Track VKs created in Virtual Keys Table tests for cleanup
+const tableTestVKs: string[] = []
 
 test.describe('Virtual Keys Table', () => {
   test.beforeEach(async ({ virtualKeysPage }) => {
     await virtualKeysPage.goto()
   })
 
+  test.afterEach(async ({ virtualKeysPage }) => {
+    await virtualKeysPage.closeSheet()
+    if (tableTestVKs.length > 0) {
+      await virtualKeysPage.cleanupVirtualKeys([...tableTestVKs])
+      tableTestVKs.length = 0
+    }
+  })
+
   test('should display virtual keys table', async ({ virtualKeysPage }) => {
+    await virtualKeysPage.page.getByRole('heading', { name: /Virtual Keys/i }).or(virtualKeysPage.emptyState).first().waitFor({ state: 'visible', timeout: 10000 })
+    const hadTable = await virtualKeysPage.table.isVisible().catch(() => false)
+    if (!hadTable) {
+      await expect(virtualKeysPage.emptyState).toBeVisible({ timeout: 10000 })
+    } else {
+      await expect(virtualKeysPage.table).toBeVisible({ timeout: 10000 })
+    }
+    const vkData = createVirtualKeyData({ name: `Table test VK ${Date.now()}`, description: 'For table display test' })
+    tableTestVKs.push(vkData.name)
+    await virtualKeysPage.createVirtualKey(vkData)
     await expect(virtualKeysPage.table).toBeVisible({ timeout: 10000 })
-    // Verify table has the expected column headers
     await expect(virtualKeysPage.table.locator('th', { hasText: 'Name' })).toBeVisible()
     await expect(virtualKeysPage.table.locator('th', { hasText: 'Key' })).toBeVisible()
   })
 
   test('should show empty state when no virtual keys', async ({ virtualKeysPage }) => {
-    // Wait for the table to be visible first so we know the page has loaded
-    await expect(virtualKeysPage.table).toBeVisible({ timeout: 10000 })
-
-    // Delete all existing virtual keys to guarantee empty state
-    await virtualKeysPage.cleanupAllVirtualKeys()
-
-    const emptyMessage = virtualKeysPage.page.getByText('No virtual keys found')
-    await expect(emptyMessage).toBeVisible({ timeout: 10000 })
+    await virtualKeysPage.page.getByRole('heading', { name: /Virtual Keys/i }).or(virtualKeysPage.emptyState).first().waitFor({ state: 'visible', timeout: 10000 })
+    const tableVisible = await virtualKeysPage.table.isVisible().catch(() => false)
+    if (tableVisible) {
+      test.skip(true, 'Pre-existing virtual keys found; empty-state assertion requires isolated data.')
+      return
+    }
+    await expect(virtualKeysPage.emptyState).toBeVisible({ timeout: 10000 })
   })
 })
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -68,12 +68,12 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/config/**', '**/plugins/**', '**/virtual-keys/**', '**/mcp-registry/**'],
+      testIgnore: ['**/config/**', '**/plugins/**', '**/virtual-keys/**', '**/mcp-registry/**', '**/model-limits/**', '**/providers/**'],
     },
     {
       name: 'chromium-serial',
       use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/plugins/**/*.spec.ts', '**/virtual-keys/**/*.spec.ts', '**/mcp-registry/**/*.spec.ts'],
+      testMatch: ['**/plugins/**/*.spec.ts', '**/virtual-keys/**/*.spec.ts', '**/mcp-registry/**/*.spec.ts', '**/model-limits/**/*.spec.ts', '**/providers/**/*.spec.ts'],
       fullyParallel: false,
     },
     {

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -234,6 +234,7 @@ export default function ClientSettingsView() {
 								href="https://docs.getbifrost.ai/features/litellm-compat"
 								target="_blank"
 								rel="noopener noreferrer"
+								data-testid="litellm-docs-link"
 							>
 								Learn more
 							</a>

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -108,7 +108,7 @@ export default function MCPView() {
 	}, [bifrostConfig, localConfig, localValues, updateCoreConfig]);
 
 	return (
-		<div className="mx-auto w-full max-w-4xl space-y-4">
+		<div className="mx-auto w-full max-w-4xl space-y-4" data-testid="mcp-settings-view">
 			<div>
 				<h2 className="text-lg font-semibold tracking-tight">MCP Settings</h2>
 				<p className="text-muted-foreground text-sm">Configure MCP (Model Context Protocol) agent and tool settings.</p>
@@ -124,6 +124,7 @@ export default function MCPView() {
 					</div>
 					<Input
 						id="mcp-agent-depth"
+						data-testid="mcp-agent-depth-input"
 						type="number"
 						className="w-24"
 						value={localValues.mcp_agent_depth}
@@ -142,6 +143,7 @@ export default function MCPView() {
 					</div>
 					<Input
 						id="mcp-tool-execution-timeout"
+						data-testid="mcp-tool-timeout-input"
 						type="number"
 						className="w-24"
 						value={localValues.mcp_tool_execution_timeout}
@@ -179,7 +181,7 @@ export default function MCPView() {
 						</p>
 					</div>
 					<Select value={localValues.mcp_code_mode_binding_level} onValueChange={handleCodeModeBindingLevelChange}>
-						<SelectTrigger id="mcp-binding-level" className="w-56">
+						<SelectTrigger id="mcp-binding-level" data-testid="mcp-binding-level" className="w-56">
 							<SelectValue placeholder="Select binding level" />
 						</SelectTrigger>
 						<SelectContent>
@@ -222,7 +224,7 @@ export default function MCPView() {
 				</div>
 			</div>
 			<div className="flex justify-end pt-2">
-				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
+				<Button onClick={handleSave} disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess} data-testid="mcp-settings-save-btn">
 					{isLoading ? "Saving..." : "Save Changes"}
 				</Button>
 			</div>

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -80,7 +80,7 @@ export default function PricingConfigView() {
 	};
 
 	return (
-		<div className="mx-auto w-full max-w-7xl space-y-4">
+		<div className="mx-auto w-full max-w-7xl space-y-4" data-testid="pricing-config-view">
 			<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Pricing Configuration</h2>
@@ -98,6 +98,7 @@ export default function PricingConfigView() {
 							id="pricing-datasheet-url"
 							type="text"
 							placeholder="https://example.com/pricing.json"
+							data-testid="pricing-datasheet-url-input"
 							{...register("pricing_datasheet_url", {
 								pattern: {
 									value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))([\/\w \.-]*)*\/?$/,
@@ -146,10 +147,10 @@ export default function PricingConfigView() {
 					</div>
 				</div>
 				<div className="flex justify-end gap-2 pt-2">
-					<Button variant="outline" type="button" onClick={handleForceSync} disabled={isForceSyncing || !hasSettingsUpdateAccess}>
+					<Button variant="outline" type="button" onClick={handleForceSync} disabled={isForceSyncing || !hasSettingsUpdateAccess} data-testid="pricing-force-sync-btn">
 						{isForceSyncing ? "Syncing..." : "Force Sync Now"}
 					</Button>
-					<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess}>
+					<Button type="submit" disabled={!hasChanges || isLoading || !hasSettingsUpdateAccess} data-testid="pricing-save-btn">
 						{isLoading ? "Saving..." : "Save Changes"}
 					</Button>
 				</div>

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -266,6 +266,7 @@ export default function SecurityView() {
 								target="_blank"
 								rel="noopener noreferrer"
 								className="text-primary underline"
+								data-testid="security-virtual-keys-docs-link"
 							>
 								documentation
 							</Link>{" "}

--- a/ui/app/workspace/governance/views/customerDialog.tsx
+++ b/ui/app/workspace/governance/views/customerDialog.tsx
@@ -210,7 +210,7 @@ export default function CustomerDialog({ customer, onSave, onCancel }: CustomerD
 
 	return (
 		<Dialog open onOpenChange={onCancel}>
-			<DialogContent className="max-w-2xl">
+			<DialogContent className="max-w-2xl" data-testid="customer-dialog-content">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">{isEditing ? "Edit Customer" : "Create Customer"}</DialogTitle>
 					<DialogDescription>
@@ -228,6 +228,7 @@ export default function CustomerDialog({ customer, onSave, onCancel }: CustomerD
 								<Label htmlFor="name">Customer Name *</Label>
 								<Input
 									id="name"
+									data-testid="customer-name-input"
 									placeholder="e.g., Acme Corporation"
 									value={formData.name}
 									maxLength={50}
@@ -246,6 +247,7 @@ export default function CustomerDialog({ customer, onSave, onCancel }: CustomerD
 							onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
 							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
 							options={resetDurationOptions}
+							dataTestId="budget-max-limit-input"
 						/>
 
 						{/* Rate Limit Configuration - Token Limits */}

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -165,6 +165,7 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 									return (
 										<TableRow
 											key={customer.id}
+											data-testid={`customer-row-${customer.name}`}
 											className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}
 										>
 											<TableCell className="max-w-[200px] py-4">

--- a/ui/app/workspace/governance/views/teamDialog.tsx
+++ b/ui/app/workspace/governance/views/teamDialog.tsx
@@ -217,7 +217,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 
 	return (
 		<Dialog open onOpenChange={onCancel}>
-			<DialogContent className="max-w-2xl">
+			<DialogContent className="max-w-2xl" data-testid="team-dialog-content">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">{isEditing ? "Edit Team" : "Create Team"}</DialogTitle>
 					<DialogDescription>
@@ -237,6 +237,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 									value={formData.name}
 									maxLength={50}
 									onChange={(e) => updateField("name", e.target.value)}
+									data-testid="team-name-input"
 								/>
 							</div>
 
@@ -274,6 +275,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 							onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
 							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
 							options={resetDurationOptions}
+							dataTestId="budget-max-limit-input"
 						/>
 
 						{/* Rate Limit Configuration - Token Limits */}

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -163,7 +163,7 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 									const isExhausted = isBudgetExhausted || isRateLimitExhausted;
 
 									return (
-										<TableRow key={team.id} className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}>
+										<TableRow key={team.id} data-testid={`team-row-${team.name}`} className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}>
 											<TableCell className="max-w-[200px] py-4">
 												<div className="flex flex-col gap-2">
 													<span className="truncate font-medium">{team.name}</span>
@@ -174,7 +174,7 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 													)}
 												</div>
 											</TableCell>
-											<TableCell>
+											<TableCell data-testid={`team-row-${team.name}-customer`}>
 												<div className="flex items-center gap-2">
 													<Badge variant={team.customer_id ? "secondary" : "outline"}>{customerName}</Badge>
 												</div>
@@ -313,6 +313,7 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 														onClick={() => handleEditTeam(team)}
 														disabled={!hasUpdateAccess}
 														aria-label={`Edit team ${team.name}`}
+														data-testid={`team-edit-btn-${team.name}`}
 													>
 														<Edit className="h-4 w-4" />
 													</Button>
@@ -324,6 +325,7 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 																className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
 																disabled={!hasDeleteAccess}
 																aria-label={`Delete team ${team.name}`}
+																data-testid={`team-delete-btn-${team.name}`}
 															>
 																<Trash2 className="h-4 w-4" />
 															</Button>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -187,7 +187,7 @@ export default function MCPClientsTable({ mcpClients, refetch }: MCPClientsTable
 									onClick={() => handleRowClick(c)}
 								>
 									<TableCell className="font-medium">{c.config.name}</TableCell>
-									<TableCell>{getConnectionTypeDisplay(c.config.connection_type)}</TableCell>
+									<TableCell data-testid="mcp-client-connection-type">{getConnectionTypeDisplay(c.config.connection_type)}</TableCell>
 									<TableCell>
 										<Badge
 											className={

--- a/ui/app/workspace/mcp-registry/views/mcpServersEmptyState.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpServersEmptyState.tsx
@@ -26,6 +26,7 @@ export function MCPServersEmptyState({ onAddClick, canCreate = true }: MCPServer
 					<Button
 						variant="outline"
 						aria-label="Read more about MCP servers (opens in new tab)"
+						data-testid="mcp-registry-button-read-more"
 						onClick={() => {
 							window.open(`${MCP_SERVERS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
 						}}

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -214,6 +214,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8"
 				onInteractOutside={(e) => { if (isEditing ? form.formState.isDirty : (!!form.watch("modelName") || hasAnyLimit)) e.preventDefault(); }}
 				onEscapeKeyDown={(e) => { if (isEditing ? form.formState.isDirty : (!!form.watch("modelName") || hasAnyLimit)) e.preventDefault(); }}
+				data-testid="model-limit-sheet"
 			>
 				<SheetHeader className="flex flex-col items-start p-0">
 					<SheetTitle>{isEditing ? "Edit Model Limit" : "Create Model Limit"}</SheetTitle>
@@ -238,7 +239,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 											disabled={isEditing}
 										>
 											<FormControl>
-												<SelectTrigger className="w-full">
+												<SelectTrigger className="w-full" data-testid="model-limit-provider-select">
 													<SelectValue placeholder="All Providers" />
 												</SelectTrigger>
 											</FormControl>
@@ -271,15 +272,17 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 									<FormItem>
 										<FormLabel>Model Name</FormLabel>
 										<FormControl>
-											<ModelMultiselect
-												provider={form.watch("provider") || undefined}
-												value={field.value}
-												onChange={field.onChange}
-												placeholder="Search for a model..."
-												isSingleSelect
-												loadModelsOnEmptyProvider="base_models"
-												disabled={isEditing}
-											/>
+											<div data-testid="model-limit-model-select">
+												<ModelMultiselect
+													provider={form.watch("provider") || undefined}
+													value={field.value}
+													onChange={field.onChange}
+													placeholder="Search for a model..."
+													isSingleSelect
+													loadModelsOnEmptyProvider="base_models"
+													disabled={isEditing}
+												/>
+											</div>
 										</FormControl>
 										<FormMessage />
 									</FormItem>

--- a/ui/app/workspace/model-limits/views/modelLimitsEmptyState.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsEmptyState.tsx
@@ -26,6 +26,7 @@ export function ModelLimitsEmptyState({ onAddClick, canCreate = true }: ModelLim
 					<Button
 						variant="outline"
 						aria-label="Read more about budgets and limits (opens in new tab)"
+						data-testid="model-limits-button-read-more"
 						onClick={() => {
 							window.open(`${MODEL_LIMITS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
 						}}
@@ -36,6 +37,7 @@ export function ModelLimitsEmptyState({ onAddClick, canCreate = true }: ModelLim
 						aria-label="Add your first model limit"
 						onClick={onAddClick}
 						disabled={!canCreate}
+						data-testid="model-limits-button-create"
 					>
 						Add Model Limit
 					</Button>

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -35,6 +35,9 @@ const formatResetDuration = (duration: string) => {
 	return resetDurationLabels[duration] || duration;
 };
 
+const toTestIdPart = (value: string) =>
+	value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
 }
@@ -106,13 +109,13 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 							Configure budgets and rate limits at the model level. For provider-specific limits, visit each provider&apos;s settings.
 						</p>
 					</div>
-					<Button onClick={handleAddModelLimit} disabled={!hasCreateAccess}>
+					<Button onClick={handleAddModelLimit} disabled={!hasCreateAccess} data-testid="model-limits-button-create">
 						<Plus className="h-4 w-4" />
 						Add Model Limit
 					</Button>
 				</div>
 
-				<div className="rounded-sm border">
+				<div className="rounded-sm border" data-testid="model-limits-table">
 					<Table>
 							<TableHeader>
 								<TableRow className="hover:bg-transparent">
@@ -151,7 +154,7 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 											: 0;
 
 									return (
-										<TableRow key={config.id} className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}>
+										<TableRow key={config.id} data-testid={`model-limit-row-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`} className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}>
 											<TableCell className="max-w-[280px] py-4">
 												<div className="flex flex-col gap-2">
 													<span className="truncate font-mono text-sm font-medium">{config.model_name}</span>
@@ -300,7 +303,7 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 														onClick={(e) => handleEditModelLimit(config, e)}
 														disabled={!hasUpdateAccess}
 														aria-label={`Edit model limit for ${config.model_name}`}
-														data-testid="model-limit-button-edit"
+														data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
 													>
 														<Edit className="h-4 w-4" />
 													</Button>
@@ -313,7 +316,7 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 																onClick={(e) => e.stopPropagation()}
 																disabled={!hasDeleteAccess}
 																aria-label={`Delete model limit for ${config.model_name}`}
-																data-testid="model-limit-button-delete"
+																data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
 															>
 																<Trash2 className="h-4 w-4" />
 															</Button>

--- a/ui/app/workspace/plugins/fragments/pluginFormFragments.tsx
+++ b/ui/app/workspace/plugins/fragments/pluginFormFragments.tsx
@@ -36,6 +36,7 @@ export function PluginFormFragment({ form, isEditMode = false }: PluginFormFragm
 						target="_blank"
 						rel="noopener noreferrer"
 						className="text-primary hover:underline"
+						data-testid="plugins-form-docs-link"
 					>
 						Learn more
 					</a>

--- a/ui/app/workspace/plugins/page.tsx
+++ b/ui/app/workspace/plugins/page.tsx
@@ -72,6 +72,7 @@ export default function PluginsPage() {
 								<button
 									type="button"
 									key={plugin.name}
+									data-testid="plugin-list-item"
 									aria-current={selectedPlugin?.name === plugin.name ? "page" : undefined}
 									className={cn(
 										"mb-1 flex max-h-[32px] w-full items-center gap-2 rounded-sm border px-3 py-1.5 text-sm",
@@ -99,6 +100,7 @@ export default function PluginsPage() {
 							))}
 							<div className="my-4">
 								<Button
+									data-testid="plugins-create-button"
 									variant="outline"
 									size="sm"
 									className="w-full justify-start"

--- a/ui/app/workspace/plugins/views/pluginsEmptyState.tsx
+++ b/ui/app/workspace/plugins/views/pluginsEmptyState.tsx
@@ -13,7 +13,7 @@ interface PluginsEmptyStateProps {
 
 export function PluginsEmptyState({ onCreateClick, canCreate = true }: PluginsEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
+		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center" data-testid="plugins-empty-state">
 			<div className="text-muted-foreground">
 				<Puzzle className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
 			</div>

--- a/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
@@ -63,7 +63,7 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6" data-testid="provider-config-debugging-content">
 				<div className="space-y-4">
 					<FormField
 						control={form.control}

--- a/ui/app/workspace/providers/views/addProviderDropdown.tsx
+++ b/ui/app/workspace/providers/views/addProviderDropdown.tsx
@@ -64,6 +64,7 @@ export function AddProviderDropdown({
 					</DropdownMenuItem>
 				))}
 				{hasKnown && <DropdownMenuSeparator />}
+				{/* Add New Provider > Custom provider... — used by E2E (add-provider-option-custom) */}
 				<DropdownMenuItem data-testid="add-provider-option-custom" onSelect={onAddCustomProvider}>
 					<Settings2Icon className="h-4 w-4" />
 					<span>Custom provider...</span>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -133,7 +133,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 						</TableHeader>
 						<TableBody>
 							{provider.keys.length === 0 && (
-								<TableRow>
+								<TableRow data-testid="keys-table-empty-state">
 									<TableCell colSpan={4} className="py-6 text-center">
 										No {entityLabelPlural} found.
 									</TableCell>
@@ -170,13 +170,14 @@ export default function ModelProviderKeysTableView({ provider, className, header
 												<span className="font-mono text-sm">{key.name}</span>
 											</div>
 										</TableCell>
-										<TableCell>
+										<TableCell data-testid="key-weight-value">
 											<div className="flex items-center space-x-2">
 												<span className="font-mono text-sm">{key.weight}</span>
 											</div>
 										</TableCell>
 										<TableCell>
 											<Switch
+												data-testid="key-enabled-switch"
 												checked={isKeyEnabled}
 												size="md"
 												disabled={!hasUpdateProviderAccess}

--- a/ui/app/workspace/providers/views/providersEmptyState.tsx
+++ b/ui/app/workspace/providers/views/providersEmptyState.tsx
@@ -25,6 +25,7 @@ export function ProvidersEmptyState({ addProviderDropdown }: ProvidersEmptyState
 					<Button
 						variant="outline"
 						aria-label="Read more about providers (opens in new tab)"
+						data-testid="providers-button-read-more"
 						onClick={() => {
 							window.open(`${PROVIDERS_DOCS_URL}?utm_source=bfd`, "_blank", "noopener,noreferrer");
 						}}

--- a/ui/app/workspace/routing-rules/views/routingRulesEmptyState.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesEmptyState.tsx
@@ -13,7 +13,7 @@ interface RoutingRulesEmptyStateProps {
 
 export function RoutingRulesEmptyState({ onAddClick, canCreate = true }: RoutingRulesEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
+		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center" data-testid="routing-rules-empty-state">
 			<div className="text-muted-foreground">
 				<Route className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
 			</div>
@@ -35,7 +35,7 @@ export function RoutingRulesEmptyState({ onAddClick, canCreate = true }: Routing
 					</Button>
 					<Button
 						aria-label="Create your first routing rule"
-						data-testid="routing-rules-empty-new-rule"
+						data-testid="create-routing-rule-btn"
 						onClick={onAddClick}
 						disabled={!canCreate}
 					>

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -125,7 +125,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 									<div className="flex flex-col gap-1">
 										<span className="truncate max-w-xs">{rule.name}</span>
 										{rule.description && (
-											<span className="text-xs text-muted-foreground truncate max-w-xs">{rule.description}</span>
+											<span data-testid="routing-rule-description" className="text-xs text-muted-foreground truncate max-w-xs">{rule.description}</span>
 										)}
 									</div>
 								</TableCell>

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -62,7 +62,12 @@ export function RoutingRulesView() {
 					<p className="text-muted-foreground text-sm">Manage CEL-based routing rules for intelligent request routing across providers</p>
 				</div>
 				{canCreate && (
-					<Button onClick={handleCreateNew} disabled={isLoading} className="gap-2">
+					<Button
+						data-testid="create-routing-rule-btn"
+						onClick={handleCreateNew}
+						disabled={isLoading}
+						className="gap-2"
+					>
 						<Plus className="h-4 w-4" />
 						<span className="hidden sm:inline">New Rule</span>
 					</Button>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysEmptyState.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysEmptyState.tsx
@@ -13,7 +13,7 @@ interface VirtualKeysEmptyStateProps {
 
 export function VirtualKeysEmptyState({ onAddClick, canCreate = true }: VirtualKeysEmptyStateProps) {
 	return (
-		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center">
+		<div className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center" data-testid="virtual-keys-empty-state">
 			<div className="text-muted-foreground">
 				<KeyRound className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />
 			</div>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -189,7 +189,7 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers }: Virt
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<div className="flex items-center gap-2">
-													<code className="cursor-default px-2 py-1 font-mono text-sm">{maskKey(vk.value, isRevealed)}</code>
+													<code className="cursor-default px-2 py-1 font-mono text-sm" data-testid="vk-key-value">{maskKey(vk.value, isRevealed)}</code>
 													<Button
 														variant="ghost"
 														size="sm"

--- a/ui/components/ui/numberAndSelect.tsx
+++ b/ui/components/ui/numberAndSelect.tsx
@@ -12,6 +12,7 @@ const NumberAndSelect = ({
 	onChangeSelect,
 	options,
 	labelClassName,
+	dataTestId,
 }: {
 	id: string;
 	label: string;
@@ -21,6 +22,7 @@ const NumberAndSelect = ({
 	onChangeSelect: (value: string) => void;
 	options: { label: string; value: string }[];
 	labelClassName?: string;
+	dataTestId?: string;
 }) => {
 	return (
 		<div className="flex w-full items-center justify-between gap-4">
@@ -30,6 +32,7 @@ const NumberAndSelect = ({
 				</Label>
 				<Input
 					id={id}
+					data-testid={dataTestId}
 					placeholder="100"
 					value={value}
 					onChange={(e) => {


### PR DESCRIPTION
## Summary

Expands end-to-end test coverage across multiple features including governance, model limits, MCP settings, observability connectors, and configuration options. Adds comprehensive test suites for team/customer management, pricing overrides, and documentation link validation.

## Changes

- **New test suites**: Added governance (teams/customers), model limits, MCP settings, MCP auth config, and MCP tool groups
- **Enhanced existing tests**: Expanded config settings, providers, observability, dashboard, MCP registry, routing rules, virtual keys, and plugins tests
- **Documentation link validation**: Added tests to verify "Read more" links point to correct documentation URLs
- **Placeholder page tests**: Added coverage for enterprise feature placeholder pages
- **Improved test reliability**: Enhanced assertions, added proper cleanup, and improved state verification
- **New page objects**: Created page objects for governance, model limits, and MCP-related features
- **Test data factories**: Added data generation utilities for consistent test data creation

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] UI (Next.js)

## How to test

Run the expanded E2E test suite:

```sh
cd tests/e2e
npm install
npx playwright test

# Run specific test suites
npx playwright test governance
npx playwright test model-limits
npx playwright test config
npx playwright test read-more-links
```

The tests cover both OSS and enterprise features, with appropriate skipping for unavailable functionality.

## Screenshots/Recordings

N/A - Test infrastructure changes only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Improves test coverage and reliability for the web UI components.

## Security considerations

Tests include validation of RBAC-protected features and proper handling of sensitive data like API keys in test scenarios.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable