### PR TITLE
feat: add filename preservation for transcription requests

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,2 @@
+- feat: add Filename field to TranscriptionInput schema to carry original filename through the request pipeline
+- fix: add AudioFilenameFromBytes utility to detect audio format from file headers with mp3 fallback

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -604,7 +604,11 @@ func writeTranscriptionMultipart(writer *multipart.Writer, reqBody *ElevenlabsTr
 	}
 
 	if len(reqBody.File) > 0 {
-		fileWriter, err := writer.CreateFormFile("file", "audio.wav")
+		filename := reqBody.Filename
+		if filename == "" {
+			filename = providerUtils.AudioFilenameFromBytes(reqBody.File)
+		}
+		fileWriter, err := writer.CreateFormFile("file", filename)
 		if err != nil {
 			return providerUtils.NewBifrostOperationError("failed to create file field", err, providerName)
 		}

--- a/core/providers/elevenlabs/transcription.go
+++ b/core/providers/elevenlabs/transcription.go
@@ -19,6 +19,7 @@ func ToElevenlabsTranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionRe
 
 	if bifrostReq.Input != nil && len(bifrostReq.Input.File) > 0 {
 		req.File = bifrostReq.Input.File
+		req.Filename = bifrostReq.Input.Filename
 	}
 
 	if bifrostReq.Params == nil {

--- a/core/providers/elevenlabs/types.go
+++ b/core/providers/elevenlabs/types.go
@@ -61,6 +61,7 @@ type ElevenlabsPronunciationDictionaryLocator struct {
 type ElevenlabsTranscriptionRequest struct {
 	ModelID               string                           `json:"model_id"`
 	File                  []byte                           `json:"-"`
+	Filename              string                           `json:"-"` // Original filename, used to preserve file format extension
 	LanguageCode          *string                          `json:"language_code,omitempty"`
 	TagAudioEvents        *bool                            `json:"tag_audio_events,omitempty"`
 	NumSpeakers           *int                             `json:"num_speakers,omitempty"`

--- a/core/providers/mistral/transcription.go
+++ b/core/providers/mistral/transcription.go
@@ -17,8 +17,9 @@ func ToMistralTranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReque
 	}
 
 	req := &MistralTranscriptionRequest{
-		Model: bifrostReq.Model,
-		File:  bifrostReq.Input.File,
+		Model:    bifrostReq.Model,
+		File:     bifrostReq.Input.File,
+		Filename: bifrostReq.Input.Filename,
 	}
 
 	if bifrostReq.Params != nil {
@@ -102,7 +103,11 @@ func createMistralTranscriptionMultipartBody(req *MistralTranscriptionRequest, p
 // parseTranscriptionFormDataBodyFromRequest writes the transcription request to a multipart form.
 func parseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, req *MistralTranscriptionRequest, providerName schemas.ModelProvider) *schemas.BifrostError {
 	// Add file field - Mistral uses "file" as the form field name
-	fileWriter, err := writer.CreateFormFile("file", "audio.mp3")
+	filename := req.Filename
+	if filename == "" {
+		filename = providerUtils.AudioFilenameFromBytes(req.File)
+	}
+	fileWriter, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return providerUtils.NewBifrostOperationError("failed to create form file", err, providerName)
 	}

--- a/core/providers/mistral/types.go
+++ b/core/providers/mistral/types.go
@@ -42,6 +42,7 @@ type MistralListModelsResponse struct {
 type MistralTranscriptionRequest struct {
 	Model                  string   `json:"model"`                             // Required: e.g., "mistral-audio-transcribe"
 	File                   []byte   `json:"file"`                              // Required: Binary audio data
+	Filename               string   `json:"filename"`                          // Original filename, used to preserve file format extension
 	Language               *string  `json:"language,omitempty"`                // Optional: ISO 639-1 language code
 	Prompt                 *string  `json:"prompt,omitempty"`                  // Optional: Context hint for transcription
 	ResponseFormat         *string  `json:"response_format,omitempty"`         // Optional: "json", "text", "srt", "verbose_json", "vtt"

--- a/core/providers/openai/transcription.go
+++ b/core/providers/openai/transcription.go
@@ -33,8 +33,9 @@ func ToOpenAITranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReques
 	params := bifrostReq.Params
 
 	openaiReq := &OpenAITranscriptionRequest{
-		Model: bifrostReq.Model,
-		File:  transcriptionInput.File,
+		Model:    bifrostReq.Model,
+		File:     transcriptionInput.File,
+		Filename: transcriptionInput.Filename,
 	}
 
 	if params != nil {
@@ -47,7 +48,11 @@ func ToOpenAITranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReques
 // ParseTranscriptionFormDataBodyFromRequest parses the transcription request and writes it to the multipart form.
 func ParseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, openaiReq *OpenAITranscriptionRequest, providerName schemas.ModelProvider) *schemas.BifrostError {
 	// Add file field
-	fileWriter, err := writer.CreateFormFile("file", "audio.mp3") // OpenAI requires a filename
+	filename := openaiReq.Filename
+	if filename == "" {
+		filename = utils.AudioFilenameFromBytes(openaiReq.File)
+	}
+	fileWriter, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		return utils.NewBifrostOperationError("failed to create form file", err, providerName)
 	}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -680,8 +680,9 @@ func (r *OpenAISpeechRequest) SetExtraParams(params map[string]interface{}) {
 // OpenAITranscriptionRequest represents an OpenAI transcription request
 // Note: This is used for JSON body parsing, actual form parsing is handled in the router
 type OpenAITranscriptionRequest struct {
-	Model string `json:"model"`
-	File  []byte `json:"file"` // Binary audio data
+	Model    string `json:"model"`
+	File     []byte `json:"file"`     // Binary audio data
+	Filename string `json:"filename"` // Original filename, used to preserve file format extension
 
 	schemas.TranscriptionParameters
 	Stream *bool `json:"stream,omitempty"`

--- a/core/providers/utils/audio.go
+++ b/core/providers/utils/audio.go
@@ -117,3 +117,20 @@ func DetectAudioMimeType(audioData []byte) string {
 	// Fallback within supported set
 	return "audio/mp3"
 }
+
+// AudioFilenameFromBytes returns a filename with the correct extension for the given audio data.
+// Falls back to "audio.mp3" if the format cannot be detected.
+func AudioFilenameFromBytes(audioData []byte) string {
+	mimeToExt := map[string]string{
+		"audio/wav":  "audio.wav",
+		"audio/aac":  "audio.aac",
+		"audio/aiff": "audio.aiff",
+		"audio/flac": "audio.flac",
+		"audio/ogg":  "audio.ogg",
+	}
+	mime := DetectAudioMimeType(audioData)
+	if ext, ok := mimeToExt[mime]; ok {
+		return ext
+	}
+	return "audio.mp3"
+}

--- a/core/schemas/transcriptions.go
+++ b/core/schemas/transcriptions.go
@@ -26,7 +26,8 @@ type BifrostTranscriptionResponse struct {
 }
 
 type TranscriptionInput struct {
-	File []byte `json:"file"`
+	File     []byte `json:"file"`
+	Filename string `json:"filename,omitempty"` // Original filename, used to preserve file format extension
 }
 
 type TranscriptionParameters struct {

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1307,7 +1307,8 @@ func prepareTranscriptionRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostTran
 		return nil, false, fmt.Errorf("failed to read uploaded file: %v", err)
 	}
 	transcriptionInput := &schemas.TranscriptionInput{
-		File: fileData,
+		File:     fileData,
+		Filename: fileHeader.Filename,
 	}
 	transcriptionParams := &schemas.TranscriptionParameters{}
 	if languageValues := form.Value["language"]; len(languageValues) > 0 && languageValues[0] != "" {

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: preserve original audio filename in transcription requests


### PR DESCRIPTION
## Summary

Enhances transcription functionality by preserving original audio filenames throughout the request pipeline and adding automatic audio format detection. This ensures that audio files maintain their proper file extensions when sent to transcription providers, improving compatibility and debugging capabilities.

## Changes

- Added `Filename` field to `TranscriptionInput` schema to carry original filename through requests
- Created `AudioFilenameFromBytes` utility function that detects audio format from file headers and generates appropriate filenames
- Updated OpenAI, Mistral, and Elevenlabs providers to use original filename when available, falling back to auto-detected format
- Modified HTTP handler to capture and preserve uploaded file's original filename
- Audio format detection supports WAV, AAC, AIFF, FLAC, and OGG with MP3 as fallback

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test transcription requests with various audio formats to verify filename preservation:

```sh
# Core/Transports
go version
go test ./...

# Test with different audio formats
curl -X POST http://localhost:8080/v1/audio/transcriptions \
  -H "Authorization: Bearer your-token" \
  -F "file=@test.wav" \
  -F "model=whisper-1"

curl -X POST http://localhost:8080/v1/audio/transcriptions \
  -H "Authorization: Bearer your-token" \
  -F "file=@test.mp3" \
  -F "model=whisper-1"
```

Verify that the correct file extensions are preserved in provider requests and that audio format detection works for files without original filenames.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The filename field only preserves the original file extension for better provider compatibility and does not expose sensitive information.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable