### PR TITLE
adds graph fixes and new graphs in dashboard

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -816,6 +817,135 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 		Buckets:           buckets,
 		BucketSizeSeconds: bucketSizeSeconds,
 		Models:            models,
+	}, nil
+}
+
+// computePercentile computes the p-th percentile (0–1) from a pre-sorted float64 slice using linear interpolation.
+func computePercentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	rank := p * float64(len(sorted)-1)
+	lower := int(math.Floor(rank))
+	upper := int(math.Ceil(rank))
+	if lower == upper {
+		return sorted[lower]
+	}
+	frac := rank - float64(lower)
+	return sorted[lower]*(1-frac) + sorted[upper]*frac
+}
+
+// GetLatencyHistogram returns time-bucketed latency percentiles (avg, p90, p95, p99) for the given filters.
+func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*LatencyHistogramResult, error) {
+	if bucketSizeSeconds <= 0 {
+		bucketSizeSeconds = 3600
+	}
+
+	dialect := s.db.Dialector.Name()
+
+	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery = s.applyFilters(baseQuery, filters)
+	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
+	baseQuery = baseQuery.Where("latency IS NOT NULL")
+
+	var results []struct {
+		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
+		Latency        float64 `gorm:"column:latency"`
+	}
+
+	var selectClause string
+	switch dialect {
+	case "sqlite":
+		selectClause = fmt.Sprintf(
+			`(CAST(strftime('%%s', timestamp) AS INTEGER) / %d) * %d as bucket_timestamp, latency`,
+			bucketSizeSeconds, bucketSizeSeconds,
+		)
+	case "mysql":
+		selectClause = fmt.Sprintf(
+			`(FLOOR(UNIX_TIMESTAMP(timestamp) / %d) * %d) as bucket_timestamp, latency`,
+			bucketSizeSeconds, bucketSizeSeconds,
+		)
+	default:
+		selectClause = fmt.Sprintf(
+			`CAST(FLOOR(EXTRACT(EPOCH FROM timestamp) / %d) * %d AS BIGINT) as bucket_timestamp, latency`,
+			bucketSizeSeconds, bucketSizeSeconds,
+		)
+	}
+
+	if err := baseQuery.
+		Select(selectClause).
+		Order("bucket_timestamp ASC, latency ASC").
+		Find(&results).Error; err != nil {
+		return nil, fmt.Errorf("failed to get latency histogram: %w", err)
+	}
+
+	// Group latency values by bucket (already sorted by latency due to ORDER BY)
+	type bucketData struct {
+		latencies []float64
+	}
+	bucketMap := make(map[int64]*bucketData)
+	var orderedKeys []int64
+
+	for _, r := range results {
+		bd, exists := bucketMap[r.BucketTimestamp]
+		if !exists {
+			bd = &bucketData{}
+			bucketMap[r.BucketTimestamp] = bd
+			orderedKeys = append(orderedKeys, r.BucketTimestamp)
+		}
+		bd.latencies = append(bd.latencies, r.Latency)
+	}
+
+	// Compute stats per bucket
+	computedBuckets := make(map[int64]LatencyHistogramBucket, len(bucketMap))
+	for ts, bd := range bucketMap {
+		var sum float64
+		for _, v := range bd.latencies {
+			sum += v
+		}
+		computedBuckets[ts] = LatencyHistogramBucket{
+			Timestamp:     time.Unix(ts, 0).UTC(),
+			AvgLatency:    sum / float64(len(bd.latencies)),
+			P90Latency:    computePercentile(bd.latencies, 0.90),
+			P95Latency:    computePercentile(bd.latencies, 0.95),
+			P99Latency:    computePercentile(bd.latencies, 0.99),
+			TotalRequests: int64(len(bd.latencies)),
+		}
+	}
+
+	// Generate all bucket timestamps for the time range
+	allTimestamps := generateBucketTimestamps(filters.StartTime, filters.EndTime, bucketSizeSeconds)
+
+	if len(allTimestamps) == 0 {
+		// No time range: return what we have sorted by timestamp
+		buckets := make([]LatencyHistogramBucket, 0, len(computedBuckets))
+		for _, ts := range orderedKeys {
+			buckets = append(buckets, computedBuckets[ts])
+		}
+		return &LatencyHistogramResult{
+			Buckets:           buckets,
+			BucketSizeSeconds: bucketSizeSeconds,
+		}, nil
+	}
+
+	// Fill in all buckets, using zeros for missing timestamps
+	buckets := make([]LatencyHistogramBucket, len(allTimestamps))
+	for i, ts := range allTimestamps {
+		if bucket, exists := computedBuckets[ts]; exists {
+			buckets[i] = bucket
+		} else {
+			buckets[i] = LatencyHistogramBucket{
+				Timestamp: time.Unix(ts, 0).UTC(),
+			}
+		}
+	}
+
+	return &LatencyHistogramResult{
+		Buckets:           buckets,
+		BucketSizeSeconds: bucketSizeSeconds,
 	}, nil
 }
 

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -32,6 +32,7 @@ type LogStore interface {
 	GetTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*TokenHistogramResult, error)
 	GetCostHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*CostHistogramResult, error)
 	GetModelHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*ModelHistogramResult, error)
+	GetLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64) (*LatencyHistogramResult, error)
 	Update(ctx context.Context, id string, entry any) error
 	BulkUpdateCost(ctx context.Context, updates map[string]float64) error
 	Flush(ctx context.Context, since time.Time) error

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1078,3 +1078,19 @@ type ModelHistogramResult struct {
 	BucketSizeSeconds int64                  `json:"bucket_size_seconds"`
 	Models            []string               `json:"models"`
 }
+
+// LatencyHistogramBucket represents a single time bucket for latency data
+type LatencyHistogramBucket struct {
+	Timestamp     time.Time `json:"timestamp"`
+	AvgLatency    float64   `json:"avg_latency"`
+	P90Latency    float64   `json:"p90_latency"`
+	P95Latency    float64   `json:"p95_latency"`
+	P99Latency    float64   `json:"p99_latency"`
+	TotalRequests int64     `json:"total_requests"`
+}
+
+// LatencyHistogramResult represents the latency histogram query result
+type LatencyHistogramResult struct {
+	Buckets           []LatencyHistogramBucket `json:"buckets"`
+	BucketSizeSeconds int64                    `json:"bucket_size_seconds"`
+}

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -484,6 +484,11 @@ func (p *LoggerPlugin) GetModelHistogram(ctx context.Context, filters logstore.S
 	return p.store.GetModelHistogram(ctx, filters, bucketSizeSeconds)
 }
 
+// GetLatencyHistogram returns time-bucketed latency percentiles for the given filters
+func (p *LoggerPlugin) GetLatencyHistogram(ctx context.Context, filters logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.LatencyHistogramResult, error) {
+	return p.store.GetLatencyHistogram(ctx, filters, bucketSizeSeconds)
+}
+
 // GetAvailableModels returns all unique models from logs
 func (p *LoggerPlugin) GetAvailableModels(ctx context.Context) []string {
 	models, err := p.store.GetDistinctModels(ctx)

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -39,6 +39,9 @@ type LogManager interface {
 	// GetModelHistogram returns time-bucketed model usage with success/error breakdown for the given filters
 	GetModelHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.ModelHistogramResult, error)
 
+	// GetLatencyHistogram returns time-bucketed latency percentiles for the given filters
+	GetLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.LatencyHistogramResult, error)
+
 	// Get the number of dropped requests
 	GetDroppedRequests(ctx context.Context) int64
 
@@ -131,6 +134,13 @@ func (p *PluginLogManager) GetModelHistogram(ctx context.Context, filters *logst
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.GetModelHistogram(ctx, *filters, bucketSizeSeconds)
+}
+
+func (p *PluginLogManager) GetLatencyHistogram(ctx context.Context, filters *logstore.SearchFilters, bucketSizeSeconds int64) (*logstore.LatencyHistogramResult, error) {
+	if filters == nil {
+		return nil, fmt.Errorf("filters cannot be nil")
+	}
+	return p.plugin.GetLatencyHistogram(ctx, *filters, bucketSizeSeconds)
 }
 
 func (p *PluginLogManager) GetDroppedRequests(ctx context.Context) int64 {

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -50,6 +50,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/logs/histogram/tokens", lib.ChainMiddlewares(h.getLogsTokenHistogram, middlewares...))
 	r.GET("/api/logs/histogram/cost", lib.ChainMiddlewares(h.getLogsCostHistogram, middlewares...))
 	r.GET("/api/logs/histogram/models", lib.ChainMiddlewares(h.getLogsModelHistogram, middlewares...))
+	r.GET("/api/logs/histogram/latency", lib.ChainMiddlewares(h.getLogsLatencyHistogram, middlewares...))
 	r.GET("/api/logs/dropped", lib.ChainMiddlewares(h.getDroppedRequests, middlewares...))
 	r.GET("/api/logs/filterdata", lib.ChainMiddlewares(h.getAvailableFilterData, middlewares...))
 	r.DELETE("/api/logs", lib.ChainMiddlewares(h.deleteLogs, middlewares...))
@@ -486,6 +487,21 @@ func (h *LoggingHandler) getLogsModelHistogram(ctx *fasthttp.RequestCtx) {
 	if err != nil {
 		logger.Error("failed to get model histogram: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Model histogram calculation failed: %v", err))
+		return
+	}
+
+	SendJSON(ctx, result)
+}
+
+// getLogsLatencyHistogram handles GET /api/logs/histogram/latency - Get time-bucketed latency percentiles
+func (h *LoggingHandler) getLogsLatencyHistogram(ctx *fasthttp.RequestCtx) {
+	filters := parseHistogramFilters(ctx)
+	bucketSizeSeconds := calculateBucketSize(filters.StartTime, filters.EndTime)
+
+	result, err := h.logManager.GetLatencyHistogram(ctx, filters, bucketSizeSeconds)
+	if err != nil {
+		logger.Error("failed to get latency histogram: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Latency histogram calculation failed: %v", err))
 		return
 	}
 

--- a/ui/app/workspace/dashboard/components/chartCard.tsx
+++ b/ui/app/workspace/dashboard/components/chartCard.tsx
@@ -13,14 +13,19 @@ interface ChartCardProps {
 }
 
 export function ChartCard({ title, children, headerActions, loading, testId }: ChartCardProps) {
+	// loading = true;
 	if (loading) {
 		return (
 			<Card className="rounded-sm px-2 py-1 shadow-none" data-testid={testId}>
 				<div className="mb-3 flex items-center justify-between">
 					<span className="text-primary pl-2 text-sm font-medium">{title}</span>
-					{headerActions && <div className="flex items-center gap-2" data-testid={testId ? `${testId}-actions` : undefined}>{headerActions}</div>}
+					{headerActions && (
+						<div className="flex items-center gap-2" data-testid={testId ? `${testId}-actions` : undefined}>
+							{headerActions}
+						</div>
+					)}
 				</div>
-				<div style={{ height: "200px" }} data-testid="skeleton">
+				<div style={{ height: "200px", marginTop: -18, marginBottom: 6 }} data-testid={testId ? `${testId}-chart-skeleton` : undefined}>
 					<Skeleton className="h-full w-full" />
 				</div>
 			</Card>
@@ -29,7 +34,7 @@ export function ChartCard({ title, children, headerActions, loading, testId }: C
 
 	return (
 		<Card className="rounded-sm px-2 py-1 shadow-none" data-testid={testId}>
-			<div className=" flex items-center justify-between">
+			<div className="flex items-center justify-between">
 				<span className="text-primary pl-2 text-sm font-medium whitespace-nowrap">{title}</span>
 				{headerActions && (
 					<div className="flex items-center gap-2" data-testid={testId ? `${testId}-actions` : undefined}>

--- a/ui/app/workspace/dashboard/components/costChart.tsx
+++ b/ui/app/workspace/dashboard/components/costChart.tsx
@@ -74,8 +74,8 @@ export function CostChart({ data, chartType, startTime, endTime, selectedModel }
 				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
 			};
 			// Flatten by_model for easier chart access
-			models.forEach((model) => {
-				item[`model_${model}`] = bucket.by_model?.[model] || 0;
+			models.forEach((model, idx) => {
+				item[`model_${idx}`] = bucket.by_model?.[model] || 0;
 			});
 			return item;
 		});
@@ -123,7 +123,7 @@ export function CostChart({ data, chartType, startTime, endTime, selectedModel }
 						{displayModels.map((model, idx) => (
 							<Bar
 								key={model}
-								dataKey={`model_${model}`}
+								dataKey={`model_${idx}`}
 								stackId="cost"
 								fill={getModelColor(idx)}
 								fillOpacity={0.9}
@@ -159,7 +159,7 @@ export function CostChart({ data, chartType, startTime, endTime, selectedModel }
 							<Area
 								key={model}
 								type="monotone"
-								dataKey={`model_${model}`}
+								dataKey={`model_${idx}`}
 								stackId="1"
 								stroke={getModelColor(idx)}
 								fill={getModelColor(idx)}

--- a/ui/app/workspace/dashboard/components/latencyChart.tsx
+++ b/ui/app/workspace/dashboard/components/latencyChart.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import type { LatencyHistogramResponse } from "@/lib/types/logs";
+import { useMemo } from "react";
+import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { formatFullTimestamp, formatLatency, formatTimestamp, LATENCY_COLORS } from "../utils/chartUtils";
+import { ChartErrorBoundary } from "./chartErrorBoundary";
+import type { ChartType } from "./chartTypeToggle";
+
+interface LatencyChartProps {
+	data: LatencyHistogramResponse | null;
+	chartType: ChartType;
+	startTime: number;
+	endTime: number;
+}
+
+function CustomTooltip({ active, payload }: any) {
+	if (!active || !payload || !payload.length) return null;
+
+	const data = payload[0]?.payload;
+	if (!data) return null;
+
+	return (
+		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+			<div className="space-y-1 text-sm">
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
+						<span className="text-zinc-600 dark:text-zinc-400">Avg</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.avg_latency)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
+						<span className="text-zinc-600 dark:text-zinc-400">P90</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.p90_latency)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
+						<span className="text-zinc-600 dark:text-zinc-400">P95</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.p95_latency)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4">
+					<span className="flex items-center gap-1.5">
+						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
+						<span className="text-zinc-600 dark:text-zinc-400">P99</span>
+					</span>
+					<span className="font-medium">{formatLatency(data.p99_latency)}</span>
+				</div>
+				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
+					<span className="text-zinc-600 dark:text-zinc-400">Requests</span>
+					<span className="font-medium">{data.total_requests.toLocaleString()}</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function LatencyChart({ data, chartType, startTime, endTime }: LatencyChartProps) {
+	const chartData = useMemo(() => {
+		if (!data?.buckets || !data.bucket_size_seconds) {
+			return [];
+		}
+
+		return data.buckets.map((bucket, index) => ({
+			...bucket,
+			index,
+			formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+		}));
+	}, [data]);
+
+	if (!data?.buckets || chartData.length === 0) {
+		return <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>;
+	}
+
+	const commonProps = {
+		data: chartData,
+	};
+
+	return (
+		<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+			<ResponsiveContainer width="100%" height="100%">
+				{chartType === "bar" ? (
+					<BarChart {...commonProps} barCategoryGap={1}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500", dy: 5 }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={55}
+							tickFormatter={formatLatency}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
+						<Bar dataKey="avg_latency" fill={LATENCY_COLORS.avg} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
+						<Bar dataKey="p90_latency" fill={LATENCY_COLORS.p90} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
+						<Bar dataKey="p95_latency" fill={LATENCY_COLORS.p95} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
+						<Bar dataKey="p99_latency" fill={LATENCY_COLORS.p99} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
+					</BarChart>
+				) : (
+					<AreaChart {...commonProps}>
+						<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
+						<XAxis
+							dataKey="index"
+							type="number"
+							domain={[-0.5, chartData.length - 0.5]}
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+							interval="preserveStartEnd"
+						/>
+						<YAxis
+							tick={{ fontSize: 11, className: "fill-zinc-500" }}
+							tickLine={false}
+							axisLine={false}
+							width={55}
+							tickFormatter={formatLatency}
+							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
+							allowDataOverflow={false}
+						/>
+						<Tooltip content={<CustomTooltip />} />
+						{/* Render P99 first (behind), then overlay in descending order so Avg is in front */}
+						<Area type="monotone" dataKey="p99_latency" stroke={LATENCY_COLORS.p99} fill={LATENCY_COLORS.p99} fillOpacity={0.15} />
+						<Area type="monotone" dataKey="p95_latency" stroke={LATENCY_COLORS.p95} fill={LATENCY_COLORS.p95} fillOpacity={0.2} />
+						<Area type="monotone" dataKey="p90_latency" stroke={LATENCY_COLORS.p90} fill={LATENCY_COLORS.p90} fillOpacity={0.25} />
+						<Area type="monotone" dataKey="avg_latency" stroke={LATENCY_COLORS.avg} fill={LATENCY_COLORS.avg} fillOpacity={0.4} />
+					</AreaChart>
+				)}
+			</ResponsiveContainer>
+		</ChartErrorBoundary>
+	);
+}

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { FilterPopover } from "@/components/filters/filterPopover";
-import { Badge } from "@/components/ui/badge";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
 	useLazyGetLogsCostHistogramQuery,
 	useLazyGetLogsHistogramQuery,
+	useLazyGetLogsLatencyHistogramQuery,
 	useLazyGetLogsModelHistogramQuery,
 	useLazyGetLogsTokenHistogramQuery,
 } from "@/lib/store";
 import type {
 	CostHistogramResponse,
+	LatencyHistogramResponse,
 	LogFilters,
 	LogsHistogramResponse,
 	ModelHistogramResponse,
@@ -23,11 +24,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChartCard } from "./components/chartCard";
 import { type ChartType, ChartTypeToggle } from "./components/chartTypeToggle";
 import { CostChart } from "./components/costChart";
+import { LatencyChart } from "./components/latencyChart";
 import { LogVolumeChart } from "./components/logVolumeChart";
 import { ModelFilterSelect } from "./components/modelFilterSelect";
 import { ModelUsageChart } from "./components/modelUsageChart";
 import { TokenUsageChart } from "./components/tokenUsageChart";
-import { CHART_COLORS, getModelColor } from "./utils/chartUtils";
+import { CHART_COLORS, getModelColor, LATENCY_COLORS } from "./utils/chartUtils";
 
 // Type-safe parser for chart type URL state
 const toChartType = (value: string): ChartType => (value === "line" ? "line" : "bar");
@@ -73,18 +75,21 @@ export default function DashboardPage() {
 	const [tokenData, setTokenData] = useState<TokenHistogramResponse | null>(null);
 	const [costData, setCostData] = useState<CostHistogramResponse | null>(null);
 	const [modelData, setModelData] = useState<ModelHistogramResponse | null>(null);
+	const [latencyData, setLatencyData] = useState<LatencyHistogramResponse | null>(null);
 
 	// Loading states
 	const [loadingHistogram, setLoadingHistogram] = useState(true);
 	const [loadingTokens, setLoadingTokens] = useState(true);
 	const [loadingCost, setLoadingCost] = useState(true);
 	const [loadingModels, setLoadingModels] = useState(true);
+	const [loadingLatency, setLoadingLatency] = useState(true);
 
 	// RTK Query lazy hooks
 	const [triggerHistogram] = useLazyGetLogsHistogramQuery({});
 	const [triggerTokens] = useLazyGetLogsTokenHistogramQuery();
 	const [triggerCost] = useLazyGetLogsCostHistogramQuery();
 	const [triggerModels] = useLazyGetLogsModelHistogramQuery();
+	const [triggerLatency] = useLazyGetLogsLatencyHistogramQuery();
 
 	// URL state management
 	const [urlState, setUrlState] = useQueryStates(
@@ -105,6 +110,7 @@ export default function DashboardPage() {
 			token_chart: parseAsString.withDefault("bar"),
 			cost_chart: parseAsString.withDefault("bar"),
 			model_chart: parseAsString.withDefault("bar"),
+			latency_chart: parseAsString.withDefault("bar"),
 			cost_model: parseAsString.withDefault("all"),
 			usage_model: parseAsString.withDefault("all"),
 		},
@@ -167,7 +173,11 @@ export default function DashboardPage() {
 		[urlState.start_time, urlState.end_time],
 	);
 
-	// Available models for dropdowns
+	// Model lists for each chart's legend (must match what the chart component actually renders)
+	const costModels = useMemo(() => costData?.models ?? [], [costData?.models]);
+	const usageModels = useMemo(() => modelData?.models ?? [], [modelData?.models]);
+
+	// Available models for filter dropdowns (union of both sources)
 	const availableModels = useMemo(() => {
 		if (costData?.models?.length) return costData.models;
 		return modelData?.models ?? [];
@@ -179,37 +189,54 @@ export default function DashboardPage() {
 		setLoadingTokens(true);
 		setLoadingCost(true);
 		setLoadingModels(true);
+		setLoadingLatency(true);
 
 		const fetchFilters = { filters };
 
 		// Fetch all in parallel, forcing fresh data (preferCacheValue: false bypasses RTK Query cache)
-		const [histogramResult, tokenResult, costResult, modelResult] = await Promise.all([
+		const [histogramResult, tokenResult, costResult, modelResult, latencyResult] = await Promise.all([
 			triggerHistogram(fetchFilters, false),
 			triggerTokens(fetchFilters, false),
 			triggerCost(fetchFilters, false),
 			triggerModels(fetchFilters, false),
+			triggerLatency(fetchFilters, false),
 		]);
 
 		if (histogramResult.data) {
 			setHistogramData(histogramResult.data);
+		} else {
+			setHistogramData(null);
 		}
 		setLoadingHistogram(false);
 
 		if (tokenResult.data) {
 			setTokenData(tokenResult.data);
+		} else {
+			setTokenData(null);
 		}
 		setLoadingTokens(false);
 
 		if (costResult.data) {
 			setCostData(costResult.data);
+		} else {
+			setCostData(null);
 		}
 		setLoadingCost(false);
 
 		if (modelResult.data) {
 			setModelData(modelResult.data);
+		} else {
+			setModelData(null);
 		}
 		setLoadingModels(false);
-	}, [filters, triggerHistogram, triggerTokens, triggerCost, triggerModels]);
+
+		if (latencyResult.data) {
+			setLatencyData(latencyResult.data);
+		} else {
+			setLatencyData(null);
+		}
+		setLoadingLatency(false);
+	}, [filters, triggerHistogram, triggerTokens, triggerCost, triggerModels, triggerLatency]);
 
 	// Fetch data on mount and when filters change
 	useEffect(() => {
@@ -248,6 +275,7 @@ export default function DashboardPage() {
 	const handleTokenChartToggle = useCallback((type: ChartType) => setUrlState({ token_chart: type }), [setUrlState]);
 	const handleCostChartToggle = useCallback((type: ChartType) => setUrlState({ cost_chart: type }), [setUrlState]);
 	const handleModelChartToggle = useCallback((type: ChartType) => setUrlState({ model_chart: type }), [setUrlState]);
+	const handleLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ latency_chart: type }), [setUrlState]);
 
 	// Filter change handler for FilterPopover
 	const handleFilterChange = useCallback(
@@ -283,10 +311,7 @@ export default function DashboardPage() {
 			{/* Header with time filter */}
 			<div className="flex items-center justify-between">
 				<div className="flex items-center gap-2">
-					<h1 className="text-lg font-semibold">Dashboard </h1>
-					<Badge variant="secondary" className="text-xs">
-						BETA
-					</Badge>
+					<h1 className="text-lg font-semibold">Dashboard </h1>					
 				</div>
 				<div className="flex items-center gap-2">
 					<FilterPopover filters={filters} onFilterChange={handleFilterChange} />
@@ -303,7 +328,7 @@ export default function DashboardPage() {
 			</div>
 
 			{/* Charts Grid */}
-			<div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+			<div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
 				{/* Log Volume Chart */}
 				<ChartCard
 					title="Request Volume"
@@ -379,25 +404,25 @@ export default function DashboardPage() {
 						<div className="flex items-center gap-3">
 							<div className="flex items-center gap-2 text-xs">
 								{urlState.cost_model === "all" ? (
-									availableModels.length > 0 && (
+									costModels.length > 0 && (
 										<>
 											<Tooltip>
 												<TooltipTrigger asChild>
 													<span className="flex items-center gap-1">
 														<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-														<span className="text-muted-foreground max-w-[100px] truncate">{availableModels[0]}</span>
+														<span className="text-muted-foreground max-w-[100px] truncate">{costModels[0]}</span>
 													</span>
 												</TooltipTrigger>
-												<TooltipContent>{availableModels[0]}</TooltipContent>
+												<TooltipContent>{costModels[0]}</TooltipContent>
 											</Tooltip>
-											{availableModels.length > 1 && (
+											{costModels.length > 1 && (
 												<Tooltip>
 													<TooltipTrigger asChild>
-														<span className="text-muted-foreground cursor-default">+{availableModels.length - 1} more</span>
+														<span className="text-muted-foreground cursor-default">+{costModels.length - 1} more</span>
 													</TooltipTrigger>
 													<TooltipContent>
 														<div className="flex flex-col gap-1">
-															{availableModels.slice(1).map((model, idx) => (
+															{costModels.slice(1).map((model, idx) => (
 																<span key={model} className="flex items-center gap-1">
 																	<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
 																	{model}
@@ -415,7 +440,7 @@ export default function DashboardPage() {
 											<span className="flex items-center gap-1">
 												<span
 													className="h-2 w-2 shrink-0 rounded-full"
-													style={{ backgroundColor: getModelColor(Math.max(0, availableModels.indexOf(urlState.cost_model))) }}
+													style={{ backgroundColor: getModelColor(0) }}
 												/>
 												<span className="text-muted-foreground max-w-[100px] truncate">{urlState.cost_model}</span>
 											</span>
@@ -456,25 +481,25 @@ export default function DashboardPage() {
 						<div className="flex items-center gap-3">
 							<div className="flex items-center gap-2 text-xs">
 								{urlState.usage_model === "all" ? (
-									availableModels.length > 0 && (
+									usageModels.length > 0 && (
 										<>
 											<Tooltip>
 												<TooltipTrigger asChild>
 													<span className="flex items-center gap-1">
 														<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-														<span className="text-muted-foreground max-w-[100px] truncate">{availableModels[0]}</span>
+														<span className="text-muted-foreground max-w-[100px] truncate">{usageModels[0]}</span>
 													</span>
 												</TooltipTrigger>
-												<TooltipContent>{availableModels[0]}</TooltipContent>
+												<TooltipContent>{usageModels[0]}</TooltipContent>
 											</Tooltip>
-											{availableModels.length > 1 && (
+											{usageModels.length > 1 && (
 												<Tooltip>
 													<TooltipTrigger asChild>
-														<span className="text-muted-foreground cursor-default">+{availableModels.length - 1} more</span>
+														<span className="text-muted-foreground cursor-default">+{usageModels.length - 1} more</span>
 													</TooltipTrigger>
 													<TooltipContent>
 														<div className="flex flex-col gap-1">
-															{availableModels.slice(1).map((model, idx) => (
+															{usageModels.slice(1).map((model, idx) => (
 																<span key={model} className="flex items-center gap-1">
 																	<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
 																	{model}
@@ -519,6 +544,47 @@ export default function DashboardPage() {
 						startTime={urlState.start_time}
 						endTime={urlState.end_time}
 						selectedModel={urlState.usage_model}
+					/>
+				</ChartCard>
+
+				{/* Latency Chart */}
+				<ChartCard
+					title="Latency"
+					loading={loadingLatency}
+					testId="chart-latency"
+					headerActions={
+						<div className="flex items-center gap-3">
+							<div className="flex items-center gap-2 text-xs">
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
+									<span className="text-muted-foreground">Avg</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
+									<span className="text-muted-foreground">P90</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
+									<span className="text-muted-foreground">P95</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
+									<span className="text-muted-foreground">P99</span>
+								</span>
+							</div>
+							<ChartTypeToggle
+								chartType={toChartType(urlState.latency_chart)}
+								onToggle={handleLatencyChartToggle}
+								data-testid="dashboard-latency-chart-toggle"
+							/>
+						</div>
+					}
+				>
+					<LatencyChart
+						data={latencyData}
+						chartType={toChartType(urlState.latency_chart)}
+						startTime={urlState.start_time}
+						endTime={urlState.end_time}
 					/>
 				</ChartCard>
 			</div>

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -64,6 +64,20 @@ export function getModelColor(index: number): string {
 	return MODEL_COLORS[index % MODEL_COLORS.length];
 }
 
+// Format latency values
+export function formatLatency(ms: number): string {
+	if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+	return `${ms.toFixed(0)}ms`;
+}
+
+// Latency chart color palette
+export const LATENCY_COLORS = {
+	avg: "#06b6d4", // cyan-500
+	p90: "#3b82f6", // blue-500
+	p95: "#f59e0b", // amber-500
+	p99: "#ef4444", // red-500
+};
+
 // Chart colors
 export const CHART_COLORS = {
 	success: "#10b981", // emerald-500

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -38,7 +38,7 @@ import {
 	UserRoundCheck,
 	Users,
 	Wallet,
-	WalletCards
+	WalletCards,
 } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -175,7 +175,7 @@ const SidebarItemView = ({
 	pathname,
 	router,
 	isSidebarCollapsed,
-	expandSidebar,	
+	expandSidebar,
 	highlightedUrl,
 }: {
 	item: SidebarItem;
@@ -187,7 +187,7 @@ const SidebarItemView = ({
 	pathname: string;
 	router: ReturnType<typeof useRouter>;
 	isSidebarCollapsed: boolean;
-	expandSidebar: () => void;	
+	expandSidebar: () => void;
 	highlightedUrl?: string;
 }) => {
 	const hasSubItems = "subItems" in item && item.subItems && item.subItems.length > 0;
@@ -512,7 +512,6 @@ export default function AppSidebar() {
 				title: "Plugins",
 				url: "/workspace/plugins",
 				icon: Puzzle,
-				tag: "BETA",
 				description: "Manage custom plugins",
 				hasAccess: hasPluginsAccess,
 			},

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -1,6 +1,7 @@
 import { RedactedDBKey, VirtualKey } from "@/lib/types/governance";
 import {
 	CostHistogramResponse,
+	LatencyHistogramResponse,
 	LogEntry,
 	LogFilters,
 	LogsHistogramResponse,
@@ -43,10 +44,10 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 	}
 	if (filters.start_time) params.start_time = filters.start_time;
 	if (filters.end_time) params.end_time = filters.end_time;
-	if (filters.min_latency) params.min_latency = filters.min_latency;
-	if (filters.max_latency) params.max_latency = filters.max_latency;
-	if (filters.min_tokens) params.min_tokens = filters.min_tokens;
-	if (filters.max_tokens) params.max_tokens = filters.max_tokens;
+	if (filters.min_latency !== undefined) params.min_latency = filters.min_latency;
+	if (filters.max_latency !== undefined) params.max_latency = filters.max_latency;
+	if (filters.min_tokens !== undefined) params.min_tokens = filters.min_tokens;
+	if (filters.max_tokens !== undefined) params.max_tokens = filters.max_tokens;
 	if (filters.missing_cost_only) params.missing_cost_only = "true";
 	if (filters.content_search) params.content_search = filters.content_search;
 
@@ -103,10 +104,10 @@ export const logsApi = baseApi.injectEndpoints({
 				}
 				if (filters.start_time) params.start_time = filters.start_time;
 				if (filters.end_time) params.end_time = filters.end_time;
-				if (filters.min_latency) params.min_latency = filters.min_latency;
-				if (filters.max_latency) params.max_latency = filters.max_latency;
-				if (filters.min_tokens) params.min_tokens = filters.min_tokens;
-				if (filters.max_tokens) params.max_tokens = filters.max_tokens;
+				if (filters.min_latency !== undefined) params.min_latency = filters.min_latency;
+				if (filters.max_latency !== undefined) params.max_latency = filters.max_latency;
+				if (filters.min_tokens !== undefined) params.min_tokens = filters.min_tokens;
+				if (filters.max_tokens !== undefined) params.max_tokens = filters.max_tokens;
 				if (filters.missing_cost_only) params.missing_cost_only = "true";
 				if (filters.content_search) params.content_search = filters.content_search;
 
@@ -155,10 +156,10 @@ export const logsApi = baseApi.injectEndpoints({
 				}
 				if (filters.start_time) params.start_time = filters.start_time;
 				if (filters.end_time) params.end_time = filters.end_time;
-				if (filters.min_latency) params.min_latency = filters.min_latency;
-				if (filters.max_latency) params.max_latency = filters.max_latency;
-				if (filters.min_tokens) params.min_tokens = filters.min_tokens;
-				if (filters.max_tokens) params.max_tokens = filters.max_tokens;
+				if (filters.min_latency !== undefined) params.min_latency = filters.min_latency;
+				if (filters.max_latency !== undefined) params.max_latency = filters.max_latency;
+				if (filters.min_tokens !== undefined) params.min_tokens = filters.min_tokens;
+				if (filters.max_tokens !== undefined) params.max_tokens = filters.max_tokens;
 				if (filters.missing_cost_only) params.missing_cost_only = "true";
 				if (filters.content_search) params.content_search = filters.content_search;
 
@@ -226,6 +227,20 @@ export const logsApi = baseApi.injectEndpoints({
 			providesTags: ["Logs"],
 		}),
 
+		// Get latency histogram with percentiles
+		getLogsLatencyHistogram: builder.query<
+			LatencyHistogramResponse,
+			{
+				filters: LogFilters;
+			}
+		>({
+			query: ({ filters }) => ({
+				url: "/logs/histogram/latency",
+				params: buildFilterParams(filters),
+			}),
+			providesTags: ["Logs"],
+		}),
+
 		// Get dropped requests count
 		getDroppedRequests: builder.query<{ dropped_requests: number }, void>({
 			query: () => "/logs/dropped",
@@ -275,6 +290,7 @@ export const {
 	useGetLogsTokenHistogramQuery,
 	useGetLogsCostHistogramQuery,
 	useGetLogsModelHistogramQuery,
+	useGetLogsLatencyHistogramQuery,
 	useGetDroppedRequestsQuery,
 	useGetAvailableFilterDataQuery,
 	useLazyGetLogsQuery,
@@ -283,6 +299,7 @@ export const {
 	useLazyGetLogsTokenHistogramQuery,
 	useLazyGetLogsCostHistogramQuery,
 	useLazyGetLogsModelHistogramQuery,
+	useLazyGetLogsLatencyHistogramQuery,
 	useLazyGetDroppedRequestsQuery,
 	useLazyGetAvailableFilterDataQuery,
 	useDeleteLogsMutation,

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -563,6 +563,21 @@ export interface ModelHistogramResponse {
 	models: string[];
 }
 
+// Latency histogram types
+export interface LatencyHistogramBucket {
+	timestamp: string;
+	avg_latency: number;
+	p90_latency: number;
+	p95_latency: number;
+	p99_latency: number;
+	total_requests: number;
+}
+
+export interface LatencyHistogramResponse {
+	buckets: LatencyHistogramBucket[];
+	bucket_size_seconds: number;
+}
+
 export interface LogsResponse {
 	logs: LogEntry[];
 	pagination: Pagination;


### PR DESCRIPTION
## Summary

Adds latency histogram functionality to provide time-bucketed latency percentiles (avg, P90, P95, P99) for request monitoring and performance analysis.

## Issues

Closes #1703 

## Changes

- Added `GetLatencyHistogram` method to the logstore interface and RDB implementation with database-agnostic SQL queries for SQLite, MySQL, and PostgreSQL
- Implemented `computePercentile` function using linear interpolation for accurate percentile calculations from sorted latency data
- Created new API endpoint `/api/logs/histogram/latency` in the HTTP transport layer
- Added `LatencyHistogramBucket` and `LatencyHistogramResponse` types to support the new data structure
- Built React component `LatencyChart` with support for both bar and area chart visualizations
- Integrated latency chart into the dashboard with proper legends, tooltips, and chart type toggles
- Added RTK Query hooks and API integration for fetching latency histogram data
- Enhanced chart utilities with latency formatting and color palette for percentile visualization
- Fixed model name sanitization in cost charts to handle special characters that interfere with Recharts

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify the latency histogram functionality works across different database backends and chart types:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test the new latency chart by:
1. Navigate to the dashboard
2. Ensure logs with latency data exist in the system
3. Verify the latency chart displays avg, P90, P95, and P99 percentiles
4. Toggle between bar and area chart types
5. Test filtering by time range and other log filters
6. Verify tooltips show formatted latency values and request counts

## Screenshots/Recordings

The dashboard now includes a third chart showing latency percentiles with color-coded lines/bars for different percentile levels and interactive tooltips displaying formatted latency values.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enhances monitoring capabilities by providing latency performance insights alongside existing request volume, token usage, cost, and model usage metrics.

## Security considerations

No security implications - uses existing authentication and authorization patterns for log data access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable