### PR TITLE
adds minor dashboard height fix

### DIFF
--- a/tests/configs/mocker/config.json
+++ b/tests/configs/mocker/config.json
@@ -1,0 +1,233 @@
+{
+    "$schema": "https://www.getbifrost.ai/schema",
+    "client": {
+        "enable_logging": true,
+        "initial_pool_size": 1000
+    },
+    "config_store": {
+        "enabled": true,
+        "type": "sqlite",
+        "config": {
+            "path": "../../tests/configs/mocker/config.db"
+        }
+    },
+    "logs_store": {
+        "enabled": true,
+        "type": "sqlite",
+        "config": {
+            "path": "../../tests/configs/mocker/logs.db"
+        }
+    },
+    "providers": {
+        "openai": {
+            "keys": [
+                {
+                    "name": "mock-openai",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "anthropic": {
+            "keys": [
+                {
+                    "name": "mock-anthropic",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "cohere": {
+            "keys": [
+                {
+                    "name": "mock-cohere",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "mistral": {
+            "keys": [
+                {
+                    "name": "mock-mistral",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "ollama": {
+            "keys": [
+                {
+                    "name": "mock-ollama",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "groq": {
+            "keys": [
+                {
+                    "name": "mock-groq",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "gemini": {
+            "keys": [
+                {
+                    "name": "mock-gemini",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "openrouter": {
+            "keys": [
+                {
+                    "name": "mock-openrouter",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "sgl": {
+            "keys": [
+                {
+                    "name": "mock-sgl",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "parasail": {
+            "keys": [
+                {
+                    "name": "mock-parasail",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "perplexity": {
+            "keys": [
+                {
+                    "name": "mock-perplexity",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "cerebras": {
+            "keys": [
+                {
+                    "name": "mock-cerebras",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "elevenlabs": {
+            "keys": [
+                {
+                    "name": "mock-elevenlabs",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "huggingface": {
+            "keys": [
+                {
+                    "name": "mock-huggingface",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        },
+        "replicate": {
+            "keys": [
+                {
+                    "name": "mock-replicate",
+                    "value": "mock-key",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "base_url": "http://localhost:8000",
+                "default_request_timeout_in_seconds": 120,
+                "max_retries": 0
+            }
+        }
+    }
+}

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -307,11 +307,11 @@ export default function DashboardPage() {
 	const handleUsageModelChange = useCallback((model: string) => setUrlState({ usage_model: model }), [setUrlState]);
 
 	return (
-		<div className="mx-auto flex h-full w-full flex-col gap-4">
+		<div className="mx-auto flex h-full min-h-screen w-full flex-col gap-4">
 			{/* Header with time filter */}
 			<div className="flex items-center justify-between">
 				<div className="flex items-center gap-2">
-					<h1 className="text-lg font-semibold">Dashboard </h1>					
+					<h1 className="text-lg font-semibold">Dashboard </h1>
 				</div>
 				<div className="flex items-center gap-2">
 					<FilterPopover filters={filters} onFilterChange={handleFilterChange} />
@@ -438,10 +438,7 @@ export default function DashboardPage() {
 									<Tooltip>
 										<TooltipTrigger asChild>
 											<span className="flex items-center gap-1">
-												<span
-													className="h-2 w-2 shrink-0 rounded-full"
-													style={{ backgroundColor: getModelColor(0) }}
-												/>
+												<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
 												<span className="text-muted-foreground max-w-[100px] truncate">{urlState.cost_model}</span>
 											</span>
 										</TooltipTrigger>


### PR DESCRIPTION
## Summary

Adds a comprehensive mock configuration for testing and improves the dashboard UI layout by fixing height constraints.

## Changes

- Created a new test configuration file `tests/configs/mocker/config.json` with mock API keys and localhost endpoints for 15 AI providers including OpenAI, Anthropic, Cohere, Mistral, Ollama, Groq, Gemini, OpenRouter, SGL, Parasail, Perplexity, Cerebras, ElevenLabs, HuggingFace, and Replicate
- All providers are configured to use `http://localhost:8000` as the base URL with 120-second timeouts and no retries
- Added `min-h-screen` class to the dashboard container to ensure proper full-screen height
- Minor code formatting cleanup in the dashboard component

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

Validate the mock configuration and UI changes:

```sh
# Verify the mock config is valid JSON
cat tests/configs/mocker/config.json | jq .

# Test UI changes
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

The mock configuration enables testing against a local mock server running on port 8000 that can simulate responses from all supported AI providers.

## Screenshots/Recordings

The dashboard now properly fills the full screen height without layout issues.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The mock configuration uses placeholder API keys (`mock-key`) and localhost endpoints, making it safe for testing environments without exposing real credentials.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable