### PR TITLE
skill changes

### DIFF
--- a/.claude/skills/changelog-writer/SKILL.md
+++ b/.claude/skills/changelog-writer/SKILL.md
@@ -206,7 +206,13 @@ Write simple flat-list entries to each module's `changelog.md`:
 - hotfix: description of urgent fix
 ```
 
-For modules with only cascading bumps (no code changes), leave their `changelog.md` empty or unchanged.
+For modules with only cascading bumps (no code changes), add a `chore:` entry describing which upstream dependencies were bumped. **No changelog should ever be left empty.** Example:
+
+```markdown
+- chore: upgraded core to v1.5.0 and framework to v1.3.0
+```
+
+If only one upstream changed, mention just that one (e.g., `- chore: upgraded core to v1.5.0`). Always use the actual new versions of the upstream modules.
 
 **Formatting rules for per-module changelogs:**
 - Each entry starts with `- ` followed by the type prefix and colon
@@ -238,6 +244,7 @@ The transports changelog uses a categorized format with bold names. Write it usi
 - Include changes from ALL modules (transports is the top-level summary)
 - Breaking changes get a `<Warning>` or `<Note>` block indented under the entry
 - Omit sections that have no entries (e.g., if there are no features, skip the Features section)
+- If the release has only cascading bumps and no meaningful features or fixes, add a `## 🔧 Maintenance` section with an entry like: `- **Dependency Upgrades** — Bumped core to v1.5.0 and framework to v1.3.0 across all modules`
 
 ### Step 6: Update Version Files
 


### PR DESCRIPTION
## Summary

Updated the changelog writer skill to ensure no changelog entries are left empty and provide better guidance for maintenance-only releases.

## Changes

- Modified the changelog writer skill to require `chore:` entries for modules with only cascading dependency bumps instead of leaving their changelogs empty
- Added specific formatting guidance for chore entries, including examples of how to describe upstream dependency upgrades with actual version numbers
- Introduced a new `🔧 Maintenance` section for the transports changelog when releases contain only dependency bumps without meaningful features or fixes

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the changelog writer skill documentation is clear and follows the updated guidelines:

```sh
# Review the skill documentation
cat .claude/skills/changelog-writer/SKILL.md

# Test the skill with a maintenance-only release scenario
# Ensure chore entries are generated instead of empty changelogs
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a documentation update for changelog generation guidelines.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable