### PR TITLE
nix: add NixOS module and flake packages for bifrost

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,57 +76,10 @@
       # Or if you use direnv:
       # direnv allow
       devShells = forEachSupportedSystem (
-        {
-          pkgs,
-        }:
+        { pkgs, ... }:
         {
           # Run `nix develop` to activate this environment or `direnv allow` if you have direnv installed
-          default = pkgs.mkShellNoCC {
-            # The name of the environment
-            name = "bifrost-nix-dev-shell";
-
-            # The Nix packages provided in the environment
-            packages = with pkgs; [
-              go
-              gopls
-              gofumpt
-              air
-              delve # provides dlv
-              go-tools # provides staticcheck
-
-              nodejs_24
-            ];
-
-            # Set any environment variables for your development environment
-            env = { };
-
-            # Add any shell logic you want executed when the environment is activated
-            shellHook = ''
-              ##
-              ## Go: project-local GOPATH/GOBIN
-              ##
-              export GOPATH="$PWD/.nix-store/go"
-              export GOBIN="$GOPATH/bin"
-              export GOMODCACHE="$GOPATH/pkg/mod"
-              export GOCACHE="$PWD/.nix-store/gocache"
-
-              mkdir -p "$GOBIN" "$GOMODCACHE" "$GOCACHE"
-
-              export PATH="$PATH:$GOBIN"
-
-              ##
-              ## Node: project-local "global" npm prefix
-              ##
-              # npm reads npm_config_prefix (or NPM_CONFIG_PREFIX) as the "prefix" config,
-              # which is where `npm i -g` installs to.
-              export npm_config_prefix="$PWD/.nix-store/npm-global"
-
-              mkdir -p "$npm_config_prefix/bin"
-
-              # Ensure "global" npm bin is on PATH for this shell only
-              export PATH="$PATH:$npm_config_prefix/bin"
-            '';
-          };
+          default = import ./nix/devshells/default.nix { inherit pkgs; };
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -7,18 +7,21 @@
   };
 
   # Flake outputs
-  outputs = {self, ...} @ inputs: let
-    # The systems supported for this flake's outputs
-    supportedSystems = [
-      "x86_64-linux" # 64-bit Intel/AMD Linux
-      "aarch64-linux" # 64-bit ARM Linux
-      "aarch64-darwin" # 64-bit ARM macOS
-    ];
+  outputs =
+    { self, ... }@inputs:
+    let
+      # The systems supported for this flake's outputs
+      supportedSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
 
-    # Helper for providing system-specific attributes
-    forEachSupportedSystem = f:
-      inputs.nixpkgs.lib.genAttrs supportedSystems (
-        system:
+      # Helper for providing system-specific attributes
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
           f {
             inherit system;
             # Provides a system-specific, configured Nixpkgs
@@ -28,65 +31,103 @@
               config.allowUnfree = true;
             };
           }
+        );
+    in
+    {
+      packages = forEachSupportedSystem (
+        {
+          pkgs,
+          system,
+        }:
+        let
+          version = "1.4.9";
+
+          bifrost-ui = pkgs.callPackage ./nix/packages/bifrost-ui.nix {
+            src = self;
+            inherit version;
+          };
+        in
+        {
+          bifrost-http = pkgs.callPackage ./nix/packages/bifrost-http.nix {
+            inherit inputs;
+            src = self;
+            inherit version;
+            inherit bifrost-ui;
+          };
+
+          default = self.packages.${system}.bifrost-http;
+        }
       );
-  in {
-    # To activate the default environment:
-    # nix develop
-    # Or if you use direnv:
-    # direnv allow
-    devShells = forEachSupportedSystem (
-      {
-        pkgs,
-        system,
-      }: {
-        # Run `nix develop` to activate this environment or `direnv allow` if you have direnv installed
-        default = pkgs.mkShellNoCC {
-          # The name of the environment
-          name = "bifrost-nix-dev-shell";
 
-          # The Nix packages provided in the environment
-          packages = with pkgs; [
-            go
-            gopls
-            gofumpt
-            air
-            delve # provides dlv
-            go-tools # provides staticcheck
+      apps = forEachSupportedSystem (
+        { system, ... }:
+        {
+          bifrost-http = {
+            type = "app";
+            program = "${self.packages.${system}.bifrost-http}/bin/bifrost-http";
+          };
 
-            nodejs_24
-          ];
+          default = self.apps.${system}.bifrost-http;
+        }
+      );
 
-          # Set any environment variables for your development environment
-          env = {};
+      # To activate the default environment:
+      # nix develop
+      # Or if you use direnv:
+      # direnv allow
+      devShells = forEachSupportedSystem (
+        {
+          pkgs,
+        }:
+        {
+          # Run `nix develop` to activate this environment or `direnv allow` if you have direnv installed
+          default = pkgs.mkShellNoCC {
+            # The name of the environment
+            name = "bifrost-nix-dev-shell";
 
-          # Add any shell logic you want executed when the environment is activated
-          shellHook = ''
-            ##
-            ## Go: project-local GOPATH/GOBIN
-            ##
-            export GOPATH="$PWD/.nix-store/go"
-            export GOBIN="$GOPATH/bin"
-            export GOMODCACHE="$GOPATH/pkg/mod"
-            export GOCACHE="$PWD/.nix-store/gocache"
+            # The Nix packages provided in the environment
+            packages = with pkgs; [
+              go
+              gopls
+              gofumpt
+              air
+              delve # provides dlv
+              go-tools # provides staticcheck
 
-            mkdir -p "$GOBIN" "$GOMODCACHE" "$GOCACHE"
+              nodejs_24
+            ];
 
-            export PATH="$PATH:$GOBIN"
+            # Set any environment variables for your development environment
+            env = { };
 
-            ##
-            ## Node: project-local "global" npm prefix
-            ##
-            # npm reads npm_config_prefix (or NPM_CONFIG_PREFIX) as the "prefix" config,
-            # which is where `npm i -g` installs to.
-            export npm_config_prefix="$PWD/.nix-store/npm-global"
+            # Add any shell logic you want executed when the environment is activated
+            shellHook = ''
+              ##
+              ## Go: project-local GOPATH/GOBIN
+              ##
+              export GOPATH="$PWD/.nix-store/go"
+              export GOBIN="$GOPATH/bin"
+              export GOMODCACHE="$GOPATH/pkg/mod"
+              export GOCACHE="$PWD/.nix-store/gocache"
 
-            mkdir -p "$npm_config_prefix/bin"
+              mkdir -p "$GOBIN" "$GOMODCACHE" "$GOCACHE"
 
-            # Ensure "global" npm bin is on PATH for this shell only
-            export PATH="$PATH:$npm_config_prefix/bin"
-          '';
-        };
-      }
-    );
-  };
+              export PATH="$PATH:$GOBIN"
+
+              ##
+              ## Node: project-local "global" npm prefix
+              ##
+              # npm reads npm_config_prefix (or NPM_CONFIG_PREFIX) as the "prefix" config,
+              # which is where `npm i -g` installs to.
+              export npm_config_prefix="$PWD/.nix-store/npm-global"
+
+              mkdir -p "$npm_config_prefix/bin"
+
+              # Ensure "global" npm bin is on PATH for this shell only
+              export PATH="$PATH:$npm_config_prefix/bin"
+            '';
+          };
+        }
+      );
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,12 @@
     in
     {
       nixosModules = {
-        bifrost = import ./nix/modules/bifrost.nix;
+        bifrost =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ./nix/modules/bifrost.nix ];
+            services.bifrost.package = lib.mkDefault self.packages.${pkgs.system}.bifrost-http;
+          };
       };
 
       packages = forEachSupportedSystem (

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,8 @@
           };
         in
         {
+          bifrost-ui = bifrost-ui;
+
           bifrost-http = pkgs.callPackage ./nix/packages/bifrost-http.nix {
             inherit inputs;
             src = self;

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,10 @@
         );
     in
     {
+      nixosModules = {
+        bifrost = import ./nix/modules/bifrost.nix;
+      };
+
       packages = forEachSupportedSystem (
         {
           pkgs,

--- a/nix/devshells/default.nix
+++ b/nix/devshells/default.nix
@@ -1,0 +1,32 @@
+{ pkgs }:
+
+pkgs.mkShellNoCC {
+  name = "bifrost-nix-dev-shell";
+
+  packages = with pkgs; [
+    go
+    gopls
+    gofumpt
+    air
+    delve
+    go-tools
+
+    nodejs_24
+  ];
+
+  env = { };
+
+  shellHook = ''
+    export GOPATH="$PWD/.nix-store/go"
+    export GOBIN="$GOPATH/bin"
+    export GOMODCACHE="$GOPATH/pkg/mod"
+    export GOCACHE="$PWD/.nix-store/gocache"
+
+    mkdir -p "$GOBIN" "$GOMODCACHE" "$GOCACHE"
+    export PATH="$PATH:$GOBIN"
+
+    export npm_config_prefix="$PWD/.nix-store/npm-global"
+    mkdir -p "$npm_config_prefix/bin"
+    export PATH="$PATH:$npm_config_prefix/bin"
+  '';
+}

--- a/nix/modules/bifrost.nix
+++ b/nix/modules/bifrost.nix
@@ -1,0 +1,216 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+
+  cfg = config.services.bifrost;
+  settingsFormat = pkgs.formats.json { };
+in
+{
+  options = {
+    services.bifrost = {
+      enable = lib.mkEnableOption "Bifrost HTTP gateway";
+
+      package = lib.mkPackageOption pkgs "bifrost-http" { };
+
+      stateDir = lib.mkOption {
+        type = types.path;
+        default = "/var/lib/bifrost";
+        example = "/var/lib/bifrost";
+        description = "Application data directory (contains config.json and logs).";
+      };
+
+      host = lib.mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        example = "0.0.0.0";
+        description = "The host address which the Bifrost HTTP server listens to.";
+      };
+
+      port = lib.mkOption {
+        type = types.port;
+        default = 8080;
+        example = 11111;
+        description = "Which port the Bifrost HTTP server listens to.";
+      };
+
+      logLevel = lib.mkOption {
+        type = types.enum [
+          "debug"
+          "info"
+          "warn"
+          "error"
+        ];
+        default = "info";
+        description = "Logger level.";
+      };
+
+      logStyle = lib.mkOption {
+        type = types.enum [
+          "json"
+          "pretty"
+        ];
+        default = "json";
+        description = "Logger output style.";
+      };
+
+      settings = lib.mkOption {
+        type = types.nullOr settingsFormat.type;
+        default = null;
+        description = ''
+          Optional content for `config.json` under `services.bifrost.stateDir`.
+
+          If set, the file will be written on service start (overwriting any existing config.json).
+          If null, Bifrost will use an existing config.json (or bootstrap from environment).
+        '';
+        example = {
+          providers = [
+            {
+              name = "openai";
+              enabled = true;
+              keys = [
+                {
+                  name = "default";
+                  value = "env.OPENAI_API_KEY";
+                }
+              ];
+            }
+          ];
+        };
+      };
+
+      environment = lib.mkOption {
+        type = types.attrsOf types.str;
+        default = { };
+        description = "Extra environment variables for Bifrost.";
+        example = {
+          OPENAI_API_KEY = "...";
+        };
+      };
+
+      environmentFile = lib.mkOption {
+        description = ''
+          Environment file to be passed to the systemd service.
+          Useful for passing secrets to the service to prevent them from being
+          world-readable in the Nix store.
+        '';
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        example = "/var/lib/secrets/bifrost.env";
+      };
+
+      openFirewall = lib.mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to open the firewall for Bifrost.
+          This adds `services.bifrost.port` to `networking.firewall.allowedTCPPorts`.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Extra CLI arguments passed to bifrost-http.";
+        example = [
+          "-some-flag"
+          "value"
+        ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions =
+      let
+        stateDirStr = toString cfg.stateDir;
+      in
+      [
+        {
+          assertion = builtins.dirOf stateDirStr == "/var/lib";
+          message = "services.bifrost.stateDir must be a direct child of /var/lib (e.g. /var/lib/bifrost) to work with systemd StateDirectory and DynamicUser.";
+        }
+      ];
+
+    systemd.services.bifrost =
+      let
+        stateDirStr = toString cfg.stateDir;
+        stateDirName = builtins.baseNameOf stateDirStr;
+        configFile =
+          if cfg.settings == null then null else settingsFormat.generate "bifrost-config.json" cfg.settings;
+      in
+      {
+        description = "Bifrost AI Gateway (bifrost-http)";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+
+        environment = cfg.environment;
+
+        preStart = lib.optionalString (configFile != null) ''
+          install -Dm600 "${configFile}" "${stateDirStr}/config.json"
+        '';
+
+        serviceConfig = {
+          ExecStart = lib.concatStringsSep " " (
+            [
+              (lib.getExe cfg.package)
+              "-host"
+              cfg.host
+              "-port"
+              (toString cfg.port)
+              "-app-dir"
+              stateDirStr
+              "-log-level"
+              cfg.logLevel
+              "-log-style"
+              cfg.logStyle
+            ]
+            ++ cfg.extraArgs
+          );
+
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+
+          WorkingDirectory = cfg.stateDir;
+          StateDirectory = stateDirName;
+          RuntimeDirectory = "bifrost";
+          RuntimeDirectoryMode = "0755";
+
+          PrivateTmp = true;
+          DynamicUser = true;
+          DevicePolicy = "closed";
+          LockPersonality = true;
+          PrivateUsers = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          UMask = "0077";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          ProtectClock = true;
+          ProtectProc = "invisible";
+        };
+      };
+
+    networking.firewall = lib.mkIf cfg.openFirewall { allowedTCPPorts = [ cfg.port ]; };
+  };
+
+  meta.maintainers = [
+    {
+      name = "ReStranger";
+      github = "ReStranger";
+    }
+  ];
+}

--- a/nix/packages/bifrost-http.nix
+++ b/nix/packages/bifrost-http.nix
@@ -1,0 +1,83 @@
+{
+  pkgs,
+  inputs,
+  src,
+  version,
+  bifrost-ui,
+}:
+let
+  lib = pkgs.lib;
+
+  # Bifrost requires Go 1.26 (go.mod/go.work). Force Go 1.26 for buildGoModule.
+  buildGoModule = pkgs.callPackage "${inputs.nixpkgs}/pkgs/build-support/go/module.nix" {
+    go = pkgs.go_1_26 or pkgs.go;
+  };
+
+  transportsLocalReplaces = ''
+    if [ -f transports/go.mod ]; then
+      cat >> transports/go.mod <<'EOF'
+
+    replace github.com/maximhq/bifrost/core => ../core
+    replace github.com/maximhq/bifrost/framework => ../framework
+    replace github.com/maximhq/bifrost/plugins/governance => ../plugins/governance
+    replace github.com/maximhq/bifrost/plugins/litellmcompat => ../plugins/litellmcompat
+    replace github.com/maximhq/bifrost/plugins/logging => ../plugins/logging
+    replace github.com/maximhq/bifrost/plugins/maxim => ../plugins/maxim
+    replace github.com/maximhq/bifrost/plugins/otel => ../plugins/otel
+    replace github.com/maximhq/bifrost/plugins/semanticcache => ../plugins/semanticcache
+    replace github.com/maximhq/bifrost/plugins/telemetry => ../plugins/telemetry
+    EOF
+    fi
+  '';
+in
+buildGoModule {
+  pname = "bifrost-http";
+  inherit version;
+  inherit src;
+
+  modRoot = "transports";
+  subPackages = [ "bifrost-http" ];
+  vendorHash = "sha256-Ck1cwv/DYI9EXmp7U2ZSNXlU+Qok8BFn5bcN1Pv7Nmc=";
+
+  doCheck = false;
+
+  overrideModAttrs = final: prev: {
+    postPatch = (prev.postPatch or "") + transportsLocalReplaces;
+  };
+
+  env = {
+    CGO_ENABLED = "1";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    gcc
+  ];
+  buildInputs = [ pkgs.sqlite ];
+
+  postPatch = transportsLocalReplaces;
+
+  preBuild = ''
+    # Provide UI assets for //go:embed all:ui
+    rm -rf bifrost-http/ui
+    mkdir -p bifrost-http/ui
+    if [ -d "${bifrost-ui}/ui" ]; then
+      cp -R --no-preserve=mode,ownership,timestamps "${bifrost-ui}/ui/." bifrost-http/ui/
+    else
+      printf '%s\n' '<!doctype html><meta charset="utf-8"><title>Bifrost</title>' > bifrost-http/ui/index.html
+    fi
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  meta = {
+    mainProgram = "bifrost-http";
+    description = "Bifrost HTTP gateway";
+    homepage = "https://github.com/maximhq/bifrost";
+    license = lib.licenses.asl20;
+  };
+}

--- a/nix/packages/bifrost-ui.nix
+++ b/nix/packages/bifrost-ui.nix
@@ -1,0 +1,48 @@
+{
+  pkgs,
+  src,
+  version,
+}:
+pkgs.buildNpmPackage {
+  pname = "bifrost-ui";
+  inherit version;
+  inherit src;
+  sourceRoot = "source/ui";
+
+  npmDepsHash = "sha256-+tI2NUJtpHwvI9sAYMXO7r00Y3Pb1E62ms1ZSd3O0hM=";
+
+  # Next's `next/font/google` requires network access at build time.
+  # Nix builds are sandboxed (no network), so patch the layout to avoid
+  # fetching Google Fonts.
+  postPatch = ''
+    cat > app/layout.tsx <<'EOF'
+    import "./globals.css"
+
+    export default function RootLayout({ children }: { children: React.ReactNode }) {
+    	return (
+    		<html lang="en" suppressHydrationWarning>
+    			<head>
+    				<link rel="dns-prefetch" href="https://getbifrost.ai" />
+    				<link rel="preconnect" href="https://getbifrost.ai" />
+    			</head>
+    			<body className="font-sans antialiased">{children}</body>
+    		</html>
+    	)
+    }
+    EOF
+  '';
+
+  # Avoid the upstream build script's copy step (writes outside $PWD).
+  npmBuildScript = "build-enterprise";
+  env.NEXT_TELEMETRY_DISABLED = "1";
+  env.NEXT_DISABLE_ESLINT = "1";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/ui"
+    cp -R --no-preserve=mode,ownership,timestamps out/. "$out/ui/"
+
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
## Summary

Add Nix flake packaging for `bifrost-http` and `bifrost-ui`, plus a NixOS module to run the gateway as a hardened systemd service.

## Changes

- Added flake outputs for `packages`/`apps`, plus a reusable devshell
- Introduced NixOS module `services.bifrost` (config.json generation, env/envFile support, firewall option, hardened systemd defaults)
- Added Nix packages:
  - `bifrost-ui` built via `buildNpmPackage` (patches layout to avoid network Google Fonts fetch)
  - `bifrost-http` built via `buildGoModule`, embeds UI assets for `//go:embed all:ui`, forces Go 1.26 (or fallback)
- Refactored `flake.nix` devShell into `nix/devshells/default.nix` for maintainability

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Nix (recommended)
# To build
nix build .#bifrost-ui
nix build .#bifrost-http

# To run
nix run .#bifrost-http

# To log into the shell
nix develop

# NixOS module (on NixOS)
sudo nixos-rebuild test --flake .#<your-host>
# then verify service
systemctl status bifrost
journalctl -u bifrost -n 200 --no-pager
curl -sSf http://127.0.0.1:8080/health
```

If adding new configs or environment variables, document them here.

- NixOS module options under `services.bifrost.*`:
  - `services.bifrost.settings` writes `${stateDir}/config.json` at service start
  - `services.bifrost.environment` and `services.bifrost.environmentFile` for env/secrets

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

N/A

## Security considerations

- NixOS module uses `DynamicUser` + hardened `systemd` options; supports `environmentFile` to avoid storing secrets in the Nix store
- If `services.bifrost.settings` is set, `config.json` is overwritten on start (intended, but worth noting)

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable



