### PR TITLE
fix: add missing created field to text completion response

### DIFF
--- a/core/providers/anthropic/text.go
+++ b/core/providers/anthropic/text.go
@@ -3,6 +3,7 @@ package anthropic
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -97,6 +98,7 @@ func (response *AnthropicTextResponse) ToBifrostTextCompletionResponse() *schema
 				},
 			},
 		},
+		Created: time.Now().Unix(),
 		Usage: &schemas.BifrostLLMUsage{
 			PromptTokens:     response.Usage.InputTokens,
 			CompletionTokens: response.Usage.OutputTokens,

--- a/core/providers/bedrock/text.go
+++ b/core/providers/bedrock/text.go
@@ -2,6 +2,7 @@ package bedrock
 
 import (
 	"strings"
+	"time"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/utils"
@@ -126,6 +127,7 @@ func (response *BedrockAnthropicTextResponse) ToBifrostTextCompletionResponse() 
 				FinishReason: &response.StopReason,
 			},
 		},
+		Created: time.Now().Unix(),
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType: schemas.TextCompletionRequest,
 			Provider:    schemas.Bedrock,
@@ -153,6 +155,7 @@ func (response *BedrockMistralTextResponse) ToBifrostTextCompletionResponse() *s
 	return &schemas.BifrostTextCompletionResponse{
 		Object:  "text_completion",
 		Choices: choices,
+		Created: time.Now().Unix(),
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType: schemas.TextCompletionRequest,
 			Provider:    schemas.Bedrock,

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -568,6 +568,7 @@ func HandleOpenAITextCompletionStreaming(
 
 		var finishReason *string
 		var messageID string
+		var created int64
 		startTime := time.Now()
 		lastChunkTime := startTime
 
@@ -678,6 +679,11 @@ func HandleOpenAITextCompletionStreaming(
 				response.Usage = nil
 			}
 
+			// Track created timestamp from any chunk so final aggregated chunk is always populated.
+			if response.Created > 0 {
+				created = response.Created
+			}
+
 			// Skip empty responses or responses without choices
 			if len(response.Choices) == 0 {
 				continue
@@ -719,7 +725,7 @@ func HandleOpenAITextCompletionStreaming(
 			}
 		}
 
-		response := providerUtils.CreateBifrostTextCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.TextCompletionStreamRequest, providerName, request.Model)
+		response := providerUtils.CreateBifrostTextCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, created, schemas.TextCompletionStreamRequest, providerName, request.Model)
 		if postResponseConverter != nil {
 			response = postResponseConverter(response)
 			if response == nil {

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -619,6 +619,7 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 
 		messageID := prediction.ID
 
+		created := time.Now().Unix()
 		for {
 			// Check for context cancellation
 			select {
@@ -666,6 +667,7 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 								},
 							},
 						},
+						Created: created,
 						ExtraFields: schemas.BifrostResponseExtraFields{
 							RequestType:    schemas.TextCompletionStreamRequest,
 							Provider:       provider.GetProviderKey(),
@@ -750,6 +752,7 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 					nil, // usage - not available in done event
 					finishReason,
 					chunkIndex,
+					created,
 					schemas.TextCompletionStreamRequest,
 					provider.GetProviderKey(),
 					request.Model,

--- a/core/providers/replicate/text.go
+++ b/core/providers/replicate/text.go
@@ -132,6 +132,8 @@ func (response *ReplicatePredictionResponse) ToBifrostTextCompletionResponse() *
 
 	bifrostResponse.Choices = []schemas.BifrostResponseChoice{choice}
 
+	bifrostResponse.Created = ParseReplicateTimestamp(response.CreatedAt)
+
 	// Extract usage information from logs
 	if response.Logs != nil {
 		inputTokens, outputTokens, totalTokens, found := parseTokenUsageFromLogs(response.Logs, schemas.TextCompletionRequest)

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2101,6 +2101,7 @@ func CreateBifrostTextCompletionChunkResponse(
 	usage *schemas.BifrostLLMUsage,
 	finishReason *string,
 	currentChunkIndex int,
+	created int64,
 	requestType schemas.RequestType,
 	providerName schemas.ModelProvider,
 	model string,
@@ -2115,6 +2116,7 @@ func CreateBifrostTextCompletionChunkResponse(
 				TextCompletionResponseChoice: &schemas.TextCompletionResponseChoice{}, // empty delta
 			},
 		},
+		Created: created,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			RequestType:    requestType,
 			Provider:       providerName,

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -29,16 +29,16 @@ func (cr *BifrostChatRequest) GetExtraParams() map[string]interface{} {
 
 // BifrostChatResponse represents the complete result from a chat completion request.
 type BifrostChatResponse struct {
-	ID                      string                     `json:"id"`
-	Choices                 []BifrostResponseChoice    `json:"choices"`
-	Created                 int                        `json:"created"` // The Unix timestamp (in seconds).
-	Model                   string                     `json:"model"`
-	Object                  string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
-	ServiceTier             *string                    `json:"service_tier,omitempty"`
-	SystemFingerprint       string                     `json:"system_fingerprint"`
-	Usage                   *BifrostLLMUsage           `json:"usage"`
-	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
-	ExtraParams             map[string]interface{}     `json:"-"`
+	ID                string                     `json:"id"`
+	Choices           []BifrostResponseChoice    `json:"choices"`
+	Created           int                        `json:"created"` // The Unix timestamp (in seconds).
+	Model             string                     `json:"model"`
+	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
+	ServiceTier       *string                    `json:"service_tier,omitempty"`
+	SystemFingerprint string                     `json:"system_fingerprint"`
+	Usage             *BifrostLLMUsage           `json:"usage"`
+	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
+	ExtraParams       map[string]interface{}     `json:"-"`
 
 	// Perplexity-specific fields
 	SearchResults []SearchResult `json:"search_results,omitempty"`
@@ -56,6 +56,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 		return &BifrostTextCompletionResponse{
 			ID:                cr.ID,
 			Model:             cr.Model,
+			Created:           int64(cr.Created),
 			Object:            "text_completion",
 			SystemFingerprint: cr.SystemFingerprint,
 			Usage:             cr.Usage,
@@ -63,7 +64,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 				RequestType:             TextCompletionRequest,
 				ChunkIndex:              cr.ExtraFields.ChunkIndex,
 				Provider:                cr.ExtraFields.Provider,
-				ModelRequested:           cr.ExtraFields.ModelRequested,
+				ModelRequested:          cr.ExtraFields.ModelRequested,
 				Latency:                 cr.ExtraFields.Latency,
 				RawResponse:             cr.ExtraFields.RawResponse,
 				CacheDebug:              cr.ExtraFields.CacheDebug,
@@ -79,6 +80,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 		return &BifrostTextCompletionResponse{
 			ID:                cr.ID,
 			Model:             cr.Model,
+			Created:           int64(cr.Created),
 			Object:            "text_completion",
 			SystemFingerprint: cr.SystemFingerprint,
 			Choices: []BifrostResponseChoice{
@@ -96,7 +98,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 				RequestType:             TextCompletionRequest,
 				ChunkIndex:              cr.ExtraFields.ChunkIndex,
 				Provider:                cr.ExtraFields.Provider,
-				ModelRequested:           cr.ExtraFields.ModelRequested,
+				ModelRequested:          cr.ExtraFields.ModelRequested,
 				Latency:                 cr.ExtraFields.Latency,
 				RawResponse:             cr.ExtraFields.RawResponse,
 				CacheDebug:              cr.ExtraFields.CacheDebug,
@@ -115,6 +117,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 		return &BifrostTextCompletionResponse{
 			ID:                cr.ID,
 			Model:             cr.Model,
+			Created:           int64(cr.Created),
 			Object:            "text_completion",
 			SystemFingerprint: cr.SystemFingerprint,
 			Choices: []BifrostResponseChoice{
@@ -132,7 +135,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 				RequestType:             TextCompletionRequest,
 				ChunkIndex:              cr.ExtraFields.ChunkIndex,
 				Provider:                cr.ExtraFields.Provider,
-				ModelRequested:           cr.ExtraFields.ModelRequested,
+				ModelRequested:          cr.ExtraFields.ModelRequested,
 				Latency:                 cr.ExtraFields.Latency,
 				RawResponse:             cr.ExtraFields.RawResponse,
 				CacheDebug:              cr.ExtraFields.CacheDebug,
@@ -145,6 +148,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 	return &BifrostTextCompletionResponse{
 		ID:                cr.ID,
 		Model:             cr.Model,
+		Created:           int64(cr.Created),
 		Object:            "text_completion",
 		SystemFingerprint: cr.SystemFingerprint,
 		Usage:             cr.Usage,

--- a/core/schemas/textcompletions.go
+++ b/core/schemas/textcompletions.go
@@ -67,6 +67,7 @@ func (r *BifrostTextCompletionRequest) ToBifrostChatRequest() *BifrostChatReques
 type BifrostTextCompletionResponse struct {
 	ID                string                     `json:"id"`
 	Choices           []BifrostResponseChoice    `json:"choices"`
+	Created           int64                      `json:"created"`
 	Model             string                     `json:"model"`
 	Object            string                     `json:"object"` // "text_completion" (same for text completion stream)
 	SystemFingerprint string                     `json:"system_fingerprint"`

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -264,7 +264,8 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 					},
 				},
 			},
-			Usage: p.Data.TokenUsage,
+			Created: p.Data.StartTimestamp.Unix(),
+			Usage:   p.Data.TokenUsage,
 		}
 
 		resp.TextCompletionResponse = textResp


### PR DESCRIPTION
## Summary

add missing created field to text completion response

ref: https://developers.openai.com/api/reference/resources/completions/methods/create

In some strictly validated client libraries, an error indicating the missing 'created' field will be reported. e.g. zed [Self-Hosted OpenAI-compatible servers](https://zed.dev/docs/ai/edit-prediction#self-hosted-openai-compatible-servers)

## Changes

- add missing created field to text completion response

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```
## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

N/A

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


