### PR TITLE
fix(anthropic): use NewSSEScanner for Responses API streaming

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -2,7 +2,6 @@
 package anthropic
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -1022,7 +1021,7 @@ func HandleAnthropicResponsesStream(
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), logger)
 		defer stopCancellation()
 
-		scanner := bufio.NewScanner(reader)
+		scanner := providerUtils.NewSSEScanner(reader)
 		chunkIndex := 0
 
 		startTime := time.Now()


### PR DESCRIPTION
## Summary

- `HandleAnthropicResponsesStream` uses `bufio.NewScanner` which has a default max token size of **64KB**. The chat completions streaming handler (`HandleAnthropicChatCompletionStreaming`) was fixed in commit `4aee833b` to use `providerUtils.NewSSEScanner` (10MB max buffer), but the Responses API path was missed.
- This causes `bufio.ErrTooLong` when any single SSE data line exceeds 64KB (e.g. large tool call results, extended thinking blocks), silently breaking the stream for Responses API clients.
- The fix replaces `bufio.NewScanner(reader)` with `providerUtils.NewSSEScanner(reader)` to match the chat completions handler.

## Test plan

- [ ] Verify existing Anthropic provider tests pass (`make test-core PROVIDER=anthropic`)
- [ ] Test Responses API streaming with a prompt that produces large SSE events (e.g. tool calls returning >64KB payloads)
- [ ] Confirm chat completions streaming is unaffected (it already uses `NewSSEScanner`)


Made with [Cursor](https://cursor.com)