### PR TITLE
fixed semantic cache plugin fixes

### DIFF
--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1030,7 +1030,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
 		"plugins": [
 			{
 				"enabled": true,
-				"name": "semanticcache",
+				"name": "semantic_cache",
 				"config": {
 					"provider": "openai",
 					"keys": ["sk-test-key"],
@@ -1052,7 +1052,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingProvider(t *testing.T) 
 		"plugins": [
 			{
 				"enabled": true,
-				"name": "semanticcache",
+				"name": "semantic_cache",
 				"config": {
 					"keys": ["sk-test-key"],
 					"dimension": 1536
@@ -1073,7 +1073,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingKeys(t *testing.T) {
 		"plugins": [
 			{
 				"enabled": true,
-				"name": "semanticcache",
+				"name": "semantic_cache",
 				"config": {
 					"provider": "openai",
 					"dimension": 1536
@@ -1094,7 +1094,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingDimension(t *testing.T)
 		"plugins": [
 			{
 				"enabled": true,
-				"name": "semanticcache",
+				"name": "semantic_cache",
 				"config": {
 					"provider": "openai",
 					"keys": ["sk-test-key"]


### PR DESCRIPTION
## Summary

Updates the semantic cache plugin name from "semanticcache" to "semantic_cache" in validator tests to align with the expected naming convention using underscores instead of camelCase.

## Changes

- Changed plugin name from "semanticcache" to "semantic_cache" in four test cases:
  - `TestValidateConfigSchema_SemanticCachePlugin_Valid`
  - `TestValidateConfigSchema_SemanticCachePlugin_MissingProvider`
  - `TestValidateConfigSchema_SemanticCachePlugin_MissingKeys`
  - `TestValidateConfigSchema_SemanticCachePlugin_MissingDimension`

This ensures consistency with the plugin naming standard and prevents validation failures due to incorrect plugin names.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the validator tests to ensure they pass with the corrected plugin name:

```sh
go test ./transports/bifrost-http/lib -v -run TestValidateConfigSchema_SemanticCachePlugin
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a test-only change that corrects plugin naming.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable