### PR TITLE
feat: added passthrough support

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1868,6 +1868,47 @@ func (bifrost *Bifrost) BatchCancelRequest(ctx *schemas.BifrostContext, req *sch
 	return response.BatchCancelResponse, nil
 }
 
+// BatchDeleteRequest deletes a batch job.
+func (bifrost *Bifrost) BatchDeleteRequest(ctx *schemas.BifrostContext, req *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	if req == nil {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "batch delete request is nil",
+			},
+		}
+	}
+	if req.Provider == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "provider is required for batch delete request",
+			},
+		}
+	}
+	if req.BatchID == "" {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: "batch_id is required for batch delete request",
+			},
+		}
+	}
+	if ctx == nil {
+		ctx = bifrost.ctx
+	}
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.BatchDeleteRequest
+	bifrostReq.BatchDeleteRequest = req
+
+	response, err := bifrost.handleRequest(ctx, bifrostReq)
+	if err != nil {
+		return nil, err
+	}
+	return response.BatchDeleteResponse, nil
+}
+
 // BatchResultsRequest retrieves results from a completed batch job.
 func (bifrost *Bifrost) BatchResultsRequest(ctx *schemas.BifrostContext, req *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	if req == nil {
@@ -2130,6 +2171,64 @@ func (bifrost *Bifrost) FileContentRequest(ctx *schemas.BifrostContext, req *sch
 		return nil, err
 	}
 	return response.FileContentResponse, nil
+}
+
+func (bifrost *Bifrost) Passthrough(
+	ctx *schemas.BifrostContext,
+	provider schemas.ModelProvider,
+	req *schemas.BifrostPassthroughRequest,
+) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	if req == nil {
+		sc := fasthttp.StatusBadRequest
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &sc,
+			Error:          &schemas.ErrorField{Message: "passthrough request is nil"},
+		}
+	}
+
+	req.Provider = provider
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.PassthroughRequest
+	bifrostReq.PassthroughRequest = req
+
+	resp, bifrostErr := bifrost.handleRequest(ctx, bifrostReq)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	if resp == nil || resp.PassthroughResponse == nil {
+		sc := fasthttp.StatusBadGateway
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &sc,
+			Error:          &schemas.ErrorField{Message: "provider returned nil passthrough response"},
+		}
+	}
+	return resp.PassthroughResponse, nil
+}
+
+func (bifrost *Bifrost) PassthroughStream(
+	ctx *schemas.BifrostContext,
+	provider schemas.ModelProvider,
+	req *schemas.BifrostPassthroughRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if req == nil {
+		sc := fasthttp.StatusBadRequest
+		return nil, &schemas.BifrostError{
+			IsBifrostError: false,
+			StatusCode:     &sc,
+			Error:          &schemas.ErrorField{Message: "passthrough request is nil"},
+		}
+	}
+
+	req.Provider = provider
+
+	bifrostReq := bifrost.getBifrostRequest()
+	bifrostReq.RequestType = schemas.PassthroughStreamRequest
+	bifrostReq.PassthroughRequest = req
+
+	return bifrost.handleStreamRequest(ctx, bifrostReq)
 }
 
 // ExecuteChatMCPTool executes an MCP tool call and returns the result as a chat message.
@@ -4982,6 +5081,12 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, req *Ch
 			return nil, bifrostError
 		}
 		response.BatchCancelResponse = batchCancelResponse
+	case schemas.BatchDeleteRequest:
+		batchDeleteResponse, bifrostError := provider.BatchDelete(req.Context, keys, req.BifrostRequest.BatchDeleteRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.BatchDeleteResponse = batchDeleteResponse
 	case schemas.BatchResultsRequest:
 		batchResultsResponse, bifrostError := provider.BatchResults(req.Context, keys, req.BifrostRequest.BatchResultsRequest)
 		if bifrostError != nil {
@@ -5042,6 +5147,12 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, req *Ch
 			return nil, bifrostError
 		}
 		response.ContainerFileDeleteResponse = containerFileDeleteResponse
+	case schemas.PassthroughRequest:
+		passthroughResponse, bifrostError := provider.Passthrough(req.Context, key, req.BifrostRequest.PassthroughRequest)
+		if bifrostError != nil {
+			return nil, bifrostError
+		}
+		response.PassthroughResponse = passthroughResponse
 	default:
 		_, model, _ := req.BifrostRequest.GetRequestFields()
 		return nil, &schemas.BifrostError{
@@ -5076,6 +5187,8 @@ func (bifrost *Bifrost) handleProviderStreamRequest(provider schemas.Provider, r
 		return provider.ImageGenerationStream(req.Context, postHookRunner, key, req.BifrostRequest.ImageGenerationRequest)
 	case schemas.ImageEditStreamRequest:
 		return provider.ImageEditStream(req.Context, postHookRunner, key, req.BifrostRequest.ImageEditRequest)
+	case schemas.PassthroughStreamRequest:
+		return provider.PassthroughStream(req.Context, postHookRunner, key, req.BifrostRequest.PassthroughRequest)
 	default:
 		_, model, _ := req.BifrostRequest.GetRequestFields()
 		return nil, &schemas.BifrostError{
@@ -5671,6 +5784,7 @@ func resetBifrostRequest(req *schemas.BifrostRequest) {
 	req.BatchListRequest = nil
 	req.BatchRetrieveRequest = nil
 	req.BatchCancelRequest = nil
+	req.BatchDeleteRequest = nil
 	req.BatchResultsRequest = nil
 	req.ContainerCreateRequest = nil
 	req.ContainerListRequest = nil
@@ -5681,6 +5795,7 @@ func resetBifrostRequest(req *schemas.BifrostRequest) {
 	req.ContainerFileRetrieveRequest = nil
 	req.ContainerFileContentRequest = nil
 	req.ContainerFileDeleteRequest = nil
+	req.PassthroughRequest = nil
 }
 
 // getBifrostRequest gets a BifrostRequest from the pool
@@ -5869,7 +5984,7 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 
 	// Skip model check conditions
 	// We can improve these conditions in the future
-	skipModelCheck := (model == "" && (isFileRequestType(requestType) || isBatchRequestType(requestType) || isContainerRequestType(requestType) || isModellessVideoRequestType(requestType))) || requestType == schemas.ListModelsRequest
+	skipModelCheck := (model == "" && (isFileRequestType(requestType) || isBatchRequestType(requestType) || isContainerRequestType(requestType) || isModellessVideoRequestType(requestType) || isPassthroughRequestType(requestType))) || requestType == schemas.ListModelsRequest
 	if skipModelCheck {
 		// When skipping model check: just verify keys are enabled and have values
 		for _, k := range keys {

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1694,6 +1694,11 @@ func (provider *AnthropicProvider) BatchCancel(ctx *schemas.BifrostContext, keys
 	return nil, lastErr
 }
 
+// BatchDelete is not supported by the Anthropic provider.
+func (provider *AnthropicProvider) BatchDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults retrieves batch results by trying each key until found.
 func (provider *AnthropicProvider) BatchResults(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.BatchResultsRequest); err != nil {
@@ -2506,4 +2511,13 @@ func (provider *AnthropicProvider) ContainerFileContent(_ *schemas.BifrostContex
 // ContainerFileDelete is not supported by the Anthropic provider.
 func (provider *AnthropicProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Anthropic provider.
+func (provider *AnthropicProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *AnthropicProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2937,6 +2937,11 @@ func (provider *AzureProvider) BatchCancel(ctx *schemas.BifrostContext, keys []s
 	return nil, lastErr
 }
 
+// BatchDelete is not supported by the Azure provider.
+func (provider *AzureProvider) BatchDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, schemas.Azure)
+}
+
 // BatchResults retrieves batch results from Azure OpenAI by trying each key until successful.
 // For Azure (like OpenAI), batch results are obtained by downloading the output_file_id.
 func (provider *AzureProvider) BatchResults(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
@@ -3042,4 +3047,13 @@ func (provider *AzureProvider) ContainerFileContent(_ *schemas.BifrostContext, _
 // ContainerFileDelete is not supported by the Azure provider.
 func (provider *AzureProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Azure provider.
+func (provider *AzureProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *AzureProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -3360,6 +3360,11 @@ func (provider *BedrockProvider) BatchCancel(ctx *schemas.BifrostContext, keys [
 	return nil, lastErr
 }
 
+// BatchDelete is not supported by the Bedrock provider.
+func (provider *BedrockProvider) BatchDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults retrieves batch results from AWS Bedrock by trying each key until successful.
 // For Bedrock, results are stored in S3 at the output S3 URI prefix.
 // The output includes JSONL files with results (*.jsonl.out) and a manifest file.
@@ -3616,4 +3621,13 @@ func (provider *BedrockProvider) ContainerFileContent(_ *schemas.BifrostContext,
 // ContainerFileDelete is not supported by the Bedrock provider.
 func (provider *BedrockProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Bedrock provider.
+func (provider *BedrockProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *BedrockProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -322,6 +322,11 @@ func (provider *CerebrasProvider) BatchCancel(_ *schemas.BifrostContext, _ []sch
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Cerebras provider.
+func (provider *CerebrasProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Cerebras provider.
 func (provider *CerebrasProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -375,4 +380,13 @@ func (provider *CerebrasProvider) ContainerFileContent(_ *schemas.BifrostContext
 // ContainerFileDelete is not supported by the Cerebras provider.
 func (provider *CerebrasProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Cerebras provider.
+func (provider *CerebrasProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *CerebrasProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -1152,6 +1152,11 @@ func (provider *CohereProvider) BatchCancel(_ *schemas.BifrostContext, _ []schem
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Cohere provider.
+func (provider *CohereProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Cohere provider.
 func (provider *CohereProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -1312,4 +1317,13 @@ func (provider *CohereProvider) ContainerFileContent(_ *schemas.BifrostContext, 
 // ContainerFileDelete is not supported by the Cohere provider.
 func (provider *CohereProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Cohere provider.
+func (provider *CohereProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *CohereProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -856,6 +856,11 @@ func (provider *ElevenlabsProvider) BatchCancel(_ *schemas.BifrostContext, _ []s
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Elevenlabs provider.
+func (provider *ElevenlabsProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Elevenlabs provider.
 func (provider *ElevenlabsProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -934,4 +939,13 @@ func (provider *ElevenlabsProvider) ContainerFileContent(_ *schemas.BifrostConte
 // ContainerFileDelete is not supported by the Elevenlabs provider.
 func (provider *ElevenlabsProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Elevenlabs provider.
+func (provider *ElevenlabsProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *ElevenlabsProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -33,6 +33,197 @@ func ToBifrostBatchStatus(geminiState string) schemas.BatchStatus {
 	}
 }
 
+// ToGeminiBatchStatus converts Bifrost batch status to Gemini batch job state.
+func ToGeminiBatchStatus(status schemas.BatchStatus) string {
+	switch status {
+	case schemas.BatchStatusValidating, schemas.BatchStatusInProgress:
+		return GeminiBatchStateRunning
+	case schemas.BatchStatusFinalizing:
+		return GeminiBatchStateRunning
+	case schemas.BatchStatusCompleted, schemas.BatchStatusEnded:
+		return GeminiBatchStateSucceeded
+	case schemas.BatchStatusFailed:
+		return GeminiBatchStateFailed
+	case schemas.BatchStatusCancelling:
+		return GeminiBatchStateCancelling
+	case schemas.BatchStatusCancelled:
+		return GeminiBatchStateCancelled
+	case schemas.BatchStatusExpired:
+		return GeminiBatchStateExpired
+	default:
+		return GeminiBatchStateUnspecified
+	}
+}
+
+// ToGeminiBatchJobResponse converts Bifrost batch create response to Gemini batch job response format.
+func ToGeminiBatchJobResponse(resp *schemas.BifrostBatchCreateResponse) *GeminiBatchJobResponse {
+	if resp == nil {
+		return nil
+	}
+
+	succeededCount := resp.RequestCounts.Succeeded
+	if succeededCount == 0 {
+		succeededCount = resp.RequestCounts.Completed
+	}
+
+	geminiResp := &GeminiBatchJobResponse{
+		Name: resp.ID,
+		Metadata: &GeminiBatchMetadata{
+			Name:       resp.ID,
+			Type:       "type.googleapis.com/google.ai.generativelanguage.v1beta.BatchPredictionJob",
+			CreateTime: formatGeminiTimestamp(resp.CreatedAt),
+			UpdateTime: formatGeminiTimestamp(resp.CreatedAt),
+			State:      ToGeminiBatchStatus(resp.Status),
+			BatchStats: &GeminiBatchStats{
+				RequestCount:           resp.RequestCounts.Total,
+				PendingRequestCount:    max(0, resp.RequestCounts.Total-succeededCount-resp.RequestCounts.Failed),
+				SuccessfulRequestCount: succeededCount,
+			},
+		},
+	}
+
+	if resp.OperationName != nil && *resp.OperationName != "" {
+		geminiResp.Metadata.Name = *resp.OperationName
+		geminiResp.Name = *resp.OperationName
+	}
+
+	if resp.InputFileID != "" {
+		geminiResp.Metadata.InputConfig = &GeminiBatchMetadataInputConfig{
+			FileName: resp.InputFileID,
+		}
+	}
+
+	if resp.OutputFileID != nil && *resp.OutputFileID != "" {
+		geminiResp.Dest = &GeminiBatchDest{
+			FileName: *resp.OutputFileID,
+		}
+		geminiResp.Metadata.Output = &GeminiBatchMetadataOutputConfig{
+			ResponsesFile: *resp.OutputFileID,
+		}
+	}
+
+	if resp.Status == schemas.BatchStatusCompleted ||
+		resp.Status == schemas.BatchStatusEnded ||
+		resp.Status == schemas.BatchStatusFailed ||
+		resp.Status == schemas.BatchStatusExpired ||
+		resp.Status == schemas.BatchStatusCancelled {
+		geminiResp.Done = true
+	}
+
+	return geminiResp
+}
+
+// ToGeminiBatchRetrieveResponse converts a Bifrost batch retrieve response to Gemini batch job response format.
+func ToGeminiBatchRetrieveResponse(resp *schemas.BifrostBatchRetrieveResponse) *GeminiBatchJobResponse {
+	if resp == nil {
+		return nil
+	}
+
+	succeededCount := resp.RequestCounts.Succeeded
+	if succeededCount == 0 {
+		succeededCount = resp.RequestCounts.Completed
+	}
+
+	pendingCount := resp.RequestCounts.Pending
+	if pendingCount == 0 && resp.RequestCounts.Total > 0 {
+		processedCount := resp.RequestCounts.Completed
+		if processedCount == 0 {
+			processedCount = succeededCount
+		}
+		pendingCount = resp.RequestCounts.Total - processedCount - resp.RequestCounts.Failed
+		if pendingCount < 0 {
+			pendingCount = 0
+		}
+	}
+
+	geminiResp := &GeminiBatchJobResponse{
+		Name: resp.ID,
+		Metadata: &GeminiBatchMetadata{
+			Name:       resp.ID,
+			Type:       "type.googleapis.com/google.ai.generativelanguage.v1beta.BatchPredictionJob",
+			CreateTime: formatGeminiTimestamp(resp.CreatedAt),
+			UpdateTime: formatGeminiTimestamp(resp.CreatedAt),
+			State:      ToGeminiBatchStatus(resp.Status),
+			BatchStats: &GeminiBatchStats{
+				RequestCount:           resp.RequestCounts.Total,
+				PendingRequestCount:    pendingCount,
+				SuccessfulRequestCount: succeededCount,
+			},
+		},
+	}
+
+	if resp.OperationName != nil && *resp.OperationName != "" {
+		geminiResp.Metadata.Name = *resp.OperationName
+		geminiResp.Name = *resp.OperationName
+	}
+
+	if resp.Done != nil {
+		geminiResp.Done = *resp.Done
+	} else {
+		geminiResp.Done = resp.Status == schemas.BatchStatusCompleted ||
+			resp.Status == schemas.BatchStatusEnded ||
+			resp.Status == schemas.BatchStatusFailed ||
+			resp.Status == schemas.BatchStatusExpired ||
+			resp.Status == schemas.BatchStatusCancelled
+	}
+
+	if resp.InputFileID != "" {
+		geminiResp.Metadata.InputConfig = &GeminiBatchMetadataInputConfig{
+			FileName: resp.InputFileID,
+		}
+	}
+
+	if resp.OutputFileID != nil && *resp.OutputFileID != "" {
+		geminiResp.Dest = &GeminiBatchDest{
+			FileName: *resp.OutputFileID,
+		}
+		geminiResp.Metadata.Output = &GeminiBatchMetadataOutputConfig{
+			ResponsesFile: *resp.OutputFileID,
+		}
+	}
+
+	// Set end time from the most relevant terminal timestamp
+	var endTime int64
+	if resp.CompletedAt != nil {
+		endTime = *resp.CompletedAt
+	} else if resp.FailedAt != nil {
+		endTime = *resp.FailedAt
+	} else if resp.ExpiredAt != nil {
+		endTime = *resp.ExpiredAt
+	} else if resp.CancelledAt != nil {
+		endTime = *resp.CancelledAt
+	}
+	if endTime > 0 {
+		geminiResp.Metadata.EndTime = formatGeminiTimestamp(endTime)
+	}
+
+	return geminiResp
+}
+
+// ToGeminiBatchListResponse converts a Bifrost batch list response to Gemini format.
+func ToGeminiBatchListResponse(resp *schemas.BifrostBatchListResponse) *GeminiBatchListResponse {
+	if resp == nil {
+		return nil
+	}
+
+	operations := make([]GeminiBatchJobResponse, 0, len(resp.Data))
+	for i := range resp.Data {
+		if geminiResp := ToGeminiBatchRetrieveResponse(&resp.Data[i]); geminiResp != nil {
+			operations = append(operations, *geminiResp)
+		}
+	}
+
+	geminiListResp := &GeminiBatchListResponse{
+		Operations: operations,
+	}
+
+	if resp.NextCursor != nil {
+		geminiListResp.NextPageToken = *resp.NextCursor
+	}
+
+	return geminiListResp
+}
+
 // parseGeminiTimestamp converts Gemini RFC3339 timestamp to Unix timestamp.
 func parseGeminiTimestamp(timestamp string) int64 {
 	if timestamp == "" {
@@ -46,93 +237,13 @@ func parseGeminiTimestamp(timestamp string) int64 {
 }
 
 // extractBatchIDFromName extracts the batch ID from the full resource name.
-// e.g., "batches/abc123" -> "batches/abc123"
+// e.g., "batches/abc123" -> "abc123"
 func extractBatchIDFromName(name string) string {
-	return name
-}
-
-// buildBatchRequestItems converts Bifrost batch requests to Gemini format.
-func buildBatchRequestItems(requests []schemas.BatchRequestItem) []GeminiBatchRequestItem {
-	items := make([]GeminiBatchRequestItem, 0, len(requests))
-
-	for _, req := range requests {
-		contents := []Content{}
-
-		// Try Body first, then fall back to Params (Anthropic SDK uses Params)
-		requestData := req.Body
-		if requestData == nil {
-			requestData = req.Params
-		}
-
-		// Extract messages from the request data - handle multiple possible types
-		// Go type assertions don't work across slice types, so we handle each case
-		if requestData != nil {
-			var messages []map[string]interface{}
-
-			// Try []interface{} first (generic JSON unmarshaling)
-			if msgsInterface, ok := requestData["messages"].([]interface{}); ok {
-				for _, m := range msgsInterface {
-					if msgMap, ok := m.(map[string]interface{}); ok {
-						messages = append(messages, msgMap)
-					}
-				}
-			} else if msgsTyped, ok := requestData["messages"].([]map[string]interface{}); ok {
-				// Try []map[string]interface{} (typed maps)
-				messages = msgsTyped
-			} else if msgsString, ok := requestData["messages"].([]map[string]string); ok {
-				// Try []map[string]string (test case format)
-				for _, m := range msgsString {
-					msgMap := make(map[string]interface{})
-					for k, v := range m {
-						msgMap[k] = v
-					}
-					messages = append(messages, msgMap)
-				}
-			}
-
-			// Process extracted messages
-			for _, msgMap := range messages {
-				role := "user"
-				if r, ok := msgMap["role"].(string); ok {
-					if r == "assistant" {
-						role = "model"
-					} else if r == "system" {
-						// System messages are handled separately in Gemini
-						continue
-					} else {
-						role = r
-					}
-				}
-
-				parts := []*Part{}
-				if c, ok := msgMap["content"].(string); ok {
-					parts = append(parts, &Part{Text: c})
-				}
-
-				contents = append(contents, Content{
-					Role:  role,
-					Parts: parts,
-				})
-			}
-		}
-
-		item := GeminiBatchRequestItem{
-			Request: GeminiBatchGenerateContentRequest{
-				Contents: contents,
-			},
-		}
-
-		// Add metadata with custom_id as key
-		if req.CustomID != "" {
-			item.Metadata = &GeminiBatchMetadata{
-				Key: req.CustomID,
-			}
-		}
-
-		items = append(items, item)
+	if name == "" {
+		return ""
 	}
-
-	return items
+	parts := strings.Split(name, "/")
+	return parts[len(parts)-1]
 }
 
 // downloadBatchResultsFile downloads and parses a batch results file from Gemini.

--- a/core/providers/gemini/files.go
+++ b/core/providers/gemini/files.go
@@ -13,16 +13,16 @@ import (
 
 // GeminiFileResponse represents a file object from Gemini's API.
 type GeminiFileResponse struct {
-	Name           string                   `json:"name"`           // Resource name (e.g., "files/abc123")
-	DisplayName    string                   `json:"displayName"`    // User-provided display name
-	MimeType       string                   `json:"mimeType"`       // MIME type of the file
-	SizeBytes      string                   `json:"sizeBytes"`      // Size in bytes (as string)
-	CreateTime     string                   `json:"createTime"`     // RFC3339 timestamp
-	UpdateTime     string                   `json:"updateTime"`     // RFC3339 timestamp
-	ExpirationTime string                   `json:"expirationTime"` // RFC3339 timestamp when file will be deleted
-	SHA256Hash     string                   `json:"sha256Hash"`     // Base64 encoded SHA256 hash
-	URI            string                   `json:"uri"`            // URI for accessing the file
-	State          string                   `json:"state"`          // "PROCESSING", "ACTIVE", "FAILED"
+	Name           string                   `json:"name"`                     // Resource name (e.g., "files/abc123")
+	DisplayName    string                   `json:"displayName"`              // User-provided display name
+	MimeType       string                   `json:"mimeType"`                 // MIME type of the file
+	SizeBytes      string                   `json:"sizeBytes"`                // Size in bytes (as string)
+	CreateTime     string                   `json:"createTime"`               // RFC3339 timestamp
+	UpdateTime     string                   `json:"updateTime"`               // RFC3339 timestamp
+	ExpirationTime string                   `json:"expirationTime,omitempty"` // RFC3339 timestamp when file will be deleted
+	SHA256Hash     string                   `json:"sha256Hash"`               // Base64 encoded SHA256 hash
+	URI            string                   `json:"uri"`                      // URI for accessing the file
+	State          string                   `json:"state"`                    // "PROCESSING", "ACTIVE", "FAILED"
 	VideoMetadata  *GeminiFileVideoMetadata `json:"videoMetadata,omitempty"`
 }
 
@@ -55,11 +55,16 @@ func ToBifrostFileStatus(state string) schemas.FileStatus {
 func ToGeminiFileListResponse(resp *schemas.BifrostFileListResponse) *GeminiFileListResponse {
 	files := make([]GeminiFileResponse, len(resp.Data))
 	for i, f := range resp.Data {
+		updateAt := f.UpdatedAt
+		if updateAt == 0 {
+			updateAt = f.CreatedAt
+		}
 		files[i] = GeminiFileResponse{
 			Name:           f.ID,
 			DisplayName:    f.Filename,
 			SizeBytes:      fmt.Sprintf("%d", f.Bytes),
 			CreateTime:     formatGeminiTimestamp(f.CreatedAt),
+			UpdateTime:     formatGeminiTimestamp(updateAt),
 			State:          toGeminiFileState(f.Status),
 			ExpirationTime: formatGeminiTimestamp(safeDerefInt64(f.ExpiresAt)),
 		}
@@ -73,11 +78,16 @@ func ToGeminiFileListResponse(resp *schemas.BifrostFileListResponse) *GeminiFile
 
 // ToGeminiFileRetrieveResponse converts a Bifrost file retrieve response to Gemini format.
 func ToGeminiFileRetrieveResponse(resp *schemas.BifrostFileRetrieveResponse) *GeminiFileResponse {
+	updateAt := resp.UpdatedAt
+	if updateAt == 0 {
+		updateAt = resp.CreatedAt
+	}
 	return &GeminiFileResponse{
 		Name:           resp.ID,
 		DisplayName:    resp.Filename,
 		SizeBytes:      fmt.Sprintf("%d", resp.Bytes),
 		CreateTime:     formatGeminiTimestamp(resp.CreatedAt),
+		UpdateTime:     formatGeminiTimestamp(updateAt),
 		State:          toGeminiFileState(resp.Status),
 		URI:            resp.StorageURI,
 		ExpirationTime: formatGeminiTimestamp(safeDerefInt64(resp.ExpiresAt)),
@@ -116,16 +126,20 @@ func safeDerefInt64(ptr *int64) int64 {
 
 // ToGeminiFileUploadResponse converts a Bifrost file upload response to Gemini format.
 func ToGeminiFileUploadResponse(resp *schemas.BifrostFileUploadResponse) map[string]interface{} {
+	file := map[string]interface{}{
+		"name":        resp.ID,
+		"displayName": resp.Filename,
+		"mimeType":    "application/octet-stream",
+		"sizeBytes":   fmt.Sprintf("%d", resp.Bytes),
+		"createTime":  formatGeminiTimestamp(resp.CreatedAt),
+		"updateTime":  formatGeminiTimestamp(resp.CreatedAt),
+		"state":       toGeminiFileState(resp.Status),
+		"uri":         resp.StorageURI,
+	}
+	if exp := formatGeminiTimestamp(safeDerefInt64(resp.ExpiresAt)); exp != "" {
+		file["expirationTime"] = exp
+	}
 	return map[string]interface{}{
-		"file": map[string]interface{}{
-			"name":           resp.ID,
-			"displayName":    resp.Filename,
-			"mimeType":       "application/octet-stream",
-			"sizeBytes":      fmt.Sprintf("%d", resp.Bytes),
-			"createTime":     formatGeminiTimestamp(resp.CreatedAt),
-			"state":          toGeminiFileState(resp.Status),
-			"uri":            resp.StorageURI,
-			"expirationTime": formatGeminiTimestamp(safeDerefInt64(resp.ExpiresAt)),
-		},
+		"file": file,
 	}
 }

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2637,10 +2637,33 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 			FileName: fileID,
 		}
 	} else {
-		// Inline requests: use requests in input_config
+		// Inline requests: convert Bifrost requests to Gemini format
+		geminiRequests := make([]GeminiBatchRequestItem, len(request.Requests))
+		for i, bifrostItem := range request.Requests {
+			requestBytes, err := sonic.Marshal(bifrostItem.Body)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError("failed to marshal gemini request", err, providerName)
+			}
+			var geminiReq GeminiBatchGenerateContentRequest
+			err = sonic.Unmarshal(requestBytes, &geminiReq)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError("failed to unmarshal gemini request", err, providerName)
+			}
+
+			geminiRequests[i] = GeminiBatchRequestItem{
+				Request: geminiReq,
+			}
+			// Set metadata with custom_id
+			if bifrostItem.CustomID != "" {
+				geminiRequests[i].Metadata = &GeminiBatchMetadata{
+					Key: bifrostItem.CustomID,
+				}
+			}
+		}
+
 		batchReq.Batch.InputConfig = GeminiBatchInputConfig{
 			Requests: &GeminiBatchRequestsWrapper{
-				Requests: buildBatchRequestItems(request.Requests),
+				Requests: geminiRequests,
 			},
 		}
 	}
@@ -3161,6 +3184,88 @@ func (provider *GeminiProvider) BatchCancel(ctx *schemas.BifrostContext, keys []
 	}
 
 	// All keys failed, return the last error
+	return nil, lastError
+}
+
+// batchDeleteByKey deletes a batch job for Gemini for a single key.
+// batches.delete indicates the client is no longer interested in the operation result.
+// It does not cancel the operation. If the server doesn't support this method, it returns UNIMPLEMENTED.
+func (provider *GeminiProvider) batchDeleteByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	providerName := provider.GetProviderKey()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	batchID := request.BatchID
+	var requestURL string
+	if strings.HasPrefix(batchID, "batches/") {
+		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, batchID)
+	} else {
+		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL, batchID)
+	}
+
+	provider.logger.Debug("gemini batch delete url: " + requestURL)
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	req.SetRequestURI(requestURL)
+	req.Header.SetMethod(http.MethodDelete)
+	if key.Value.GetValue() != "" {
+		req.Header.Set("x-goog-api-key", key.Value.GetValue())
+	}
+
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	if resp.StatusCode() != fasthttp.StatusOK && resp.StatusCode() != fasthttp.StatusNoContent {
+		return nil, parseGeminiError(resp, &providerUtils.RequestMetadata{
+			Provider:    providerName,
+			RequestType: schemas.BatchDeleteRequest,
+		})
+	}
+
+	return &schemas.BifrostBatchDeleteResponse{
+		ID:     request.BatchID,
+		Object: "batch",
+		Status: schemas.BatchStatusDeleted,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.BatchDeleteRequest,
+			Provider:    providerName,
+			Latency:     latency.Milliseconds(),
+		},
+	}, nil
+}
+
+// BatchDelete deletes a batch job for Gemini, trying each key until successful.
+// This indicates the client is no longer interested in the operation result.
+// It does not cancel the operation. If the server doesn't support this method, it returns UNIMPLEMENTED.
+func (provider *GeminiProvider) BatchDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.BatchDeleteRequest); err != nil {
+		return nil, err
+	}
+
+	providerName := provider.GetProviderKey()
+
+	if request.BatchID == "" {
+		return nil, providerUtils.NewBifrostOperationError("batch_id is required", nil, providerName)
+	}
+
+	if len(keys) == 0 {
+		return nil, providerUtils.NewBifrostOperationError("no keys provided for batch delete", nil, providerName)
+	}
+
+	var lastError *schemas.BifrostError
+	for _, key := range keys {
+		resp, err := provider.batchDeleteByKey(ctx, key, request)
+		if err == nil {
+			return resp, nil
+		}
+		lastError = err
+		provider.logger.Debug("BatchDelete failed for key %s: %v", key.Name, err.Error)
+	}
+
 	return nil, lastError
 }
 
@@ -3701,6 +3806,10 @@ func (provider *GeminiProvider) fileListByKey(ctx *schemas.BifrostContext, key s
 		if t, err := time.Parse(time.RFC3339, file.CreateTime); err == nil {
 			createdAt = t.Unix()
 		}
+		var updatedAt int64
+		if t, err := time.Parse(time.RFC3339, file.UpdateTime); err == nil {
+			updatedAt = t.Unix()
+		}
 
 		var expiresAt *int64
 		if file.ExpirationTime != "" {
@@ -3715,6 +3824,7 @@ func (provider *GeminiProvider) fileListByKey(ctx *schemas.BifrostContext, key s
 			Object:    "file",
 			Bytes:     sizeBytes,
 			CreatedAt: createdAt,
+			UpdatedAt: updatedAt,
 			Filename:  file.DisplayName,
 			Purpose:   schemas.FilePurposeVision,
 			Status:    ToBifrostFileStatus(file.State),
@@ -3857,6 +3967,11 @@ func (provider *GeminiProvider) fileRetrieveByKey(ctx *schemas.BifrostContext, k
 		createdAt = t.Unix()
 	}
 
+	var updatedAt int64
+	if t, err := time.Parse(time.RFC3339, geminiResp.UpdateTime); err == nil {
+		updatedAt = t.Unix()
+	}
+
 	var expiresAt *int64
 	if geminiResp.ExpirationTime != "" {
 		if t, err := time.Parse(time.RFC3339, geminiResp.ExpirationTime); err == nil {
@@ -3870,6 +3985,7 @@ func (provider *GeminiProvider) fileRetrieveByKey(ctx *schemas.BifrostContext, k
 		Object:         "file",
 		Bytes:          sizeBytes,
 		CreatedAt:      createdAt,
+		UpdatedAt:      updatedAt,
 		Filename:       geminiResp.DisplayName,
 		Purpose:        schemas.FilePurposeVision,
 		Status:         ToBifrostFileStatus(geminiResp.State),
@@ -4188,4 +4304,219 @@ func (provider *GeminiProvider) ContainerFileContent(_ *schemas.BifrostContext, 
 // ContainerFileDelete is not supported by the Gemini provider.
 func (provider *GeminiProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *GeminiProvider) Passthrough(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.PassthroughRequest); err != nil {
+		return nil, err
+	}
+	url := provider.networkConfig.BaseURL + req.Path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+
+	url = strings.Replace(url, "v1beta/upload/v1beta", "upload/v1beta", 1)
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	if key.Value.GetValue() != "" {
+		fasthttpReq.Header.Set("x-goog-api-key", key.Value.GetValue())
+	}
+
+	fasthttpReq.SetBody(req.Body)
+
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err, provider.GetProviderKey())
+	}
+	for k := range headers {
+		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
+			delete(headers, k)
+		}
+	}
+	body = append([]byte(nil), body...)
+	bifrostResponse := &schemas.BifrostPassthroughResponse{
+		StatusCode: resp.StatusCode(),
+		Headers:    headers,
+		Body:       body,
+	}
+
+	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
+	bifrostResponse.ExtraFields.ModelRequested = req.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.PassthroughRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+	}
+
+	return bifrostResponse, nil
+}
+
+func (provider *GeminiProvider) PassthroughStream(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.PassthroughStreamRequest); err != nil {
+		return nil, err
+	}
+
+	url := provider.networkConfig.BaseURL + req.Path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+
+	url = strings.Replace(url, "v1beta/upload/v1beta", "upload/v1beta", 1)
+
+	startTime := time.Now()
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	if key.Value.GetValue() != "" {
+		fasthttpReq.Header.Set("x-goog-api-key", key.Value.GetValue())
+	}
+
+	fasthttpReq.Header.Set("Connection", "close")
+
+	fasthttpReq.SetBody(req.Body)
+
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
+	if err := activeClient.Do(fasthttpReq, resp); err != nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, provider.GetProviderKey())
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey())
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		return nil, providerUtils.NewBifrostOperationError(
+			"provider returned an empty stream body",
+			fmt.Errorf("provider returned an empty stream body"),
+			provider.GetProviderKey(),
+		)
+	}
+
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+
+	extraFields := schemas.BifrostResponseExtraFields{
+		Provider:       provider.GetProviderKey(),
+		ModelRequested: req.Model,
+		RequestType:    schemas.PassthroughStreamRequest,
+	}
+	statusCode := resp.StatusCode()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
+	}
+
+	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			}
+			close(ch)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		defer stopCancellation()
+
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := bodyStream.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				select {
+				case ch <- &schemas.BifrostStreamChunk{
+					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						Body:        chunk,
+						ExtraFields: extraFields,
+					},
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if readErr == io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				finalResp := &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						ExtraFields: extraFields,
+					},
+				}
+				postHookRunner(ctx, finalResp, nil)
+				if finalizer, ok := ctx.Value(schemas.BifrostContextKeyPostHookSpanFinalizer).(func(context.Context)); ok && finalizer != nil {
+					finalizer(ctx)
+				}
+				return
+			}
+			if readErr != nil {
+				if ctx.Err() != nil {
+					return // let defer handle cancel/timeout
+				}
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, ch, schemas.PassthroughStreamRequest, provider.GetProviderKey(), req.Model, provider.logger)
+				return
+			}
+		}
+	}()
+	return ch, nil
 }

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -52,7 +52,7 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 		params.Tools = convertGeminiToolsToResponsesTools(request.Tools)
 	}
 
-	if request.ToolConfig.FunctionCallingConfig != nil {
+	if request.ToolConfig != nil && request.ToolConfig.FunctionCallingConfig != nil {
 		params.ToolChoice = convertGeminiToolConfigToToolChoice(request.ToolConfig)
 	}
 
@@ -1990,8 +1990,8 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 	return responsesTools
 }
 
-func convertGeminiToolConfigToToolChoice(toolConfig ToolConfig) *schemas.ResponsesToolChoice {
-	if toolConfig.FunctionCallingConfig == nil {
+func convertGeminiToolConfigToToolChoice(toolConfig *ToolConfig) *schemas.ResponsesToolChoice {
+	if toolConfig == nil || toolConfig.FunctionCallingConfig == nil {
 		return nil
 	}
 
@@ -2628,8 +2628,8 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 }
 
 // convertResponsesToolChoiceToGemini converts Responses tool choice to Gemini tool config
-func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice) ToolConfig {
-	config := ToolConfig{}
+func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice) *ToolConfig {
+	config := &ToolConfig{}
 
 	if toolChoice.ResponsesToolChoiceStruct != nil {
 		funcConfig := &FunctionCallingConfig{}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -74,7 +74,7 @@ type GeminiGenerationRequest struct {
 	GenerationConfig  GenerationConfig         `json:"generationConfig,omitempty"`
 	SafetySettings    []SafetySetting          `json:"safetySettings,omitempty"`
 	Tools             []Tool                   `json:"tools,omitempty"`
-	ToolConfig        ToolConfig               `json:"toolConfig,omitempty"`
+	ToolConfig        *ToolConfig              `json:"toolConfig,omitempty"`
 	Labels            map[string]string        `json:"labels,omitempty"`
 	CachedContent     string                   `json:"cachedContent,omitempty"`
 	Stream            bool                     `json:"-"` // Internal field to track streaming requests
@@ -1916,20 +1916,21 @@ type GeminiListModelsResponse struct {
 
 // GeminiBatchCreateRequest represents the top-level request structure for creating a batch.
 type GeminiBatchCreateRequest struct {
+	Model string            `json:"-"`
 	Batch GeminiBatchConfig `json:"batch"`
 }
 
 // GeminiBatchConfig represents the batch configuration.
 type GeminiBatchConfig struct {
-	DisplayName string                 `json:"display_name,omitempty"`
-	InputConfig GeminiBatchInputConfig `json:"input_config"`
+	DisplayName string                 `json:"displayName,omitempty"`
+	InputConfig GeminiBatchInputConfig `json:"inputConfig"`
 }
 
 // GeminiBatchInputConfig represents the input configuration for batch requests.
 // Supports both inline requests and file-based input.
 type GeminiBatchInputConfig struct {
 	Requests *GeminiBatchRequestsWrapper `json:"requests,omitempty"`
-	FileName string                      `json:"file_name,omitempty"`
+	FileName string                      `json:"fileName,omitempty"`
 }
 
 // GeminiBatchRequestsWrapper wraps the array of batch request items.
@@ -2210,6 +2211,7 @@ var GeminiRequestSuffixPaths = []string{
 	":countTokens",
 	":embedContent",
 	":batchEmbedContents",
+	":batchGenerateContent",
 	":predict",
 	":predictLongRunning",
 }
@@ -2605,4 +2607,52 @@ type GenerateVideosOperation struct {
 	Error map[string]any `json:"error,omitempty"`
 	// Optional. The long-running operation response payload.
 	Response *GenerateVideosOperationResponse `json:"response,omitempty"`
+}
+
+// geminiResumableUploadSession holds the metadata stored in the KV store
+// between step 1 (resumable upload initiation) and step 2 (binary upload)
+// of a Gemini-format file upload destined for non-Gemini/Vertex providers.
+type GeminiResumableUploadSession struct {
+	DisplayName string
+	MimeType    string
+	Provider    schemas.ModelProvider
+}
+
+// GeminiFileUploadHandlerReqFile represents the file metadata in a Gemini file upload request.
+type GeminiFileUploadHandlerReqFile struct {
+	DisplayName string `json:"display_name"`
+}
+
+func (f *GeminiFileUploadHandlerReqFile) UnmarshalJSON(data []byte) error {
+	type Alias struct {
+		DisplayNameCamel string `json:"displayName"`
+		DisplayNameSnake string `json:"display_name"`
+	}
+	var alias Alias
+	if err := sonic.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	// Prefer camelCase over snake_case
+	if alias.DisplayNameCamel != "" {
+		f.DisplayName = alias.DisplayNameCamel
+	} else {
+		f.DisplayName = alias.DisplayNameSnake
+	}
+	return nil
+}
+
+// geminiFileUploadHandlerReq is the unified request object for the GenAI file
+// upload route. It handles both step 1 (JSON metadata body) and step 2 (raw
+// binary body with upload_id query param).
+type GeminiFileUploadHandlerReq struct {
+	// Step 1 JSON fields — Gemini sends {"file": {"displayName": "..."}} or {"file": {"display_name": "..."}}
+	File GeminiFileUploadHandlerReqFile `json:"file"`
+
+	// Populated by RequestParser / PreCallback
+	Provider schemas.ModelProvider `json:"-"`
+	MimeType string                `json:"-"` // from X-Goog-Upload-Header-Content-Type
+
+	// Step 2 fields — populated when upload_id is present in query
+	UploadID string `json:"-"`
+	FileData []byte `json:"-"`
 }

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1366,8 +1366,11 @@ func toFloat64(v interface{}) (float64, bool) {
 }
 
 // convertToolChoiceToToolConfig converts Bifrost tool choice to Gemini tool config
-func convertToolChoiceToToolConfig(toolChoice *schemas.ChatToolChoice) ToolConfig {
-	config := ToolConfig{}
+func convertToolChoiceToToolConfig(toolChoice *schemas.ChatToolChoice) *ToolConfig {
+	if toolChoice == nil || (toolChoice.ChatToolChoiceStr == nil && toolChoice.ChatToolChoiceStruct == nil) {
+		return nil
+	}
+	config := &ToolConfig{}
 	functionCallingConfig := FunctionCallingConfig{}
 
 	if toolChoice.ChatToolChoiceStr != nil {

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -268,6 +268,11 @@ func (provider *GroqProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Groq provider.
+func (provider *GroqProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Groq provider.
 func (provider *GroqProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -346,4 +351,13 @@ func (provider *GroqProvider) ContainerFileContent(_ *schemas.BifrostContext, _ 
 // ContainerFileDelete is not supported by the Groq provider.
 func (provider *GroqProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Groq provider.
+func (provider *GroqProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *GroqProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -1835,6 +1835,11 @@ func (provider *HuggingFaceProvider) BatchCancel(_ *schemas.BifrostContext, _ []
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by the Hugging Face provider.
 func (provider *HuggingFaceProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -1913,4 +1918,13 @@ func (provider *HuggingFaceProvider) ContainerFileContent(_ *schemas.BifrostCont
 // ContainerFileDelete is not supported by the Hugging Face provider.
 func (provider *HuggingFaceProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Hugging Face provider.
+func (provider *HuggingFaceProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *HuggingFaceProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -617,6 +617,11 @@ func (provider *MistralProvider) BatchCancel(_ *schemas.BifrostContext, _ []sche
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Mistral provider.
+func (provider *MistralProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Mistral provider.
 func (provider *MistralProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -750,4 +755,13 @@ func (provider *MistralProvider) ContainerFileContent(_ *schemas.BifrostContext,
 // ContainerFileDelete is not supported by the Mistral provider.
 func (provider *MistralProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Mistral provider.
+func (provider *MistralProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *MistralProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -435,6 +435,11 @@ func (provider *NebiusProvider) BatchCancel(_ *schemas.BifrostContext, _ []schem
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Nebius provider.
+func (provider *NebiusProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Nebius provider.
 func (provider *NebiusProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -513,4 +518,13 @@ func (provider *NebiusProvider) ContainerFileContent(_ *schemas.BifrostContext, 
 // ContainerFileDelete is not supported by the Nebius provider.
 func (provider *NebiusProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Nebius provider.
+func (provider *NebiusProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *NebiusProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -310,6 +310,11 @@ func (provider *OllamaProvider) BatchCancel(_ *schemas.BifrostContext, _ []schem
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Ollama provider.
+func (provider *OllamaProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Ollama provider.
 func (provider *OllamaProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -387,4 +392,13 @@ func (provider *OllamaProvider) ContainerFileContent(_ *schemas.BifrostContext, 
 // ContainerFileDelete is not supported by the Ollama provider.
 func (provider *OllamaProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Ollama provider.
+func (provider *OllamaProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *OllamaProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -5716,6 +5716,11 @@ func (provider *OpenAIProvider) BatchCancel(ctx *schemas.BifrostContext, keys []
 	return nil, lastErr
 }
 
+// BatchDelete is not supported by the OpenAI provider.
+func (provider *OpenAIProvider) BatchDelete(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults retrieves batch results by trying each key until successful.
 // Note: For OpenAI, batch results are obtained by downloading the output_file_id.
 // This method returns the file content parsed as batch results.
@@ -6890,4 +6895,232 @@ func (provider *OpenAIProvider) ContainerFileDelete(ctx *schemas.BifrostContext,
 	}
 
 	return nil, lastErr
+}
+
+func (provider *OpenAIProvider) Passthrough(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.PassthroughRequest); err != nil {
+		return nil, err
+	}
+
+	path := req.Path
+	// if path has v1 or v1/ remove it
+	if after, ok := strings.CutPrefix(path, "/v1"); ok {
+		path = after
+	}
+
+	url := provider.networkConfig.BaseURL + "/v1" + path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	if key.Value.GetValue() != "" {
+		fasthttpReq.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	fasthttpReq.SetBody(req.Body)
+
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err, provider.GetProviderKey())
+	}
+
+	// Remove wire-level encoding headers after decoding; downstream should recalculate them for the buffered body.
+	for k := range headers {
+		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
+			delete(headers, k)
+		}
+	}
+
+	bifrostResponse := &schemas.BifrostPassthroughResponse{
+		StatusCode: resp.StatusCode(),
+		Headers:    headers,
+		Body:       body,
+	}
+
+	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
+	bifrostResponse.ExtraFields.ModelRequested = req.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.PassthroughRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+	}
+
+	return bifrostResponse, nil
+}
+
+func (provider *OpenAIProvider) PassthroughStream(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.PassthroughStreamRequest); err != nil {
+		return nil, err
+	}
+
+	path := req.Path
+	if after, ok := strings.CutPrefix(path, "/v1"); ok {
+		path = after
+	}
+	url := provider.networkConfig.BaseURL + "/v1" + path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+	startTime := time.Now()
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	fasthttpReq.Header.Set("Connection", "close")
+
+	if key.Value.GetValue() != "" {
+		fasthttpReq.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	fasthttpReq.SetBody(req.Body)
+
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
+	if err := activeClient.Do(fasthttpReq, resp); err != nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, provider.GetProviderKey())
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey())
+	}
+
+	headers := make(map[string]string)
+	resp.Header.All()(func(k, v []byte) bool {
+		headers[string(k)] = string(v)
+		return true
+	})
+
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		return nil, providerUtils.NewBifrostOperationError(
+			"provider returned an empty stream body",
+			fmt.Errorf("provider returned an empty stream body"),
+			provider.GetProviderKey(),
+		)
+	}
+
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+
+	extraFields := schemas.BifrostResponseExtraFields{
+		Provider:       provider.GetProviderKey(),
+		ModelRequested: req.Model,
+		RequestType:    schemas.PassthroughStreamRequest,
+	}
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
+	}
+	statusCode := resp.StatusCode()
+
+	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			}
+			close(ch)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		defer stopCancellation()
+
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := bodyStream.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				select {
+				case ch <- &schemas.BifrostStreamChunk{
+					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						Body:        chunk,
+						ExtraFields: extraFields,
+					},
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if readErr == io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				finalResp := &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						ExtraFields: extraFields,
+					},
+				}
+				postHookRunner(ctx, finalResp, nil)
+				if finalizer, ok := ctx.Value(schemas.BifrostContextKeyPostHookSpanFinalizer).(func(context.Context)); ok && finalizer != nil {
+					finalizer(ctx)
+				}
+				return
+			}
+			if readErr != nil {
+				if ctx.Err() != nil {
+					return // let defer handle cancel/timeout
+				}
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, ch, schemas.PassthroughStreamRequest, provider.GetProviderKey(), req.Model, provider.logger)
+				return
+			}
+		}
+	}()
+	return ch, nil
 }

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -1,6 +1,8 @@
 package openai
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
 
 // CustomResponseHandler is a function that produces a Bifrost response from a Bifrost request.
 // T is the concrete Bifrost response type (e.g. BifrostEmbeddingResponse, BifrostTextCompletionResponse, BifrostChatResponse, BifrostResponsesResponse, BifrostImageGenerationResponse, BifrostTranscriptionResponse).

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -467,6 +467,11 @@ func (provider *OpenRouterProvider) BatchCancel(_ *schemas.BifrostContext, _ []s
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by OpenRouter provider.
+func (provider *OpenRouterProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by OpenRouter provider.
 func (provider *OpenRouterProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -545,4 +550,13 @@ func (provider *OpenRouterProvider) ContainerFileContent(_ *schemas.BifrostConte
 // ContainerFileDelete is not supported by the OpenRouter provider.
 func (provider *OpenRouterProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the OpenRouter provider.
+func (provider *OpenRouterProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *OpenRouterProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -289,6 +289,11 @@ func (provider *ParasailProvider) BatchCancel(_ *schemas.BifrostContext, _ []sch
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Parasail provider.
+func (provider *ParasailProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Parasail provider.
 func (provider *ParasailProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -342,4 +347,14 @@ func (provider *ParasailProvider) ContainerFileContent(_ *schemas.BifrostContext
 // ContainerFileDelete is not supported by the Parasail provider.
 func (provider *ParasailProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Parasail provider.
+func (provider *ParasailProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+// PassthroughStream is not supported by the Parasail provider.
+func (provider *ParasailProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -341,6 +341,11 @@ func (provider *PerplexityProvider) BatchCancel(_ *schemas.BifrostContext, _ []s
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Perplexity provider.
+func (provider *PerplexityProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Perplexity provider.
 func (provider *PerplexityProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -419,4 +424,13 @@ func (provider *PerplexityProvider) ContainerFileContent(_ *schemas.BifrostConte
 // ContainerFileDelete is not supported by the Perplexity provider.
 func (provider *PerplexityProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Perplexity provider.
+func (provider *PerplexityProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *PerplexityProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -2926,6 +2926,11 @@ func (provider *ReplicateProvider) BatchCancel(_ *schemas.BifrostContext, _ []sc
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by replicate provider.
+func (provider *ReplicateProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by replicate provider.
 func (provider *ReplicateProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -3439,4 +3444,13 @@ func (provider *ReplicateProvider) ContainerFileContent(_ *schemas.BifrostContex
 // ContainerFileDelete is not supported by replicate provider.
 func (provider *ReplicateProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Replicate provider.
+func (provider *ReplicateProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *ReplicateProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -500,6 +500,11 @@ func (provider *RunwayProvider) BatchCancel(_ *schemas.BifrostContext, _ []schem
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Runway provider.
+func (provider *RunwayProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Runway provider.
 func (provider *RunwayProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -553,4 +558,13 @@ func (provider *RunwayProvider) ContainerFileContent(_ *schemas.BifrostContext, 
 // ContainerFileDelete is not supported by the Runway provider.
 func (provider *RunwayProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the Runway provider.
+func (provider *RunwayProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *RunwayProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -332,6 +332,11 @@ func (provider *SGLProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas.
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by SGL provider.
+func (provider *SGLProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by SGL provider.
 func (provider *SGLProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -385,4 +390,13 @@ func (provider *SGLProvider) ContainerFileContent(_ *schemas.BifrostContext, _ [
 // ContainerFileDelete is not supported by the SGL provider.
 func (provider *SGLProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the SGL provider.
+func (provider *SGLProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *SGLProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -5,10 +5,10 @@ package utils
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -350,34 +350,34 @@ func filterHeaders(headers map[string][]string) map[string][]string {
 // providerResponseFilterHeaders are headers to exclude when forwarding provider response headers.
 // These are transport-level headers that don't apply when re-serving the response.
 var providerResponseFilterHeaders = map[string]bool{
-	"content-length":                    true,
-	"content-encoding":                  true,
-	"transfer-encoding":                 true,
-	"connection":                        true,
-	"keep-alive":                        true,
-	"proxy-connection":                  true,
-	"proxy-authenticate":                true,
-	"proxy-authorization":               true,
-	"authorization":                     true,
-	"cookie":                            true,
-	"set-cookie":                        true,
-	"set-cookie2":                       true,
-	"www-authenticate":                  true,
-	"te":                                true,
-	"trailer":                           true,
-	"upgrade":                           true,
-	"host":                              true,
-	"date":                              true,
-	"server":                            true,
-	"alt-svc":                           true,
-	"strict-transport-security":         true,
-	"content-type":                      true,
-	"access-control-allow-origin":       true,
-	"access-control-allow-methods":      true,
-	"access-control-allow-headers":      true,
-	"access-control-expose-headers":     true,
-	"access-control-allow-credentials":  true,
-	"access-control-max-age":            true,
+	"content-length":                   true,
+	"content-encoding":                 true,
+	"transfer-encoding":                true,
+	"connection":                       true,
+	"keep-alive":                       true,
+	"proxy-connection":                 true,
+	"proxy-authenticate":               true,
+	"proxy-authorization":              true,
+	"authorization":                    true,
+	"cookie":                           true,
+	"set-cookie":                       true,
+	"set-cookie2":                      true,
+	"www-authenticate":                 true,
+	"te":                               true,
+	"trailer":                          true,
+	"upgrade":                          true,
+	"host":                             true,
+	"date":                             true,
+	"server":                           true,
+	"alt-svc":                          true,
+	"strict-transport-security":        true,
+	"content-type":                     true,
+	"access-control-allow-origin":      true,
+	"access-control-allow-methods":     true,
+	"access-control-allow-headers":     true,
+	"access-control-expose-headers":    true,
+	"access-control-allow-credentials": true,
+	"access-control-max-age":           true,
 }
 
 // ExtractProviderResponseHeaders extracts and filters response headers from a
@@ -1279,6 +1279,16 @@ func compactRawJSON(data []byte) json.RawMessage {
 func ParseAndSetRawRequest(extraFields *schemas.BifrostResponseExtraFields, jsonBody []byte) {
 	if len(jsonBody) > 0 {
 		extraFields.RawRequest = compactRawJSON(jsonBody)
+	}
+}
+
+// ParseAndSetRawRequestIfJSON parses the request body if it's JSON and sets the raw request in the extra fields.
+func ParseAndSetRawRequestIfJSON(fasthttpReq *fasthttp.Request, extraFields *schemas.BifrostResponseExtraFields) {
+	extraFields.RawRequest = nil
+	contentType := strings.ToLower(string(fasthttpReq.Header.ContentType()))
+	if strings.Contains(contentType, "application/json") {
+		body := append([]byte(nil), fasthttpReq.Body()...)
+		ParseAndSetRawRequest(extraFields, body)
 	}
 }
 

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -5,9 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -36,6 +39,19 @@ type VertexError struct {
 // This avoids creating and authenticating clients for every request.
 // Uses sync.Map for atomic operations without explicit locking.
 var vertexClientPool sync.Map
+
+// vertexLocationsPathRe matches /locations/{region} in Vertex API paths for region replacement.
+var vertexLocationsPathRe = regexp.MustCompile(`/locations/[^/]+`)
+
+var vertexProjectsPathRe = regexp.MustCompile(`/projects/[^/]+`)
+
+// vertexBodyProjectsRe matches projects/{project} in body JSON values,
+// where the path may appear as "projects/X (after a JSON quote) or /projects/X (mid-path).
+var vertexBodyProjectsRe = regexp.MustCompile(`(["/])projects/[^/"]+`)
+
+// vertexShortModelRe matches short-form model names like "models/X" in JSON bodies
+// that need expanding to the full Vertex resource path.
+var vertexShortModelRe = regexp.MustCompile(`"(models/[^/"]+)"`)
 
 // getClientKey generates a unique key for caching authenticated clients.
 // It uses a hash of the auth credentials for security.
@@ -2699,6 +2715,11 @@ func (provider *VertexProvider) BatchCancel(_ *schemas.BifrostContext, _ []schem
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by Vertex AI provider.
+func (provider *VertexProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by Vertex AI provider.
 func (provider *VertexProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -3022,4 +3043,383 @@ func (provider *VertexProvider) ContainerFileContent(_ *schemas.BifrostContext, 
 // ContainerFileDelete is not supported by the Vertex provider.
 func (provider *VertexProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+func (provider *VertexProvider) Passthrough(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+
+	if key.VertexKeyConfig == nil {
+		return nil, providerUtils.NewBifrostOperationError("vertex key config is not set", nil, schemas.Vertex)
+	}
+
+	projectID := strings.TrimSpace(key.VertexKeyConfig.ProjectID.GetValue())
+	if projectID == "" {
+		return nil, providerUtils.NewConfigurationError("project ID is not set", provider.GetProviderKey())
+	}
+
+	keyRegion := key.VertexKeyConfig.Region.GetValue()
+	if keyRegion == "" {
+		keyRegion = "global"
+	}
+
+	var baseURL string
+	if keyRegion == "global" {
+		baseURL = "https://aiplatform.googleapis.com/v1"
+	} else {
+		baseURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", keyRegion)
+	}
+
+	// Normalize path: remove leading /v1 or /v1/ to avoid duplicate version segments (e.g. /v1/v1/...)
+	path := req.Path
+	for strings.HasPrefix(path, "/v1/") || path == "/v1" {
+		path = strings.TrimPrefix(path, "/v1/")
+		path = strings.TrimPrefix(path, "/v1")
+		if path != "" && !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+	}
+
+	// Replace region in path with key's configured region (client path may have different region)
+	if strings.Contains(path, "/locations/") {
+		path = vertexLocationsPathRe.ReplaceAllString(path, "/locations/"+keyRegion)
+		if strings.Contains(path, "/projects/") {
+			path = vertexProjectsPathRe.ReplaceAllString(path, "/projects/"+projectID)
+		}
+	} else {
+		// add projects/%s/locations/%s/publishers/google to path
+		path = fmt.Sprintf("/projects/%s/locations/%s%s", projectID, keyRegion, path)
+	}
+
+	requestURL := baseURL + path
+	if req.RawQuery != "" {
+		requestURL += "?" + req.RawQuery
+	}
+
+	// Only use API key for Google publisher endpoints; Anthropic/Mistral/OpenAPI-style paths require OAuth.
+	authQuery := ""
+	if key.Value.GetValue() != "" && strings.Contains(path, "publishers/google") {
+		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
+	}
+
+	// Prepare fasthttp request
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+
+	// If auth query is set, add it to the URL; otherwise use OAuth2
+	if authQuery != "" {
+		if strings.Contains(requestURL, "?") {
+			requestURL += "&" + authQuery
+		} else {
+			requestURL += "?" + authQuery
+		}
+	} else {
+		tokenSource, err := getAuthTokenSource(key)
+		if err != nil {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+			return nil, providerUtils.NewBifrostOperationError("error creating auth token source", err, schemas.Vertex)
+		}
+		token, err := tokenSource.Token()
+		if err != nil {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+			return nil, providerUtils.NewBifrostOperationError("error getting token", err, schemas.Vertex)
+		}
+		fasthttpReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	}
+
+	fasthttpReq.SetRequestURI(requestURL)
+
+	// Set extra headers from provider network config
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	// Set safe headers from client request
+	for k, v := range req.SafeHeaders {
+		if strings.EqualFold(k, "authorization") || strings.EqualFold(k, "proxy-authorization") {
+			continue
+		}
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	if len(req.Body) > 0 && strings.Contains(strings.ToLower(string(fasthttpReq.Header.ContentType())), "application/json") {
+		region := keyRegion
+		// Replace fully-qualified model paths that have placeholder project/location
+		// e.g. "projects/None/locations/None/publishers/..." -> "projects/real-id/locations/real-region/..."
+		body := req.Body
+		bodyStr := vertexBodyProjectsRe.ReplaceAllString(string(body), "${1}projects/"+projectID)
+		bodyStr = vertexLocationsPathRe.ReplaceAllString(bodyStr, "/locations/"+region)
+		// Expand short-form model names: "models/X" -> "projects/P/locations/L/publishers/google/models/X"
+		bodyStr = vertexShortModelRe.ReplaceAllString(bodyStr,
+			fmt.Sprintf(`"projects/%s/locations/%s/publishers/google/$1"`, projectID, keyRegion))
+		fasthttpReq.SetBodyString(bodyStr)
+	} else if len(req.Body) > 0 {
+		fasthttpReq.SetBody(req.Body)
+	}
+
+	// Execute request
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Remove client from pool for authentication/authorization errors
+	if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+		removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err, schemas.Vertex)
+	}
+	for k := range headers {
+		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
+			delete(headers, k)
+		}
+	}
+	bifrostResponse := &schemas.BifrostPassthroughResponse{
+		StatusCode: resp.StatusCode(),
+		Headers:    headers,
+		Body:       body,
+	}
+
+	bifrostResponse.ExtraFields.ProviderResponseHeaders = headers
+	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
+	bifrostResponse.ExtraFields.RequestType = schemas.PassthroughRequest
+	bifrostResponse.ExtraFields.ModelRequested = req.Model
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+	}
+
+	return bifrostResponse, nil
+}
+
+func (provider *VertexProvider) PassthroughStream(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if key.VertexKeyConfig == nil {
+		return nil, providerUtils.NewBifrostOperationError("vertex key config is not set", nil, schemas.Vertex)
+	}
+
+	projectID := strings.TrimSpace(key.VertexKeyConfig.ProjectID.GetValue())
+	if projectID == "" {
+		return nil, providerUtils.NewConfigurationError("project ID is not set", provider.GetProviderKey())
+	}
+
+	keyRegion := key.VertexKeyConfig.Region.GetValue()
+	if keyRegion == "" {
+		keyRegion = "global"
+	}
+
+	var baseURL string
+	if keyRegion == "global" {
+		baseURL = "https://aiplatform.googleapis.com/v1"
+	} else {
+		baseURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", keyRegion)
+	}
+
+	// Normalize path: remove leading /v1 or /v1/ to avoid duplicate version segments.
+	path := req.Path
+	for strings.HasPrefix(path, "/v1/") || path == "/v1" {
+		path = strings.TrimPrefix(path, "/v1/")
+		path = strings.TrimPrefix(path, "/v1")
+		if path != "" && !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+	}
+
+	// Replace region and project in path with key's configured values.
+	if strings.Contains(path, "/locations/") {
+		path = vertexLocationsPathRe.ReplaceAllString(path, "/locations/"+keyRegion)
+		if strings.Contains(path, "/projects/") {
+			path = vertexProjectsPathRe.ReplaceAllString(path, "/projects/"+projectID)
+		}
+	} else {
+		path = fmt.Sprintf("/projects/%s/locations/%s%s", projectID, keyRegion, path)
+	}
+
+	requestURL := baseURL + path
+	if req.RawQuery != "" {
+		requestURL += "?" + req.RawQuery
+	}
+
+	startTime := time.Now()
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+
+	// Only use API key for Google publisher endpoints; Anthropic/Mistral/OpenAPI-style paths require OAuth.
+	authQuery := ""
+	if key.Value.GetValue() != "" && strings.Contains(path, "publishers/google") {
+		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
+	}
+
+	if authQuery != "" {
+		if strings.Contains(requestURL, "?") {
+			requestURL += "&" + authQuery
+		} else {
+			requestURL += "?" + authQuery
+		}
+	} else {
+		tokenSource, err := getAuthTokenSource(key)
+		if err != nil {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+			providerUtils.ReleaseStreamingResponse(resp)
+			return nil, providerUtils.NewBifrostOperationError("error creating auth token source", err, schemas.Vertex)
+		}
+		token, err := tokenSource.Token()
+		if err != nil {
+			removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+			providerUtils.ReleaseStreamingResponse(resp)
+			return nil, providerUtils.NewBifrostOperationError("error getting token", err, schemas.Vertex)
+		}
+		fasthttpReq.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	}
+
+	fasthttpReq.SetRequestURI(requestURL)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		if strings.EqualFold(k, "authorization") || strings.EqualFold(k, "proxy-authorization") {
+			continue
+		}
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	if len(req.Body) > 0 && strings.Contains(strings.ToLower(string(fasthttpReq.Header.ContentType())), "application/json") {
+		bodyStr := vertexBodyProjectsRe.ReplaceAllString(string(req.Body), "${1}projects/"+projectID)
+		bodyStr = vertexLocationsPathRe.ReplaceAllString(bodyStr, "/locations/"+keyRegion)
+		bodyStr = vertexShortModelRe.ReplaceAllString(bodyStr,
+			fmt.Sprintf(`"projects/%s/locations/%s/publishers/google/$1"`, projectID, keyRegion))
+		fasthttpReq.SetBodyString(bodyStr)
+	} else if len(req.Body) > 0 {
+		fasthttpReq.SetBody(req.Body)
+	}
+
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
+	if err := activeClient.Do(fasthttpReq, resp); err != nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, provider.GetProviderKey())
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey())
+	}
+
+	if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
+		removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
+
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		return nil, providerUtils.NewBifrostOperationError(
+			"provider returned an empty stream body",
+			fmt.Errorf("provider returned an empty stream body"),
+			provider.GetProviderKey(),
+		)
+	}
+
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+
+	extraFields := schemas.BifrostResponseExtraFields{
+		Provider:       provider.GetProviderKey(),
+		ModelRequested: req.Model,
+		RequestType:    schemas.PassthroughStreamRequest,
+	}
+	statusCode := resp.StatusCode()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
+	}
+
+	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			}
+			close(ch)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		defer stopCancellation()
+
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := bodyStream.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				select {
+				case ch <- &schemas.BifrostStreamChunk{
+					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						Body:        chunk,
+						ExtraFields: extraFields,
+					},
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if readErr == io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				finalResp := &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						ExtraFields: extraFields,
+					},
+				}
+				postHookRunner(ctx, finalResp, nil)
+				if finalizer, ok := ctx.Value(schemas.BifrostContextKeyPostHookSpanFinalizer).(func(context.Context)); ok && finalizer != nil {
+					finalizer(ctx)
+				}
+				return
+			}
+			if readErr != nil {
+				if ctx.Err() != nil {
+					return // let defer handle cancel/timeout
+				}
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, ch, schemas.PassthroughStreamRequest, provider.GetProviderKey(), req.Model, provider.logger)
+				return
+			}
+		}
+	}()
+	return ch, nil
 }

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -719,6 +719,11 @@ func (provider *VLLMProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by the vLLM provider.
+func (provider *VLLMProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by the vLLM provider.
 func (provider *VLLMProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -772,4 +777,13 @@ func (provider *VLLMProvider) ContainerFileContent(_ *schemas.BifrostContext, _ 
 // ContainerFileDelete is not supported by the vLLM provider.
 func (provider *VLLMProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the vLLM provider.
+func (provider *VLLMProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *VLLMProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/providers/xai/xai.go
+++ b/core/providers/xai/xai.go
@@ -323,6 +323,11 @@ func (provider *XAIProvider) BatchCancel(_ *schemas.BifrostContext, _ []schemas.
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchCancelRequest, provider.GetProviderKey())
 }
 
+// BatchDelete is not supported by xAI provider.
+func (provider *XAIProvider) BatchDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchDeleteRequest) (*schemas.BifrostBatchDeleteResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchDeleteRequest, provider.GetProviderKey())
+}
+
 // BatchResults is not supported by xAI provider.
 func (provider *XAIProvider) BatchResults(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostBatchResultsRequest) (*schemas.BifrostBatchResultsResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.BatchResultsRequest, provider.GetProviderKey())
@@ -400,4 +405,13 @@ func (provider *XAIProvider) ContainerFileContent(_ *schemas.BifrostContext, _ [
 // ContainerFileDelete is not supported by the xAI provider.
 func (provider *XAIProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ []schemas.Key, _ *schemas.BifrostContainerFileDeleteRequest) (*schemas.BifrostContainerFileDeleteResponse, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
+}
+
+// Passthrough is not supported by the xAI provider.
+func (provider *XAIProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+}
+
+func (provider *XAIProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
 }

--- a/core/schemas/batch.go
+++ b/core/schemas/batch.go
@@ -13,7 +13,8 @@ const (
 	BatchStatusExpired    BatchStatus = "expired"
 	BatchStatusCancelling BatchStatus = "cancelling"
 	BatchStatusCancelled  BatchStatus = "cancelled"
-	BatchStatusEnded      BatchStatus = "ended" // Anthropic-specific
+	BatchStatusEnded      BatchStatus = "ended"   // Anthropic-specific
+	BatchStatusDeleted    BatchStatus = "deleted" // Gemini-specific
 )
 
 // BatchEndpoint represents supported batch API endpoints.
@@ -74,10 +75,10 @@ type BifrostBatchCreateRequest struct {
 	Requests []BatchRequestItem `json:"requests,omitempty"` // Inline request items
 
 	// Common fields
-	Endpoint            BatchEndpoint      `json:"endpoint,omitempty"`              // Target endpoint for batch requests
-	CompletionWindow    string             `json:"completion_window,omitempty"`     // Time window (e.g., "24h")
-	Metadata            map[string]string  `json:"metadata,omitempty"`              // User-provided metadata
-	OutputExpiresAfter  *BatchExpiresAfter `json:"output_expires_after,omitempty"` // Expiration for batch output (OpenAI only)
+	Endpoint           BatchEndpoint      `json:"endpoint,omitempty"`             // Target endpoint for batch requests
+	CompletionWindow   string             `json:"completion_window,omitempty"`    // Time window (e.g., "24h")
+	Metadata           map[string]string  `json:"metadata,omitempty"`             // User-provided metadata
+	OutputExpiresAfter *BatchExpiresAfter `json:"output_expires_after,omitempty"` // Expiration for batch output (OpenAI only)
 
 	// Extra parameters for provider-specific features
 	ExtraParams map[string]interface{} `json:"-"`
@@ -233,6 +234,33 @@ type BifrostBatchCancelResponse struct {
 	RequestCounts BatchRequestCounts `json:"request_counts,omitempty"`
 	CancellingAt  *int64             `json:"cancelling_at,omitempty"`
 	CancelledAt   *int64             `json:"cancelled_at,omitempty"`
+
+	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+}
+
+// BifrostBatchDeleteRequest represents a request to delete a batch job.
+type BifrostBatchDeleteRequest struct {
+	Provider ModelProvider `json:"provider"`
+	Model    *string       `json:"model"`
+	BatchID  string        `json:"batch_id"` // ID of the batch to delete
+
+	RawRequestBody []byte `json:"-"` // Raw request body (not serialized)
+
+	// Extra parameters for provider-specific features
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+// GetRawRequestBody returns the raw request body.
+func (request *BifrostBatchDeleteRequest) GetRawRequestBody() []byte {
+	return request.RawRequestBody
+}
+
+// BifrostBatchDeleteResponse represents the response from deleting a batch job.
+type BifrostBatchDeleteResponse struct {
+	ID            string             `json:"id"`
+	Object        string             `json:"object,omitempty"`
+	Status        BatchStatus        `json:"status"`
+	RequestCounts BatchRequestCounts `json:"request_counts,omitempty"`
 
 	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
 }

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -127,6 +127,7 @@ const (
 	BatchRetrieveRequest         RequestType = "batch_retrieve"
 	BatchCancelRequest           RequestType = "batch_cancel"
 	BatchResultsRequest          RequestType = "batch_results"
+	BatchDeleteRequest           RequestType = "batch_delete"
 	FileUploadRequest            RequestType = "file_upload"
 	FileListRequest              RequestType = "file_list"
 	FileRetrieveRequest          RequestType = "file_retrieve"
@@ -144,6 +145,8 @@ const (
 	RerankRequest                RequestType = "rerank"
 	CountTokensRequest           RequestType = "count_tokens"
 	MCPToolExecutionRequest      RequestType = "mcp_tool_execution"
+	PassthroughRequest           RequestType = "passthrough"
+	PassthroughStreamRequest     RequestType = "passthrough_stream"
 	UnknownRequest               RequestType = "unknown"
 )
 
@@ -235,7 +238,9 @@ const (
 	BifrostContextKeyDeferredUsage                       BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
 	BifrostContextKeyDeferredLargePayloadMetadata        BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
 	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
+)
 
+const (
 	// DefaultLargePayloadRequestThresholdBytes is the default request-size heuristic
 	// used by transport guards when no enterprise threshold is present on context.
 	DefaultLargePayloadRequestThresholdBytes = 10 * 1024 * 1024 // 10MB
@@ -321,6 +326,7 @@ type BifrostRequest struct {
 	BatchRetrieveRequest         *BifrostBatchRetrieveRequest
 	BatchCancelRequest           *BifrostBatchCancelRequest
 	BatchResultsRequest          *BifrostBatchResultsRequest
+	BatchDeleteRequest           *BifrostBatchDeleteRequest
 	ContainerCreateRequest       *BifrostContainerCreateRequest
 	ContainerListRequest         *BifrostContainerListRequest
 	ContainerRetrieveRequest     *BifrostContainerRetrieveRequest
@@ -330,6 +336,7 @@ type BifrostRequest struct {
 	ContainerFileRetrieveRequest *BifrostContainerFileRetrieveRequest
 	ContainerFileContentRequest  *BifrostContainerFileContentRequest
 	ContainerFileDeleteRequest   *BifrostContainerFileDeleteRequest
+	PassthroughRequest           *BifrostPassthroughRequest
 }
 
 // GetRequestFields returns the provider, model, and fallbacks from the request.
@@ -421,6 +428,11 @@ func (br *BifrostRequest) GetRequestFields() (provider ModelProvider, model stri
 			return br.BatchResultsRequest.Provider, *br.BatchResultsRequest.Model, nil
 		}
 		return br.BatchResultsRequest.Provider, "", nil
+	case br.BatchDeleteRequest != nil:
+		if br.BatchDeleteRequest.Model != nil {
+			return br.BatchDeleteRequest.Provider, *br.BatchDeleteRequest.Model, nil
+		}
+		return br.BatchDeleteRequest.Provider, "", nil
 	case br.ContainerCreateRequest != nil:
 		return br.ContainerCreateRequest.Provider, "", nil
 	case br.ContainerListRequest != nil:
@@ -439,6 +451,8 @@ func (br *BifrostRequest) GetRequestFields() (provider ModelProvider, model stri
 		return br.ContainerFileContentRequest.Provider, "", nil
 	case br.ContainerFileDeleteRequest != nil:
 		return br.ContainerFileDeleteRequest.Provider, "", nil
+	case br.PassthroughRequest != nil:
+		return br.PassthroughRequest.Provider, br.PassthroughRequest.Model, nil
 	}
 	return "", "", nil
 }
@@ -647,6 +661,7 @@ type BifrostResponse struct {
 	BatchRetrieveResponse         *BifrostBatchRetrieveResponse
 	BatchCancelResponse           *BifrostBatchCancelResponse
 	BatchResultsResponse          *BifrostBatchResultsResponse
+	BatchDeleteResponse           *BifrostBatchDeleteResponse
 	ContainerCreateResponse       *BifrostContainerCreateResponse
 	ContainerListResponse         *BifrostContainerListResponse
 	ContainerRetrieveResponse     *BifrostContainerRetrieveResponse
@@ -656,6 +671,7 @@ type BifrostResponse struct {
 	ContainerFileRetrieveResponse *BifrostContainerFileRetrieveResponse
 	ContainerFileContentResponse  *BifrostContainerFileContentResponse
 	ContainerFileDeleteResponse   *BifrostContainerFileDeleteResponse
+	PassthroughResponse           *BifrostPassthroughResponse
 }
 
 func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
@@ -714,6 +730,8 @@ func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 		return &r.BatchRetrieveResponse.ExtraFields
 	case r.BatchCancelResponse != nil:
 		return &r.BatchCancelResponse.ExtraFields
+	case r.BatchDeleteResponse != nil:
+		return &r.BatchDeleteResponse.ExtraFields
 	case r.BatchResultsResponse != nil:
 		return &r.BatchResultsResponse.ExtraFields
 	case r.ContainerCreateResponse != nil:
@@ -734,6 +752,8 @@ func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 		return &r.ContainerFileContentResponse.ExtraFields
 	case r.ContainerFileDeleteResponse != nil:
 		return &r.ContainerFileDeleteResponse.ExtraFields
+	case r.PassthroughResponse != nil:
+		return &r.PassthroughResponse.ExtraFields
 	}
 
 	return &BifrostResponseExtraFields{}
@@ -802,6 +822,7 @@ type BifrostStreamChunk struct {
 	*BifrostSpeechStreamResponse
 	*BifrostTranscriptionStreamResponse
 	*BifrostImageGenerationStreamResponse
+	*BifrostPassthroughResponse
 	*BifrostError
 }
 
@@ -820,6 +841,8 @@ func (bs BifrostStreamChunk) MarshalJSON() ([]byte, error) {
 		return Marshal(bs.BifrostTranscriptionStreamResponse)
 	} else if bs.BifrostImageGenerationStreamResponse != nil {
 		return Marshal(bs.BifrostImageGenerationStreamResponse)
+	} else if bs.BifrostPassthroughResponse != nil {
+		return Marshal(bs.BifrostPassthroughResponse)
 	} else if bs.BifrostError != nil {
 		return Marshal(bs.BifrostError)
 	}

--- a/core/schemas/files.go
+++ b/core/schemas/files.go
@@ -42,6 +42,7 @@ type FileObject struct {
 	Object        string      `json:"object,omitempty"` // "file"
 	Bytes         int64       `json:"bytes"`
 	CreatedAt     int64       `json:"created_at"`
+	UpdatedAt     int64       `json:"updated_at,omitempty"`
 	Filename      string      `json:"filename"`
 	Purpose       FilePurpose `json:"purpose"`
 	Status        FileStatus  `json:"status,omitempty"`
@@ -179,6 +180,7 @@ type BifrostFileRetrieveResponse struct {
 	Object        string      `json:"object,omitempty"` // "file"
 	Bytes         int64       `json:"bytes"`
 	CreatedAt     int64       `json:"created_at"`
+	UpdatedAt     int64       `json:"updated_at,omitempty"`
 	Filename      string      `json:"filename"`
 	Purpose       FilePurpose `json:"purpose"`
 	Status        FileStatus  `json:"status,omitempty"`

--- a/core/schemas/passthrough.go
+++ b/core/schemas/passthrough.go
@@ -1,0 +1,25 @@
+package schemas
+
+type BifrostPassthroughRequest struct {
+	Provider    ModelProvider // provider extracted from path or body, used for key selection when non-empty
+	Model       string        // model extracted from path or body, used for key selection when non-empty
+	Method      string
+	Path        string // stripped path, e.g. "/v1/fine-tuning/jobs"
+	RawQuery    string // raw query string, no "?"
+	Body        []byte
+	SafeHeaders map[string]string // client headers, auth already stripped
+}
+
+type BifrostPassthroughResponse struct {
+	StatusCode  int
+	Headers     map[string]string
+	Body        []byte
+	ExtraFields BifrostResponseExtraFields
+}
+
+type PassthroughLogParams struct {
+	Method     string `json:"method"`
+	Path       string `json:"path"`      // stripped path, e.g. "/v1/fine-tuning/jobs"
+	RawQuery   string `json:"raw_query"` // raw query string, no "?"
+	StatusCode int    `json:"status_code"`
+}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -217,6 +217,7 @@ type AllowedRequests struct {
 	BatchList             bool `json:"batch_list"`
 	BatchRetrieve         bool `json:"batch_retrieve"`
 	BatchCancel           bool `json:"batch_cancel"`
+	BatchDelete           bool `json:"batch_delete"`
 	BatchResults          bool `json:"batch_results"`
 	FileUpload            bool `json:"file_upload"`
 	FileList              bool `json:"file_list"`
@@ -232,6 +233,8 @@ type AllowedRequests struct {
 	ContainerFileRetrieve bool `json:"container_file_retrieve"`
 	ContainerFileContent  bool `json:"container_file_content"`
 	ContainerFileDelete   bool `json:"container_file_delete"`
+	Passthrough           bool `json:"passthrough"`
+	PassthroughStream     bool `json:"passthrough_stream"`
 }
 
 // IsOperationAllowed checks if a specific operation is allowed
@@ -299,6 +302,8 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 		return ar.BatchRetrieve
 	case BatchCancelRequest:
 		return ar.BatchCancel
+	case BatchDeleteRequest:
+		return ar.BatchDelete
 	case BatchResultsRequest:
 		return ar.BatchResults
 	case FileUploadRequest:
@@ -329,6 +334,10 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 		return ar.ContainerFileContent
 	case ContainerFileDeleteRequest:
 		return ar.ContainerFileDelete
+	case PassthroughRequest:
+		return ar.Passthrough
+	case PassthroughStreamRequest:
+		return ar.PassthroughStream
 	default:
 		return false // Default to not allowed for unknown operations
 	}
@@ -521,6 +530,8 @@ type Provider interface {
 	BatchRetrieve(ctx *BifrostContext, keys []Key, request *BifrostBatchRetrieveRequest) (*BifrostBatchRetrieveResponse, *BifrostError)
 	// BatchCancel cancels a batch job
 	BatchCancel(ctx *BifrostContext, keys []Key, request *BifrostBatchCancelRequest) (*BifrostBatchCancelResponse, *BifrostError)
+	// BatchDelete deletes a batch job
+	BatchDelete(ctx *BifrostContext, keys []Key, request *BifrostBatchDeleteRequest) (*BifrostBatchDeleteResponse, *BifrostError)
 	// BatchResults retrieves results from a completed batch job
 	BatchResults(ctx *BifrostContext, keys []Key, request *BifrostBatchResultsRequest) (*BifrostBatchResultsResponse, *BifrostError)
 	// FileUpload uploads a file to the provider
@@ -551,4 +562,8 @@ type Provider interface {
 	ContainerFileContent(ctx *BifrostContext, keys []Key, request *BifrostContainerFileContentRequest) (*BifrostContainerFileContentResponse, *BifrostError)
 	// ContainerFileDelete deletes a file from a container
 	ContainerFileDelete(ctx *BifrostContext, keys []Key, request *BifrostContainerFileDeleteRequest) (*BifrostContainerFileDeleteResponse, *BifrostError)
+	// Passthrough executes a non-streaming passthrough; body is fully buffered.
+	Passthrough(ctx *BifrostContext, key Key, req *BifrostPassthroughRequest) (*BifrostPassthroughResponse, *BifrostError)
+	// PassthroughStream executes a streaming passthrough, forwarding raw response bytes as BifrostStreamChunks.
+	PassthroughStream(ctx *BifrostContext, postHookRunner PostHookRunner, key Key, req *BifrostPassthroughRequest) (chan *BifrostStreamChunk, *BifrostError)
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -223,7 +223,7 @@ func IsKeylessProvider(providerKey schemas.ModelProvider) bool {
 
 // IsStreamRequestType returns true if the given request type is a stream request.
 func IsStreamRequestType(reqType schemas.RequestType) bool {
-	return reqType == schemas.TextCompletionStreamRequest || reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.ResponsesStreamRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionStreamRequest || reqType == schemas.ImageGenerationStreamRequest || reqType == schemas.ImageEditStreamRequest
+	return reqType == schemas.TextCompletionStreamRequest || reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.ResponsesStreamRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionStreamRequest || reqType == schemas.ImageGenerationStreamRequest || reqType == schemas.ImageEditStreamRequest || reqType == schemas.PassthroughStreamRequest
 }
 
 func GetTracerFromContext(ctx *schemas.BifrostContext) (schemas.Tracer, string, error) {
@@ -240,7 +240,7 @@ func GetTracerFromContext(ctx *schemas.BifrostContext) (schemas.Tracer, string, 
 
 // isBatchRequestType returns true if the given request type is a batch API operation.
 func isBatchRequestType(reqType schemas.RequestType) bool {
-	return reqType == schemas.BatchCreateRequest || reqType == schemas.BatchListRequest || reqType == schemas.BatchRetrieveRequest || reqType == schemas.BatchCancelRequest || reqType == schemas.BatchResultsRequest
+	return reqType == schemas.BatchCreateRequest || reqType == schemas.BatchListRequest || reqType == schemas.BatchRetrieveRequest || reqType == schemas.BatchCancelRequest || reqType == schemas.BatchDeleteRequest || reqType == schemas.BatchResultsRequest
 }
 
 // isFileRequestType returns true if the given request type is a file API operation.
@@ -266,6 +266,11 @@ func isModellessVideoRequestType(reqType schemas.RequestType) bool {
 	default:
 		return false
 	}
+}
+
+// isPassthroughRequestType returns true if the given request type is a passthrough request.
+func isPassthroughRequestType(reqType schemas.RequestType) bool {
+	return reqType == schemas.PassthroughRequest || reqType == schemas.PassthroughStreamRequest
 }
 
 // IsFinalChunk returns true if the given context is a final chunk.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -179,7 +179,8 @@
               },
               "integrations/litellm-sdk",
               "integrations/langchain-sdk",
-              "integrations/pydanticai-sdk"
+              "integrations/pydanticai-sdk",
+              "integrations/passthrough"
             ]
           },
           {

--- a/docs/integrations/passthrough.mdx
+++ b/docs/integrations/passthrough.mdx
@@ -1,0 +1,167 @@
+---
+title: "Passthrough"
+description: "Forward provider-native requests through Bifrost with full core pipeline processing, including logs and observability."
+icon: "route"
+---
+
+## Overview
+
+Passthrough integrations let you call provider-native API paths and payloads through Bifrost without route-level request/response conversion.
+
+When you use passthrough endpoints, the request still flows through Bifrost core logic. You keep Bifrost features such as logging and observability while sending provider-native paths and bodies.
+
+---
+
+## Endpoints
+
+- `/openai_passthrough`  
+  Default provider: `openai`
+- `/genai_passthrough`  
+  Default provider: `gemini` (with automatic Vertex detection for clients configured to use Vertex)
+
+---
+
+## How It Works
+
+1. Send your request to a passthrough endpoint (OpenAI or GenAI passthrough).
+2. The integration strips the passthrough prefix and forwards the remaining provider-native path/body.
+3. Bifrost handles provider execution through core inference and plugin pipelines.
+4. Response status, headers, and body are returned as passthrough output (for both stream and non-stream requests).
+
+---
+
+## Provider Selection Rules
+
+### OpenAI Passthrough
+
+- Uses `openai` as the default provider.
+
+### GenAI Passthrough
+
+- Uses `gemini` by default.
+- Automatically switches to `vertex` when Vertex patterns are detected, such as:
+  - URL path containing `/projects/{PROJECT_ID}/locations/{LOCATION}/`
+  - Request body `model` containing a Vertex resource path
+  - OAuth token pattern typically used for Vertex (`Bearer ya29...`)
+
+---
+
+## Usage Examples
+
+### OpenAI Passthrough
+
+<Tabs group="openai-passthrough">
+<Tab title="Python SDK">
+
+```python
+import openai
+
+client = openai.OpenAI(
+    base_url="http://localhost:8080/openai_passthrough/v1",
+    api_key="dummy-key"
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "hello from passthrough"}]
+)
+
+print(response.choices[0].message.content)
+```
+
+</Tab>
+<Tab title="cURL">
+
+```bash
+curl -X POST "http://localhost:8080/openai_passthrough/v1/chat/completions" \
+  -H "content-type: application/json" \
+  -H "authorization: Bearer sk-your-openai-key" \
+  -d '{
+    "model": "gpt-4o-mini",
+    "messages": [{"role":"user","content":"hello from passthrough"}]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+### GenAI Passthrough (Gemini)
+
+<Tabs group="genai-passthrough">
+<Tab title="Python SDK">
+
+```python
+from google import genai
+from google.genai.types import HttpOptions
+
+client = genai.Client(
+    api_key="dummy-key",
+    http_options=HttpOptions(base_url="http://localhost:8080/genai_passthrough")
+)
+
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="hello from passthrough"
+)
+
+print(response.text)
+```
+
+</Tab>
+<Tab title="cURL">
+
+```bash
+curl -X POST "http://localhost:8080/genai_passthrough/v1beta/models/gemini-2.5-flash:generateContent" \
+  -H "content-type: application/json" \
+  -H "x-goog-api-key: your-gemini-key" \
+  -d '{
+    "contents":[{"parts":[{"text":"hello from passthrough"}]}]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+### GenAI Passthrough (Vertex-style request)
+
+<Tabs group="vertex-passthrough">
+<Tab title="Python SDK">
+
+```python
+from google import genai
+from google.genai.types import HttpOptions
+
+client = genai.Client(
+    vertexai=True,
+    api_key="dummy-key",
+    http_options=HttpOptions(base_url="http://localhost:8080/genai_passthrough")
+)
+
+response = client.models.generate_content(
+    model="gemini-2.5-flash",
+    contents="hello from vertex passthrough"
+)
+
+print(response.text)
+```
+
+</Tab>
+<Tab title="cURL">
+
+```bash
+curl -X POST "http://localhost:8080/genai_passthrough/v1/projects/my-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent" \
+  -H "content-type: application/json" \
+  -H "authorization: Bearer ya29.your-vertex-token" \
+  -d '{
+    "contents":[{"parts":[{"text":"hello from vertex passthrough"}]}]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Notes
+
+- Use passthrough when you need a provider endpoint that is not directly supported by Bifrost integration routes yet.

--- a/docs/quickstart/gateway/integrations.mdx
+++ b/docs/quickstart/gateway/integrations.mdx
@@ -44,6 +44,7 @@ Bifrost provides complete compatibility with these popular AI SDKs:
 - **[Google GenAI SDK](../../integrations/genai-sdk)**
 - **[LiteLLM](../../integrations/litellm-sdk)**
 - **[LangChain](../../integrations/langchain-sdk)**
+- **[Passthrough Endpoints](../../integrations/passthrough)**
 
 ## Learn More
 

--- a/framework/kvstore/kvstore.go
+++ b/framework/kvstore/kvstore.go
@@ -1,0 +1,382 @@
+package kvstore
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/bytedance/sonic"
+)
+
+var (
+	ErrClosed     = errors.New("kvstore is closed")
+	ErrEmptyKey   = errors.New("key cannot be empty")
+	ErrNotFound   = errors.New("key not found")
+	ErrInvalidTTL = errors.New("ttl cannot be negative")
+)
+
+const (
+	defaultCleanupInterval = 30 * time.Second
+	noExpirationUnixNanos  = int64(0)
+)
+
+// Config controls in-memory KV store behavior.
+type Config struct {
+	// CleanupInterval controls how often expired entries are removed.
+	// If <= 0, defaults to 30s.
+	CleanupInterval time.Duration
+	// DefaultTTL applies when Set is used.
+	// A zero value means entries do not expire by default.
+	DefaultTTL time.Duration
+}
+
+type entry struct {
+	value     any
+	writtenAt int64 // unix nanos, 0 means not written yet
+	expiresAt int64 // unix nanos, 0 means no expiration
+}
+
+// Store is an in-memory KV store with optional TTL support.
+type Store struct {
+	mu   sync.RWMutex
+	data map[string]entry
+
+	defaultTTL      time.Duration
+	cleanupInterval time.Duration
+
+	closed    atomic.Bool
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	cleanupWg sync.WaitGroup
+
+	delegate  SyncDelegate
+	decoders  map[string]TypeDecoder
+	decoderMu sync.RWMutex
+}
+
+// SyncDelegate is notified of all mutations, enabling cross-node replication.
+// All calls happen synchronously after the local mutation has succeeded.
+// writtenAt / deletedAt are absolute Unix nanosecond timestamps used by remote
+// nodes for last-write-wins conflict resolution.
+// expiresAt is an absolute Unix nanosecond timestamp; 0 means no expiration.
+type SyncDelegate interface {
+	OnSet(key string, valueJSON []byte, writtenAt int64, expiresAt int64)
+	OnDelete(key string, deletedAt int64)
+}
+
+// TypeDecoder reconstructs a concrete value from its JSON representation.
+// Register decoders by key prefix via RegisterDecoder.
+type TypeDecoder func(data []byte) (any, error)
+
+// SetDelegate plugs in the cluster sync implementation.
+func (s *Store) SetDelegate(d SyncDelegate) {
+	s.delegate = d
+}
+
+// RegisterDecoder registers a decoder for keys matching the given prefix.
+// Used by the receiving side to reconstruct concrete types from gossip payloads.
+func (s *Store) RegisterDecoder(keyPrefix string, decoder TypeDecoder) {
+	s.decoderMu.Lock()
+	s.decoders[keyPrefix] = decoder
+	s.decoderMu.Unlock()
+}
+
+// New creates a new in-memory KV store.
+func New(cfg Config) (*Store, error) {
+	if cfg.DefaultTTL < 0 {
+		return nil, ErrInvalidTTL
+	}
+
+	cleanupInterval := cfg.CleanupInterval
+	if cleanupInterval <= 0 {
+		cleanupInterval = defaultCleanupInterval
+	}
+
+	s := &Store{
+		data:            make(map[string]entry),
+		defaultTTL:      cfg.DefaultTTL,
+		cleanupInterval: cleanupInterval,
+		stopCh:          make(chan struct{}),
+		decoders:        make(map[string]TypeDecoder),
+	}
+
+	s.cleanupWg.Add(1)
+	go s.cleanupLoop()
+
+	return s, nil
+}
+
+// Set stores a value using the store's default TTL.
+func (s *Store) Set(key string, value any) error {
+	return s.SetWithTTL(key, value, s.defaultTTL)
+}
+
+// SetWithTTL stores a value with an explicit TTL.
+// ttl=0 means no expiration.
+func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
+	if err := s.validateMutable(key, ttl); err != nil {
+		return err
+	}
+
+	now := time.Now().UnixNano()
+	var expiresAt int64
+	if ttl > 0 {
+		expiresAt = now + int64(ttl)
+	}
+
+	var valueJSON []byte
+	var err error
+
+	if s.delegate != nil {
+		valueJSON, err = sonic.Marshal(value)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.mu.Lock()
+	s.data[key] = entry{
+		value:     value,
+		writtenAt: now,
+		expiresAt: expiresAt,
+	}
+	s.mu.Unlock()
+
+	if s.delegate != nil {
+		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	}
+
+	return nil
+}
+
+// SetRemote applies a remotely-gossiped entry without triggering OnSet.
+// writtenAt and expiresAt must be absolute Unix nanosecond timestamps.
+// If the local entry was written more recently than writtenAt the update is
+// silently skipped (last-write-wins by wall clock on the writing node).
+func (s *Store) SetRemote(key string, valueJSON []byte, writtenAt int64, expiresAt int64) error {
+	if key == "" {
+		return ErrEmptyKey
+	}
+	if s.closed.Load() {
+		return ErrClosed
+	}
+
+	value := s.decodeValue(key, valueJSON)
+
+	s.mu.Lock()
+	if existing, ok := s.data[key]; ok && existing.writtenAt > writtenAt {
+		s.mu.Unlock()
+		return nil // stale gossip — local entry is newer
+	}
+	s.data[key] = entry{value: value, writtenAt: writtenAt, expiresAt: expiresAt}
+	s.mu.Unlock()
+	return nil
+}
+
+// Get retrieves a value by key.
+func (s *Store) Get(key string) (any, error) {
+	if key == "" {
+		return nil, ErrEmptyKey
+	}
+	if s.closed.Load() {
+		return nil, ErrClosed
+	}
+
+	now := time.Now().UnixNano()
+
+	s.mu.RLock()
+	e, ok := s.data[key]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, ErrNotFound
+	}
+	if isExpired(e, now) {
+		s.mu.Lock()
+		if latest, exists := s.data[key]; exists && isExpired(latest, time.Now().UnixNano()) {
+			delete(s.data, key)
+		}
+		s.mu.Unlock()
+		return nil, ErrNotFound
+	}
+
+	return e.value, nil
+}
+
+// GetAndDelete retrieves and deletes a key atomically.
+func (s *Store) GetAndDelete(key string) (any, error) {
+	if key == "" {
+		return nil, ErrEmptyKey
+	}
+	if s.closed.Load() {
+		return nil, ErrClosed
+	}
+
+	now := time.Now().UnixNano()
+
+	s.mu.Lock()
+	e, ok := s.data[key]
+	if ok {
+		delete(s.data, key)
+	}
+	s.mu.Unlock()
+
+	if !ok || isExpired(e, now) {
+		return nil, ErrNotFound
+	}
+	if s.delegate != nil {
+		s.delegate.OnDelete(key, now)
+	}
+	return e.value, nil
+}
+
+// Delete removes a key.
+func (s *Store) Delete(key string) (bool, error) {
+	if key == "" {
+		return false, ErrEmptyKey
+	}
+	if s.closed.Load() {
+		return false, ErrClosed
+	}
+
+	deletedAt := time.Now().UnixNano()
+
+	s.mu.Lock()
+	_, ok := s.data[key]
+	if ok {
+		delete(s.data, key)
+	}
+	s.mu.Unlock()
+
+	if !ok {
+		return false, nil
+	}
+	if s.delegate != nil {
+		s.delegate.OnDelete(key, deletedAt)
+	}
+	return true, nil
+}
+
+// DeleteRemote applies a remotely-gossiped delete without triggering OnDelete.
+// deletedAt is the absolute Unix nanosecond timestamp when the delete was issued.
+// The delete is skipped if the local entry was written after the delete intent
+// (last-write-wins).
+func (s *Store) DeleteRemote(key string, deletedAt int64) error {
+	if key == "" {
+		return ErrEmptyKey
+	}
+	if s.closed.Load() {
+		return ErrClosed
+	}
+
+	s.mu.Lock()
+	if existing, ok := s.data[key]; ok && existing.writtenAt > deletedAt {
+		s.mu.Unlock()
+		return nil // entry was written after the delete intent — write wins
+	}
+	delete(s.data, key)
+	s.mu.Unlock()
+	return nil
+}
+
+// Len returns the number of currently non-expired keys.
+func (s *Store) Len() int {
+	if s.closed.Load() {
+		return 0
+	}
+
+	now := time.Now().UnixNano()
+	total := 0
+
+	s.mu.RLock()
+	for _, v := range s.data {
+		if isExpired(v, now) {
+			continue
+		}
+		total++
+	}
+	s.mu.RUnlock()
+
+	return total
+}
+
+// Close stops background cleanup and prevents further operations.
+func (s *Store) Close() error {
+	s.stopOnce.Do(func() {
+		s.closed.Store(true)
+		close(s.stopCh)
+	})
+	s.cleanupWg.Wait()
+	return nil
+}
+
+func (s *Store) cleanupLoop() {
+	defer s.cleanupWg.Done()
+
+	ticker := time.NewTicker(s.cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.cleanupExpired()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *Store) cleanupExpired() {
+	now := time.Now().UnixNano()
+
+	s.mu.Lock()
+	for k, v := range s.data {
+		if isExpired(v, now) {
+			delete(s.data, k)
+		}
+	}
+	s.mu.Unlock()
+}
+
+func (s *Store) validateMutable(key string, ttl time.Duration) error {
+	if key == "" {
+		return ErrEmptyKey
+	}
+	if ttl < 0 {
+		return ErrInvalidTTL
+	}
+	if s.closed.Load() {
+		return ErrClosed
+	}
+	return nil
+}
+
+// decodeValue uses the registered decoder for the key's prefix, falling back
+// to raw []byte if no decoder matches.
+func (s *Store) decodeValue(key string, valueJSON []byte) any {
+	s.decoderMu.RLock()
+
+	var bestPrefix string
+	var bestDecode TypeDecoder
+	for prefix, decode := range s.decoders {
+		if strings.HasPrefix(key, prefix) && len(prefix) > len(bestPrefix) {
+			bestPrefix = prefix
+			bestDecode = decode
+		}
+	}
+
+	s.decoderMu.RUnlock()
+
+	if bestDecode != nil {
+		if v, err := bestDecode(valueJSON); err == nil {
+			return v
+		}
+	}
+	return valueJSON
+}
+
+func isExpired(e entry, nowUnixNano int64) bool {
+	return e.expiresAt != noExpirationUnixNanos && nowUnixNano >= e.expiresAt
+}

--- a/framework/kvstore/kvstore_test.go
+++ b/framework/kvstore/kvstore_test.go
@@ -1,0 +1,100 @@
+package kvstore
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestStoreSetGetDelete(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("k1", "v1"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	v, err := store.Get("k1")
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if v.(string) != "v1" {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	deleted, err := store.Delete("k1")
+	if err != nil {
+		t.Fatalf("delete failed: %v", err)
+	}
+	if !deleted {
+		t.Fatal("expected key to be deleted")
+	}
+
+	if _, err := store.Get("k1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestStoreTTLExpiration(t *testing.T) {
+	store, err := New(Config{
+		CleanupInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetWithTTL("exp", "value", 25*time.Millisecond); err != nil {
+		t.Fatalf("set with ttl failed: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if _, err := store.Get("exp"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound after expiry, got: %v", err)
+	}
+}
+
+func TestStoreGetAndDelete(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.Set("k", "v"); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	v, err := store.GetAndDelete("k")
+	if err != nil {
+		t.Fatalf("get and delete failed: %v", err)
+	}
+	if v.(string) != "v" {
+		t.Fatalf("unexpected value: %v", v)
+	}
+
+	if _, err := store.Get("k"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected missing key after get-and-delete, got: %v", err)
+	}
+}
+
+func TestStoreClose(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+
+	if err := store.Set("k", "v"); !errors.Is(err, ErrClosed) {
+		t.Fatalf("expected ErrClosed on set, got: %v", err)
+	}
+	if _, err := store.Get("k"); !errors.Is(err, ErrClosed) {
+		t.Fatalf("expected ErrClosed on get, got: %v", err)
+	}
+}

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -160,6 +160,12 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddLargePayloadColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddPassthroughRequestBodyColumn(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddPassthroughResponseBodyColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1605,6 +1611,72 @@ func migrationAddProviderHistogramIndex(ctx context.Context, db *gorm.DB) error 
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding provider histogram index: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddPassthroughRequestBodyColumn(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_passthrough_request_body_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "passthrough_request_body") {
+				if err := migrator.AddColumn(&Log{}, "passthrough_request_body"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&Log{}, "passthrough_request_body") {
+				if err := migrator.DropColumn(&Log{}, "passthrough_request_body"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding passthrough request body column: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddPassthroughResponseBodyColumn(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_passthrough_response_body_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "passthrough_response_body") {
+				if err := migrator.AddColumn(&Log{}, "passthrough_response_body"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&Log{}, "passthrough_response_body") {
+				if err := migrator.DropColumn(&Log{}, "passthrough_response_body"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding passthrough response body column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -77,55 +77,57 @@ type SearchStats struct {
 // Log represents a complete log entry for a request/response cycle
 // This is the GORM model with appropriate tags
 type Log struct {
-	ID                    string    `gorm:"primaryKey;type:varchar(255)" json:"id"`
-	ParentRequestID       *string   `gorm:"type:varchar(255)" json:"parent_request_id"`
-	Timestamp             time.Time `gorm:"index;index:idx_logs_ts_provider_status,priority:1;not null" json:"timestamp"`
-	Object                string    `gorm:"type:varchar(255);index;not null;column:object_type" json:"object"` // text.completion, chat.completion, or embedding
-	Provider              string    `gorm:"type:varchar(255);index;index:idx_logs_ts_provider_status,priority:2;not null" json:"provider"`
-	Model                 string    `gorm:"type:varchar(255);index;not null" json:"model"`
-	NumberOfRetries       int       `gorm:"default:0" json:"number_of_retries"`
-	FallbackIndex         int       `gorm:"default:0" json:"fallback_index"`
-	SelectedKeyID         string    `gorm:"type:varchar(255);index:idx_logs_selected_key_id" json:"selected_key_id"`
-	SelectedKeyName       string    `gorm:"type:varchar(255)" json:"selected_key_name"`
-	VirtualKeyID          *string   `gorm:"type:varchar(255);index:idx_logs_virtual_key_id" json:"virtual_key_id"`
-	VirtualKeyName        *string   `gorm:"type:varchar(255)" json:"virtual_key_name"`
-	RoutingEnginesUsedStr *string   `gorm:"type:varchar(255);column:routing_engines_used" json:"-"` // Comma-separated routing engines
-	RoutingRuleID         *string   `gorm:"type:varchar(255);index:idx_logs_routing_rule_id" json:"routing_rule_id"`
-	RoutingRuleName       *string   `gorm:"type:varchar(255)" json:"routing_rule_name"`
-	InputHistory          string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ChatMessage
-	ResponsesInputHistory string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ResponsesMessage
-	OutputMessage         string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ChatMessage
-	ResponsesOutput       string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ResponsesMessage
-	EmbeddingOutput       string    `gorm:"type:text" json:"-"` // JSON serialized [][]float32
-	RerankOutput          string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.RerankResult
-	Params                string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ModelParameters
-	Tools                 string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.Tool
-	ToolCalls             string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ToolCall (For backward compatibility, tool calls are now in the content)
-	SpeechInput           string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.SpeechInput
-	TranscriptionInput    string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.TranscriptionInput
-	ImageGenerationInput  string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ImageGenerationInput
-	VideoGenerationInput  string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.VideoGenerationInput
-	SpeechOutput          string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostSpeech
-	TranscriptionOutput   string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostTranscribe
-	ImageGenerationOutput string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostImageGenerationResponse
-	ListModelsOutput      string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.Model
-	VideoGenerationOutput string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoGenerationResponse
-	VideoRetrieveOutput   string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoRetrieveResponse
-	VideoDownloadOutput   string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoDownloadResponse
-	VideoListOutput       string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoListResponse
-	VideoDeleteOutput     string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoDeleteResponse
-	CacheDebug            string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostCacheDebug
-	Latency               *float64  `gorm:"index:idx_logs_latency" json:"latency,omitempty"`
-	TokenUsage            string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.LLMUsage
-	Cost                  *float64  `gorm:"index" json:"cost,omitempty"`                   // Cost in dollars (total cost of the request - includes cache lookup cost)
-	Status                string    `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"
-	ErrorDetails          string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.BifrostError
-	Stream                bool      `gorm:"default:false" json:"stream"`                   // true if this was a streaming response
-	ContentSummary        string    `gorm:"type:text" json:"-"`
-	RawRequest            string    `gorm:"type:text" json:"raw_request"`                   // Populated when `send-back-raw-request` is on
-	RawResponse           string    `gorm:"type:text" json:"raw_response"`                  // Populated when `send-back-raw-response` is on
-	RoutingEngineLogs     string    `gorm:"type:text" json:"routing_engine_logs,omitempty"` // Formatted routing engine decision logs
-	Metadata              string    `gorm:"type:text" json:"-"`                             // JSON serialized map[string]interface{}
+	ID                     string    `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	ParentRequestID        *string   `gorm:"type:varchar(255)" json:"parent_request_id"`
+	Timestamp              time.Time `gorm:"index;index:idx_logs_ts_provider_status,priority:1;not null" json:"timestamp"`
+	Object                 string    `gorm:"type:varchar(255);index;not null;column:object_type" json:"object"` // text.completion, chat.completion, or embedding
+	Provider               string    `gorm:"type:varchar(255);index;index:idx_logs_ts_provider_status,priority:2;not null" json:"provider"`
+	Model                  string    `gorm:"type:varchar(255);index;not null" json:"model"`
+	NumberOfRetries        int       `gorm:"default:0" json:"number_of_retries"`
+	FallbackIndex          int       `gorm:"default:0" json:"fallback_index"`
+	SelectedKeyID          string    `gorm:"type:varchar(255);index:idx_logs_selected_key_id" json:"selected_key_id"`
+	SelectedKeyName        string    `gorm:"type:varchar(255)" json:"selected_key_name"`
+	VirtualKeyID           *string   `gorm:"type:varchar(255);index:idx_logs_virtual_key_id" json:"virtual_key_id"`
+	VirtualKeyName         *string   `gorm:"type:varchar(255)" json:"virtual_key_name"`
+	RoutingEnginesUsedStr   *string   `gorm:"type:varchar(255);column:routing_engines_used" json:"-"` // Comma-separated routing engines
+	RoutingRuleID          *string   `gorm:"type:varchar(255);index:idx_logs_routing_rule_id" json:"routing_rule_id"`
+	RoutingRuleName        *string   `gorm:"type:varchar(255)" json:"routing_rule_name"`
+	InputHistory           string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ChatMessage
+	ResponsesInputHistory  string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ResponsesMessage
+	OutputMessage          string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ChatMessage
+	ResponsesOutput        string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ResponsesMessage
+	EmbeddingOutput        string    `gorm:"type:text" json:"-"` // JSON serialized [][]float32
+	RerankOutput           string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.RerankResult
+	Params                 string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ModelParameters
+	Tools                  string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.Tool
+	ToolCalls              string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ToolCall (For backward compatibility, tool calls are now in the content)
+	SpeechInput            string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.SpeechInput
+	TranscriptionInput     string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.TranscriptionInput
+	ImageGenerationInput   string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ImageGenerationInput
+	VideoGenerationInput   string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.VideoGenerationInput
+	SpeechOutput           string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostSpeech
+	TranscriptionOutput    string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostTranscribe
+	ImageGenerationOutput  string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostImageGenerationResponse
+	ListModelsOutput       string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.Model
+	VideoGenerationOutput  string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoGenerationResponse
+	VideoRetrieveOutput    string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoRetrieveResponse
+	VideoDownloadOutput    string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoDownloadResponse
+	VideoListOutput        string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoListResponse
+	VideoDeleteOutput      string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoDeleteResponse
+	CacheDebug             string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostCacheDebug
+	Latency                *float64  `gorm:"index:idx_logs_latency" json:"latency,omitempty"`
+	TokenUsage             string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.LLMUsage
+	Cost                   *float64  `gorm:"index" json:"cost,omitempty"`                   // Cost in dollars (total cost of the request - includes cache lookup cost)
+	Status                 string    `gorm:"type:varchar(50);index;index:idx_logs_ts_provider_status,priority:3;not null" json:"status"` // "processing", "success", or "error"
+	ErrorDetails           string    `gorm:"type:text" json:"-"`                            // JSON serialized *schemas.BifrostError
+	Stream                 bool      `gorm:"default:false" json:"stream"`                   // true if this was a streaming response
+	ContentSummary         string    `gorm:"type:text" json:"-"`
+	RawRequest             string    `gorm:"type:text" json:"raw_request"`                        // Populated when `send-back-raw-request` is on
+	RawResponse            string    `gorm:"type:text" json:"raw_response"`                       // Populated when `send-back-raw-response` is on
+	PassthroughRequestBody  string    `gorm:"type:text" json:"passthrough_request_body,omitempty"`  // Raw body for passthrough requests (UTF-8)
+	PassthroughResponseBody string    `gorm:"type:text" json:"passthrough_response_body,omitempty"` // Raw body for passthrough responses (UTF-8)
+	RoutingEngineLogs      string    `gorm:"type:text" json:"routing_engine_logs,omitempty"`       // Formatted routing engine decision logs
+	Metadata               string    `gorm:"type:text" json:"-"`                                  // JSON serialized map[string]interface{}
 	IsLargePayloadRequest  bool      `gorm:"default:false" json:"is_large_payload_request"`
 	IsLargePayloadResponse bool      `gorm:"default:false" json:"is_large_payload_response"`
 

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -164,20 +164,21 @@ type LogMessage struct {
 
 // InitialLogData contains data for initial log entry creation
 type InitialLogData struct {
-	Status                string
-	Provider              string
-	Model                 string
-	Object                string
-	InputHistory          []schemas.ChatMessage
-	ResponsesInputHistory []schemas.ResponsesMessage
-	Params                interface{}
-	SpeechInput           *schemas.SpeechInput
-	TranscriptionInput    *schemas.TranscriptionInput
-	ImageGenerationInput  *schemas.ImageGenerationInput
-	VideoGenerationInput  *schemas.VideoGenerationInput
-	Tools                 []schemas.ChatTool
-	RoutingEngineUsed     []string
-	Metadata              map[string]interface{}
+	Status                 string
+	Provider               string
+	Model                  string
+	Object                 string
+	InputHistory           []schemas.ChatMessage
+	ResponsesInputHistory  []schemas.ResponsesMessage
+	Params                 interface{}
+	SpeechInput            *schemas.SpeechInput
+	TranscriptionInput     *schemas.TranscriptionInput
+	ImageGenerationInput   *schemas.ImageGenerationInput
+	VideoGenerationInput   *schemas.VideoGenerationInput
+	Tools                  []schemas.ChatTool
+	RoutingEngineUsed      []string
+	Metadata               map[string]interface{}
+	PassthroughRequestBody string // Raw body for passthrough requests (UTF-8)
 }
 
 // LogCallback is a function that gets called when a new log entry is created
@@ -394,7 +395,8 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	createdTimestamp := time.Now().UTC()
 
 	// If request type is streaming we create a stream accumulator via the tracer
-	if bifrost.IsStreamRequestType(req.RequestType) {
+	// Skip for passthrough streams — they carry raw bytes, not LLM response chunks
+	if bifrost.IsStreamRequestType(req.RequestType) && req.RequestType != schemas.PassthroughStreamRequest {
 		tracer, traceID, err := bifrost.GetTracerFromContext(ctx)
 		if err == nil && tracer != nil && traceID != "" {
 			tracer.CreateStreamAccumulator(traceID, createdTimestamp)
@@ -472,6 +474,18 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		case schemas.VideoDeleteRequest:
 			initialData.Params = &schemas.VideoLogParams{
 				VideoID: req.VideoDeleteRequest.ID,
+			}
+		case schemas.PassthroughRequest, schemas.PassthroughStreamRequest:
+			initialData.Params = &schemas.PassthroughLogParams{
+				Method:   req.PassthroughRequest.Method,
+				Path:     req.PassthroughRequest.Path,
+				RawQuery: req.PassthroughRequest.RawQuery,
+			}
+			if len(req.PassthroughRequest.Body) > 0 {
+				ct := strings.ToLower(req.PassthroughRequest.SafeHeaders["content-type"])
+				if strings.Contains(ct, "application/json") {
+					initialData.PassthroughRequestBody = string(req.PassthroughRequest.Body)
+				}
 			}
 		}
 	}
@@ -575,7 +589,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	var tracer schemas.Tracer
 	var traceID string
-	if bifrost.IsStreamRequestType(requestType) {
+	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.PassthroughStreamRequest {
 		var err error
 		tracer, traceID, err = bifrost.GetTracerFromContext(ctx)
 		if err != nil {
@@ -589,7 +603,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// and skip the write queue entirely. The accumulator work (ProcessStreamingChunk)
 	// is fast (mutex + append). Only final chunks, errors, and non-streaming
 	// responses need a DB write.
-	if bifrost.IsStreamRequestType(requestType) && !isFinalChunk && result != nil && bifrostErr == nil {
+	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.PassthroughStreamRequest && !isFinalChunk && result != nil && bifrostErr == nil {
 		if tracer != nil && traceID != "" {
 			tracer.ProcessStreamingChunk(traceID, false, result, bifrostErr)
 		}
@@ -679,7 +693,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// Path B: Streaming final chunk
 	if bifrost.IsStreamRequestType(requestType) {
 		var streamResponse *streaming.ProcessedStreamResponse
-		if tracer != nil && traceID != "" {
+		if requestType != schemas.PassthroughStreamRequest && tracer != nil && traceID != "" {
 			accResult := tracer.ProcessStreamingChunk(traceID, isFinalChunk, result, bifrostErr)
 			if accResult != nil {
 				streamResponse = convertToProcessedStreamResponse(accResult, requestType)
@@ -702,10 +716,15 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.Stream = true
 			p.applyStreamingOutputToEntry(entry, streamResponse)
 		}
+		// Backfill passthrough status_code from response (streaming path)
+		if result != nil && result.PassthroughResponse != nil {
+			if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {
+				params.StatusCode = result.PassthroughResponse.StatusCode
+			}
+		}
 		applyLargePayloadPreviewsToEntry(ctx, entry)
 
-		// Cleanup stream accumulator
-		if tracer != nil && traceID != "" {
+		if requestType != schemas.PassthroughStreamRequest && tracer != nil && traceID != "" {
 			tracer.CleanupStreamAccumulator(traceID)
 		}
 

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -43,6 +43,7 @@ func (p *LoggerPlugin) insertInitialLogEntry(
 		RoutingEnginesUsed:          routingEnginesUsed,
 		MetadataParsed:              data.Metadata,
 		VideoGenerationInputParsed:  data.VideoGenerationInput,
+		PassthroughRequestBody:      data.PassthroughRequestBody,
 	}
 	if parentRequestID != "" {
 		entry.ParentRequestID = &parentRequestID
@@ -676,6 +677,15 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 		}
 		if result.ImageGenerationResponse != nil {
 			entry.ImageGenerationOutputParsed = result.ImageGenerationResponse
+		}
+		if result.PassthroughResponse != nil && len(result.PassthroughResponse.Body) > 0 {
+			entry.PassthroughResponseBody = string(result.PassthroughResponse.Body)
+		}
+	}
+
+	if result.PassthroughResponse != nil {
+		if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {
+			params.StatusCode = result.PassthroughResponse.StatusCode
 		}
 	}
 }

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -202,6 +202,7 @@ func buildInitialLogEntry(pending *PendingLogData) *logstore.Log {
 		ResponsesInputHistoryParsed: pending.InitialData.ResponsesInputHistory,
 		ParamsParsed:                pending.InitialData.Params,
 		ToolsParsed:                 pending.InitialData.Tools,
+		PassthroughRequestBody:      pending.InitialData.PassthroughRequestBody,
 	}
 	if pending.ParentRequestID != "" {
 		entry.ParentRequestID = &pending.ParentRequestID
@@ -232,6 +233,7 @@ func buildCompleteLogEntryFromPending(pending *PendingLogData) *logstore.Log {
 		SpeechInputParsed:           pending.InitialData.SpeechInput,
 		TranscriptionInputParsed:    pending.InitialData.TranscriptionInput,
 		ImageGenerationInputParsed:  pending.InitialData.ImageGenerationInput,
+		PassthroughRequestBody:      pending.InitialData.PassthroughRequestBody,
 	}
 	if pending.ParentRequestID != "" {
 		entry.ParentRequestID = &pending.ParentRequestID

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -27,6 +27,10 @@ func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStor
 		integrations.NewLangChainRouter(client, handlerStore, logger),
 		integrations.NewPydanticAIRouter(client, handlerStore, logger),
 		integrations.NewBedrockRouter(client, handlerStore, logger),
+
+		// passthrough routers
+		integrations.NewGenAIPassthroughRouter(client, handlerStore, logger),
+		integrations.NewOpenAIPassthroughRouter(client, handlerStore, logger),
 	}
 
 	return &IntegrationHandler{

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -1070,6 +1070,6 @@ func NewAnthropicRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	routes = append(routes, CreateAnthropicFilesRouteConfigs("/anthropic", handlerStore)...)
 
 	return &AnthropicRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -705,7 +705,7 @@ func NewBedrockRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, lo
 	routes = append(routes, createBedrockFilesRouteConfigs("/bedrock/files", handlerStore)...)
 
 	return &BedrockRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/bedrock"
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,10 @@ func (m *mockHandlerStore) GetAsyncJobExecutor() *logstore.AsyncJobExecutor {
 
 func (m *mockHandlerStore) GetAsyncJobResultTTL() int {
 	return 3600
+}
+
+func (m *mockHandlerStore) GetKVStore() *kvstore.Store {
+	return nil
 }
 
 // Ensure mockHandlerStore implements lib.HandlerStore

--- a/transports/bifrost-http/integrations/cohere.go
+++ b/transports/bifrost-http/integrations/cohere.go
@@ -65,7 +65,7 @@ type CohereRouter struct {
 // NewCohereRouter creates a new CohereRouter with the given bifrost client.
 func NewCohereRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *CohereRouter {
 	return &CohereRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, CreateCohereRouteConfigs("/cohere"), logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, CreateCohereRouteConfigs("/cohere"), nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -2,12 +2,14 @@ package integrations
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -23,6 +25,8 @@ import (
 const isGeminiEmbedContentRequestContextKey schemas.BifrostContextKey = "bifrost-is-gemini-embed-content-request"
 
 const isGeminiVideoGenerationRequestContextKey schemas.BifrostContextKey = "bifrost-is-gemini-video-generation-request"
+
+const isGeminiBatchCreateRequestContextKey schemas.BifrostContextKey = "bifrost-is-gemini-batch-create-request"
 
 // GenAIRouter holds route registrations for genai endpoints.
 type GenAIRouter struct {
@@ -77,6 +81,9 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			}
 			if requestType, ok := ctx.Value(schemas.BifrostContextKeyHTTPRequestType).(schemas.RequestType); ok && requestType == schemas.VideoGenerationRequest && ctx.Value(isGeminiVideoGenerationRequestContextKey) != nil {
 				return &gemini.GeminiVideoGenerationRequest{}
+			}
+			if requestType, ok := ctx.Value(schemas.BifrostContextKeyHTTPRequestType).(schemas.RequestType); ok && requestType == schemas.BatchCreateRequest && ctx.Value(isGeminiBatchCreateRequestContextKey) != nil {
+				return &gemini.GeminiBatchCreateRequest{}
 			}
 			return &gemini.GeminiGenerationRequest{}
 		},
@@ -133,6 +140,62 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			}
 			return nil, errors.New("invalid request type")
 		},
+		BatchRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*BatchRequest, error) {
+			if geminiReq, ok := req.(*gemini.GeminiBatchCreateRequest); ok {
+				// Get provider from context
+				provider, ok := ctx.Value(bifrostContextKeyProvider).(schemas.ModelProvider)
+				if !ok {
+					provider = schemas.Gemini
+				}
+
+				// Convert Gemini batch request items directly to Bifrost format
+				var requests []schemas.BatchRequestItem
+				if geminiReq.Batch.InputConfig.Requests != nil && len(geminiReq.Batch.InputConfig.Requests.Requests) > 0 {
+					requests = make([]schemas.BatchRequestItem, len(geminiReq.Batch.InputConfig.Requests.Requests))
+					for i, geminiItem := range geminiReq.Batch.InputConfig.Requests.Requests {
+						requestMap := make(map[string]interface{})
+						if geminiItem.Request.Contents != nil {
+							requestMap["contents"] = geminiItem.Request.Contents
+						}
+						if geminiItem.Request.GenerationConfig != nil {
+							requestMap["generationConfig"] = geminiItem.Request.GenerationConfig
+						}
+						if len(geminiItem.Request.SafetySettings) > 0 {
+							requestMap["safetySettings"] = geminiItem.Request.SafetySettings
+						}
+						if geminiItem.Request.SystemInstruction != nil {
+							requestMap["systemInstruction"] = geminiItem.Request.SystemInstruction
+						}
+
+						requests[i] = schemas.BatchRequestItem{
+							CustomID: "",
+							Body:     requestMap,
+						}
+						// Extract custom_id from metadata
+						if geminiItem.Metadata != nil && geminiItem.Metadata.Key != "" {
+							requests[i].CustomID = geminiItem.Metadata.Key
+						}
+					}
+				}
+
+				bifrostBatchReq := &schemas.BifrostBatchCreateRequest{
+					Provider: provider,
+					Model:    &geminiReq.Model,
+					Requests: requests,
+				}
+
+				// Handle file-based input
+				if geminiReq.Batch.InputConfig.FileName != "" {
+					bifrostBatchReq.InputFileID = geminiReq.Batch.InputConfig.FileName
+				}
+
+				return &BatchRequest{
+					Type:          schemas.BatchCreateRequest,
+					CreateRequest: bifrostBatchReq,
+				}, nil
+			}
+			return nil, errors.New("invalid batch create request type")
+		},
 		EmbeddingResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
 			return gemini.ToGeminiEmbeddingResponse(resp), nil
 		},
@@ -153,6 +216,9 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 		},
 		VideoGenerationResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostVideoGenerationResponse) (interface{}, error) {
 			return gemini.ToGeminiVideoGenerationResponse(resp), nil
+		},
+		BatchCreateResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchCreateResponse) (interface{}, error) {
+			return gemini.ToGeminiBatchJobResponse(resp), nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return gemini.ToGeminiError(err)
@@ -228,27 +294,122 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 			return schemas.FileUploadRequest
 		},
 		GetRequestTypeInstance: func(ctx context.Context) interface{} {
-			return &schemas.BifrostFileUploadRequest{}
+			return &gemini.GeminiFileUploadHandlerReq{}
 		},
-		RequestParser: parseGeminiFileUploadRequest,
-		FileRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error) {
-			if uploadReq, ok := req.(*schemas.BifrostFileUploadRequest); ok {
-				uploadReq.Provider = schemas.Gemini
-				return &FileRequest{
-					Type:          schemas.FileUploadRequest,
-					UploadRequest: uploadReq,
-				}, nil
+		// RequestParser detects which step we are in and populates the request
+		// object accordingly without trying to JSON-decode binary payloads.
+		RequestParser: func(ctx *fasthttp.RequestCtx, req interface{}) error {
+			r := req.(*gemini.GeminiFileUploadHandlerReq)
+			uploadID := string(ctx.QueryArgs().Peek("upload_id"))
+			if uploadID != "" {
+				// Step 2: body is raw binary — do not JSON-decode.
+				r.UploadID = uploadID
+				r.FileData = ctx.Request.Body()
+				return nil
 			}
-			return nil, errors.New("invalid file upload request type")
+			// Step 1: body is JSON metadata.
+			if body := ctx.Request.Body(); len(body) > 0 {
+				return sonic.Unmarshal(body, r)
+			}
+			return nil
+		},
+		// ShortCircuit handles step 1 for non-Gemini providers: it acknowledges
+		// the initiation by returning a synthetic upload URL and exits early so
+		// that no Bifrost call is made.
+		ShortCircuit: func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) (bool, error) {
+			r, ok := req.(*gemini.GeminiFileUploadHandlerReq)
+			if !ok || r.UploadID != "" {
+				return false, nil
+			}
+
+			uploadID, err := generateUploadID()
+			if err != nil {
+				return true, fmt.Errorf("failed to generate upload ID: %w", err)
+			}
+
+			kvStore := handlerStore.GetKVStore()
+			if kvStore == nil {
+				return true, errors.New("kvstore not initialized")
+			}
+
+			session := &gemini.GeminiResumableUploadSession{
+				DisplayName: r.File.DisplayName,
+				MimeType:    r.MimeType,
+				Provider:    r.Provider,
+			}
+			if err := kvStore.SetWithTTL(uploadID, session, 1*time.Minute); err != nil {
+				return true, fmt.Errorf("failed to store upload session: %w", err)
+			}
+
+			scheme := "http"
+			if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+				scheme = "https"
+			}
+			uploadURL := scheme + "://" + string(ctx.Host()) + pathPrefix + "/upload/v1beta/files?upload_id=" + uploadID
+
+			ctx.SetStatusCode(fasthttp.StatusOK)
+			ctx.Response.Header.Set("X-Goog-Upload-URL", uploadURL)
+			ctx.Response.Header.Set("X-Goog-Upload-Status", "active")
+			ctx.SetContentType("application/json")
+			ctx.SetBody([]byte("{}"))
+			return true, nil
+		},
+		// FileRequestConverter handles step 2: retrieves the saved session from
+		// the KV store and builds a full BifrostFileUploadRequest.
+		FileRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error) {
+			r, ok := req.(*gemini.GeminiFileUploadHandlerReq)
+			if !ok {
+				return nil, errors.New("invalid file upload request type")
+			}
+			if r.UploadID == "" {
+				return nil, errors.New("upload_id missing — step 1 should have been short-circuited")
+			}
+
+			kvStore := handlerStore.GetKVStore()
+			if kvStore == nil {
+				return nil, errors.New("kvstore not initialized")
+			}
+
+			val, err := kvStore.GetAndDelete(r.UploadID)
+			if err != nil {
+				return nil, fmt.Errorf("upload session not found for id %q: %w", r.UploadID, err)
+			}
+
+			session, ok := val.(*gemini.GeminiResumableUploadSession)
+			if !ok {
+				return nil, errors.New("invalid upload session type in kvstore")
+			}
+
+			filename := session.DisplayName
+			if filename == "" {
+				filename = "upload"
+			}
+			contentType := session.MimeType
+
+			return &FileRequest{
+				Type: schemas.FileUploadRequest,
+				UploadRequest: &schemas.BifrostFileUploadRequest{
+					Provider:    session.Provider,
+					File:        r.FileData,
+					Filename:    filename,
+					ContentType: &contentType,
+					Purpose:     schemas.FilePurposeBatch,
+				},
+			}, nil
 		},
 		FileUploadResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostFileUploadResponse) (interface{}, error) {
-			if resp.ExtraFields.RawResponse != nil {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
 				return resp.ExtraFields.RawResponse, nil
 			}
 			return gemini.ToGeminiFileUploadResponse(resp), nil
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return gemini.ToGeminiError(err)
+		},
+		PreCallback: extractGeminiFileUploadParams,
+		PostCallback: func(ctx *fasthttp.RequestCtx, req interface{}, resp interface{}) error {
+			ctx.Response.Header.Set("X-Goog-Upload-Status", "final")
+			return nil
 		},
 	})
 
@@ -265,7 +426,6 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		},
 		FileRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error) {
 			if listReq, ok := req.(*schemas.BifrostFileListRequest); ok {
-				listReq.Provider = schemas.Gemini
 				return &FileRequest{
 					Type:        schemas.FileListRequest,
 					ListRequest: listReq,
@@ -274,7 +434,7 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 			return nil, errors.New("invalid file list request type")
 		},
 		FileListResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostFileListResponse) (interface{}, error) {
-			if resp.ExtraFields.RawResponse != nil {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
 				return resp.ExtraFields.RawResponse, nil
 			}
 			return gemini.ToGeminiFileListResponse(resp), nil
@@ -298,7 +458,6 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		},
 		FileRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error) {
 			if retrieveReq, ok := req.(*schemas.BifrostFileRetrieveRequest); ok {
-				retrieveReq.Provider = schemas.Gemini
 				return &FileRequest{
 					Type:            schemas.FileRetrieveRequest,
 					RetrieveRequest: retrieveReq,
@@ -307,7 +466,7 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 			return nil, errors.New("invalid file retrieve request type")
 		},
 		FileRetrieveResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostFileRetrieveResponse) (interface{}, error) {
-			if resp.ExtraFields.RawResponse != nil {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
 				return resp.ExtraFields.RawResponse, nil
 			}
 			return gemini.ToGeminiFileRetrieveResponse(resp), nil
@@ -331,7 +490,6 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 		},
 		FileRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*FileRequest, error) {
 			if deleteReq, ok := req.(*schemas.BifrostFileDeleteRequest); ok {
-				deleteReq.Provider = schemas.Gemini
 				return &FileRequest{
 					Type:          schemas.FileDeleteRequest,
 					DeleteRequest: deleteReq,
@@ -340,7 +498,7 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 			return nil, errors.New("invalid file delete request type")
 		},
 		FileDeleteResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostFileDeleteResponse) (interface{}, error) {
-			if resp.ExtraFields.RawResponse != nil {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
 				return resp.ExtraFields.RawResponse, nil
 			}
 			return map[string]interface{}{}, nil // Gemini returns empty response on delete
@@ -354,54 +512,188 @@ func CreateGenAIFileRouteConfigs(pathPrefix string, handlerStore lib.HandlerStor
 	return routes
 }
 
-// parseGeminiFileUploadRequest parses multipart/form-data for Gemini file upload requests
-func parseGeminiFileUploadRequest(ctx *fasthttp.RequestCtx, req interface{}) error {
-	uploadReq, ok := req.(*schemas.BifrostFileUploadRequest)
-	if !ok {
-		return errors.New("invalid request type for file upload")
+func CreateGenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) []RouteConfig {
+	var routes []RouteConfig
+	// List batches endpoint - GET /v1beta/batches
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeGenAI,
+		Path:   pathPrefix + "/v1beta/batches",
+		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchListRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &schemas.BifrostBatchListRequest{}
+		},
+		BatchRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*BatchRequest, error) {
+			if listReq, ok := req.(*schemas.BifrostBatchListRequest); ok {
+				return &BatchRequest{
+					Type:        schemas.BatchListRequest,
+					ListRequest: listReq,
+				}, nil
+			}
+			return nil, errors.New("invalid batch list request type")
+		},
+		BatchListResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchListResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
+				return resp.ExtraFields.RawResponse, nil
+			}
+			return gemini.ToGeminiBatchListResponse(resp), nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return gemini.ToGeminiError(err)
+		},
+		PreCallback: extractGeminiFileListQueryParams,
+	})
+	// Retrieve batch endpoint - GET /v1beta/batches/{batch_id}
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeGenAI,
+		Path:   pathPrefix + "/v1beta/batches/{batch_id}",
+		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchRetrieveRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &schemas.BifrostBatchRetrieveRequest{}
+		},
+		BatchRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*BatchRequest, error) {
+			if retrieveReq, ok := req.(*schemas.BifrostBatchRetrieveRequest); ok {
+				return &BatchRequest{
+					Type:            schemas.BatchRetrieveRequest,
+					RetrieveRequest: retrieveReq,
+				}, nil
+			}
+			return nil, errors.New("invalid batch retrieve request type")
+		},
+		BatchRetrieveResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchRetrieveResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
+				return resp.ExtraFields.RawResponse, nil
+			}
+			return gemini.ToGeminiBatchRetrieveResponse(resp), nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return gemini.ToGeminiError(err)
+		},
+		PreCallback: extractGeminiBatchIDFromPath,
+	})
+	// Retrieve batch endpoint - POST /v1beta/batches/{batch_id}:cancel
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeGenAI,
+		Path:   pathPrefix + "/v1beta/batches/{batch_id}",
+		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchCancelRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &schemas.BifrostBatchCancelRequest{}
+		},
+		BatchRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*BatchRequest, error) {
+			if cancelReq, ok := req.(*schemas.BifrostBatchCancelRequest); ok {
+				return &BatchRequest{
+					Type:          schemas.BatchCancelRequest,
+					CancelRequest: cancelReq,
+				}, nil
+			}
+			return nil, errors.New("invalid batch cancel request type")
+		},
+		BatchCancelResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchCancelResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
+				return resp.ExtraFields.RawResponse, nil
+			}
+			return map[string]interface{}{}, nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return gemini.ToGeminiError(err)
+		},
+		PreCallback: extractGeminiBatchIDFromPath,
+	})
+	// Delete batch endpoint - DELETE /v1beta/batches/{batch_id}
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeGenAI,
+		Path:   pathPrefix + "/v1beta/batches/{batch_id}",
+		Method: "DELETE",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.BatchDeleteRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &schemas.BifrostBatchDeleteRequest{}
+		},
+		BatchRequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*BatchRequest, error) {
+			if deleteReq, ok := req.(*schemas.BifrostBatchDeleteRequest); ok {
+				return &BatchRequest{
+					Type:          schemas.BatchDeleteRequest,
+					DeleteRequest: deleteReq,
+				}, nil
+			}
+			return nil, errors.New("invalid batch delete request type")
+		},
+		BatchDeleteResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchDeleteResponse) (interface{}, error) {
+			if resp.ExtraFields.Provider == schemas.Gemini && resp.ExtraFields.RawResponse != nil {
+				return resp.ExtraFields.RawResponse, nil
+			}
+			return map[string]interface{}{}, nil // Gemini returns empty response on delete
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return gemini.ToGeminiError(err)
+		},
+		PreCallback: extractGeminiBatchIDFromPath,
+	})
+
+	return routes
+}
+
+// extractGeminiBatchIDFromPath extracts batch_id from path parameters for Gemini
+func extractGeminiBatchIDFromPath(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+	provider := getProviderFromHeader(ctx, schemas.Gemini)
+
+	batchID := ctx.UserValue("batch_id")
+	if batchID == nil {
+		return errors.New("batch_id is required")
 	}
 
-	// Parse multipart form
-	form, err := ctx.MultipartForm()
-	if err != nil {
-		return err
+	batchIDStr, ok := batchID.(string)
+	if !ok || batchIDStr == "" {
+		return errors.New("batch_id must be a non-empty string")
 	}
 
-	// Extract metadata (optional JSON with displayName)
-	if metadataValues := form.Value["metadata"]; len(metadataValues) > 0 && metadataValues[0] != "" {
-		// Could parse JSON metadata to extract displayName
-		// For now, just use filename from file header
-	}
+	// strip :cancel from batchID
+	batchIDStr = strings.TrimSuffix(batchIDStr, ":cancel")
 
-	// Extract file (required)
-	fileHeaders := form.File["file"]
-	if len(fileHeaders) == 0 {
-		return errors.New("file field is required")
+	switch r := req.(type) {
+	case *schemas.BifrostBatchCancelRequest:
+		r.BatchID = batchIDStr
+		r.Provider = provider
+	case *schemas.BifrostBatchRetrieveRequest:
+		r.BatchID = batchIDStr
+		r.Provider = provider
+	case *schemas.BifrostBatchDeleteRequest:
+		r.BatchID = batchIDStr
+		r.Provider = provider
 	}
-
-	fileHeader := fileHeaders[0]
-	file, err := fileHeader.Open()
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	// Read file data
-	fileData, err := io.ReadAll(file)
-	if err != nil {
-		return err
-	}
-
-	uploadReq.File = fileData
-	uploadReq.Filename = fileHeader.Filename
 
 	return nil
 }
 
 // extractGeminiFileListQueryParams extracts query parameters for Gemini file list requests
 func extractGeminiFileListQueryParams(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+	provider := getProviderFromHeader(ctx, schemas.Gemini)
+
 	if listReq, ok := req.(*schemas.BifrostFileListRequest); ok {
-		listReq.Provider = schemas.Gemini
+		listReq.Provider = provider
+
+		// Extract pageSize from query parameters
+		if pageSizeStr := string(ctx.QueryArgs().Peek("pageSize")); pageSizeStr != "" {
+			if pageSize, err := strconv.Atoi(pageSizeStr); err == nil {
+				listReq.Limit = pageSize
+			}
+		}
+
+		// Extract pageToken from query parameters
+		if pageToken := string(ctx.QueryArgs().Peek("pageToken")); pageToken != "" {
+			listReq.After = &pageToken
+		}
+	} else if listReq, ok := req.(*schemas.BifrostBatchListRequest); ok {
+		listReq.Provider = provider
 
 		// Extract pageSize from query parameters
 		if pageSizeStr := string(ctx.QueryArgs().Peek("pageSize")); pageSizeStr != "" {
@@ -421,6 +713,8 @@ func extractGeminiFileListQueryParams(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 
 // extractGeminiFileIDFromPath extracts file_id from path parameters for Gemini
 func extractGeminiFileIDFromPath(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+	provider := getProviderFromHeader(ctx, schemas.Gemini)
+
 	fileID := ctx.UserValue("file_id")
 	if fileID == nil {
 		return errors.New("file_id is required")
@@ -434,10 +728,23 @@ func extractGeminiFileIDFromPath(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.B
 	switch r := req.(type) {
 	case *schemas.BifrostFileRetrieveRequest:
 		r.FileID = fileIDStr
-		r.Provider = schemas.Gemini
+		r.Provider = provider
 	case *schemas.BifrostFileDeleteRequest:
 		r.FileID = fileIDStr
-		r.Provider = schemas.Gemini
+		r.Provider = provider
+	}
+
+	return nil
+}
+
+// extractGeminiFileUploadParams populates provider and MIME-type fields on the
+// upload handler request from HTTP headers.
+func extractGeminiFileUploadParams(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+	provider := getProviderFromHeader(ctx, schemas.Gemini)
+
+	if r, ok := req.(*gemini.GeminiFileUploadHandlerReq); ok {
+		r.Provider = provider
+		r.MimeType = string(ctx.Request.Header.Peek("x-goog-upload-header-content-type"))
 	}
 
 	return nil
@@ -482,9 +789,10 @@ func createGenAIRerankRouteConfig(pathPrefix string) RouteConfig {
 func NewGenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *GenAIRouter {
 	routes := CreateGenAIRouteConfigs("/genai")
 	routes = append(routes, CreateGenAIFileRouteConfigs("/genai", handlerStore)...)
+	routes = append(routes, CreateGenAIBatchRouteConfigs("/genai", handlerStore)...)
 
 	return &GenAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }
 
@@ -512,6 +820,10 @@ func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 	if model == nil {
 		return fmt.Errorf("model parameter is required")
 	}
+
+	provider := getProviderFromHeader(ctx, schemas.Gemini)
+	// set in context
+	bifrostCtx.SetValue(bifrostContextKeyProvider, provider)
 
 	modelStr := model.(string)
 
@@ -598,6 +910,11 @@ func extractAndSetModelAndRequestType(ctx *fasthttp.RequestCtx, bifrostCtx *sche
 			r.Model = modelStr
 		}
 		return nil
+	case *gemini.GeminiBatchCreateRequest:
+		if modelStr != "" {
+			r.Model = modelStr
+		}
+		return nil
 	}
 
 	return fmt.Errorf("invalid request type for GenAI")
@@ -619,6 +936,7 @@ func extractModelAndRequestType(ctx *fasthttp.RequestCtx) (string, schemas.Reque
 
 	isPredict := strings.HasSuffix(modelStr, ":predict")
 	isVideoGeneration := strings.HasSuffix(modelStr, ":predictLongRunning")
+	isBatchCreate := strings.HasSuffix(modelStr, ":batchGenerateContent")
 
 	// Check if this is an embedding request
 	isEmbedding := false
@@ -638,6 +956,11 @@ func extractModelAndRequestType(ctx *fasthttp.RequestCtx) (string, schemas.Reque
 	if isVideoGeneration {
 		ctx.SetUserValue(isGeminiVideoGenerationRequestContextKey, true)
 		return modelStr, schemas.VideoGenerationRequest
+	}
+
+	if isBatchCreate {
+		ctx.SetUserValue(isGeminiBatchCreateRequestContextKey, true)
+		return modelStr, schemas.BatchCreateRequest
 	}
 
 	// Remove Google GenAI API endpoint suffixes if present
@@ -914,4 +1237,32 @@ func extractGeminiVideoOperationFromPath(ctx *fasthttp.RequestCtx, bifrostCtx *s
 	}
 
 	return nil
+}
+
+// detectProviderFromGenAIRequest determines if the request is for Vertex AI or Gemini
+// based on URL path, model name format, and authorization type
+func detectProviderFromGenAIRequest(ctx *fasthttp.RequestCtx, bodyModel string) schemas.ModelProvider {
+	path := string(ctx.Path())
+	if strings.Contains(path, "/projects/") && strings.Contains(path, "/locations/") {
+		return schemas.Vertex
+	}
+	// Use pre-parsed model — no body read here
+	if bodyModel != "" && strings.Contains(bodyModel, "projects/") && strings.Contains(bodyModel, "/locations/") {
+		return schemas.Vertex
+	}
+	authHeader := strings.TrimSpace(string(ctx.Request.Header.Peek("authorization")))
+	parts := strings.Fields(authHeader)
+	if len(parts) == 2 && strings.EqualFold(parts[0], "Bearer") && strings.HasPrefix(parts[1], "ya29.") {
+		return schemas.Vertex
+	}
+	return schemas.Gemini
+}
+
+func generateUploadID() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	encoded := base64.RawURLEncoding.EncodeToString(b)
+	return "genai_upload_session:" + encoded, nil
 }

--- a/transports/bifrost-http/integrations/langchain.go
+++ b/transports/bifrost-http/integrations/langchain.go
@@ -37,6 +37,6 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	routes = append(routes, CreateCohereRouteConfigs("/langchain")...)
 
 	return &LangChainRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/litellm.go
+++ b/transports/bifrost-http/integrations/litellm.go
@@ -34,6 +34,6 @@ func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, lo
 	routes = append(routes, CreateCohereRouteConfigs("/litellm")...)
 
 	return &LiteLLMRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -2757,7 +2757,7 @@ func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, log
 	routes = append(routes, CreateOpenAIContainerFileRouteConfigs("/openai", handlerStore)...)
 
 	return &OpenAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }
 
@@ -3260,3 +3260,4 @@ func parseContainerFileCreateMultipartRequest(ctx *fasthttp.RequestCtx, req inte
 
 	return nil
 }
+

--- a/transports/bifrost-http/integrations/passthrough.go
+++ b/transports/bifrost-http/integrations/passthrough.go
@@ -1,0 +1,52 @@
+package integrations
+
+import (
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+)
+
+// PassthroughRouter is a catch-all router that forwards all requests directly
+// to the provider without matching against known route patterns.
+type PassthroughRouter struct {
+	*GenericRouter
+}
+
+// NewPassthroughRouter creates a passthrough-only router for any prefix/provider combo.
+func NewPassthroughRouter(
+	client *bifrost.Bifrost,
+	handlerStore lib.HandlerStore,
+	logger schemas.Logger,
+	cfg *PassthroughConfig,
+) *PassthroughRouter {
+	if cfg == nil {
+		cfg = &PassthroughConfig{}
+	}
+	return &PassthroughRouter{
+		GenericRouter: NewGenericRouter(client, handlerStore, nil, cfg, logger),
+	}
+}
+
+// NewOpenAIPassthroughRouter creates a passthrough router for /openai_passthrough.
+func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+		Provider: schemas.OpenAI,
+		StripPrefix: []string{
+			"/openai_passthrough",
+		},
+	})
+}
+
+// NewGenAIPassthroughRouter creates a passthrough router for /genai_passthrough.
+func NewGenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+		Provider:         schemas.Gemini,
+		ProviderDetector: detectProviderFromGenAIRequest,
+		StripPrefix: []string{
+			"/genai_passthrough/v1beta1",
+			"/genai_passthrough/v1beta",
+			"/genai_passthrough/v1",
+			"/genai_passthrough",
+		},
+	})
+}

--- a/transports/bifrost-http/integrations/pydanticai.go
+++ b/transports/bifrost-http/integrations/pydanticai.go
@@ -33,6 +33,6 @@ func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore,
 	// Supports: converse, converse-stream, invoke, invoke-with-response-stream
 	routes = append(routes, CreateBedrockRouteConfigs("/pydanticai", handlerStore)...)
 	return &PydanticAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -49,8 +49,12 @@ package integrations
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
 	"strconv"
 	"strings"
 
@@ -91,6 +95,7 @@ type BatchRequest struct {
 	ListRequest     *schemas.BifrostBatchListRequest
 	RetrieveRequest *schemas.BifrostBatchRetrieveRequest
 	CancelRequest   *schemas.BifrostBatchCancelRequest
+	DeleteRequest   *schemas.BifrostBatchDeleteRequest
 	ResultsRequest  *schemas.BifrostBatchResultsRequest
 }
 
@@ -198,6 +203,10 @@ type BatchCancelResponseConverter func(ctx *schemas.BifrostContext, resp *schema
 // BatchResultsResponseConverter is a function that converts BifrostBatchResultsResponse to integration-specific format.
 // It takes a BifrostBatchResultsResponse and returns the format expected by the specific integration.
 type BatchResultsResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchResultsResponse) (interface{}, error)
+
+// BatchDeleteResponseConverter is a function that converts BifrostBatchDeleteResponse to integration-specific format.
+// It takes a BifrostBatchDeleteResponse and returns the format expected by the specific integration.
+type BatchDeleteResponseConverter func(ctx *schemas.BifrostContext, resp *schemas.BifrostBatchDeleteResponse) (interface{}, error)
 
 // FileUploadResponseConverter is a function that converts BifrostFileUploadResponse to integration-specific format.
 // It takes a BifrostFileUploadResponse and returns the format expected by the specific integration.
@@ -341,6 +350,9 @@ type PostRequestCallback func(ctx *fasthttp.RequestCtx, req interface{}, resp in
 // returns a schemas.RequestType indicating the HTTP request type derived from the context.
 type HTTPRequestTypeGetter func(ctx *fasthttp.RequestCtx) schemas.RequestType
 
+// ShortCircuit is a function that determines if the request should be short-circuited.
+type ShortCircuit func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) (bool, error)
+
 // StreamConfig defines streaming-specific configuration for an integration
 //
 // SSE FORMAT BEHAVIOR:
@@ -414,6 +426,7 @@ type RouteConfig struct {
 	BatchListResponseConverter             BatchListResponseConverter             // Function to convert BifrostBatchListResponse to integration format
 	BatchRetrieveResponseConverter         BatchRetrieveResponseConverter         // Function to convert BifrostBatchRetrieveResponse to integration format
 	BatchCancelResponseConverter           BatchCancelResponseConverter           // Function to convert BifrostBatchCancelResponse to integration format
+	BatchDeleteResponseConverter           BatchDeleteResponseConverter           // Function to convert BifrostBatchDeleteResponse to integration format
 	BatchResultsResponseConverter          BatchResultsResponseConverter          // Function to convert BifrostBatchResultsResponse to integration format
 	FileUploadResponseConverter            FileUploadResponseConverter            // Function to convert BifrostFileUploadResponse to integration format
 	FileListResponseConverter              FileListResponseConverter              // Function to convert BifrostFileListResponse to integration format
@@ -434,6 +447,13 @@ type RouteConfig struct {
 	StreamConfig                           *StreamConfig                          // Optional: Streaming configuration (if nil, streaming not supported)
 	PreCallback                            PreRequestCallback                     // Optional: called after parsing but before Bifrost processing
 	PostCallback                           PostRequestCallback                    // Optional: called after request processing
+	ShortCircuit                           ShortCircuit
+}
+
+type PassthroughConfig struct {
+	Provider         schemas.ModelProvider                                              // which provider's key pool to draw from
+	ProviderDetector func(ctx *fasthttp.RequestCtx, model string) schemas.ModelProvider // optional: dynamic provider detection
+	StripPrefix      []string                                                           // e.g. "/openai" — stripped before forwarding
 }
 
 // LargePayloadHook is called before body parsing to detect and set up large payload streaming.
@@ -461,9 +481,10 @@ type LargeResponseHook func(
 // It handles the common flow of: parse request → convert to Bifrost → execute → convert response.
 // Integration-specific logic is handled through the RouteConfig callbacks and converters.
 type GenericRouter struct {
-	client            *bifrost.Bifrost  // Bifrost client for executing requests
-	handlerStore      lib.HandlerStore  // Config provider for the router
-	routes            []RouteConfig     // List of route configurations
+	client            *bifrost.Bifrost // Bifrost client for executing requests
+	handlerStore      lib.HandlerStore // Config provider for the router
+	routes            []RouteConfig    // List of route configurations
+	passthroughCfg    *PassthroughConfig
 	logger            schemas.Logger    // Logger for the router
 	largePayloadHook  LargePayloadHook  // Optional: enterprise hook for large payload detection
 	largeResponseHook LargeResponseHook // Optional: enterprise hook for large response scanning
@@ -485,12 +506,13 @@ func (g *GenericRouter) SetLargeResponseHook(hook LargeResponseHook) {
 
 // NewGenericRouter creates a new generic router with the given bifrost client and route configurations.
 // Each integration should create their own routes and pass them to this constructor.
-func NewGenericRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, routes []RouteConfig, logger schemas.Logger) *GenericRouter {
+func NewGenericRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, routes []RouteConfig, passthroughCfg *PassthroughConfig, logger schemas.Logger) *GenericRouter {
 	return &GenericRouter{
-		client:       client,
-		handlerStore: handlerStore,
-		routes:       routes,
-		logger:       logger,
+		client:         client,
+		handlerStore:   handlerStore,
+		routes:         routes,
+		passthroughCfg: passthroughCfg,
+		logger:         logger,
 	}
 }
 
@@ -557,6 +579,16 @@ func (g *GenericRouter) RegisterRoutes(r *router.Router, middlewares ...schemas.
 			r.HEAD(route.Path, lib.ChainMiddlewares(handler, routeMiddlewares...))
 		default:
 			r.POST(route.Path, lib.ChainMiddlewares(handler, routeMiddlewares...)) // Default to POST
+		}
+	}
+
+	if g.passthroughCfg != nil {
+		catchAll := lib.ChainMiddlewares(g.handlePassthrough, middlewares...)
+		// Register for all methods that need forwarding
+		for _, method := range []string{fasthttp.MethodGet, fasthttp.MethodPost, fasthttp.MethodPut, fasthttp.MethodDelete, fasthttp.MethodPatch, fasthttp.MethodHead} {
+			for _, prefix := range g.passthroughCfg.StripPrefix {
+				r.Handle(method, prefix+"/{path:*}", catchAll)
+			}
 		}
 	}
 }
@@ -664,6 +696,22 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			}
 		}
 
+		// Execute short-circuit handler if configured.
+		// If it returns handled=true the callback has already written a response
+		// to ctx and we return immediately, bypassing the Bifrost flow entirely.
+		if config.ShortCircuit != nil {
+			handled, err := config.ShortCircuit(ctx, bifrostCtx, req)
+			if err != nil {
+				defer cancel()
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "short-circuit handler error: "+err.Error()))
+				return
+			}
+			if handled {
+				defer cancel()
+				return
+			}
+		}
+
 		// Set direct key from context if available
 		if ctx.UserValue(string(schemas.BifrostContextKeyDirectKey)) != nil {
 			key, ok := ctx.UserValue(string(schemas.BifrostContextKeyDirectKey)).(schemas.Key)
@@ -673,7 +721,11 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 		}
 
 		// Handle batch requests if BatchRequestConverter is set
-		if config.BatchRequestConverter != nil {
+		// GenAI has two cases: (1) Dedicated batch routes (list/retrieve) have only BatchRequestConverter — always use batch path.
+		// (2) The models path has both BatchRequestConverter and RequestConverter — use batch path only for batch create.
+		isGenAIBatchCreate := config.Type == RouteConfigTypeGenAI && bifrostCtx.Value(isGeminiBatchCreateRequestContextKey) != nil
+		useBatchPath := config.BatchRequestConverter != nil && (config.RequestConverter == nil || config.Type != RouteConfigTypeGenAI || isGenAIBatchCreate)
+		if useBatchPath {
 			defer cancel()
 			batchReq, err := config.BatchRequestConverter(bifrostCtx, req)
 			if err != nil {
@@ -681,13 +733,12 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				return
 			}
 			if batchReq == nil {
-				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid batch request"))
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch request"))
 				return
 			}
 			g.handleBatchRequest(ctx, config, req, batchReq, bifrostCtx)
 			return
 		}
-
 		// Handle file requests if FileRequestConverter is set
 		if config.FileRequestConverter != nil {
 			defer cancel()
@@ -697,7 +748,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				return
 			}
 			if fileReq == nil {
-				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid file request"))
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid file request"))
 				return
 			}
 			g.handleFileRequest(ctx, config, req, fileReq, bifrostCtx)
@@ -713,7 +764,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				return
 			}
 			if containerReq == nil {
-				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container request"))
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container request"))
 				return
 			}
 			g.handleContainerRequest(ctx, config, req, containerReq, bifrostCtx)
@@ -729,7 +780,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				return
 			}
 			if containerFileReq == nil {
-				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container file request"))
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container file request"))
 				return
 			}
 			g.handleContainerFileRequest(ctx, config, req, containerFileReq, bifrostCtx)
@@ -743,7 +794,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			return
 		}
 		if bifrostReq == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid request"))
 			return
 		}
 		if sendRawRequestBody, ok := (*bifrostCtx).Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && sendRawRequestBody {
@@ -1515,7 +1566,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 	switch batchReq.Type {
 	case schemas.BatchCreateRequest:
 		if batchReq.CreateRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid batch create request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch create request"))
 			return
 		}
 		batchResponse, bifrostErr := g.client.BatchCreateRequest(bifrostCtx, batchReq.CreateRequest)
@@ -1537,7 +1588,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 
 	case schemas.BatchListRequest:
 		if batchReq.ListRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid batch list request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch list request"))
 			return
 		}
 		batchResponse, bifrostErr := g.client.BatchListRequest(bifrostCtx, batchReq.ListRequest)
@@ -1559,7 +1610,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 
 	case schemas.BatchRetrieveRequest:
 		if batchReq.RetrieveRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid batch retrieve request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch retrieve request"))
 			return
 		}
 		batchResponse, bifrostErr := g.client.BatchRetrieveRequest(bifrostCtx, batchReq.RetrieveRequest)
@@ -1581,7 +1632,7 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 
 	case schemas.BatchCancelRequest:
 		if batchReq.CancelRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid batch cancel request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch cancel request"))
 			return
 		}
 		batchResponse, bifrostErr := g.client.BatchCancelRequest(bifrostCtx, batchReq.CancelRequest)
@@ -1600,10 +1651,31 @@ func (g *GenericRouter) handleBatchRequest(ctx *fasthttp.RequestCtx, config Rout
 		} else {
 			response = batchResponse
 		}
+	case schemas.BatchDeleteRequest:
+		if batchReq.DeleteRequest == nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch delete request"))
+			return
+		}
+		batchResponse, bifrostErr := g.client.BatchDeleteRequest(bifrostCtx, batchReq.DeleteRequest)
+		if bifrostErr != nil {
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, bifrostErr)
+			return
+		}
+		if config.PostCallback != nil {
+			if err := config.PostCallback(ctx, req, batchResponse); err != nil {
+				g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(err, "failed to execute post-request callback"))
+				return
+			}
+		}
+		if config.BatchDeleteResponseConverter != nil {
+			response, err = config.BatchDeleteResponseConverter(bifrostCtx, batchResponse)
+		} else {
+			response = batchResponse
+		}
 
 	case schemas.BatchResultsRequest:
 		if batchReq.ResultsRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid batch results request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid batch results request"))
 			return
 		}
 		batchResponse, bifrostErr := g.client.BatchResultsRequest(bifrostCtx, batchReq.ResultsRequest)
@@ -1645,7 +1717,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 	switch fileReq.Type {
 	case schemas.FileUploadRequest:
 		if fileReq.UploadRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid file upload request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid file upload request"))
 			return
 		}
 		fileResponse, bifrostErr := g.client.FileUploadRequest(bifrostCtx, fileReq.UploadRequest)
@@ -1667,7 +1739,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 
 	case schemas.FileListRequest:
 		if fileReq.ListRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid file list request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid file list request"))
 			return
 		}
 		fileResponse, bifrostErr := g.client.FileListRequest(bifrostCtx, fileReq.ListRequest)
@@ -1698,7 +1770,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 
 	case schemas.FileRetrieveRequest:
 		if fileReq.RetrieveRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid file retrieve request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid file retrieve request"))
 			return
 		}
 		fileResponse, bifrostErr := g.client.FileRetrieveRequest(bifrostCtx, fileReq.RetrieveRequest)
@@ -1720,7 +1792,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 
 	case schemas.FileDeleteRequest:
 		if fileReq.DeleteRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid file delete request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid file delete request"))
 			return
 		}
 		fileResponse, bifrostErr := g.client.FileDeleteRequest(bifrostCtx, fileReq.DeleteRequest)
@@ -1742,7 +1814,7 @@ func (g *GenericRouter) handleFileRequest(ctx *fasthttp.RequestCtx, config Route
 
 	case schemas.FileContentRequest:
 		if fileReq.ContentRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid file content request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid file content request"))
 			return
 		}
 		fileResponse, bifrostErr := g.client.FileContentRequest(bifrostCtx, fileReq.ContentRequest)
@@ -1805,7 +1877,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 	switch containerReq.Type {
 	case schemas.ContainerCreateRequest:
 		if containerReq.CreateRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container create request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container create request"))
 			return
 		}
 		containerResponse, bifrostErr := g.client.ContainerCreateRequest(bifrostCtx, containerReq.CreateRequest)
@@ -1827,7 +1899,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 
 	case schemas.ContainerListRequest:
 		if containerReq.ListRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container list request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container list request"))
 			return
 		}
 		containerResponse, bifrostErr := g.client.ContainerListRequest(bifrostCtx, containerReq.ListRequest)
@@ -1849,7 +1921,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 
 	case schemas.ContainerRetrieveRequest:
 		if containerReq.RetrieveRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container retrieve request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container retrieve request"))
 			return
 		}
 		containerResponse, bifrostErr := g.client.ContainerRetrieveRequest(bifrostCtx, containerReq.RetrieveRequest)
@@ -1871,7 +1943,7 @@ func (g *GenericRouter) handleContainerRequest(ctx *fasthttp.RequestCtx, config 
 
 	case schemas.ContainerDeleteRequest:
 		if containerReq.DeleteRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container delete request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container delete request"))
 			return
 		}
 		containerResponse, bifrostErr := g.client.ContainerDeleteRequest(bifrostCtx, containerReq.DeleteRequest)
@@ -1912,7 +1984,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 	switch containerFileReq.Type {
 	case schemas.ContainerFileCreateRequest:
 		if containerFileReq.CreateRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container file create request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container file create request"))
 			return
 		}
 		containerFileResponse, bifrostErr := g.client.ContainerFileCreateRequest(bifrostCtx, containerFileReq.CreateRequest)
@@ -1934,7 +2006,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 
 	case schemas.ContainerFileListRequest:
 		if containerFileReq.ListRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container file list request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container file list request"))
 			return
 		}
 		containerFileResponse, bifrostErr := g.client.ContainerFileListRequest(bifrostCtx, containerFileReq.ListRequest)
@@ -1956,7 +2028,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 
 	case schemas.ContainerFileRetrieveRequest:
 		if containerFileReq.RetrieveRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container file retrieve request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container file retrieve request"))
 			return
 		}
 		containerFileResponse, bifrostErr := g.client.ContainerFileRetrieveRequest(bifrostCtx, containerFileReq.RetrieveRequest)
@@ -1978,7 +2050,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 
 	case schemas.ContainerFileContentRequest:
 		if containerFileReq.ContentRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container file content request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container file content request"))
 			return
 		}
 		containerFileResponse, bifrostErr := g.client.ContainerFileContentRequest(bifrostCtx, containerFileReq.ContentRequest)
@@ -2017,7 +2089,7 @@ func (g *GenericRouter) handleContainerFileRequest(ctx *fasthttp.RequestCtx, con
 
 	case schemas.ContainerFileDeleteRequest:
 		if containerFileReq.DeleteRequest == nil {
-			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid container file delete request"))
+			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "invalid container file delete request"))
 			return
 		}
 		containerFileResponse, bifrostErr := g.client.ContainerFileDeleteRequest(bifrostCtx, containerFileReq.DeleteRequest)
@@ -2107,7 +2179,10 @@ func (g *GenericRouter) handleStreamingRequest(ctx *fasthttp.RequestCtx, config 
 		ctx.Response.Header.Set("Connection", "keep-alive")
 		ctx.Response.Header.Set("Access-Control-Allow-Origin", "*")
 		cancel()
-		go func() { for range stream {} }()
+		go func() {
+			for range stream {
+			}
+		}()
 		return
 	}
 
@@ -2470,6 +2545,281 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 				g.logger.Warn("Failed to write SSE done marker: %v", err)
 				cancel()
 				return // End stream on error, Bifrost handles cleanup internally
+			}
+		}
+	})
+}
+
+// extractPassthroughModel extracts the model from the passthrough request path and/or body.
+// Path patterns: models/{model}, models/{model}:suffix (GenAI), .../models/{model} (Vertex), tunedModels/{model}.
+// Body is pre-parsed by parsePassthroughBody to avoid redundant unmarshaling.
+func extractPassthroughModel(path string, bodyModel string) string {
+	if model := extractModelFromPath(path); model != "" {
+		return model
+	}
+	return bodyModel
+}
+
+func extractModelFromPath(path string) string {
+	path = strings.TrimPrefix(path, "/")
+	parts := strings.Split(path, "/")
+	for i, p := range parts {
+		if p == "models" || p == "tunedModels" {
+			if i+1 < len(parts) {
+				model := parts[i+1]
+				// Strip :suffix for GenAI (e.g. :generateContent, :streamGenerateContent)
+				if idx := strings.Index(model, ":"); idx > 0 {
+					model = model[:idx]
+				}
+				return strings.TrimSpace(model)
+			}
+			break
+		}
+	}
+	return ""
+}
+
+// parsePassthroughBody extracts model and streaming flag from the request body in a
+// single unmarshal pass. Pass the raw Content-Type header value so multipart boundaries
+// are resolved from the header rather than scraped from the body bytes.
+func parsePassthroughBody(contentType string, body []byte) (model string, isStream bool) {
+	if len(body) == 0 {
+		return
+	}
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err == nil && strings.HasPrefix(mediaType, "multipart/") {
+		if boundary := params["boundary"]; boundary != "" {
+			return parseMultipartPassthroughBody(body, boundary)
+		}
+	}
+	// JSON (or unknown) body — one unmarshal for both fields.
+	var parsed struct {
+		Model  string `json:"model"`
+		Stream bool   `json:"stream"`
+	}
+	if err := sonic.Unmarshal(body, &parsed); err == nil {
+		model = strings.TrimSpace(parsed.Model)
+		isStream = parsed.Stream
+	}
+	return
+}
+
+// parseMultipartPassthroughBody scans multipart parts and extracts model and stream.
+//   - Form fields (Content-Disposition name="model"/"stream"): read as plain text.
+func parseMultipartPassthroughBody(body []byte, boundary string) (model string, isStream bool) {
+	mr := multipart.NewReader(bytes.NewReader(body), boundary)
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		// Plain form field — check by name.
+		switch part.FormName() {
+		case "model":
+			val, _ := io.ReadAll(part)
+			part.Close()
+			model = strings.TrimSpace(string(val))
+		case "stream":
+			val, _ := io.ReadAll(part)
+			part.Close()
+			s := strings.TrimSpace(strings.ToLower(string(val)))
+			isStream = s == "true" || s == "1"
+		default:
+			part.Close()
+		}
+
+		if model != "" && isStream {
+			break
+		}
+	}
+	return
+}
+
+func (g *GenericRouter) handlePassthrough(ctx *fasthttp.RequestCtx) {
+	cfg := g.passthroughCfg
+
+	safeHeaders := make(map[string]string)
+	ctx.Request.Header.All()(func(key, value []byte) bool {
+		keyStr := strings.ToLower(string(key))
+		switch keyStr {
+		case "authorization", "api-key", "x-api-key", "x-goog-api-key",
+			"host", "connection", "transfer-encoding", "cookie", "set-cookie", "proxy-authorization":
+		default:
+			if strings.HasPrefix(keyStr, "x-bf-") {
+				return true // drop internal gateway headers
+			}
+			safeHeaders[keyStr] = string(value)
+		}
+		return true
+	})
+
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, g.handlerStore.ShouldAllowDirectKeys(), g.handlerStore.GetHeaderFilterConfig())
+	if directKey := ctx.UserValue(string(schemas.BifrostContextKeyDirectKey)); directKey != nil {
+		if key, ok := directKey.(schemas.Key); ok {
+			bifrostCtx.SetValue(schemas.BifrostContextKeyDirectKey, key)
+		}
+	}
+
+	path := string(ctx.Path())
+	for _, prefix := range g.passthroughCfg.StripPrefix {
+		if strings.HasPrefix(path, prefix) {
+			path = path[len(prefix):]
+			break
+		}
+	}
+
+	body := ctx.Request.Body()
+	// Parse body once to get both model and stream flag.
+	contentType := string(ctx.Request.Header.ContentType())
+	bodyModel, bodyStream := parsePassthroughBody(contentType, body)
+	resolvedModel := extractPassthroughModel(path, bodyModel)
+	provider := cfg.Provider
+	if cfg.ProviderDetector != nil {
+		provider = cfg.ProviderDetector(ctx, resolvedModel)
+	}
+	provider = getProviderFromHeader(ctx, provider)
+	isStreaming := strings.Contains(strings.ToLower(path), "stream") || bodyStream
+
+	passthroughReq := &schemas.BifrostPassthroughRequest{
+		Method:      string(ctx.Method()),
+		Path:        path,
+		RawQuery:    string(ctx.URI().QueryString()),
+		Body:        body,
+		SafeHeaders: safeHeaders,
+		Provider:    provider,
+		Model:       resolvedModel,
+	}
+
+	if isStreaming {
+		g.handlePassthroughStream(ctx, bifrostCtx, cancel, provider, passthroughReq)
+	} else {
+		g.handlePassthroughNonStream(ctx, bifrostCtx, cancel, provider, passthroughReq)
+	}
+}
+
+func (g *GenericRouter) handlePassthroughNonStream(
+	ctx *fasthttp.RequestCtx,
+	bifrostCtx *schemas.BifrostContext,
+	cancel context.CancelFunc,
+	provider schemas.ModelProvider,
+	req *schemas.BifrostPassthroughRequest,
+) {
+	defer cancel()
+
+	resp, bifrostErr := g.client.Passthrough(bifrostCtx, provider, req)
+	if bifrostErr != nil {
+		g.sendError(ctx, bifrostCtx, func(_ *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		}, bifrostErr)
+		return
+	}
+
+	ctx.SetStatusCode(resp.StatusCode)
+	for k, v := range resp.Headers {
+		switch strings.ToLower(k) {
+		case "connection", "transfer-encoding", "set-cookie", "proxy-authenticate", "www-authenticate":
+			// drop
+		default:
+			ctx.Response.Header.Set(k, v)
+		}
+	}
+	ctx.Response.SetBody(resp.Body)
+}
+
+func (g *GenericRouter) handlePassthroughStream(
+	ctx *fasthttp.RequestCtx,
+	bifrostCtx *schemas.BifrostContext,
+	cancel context.CancelFunc,
+	provider schemas.ModelProvider,
+	req *schemas.BifrostPassthroughRequest,
+) {
+	stream, bifrostErr := g.client.PassthroughStream(bifrostCtx, provider, req)
+	if bifrostErr != nil {
+		cancel()
+		g.sendError(ctx, bifrostCtx, func(_ *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		}, bifrostErr)
+		return
+	}
+
+	// Read the first chunk to extract status code and headers before streaming begins.
+	firstChunk, ok := <-stream
+	if !ok {
+		cancel()
+		g.sendError(ctx, bifrostCtx, func(_ *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		}, newBifrostError(nil, "passthrough stream ended before headers were received"))
+		return
+	}
+	if firstChunk == nil {
+		cancel()
+		g.sendError(ctx, bifrostCtx, func(_ *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		}, newBifrostError(nil, "passthrough stream returned nil first chunk"))
+		return
+	}
+	if firstChunk.BifrostError != nil {
+		cancel()
+		g.sendError(ctx, bifrostCtx, func(_ *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		}, firstChunk.BifrostError)
+		return
+	}
+
+	passthroughResp := firstChunk.BifrostPassthroughResponse
+	if passthroughResp == nil {
+		cancel()
+		g.sendError(ctx, bifrostCtx, func(_ *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		}, newBifrostError(nil, "passthrough stream returned empty first chunk"))
+		return
+	}
+
+	ctx.SetStatusCode(passthroughResp.StatusCode)
+	ctx.SetConnectionClose()
+	for k, v := range passthroughResp.Headers {
+		switch strings.ToLower(k) {
+		case "connection", "transfer-encoding", "content-length", "set-cookie", "proxy-authenticate", "www-authenticate":
+			// drop — content-length is invalid for a streaming response
+		default:
+			ctx.Response.Header.Set(k, v)
+		}
+	}
+
+	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+		defer func() {
+			w.Flush()
+			cancel()
+		}()
+
+		// Write the first chunk's data.
+		if len(passthroughResp.Body) > 0 {
+			if _, err := w.Write(passthroughResp.Body); err != nil {
+				cancel()
+				return
+			}
+			if err := w.Flush(); err != nil {
+				cancel()
+				return
+			}
+		}
+
+		for chunk := range stream {
+			if chunk == nil {
+				continue
+			}
+			if chunk.BifrostError != nil {
+				break
+			}
+			if chunk.BifrostPassthroughResponse != nil && len(chunk.BifrostPassthroughResponse.Body) > 0 {
+				if _, err := w.Write(chunk.BifrostPassthroughResponse.Body); err != nil {
+					cancel()
+					return
+				}
+				if err := w.Flush(); err != nil {
+					cancel()
+					return
+				}
 			}
 		}
 	})

--- a/transports/bifrost-http/integrations/router_large_payload_test.go
+++ b/transports/bifrost-http/integrations/router_large_payload_test.go
@@ -38,7 +38,7 @@ func TestCreateHandler_SkipsRequestParserInLargePayloadMode(t *testing.T) {
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
 	router.SetLargePayloadHook(func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, routeType RouteConfigType) (bool, error) {
 		return true, nil
 	})
@@ -80,7 +80,7 @@ func TestCreateHandler_UsesRequestParserWhenNotInLargePayloadMode(t *testing.T) 
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
 
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -475,4 +477,19 @@ func ParseProviderScopedVideoID(videoID string) (schemas.ModelProvider, string, 
 	}
 
 	return provider, rawID, nil
+}
+
+func getProviderFromHeader(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) schemas.ModelProvider {
+	providerHeader := string(ctx.Request.Header.Peek("x-model-provider"))
+	if providerHeader == "" {
+		return defaultProvider
+	}
+	return schemas.ModelProvider(providerHeader)
+}
+
+func RegisterKVDecoders(store *kvstore.Store) {
+	store.RegisterDecoder("genai_upload_session:", func(data []byte) (any, error) {
+		var v gemini.GeminiResumableUploadSession
+		return &v, sonic.Unmarshal(data, &v)
+	})
 }

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -17,12 +17,12 @@ import (
 // testLogger implements schemas.Logger for testing (all no-ops)
 type testLogger struct{}
 
-func (t *testLogger) Debug(msg string, args ...any) {}
-func (t *testLogger) Info(msg string, args ...any)  {}
-func (t *testLogger) Warn(msg string, args ...any)  {}
-func (t *testLogger) Error(msg string, args ...any) {}
-func (t *testLogger) Fatal(msg string, args ...any) {}
-func (t *testLogger) SetLevel(level schemas.LogLevel) {}
+func (t *testLogger) Debug(msg string, args ...any)                     {}
+func (t *testLogger) Info(msg string, args ...any)                      {}
+func (t *testLogger) Warn(msg string, args ...any)                      {}
+func (t *testLogger) Error(msg string, args ...any)                     {}
+func (t *testLogger) Fatal(msg string, args ...any)                     {}
+func (t *testLogger) SetLevel(level schemas.LogLevel)                   {}
 func (t *testLogger) SetOutputType(outputType schemas.LoggerOutputType) {}
 func (t *testLogger) LogHTTPRequest(level schemas.LogLevel, msg string) schemas.LogEventBuilder {
 	return schemas.NoopLogEvent
@@ -39,7 +39,7 @@ func strPtr(s string) *string {
 }
 
 func newTestGenericRouter() *GenericRouter {
-	return NewGenericRouter(nil, &mockHandlerStore{}, nil, &testLogger{})
+	return NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, &testLogger{})
 }
 
 func newTestBifrostContext() *schemas.BifrostContext {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -26,6 +26,7 @@ import (
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/envutils"
+	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
@@ -69,6 +70,9 @@ type HandlerStore interface {
 	GetAsyncJobExecutor() *logstore.AsyncJobExecutor
 	// GetAsyncJobResultTTL returns the default TTL for async job results in seconds.
 	GetAsyncJobResultTTL() int
+	// GetKVStore returns the shared in-memory kvstore instance.
+	// Returns nil if not initialized.
+	GetKVStore() *kvstore.Store
 }
 
 // Retry backoff constants for validation
@@ -295,6 +299,8 @@ type Config struct {
 
 	// Async job executor (initialized during setup if LogsStore + governance are available)
 	AsyncJobExecutor *logstore.AsyncJobExecutor
+	// Shared in-memory kvstore for transport-level protocol coordination.
+	KVStore *kvstore.Store
 
 	// Catalog managers
 	ModelCatalog *modelcatalog.ModelCatalog
@@ -2541,6 +2547,11 @@ func (c *Config) GetAsyncJobResultTTL() int {
 		return c.ClientConfig.AsyncJobResultTTL
 	}
 	return logstore.DefaultAsyncJobResultTTL
+}
+
+// GetKVStore returns the shared in-memory kvstore instance.
+func (c *Config) GetKVStore() *kvstore.Store {
+	return c.KVStore
 }
 
 // GetLoadedMCPPlugins returns the current snapshot of loaded MCP plugins.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	dynamicPlugins "github.com/maximhq/bifrost/framework/plugins"
@@ -28,6 +29,7 @@ import (
 	"github.com/maximhq/bifrost/plugins/semanticcache"
 	"github.com/maximhq/bifrost/plugins/telemetry"
 	"github.com/maximhq/bifrost/transports/bifrost-http/handlers"
+	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/valyala/fasthttp"
@@ -1120,6 +1122,14 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config %v", err)
 	}
+	s.Config.KVStore, err = kvstore.New(kvstore.Config{
+		DefaultTTL:      30 * time.Minute,
+		CleanupInterval: 1 * time.Minute,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize kvstore: %w", err)
+	}
+	integrations.RegisterKVDecoders(s.Config.KVStore)
 	// Initialize WebSocket handler early so plugins can wire event broadcasters during Init.
 	// Log callbacks are registered later in RegisterAPIRoutes when logging plugin is available.
 	s.WebSocketHandler = handlers.NewWebSocketHandler(s.Ctx, s.Config.ClientConfig.AllowedOrigins)
@@ -1397,6 +1407,11 @@ func (s *BifrostHTTPServer) Start() error {
 			}
 			if s.Config != nil && s.Config.VectorStore != nil {
 				s.Config.VectorStore.Close(shutdownCtx, "")
+			}
+			if s.Config != nil && s.Config.KVStore != nil {
+				if err := s.Config.KVStore.Close(); err != nil {
+					logger.Warn("failed to close kvstore: %v", err)
+				}
 			}
 			logger.Info("storage engines cleanup completed")
 		}()

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1876,6 +1876,7 @@
             "batch_list": { "type": "boolean" },
             "batch_retrieve": { "type": "boolean" },
             "batch_cancel": { "type": "boolean" },
+            "batch_delete": { "type": "boolean" },
             "batch_results": { "type": "boolean" },
             "file_upload": { "type": "boolean" },
             "file_list": { "type": "boolean" },
@@ -1890,7 +1891,9 @@
             "container_file_list": { "type": "boolean" },
             "container_file_retrieve": { "type": "boolean" },
             "container_file_content": { "type": "boolean" },
-            "container_file_delete": { "type": "boolean" }
+            "container_file_delete": { "type": "boolean" },
+            "passthrough": { "type": "boolean" },
+            "passthrough_stream": { "type": "boolean" }
           },
           "additionalProperties": false
         },

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -57,6 +57,10 @@ interface LogDetailSheetProps {
 	handleDelete: (log: LogEntry) => void;
 }
 
+// Helper to detect passthrough operations
+const isPassthroughOperation = (object: string) =>
+	object === "passthrough" || object === "passthrough_stream";
+
 // Helper to detect container operations (for hiding irrelevant fields like Model/Tokens)
 const isContainerOperation = (object: string) => {
 	const containerTypes = [
@@ -88,8 +92,19 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 	// Guard against stale data: only use fullLog if it belongs to the currently opened log entry.
 	const rawRequest = fullLog?.id === log.id ? fullLog.raw_request : log.raw_request;
 	const rawResponse = fullLog?.id === log.id ? fullLog.raw_response : log.raw_response;
+	const passthroughRequestBody = fullLog?.id === log.id ? fullLog.passthrough_request_body : log.passthrough_request_body;
+	const passthroughResponseBody = fullLog?.id === log.id ? fullLog.passthrough_response_body : log.passthrough_response_body;
 
 	const isContainer = isContainerOperation(log.object);
+	const isPassthrough = isPassthroughOperation(log.object);
+	const passthroughParams = isPassthrough
+		? (log.params as {
+				method?: string;
+				path?: string;
+				raw_query?: string;
+				status_code?: number;
+		  })
+		: null;
 
 	// Taking out tool call
 	let toolsParameter = null;
@@ -276,15 +291,45 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								</>
 							)}
 
+							{/* Display passthrough params (method, path, raw_query, status_code) */}
+							{passthroughParams && (
+								<>
+									{passthroughParams.method && (
+										<LogEntryDetailsView className="w-full" label="Method" value={passthroughParams.method} />
+									)}
+									{passthroughParams.path && (
+										<LogEntryDetailsView className="w-full" label="Path" value={passthroughParams.path} />
+									)}
+									{passthroughParams.raw_query && (
+										<LogEntryDetailsView className="w-full" label="Query" value={passthroughParams.raw_query} />
+									)}
+									{(passthroughParams.status_code ?? 0) !== 0 && (
+										<LogEntryDetailsView
+											className="w-full"
+											label="Status Code"
+											value={passthroughParams.status_code}
+										/>
+									)}
+								</>
+							)}
+
 							{log.params &&
 								Object.keys(log.params).length > 0 &&
 								Object.entries(log.params)
-									.filter(([key]) => key !== "tools" && key !== "instructions" && key !== "audio")
+									.filter(([key]) => {
+										const passthroughKeys = ["method", "path", "raw_query", "status_code"];
+										return (
+											key !== "tools" &&
+											key !== "instructions" &&
+											key !== "audio" &&
+											!(isPassthrough && passthroughKeys.includes(key))
+										);
+									})
 									.filter(([_, value]) => typeof value === "boolean" || typeof value === "number" || typeof value === "string")
 									.map(([key, value]) => <LogEntryDetailsView key={key} className="w-full" label={key} value={value} />)}
 						</div>
 					</div>
-					{log.status === "success" && !isContainer && (
+					{log.status === "success" && !isContainer && !isPassthrough && (
 						<>
 							<DottedSeparator />
 							<div className="space-y-4">
@@ -570,6 +615,36 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 					</CollapsibleBox>
 				)}
 
+				{/* Passthrough request body */}
+				{isPassthrough && passthroughRequestBody && (() => {
+					return (
+						<CollapsibleBox title="Request Body" 									onCopy={() => {
+							try {
+								return JSON.stringify(JSON.parse(passthroughRequestBody || ""), null, 2);
+							} catch {
+								return passthroughRequestBody || "";
+							}
+						}}>
+							<CodeEditor
+								className="z-0 w-full"
+								shouldAdjustInitialHeight={true}
+								maxHeight={450}
+								wrap={true}
+								code={(() => {
+									try {
+										return JSON.stringify(JSON.parse(passthroughRequestBody || ""), null, 2);
+									} catch {
+										return passthroughRequestBody || "";
+									}
+								})()}
+								lang="json"
+								readonly={true}
+								options={{ scrollBeyondLastLine: false, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+							/>
+						</CollapsibleBox>
+					);
+				})()}
+
 				{/* Show conversation history for chat/text completions */}
 				{log.input_history && log.input_history.length > 1 && (
 					<>
@@ -659,6 +734,36 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									/>
 								</CollapsibleBox>
 							</>
+						)}
+						{/* Passthrough response body */}
+						{isPassthrough && passthroughResponseBody && (
+							<CollapsibleBox
+								title="Response Body"
+								onCopy={() => {
+									try {
+										return JSON.stringify(JSON.parse(passthroughResponseBody || ""), null, 2);
+									} catch {
+										return passthroughResponseBody || "";
+									}
+								}}
+							>
+								<CodeEditor
+									className="z-0 w-full"
+									shouldAdjustInitialHeight={true}
+									maxHeight={450}
+									wrap={true}
+									code={(() => {
+										try {
+											return JSON.stringify(JSON.parse(passthroughResponseBody || ""), null, 2);
+										} catch {
+											return passthroughResponseBody || "";
+										}
+									})()}
+									lang="json"
+									readonly={true}
+									options={{ scrollBeyondLastLine: false, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
+								/>
+							</CollapsibleBox>
 						)}
 						{rawRequest && (
 							<>

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -68,6 +68,8 @@ export const RequestTypes = [
 	"container_file_retrieve",
 	"container_file_content",
 	"container_file_delete",
+	"passthrough",
+	"passthrough_stream",
 ] as const;
 
 export const ProviderLabels: Record<ProviderName, string> = {
@@ -168,6 +170,7 @@ export const RequestTypeLabels = {
 	batch_list: "Batch List",
 	batch_retrieve: "Batch Retrieve",
 	batch_cancel: "Batch Cancel",
+	batch_delete: "Batch Delete",
 	batch_results: "Batch Results",
 
 	file_upload: "File Upload",
@@ -188,6 +191,9 @@ export const RequestTypeLabels = {
 	container_file_retrieve: "Container File Retrieve",
 	container_file_content: "Container File Content",
 	container_file_delete: "Container File Delete",
+
+	passthrough: "Passthrough",
+	passthrough_stream: "Passthrough Stream",
 } as const;
 
 export const RequestTypeColors = {
@@ -249,10 +255,14 @@ export const RequestTypeColors = {
 	container_file_content: "bg-sky-100 text-sky-800",
 	container_file_delete: "bg-rose-100 text-rose-800",
 
+	passthrough: "bg-slate-100 text-slate-800",
+	passthrough_stream: "bg-slate-200 text-slate-800",
+
 	batch_create: "bg-green-100 text-green-800",
 	batch_list: "bg-blue-100 text-blue-800",
 	batch_retrieve: "bg-red-100 text-red-800",
 	batch_cancel: "bg-yellow-100 text-yellow-800",
+	batch_delete: "bg-amber-100 text-amber-800",
 	batch_results: "bg-purple-100 text-purple-800",
 
 	file_upload: "bg-pink-100 text-pink-800",

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -471,9 +471,11 @@ export interface LogEntry {
 	created_at: string; // ISO string format from Go time.Time - when the log was first created
 	raw_request?: string; // Raw provider request
 	raw_response?: string; // Raw provider response
-	metadata?: Record<string, unknown>; // JSON metadata (e.g., isAsyncRequest)
 	is_large_payload_request?: boolean; // true if request used large payload streaming
 	is_large_payload_response?: boolean; // true if response used large payload streaming
+	passthrough_request_body?: string; // Raw passthrough request body (UTF-8)
+	passthrough_response_body?: string; // Raw passthrough response body (UTF-8)
+	metadata?: Record<string, string>; // JSON metadata (e.g., isAsyncRequest)
 }
 
 export interface LogFilters {


### PR DESCRIPTION
## Summary

This PR adds comprehensive batch delete functionality and passthrough support across all providers, along with an in-memory KV store for transport-level protocol coordination. It also enhances the GenAI integration with improved batch operations, file handling, and provider detection.

## Changes

- **Batch Delete Operations**: Added `BatchDelete` method to all providers with proper request/response handling and routing
- **Passthrough Support**: Implemented generic passthrough functionality allowing raw HTTP requests to be forwarded to providers with proper authentication and streaming support
- **KV Store Framework**: Added in-memory key-value store with TTL support, cleanup routines, and type decoders for cross-request state management
- **GenAI Integration Enhancements**: 
  - Improved batch create/list/retrieve/delete operations with proper Gemini format conversion
  - Enhanced file upload handling with resumable upload support via KV store sessions
  - Added dynamic provider detection (Gemini vs Vertex AI) based on URL patterns and auth headers
- **Provider Updates**: All providers now implement the new `BatchDelete` and `Passthrough` interface methods
- **Core Bifrost**: Added batch delete request handling and passthrough execution with key selection logic

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
# Core/Transports
go version
go test ./...

# Test batch delete operations
curl -X DELETE "http://localhost:8080/genai/v1beta/batches/{batch_id}" \
  -H "x-goog-api-key: your-key"

# Test passthrough functionality
curl -X GET "http://localhost:8080/genai/v1beta/files" \
  -H "x-goog-api-key: your-key"

# Test resumable file uploads
curl -X POST "http://localhost:8080/genai/upload/v1beta/files" \
  -H "Content-Type: application/json" \
  -H "x-goog-upload-header-content-type: text/plain" \
  -d '{"file": {"display_name": "test.txt"}}'
```

The KV store is automatically initialized with a 30-minute default TTL and 1-minute cleanup interval.

## Breaking changes

- [x] Yes

**Impact**: All provider implementations must now implement the new `BatchDelete` and `Passthrough` methods. The `Provider` interface has been extended with these required methods.

**Migration**: Existing custom providers need to add these method implementations. For providers that don't support these operations, they can return `providerUtils.NewUnsupportedOperationError()` as shown in the existing provider implementations.

## Security considerations

- Passthrough functionality properly strips sensitive headers (authorization, api keys) and re-applies provider-specific authentication
- KV store sessions use cryptographically secure random IDs for upload session management
- Provider detection logic prevents cross-provider request routing attacks by validating URL patterns and auth token formats

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable