### PR TITLE
disable dependabot to send PRs instead create issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       - "/examples/**"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "npm"
     directories:
@@ -17,13 +18,16 @@ updates:
       - "/examples/**"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "docker"
     directory: "/transports"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0

--- a/.github/workflows/dependabot-alerts.yml
+++ b/.github/workflows/dependabot-alerts.yml
@@ -1,0 +1,54 @@
+name: Dependabot Alerts to Issues
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Weekly on Monday at 9am UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  create-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issues from Dependabot alerts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          alerts=$(gh api repos/${{ github.repository }}/dependabot/alerts \
+            --jq '[.[] | select(.state == "open")]')
+
+          echo "$alerts" | jq -c '.[]' | while read -r alert; do
+            pkg=$(echo "$alert" | jq -r '.dependency.package.name')
+            number=$(echo "$alert" | jq -r '.number')
+            severity=$(echo "$alert" | jq -r '.security_advisory.severity')
+            summary=$(echo "$alert" | jq -r '.security_advisory.summary')
+            url=$(echo "$alert" | jq -r '.html_url')
+            ecosystem=$(echo "$alert" | jq -r '.dependency.package.ecosystem')
+
+            # Skip if issue already exists for this alert
+            existing=$(gh issue list \
+              --repo "${{ github.repository }}" \
+              --search "Dependabot Alert #${number}" \
+              --json number --jq 'length')
+
+            if [ "$existing" = "0" ]; then
+              gh issue create \
+                --repo "${{ github.repository }}" \
+                --title "dep: update ${pkg} (${severity})" \
+                --label "dependencies" \
+                --body "$(cat <<EOF
+          ## Dependabot Alert #${number}
+
+          **Package:** \`${pkg}\`
+          **Ecosystem:** ${ecosystem}
+          **Severity:** ${severity}
+
+          ${summary}
+
+          [View Alert](${url})
+          EOF
+              )"
+            fi
+          done


### PR DESCRIPTION
## Summary

Disables automatic Dependabot pull requests and implements a workflow to convert security alerts into GitHub issues for manual dependency management.

## Changes

- Disabled automatic Dependabot pull requests by setting `open-pull-requests-limit: 0` for all package ecosystems (Go modules, npm, Docker, GitHub Actions)
- Added a new GitHub Actions workflow that runs weekly to convert open Dependabot security alerts into GitHub issues
- The workflow creates issues with detailed information including package name, severity, ecosystem, and links to the original alerts
- Includes duplicate prevention to avoid creating multiple issues for the same alert

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Chore/CI

## How to test

The workflow can be tested by triggering it manually:

```sh
# Trigger the workflow manually via GitHub UI or CLI
gh workflow run "Dependabot Alerts to Issues"

# Check for created issues
gh issue list --label "dependencies"
```

To validate the configuration:
- Verify Dependabot no longer creates automatic PRs for dependency updates
- Confirm the workflow runs weekly on Mondays at 9am UTC
- Check that security alerts are converted to issues with proper formatting

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes

This changes the dependency management workflow from automatic pull requests to manual issue-based tracking. Teams will need to manually address dependency updates through the created issues rather than reviewing automated PRs.

## Related issues

N/A

## Security considerations

- The workflow requires `issues: write` permissions to create GitHub issues
- Uses `GITHUB_TOKEN` to access Dependabot alerts and create issues
- Security alerts will be publicly visible as GitHub issues (consider repository visibility)

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable