### PR TITLE
fix: Codex compatibility issues in fallback handling and request decompression

### DIFF
--- a/core/providers/openai/errors.go
+++ b/core/providers/openai/errors.go
@@ -1,6 +1,9 @@
 package openai
 
 import (
+	"fmt"
+	"strings"
+
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
@@ -25,10 +28,23 @@ func ParseOpenAIError(resp *fasthttp.Response, requestType schemas.RequestType, 
 		}
 		bifrostErr.Error.Type = errorResp.Error.Type
 		bifrostErr.Error.Code = errorResp.Error.Code
-		bifrostErr.Error.Message = errorResp.Error.Message
+		if errorResp.Error.Message != "" {
+			bifrostErr.Error.Message = errorResp.Error.Message
+		}
 		bifrostErr.Error.Param = errorResp.Error.Param
 		if errorResp.Error.EventID != nil {
 			bifrostErr.Error.EventID = errorResp.Error.EventID
+		}
+	}
+
+	if bifrostErr.Error == nil {
+		bifrostErr.Error = &schemas.ErrorField{}
+	}
+	if strings.TrimSpace(bifrostErr.Error.Message) == "" {
+		if bifrostErr.StatusCode != nil {
+			bifrostErr.Error.Message = fmt.Sprintf("provider API error (status %d)", *bifrostErr.StatusCode)
+		} else {
+			bifrostErr.Error.Message = "provider API error"
 		}
 	}
 

--- a/core/providers/openai/errors_test.go
+++ b/core/providers/openai/errors_test.go
@@ -1,0 +1,82 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+func TestParseOpenAIError_FallbackMessageWhenProviderBodyIsNonOpenAIShape(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusUnprocessableEntity)
+	resp.SetBodyString(`{"detail":[{"loc":["body","messages",0,"role"],"msg":"value is not a valid enumeration member"}]}`)
+
+	errResp := ParseOpenAIError(&resp, schemas.ResponsesStreamRequest, schemas.Cerebras, "llama3.1-8b")
+	if errResp == nil || errResp.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	if errResp.Error.Message == "" {
+		t.Fatal("expected non-empty error message")
+	}
+	if errResp.Error.Message != "provider API error (status 422)" {
+		t.Fatalf("expected fallback message, got %q", errResp.Error.Message)
+	}
+}
+
+func TestParseOpenAIError_PreservesProviderMessageWhenPresent(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusUnprocessableEntity)
+	resp.SetBodyString(`{"error":{"message":"unsupported role: developer","type":"invalid_request_error","param":"messages.0.role","code":"invalid_value"}}`)
+
+	errResp := ParseOpenAIError(&resp, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4o")
+	if errResp == nil || errResp.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	if errResp.Error.Message != "unsupported role: developer" {
+		t.Fatalf("expected provider message, got %q", errResp.Error.Message)
+	}
+}
+
+func TestParseOpenAIError_FallbackMessageWhenBodyIsEmpty(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBody(nil)
+
+	errResp := ParseOpenAIError(&resp, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4o")
+	if errResp == nil || errResp.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	// HandleProviderAPIError returns ErrProviderResponseEmpty for empty bodies.
+	if errResp.Error.Message != schemas.ErrProviderResponseEmpty {
+		t.Fatalf("expected empty-response message, got %q", errResp.Error.Message)
+	}
+}
+
+func TestParseOpenAIError_WhitespaceProviderMessageFallsBack(t *testing.T) {
+	var resp fasthttp.Response
+	resp.SetStatusCode(fasthttp.StatusBadRequest)
+	resp.SetBodyString(`{"error":{"message":"   ","type":"invalid_request_error"}}`)
+
+	errResp := ParseOpenAIError(&resp, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4o")
+	if errResp == nil || errResp.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	if errResp.Error.Message != "provider API error (status 400)" {
+		t.Fatalf("expected fallback message, got %q", errResp.Error.Message)
+	}
+}
+
+func TestParseOpenAIError_DefaultStatusCodeFallsBackWithStatusNumber(t *testing.T) {
+	var resp fasthttp.Response
+	// fasthttp defaults zero-value response status code to 200.
+	resp.SetBodyString(`{"error":{"message":""}}`)
+
+	errResp := ParseOpenAIError(&resp, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4o")
+	if errResp == nil || errResp.Error == nil {
+		t.Fatal("expected non-nil error response")
+	}
+	if errResp.Error.Message != "provider API error (status 200)" {
+		t.Fatalf("expected fallback message with default status, got %q", errResp.Error.Message)
+	}
+}

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -1009,6 +1010,7 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 
 	// Convert Input messages using existing ToChatMessages()
 	bcr.Input = ToChatMessages(brr.Input)
+	normalizeDeveloperRoleForChatFallback(bcr.Input)
 
 	// Convert Parameters
 	if brr.Params != nil {
@@ -1037,20 +1039,13 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 			}
 		}
 
-		// Convert Tools using existing ResponsesTool.ToChatTool()
-		if len(brr.Params.Tools) > 0 {
-			chatTools := make([]ChatTool, 0, len(brr.Params.Tools))
-			for _, responsesTool := range brr.Params.Tools {
-				chatTool := responsesTool.ToChatTool()
-				chatTools = append(chatTools, *chatTool)
-			}
-			bcr.Params.Tools = chatTools
-		}
+		// Responses -> Chat fallback only supports function tools in a valid chat shape.
+		bcr.Params.Tools = sanitizeResponsesToolsForChatFallback(brr.Params.Tools)
 
 		// Convert ToolChoice using existing ResponsesToolChoice.ToChatToolChoice()
 		if brr.Params.ToolChoice != nil {
 			chatToolChoice := brr.Params.ToolChoice.ToChatToolChoice()
-			bcr.Params.ToolChoice = chatToolChoice
+			bcr.Params.ToolChoice = sanitizeChatToolChoiceForFallback(chatToolChoice, bcr.Params.Tools)
 		}
 
 		// Handle Reasoning from Reasoning
@@ -1070,6 +1065,77 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 	bcr.RawRequestBody = brr.RawRequestBody
 
 	return bcr
+}
+
+func sanitizeResponsesToolsForChatFallback(tools []ResponsesTool) []ChatTool {
+	if len(tools) == 0 {
+		return nil
+	}
+
+	chatTools := make([]ChatTool, 0, len(tools))
+	for _, responsesTool := range tools {
+		if responsesTool.Type != ResponsesToolTypeFunction {
+			continue
+		}
+		if responsesTool.Name == nil || strings.TrimSpace(*responsesTool.Name) == "" {
+			continue
+		}
+
+		chatTool := responsesTool.ToChatTool()
+		if chatTool == nil || chatTool.Function == nil || strings.TrimSpace(chatTool.Function.Name) == "" {
+			continue
+		}
+
+		chatTool.Type = ChatToolTypeFunction
+		chatTool.Custom = nil
+		chatTools = append(chatTools, *chatTool)
+	}
+
+	if len(chatTools) == 0 {
+		return nil
+	}
+
+	return chatTools
+}
+
+func normalizeDeveloperRoleForChatFallback(messages []ChatMessage) {
+	for i := range messages {
+		if messages[i].Role == ChatMessageRoleDeveloper {
+			messages[i].Role = ChatMessageRoleSystem
+		}
+	}
+}
+
+func sanitizeChatToolChoiceForFallback(toolChoice *ChatToolChoice, tools []ChatTool) *ChatToolChoice {
+	if toolChoice == nil {
+		return nil
+	}
+	if len(tools) == 0 {
+		return nil
+	}
+
+	validToolNames := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		if tool.Function != nil && strings.TrimSpace(tool.Function.Name) != "" {
+			validToolNames[tool.Function.Name] = struct{}{}
+		}
+	}
+
+	if toolChoice.ChatToolChoiceStruct != nil {
+		switch toolChoice.ChatToolChoiceStruct.Type {
+		case ChatToolChoiceTypeFunction:
+			if toolChoice.ChatToolChoiceStruct.Function == nil {
+				return nil
+			}
+			if _, ok := validToolNames[toolChoice.ChatToolChoiceStruct.Function.Name]; !ok {
+				return nil
+			}
+		case ChatToolChoiceTypeAllowedTools, ChatToolChoiceTypeCustom:
+			return nil
+		}
+	}
+
+	return toolChoice
 }
 
 // =============================================================================
@@ -1185,6 +1251,7 @@ type ChatToResponsesStreamState struct {
 	TextItemAdded         bool              // Whether text item has been added
 	TextItemClosed        bool              // Whether text item has been closed
 	TextItemHasContent    bool              // Whether text item has received any content deltas
+	TextBuffer            strings.Builder   // Accumulated text deltas for output_text.done/content_part.done
 	CurrentOutputIndex    int               // Current output index counter
 	ToolCallOutputIndices map[string]int    // Maps tool call ID to output index
 	SequenceNumber        int               // Monotonic sequence number across all chunks
@@ -1207,6 +1274,7 @@ var chatToResponsesStreamStatePool = sync.Pool{
 			TextItemAdded:         false,
 			TextItemClosed:        false,
 			TextItemHasContent:    false,
+			TextBuffer:            strings.Builder{},
 		}
 	},
 }
@@ -1251,6 +1319,7 @@ func AcquireChatToResponsesStreamState() *ChatToResponsesStreamState {
 	state.TextItemAdded = false
 	state.TextItemClosed = false
 	state.TextItemHasContent = false
+	state.TextBuffer = strings.Builder{}
 	state.SequenceNumber = 0
 	return state
 }
@@ -1284,6 +1353,7 @@ func ReleaseChatToResponsesStreamState(state *ChatToResponsesStreamState) {
 		state.TextItemAdded = false
 		state.TextItemClosed = false
 		state.TextItemHasContent = false
+		state.TextBuffer = strings.Builder{}
 		state.SequenceNumber = 0
 		chatToResponsesStreamStatePool.Put(state)
 	}
@@ -1423,6 +1493,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			var contentDelta string
 			if hasContent {
 				contentDelta = *delta.Content
+				state.TextBuffer.WriteString(contentDelta)
 			} else {
 				// For reasoning-only responses, emit empty delta on first chunk
 				contentDelta = ""
@@ -1474,15 +1545,14 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 					outputIndex := 0
 					itemID := state.ItemIDs["text"]
 
-					// Emit output_text.done (without accumulated text, just the event)
-					emptyText := ""
+					finalText := state.TextBuffer.String()
 					responses = append(responses, &BifrostResponsesStreamResponse{
 						Type:           ResponsesStreamResponseTypeOutputTextDone,
 						SequenceNumber: state.SequenceNumber,
 						OutputIndex:    Ptr(outputIndex),
 						ContentIndex:   Ptr(0),
 						ItemID:         &itemID,
-						Text:           &emptyText,
+						Text:           &finalText,
 						LogProbs:       []ResponsesOutputMessageContentTextLogProb{},
 						ExtraFields:    cr.ExtraFields,
 					})
@@ -1491,7 +1561,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 					// Emit content_part.done
 					part := &ResponsesMessageContentBlock{
 						Type: ResponsesOutputMessageContentTypeText,
-						Text: &emptyText,
+						Text: &finalText,
 						ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
 							LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
 							Annotations: []ResponsesOutputMessageContentTextAnnotation{},
@@ -1512,12 +1582,22 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 					statusCompleted := "completed"
 					messageType := ResponsesMessageTypeMessage
 					role := ResponsesInputMessageRoleAssistant
+					textType := ResponsesOutputMessageContentTypeText
 					doneItem := &ResponsesMessage{
 						Type:   &messageType,
 						Role:   &role,
 						Status: &statusCompleted,
 						Content: &ResponsesMessageContent{
-							ContentBlocks: []ResponsesMessageContentBlock{},
+							ContentBlocks: []ResponsesMessageContentBlock{
+								{
+									Type: textType,
+									Text: &finalText,
+									ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
+										LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
+										Annotations: []ResponsesOutputMessageContentTextAnnotation{},
+									},
+								},
+							},
 						},
 					}
 					if itemID != "" {
@@ -1634,15 +1714,14 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			outputIndex := 0
 			itemID := state.ItemIDs["text"]
 
-			// Emit output_text.done (without accumulated text, just the event)
-			emptyText := ""
+			finalText := state.TextBuffer.String()
 			responses = append(responses, &BifrostResponsesStreamResponse{
 				Type:           ResponsesStreamResponseTypeOutputTextDone,
 				SequenceNumber: state.SequenceNumber,
 				OutputIndex:    Ptr(outputIndex),
 				ContentIndex:   Ptr(0),
 				ItemID:         &itemID,
-				Text:           &emptyText,
+				Text:           &finalText,
 				LogProbs:       []ResponsesOutputMessageContentTextLogProb{},
 				ExtraFields:    cr.ExtraFields,
 			})
@@ -1651,7 +1730,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			// Emit content_part.done
 			part := &ResponsesMessageContentBlock{
 				Type: ResponsesOutputMessageContentTypeText,
-				Text: &emptyText,
+				Text: &finalText,
 				ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
 					LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
 					Annotations: []ResponsesOutputMessageContentTextAnnotation{},
@@ -1672,12 +1751,22 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			statusCompleted := "completed"
 			messageType := ResponsesMessageTypeMessage
 			role := ResponsesInputMessageRoleAssistant
+			textType := ResponsesOutputMessageContentTypeText
 			doneItem := &ResponsesMessage{
 				Type:   &messageType,
 				Role:   &role,
 				Status: &statusCompleted,
 				Content: &ResponsesMessageContent{
-					ContentBlocks: []ResponsesMessageContentBlock{},
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{
+							Type: textType,
+							Text: &finalText,
+							ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
+								LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
+								Annotations: []ResponsesOutputMessageContentTextAnnotation{},
+							},
+						},
+					},
 				},
 			}
 			if itemID != "" {
@@ -1764,6 +1853,36 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 
 		if state.Model != nil {
 			response.Model = *state.Model
+		}
+		if state.TextItemAdded {
+			statusCompleted := "completed"
+			messageType := ResponsesMessageTypeMessage
+			role := ResponsesInputMessageRoleAssistant
+			textType := ResponsesOutputMessageContentTypeText
+			finalText := state.TextBuffer.String()
+			itemID := state.ItemIDs["text"]
+
+			msg := ResponsesMessage{
+				Type:   &messageType,
+				Role:   &role,
+				Status: &statusCompleted,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{
+							Type: textType,
+							Text: &finalText,
+							ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
+								LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
+								Annotations: []ResponsesOutputMessageContentTextAnnotation{},
+							},
+						},
+					},
+				},
+			}
+			if itemID != "" {
+				msg.ID = &itemID
+			}
+			response.Output = []ResponsesMessage{msg}
 		}
 
 		responses = append(responses, &BifrostResponsesStreamResponse{

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -1,0 +1,321 @@
+package schemas
+
+import "testing"
+
+func TestToChatMessages_PreservesDeveloperRole(t *testing.T) {
+	messages := []ResponsesMessage{
+		{
+			Role: Ptr(ResponsesInputMessageRoleDeveloper),
+			Content: &ResponsesMessageContent{
+				ContentBlocks: []ResponsesMessageContentBlock{
+					{
+						Type: ResponsesInputMessageContentBlockTypeText,
+						Text: Ptr("You are helpful"),
+					},
+				},
+			},
+		},
+	}
+
+	chatMessages := ToChatMessages(messages)
+	if len(chatMessages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(chatMessages))
+	}
+	if chatMessages[0].Role != ChatMessageRoleDeveloper {
+		t.Fatalf("expected role %q, got %q", ChatMessageRoleDeveloper, chatMessages[0].Role)
+	}
+}
+
+func TestToChatRequest_NormalizesDeveloperRoleToSystemForFallback(t *testing.T) {
+	req := &BifrostResponsesRequest{
+		Input: []ResponsesMessage{
+			{
+				Role: Ptr(ResponsesInputMessageRoleDeveloper),
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{
+							Type: ResponsesInputMessageContentBlockTypeText,
+							Text: Ptr("You are helpful"),
+						},
+					},
+				},
+			},
+		},
+		Params: &ResponsesParameters{},
+	}
+
+	chatReq := req.ToChatRequest()
+	if chatReq == nil {
+		t.Fatal("expected non-nil chat request")
+	}
+	if len(chatReq.Input) != 1 {
+		t.Fatalf("expected 1 chat message, got %d", len(chatReq.Input))
+	}
+	if chatReq.Input[0].Role != ChatMessageRoleSystem {
+		t.Fatalf("expected role %q in fallback conversion, got %q", ChatMessageRoleSystem, chatReq.Input[0].Role)
+	}
+}
+
+func TestToChatMessages_LeavesExistingSupportedRolesUnchanged(t *testing.T) {
+	messages := []ResponsesMessage{
+		{Role: Ptr(ResponsesInputMessageRoleSystem)},
+		{Role: Ptr(ResponsesInputMessageRoleUser)},
+		{Role: Ptr(ResponsesInputMessageRoleAssistant)},
+	}
+
+	chatMessages := ToChatMessages(messages)
+	if len(chatMessages) != len(messages) {
+		t.Fatalf("expected %d messages, got %d", len(messages), len(chatMessages))
+	}
+
+	if chatMessages[0].Role != ChatMessageRoleSystem {
+		t.Fatalf("expected system role, got %q", chatMessages[0].Role)
+	}
+	if chatMessages[1].Role != ChatMessageRoleUser {
+		t.Fatalf("expected user role, got %q", chatMessages[1].Role)
+	}
+	if chatMessages[2].Role != ChatMessageRoleAssistant {
+		t.Fatalf("expected assistant role, got %q", chatMessages[2].Role)
+	}
+}
+
+func TestToChatRequest_FiltersUnsupportedResponsesToolsForFallback(t *testing.T) {
+	validName := "valid_tool"
+	invalidName := "  "
+	req := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			Tools: []ResponsesTool{
+				{
+					Type: ResponsesToolTypeFunction,
+					Name: &validName,
+					ResponsesToolFunction: &ResponsesToolFunction{
+						Parameters: &ToolFunctionParameters{
+							Type:       "object",
+							Properties: &OrderedMap{},
+						},
+					},
+				},
+				{
+					Type: ResponsesToolTypeFunction,
+					Name: &invalidName,
+				},
+				{
+					Type: ResponsesToolTypeMCP,
+					Name: Ptr("mcp_tool"),
+				},
+				{
+					Type: ResponsesToolTypeWebSearch,
+					Name: Ptr("web_search"),
+				},
+			},
+		},
+	}
+
+	chatReq := req.ToChatRequest()
+	if chatReq == nil || chatReq.Params == nil {
+		t.Fatal("expected non-nil chat request params")
+	}
+	if len(chatReq.Params.Tools) != 1 {
+		t.Fatalf("expected 1 valid fallback tool, got %d", len(chatReq.Params.Tools))
+	}
+	if chatReq.Params.Tools[0].Type != ChatToolTypeFunction {
+		t.Fatalf("expected tool type %q, got %q", ChatToolTypeFunction, chatReq.Params.Tools[0].Type)
+	}
+	if chatReq.Params.Tools[0].Function == nil || chatReq.Params.Tools[0].Function.Name != validName {
+		t.Fatalf("expected function tool %q to be preserved", validName)
+	}
+}
+
+func TestToChatRequest_DropsInvalidToolChoiceForFallback(t *testing.T) {
+	validName := "valid_tool"
+	invalidChoiceName := "missing_tool"
+	req := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			Tools: []ResponsesTool{
+				{
+					Type: ResponsesToolTypeFunction,
+					Name: &validName,
+				},
+			},
+			ToolChoice: &ResponsesToolChoice{
+				ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{
+					Type: ResponsesToolChoiceTypeFunction,
+					Name: &invalidChoiceName,
+				},
+			},
+		},
+	}
+
+	chatReq := req.ToChatRequest()
+	if chatReq == nil || chatReq.Params == nil {
+		t.Fatal("expected non-nil chat request params")
+	}
+	if chatReq.Params.ToolChoice != nil {
+		t.Fatal("expected incompatible tool choice to be removed for fallback")
+	}
+}
+
+func TestToChatRequest_AllNonFunctionToolsDropsToolsAndToolChoice(t *testing.T) {
+	auto := string(ChatToolChoiceTypeAuto)
+	req := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			Tools: []ResponsesTool{
+				{Type: ResponsesToolTypeMCP, Name: Ptr("mcp")},
+				{Type: ResponsesToolTypeWebSearch, Name: Ptr("search")},
+			},
+			ToolChoice: &ResponsesToolChoice{
+				ResponsesToolChoiceStr: &auto,
+			},
+		},
+	}
+
+	chatReq := req.ToChatRequest()
+	if chatReq == nil || chatReq.Params == nil {
+		t.Fatal("expected non-nil chat request params")
+	}
+	if chatReq.Params.Tools != nil {
+		t.Fatalf("expected nil tools when all tools are unsupported, got %d", len(chatReq.Params.Tools))
+	}
+	if chatReq.Params.ToolChoice != nil {
+		t.Fatal("expected tool choice to be dropped when no valid tools remain")
+	}
+}
+
+func TestToChatRequest_DropsAllowedToolsAndCustomToolChoiceForFallback(t *testing.T) {
+	validName := "valid_tool"
+	tests := []ResponsesToolChoiceType{
+		ResponsesToolChoiceTypeAllowedTools,
+		ResponsesToolChoiceTypeCustom,
+	}
+
+	for _, choiceType := range tests {
+		t.Run(string(choiceType), func(t *testing.T) {
+			req := &BifrostResponsesRequest{
+				Params: &ResponsesParameters{
+					Tools: []ResponsesTool{
+						{
+							Type: ResponsesToolTypeFunction,
+							Name: &validName,
+						},
+					},
+					ToolChoice: &ResponsesToolChoice{
+						ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{
+							Type: choiceType,
+						},
+					},
+				},
+			}
+
+			chatReq := req.ToChatRequest()
+			if chatReq == nil || chatReq.Params == nil {
+				t.Fatal("expected non-nil chat request params")
+			}
+			if chatReq.Params.ToolChoice != nil {
+				t.Fatalf("expected %q tool choice to be dropped for fallback", choiceType)
+			}
+		})
+	}
+}
+
+func TestToChatRequest_PreservesStringToolChoiceAutoAndNone(t *testing.T) {
+	validName := "valid_tool"
+	tests := []string{
+		string(ChatToolChoiceTypeAuto),
+		string(ChatToolChoiceTypeNone),
+	}
+
+	for _, choice := range tests {
+		t.Run(choice, func(t *testing.T) {
+			req := &BifrostResponsesRequest{
+				Params: &ResponsesParameters{
+					Tools: []ResponsesTool{
+						{
+							Type: ResponsesToolTypeFunction,
+							Name: &validName,
+						},
+					},
+					ToolChoice: &ResponsesToolChoice{
+						ResponsesToolChoiceStr: &choice,
+					},
+				},
+			}
+
+			chatReq := req.ToChatRequest()
+			if chatReq == nil || chatReq.Params == nil {
+				t.Fatal("expected non-nil chat request params")
+			}
+			if chatReq.Params.ToolChoice == nil || chatReq.Params.ToolChoice.ChatToolChoiceStr == nil {
+				t.Fatal("expected string tool choice to be preserved")
+			}
+			if *chatReq.Params.ToolChoice.ChatToolChoiceStr != choice {
+				t.Fatalf("expected tool choice %q, got %q", choice, *chatReq.Params.ToolChoice.ChatToolChoiceStr)
+			}
+		})
+	}
+}
+
+func TestToBifrostResponsesStreamResponse_PopulatesFinalDoneTextAndCompletedOutput(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	makeChunk := func(role *string, content *string, finishReason *string) *BifrostChatResponse {
+		return &BifrostChatResponse{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []BifrostResponseChoice{
+				{
+					FinishReason: finishReason,
+					ChatStreamResponseChoice: &ChatStreamResponseChoice{
+						Delta: &ChatStreamResponseChoiceDelta{
+							Role:    role,
+							Content: content,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	role := string(ChatMessageRoleAssistant)
+	part1 := "Hello"
+	part2 := " world"
+	stop := string(BifrostFinishReasonStop)
+
+	var all []*BifrostResponsesStreamResponse
+	all = append(all, makeChunk(&role, nil, nil).ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, makeChunk(nil, &part1, nil).ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, makeChunk(nil, &part2, nil).ToBifrostResponsesStreamResponse(state)...)
+	all = append(all, makeChunk(nil, nil, &stop).ToBifrostResponsesStreamResponse(state)...)
+
+	var outputTextDone *BifrostResponsesStreamResponse
+	var completed *BifrostResponsesStreamResponse
+	for _, evt := range all {
+		if evt == nil {
+			continue
+		}
+		if evt.Type == ResponsesStreamResponseTypeOutputTextDone {
+			outputTextDone = evt
+		}
+		if evt.Type == ResponsesStreamResponseTypeCompleted {
+			completed = evt
+		}
+	}
+
+	if outputTextDone == nil || outputTextDone.Text == nil {
+		t.Fatal("expected response.output_text.done with text")
+	}
+	if *outputTextDone.Text != "Hello world" {
+		t.Fatalf("expected output_text.done text %q, got %q", "Hello world", *outputTextDone.Text)
+	}
+
+	if completed == nil || completed.Response == nil || len(completed.Response.Output) != 1 {
+		t.Fatal("expected response.completed with one output message")
+	}
+	msg := completed.Response.Output[0]
+	if msg.Content == nil || len(msg.Content.ContentBlocks) == 0 || msg.Content.ContentBlocks[0].Text == nil {
+		t.Fatal("expected completed output message to include text content block")
+	}
+	if *msg.Content.ContentBlocks[0].Text != "Hello world" {
+		t.Fatalf("expected completed output text %q, got %q", "Hello world", *msg.Content.ContentBlocks[0].Text)
+	}
+}

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -86,15 +86,29 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 
 // RequestDecompressionMiddleware transparently decompresses compressed request bodies.
 // fasthttp supports gzip/deflate/br/zstd via BodyUncompressed().
-func RequestDecompressionMiddleware(_ *lib.Config) schemas.BifrostHTTPMiddleware {
+func RequestDecompressionMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			if len(ctx.Request.Header.ContentEncoding()) > 0 {
+				maxRequestBodyBytes := 0
+				if config != nil && config.ClientConfig.MaxRequestBodySizeMB > 0 {
+					maxRequestBodyBytes = config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024
+				}
+
 				body, err := ctx.Request.BodyUncompressed()
 				if err != nil {
 					SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid compressed request body: %v", err))
 					return
 				}
+				if maxRequestBodyBytes > 0 && len(body) > maxRequestBodyBytes {
+					SendError(
+						ctx,
+						fasthttp.StatusRequestEntityTooLarge,
+						fmt.Sprintf("decompressed request body exceeds max allowed size of %d bytes", maxRequestBodyBytes),
+					)
+					return
+				}
+
 				ctx.Request.SetBodyRaw(body)
 				ctx.Request.Header.Del(fasthttp.HeaderContentEncoding)
 				ctx.Request.Header.Del(fasthttp.HeaderContentLength)

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -84,6 +84,26 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	}
 }
 
+// RequestDecompressionMiddleware transparently decompresses compressed request bodies.
+// fasthttp supports gzip/deflate/br/zstd via BodyUncompressed().
+func RequestDecompressionMiddleware(_ *lib.Config) schemas.BifrostHTTPMiddleware {
+	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
+		return func(ctx *fasthttp.RequestCtx) {
+			if len(ctx.Request.Header.ContentEncoding()) > 0 {
+				body, err := ctx.Request.BodyUncompressed()
+				if err != nil {
+					SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid compressed request body: %v", err))
+					return
+				}
+				ctx.Request.SetBodyRaw(body)
+				ctx.Request.Header.Del(fasthttp.HeaderContentEncoding)
+				ctx.Request.Header.Del(fasthttp.HeaderContentLength)
+			}
+			next(ctx)
+		}
+	}
+}
+
 // TransportInterceptorMiddleware runs all plugin HTTP transport interceptors.
 // It converts the fasthttp request to a serializable HTTPRequest, runs all plugin interceptors,
 // and applies any modifications back to the fasthttp context.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1290,7 +1290,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	s.RegisterUIRoutes()
 	// Create fasthttp server instance
 	s.Server = &fasthttp.Server{
-		Handler:            handlers.CorsMiddleware(s.Config)(s.Router.Handler),
+		Handler:            handlers.CorsMiddleware(s.Config)(handlers.RequestDecompressionMiddleware(s.Config)(s.Router.Handler)),
 		MaxRequestBodySize: s.Config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024,
 		ReadBufferSize:     1024 * 64, // 64kb
 	}


### PR DESCRIPTION
## Summary

Improves error handling and API compatibility by adding fallback error messages for OpenAI provider errors, enhancing request/response conversion between chat and responses formats, and adding support for compressed request bodies.

## Changes

* OpenAI Error Handling: Added fallback error messages when provider responses lack proper error messages or have non-OpenAI shaped error bodies, ensuring users always receive meaningful error information
* Chat/Responses Conversion: Enhanced bidirectional conversion between chat and responses API formats with proper sanitization of tools, tool choices, and role normalization (developer → system for chat fallback)
* Stream Response Improvements: Fixed text accumulation in streaming responses to properly populate final text content in output_text.done and content_part.done events
* Request Decompression: Added middleware to transparently handle compressed request bodies (gzip/deflate/br/zstd)

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

## How to test

Validate error handling improvements:

```bash
# Test OpenAI provider error fallbacks
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"openai/does-not-exist","messages":[{"role":"user","content":"test"}]}'
```

```bash
# Test compressed request handling
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Content-Encoding: gzip" \
  --data-binary @<(echo '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"test"}]}' | gzip)
```

Run tests to verify conversion logic:

```bash
(cd core && go test ./schemas -v)
(cd core && go test ./providers/openai -v)
(cd transports && go build ./bifrost-http/server)
```

## Screenshots/Recordings

N/A

## Breaking changes

* [ ] Yes
* [x] No

## Related issues

Fixes #1708

## Security considerations

The request decompression middleware uses fasthttp's built-in decompression. Request size remains bounded by server MaxRequestBodySize configuration.

## Checklist

* [x] I read docs/contributing/README.md and followed the guidelines
* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable
