### PR TITLE
fix: improve Valkey Search compatibility and correctness in Redis vector store

### DIFF
--- a/docs/architecture/framework/vector-store.mdx
+++ b/docs/architecture/framework/vector-store.mdx
@@ -12,7 +12,7 @@ The VectorStore is a core component of Bifrost's framework package that provides
 - **Vector Similarity Search**: Find semantically similar content using embeddings
 - **Namespace Management**: Organize data into separate collections with custom schemas
 - **Flexible Filtering**: Query data with complex filters and pagination
-- **Multiple Backends**: Support for Weaviate, Redis, Qdrant, and Pinecone vector stores
+- **Multiple Backends**: Support for Weaviate, Redis/Valkey-compatible, Qdrant, and Pinecone vector stores
 - **High Performance**: Optimized for production workloads
 - **Scalable Storage**: Handle millions of vectors with efficient indexing
 
@@ -21,7 +21,7 @@ The VectorStore is a core component of Bifrost's framework package that provides
 Bifrost currently supports four vector store implementations:
 
 - **[Weaviate](#weaviate)**: Production-ready vector database with gRPC support and advanced querying
-- **[Redis](#redis)**: High-performance in-memory vector store using RediSearch
+- **[Redis](#redis)**: High-performance in-memory vector store using RediSearch/Valkey Search
 - **[Qdrant](#qdrant)**: Rust-based vector search engine with advanced filtering
 - **[Pinecone](#pinecone)**: Managed vector database service with serverless and pod-based options
 
@@ -276,7 +276,7 @@ vectorConfig := &vectorstore.Config{
 
 ## Redis
 
-Redis provides high-performance in-memory vector storage using RediSearch, ideal for applications requiring sub-millisecond response times and fast semantic search capabilities.
+Redis provides high-performance in-memory vector storage using RediSearch-compatible APIs, ideal for applications requiring sub-millisecond response times and fast semantic search capabilities. Valkey deployments that expose compatible `FT.*` commands are supported through the same configuration.
 
 ### Key Features
 
@@ -301,6 +301,12 @@ Redis provides high-performance in-memory vector storage using RediSearch, ideal
 docker run -d --name redis-stack -p 6379:6379 redis/redis-stack:latest
 ```
 
+**Local Valkey Bundle:**
+```bash
+# Example Valkey bundle with search/vector support
+docker run -d --name valkey-bundle -p 6379:6379 valkey/valkey-bundle:9.0.0
+```
+
 ### Configuration Options
 
 <Tabs group="redis-config">
@@ -308,12 +314,12 @@ docker run -d --name redis-stack -p 6379:6379 redis/redis-stack:latest
 <Tab title="Go SDK">
 
 ```go
-// Configure Redis vector store
+// Configure Redis-compatible vector store (Redis or Valkey endpoint)
 vectorConfig := &vectorstore.Config{
     Enabled: true,
-    Type:    vectorstore.VectorStoreTypeRedis,
+    Type:    vectorstore.VectorStoreTypeRedis, // Keep type as "redis" for Valkey too
     Config: vectorstore.RedisConfig{
-        Addr:     "localhost:6379",        // Redis server address - REQUIRED
+        Addr:     "localhost:6379",        // Redis/Valkey server address - REQUIRED
         Username: "",                      // Optional: Redis username
         Password: "",                      // Optional: Redis password
         DB:       0,                       // Optional: Redis database number (default: 0)
@@ -366,7 +372,7 @@ if err != nil {
 }
 ```
 
-**For Redis Cloud:**
+**For Redis Cloud or Valkey service endpoints:**
 ```json
 {
   "vector_store": {
@@ -454,7 +460,7 @@ deleteResults, err := store.DeleteAll(ctx, namespace, queries)
 ### Production Considerations
 
 <Info>
-**RediSearch Module Required**: Redis integration requires the RediSearch module to be enabled on your Redis instance. This module provides the vector search capabilities needed for semantic caching.
+**Search Module Required**: Redis/Valkey integration requires a search module/API that supports `FT.*` commands (index creation and vector search). If `FT.INFO` or `FT.SEARCH` is unavailable, semantic caching will not work.
 </Info>
 
 <Warning>

--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -464,7 +464,7 @@ helm install bifrost bifrost/bifrost -f secrets-config.yaml
 | `storage.persistence.size` | PVC size for SQLite | `10Gi` |
 | `postgresql.enabled` | Deploy PostgreSQL | `false` |
 | `vectorStore.enabled` | Enable vector store | `false` |
-| `vectorStore.type` | Vector store type (weaviate/redis/qdrant) | `none` |
+| `vectorStore.type` | Vector store type (weaviate/redis/qdrant). Use `redis` for Redis or Valkey-compatible services | `none` |
 | `bifrost.encryptionKey` | Encryption key | `""` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `autoscaling.enabled` | Enable HPA | `false` |

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -30,7 +30,7 @@ Semantic caching uses vector similarity search to intelligently cache AI respons
 Semantic caching requires a configured vector store. Bifrost supports the following vector databases:
 
 - **[Weaviate](/architecture/framework/vector-store#weaviate)**: Production-ready vector database with gRPC support
-- **[Redis](/architecture/framework/vector-store#redis)**: High-performance in-memory vector store using RediSearch
+- **[Redis](/architecture/framework/vector-store#redis)**: High-performance in-memory vector store using RediSearch-compatible APIs (including Valkey bundles with `FT.*` support)
 - **[Qdrant](/architecture/framework/vector-store#qdrant)**: Rust-based vector search engine with advanced filtering
 - **[Pinecone](/architecture/framework/vector-store#pinecone)**: Managed vector database service with serverless options
 
@@ -287,7 +287,7 @@ When initialized this way, all requests automatically use direct hash matching r
 
 ### Recommended Vector Store
 
-**Redis** is recommended for direct hash mode. It does not require vectors for metadata-only entries, and all cache fields are indexed as RediSearch TAG fields for fast exact-match lookups.
+**Redis/Valkey-compatible stores** are recommended for direct hash mode. They do not require vectors for metadata-only entries, and all cache fields are indexed as TAG fields for fast exact-match lookups.
 
 <Warning>
 Qdrant and Pinecone are not compatible with direct hash mode when no embedding provider is configured. These stores require a vector for every entry; the plugin's zero-vector placeholder codepath requires an initialised embedding client, so storage will fail if no provider is set. Weaviate requires a vector per entry as well and is therefore also not recommended for direct-only mode.
@@ -304,7 +304,7 @@ vectorStore:
   redis:
     external:
       enabled: true
-      host: "redis-stack.example.com"
+      host: "redis-or-valkey.example.com"
       port: 6379
       password: "your-redis-password"
 ```
@@ -324,6 +324,10 @@ vectorStore:
   }
 }
 ```
+
+<Info>
+For Valkey deployments, keep `vector_store.type` as `"redis"` and point `config.addr` to your Valkey endpoint.
+</Info>
 
 </Tab>
 
@@ -649,5 +653,5 @@ The semantic cache namespace and all its cache entries are deleted when Bifrost 
 ---
 
 <Info>
-**Vector Store Requirement**: Semantic caching requires a configured vector store. Bifrost supports Weaviate, Redis, Qdrant, and Pinecone. See the [Vector Store documentation](/architecture/framework/vector-store) for setup details.
+**Vector Store Requirement**: Semantic caching requires a configured vector store. Bifrost supports Weaviate, Redis/Valkey-compatible endpoints, Qdrant, and Pinecone. See the [Vector Store documentation](/architecture/framework/vector-store) for setup details.
 </Info>

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -44,6 +46,9 @@ type RedisStore struct {
 	client *redis.Client
 	config RedisConfig
 	logger schemas.Logger
+
+	namespaceFieldTypesMu sync.RWMutex
+	namespaceFieldTypes   map[string]map[string]VectorStorePropertyType
 }
 
 // Ping checks if the Redis server is reachable.
@@ -59,6 +64,7 @@ func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dime
 	// Check if index already exists
 	infoResult := s.client.Do(ctx, "FT.INFO", namespace)
 	if infoResult.Err() == nil {
+		s.cacheNamespaceFieldTypes(namespace, properties)
 		return nil // Index already exists
 	}
 	if err := infoResult.Err(); err != nil && strings.Contains(strings.ToLower(err.Error()), "unknown command") {
@@ -108,6 +114,7 @@ func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dime
 		return fmt.Errorf("failed to create semantic vector index %s: %w", namespace, err)
 	}
 
+	s.cacheNamespaceFieldTypes(namespace, properties)
 	return nil
 }
 
@@ -223,7 +230,7 @@ func (s *RedisStore) GetAll(ctx context.Context, namespace string, queries []Que
 	}
 
 	// Build Redis query from the provided queries
-	redisQuery := buildRedisQuery(queries)
+	redisQuery := buildRedisQuery(queries, s.getNamespaceFieldTypes(namespace))
 
 	// Build FT.SEARCH command
 	args := []interface{}{
@@ -317,17 +324,10 @@ func (s *RedisStore) getAllByScan(ctx context.Context, namespace string, queries
 		all        []SearchResult
 	)
 
-	// Parse offset early so we can compute an early-exit target.
+	// Parse offset for deterministic in-memory pagination after full scan.
 	offset, err := parseOffsetCursor(cursor)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// Pre-calculate target count for early exit on bounded queries.
-	// Collect one extra result beyond offset+limit to know if there are more.
-	target := 0
-	if limit > 0 {
-		target = offset + int(limit) + 1
 	}
 
 	for {
@@ -387,20 +387,19 @@ func (s *RedisStore) getAllByScan(ctx context.Context, namespace string, queries
 				}
 
 				all = append(all, searchResult)
-				if target > 0 && len(all) >= target {
-					break
-				}
 			}
 		}
 
-		if target > 0 && len(all) >= target {
-			break
-		}
 		scanCursor = nextCursor
 		if scanCursor == 0 {
 			break
 		}
 	}
+
+	// Ensure stable pagination boundaries for offset cursors across calls.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].ID < all[j].ID
+	})
 
 	if offset > len(all) {
 		offset = len(all)
@@ -431,6 +430,13 @@ func (s *RedisStore) getAllByScan(ctx context.Context, namespace string, queries
 func matchesQueriesForScan(properties map[string]interface{}, queries []Query) bool {
 	for _, q := range queries {
 		raw, exists := properties[q.Field]
+
+		// NOTE: missing fields are treated as non-matching for most operators
+		// (Equal, Like, GreaterThan, etc.) but pass NotEqual — i.e. a document
+		// without the field is considered "not equal" to any value. This differs
+		// from SQL NULL semantics where NULL != value evaluates to NULL/unknown.
+		// Change this if scan results need to match FT.SEARCH behavior exactly.
+
 		rawStr := fmt.Sprintf("%v", raw)
 		queryStr := fmt.Sprintf("%v", q.Value)
 
@@ -734,15 +740,53 @@ func containsField(fields []string, candidate string) bool {
 	return false
 }
 
+func (s *RedisStore) cacheNamespaceFieldTypes(namespace string, properties map[string]VectorStoreProperties) {
+	if strings.TrimSpace(namespace) == "" || len(properties) == 0 {
+		return
+	}
+
+	fieldTypes := make(map[string]VectorStorePropertyType, len(properties))
+	for field, prop := range properties {
+		fieldTypes[field] = prop.DataType
+	}
+
+	s.namespaceFieldTypesMu.Lock()
+	defer s.namespaceFieldTypesMu.Unlock()
+	if s.namespaceFieldTypes == nil {
+		s.namespaceFieldTypes = make(map[string]map[string]VectorStorePropertyType)
+	}
+	s.namespaceFieldTypes[namespace] = fieldTypes
+}
+
+func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorStorePropertyType {
+	if strings.TrimSpace(namespace) == "" {
+		return nil
+	}
+
+	s.namespaceFieldTypesMu.RLock()
+	defer s.namespaceFieldTypesMu.RUnlock()
+
+	fieldTypes, ok := s.namespaceFieldTypes[namespace]
+	if !ok {
+		return nil
+	}
+
+	copied := make(map[string]VectorStorePropertyType, len(fieldTypes))
+	for field, dataType := range fieldTypes {
+		copied[field] = dataType
+	}
+	return copied
+}
+
 // buildRedisQuery converts []Query to Redis query syntax
-func buildRedisQuery(queries []Query) string {
+func buildRedisQuery(queries []Query, fieldTypes map[string]VectorStorePropertyType) string {
 	if len(queries) == 0 {
 		return "*"
 	}
 
 	var conditions []string
 	for _, query := range queries {
-		condition := buildRedisQueryCondition(query)
+		condition := buildRedisQueryCondition(query, fieldTypes)
 		if condition != "" {
 			conditions = append(conditions, condition)
 		}
@@ -756,8 +800,60 @@ func buildRedisQuery(queries []Query) string {
 	return strings.Join(conditions, " ")
 }
 
+func shouldUseNumericEquality(field string, value interface{}, fieldTypes map[string]VectorStorePropertyType) (string, bool) {
+	if fieldTypes != nil {
+		if dataType, ok := fieldTypes[field]; ok {
+			if dataType == VectorStorePropertyTypeInteger {
+				return normalizeNumericQueryValue(value)
+			}
+			return "", false
+		}
+	}
+	return normalizeNumericQueryValue(value)
+}
+
+func normalizeNumericQueryValue(value interface{}) (string, bool) {
+	switch v := value.(type) {
+	case int:
+		return strconv.FormatInt(int64(v), 10), true
+	case int8:
+		return strconv.FormatInt(int64(v), 10), true
+	case int16:
+		return strconv.FormatInt(int64(v), 10), true
+	case int32:
+		return strconv.FormatInt(int64(v), 10), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case uint:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10), true
+	case uint64:
+		return strconv.FormatUint(v, 10), true
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	case string:
+		trimmed := strings.TrimSpace(v)
+		if trimmed == "" {
+			return "", false
+		}
+		if _, err := strconv.ParseFloat(trimmed, 64); err != nil {
+			return "", false
+		}
+		return trimmed, true
+	default:
+		return "", false
+	}
+}
+
 // buildRedisQueryCondition builds a single Redis query condition
-func buildRedisQueryCondition(query Query) string {
+func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStorePropertyType) string {
 	field := query.Field
 	operator := query.Operator
 	value := query.Value
@@ -779,9 +875,15 @@ func buildRedisQueryCondition(query Query) string {
 
 	switch operator {
 	case QueryOperatorEqual:
+		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldTypes); useNumeric {
+			return fmt.Sprintf("@%s:[%s %s]", field, numericValue, numericValue)
+		}
 		// TAG exact match
 		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
 	case QueryOperatorNotEqual:
+		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldTypes); useNumeric {
+			return fmt.Sprintf("-@%s:[%s %s]", field, numericValue, numericValue)
+		}
 		// TAG negation
 		return fmt.Sprintf("-@%s:{%s}", field, escapedValue)
 	case QueryOperatorLike:
@@ -832,7 +934,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 	defer cancel()
 
 	// Build Redis query from the provided queries
-	redisQuery := buildRedisQuery(queries)
+	redisQuery := buildRedisQuery(queries, s.getNamespaceFieldTypes(namespace))
 
 	// Convert query embedding to binary format
 	queryBytes := float32SliceToBytes(vector)
@@ -1021,14 +1123,13 @@ func (s *RedisStore) DeleteAll(ctx context.Context, namespace string, queries []
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
 	defer cancel()
 
-	// Use cursor-based deletion to handle large datasets efficiently
-	return s.deleteAllWithCursor(ctx, namespace, queries, nil)
+	return s.deleteAllBySnapshot(ctx, namespace, queries)
 }
 
-// deleteAllWithCursor performs cursor-based deletion for large datasets
-func (s *RedisStore) deleteAllWithCursor(ctx context.Context, namespace string, queries []Query, cursor *string) ([]DeleteResult, error) {
-	// Get a batch of documents to delete (using pagination)
-	results, nextCursor, err := s.GetAll(ctx, namespace, queries, []string{}, cursor, BatchLimit)
+// deleteAllBySnapshot snapshots matching ids before deleting to avoid
+// offset/cursor drift while mutating the dataset.
+func (s *RedisStore) deleteAllBySnapshot(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error) {
+	results, _, err := s.GetAll(ctx, namespace, queries, []string{}, nil, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find documents to delete: %w", err)
 	}
@@ -1101,16 +1202,6 @@ func (s *RedisStore) deleteAllWithCursor(ctx context.Context, namespace string, 
 				})
 			}
 		}
-	}
-
-	// If there are more results, continue with next cursor
-	if nextCursor != nil {
-		nextResults, err := s.deleteAllWithCursor(ctx, namespace, queries, nextCursor)
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete remaining documents: %w", err)
-		}
-		// Combine results from this batch and subsequent batches
-		deleteResults = append(deleteResults, nextResults...)
 	}
 
 	return deleteResults, nil
@@ -1340,6 +1431,7 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 		client: client,
 		config: config,
 		logger: logger,
+		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
 	}
 	return store, nil
 }

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -68,7 +68,7 @@ func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dime
 		return nil // Index already exists
 	}
 	if err := infoResult.Err(); err != nil && strings.Contains(strings.ToLower(err.Error()), "unknown command") {
-		return fmt.Errorf("search module not available: please use Redis Stack or a Valkey bundle with search support (FT.* commands required). Original error: %w", err)
+		return fmt.Errorf("search module not available: please use Redis Stack or a Valkey bundle with search support (FT.* commands required). original error: %w", err)
 	}
 
 	// Extract metadata field names from properties
@@ -597,6 +597,71 @@ func (s *RedisStore) parseSearchResults(result interface{}, namespace string, se
 	}
 }
 
+func parseSearchResultIDs(result interface{}, namespace string) []string {
+	ids := make([]string, 0)
+	appendID := func(value interface{}) {
+		id, ok := toString(value)
+		if !ok {
+			return
+		}
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if namespace != "" {
+			prefix := namespace + ":"
+			if strings.HasPrefix(id, prefix) {
+				id = strings.TrimPrefix(id, prefix)
+			}
+		}
+		if id == "" {
+			return
+		}
+		ids = append(ids, id)
+	}
+
+	extractRESP3IDs := func(rawResults interface{}) {
+		resultItems, ok := rawResults.([]interface{})
+		if !ok {
+			return
+		}
+		for _, item := range resultItems {
+			switch doc := item.(type) {
+			case map[string]interface{}:
+				appendID(doc["id"])
+			case map[interface{}]interface{}:
+				appendID(doc["id"])
+			default:
+				appendID(item)
+			}
+		}
+	}
+
+	switch typed := result.(type) {
+	case map[interface{}]interface{}:
+		extractRESP3IDs(typed["results"])
+	case map[string]interface{}:
+		extractRESP3IDs(typed["results"])
+	case []interface{}:
+		if len(typed) < 2 {
+			return ids
+		}
+		for i := 1; i < len(typed); i++ {
+			appendID(typed[i])
+
+			// RESP2 payloads can be [total, id, attrs, id, attrs, ...].
+			if i+1 < len(typed) {
+				switch typed[i+1].(type) {
+				case []interface{}, map[string]interface{}, map[interface{}]interface{}:
+					i++
+				}
+			}
+		}
+	}
+
+	return ids
+}
+
 func parseSearchResultDocument(resultItem interface{}, namespace string, selectFields []string) (SearchResult, bool) {
 	var docMap map[string]interface{}
 
@@ -756,6 +821,15 @@ func (s *RedisStore) cacheNamespaceFieldTypes(namespace string, properties map[s
 		s.namespaceFieldTypes = make(map[string]map[string]VectorStorePropertyType)
 	}
 	s.namespaceFieldTypes[namespace] = fieldTypes
+}
+
+func (s *RedisStore) deleteNamespaceFieldTypes(namespace string) {
+	if strings.TrimSpace(namespace) == "" {
+		return
+	}
+	s.namespaceFieldTypesMu.Lock()
+	defer s.namespaceFieldTypesMu.Unlock()
+	delete(s.namespaceFieldTypes, namespace)
 }
 
 func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorStorePropertyType {
@@ -1129,19 +1203,13 @@ func (s *RedisStore) DeleteAll(ctx context.Context, namespace string, queries []
 // deleteAllBySnapshot snapshots matching ids before deleting to avoid
 // offset/cursor drift while mutating the dataset.
 func (s *RedisStore) deleteAllBySnapshot(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error) {
-	results, _, err := s.GetAll(ctx, namespace, queries, []string{}, nil, 0)
+	ids, err := s.getAllMatchingIDs(ctx, namespace, queries)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find documents to delete: %w", err)
 	}
 
-	if len(results) == 0 {
+	if len(ids) == 0 {
 		return []DeleteResult{}, nil
-	}
-
-	// Extract IDs from results
-	ids := make([]string, len(results))
-	for i, result := range results {
-		ids[i] = result.ID
 	}
 
 	// Delete this batch of documents
@@ -1207,6 +1275,68 @@ func (s *RedisStore) deleteAllBySnapshot(ctx context.Context, namespace string, 
 	return deleteResults, nil
 }
 
+func (s *RedisStore) getAllMatchingIDs(ctx context.Context, namespace string, queries []Query) ([]string, error) {
+	redisQuery := buildRedisQuery(queries, s.getNamespaceFieldTypes(namespace))
+	offset := 0
+	ids := make([]string, 0)
+
+	for {
+		args := []interface{}{
+			"FT.SEARCH", namespace,
+			redisQuery,
+			"RETURN", 0,
+			"LIMIT", offset, BatchLimit,
+			"DIALECT", "2",
+		}
+
+		result := s.client.Do(ctx, args...)
+		if result.Err() != nil {
+			errMsg := strings.ToLower(result.Err().Error())
+			if isQuerySyntaxError(errMsg) {
+				s.logger.Debug(fmt.Sprintf("FT.SEARCH DIALECT fallback triggered for namespace %s while collecting ids: %s", namespace, result.Err()))
+				compatArgs := make([]interface{}, 0, len(args)-2)
+				for i := 0; i < len(args); i++ {
+					if i+1 < len(args) && args[i] == "DIALECT" {
+						i++
+						continue
+					}
+					compatArgs = append(compatArgs, args[i])
+				}
+				result = s.client.Do(ctx, compatArgs...)
+			}
+			if result.Err() != nil {
+				errMsg = strings.ToLower(result.Err().Error())
+				if isQuerySyntaxError(errMsg) {
+					s.logger.Debug(fmt.Sprintf("FT.SEARCH scan fallback triggered for namespace %s while collecting ids: %s", namespace, result.Err()))
+					scanResults, _, scanErr := s.getAllByScan(ctx, namespace, queries, nil, nil, 0)
+					if scanErr != nil {
+						return nil, fmt.Errorf("failed to collect matching ids via scan fallback: %w", scanErr)
+					}
+					scanIDs := make([]string, 0, len(scanResults))
+					for _, scanResult := range scanResults {
+						scanIDs = append(scanIDs, scanResult.ID)
+					}
+					return scanIDs, nil
+				}
+				return nil, fmt.Errorf("failed to search for matching ids: %w", result.Err())
+			}
+		}
+
+		pageIDs := parseSearchResultIDs(result.Val(), namespace)
+		if len(pageIDs) == 0 {
+			break
+		}
+		ids = append(ids, pageIDs...)
+
+		if len(pageIDs) < BatchLimit {
+			break
+		}
+		offset += len(pageIDs)
+	}
+
+	return ids, nil
+}
+
 // DeleteNamespace deletes a namespace from the Redis vector store.
 func (s *RedisStore) DeleteNamespace(ctx context.Context, namespace string) error {
 	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
@@ -1216,11 +1346,13 @@ func (s *RedisStore) DeleteNamespace(ctx context.Context, namespace string) erro
 	if err := s.client.Do(ctx, "FT.DROPINDEX", namespace).Err(); err != nil {
 		// Check if error is "Unknown Index name" - that's OK, index doesn't exist
 		if strings.Contains(strings.ToLower(err.Error()), "unknown index name") {
+			s.deleteNamespaceFieldTypes(namespace)
 			return nil // Index doesn't exist, nothing to drop
 		}
 		return fmt.Errorf("failed to drop semantic index %s: %w", namespace, err)
 	}
 
+	s.deleteNamespaceFieldTypes(namespace)
 	return nil
 }
 
@@ -1428,9 +1560,9 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 	})
 	// Creating store connection
 	store := &RedisStore{
-		client: client,
-		config: config,
-		logger: logger,
+		client:              client,
+		config:              config,
+		logger:              logger,
 		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
 	}
 	return store, nil

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -486,6 +486,55 @@ func TestMatchesQueriesForScan(t *testing.T) {
 			queries:    []Query{},
 			expected:   true,
 		},
+		// ContainsAny / ContainsAll
+		{
+			name:       "ContainsAny true with JSON array property",
+			properties: map[string]interface{}{"tags": "[\"red\",\"blue\"]"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAny, Value: []interface{}{"green", "blue"}}},
+			expected:   true,
+		},
+		{
+			name:       "ContainsAny false with JSON array property",
+			properties: map[string]interface{}{"tags": "[\"red\",\"blue\"]"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAny, Value: []interface{}{"green", "yellow"}}},
+			expected:   false,
+		},
+		{
+			name:       "ContainsAll true with JSON array property",
+			properties: map[string]interface{}{"tags": "[\"red\",\"blue\",\"green\"]"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAll, Value: []interface{}{"red", "green"}}},
+			expected:   true,
+		},
+		{
+			name:       "ContainsAll false with JSON array property",
+			properties: map[string]interface{}{"tags": "[\"red\",\"blue\"]"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAll, Value: []interface{}{"red", "green"}}},
+			expected:   false,
+		},
+		{
+			name:       "ContainsAny true with scalar string property",
+			properties: map[string]interface{}{"tags": "red"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAny, Value: []interface{}{"red", "green"}}},
+			expected:   true,
+		},
+		{
+			name:       "ContainsAll false with scalar string property",
+			properties: map[string]interface{}{"tags": "red"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAll, Value: []interface{}{"red", "green"}}},
+			expected:   false,
+		},
+		{
+			name:       "ContainsAny malformed query value returns false",
+			properties: map[string]interface{}{"tags": "[\"red\",\"blue\"]"},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAny, Value: "red"}},
+			expected:   false,
+		},
+		{
+			name:       "ContainsAll missing field returns false",
+			properties: map[string]interface{}{},
+			queries:    []Query{{Field: "tags", Operator: QueryOperatorContainsAll, Value: []interface{}{"red"}}},
+			expected:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -358,6 +358,45 @@ func TestRedisStore_ParseSearchResults_NamespaceWithColon(t *testing.T) {
 	assert.Equal(t, "doc-1", results[0].ID)
 }
 
+func TestParseSearchResultIDs(t *testing.T) {
+	t.Run("RESP3 map parses namespace-trimmed ids", func(t *testing.T) {
+		namespace := "ns:team"
+		resp := map[interface{}]interface{}{
+			"results": []interface{}{
+				map[interface{}]interface{}{"id": namespace + ":doc-1"},
+				map[interface{}]interface{}{"id": "other:doc-2"},
+			},
+		}
+
+		ids := parseSearchResultIDs(resp, namespace)
+		assert.Equal(t, []string{"doc-1", "other:doc-2"}, ids)
+	})
+
+	t.Run("RESP2 no-content parses ids", func(t *testing.T) {
+		namespace := "ns"
+		resp := []interface{}{
+			int64(2),
+			"ns:doc-1",
+			"ns:doc-2",
+		}
+
+		ids := parseSearchResultIDs(resp, namespace)
+		assert.Equal(t, []string{"doc-1", "doc-2"}, ids)
+	})
+
+	t.Run("RESP2 pair payload parses ids", func(t *testing.T) {
+		namespace := "ns"
+		resp := []interface{}{
+			int64(2),
+			"ns:doc-1", []interface{}{"field", "value"},
+			"ns:doc-2", []interface{}{"field", "value"},
+		}
+
+		ids := parseSearchResultIDs(resp, namespace)
+		assert.Equal(t, []string{"doc-1", "doc-2"}, ids)
+	})
+}
+
 func TestParseOffsetCursor(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -478,7 +517,7 @@ func TestBuildRedisQueryCondition_NumericEquality(t *testing.T) {
 }
 
 func ptr(v string) *string {
-	return &v
+	return bifrost.Ptr(v)
 }
 
 func TestMatchesQueriesForScan(t *testing.T) {
@@ -1284,6 +1323,39 @@ func TestRedisStore_DeleteOperations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "keep_large", keepDoc.Properties["type"])
 	})
+
+	t.Run("getAllMatchingIDs returns matching ids", func(t *testing.T) {
+		targetType := "ids_only_target"
+		for i := 0; i < 3; i++ {
+			err := setup.Store.Add(
+				setup.ctx,
+				TestNamespace,
+				generateUUID(),
+				generateTestEmbedding(RedisTestDimension),
+				map[string]interface{}{"type": targetType, "category": "test"},
+			)
+			require.NoError(t, err)
+		}
+		err := setup.Store.Add(
+			setup.ctx,
+			TestNamespace,
+			generateUUID(),
+			generateTestEmbedding(RedisTestDimension),
+			map[string]interface{}{"type": "ids_only_other", "category": "test"},
+		)
+		require.NoError(t, err)
+
+		time.Sleep(300 * time.Millisecond)
+
+		ids, err := setup.Store.getAllMatchingIDs(setup.ctx, TestNamespace, []Query{
+			{Field: "type", Operator: QueryOperatorEqual, Value: targetType},
+		})
+		require.NoError(t, err)
+		assert.Len(t, ids, 3)
+		for _, id := range ids {
+			assert.NotEmpty(t, id)
+		}
+	})
 }
 
 // ============================================================================
@@ -1398,6 +1470,7 @@ func TestRedisStore_NamespaceDimensionHandling(t *testing.T) {
 		// Step 2: Delete the namespace
 		err = setup.Store.DeleteNamespace(setup.ctx, testNamespace)
 		require.NoError(t, err)
+		assert.Empty(t, setup.Store.getNamespaceFieldTypes(testNamespace))
 
 		// Step 3: Create namespace with same name but different dimension - should not crash
 		err = setup.Store.CreateNamespace(setup.ctx, testNamespace, 1024, properties)
@@ -1429,5 +1502,6 @@ func TestRedisStore_NamespaceDimensionHandling(t *testing.T) {
 		if err != nil {
 			t.Logf("Warning: Failed to cleanup namespace: %v", err)
 		}
+		assert.Empty(t, setup.Store.getNamespaceFieldTypes(testNamespace))
 	})
 }

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -411,6 +411,72 @@ func TestParseOffsetCursor(t *testing.T) {
 	}
 }
 
+func TestBuildRedisQueryCondition_NumericEquality(t *testing.T) {
+	fieldTypes := map[string]VectorStorePropertyType{
+		"size": VectorStorePropertyTypeInteger,
+		"type": VectorStorePropertyTypeString,
+	}
+
+	tests := []struct {
+		name     string
+		query    Query
+		expected string
+	}{
+		{
+			name: "numeric equal uses range syntax for integer field",
+			query: Query{
+				Field:    "size",
+				Operator: QueryOperatorEqual,
+				Value:    1024,
+			},
+			expected: "@size:[1024 1024]",
+		},
+		{
+			name: "numeric not equal uses negative range syntax for integer field",
+			query: Query{
+				Field:    "size",
+				Operator: QueryOperatorNotEqual,
+				Value:    1024,
+			},
+			expected: "-@size:[1024 1024]",
+		},
+		{
+			name: "string field equal remains tag syntax",
+			query: Query{
+				Field:    "type",
+				Operator: QueryOperatorEqual,
+				Value:    "pdf",
+			},
+			expected: "@type:{pdf}",
+		},
+		{
+			name: "unknown field with numeric literal falls back to numeric range",
+			query: Query{
+				Field:    "unknown_field",
+				Operator: QueryOperatorEqual,
+				Value:    7,
+			},
+			expected: "@unknown_field:[7 7]",
+		},
+		{
+			name: "known non-numeric field with numeric literal remains tag",
+			query: Query{
+				Field:    "type",
+				Operator: QueryOperatorEqual,
+				Value:    7,
+			},
+			expected: "@type:{7}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRedisQueryCondition(tt.query, fieldTypes)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func ptr(v string) *string {
 	return &v
 }
@@ -782,6 +848,27 @@ func TestRedisStore_FilteringScenarios(t *testing.T) {
 		assert.Len(t, results, 2) // doc1 (1024) and doc2 (2048)
 	})
 
+	t.Run("Filter by numeric equality", func(t *testing.T) {
+		queries := []Query{
+			{Field: "size", Operator: QueryOperatorEqual, Value: 1024},
+		}
+
+		results, _, err := setup.Store.GetAll(setup.ctx, TestNamespace, queries, filterFields, nil, 10)
+		require.NoError(t, err)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "1024", results[0].Properties["size"])
+	})
+
+	t.Run("Filter by numeric inequality", func(t *testing.T) {
+		queries := []Query{
+			{Field: "size", Operator: QueryOperatorNotEqual, Value: 1024},
+		}
+
+		results, _, err := setup.Store.GetAll(setup.ctx, TestNamespace, queries, filterFields, nil, 10)
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
 	t.Run("Filter by boolean", func(t *testing.T) {
 		queries := []Query{
 			{Field: "public", Operator: QueryOperatorEqual, Value: true},
@@ -827,6 +914,29 @@ func TestRedisStore_FilteringScenarios(t *testing.T) {
 			require.NoError(t, err)
 			assert.LessOrEqual(t, len(nextResults), 2)
 			t.Logf("First page: %d results, Next page: %d results", len(results), len(nextResults))
+		}
+	})
+
+	t.Run("Scan fallback pagination is deterministic", func(t *testing.T) {
+		firstPage, cursor, err := setup.Store.getAllByScan(setup.ctx, TestNamespace, nil, filterFields, nil, 2)
+		require.NoError(t, err)
+		require.Len(t, firstPage, 2)
+		require.NotNil(t, cursor)
+
+		secondPage, _, err := setup.Store.getAllByScan(setup.ctx, TestNamespace, nil, filterFields, cursor, 2)
+		require.NoError(t, err)
+		require.Len(t, secondPage, 2)
+
+		combined := append(firstPage, secondPage...)
+		for i := 1; i < len(combined); i++ {
+			assert.LessOrEqual(t, combined[i-1].ID, combined[i].ID)
+		}
+
+		seen := make(map[string]struct{}, len(combined))
+		for _, result := range combined {
+			_, exists := seen[result.ID]
+			assert.False(t, exists, "duplicate id across pages: %s", result.ID)
+			seen[result.ID] = struct{}{}
 		}
 	})
 }
@@ -1128,6 +1238,51 @@ func TestRedisStore_DeleteOperations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, allResults, 1) // Only the "keep_me" item should remain
 		assert.Equal(t, "keep_me", allResults[0].Properties["type"])
+	})
+
+	t.Run("DeleteAll with more than BatchLimit matches", func(t *testing.T) {
+		const deleteCount = BatchLimit + 23
+		for i := 0; i < deleteCount; i++ {
+			err := setup.Store.Add(
+				setup.ctx,
+				TestNamespace,
+				generateUUID(),
+				generateTestEmbedding(RedisTestDimension),
+				map[string]interface{}{"type": "delete_me_large", "category": "test"},
+			)
+			require.NoError(t, err)
+		}
+
+		keepID := generateUUID()
+		err := setup.Store.Add(
+			setup.ctx,
+			TestNamespace,
+			keepID,
+			generateTestEmbedding(RedisTestDimension),
+			map[string]interface{}{"type": "keep_large", "category": "test"},
+		)
+		require.NoError(t, err)
+
+		time.Sleep(500 * time.Millisecond)
+
+		deleteQuery := []Query{
+			{Field: "type", Operator: QueryOperatorEqual, Value: "delete_me_large"},
+		}
+		beforeDelete, _, err := setup.Store.GetAll(setup.ctx, TestNamespace, deleteQuery, []string{"type"}, nil, 0)
+		require.NoError(t, err)
+		require.Len(t, beforeDelete, deleteCount)
+
+		deleteResults, err := setup.Store.DeleteAll(setup.ctx, TestNamespace, deleteQuery)
+		require.NoError(t, err)
+		assert.Len(t, deleteResults, deleteCount)
+
+		afterDelete, _, err := setup.Store.GetAll(setup.ctx, TestNamespace, deleteQuery, []string{"type"}, nil, 0)
+		require.NoError(t, err)
+		assert.Len(t, afterDelete, 0)
+
+		keepDoc, err := setup.Store.GetChunk(setup.ctx, TestNamespace, keepID)
+		require.NoError(t, err)
+		assert.Equal(t, "keep_large", keepDoc.Properties["type"])
 	})
 }
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1737,27 +1737,27 @@
                 },
                 "host": {
                   "type": "string",
-                  "description": "Redis server host"
+                  "description": "Redis/Valkey server host"
                 },
                 "port": {
                   "type": "integer",
                   "minimum": 1,
                   "maximum": 65535,
-                  "description": "Redis server port"
+                  "description": "Redis/Valkey server port"
                 },
                 "username": {
                   "type": "string",
-                  "description": "Username for Redis AUTH"
+                  "description": "Username for Redis/Valkey AUTH"
                 },
                 "password": {
                   "type": "string",
-                  "description": "Password for Redis AUTH"
+                  "description": "Password for Redis/Valkey AUTH"
                 },
                 "database": {
                   "type": "integer",
                   "minimum": 0,
                   "default": 0,
-                  "description": "Redis database number"
+                  "description": "Redis/Valkey database number"
                 },
                 "poolSize": {
                   "type": "integer",
@@ -1803,7 +1803,7 @@
                 "contextTimeout": {
                   "type": "string",
                   "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
-                  "description": "Timeout for Redis operations (e.g., '10s')"
+                  "description": "Timeout for Redis/Valkey operations (e.g., '10s')"
                 },
                 "existingSecret": {
                   "type": "string"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -496,7 +496,7 @@
             "qdrant",
             "pinecone"
           ],
-          "description": "Vector store type"
+          "description": "Vector store type (use \"redis\" for Redis or Valkey-compatible endpoints)"
         },
         "config": {
           "anyOf": [
@@ -2310,11 +2310,11 @@
     },
     "redis_config": {
       "type": "object",
-      "description": "Redis configuration for vector store",
+      "description": "Redis configuration for vector store (also used for Valkey-compatible endpoints)",
       "properties": {
         "addr": {
           "type": "string",
-          "description": "Redis server address (host:port) - REQUIRED (can use env. prefix)"
+          "description": "Redis/Valkey server address (host:port) - REQUIRED (can use env. prefix)"
         },
         "username": {
           "type": "string",


### PR DESCRIPTION
## Summary

Fixes Valkey compatibility for semantic cache and vector-store flows by extending the existing Redis vector store implementation.

Valkey deployments that expose compatible `FT.*` commands can now be used through the same Redis configuration type (`vector_store.type: "redis"`).

## Changes

- Updated docs to clarify Redis/Valkey-compatible endpoint support across Vector Store, Semantic Caching, and Helm guides
- Enhanced Redis vector store compatibility logic for query syntax differences between Redis Stack and Valkey Search
- Added parsing support for both RESP2 and RESP3 `FT.SEARCH` result shapes
- Added fallback behavior when `FT.SEARCH` filter syntax is incompatible:
  - Retry without explicit `DIALECT`
  - Final fallback to scan-based retrieval for correctness
- Added or expanded test coverage for parsing and scan fallback matching logic (including numeric operators)
- Updated config schemas and descriptions to document Redis/Valkey compatibility
- Hardened `DeleteNamespace` handling with case-insensitive `"unknown index name"` matching
- Replaced cursor-based deletion with snapshot-based deletion to prevent offset drift while mutating the dataset
- Ensured deterministic scan fallback pagination by fully materializing results and sorting by ID before applying offset
- Added namespace field type cache so numeric fields use range query syntax instead of tag syntax
- Documented missing-field semantics in scan fallback matching logic

## Type of change

- [x] Bug fix
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Docs

## How to test

### Redis Stack

```sh
docker run -d --name redis-stack -p 6379:6379 redis/redis-stack:latest

cd framework
go test ./vectorstore -v -count=1 -run 'TestRedisStore_ParseSearchResults_|TestMatchesQueriesForScan|TestRedisStore_FilteringScenarios|TestRedisStore_VectorSearch|TestRedisStore_CompleteUseCases|TestRedisStore_Integration|TestRedisStore_DeleteOperations|TestRedisStore_NamespaceDimensionHandling|TestRedisStore_ErrorHandling|TestVectorStoreFactory_Redis'
```

### Valkey bundle

```sh
docker run -d --name valkey-bundle -p 6379:6379 valkey/valkey-bundle:9.0.0

# Keep vector_store.type as "redis" and point config.addr to the Valkey endpoint.
cd framework
go test ./vectorstore -v -count=1 -run 'TestRedisStore_ParseSearchResults_|TestMatchesQueriesForScan|TestRedisStore_FilteringScenarios|TestRedisStore_VectorSearch|TestRedisStore_CompleteUseCases|TestRedisStore_Integration|TestRedisStore_DeleteOperations|TestRedisStore_NamespaceDimensionHandling|TestRedisStore_ErrorHandling|TestVectorStoreFactory_Redis'
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

No breaking API or config changes. Existing Redis configurations continue to work unchanged.  
Valkey support is additive through the same Redis config interface.

## Related issues

Closes #1713
Closes #1915 

## Security considerations

No new security implications. Existing Redis authentication and connection mechanisms are reused for Valkey-compatible endpoints.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added or updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified relevant tests pass for changed areas