### PR TITLE
fixed compilation issue

### DIFF
--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -107,7 +107,7 @@ export default function Providers() {
 	// When current provider is no longer configured (e.g. all keys deleted), switch to another configured provider
 	useEffect(() => {
 		if (!provider || configuredProviderNamesArr.length === 0) return;
-		const isCurrentConfigured = configuredProviderNamesArr.includes(provider);
+		const isCurrentConfigured = configuredProviderNamesArr.includes(provider as ModelProviderName);
 		if (!isCurrentConfigured) {
 			setProvider(configuredProviderNamesArr[0]);
 		}


### PR DESCRIPTION
## Summary

Fixed a TypeScript type error in the providers page by adding explicit type casting for the provider parameter when checking if it's included in the configured providers array.

## Changes

- Added type casting `(provider as ModelProviderName)` to resolve TypeScript compilation error when checking if the current provider exists in the configured providers list
- This ensures type compatibility between the `provider` variable and the `configuredProviderNamesArr.includes()` method

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the UI builds successfully and the providers page functions correctly when switching between configured providers.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Navigate to the workspace providers page and test provider switching functionality, especially when deleting all keys for the currently selected provider.

## Screenshots/Recordings

N/A - This is a TypeScript compilation fix with no visual changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a minor type casting fix with no security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable