### PR TITLE
fix: fix model limit form validation

### DIFF
--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -100,6 +100,9 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		},
 	});
 
+	const parseLimit = (v: string | undefined) => { const n = parseFloat(v ?? ""); return !isNaN(n) && n > 0; };
+	const hasAnyLimit = parseLimit(form.watch("budgetMaxLimit")) || parseLimit(form.watch("tokenMaxLimit")) || parseLimit(form.watch("requestMaxLimit"));
+
 	useEffect(() => {
 		if (modelConfig) {
 			// Never reset form if user is editing - skip reset entirely
@@ -209,8 +212,8 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
 			<SheetContent
 				className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8"
-				onInteractOutside={(e) => { if (form.formState.isDirty) e.preventDefault(); }}
-				onEscapeKeyDown={(e) => { if (form.formState.isDirty) e.preventDefault(); }}
+				onInteractOutside={(e) => { if (isEditing ? form.formState.isDirty : (!!form.watch("modelName") || hasAnyLimit)) e.preventDefault(); }}
+				onEscapeKeyDown={(e) => { if (isEditing ? form.formState.isDirty : (!!form.watch("modelName") || hasAnyLimit)) e.preventDefault(); }}
 			>
 				<SheetHeader className="flex flex-col items-start p-0">
 					<SheetTitle>{isEditing ? "Edit Model Limit" : "Create Model Limit"}</SheetTitle>
@@ -405,12 +408,12 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 									<Tooltip>
 										<TooltipTrigger asChild>
 											<span className="inline-block">
-												<Button type="submit" disabled={isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit || !form.watch("modelName")}>
+												<Button type="submit" data-testid="model-limit-button-submit" disabled={isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit || !form.watch("modelName") || !hasAnyLimit}>
 													{isLoading ? "Saving..." : isEditing ? "Save Changes" : "Create Limit"}
 												</Button>
 											</span>
 										</TooltipTrigger>
-										{(isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit || !form.watch("modelName")) && (
+										{(isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit || !form.watch("modelName") || !hasAnyLimit) && (
 											<TooltipContent>
 												<p>
 													{!canSubmit
@@ -421,7 +424,9 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 																? "No changes made"
 																: !form.watch("modelName")
 																	? "Model name is required"
-																	: "Please fix validation errors"}
+																	: !hasAnyLimit
+																		? "At least one budget or rate limit is required"
+																		: "Please fix validation errors"}
 												</p>
 											</TooltipContent>
 										)}


### PR DESCRIPTION
## Summary

Enhanced the model limit sheet validation to require at least one limit type (budget, token, or request) and improved the sheet close prevention logic to handle both editing and creation scenarios appropriately.

## Changes

- Added validation to require at least one limit type (budgetMaxLimit, tokenMaxLimit, or requestMaxLimit) before allowing form submission
- Updated sheet close prevention logic to differentiate between editing mode (uses form dirty state) and creation mode (checks for model name or any limit values)
- Enhanced submit button tooltip to display specific error message when no limits are set
- Added `hasAnyLimit` computed value to track whether any limit fields have been populated

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the model limits section in the workspace
2. Try creating a new model limit with only a model name (no budget/rate limits) - submit should be disabled with tooltip "At least one budget or rate limit is required"
3. Add any limit value - submit should become enabled
4. Test sheet close prevention by entering a model name or limit values and attempting to click outside or press escape
5. Verify editing existing limits still works with the original dirty state logic

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a client-side validation enhancement.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable