### PR TITLE
fix: default Anthropic error type to "api_error" instead of empty string

### DIFF
--- a/core/providers/anthropic/errors.go
+++ b/core/providers/anthropic/errors.go
@@ -16,10 +16,10 @@ func ToAnthropicChatCompletionError(bifrostErr *schemas.BifrostError) *Anthropic
 	}
 
 	// Safely extract type and message from nested error
-	errorType := ""
+	errorType := "api_error"
 	message := ""
 	if bifrostErr.Error != nil {
-		if bifrostErr.Error.Type != nil {
+		if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type != "" {
 			errorType = *bifrostErr.Error.Type
 		}
 		message = bifrostErr.Error.Message


### PR DESCRIPTION
Fixes #1877.

When bifrost proxies certain errors through the Anthropic SSE endpoint, the inner `error.type` field can end up as an empty string `""`:

- **Connection-level failures** (`ErrProviderDoRequest`, `ErrProviderNetworkError`): `BifrostError.Error.Type` is nil, so `errorType` defaults to `""`.
- **Provider errors with empty type** (e.g. Azure rate limits): some providers return `"type":""` themselves, which bifrost passes through unchanged.

`AnthropicMessageErrorStruct.Type` is a plain `string` with no `omitempty`, so `""` always serializes into the response.

This breaks consumers that use `type` as a union discriminator (e.g. the Vercel AI SDK's Zod schema for Anthropic errors), causing `Type validation failed` instead of a meaningful error — and incorrectly marking retryable errors like rate limits as `isRetryable: false`.

## Change

In `ToAnthropicChatCompletionError`, default `errorType` to `"api_error"` and guard against empty strings from providers:

```go
// Before
errorType := ""
if bifrostErr.Error.Type != nil {
    errorType = *bifrostErr.Error.Type
}

// After
errorType := "api_error"
if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type != "" {
    errorType = *bifrostErr.Error.Type
}
```

`"api_error"` is consistent with the [Anthropic API error spec](https://docs.anthropic.com/en/api/errors) for generic server-side errors.