### PR TITLE
fixes raw request serialization in sse events

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -840,8 +840,9 @@ func EnrichError(
 	}
 
 	if ShouldSendBackRawRequest(ctx, sendBackRawRequest) && len(requestBody) > 0 {
-		// Store as json.RawMessage to preserve exact JSON bytes (including key ordering)
-		bifrostErr.ExtraFields.RawRequest = json.RawMessage(requestBody)
+		// Store as json.RawMessage to preserve exact JSON bytes (including key ordering).
+		// Compact to remove insignificant whitespace that would break SSE framing.
+		bifrostErr.ExtraFields.RawRequest = compactRawJSON(requestBody)
 	} else {
 		bifrostErr.ExtraFields.RawRequest = nil
 	}
@@ -882,7 +883,8 @@ func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody
 		// Store as json.RawMessage to preserve the exact JSON bytes (including key ordering).
 		// Previously this used sonic.Unmarshal into interface{} which created map[string]interface{}
 		// and destroyed key ordering in tool schemas and other order-sensitive structures.
-		rawRequest = json.RawMessage(requestBody)
+		// Compact to remove insignificant whitespace that would break SSE framing.
+		rawRequest = compactRawJSON(requestBody)
 	}
 
 	if sendBackRawResponse {
@@ -919,11 +921,24 @@ func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody
 	return nil, nil, nil
 }
 
+// compactRawJSON removes insignificant whitespace from JSON bytes, returning a
+// json.RawMessage safe for SSE streaming (no literal newlines). Falls back to
+// the original bytes if compaction fails (e.g., invalid JSON).
+func compactRawJSON(data []byte) json.RawMessage {
+	var buf bytes.Buffer
+	if err := schemas.Compact(&buf, data); err == nil {
+		return json.RawMessage(buf.Bytes())
+	}
+	return json.RawMessage(data)
+}
+
 // ParseAndSetRawRequest stores the raw request body in the extra fields.
 // Uses json.RawMessage to preserve the exact JSON bytes (including key ordering).
+// The body is compacted to remove insignificant whitespace, which prevents
+// literal newlines from breaking SSE data-line framing during streaming.
 func ParseAndSetRawRequest(extraFields *schemas.BifrostResponseExtraFields, jsonBody []byte) {
 	if len(jsonBody) > 0 {
-		extraFields.RawRequest = json.RawMessage(jsonBody)
+		extraFields.RawRequest = compactRawJSON(jsonBody)
 	}
 }
 

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/bytedance/sonic"
@@ -819,5 +821,182 @@ func TestMergeExtraParamsIntoJSON_EmptyExtraParams(t *testing.T) {
 	}
 	if len(parsed) != 2 {
 		t.Fatalf("Expected 2 keys, got %d", len(parsed))
+	}
+}
+
+// TestParseAndSetRawRequest_CompactsJSON verifies that indented JSON input
+// (with literal newlines from MarshalIndent) is compacted to a single line.
+// This is critical for SSE streaming where newlines break data-line framing.
+func TestParseAndSetRawRequest_CompactsJSON(t *testing.T) {
+	indentedJSON := []byte(`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello"
+    }
+  ],
+  "temperature": 0.7
+}`)
+
+	var extraFields schemas.BifrostResponseExtraFields
+	ParseAndSetRawRequest(&extraFields, indentedJSON)
+
+	if extraFields.RawRequest == nil {
+		t.Fatal("RawRequest should be set")
+	}
+
+	raw, ok := extraFields.RawRequest.(json.RawMessage)
+	if !ok {
+		t.Fatalf("RawRequest should be json.RawMessage, got %T", extraFields.RawRequest)
+	}
+
+	// The compacted output must not contain any literal newlines
+	if strings.Contains(string(raw), "\n") {
+		t.Errorf("Compacted RawRequest should not contain newlines, got:\n%s", string(raw))
+	}
+
+	// Verify it's still valid JSON with the same content
+	var parsed map[string]interface{}
+	if err := sonic.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("Compacted RawRequest is not valid JSON: %v", err)
+	}
+
+	if parsed["model"] != "gpt-4" {
+		t.Errorf("Expected model=gpt-4, got %v", parsed["model"])
+	}
+}
+
+// TestParseAndSetRawRequest_PreservesKeyOrdering verifies that JSON key order
+// is maintained after compaction. This is essential for LLM prompt caching
+// where key ordering affects cache hit rates.
+func TestParseAndSetRawRequest_PreservesKeyOrdering(t *testing.T) {
+	// Keys are intentionally not alphabetically sorted
+	jsonBody := []byte(`{"z_last":"z","a_first":"a","m_middle":"m"}`)
+
+	var extraFields schemas.BifrostResponseExtraFields
+	ParseAndSetRawRequest(&extraFields, jsonBody)
+
+	raw := extraFields.RawRequest.(json.RawMessage)
+	result := string(raw)
+
+	zIdx := strings.Index(result, `"z_last"`)
+	aIdx := strings.Index(result, `"a_first"`)
+	mIdx := strings.Index(result, `"m_middle"`)
+
+	if zIdx >= aIdx || aIdx >= mIdx {
+		t.Errorf("Key ordering not preserved. Got: %s", result)
+	}
+}
+
+// TestParseAndSetRawRequest_EmptyBody verifies that empty input is a no-op.
+func TestParseAndSetRawRequest_EmptyBody(t *testing.T) {
+	var extraFields schemas.BifrostResponseExtraFields
+	ParseAndSetRawRequest(&extraFields, []byte{})
+
+	if extraFields.RawRequest != nil {
+		t.Error("RawRequest should be nil for empty body")
+	}
+
+	ParseAndSetRawRequest(&extraFields, nil)
+
+	if extraFields.RawRequest != nil {
+		t.Error("RawRequest should be nil for nil body")
+	}
+}
+
+// TestParseAndSetRawRequest_SSEStreamingChunks simulates the actual SSE streaming
+// flow end-to-end: a response chunk with raw_request containing indented JSON is
+// marshaled, framed as SSE "data: <json>\n\n", and then each SSE data line is
+// parsed back. This is the exact scenario that caused issue #1905 — pretty-printed
+// JSON in raw_request introduced literal newlines that broke SSE data-line framing.
+func TestParseAndSetRawRequest_SSEStreamingChunks(t *testing.T) {
+	// Simulate indented request body (as produced by MarshalSortedIndent)
+	indentedRequest := []byte(`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Hello"
+    }
+  ],
+  "stream": true,
+  "temperature": 0.7
+}`)
+
+	// Build a response chunk with raw_request set via ParseAndSetRawRequest.
+	// Uses BifrostChatResponse which is the actual type marshaled in the streaming path.
+	chunk := schemas.BifrostChatResponse{
+		ID:     "chatcmpl-test",
+		Model:  "gpt-4",
+		Object: "chat.completion.chunk",
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				Index: 0,
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{
+						Content: schemas.Ptr("Hello"),
+					},
+				},
+			},
+		},
+	}
+	ParseAndSetRawRequest(&chunk.ExtraFields, indentedRequest)
+
+	// Marshal the chunk (exactly like the transport layer does: sonic.Marshal)
+	chunkJSON, err := sonic.Marshal(chunk)
+	if err != nil {
+		t.Fatalf("Failed to marshal chunk: %v", err)
+	}
+
+	// Frame as SSE: "data: <json>\n\n" (exactly as in inference.go:1591)
+	sseFrame := fmt.Sprintf("data: %s\n\n", chunkJSON)
+
+	// Parse the SSE frame line-by-line as a real SSE client would.
+	// Split on \n and check that there is exactly one "data:" line.
+	lines := strings.Split(strings.TrimRight(sseFrame, "\n"), "\n")
+
+	var dataLines []string
+	for _, line := range lines {
+		if strings.HasPrefix(line, "data: ") {
+			dataLines = append(dataLines, line)
+		} else if line != "" {
+			// Any non-empty, non-data line means SSE framing is broken —
+			// this is exactly what happened in #1905
+			t.Errorf("Unexpected non-data line in SSE frame (broken framing): %q", line)
+		}
+	}
+
+	if len(dataLines) != 1 {
+		t.Fatalf("Expected exactly 1 SSE data line, got %d:\n%s", len(dataLines), sseFrame)
+	}
+
+	// Parse the JSON payload from the single data line
+	jsonPayload := strings.TrimPrefix(dataLines[0], "data: ")
+	var parsed schemas.BifrostChatResponse
+	if err := sonic.Unmarshal([]byte(jsonPayload), &parsed); err != nil {
+		t.Fatalf("Failed to parse SSE data line as JSON (this is the #1905 bug): %v\nPayload: %s", err, jsonPayload)
+	}
+
+	// Verify the parsed response has the correct content
+	if parsed.ID != "chatcmpl-test" {
+		t.Errorf("Expected ID=chatcmpl-test, got %s", parsed.ID)
+	}
+	if parsed.ExtraFields.RawRequest == nil {
+		t.Error("RawRequest should be present in parsed chunk")
+	}
+
+	// Verify raw_request round-trips correctly — the client should be able
+	// to parse it back into the original request structure
+	rawBytes, err := sonic.Marshal(parsed.ExtraFields.RawRequest)
+	if err != nil {
+		t.Fatalf("Failed to marshal raw_request: %v", err)
+	}
+	var rawParsed map[string]interface{}
+	if err := sonic.Unmarshal(rawBytes, &rawParsed); err != nil {
+		t.Fatalf("raw_request is not valid JSON after round-trip: %v", err)
+	}
+	if rawParsed["model"] != "gpt-4" {
+		t.Errorf("Expected raw_request.model=gpt-4, got %v", rawParsed["model"])
 	}
 }

--- a/core/schemas/json_native.go
+++ b/core/schemas/json_native.go
@@ -2,7 +2,12 @@
 
 package schemas
 
-import "github.com/bytedance/sonic"
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/bytedance/sonic"
+)
 
 // Marshal encodes v to JSON bytes using the high-performance sonic library.
 func Marshal(v interface{}) ([]byte, error) {
@@ -17,4 +22,10 @@ func MarshalString(v interface{}) (string, error) {
 // Unmarshal decodes JSON data into v using sonic.
 func Unmarshal(data []byte, v interface{}) error {
 	return sonic.Unmarshal(data, v)
+}
+
+// Compact removes insignificant whitespace from JSON-encoded src
+// and appends the result to dst.
+func Compact(dst *bytes.Buffer, src []byte) error {
+	return json.Compact(dst, src)
 }

--- a/core/schemas/json_wasm.go
+++ b/core/schemas/json_wasm.go
@@ -2,7 +2,10 @@
 
 package schemas
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 // Marshal encodes v to JSON bytes using the standard library.
 func Marshal(v interface{}) ([]byte, error) {
@@ -21,4 +24,10 @@ func MarshalString(v interface{}) (string, error) {
 // Unmarshal decodes JSON data into v using the standard library.
 func Unmarshal(data []byte, v interface{}) error {
 	return json.Unmarshal(data, v)
+}
+
+// Compact removes insignificant whitespace from JSON-encoded src
+// and appends the result to dst.
+func Compact(dst *bytes.Buffer, src []byte) error {
+	return json.Compact(dst, src)
 }


### PR DESCRIPTION
## Summary

Fixes SSE streaming issues by compacting JSON in raw request fields to remove literal newlines that break SSE data-line framing. When indented JSON containing newlines was included in streaming responses, it caused SSE parsing failures on the client side.

## Issues

Fixes #1905

## Changes

- Added `compactRawJSON()` function that removes insignificant whitespace from JSON while preserving key ordering and falling back gracefully for invalid JSON
- Modified `EnrichError()`, `HandleProviderResponse()`, and `ParseAndSetRawRequest()` to compact raw request JSON before storing
- Added `Compact()` function to both native and WASM JSON schemas for cross-platform JSON compaction
- Comprehensive test coverage including SSE streaming simulation that reproduces the exact failure scenario

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that SSE streaming works correctly with indented JSON requests:

```sh
# Core/Transports
go version
go test ./core/providers/utils/... -v
go test ./core/schemas/... -v

# Test the specific SSE streaming scenario
go test ./core/providers/utils/... -run TestParseAndSetRawRequest_SSEStreamingChunks -v
```

The tests verify that:
- Indented JSON is compacted to single-line format
- Key ordering is preserved for cache consistency
- SSE framing remains intact during streaming
- JSON round-trip parsing works correctly

## Screenshots/Recordings

N/A - Backend streaming fix

## Breaking changes

- [ ] Yes
- [x] No

This change only affects internal JSON formatting and maintains full API compatibility.

## Related issues

Fixes SSE streaming failures caused by literal newlines in raw request JSON breaking data-line framing.

## Security considerations

No security implications - this only changes JSON whitespace formatting without affecting data content or access controls.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable