### PR TITLE
fix: handle empty string customer_id in team updates

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1230,7 +1230,11 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 			team.Name = *req.Name
 		}
 		if req.CustomerID != nil {
-			team.CustomerID = req.CustomerID
+			if *req.CustomerID == "" {
+				team.CustomerID = nil
+			} else {
+				team.CustomerID = req.CustomerID
+			}
 		}
 		// Handle budget updates
 		if req.Budget != nil {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -11,3 +11,4 @@
   <Note>
     **Breaking change.** Cache tokens moved from usage top-level into `prompt_tokens_details` (Chat) and `input_tokens_details` (Responses), with standardized keys. If you have persisted data (logs, analytics, or custom storage), migrate: (1) move `usage.cache_read_input_tokens` → `usage.prompt_tokens_details.cached_read_tokens` or `usage.input_tokens_details.cached_read_tokens`; (2) move `usage.cache_creation_input_tokens` → `usage.prompt_tokens_details.cached_write_tokens` or `usage.input_tokens_details.cached_write_tokens`.
   </Note>
+- fix: nil handling for customer_id in update team


### PR DESCRIPTION
## Summary

Fixes nil handling for customer_id field when updating teams. Previously, setting customer_id to an empty string would not properly clear the field, now empty strings are converted to nil values.

## Changes

- Added conditional logic in `updateTeam` handler to check if `customer_id` is an empty string and set it to `nil` instead of the empty string value
- This ensures proper database handling where empty customer associations should be stored as null rather than empty strings

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test updating a team's customer_id field with various values:

```sh
# Test with empty string - should set customer_id to null
curl -X PUT /api/teams/{team_id} -d '{"customer_id": ""}'

# Test with valid customer_id - should set the value
curl -X PUT /api/teams/{team_id} -d '{"customer_id": "customer-123"}'

# Test without customer_id field - should leave existing value unchanged
curl -X PUT /api/teams/{team_id} -d '{"name": "Updated Team Name"}'

# Run tests
go test ./transports/bifrost-http/handlers/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a data handling improvement for team management.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable