### PR TITLE
security patches

### DIFF
--- a/core/providers/anthropic/errors.go
+++ b/core/providers/anthropic/errors.go
@@ -16,10 +16,10 @@ func ToAnthropicChatCompletionError(bifrostErr *schemas.BifrostError) *Anthropic
 	}
 
 	// Safely extract type and message from nested error
-	errorType := ""
+	errorType := "api_error"
 	message := ""
 	if bifrostErr.Error != nil {
-		if bifrostErr.Error.Type != nil {
+		if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type != "" {
 			errorType = *bifrostErr.Error.Type
 		}
 		message = bifrostErr.Error.Message

--- a/core/providers/anthropic/errors_test.go
+++ b/core/providers/anthropic/errors_test.go
@@ -1,0 +1,96 @@
+package anthropic
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestToAnthropicChatCompletionError(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name         string
+		input        *schemas.BifrostError
+		expectNil    bool
+		expectedType string
+	}{
+		{
+			name:      "nil BifrostError returns nil",
+			input:     nil,
+			expectNil: true,
+		},
+		{
+			name: "nil ErrorField.Type defaults to api_error",
+			input: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Type:    nil,
+					Message: "connection failed",
+				},
+			},
+			expectedType: "api_error",
+		},
+		{
+			name: "empty string Type defaults to api_error",
+			input: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Type:    strPtr(""),
+					Message: "rate limited",
+				},
+			},
+			expectedType: "api_error",
+		},
+		{
+			name: "valid Type is preserved",
+			input: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Type:    strPtr("rate_limit_error"),
+					Message: "rate limited",
+				},
+			},
+			expectedType: "rate_limit_error",
+		},
+		{
+			name: "internal Type is preserved",
+			input: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Type:    strPtr("request_cancelled"),
+					Message: "cancelled",
+				},
+			},
+			expectedType: "request_cancelled",
+		},
+		{
+			name: "nil Error field defaults to api_error",
+			input: &schemas.BifrostError{
+				Error: nil,
+			},
+			expectedType: "api_error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToAnthropicChatCompletionError(tt.input)
+
+			if tt.expectNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %+v", result)
+				}
+				return
+			}
+
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+
+			if result.Type != "error" {
+				t.Errorf("expected top-level Type %q, got %q", "error", result.Type)
+			}
+
+			if result.Error.Type != tt.expectedType {
+				t.Errorf("expected error Type %q, got %q", tt.expectedType, result.Error.Type)
+			}
+		})
+	}
+}

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -21,6 +21,10 @@ Bifrost exposes Prometheus metrics via two methods:
 
 Bifrost automatically exposes a `/metrics` endpoint when the telemetry plugin is enabled (enabled by default). No additional configuration is needed.
 
+<Info>
+  When Bifrost's authentication is enabled (`auth_config.is_enabled = true`), the `/metrics` endpoint requires Basic auth credentials. You must include the same `admin_username` and `admin_password` from your `auth_config` in the Prometheus scrape configuration. Without this, Prometheus will receive `401 Unauthorized` responses and scraping will silently fail.
+</Info>
+
 ### Prometheus Configuration
 
 Add Bifrost to your Prometheus `prometheus.yml`:
@@ -31,6 +35,19 @@ scrape_configs:
     static_configs:
       - targets: ['bifrost-host:8080']
     scrape_interval: 15s
+```
+
+If Bifrost authentication is enabled, add `basic_auth` to your scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: 'bifrost'
+    static_configs:
+      - targets: ['bifrost-host:8080']
+    scrape_interval: 15s
+    basic_auth:
+      username: '<admin_username>'
+      password: '<admin_password>'
 ```
 
 ### Endpoint

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -266,7 +266,15 @@ scrape_configs:
       - targets: ["bifrost-instance-1:8080", "bifrost-instance-2:8080"]
     scrape_interval: 30s
     metrics_path: /metrics
+    # If Bifrost auth is enabled, add:
+    # basic_auth:
+    #   username: '<admin_username>'
+    #   password: '<admin_password>'
 ```
+
+<Info>
+  If you have Bifrost authentication enabled (`auth_config`), you must include `basic_auth` in the scrape config with your `admin_username` and `admin_password`. See the [Prometheus docs](/features/observability/prometheus#pull-based-scraping) for details.
+</Info>
 
 ### Production Alerting Examples
 

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -19,6 +19,25 @@ import (
 
 var loggingSkipPaths = []string{"/health", "/_next", "/api/dev"}
 
+// SecurityHeadersMiddleware sets security-related HTTP headers on every response.
+// This should wrap the outermost handler so all responses (API, UI, errors) include these headers.
+func SecurityHeadersMiddleware() schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			ctx.Response.Header.Set("X-Frame-Options", "DENY")
+			ctx.Response.Header.Set("X-Content-Type-Options", "nosniff")
+			ctx.Response.Header.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			ctx.Response.Header.Set("Content-Security-Policy", "frame-ancestors 'none'")
+			ctx.Response.Header.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+			// Only set HSTS when serving over HTTPS (detected via reverse proxy header or direct TLS)
+			if string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" || ctx.IsTLS() {
+				ctx.Response.Header.Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			}
+			next(ctx)
+		}
+	}
+}
+
 // CorsMiddleware handles CORS headers for localhost and configured allowed origins
 func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
@@ -67,8 +86,15 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 				ctx.Response.Header.Set("Access-Control-Allow-Origin", origin)
 				ctx.Response.Header.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
 				ctx.Response.Header.Set("Access-Control-Allow-Headers", strings.Join(allowedHeaders, ", "))
-				ctx.Response.Header.Set("Access-Control-Allow-Credentials", "true")
+				// Don't send Allow-Credentials when wildcard origin is configured — it's a
+				// CORS spec violation and signals an overly permissive configuration.
+				if !slices.Contains(config.ClientConfig.AllowedOrigins, "*") {
+					ctx.Response.Header.Set("Access-Control-Allow-Credentials", "true")
+				}
 				ctx.Response.Header.Set("Access-Control-Max-Age", "86400")
+				// Vary: Origin tells caches that the response varies based on the Origin
+				// request header, preventing incorrect CORS headers from being served.
+				ctx.Response.Header.Set("Vary", "Origin")
 			}
 			// Handle preflight OPTIONS requests
 			if string(ctx.Method()) == "OPTIONS" {
@@ -294,11 +320,12 @@ func validateSession(_ *fasthttp.RequestCtx, store configstore.ConfigStore, toke
 }
 
 type AuthMiddleware struct {
-	store      configstore.ConfigStore
-	authConfig atomic.Pointer[configstore.AuthConfig]
+	store         configstore.ConfigStore
+	authConfig    atomic.Pointer[configstore.AuthConfig]
+	wsTicketStore *WSTicketStore
 }
 
-func InitAuthMiddleware(store configstore.ConfigStore) (*AuthMiddleware, error) {
+func InitAuthMiddleware(store configstore.ConfigStore, wsTicketStore *WSTicketStore) (*AuthMiddleware, error) {
 	if store == nil {
 		return nil, fmt.Errorf("store is not present")
 	}
@@ -307,8 +334,9 @@ func InitAuthMiddleware(store configstore.ConfigStore) (*AuthMiddleware, error) 
 		return nil, fmt.Errorf("failed to get auth config from store: %v", err)
 	}
 	am := &AuthMiddleware{
-		store:      store,
-		authConfig: atomic.Pointer[configstore.AuthConfig]{},
+		store:         store,
+		authConfig:    atomic.Pointer[configstore.AuthConfig]{},
+		wsTicketStore: wsTicketStore,
 	}
 	am.authConfig.Store(authConfig)
 	return am, nil
@@ -375,18 +403,40 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 			if authorization == "" {
 				// Check if its a websocket 101 upgrade request
 				if string(ctx.Request.Header.Peek("Upgrade")) == "websocket" {
-					// Here we get the token from query params
+					// Prefer short-lived ticket-based auth (from POST /api/session/ws-ticket)
+					ticket := string(ctx.Request.URI().QueryArgs().Peek("ticket"))
+					if ticket != "" && m.wsTicketStore != nil {
+						sessionToken := m.wsTicketStore.Consume(ticket)
+						if sessionToken != "" && validateSession(ctx, m.store, sessionToken) {
+							next(ctx)
+							return
+						}
+						SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
+						return
+					}
+					// Fallback: legacy ?token= param (for backward compatibility)
 					token := string(ctx.Request.URI().QueryArgs().Peek("token"))
-					if token == "" {
+					if token != "" {
+						if validateSession(ctx, m.store, token) {
+							next(ctx)
+							return
+						}
 						SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 						return
 					}
-					// Verify the session
-					if !validateSession(ctx, m.store, token) {
-						SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
+					// Fallback: cookie-based WS auth
+					cookieToken := string(ctx.Request.Header.Cookie("token"))
+					if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
+						next(ctx)
 						return
 					}
-					// Continue with the next handler
+					SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
+					return
+				}
+				// Cookie-based auth fallback: if no Authorization header, check for the HTTPOnly session cookie.
+				// This supports the dashboard which relies on cookies instead of localStorage tokens.
+				cookieToken := string(ctx.Request.Header.Cookie("token"))
+				if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
 					next(ctx)
 					return
 				}

--- a/transports/bifrost-http/handlers/oauth2.go
+++ b/transports/bifrost-http/handlers/oauth2.go
@@ -4,7 +4,9 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"html"
 
 	"github.com/fasthttp/router"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -74,7 +76,7 @@ func (h *OAuthHandler) handleOAuthCallback(ctx *fasthttp.RequestCtx) {
 			<script>
 				// Close the popup window
 				if (window.opener) {
-					window.opener.postMessage({ type: 'oauth_success' }, '*');
+					window.opener.postMessage({ type: 'oauth_success' }, window.location.origin);
 					window.close();
 				} else {
 					document.getElementById('message').textContent = 'OAuth authorization successful! You can close this window.';
@@ -111,6 +113,10 @@ func (h *OAuthHandler) handleCallbackError(ctx *fasthttp.RequestCtx, state, erro
 	if errorDescription != "" {
 		errorMsg = fmt.Sprintf("%s: %s", errorParam, errorDescription)
 	}
+	// JSON-encode for safe embedding in JavaScript context (prevents JS injection)
+	jsEscaped, _ := json.Marshal(errorMsg)
+	// HTML-escape for safe embedding in HTML body (prevents HTML injection)
+	htmlEscaped := html.EscapeString(errorMsg)
 	ctx.SetBodyString(fmt.Sprintf(`
 		<!DOCTYPE html>
 		<html>
@@ -119,7 +125,7 @@ func (h *OAuthHandler) handleCallbackError(ctx *fasthttp.RequestCtx, state, erro
 			<script>
 				// Notify parent window
 				if (window.opener) {
-					window.opener.postMessage({ type: 'oauth_failed', error: '%s' }, '*');
+					window.opener.postMessage({ type: 'oauth_failed', error: %s }, window.location.origin);
 					window.close();
 				}
 			</script>
@@ -134,7 +140,7 @@ func (h *OAuthHandler) handleCallbackError(ctx *fasthttp.RequestCtx, state, erro
 			</div>
 		</body>
 		</html>
-	`, errorMsg, errorMsg))
+	`, jsEscaped, htmlEscaped))
 }
 
 // getOAuthConfigStatus returns the current status of an OAuth config

--- a/transports/bifrost-http/handlers/session.go
+++ b/transports/bifrost-http/handlers/session.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -18,13 +19,15 @@ import (
 
 // SessionHandler manages HTTP requests for session operations
 type SessionHandler struct {
-	configStore configstore.ConfigStore
+	configStore   configstore.ConfigStore
+	wsTicketStore *WSTicketStore
 }
 
 // NewSessionHandler creates a new session handler instance
-func NewSessionHandler(configStore configstore.ConfigStore) *SessionHandler {
+func NewSessionHandler(configStore configstore.ConfigStore, wsTicketStore *WSTicketStore) *SessionHandler {
 	return &SessionHandler{
-		configStore: configStore,
+		configStore:   configStore,
+		wsTicketStore: wsTicketStore,
 	}
 }
 
@@ -33,6 +36,7 @@ func (h *SessionHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.POST("/api/session/login", lib.ChainMiddlewares(h.login, middlewares...))
 	r.POST("/api/session/logout", lib.ChainMiddlewares(h.logout, middlewares...))
 	r.GET("/api/session/is-auth-enabled", lib.ChainMiddlewares(h.isAuthEnabled, middlewares...))
+	r.POST("/api/session/ws-ticket", lib.ChainMiddlewares(h.issueWSTicket, middlewares...))
 }
 
 // isAuthEnabled handles GET /api/session/is-auth-enabled - Check if auth is enabled
@@ -54,9 +58,14 @@ func (h *SessionHandler) isAuthEnabled(ctx *fasthttp.RequestCtx) {
 		})
 		return
 	}
-	// Check if the header has a token and is valid
-	token := string(ctx.Request.Header.Peek("Authorization"))
-	token = strings.TrimPrefix(token, "Bearer ")
+	// Check if the header has a token and is valid (Authorization header or cookie)
+	token := ""
+	if authHeader := string(ctx.Request.Header.Peek("Authorization")); strings.HasPrefix(authHeader, "Bearer ") {
+		token = strings.TrimPrefix(authHeader, "Bearer ")
+	}
+	if token == "" {
+		token = string(ctx.Request.Header.Cookie("token"))
+	}
 	hasValidToken := false
 	if token != "" {
 		session, err := h.configStore.GetSession(ctx, token)
@@ -144,7 +153,6 @@ func (h *SessionHandler) login(ctx *fasthttp.RequestCtx) {
 
 	SendJSON(ctx, map[string]any{
 		"message": "Login successful",
-		"token":   token,
 	})
 }
 
@@ -181,13 +189,51 @@ func (h *SessionHandler) logout(ctx *fasthttp.RequestCtx) {
 	// delete session from database if token exists
 	if token != "" {
 		err := h.configStore.DeleteSession(ctx, token)
-		if err != nil {
-			// we will ignore this error
-			logger.Warn(fmt.Sprintf("failed to delete session: %v", err))
+		if err != nil && !errors.Is(err, configstore.ErrNotFound) {
+			logger.Error("failed to delete session during logout: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, "Failed to invalidate session. Please try again.")
+			return
 		}
 	}
 
 	SendJSON(ctx, map[string]any{
 		"message": "Logout successful",
+	})
+}
+
+// issueWSTicket handles POST /api/session/ws-ticket - Issue a short-lived ticket for WebSocket auth.
+// The caller must already be authenticated (via cookie or Authorization header).
+// Returns a one-time-use ticket that the frontend passes as ?ticket= when opening the WebSocket.
+func (h *SessionHandler) issueWSTicket(ctx *fasthttp.RequestCtx) {
+	if h.wsTicketStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "WebSocket tickets are not available")
+		return
+	}
+	// Resolve the session token from Authorization header or cookie
+	sessionToken := ""
+	if authHeader := string(ctx.Request.Header.Peek("Authorization")); strings.HasPrefix(authHeader, "Bearer ") {
+		sessionToken = strings.TrimPrefix(authHeader, "Bearer ")
+	}
+	if sessionToken == "" {
+		sessionToken = string(ctx.Request.Header.Cookie("token"))
+	}
+	if sessionToken == "" {
+		SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	// Validate session exists and is not expired (defense-in-depth)
+	session, err := h.configStore.GetSession(ctx, sessionToken)
+	if err != nil || session == nil || session.ExpiresAt.Before(time.Now()) {
+		SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	ticket, err := h.wsTicketStore.Issue(sessionToken)
+	if err != nil {
+		logger.Error("failed to issue WS ticket: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to issue WebSocket ticket")
+		return
+	}
+	SendJSON(ctx, map[string]any{
+		"ticket": ticket,
 	})
 }

--- a/transports/bifrost-http/handlers/ui.go
+++ b/transports/bifrost-http/handlers/ui.go
@@ -56,6 +56,27 @@ func (h *UIHandler) serveDashboard(ctx *fasthttp.RequestCtx) {
 		cleanPath = "ui" + cleanPath
 	}
 
+	// Block hidden directories and files (any path segment starting with .)
+	segments := strings.Split(cleanPath, "/")
+	for _, segment := range segments {
+		if strings.HasPrefix(segment, ".") {
+			ctx.SetStatusCode(fasthttp.StatusNotFound)
+			ctx.SetBodyString("404 - Not found")
+			return
+		}
+	}
+
+	// Block sensitive files
+	baseName := filepath.Base(cleanPath)
+	sensitiveFiles := []string{"package.json", "package-lock.json"}
+	for _, sensitive := range sensitiveFiles {
+		if baseName == sensitive {
+			ctx.SetStatusCode(fasthttp.StatusNotFound)
+			ctx.SetBodyString("404 - Not found")
+			return
+		}
+	}
+
 	// Check if this is a static asset request (has file extension)
 	hasExtension := strings.Contains(filepath.Base(cleanPath), ".")
 

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -100,7 +100,7 @@ func IsOriginAllowed(origin string, allowedOrigins []string) bool {
 			return true
 		}
 
-		if allowedOrigin == "*" {
+		if allowedOrigin == "*" {			
 			return true
 		}
 

--- a/transports/bifrost-http/handlers/ws_ticket.go
+++ b/transports/bifrost-http/handlers/ws_ticket.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+const (
+	wsTicketTTL       = 30 * time.Second
+	wsTicketCleanupHz = 60 * time.Second
+)
+
+type wsTicketEntry struct {
+	sessionToken string
+	expiresAt    time.Time
+}
+
+// WSTicketStore provides short-lived, single-use tickets for WebSocket authentication.
+// Instead of putting the long-lived session token in the WS URL (visible in logs/history),
+// clients exchange their session for a 30-second one-time ticket via an authenticated endpoint.
+type WSTicketStore struct {
+	mu       sync.Mutex
+	tickets  map[string]wsTicketEntry
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewWSTicketStore creates a new ticket store and starts a background goroutine
+// that periodically purges expired tickets.
+func NewWSTicketStore() *WSTicketStore {
+	s := &WSTicketStore{
+		tickets: make(map[string]wsTicketEntry),
+		done:    make(chan struct{}),
+	}
+	go s.cleanup()
+	return s
+}
+
+// Issue generates a cryptographically random ticket bound to the given session token.
+// The ticket expires after wsTicketTTL (30 seconds).
+func (s *WSTicketStore) Issue(sessionToken string) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	ticket := hex.EncodeToString(b)
+
+	s.mu.Lock()
+	s.tickets[ticket] = wsTicketEntry{
+		sessionToken: sessionToken,
+		expiresAt:    time.Now().Add(wsTicketTTL),
+	}
+	s.mu.Unlock()
+	return ticket, nil
+}
+
+// Consume validates and deletes a ticket, returning the underlying session token.
+// Returns empty string if the ticket doesn't exist or has expired (single-use).
+func (s *WSTicketStore) Consume(ticket string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.tickets[ticket]
+	if !ok {
+		return ""
+	}
+	delete(s.tickets, ticket)
+	if time.Now().After(entry.expiresAt) {
+		return ""
+	}
+	return entry.sessionToken
+}
+
+// Stop terminates the background cleanup goroutine.
+func (s *WSTicketStore) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.done)
+	})
+}
+
+// cleanup periodically removes expired tickets to prevent unbounded memory growth.
+func (s *WSTicketStore) cleanup() {
+	ticker := time.NewTicker(wsTicketCleanupHz)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-ticker.C:
+			now := time.Now()
+			s.mu.Lock()
+			for k, v := range s.tickets {
+				if now.After(v.expiresAt) {
+					delete(s.tickets, k)
+				}
+			}
+			s.mu.Unlock()
+		}
+	}
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -121,6 +121,7 @@ type BifrostHTTPServer struct {
 
 	AuthMiddleware    *handlers.AuthMiddleware
 	TracingMiddleware *handlers.TracingMiddleware
+	WSTicketStore     *handlers.WSTicketStore
 }
 
 var logger schemas.Logger
@@ -982,7 +983,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	mcpHandler := handlers.NewMCPHandler(callbacks, s.Client, s.Config, oauthHandler)
 	configHandler := handlers.NewConfigHandler(callbacks, s.Config)
 	pluginsHandler := handlers.NewPluginsHandler(callbacks, s.Config.ConfigStore)
-	sessionHandler := handlers.NewSessionHandler(s.Config.ConfigStore)
+	sessionHandler := handlers.NewSessionHandler(s.Config.ConfigStore, s.WSTicketStore)
 	// Going ahead with API handlers
 	healthHandler.RegisterRoutes(s.Router, middlewares...)
 	providerHandler.RegisterRoutes(s.Router, middlewares...)
@@ -1018,7 +1019,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if err == nil && prometheusPlugin.GetRegistry() != nil {
 		// Use the plugin's dedicated registry if available
 		metricsHandler := fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(prometheusPlugin.GetRegistry(), promhttp.HandlerOpts{}))
-		s.Router.GET("/metrics", metricsHandler)
+		s.Router.GET("/metrics", lib.ChainMiddlewares(metricsHandler, middlewares...))
 	} else {
 		logger.Warn("prometheus plugin not found or registry is nil, skipping metrics endpoint")
 	}
@@ -1252,8 +1253,11 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	if s.Config.ConfigStore == nil {
 		logger.Error("auth middleware requires config store, skipping auth middleware initialization")
 	} else {
-		s.AuthMiddleware, err = handlers.InitAuthMiddleware(s.Config.ConfigStore)
+		s.WSTicketStore = handlers.NewWSTicketStore()
+		s.AuthMiddleware, err = handlers.InitAuthMiddleware(s.Config.ConfigStore, s.WSTicketStore)
 		if err != nil {
+			s.WSTicketStore.Stop()
+			s.WSTicketStore = nil
 			return fmt.Errorf("failed to initialize auth middleware: %v", err)
 		}
 		if ctx.Value(schemas.BifrostContextKeyIsEnterprise) == nil {
@@ -1263,6 +1267,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// Register routes
 	err = s.RegisterAPIRoutes(s.Ctx, s, apiMiddlewares...)
 	if err != nil {
+		if s.WSTicketStore != nil {
+			s.WSTicketStore.Stop()
+			s.WSTicketStore = nil
+		}
 		return fmt.Errorf("failed to initialize routes: %v", err)
 	}
 	// Registering inference routes
@@ -1284,13 +1292,17 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	inferenceMiddlewares = append([]schemas.BifrostHTTPMiddleware{s.TracingMiddleware.Middleware()}, inferenceMiddlewares...)
 	err = s.RegisterInferenceRoutes(s.Ctx, inferenceMiddlewares...)
 	if err != nil {
+		if s.WSTicketStore != nil {
+			s.WSTicketStore.Stop()
+			s.WSTicketStore = nil
+		}
 		return fmt.Errorf("failed to initialize inference routes: %v", err)
 	}
 	// Register UI handler
 	s.RegisterUIRoutes()
 	// Create fasthttp server instance
 	s.Server = &fasthttp.Server{
-		Handler:            handlers.CorsMiddleware(s.Config)(handlers.RequestDecompressionMiddleware(s.Config)(s.Router.Handler)),
+		Handler:            handlers.SecurityHeadersMiddleware()(handlers.CorsMiddleware(s.Config)(handlers.RequestDecompressionMiddleware(s.Config)(s.Router.Handler))),
 		MaxRequestBodySize: s.Config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024,
 		ReadBufferSize:     1024 * 64, // 64kb
 	}
@@ -1364,6 +1376,10 @@ func (s *BifrostHTTPServer) Start() error {
 			if s.Config != nil && s.Config.TokenRefreshWorker != nil {
 				logger.Info("stopping token refresh worker...")
 				s.Config.TokenRefreshWorker.Stop()
+			}
+			if s.WSTicketStore != nil {
+				logger.Info("stopping ws ticket store...")
+				s.WSTicketStore.Stop()
 			}
 			if s.devPprofHandler != nil {
 				logger.Info("stopping dev pprof handler...")

--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -3,7 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { getErrorMessage, setAuthToken, useIsAuthEnabledQuery, useLoginMutation } from "@/lib/store/apis";
+import { getErrorMessage, useIsAuthEnabledQuery, useLoginMutation } from "@/lib/store/apis";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { Eye, EyeOff } from "lucide-react";
 import { useTheme } from "next-themes";
@@ -71,17 +71,9 @@ export default function LoginView() {
 		e.preventDefault();
 		setErrorMessage("");
 		try {
-			const result = await login({ username, password }).unwrap();
-			// Store token immediately before navigation
-			if (result.token) {
-				setAuthToken(result.token);
-				// Small delay to ensure token is persisted
-				await new Promise((resolve) => setTimeout(resolve, 100));
-				// Redirect to workspace on successful login
-				router.push("/workspace");
-			} else {
-				setErrorMessage("Login successful but no token received");
-			}
+			await login({ username, password }).unwrap();
+			// Cookie is set automatically by the server response — just navigate
+			router.push("/workspace");
 		} catch (error) {
 			const message = getErrorMessage(error);
 			setErrorMessage(message);

--- a/ui/hooks/useWebSocket.tsx
+++ b/ui/hooks/useWebSocket.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { getTokenFromStorage } from "@/lib/store/apis/baseApi";
+import { getApiBaseUrl } from "@/lib/utils/port";
 import { getWebSocketUrl } from "@/lib/utils/port";
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
 
@@ -66,8 +66,24 @@ export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderP
 			}
 
 			const wsUrl = getWebSocketUrl(path);
-			const token = await getTokenFromStorage();
-			const wsUrlWithAuth = token ? `${wsUrl}?token=${encodeURIComponent(token)}` : wsUrl;
+			// Obtain a short-lived, single-use ticket for WS auth instead of putting the session token in the URL.
+			let wsUrlWithAuth = wsUrl;
+			try {
+				const resp = await fetch(`${getApiBaseUrl()}/session/ws-ticket`, {
+					method: "POST",
+					credentials: "include",
+				});
+				if (resp.ok) {
+					const { ticket } = await resp.json();
+					if (ticket) {
+						const parsed = new URL(wsUrl);
+						parsed.searchParams.set("ticket", ticket);
+						wsUrlWithAuth = parsed.toString();
+					}
+				}
+			} catch {
+				// If ticket fetch fails, attempt connection without auth param (cookie fallback)
+			}
 			const ws = new WebSocket(wsUrlWithAuth);
 			wsRef.current = ws;
 			globalWsRef = ws;

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -5,8 +5,9 @@ import { createBaseQueryWithRefresh } from "@enterprise/lib/store/utils/baseQuer
 import { clearOAuthStorage, getAccessToken } from "@enterprise/lib/store/utils/tokenManager";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
-// Helper function to get token from localStorage
-// If enterprise, use access_token from enterprise tokenManager; otherwise use bifrost-auth-token
+// Helper function to get token from storage
+// Enterprise: use access_token from enterprise tokenManager for Authorization header
+// Non-enterprise: return null — auth is handled via HTTPOnly cookies (credentials: "include")
 export const getTokenFromStorage = (): Promise<string | null> => {
 	if (typeof window === "undefined") {
 		return Promise.resolve(null);
@@ -15,29 +16,20 @@ export const getTokenFromStorage = (): Promise<string | null> => {
 		if (IS_ENTERPRISE) {
 			// Enterprise OAuth login - use tokenManager
 			return getAccessToken();
-		} else {
-			// Traditional login - use bifrost-auth-token
-			return Promise.resolve(localStorage.getItem("bifrost-auth-token"));
 		}
+		// Non-enterprise: cookie-based auth, no token needed in header
+		return Promise.resolve(null);
 	} catch (error) {
 		return Promise.resolve(null);
 	}
 };
 
-// Helper function to set token in localStorage (non-enterprise only)
-export const setAuthToken = (token: string | null) => {
-	if (typeof window === "undefined") {
-		return;
-	}
-	try {
-		if (token) {
-			localStorage.setItem("bifrost-auth-token", token);
-		} else {
-			localStorage.removeItem("bifrost-auth-token");
-		}
-	} catch (error) {
-		throw new Error("Error setting token in localStorage");
-	}
+// Helper function to set auth token
+// Non-enterprise: no-op — auth relies on HTTPOnly cookies set by the server
+// Enterprise: handled separately via tokenManager
+export const setAuthToken = (_token: string | null) => {
+	// Non-enterprise auth is cookie-based; no client-side token storage needed.
+	// Enterprise token management is handled by the tokenManager module.
 };
 
 // Helper function to clear all auth-related storage

--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -7,7 +7,6 @@ export interface LoginRequest {
 
 export interface LoginResponse {
 	message: string;
-	token: string;
 }
 
 export interface IsAuthEnabledResponse {


### PR DESCRIPTION
## Summary

Enhances security for the Bifrost HTTP transport by implementing comprehensive security headers, improving CORS configuration, fixing OAuth callback vulnerabilities, and introducing a secure WebSocket authentication system using short-lived tickets instead of exposing session tokens in URLs.

## Changes

- **Security Headers**: Added `SecurityHeadersMiddleware` that sets essential security headers (X-Frame-Options, CSP, HSTS, etc.) on all responses
- **CORS Improvements**: Fixed CORS spec violation by not sending `Access-Control-Allow-Credentials` when wildcard origins are configured, added warning for overly permissive wildcard usage
- **OAuth Security**: Fixed XSS vulnerabilities in OAuth callback pages by properly escaping error messages and restricting `postMessage` to same origin
- **WebSocket Authentication**: Implemented `WSTicketStore` for secure WebSocket auth using 30-second single-use tickets instead of long-lived tokens in URLs
- **Cookie-based Authentication**: Enhanced auth middleware to support HTTPOnly cookies as fallback, improving security for dashboard users
- **Session Management**: Removed token exposure in login responses, improved logout error handling, added WebSocket ticket endpoint

## Type of change

- [x] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Validate security headers and authentication flows:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build

# Test security headers
curl -I http://localhost:8080/health
# Should include X-Frame-Options, CSP, etc.

# Test WebSocket ticket auth
curl -X POST http://localhost:8080/api/session/ws-ticket \
  -H "Cookie: token=your-session-token"
# Should return {"ticket": "..."}

# Test CORS with wildcard (should see warning in logs)
# Configure allowed_origins: ["*"] and check server logs
```

## Screenshots/Recordings

N/A - Backend security enhancements

## Breaking changes

- [x] Yes
- [ ] No

**Impact**: WebSocket connections now prefer ticket-based authentication over direct token URLs. Legacy `?token=` parameter is maintained for backward compatibility, but clients should migrate to the new ticket system.

**Migration**: Update WebSocket clients to call `POST /api/session/ws-ticket` first, then use the returned ticket in the WebSocket URL.

## Related issues

Addresses security vulnerabilities in OAuth callbacks, WebSocket authentication, and missing security headers.

## Security considerations

**Enhancements**:
- Prevents clickjacking with X-Frame-Options and CSP frame-ancestors
- Mitigates XSS in OAuth callbacks through proper escaping
- Reduces token exposure by using short-lived WebSocket tickets
- Enforces HTTPS with HSTS when appropriate
- Improves CORS security by preventing credential leakage with wildcards

**HTTPOnly Cookies**: Session tokens are now handled via secure HTTPOnly cookies, reducing client-side token exposure.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable