### PR TITLE
adds gzip for azure speech stream

### DIFF
--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1046,12 +1046,15 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 		}()
 		// Always release response on exit; bodyStream close should prevent indefinite blocking.
 		defer providerUtils.ReleaseStreamingResponse(resp)
+		// Decompress gzip-encoded streams transparently (no-op for non-gzip)
+		reader, releaseGzip := providerUtils.DecompressStreamBody(resp)
+		defer releaseGzip()
 		// Setup cancellation handler to close body stream on ctx cancellation
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), provider.logger)
 		defer stopCancellation()
 
 		// Check if response is compressed
-		bodyStream := resp.BodyStream()
+		
 		chunkIndex := -1
 		startTime := time.Now()
 		lastChunkTime := startTime
@@ -1069,7 +1072,7 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 				return
 			}
 			// Read from stream
-			n, readErr := bodyStream.Read(readBuffer)
+			n, readErr := reader.Read(readBuffer)
 			if n > 0 {
 				accumulated = append(accumulated, readBuffer[:n]...)
 


### PR DESCRIPTION
## Summary

Adds transparent gzip decompression support to Azure provider's speech streaming functionality to properly handle compressed response streams.

## Changes

- Integrated `providerUtils.DecompressStreamBody()` to automatically detect and decompress gzip-encoded streams
- Replaced direct `bodyStream.Read()` calls with reads from the decompression reader
- Added proper cleanup with `defer releaseGzip()` to prevent resource leaks
- Maintains backward compatibility as decompression is a no-op for non-gzip streams

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Azure speech streaming with both compressed and uncompressed responses:

```sh
# Core/Transports
go version
go test ./...

# Test specifically with Azure provider speech streaming
go test ./core/providers/azure -v -run TestSpeechStream
```

Verify that gzip-compressed speech streams are properly decompressed and processed without corruption.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects stream decompression handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable