### PR TITLE
fix: strip governance model prefix from raw body in Anthropic passthrough

### DIFF
--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/bytedance/sonic"
+	"github.com/bytedance/sonic/ast"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -274,6 +275,34 @@ func CreateAnthropicListModelsRouteConfigs(pathPrefix string, handlerStore lib.H
 	}
 }
 
+// stripModelPrefixFromBody replaces a provider-prefixed model name
+// (e.g. "anthropic/claude-sonnet-4-6") with the bare model name in the raw
+// HTTP request body. Uses sonic's lazy AST so only the "model" field is
+// parsed and re-serialized; the rest of the body is copied as raw bytes.
+func stripModelPrefixFromBody(ctx *fasthttp.RequestCtx, prefixedModel, bareModel string) {
+	body := ctx.Request.Body()
+	if len(body) == 0 {
+		return
+	}
+	root := ast.NewRaw(string(body))
+	modelNode := root.Get("model")
+	if modelNode == nil || modelNode.TypeSafe() != ast.V_STRING {
+		return
+	}
+	currentModel, err := modelNode.StrictString()
+	if err != nil || currentModel != prefixedModel {
+		return
+	}
+	if _, err := root.Set("model", ast.NewString(bareModel)); err != nil {
+		return
+	}
+	newBody, err := root.MarshalJSON()
+	if err != nil {
+		return
+	}
+	ctx.Request.SetBody(newBody)
+}
+
 // checkAnthropicPassthrough pre-callback checks if the request is for a claude model.
 // If it is, it attaches the raw request body for direct use by the provider.
 // It also checks for anthropic oauth headers and sets the bifrost context.
@@ -284,15 +313,15 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 	switch r := req.(type) {
 	case *anthropic.AnthropicTextRequest:
 		provider, model = schemas.ParseModelString(r.Model, "")
-		// Check if model parameter explicitly has `anthropic/` prefix
 		if provider == schemas.Anthropic {
+			stripModelPrefixFromBody(ctx, r.Model, model)
 			r.Model = model
 		}
 
 	case *anthropic.AnthropicMessageRequest:
 		provider, model = schemas.ParseModelString(r.Model, "")
-		// Check if model parameter explicitly has `anthropic/` prefix
 		if provider == schemas.Anthropic {
+			stripModelPrefixFromBody(ctx, r.Model, model)
 			r.Model = model
 		}
 	}

--- a/transports/bifrost-http/integrations/anthropic_test.go
+++ b/transports/bifrost-http/integrations/anthropic_test.go
@@ -3,7 +3,10 @@ package integrations
 import (
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 func TestFilterVertexUnsupportedBetaHeaders(t *testing.T) {
@@ -83,5 +86,72 @@ func TestFilterVertexUnsupportedBetaHeaders(t *testing.T) {
 		vals, ok := result["Anthropic-Beta"]
 		assert.True(t, ok, "header key casing should be preserved and matching should be case-insensitive")
 		assert.Equal(t, []string{"interleaved-thinking-2025-05-14"}, vals)
+	})
+}
+
+func TestStripModelPrefixFromBody(t *testing.T) {
+	makeCtx := func(body string) *fasthttp.RequestCtx {
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetBodyString(body)
+		return ctx
+	}
+
+	bodyModel := func(ctx *fasthttp.RequestCtx) string {
+		var m map[string]any
+		require.NoError(t, sonic.Unmarshal(ctx.Request.Body(), &m))
+		return m["model"].(string)
+	}
+
+	t.Run("strips matching provider prefix from model field", func(t *testing.T) {
+		ctx := makeCtx(`{"model":"anthropic/claude-sonnet-4-6","max_tokens":1024}`)
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		assert.Equal(t, "claude-sonnet-4-6", bodyModel(ctx))
+	})
+
+	t.Run("preserves other fields unchanged", func(t *testing.T) {
+		ctx := makeCtx(`{"model":"anthropic/claude-sonnet-4-6","max_tokens":1024,"stream":true}`)
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		var m map[string]any
+		require.NoError(t, sonic.Unmarshal(ctx.Request.Body(), &m))
+		assert.Equal(t, "claude-sonnet-4-6", m["model"])
+		assert.Equal(t, float64(1024), m["max_tokens"])
+		assert.Equal(t, true, m["stream"])
+	})
+
+	t.Run("no-op when model does not match", func(t *testing.T) {
+		ctx := makeCtx(`{"model":"openai/gpt-4o","max_tokens":1024}`)
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		assert.Equal(t, "openai/gpt-4o", bodyModel(ctx))
+	})
+
+	t.Run("no-op when body has no model field", func(t *testing.T) {
+		original := `{"max_tokens":1024}`
+		ctx := makeCtx(original)
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		assert.JSONEq(t, original, string(ctx.Request.Body()))
+	})
+
+	t.Run("no-op on empty body", func(t *testing.T) {
+		ctx := makeCtx("")
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		assert.Empty(t, ctx.Request.Body())
+	})
+
+	t.Run("no-op on invalid JSON", func(t *testing.T) {
+		original := `{invalid`
+		ctx := makeCtx(original)
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		assert.Equal(t, original, string(ctx.Request.Body()))
+	})
+
+	t.Run("preserves nested content containing the model name", func(t *testing.T) {
+		ctx := makeCtx(`{"model":"anthropic/claude-sonnet-4-6","messages":[{"content":"use anthropic/claude-sonnet-4-6"}]}`)
+		stripModelPrefixFromBody(ctx, "anthropic/claude-sonnet-4-6", "claude-sonnet-4-6")
+		var m map[string]any
+		require.NoError(t, sonic.Unmarshal(ctx.Request.Body(), &m))
+		assert.Equal(t, "claude-sonnet-4-6", m["model"])
+		msgs := m["messages"].([]any)
+		msg := msgs[0].(map[string]any)
+		assert.Equal(t, "use anthropic/claude-sonnet-4-6", msg["content"], "nested content must not be modified")
 	})
 }

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -686,7 +686,10 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			return
 		}
 		if sendRawRequestBody, ok := (*bifrostCtx).Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && sendRawRequestBody {
-			bifrostReq.SetRawRequestBody(rawBody)
+			// Re-read the body from the context: PreCallback (e.g.
+			// checkAnthropicPassthrough) may have updated it to strip
+			// the provider prefix that the governance plugin added.
+			bifrostReq.SetRawRequestBody(ctx.Request.Body())
 		}
 
 		// Extract and parse fallbacks from the request if present


### PR DESCRIPTION
## Summary

- Fix 404 errors on Anthropic `count_tokens` (and other) requests when the governance plugin is active with passthrough mode
- The governance plugin's load balancer prepends `anthropic/` to the model name in the request body for routing, but `checkAnthropicPassthrough` only stripped the prefix from the parsed struct—not from the raw HTTP body used by passthrough mode
- Anthropic's API rejects the prefixed model name (`"anthropic/claude-sonnet-4-6"`) → 404

## Changes

1. **`anthropic.go`**: Added `stripModelPrefixFromBody()` using sonic's lazy AST (`ast.NewRaw` + `root.Get` + `root.Set` + `root.MarshalJSON`) to replace the governance-prefixed model with the bare model name. Only the `"model"` field is parsed and re-serialized; the rest of the body is copied as raw bytes — avoiding a full `Unmarshal`/`Marshal` round-trip on potentially large LLM request bodies.

2. **`router.go`**: Changed `SetRawRequestBody(rawBody)` to `SetRawRequestBody(ctx.Request.Body())` so the passthrough path picks up the body corrected by `PreCallback` instead of the stale pre-callback snapshot.

3. **`anthropic_test.go`**: Added 7 unit tests for `stripModelPrefixFromBody` covering: prefix stripping, field preservation, non-matching model, missing model field, empty body, invalid JSON, and nested content safety (model name appearing inside message content is not modified).

## Conditions for the bug

All three must be true simultaneously:
1. Governance plugin active with a virtual key (triggers `loadBalanceProvider` which adds provider prefix)
2. Passthrough mode enabled (Claude Code request detected → `BifrostContextKeyUseRawRequestBody = true`)
3. Request goes through an Anthropic integration route (`/anthropic/v1/messages/count_tokens`, etc.)

## Test plan

- [x] Verified the build compiles (`go build ./bifrost-http/integrations/...`)
- [x] Unit tests for `stripModelPrefixFromBody` (7 cases, all passing)
- [x] Existing integration tests pass (`go test ./bifrost-http/integrations/...`)
- [ ] Test with Anthropic `count_tokens` endpoint through governance + passthrough
- [ ] Verify regular `responses` and `responses_stream` requests still work with passthrough
- [ ] Verify non-passthrough requests are unaffected

Made with [Cursor](https://cursor.com)