### PR TITLE
adds raw request repsonses based test cases

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -117,6 +117,7 @@ type ComprehensiveTestConfig struct {
 	BatchExtraParams         map[string]interface{} // Extra params for batch operations (e.g., role_arn, output_s3_uri for Bedrock)
 	FileExtraParams          map[string]interface{} // Extra params for file operations (e.g., s3_bucket for Bedrock)
 	DisableParallelFor       []string               // Test scenarios to disable parallel execution for (e.g., "Transcription" for rate-limited APIs)
+	ExpectRawRequestResponse bool                   // When true, validate rawRequest/rawResponse in ExtraFields
 }
 
 // ComprehensiveTestAccount provides a test implementation of the Account interface for comprehensive testing.

--- a/core/internal/llmtests/chat_completion_stream.go
+++ b/core/internal/llmtests/chat_completion_stream.go
@@ -250,7 +250,7 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 			if len(lastResponse.BifrostChatResponse.Choices) > 0 && lastResponse.BifrostChatResponse.Choices[0].FinishReason != nil {
 				consolidatedResponse.Choices[0].FinishReason = lastResponse.BifrostChatResponse.Choices[0].FinishReason
 			}
-			consolidatedResponse.ExtraFields.Latency = lastResponse.BifrostChatResponse.ExtraFields.Latency
+			consolidatedResponse.ExtraFields = lastResponse.BifrostChatResponse.ExtraFields
 		}
 
 		// Enhanced validation expectations for streaming

--- a/core/internal/llmtests/raw_request_response_validation.go
+++ b/core/internal/llmtests/raw_request_response_validation.go
@@ -1,0 +1,97 @@
+package llmtests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// validateRawFields checks raw request/response fields and integrates errors into the ValidationResult.
+func validateRawFields(expectations ResponseExpectations, rawRequest, rawResponse interface{}, result *ValidationResult) {
+	if expectations.ShouldHaveRawRequest {
+		if err := ValidateRawField(rawRequest, "RawRequest"); err != nil {
+			result.Passed = false
+			result.Errors = append(result.Errors, err.Error())
+		}
+	}
+	if expectations.ShouldHaveRawResponse {
+		if err := ValidateRawField(rawResponse, "RawResponse"); err != nil {
+			result.Passed = false
+			result.Errors = append(result.Errors, err.Error())
+		}
+	}
+}
+
+// ValidateRawField checks that a raw request/response field is:
+// 1. Non-nil
+// 2. Valid JSON (parseable)
+// 3. Compact JSON (no unnecessary whitespace)
+// Returns an error describing the validation failure, or nil if valid.
+func ValidateRawField(field interface{}, fieldName string) error {
+	if field == nil {
+		return fmt.Errorf("%s should be non-nil when raw request/response is enabled", fieldName)
+	}
+
+	// Get the raw bytes depending on the underlying type
+	var rawBytes []byte
+	var err error
+
+	switch v := field.(type) {
+	case json.RawMessage:
+		rawBytes = []byte(v)
+	case []byte:
+		rawBytes = v
+	case string:
+		rawBytes = []byte(v)
+	default:
+		// For other types (e.g., map[string]interface{}), marshal to JSON first
+		rawBytes, err = sonic.Marshal(field)
+		if err != nil {
+			return fmt.Errorf("%s failed to marshal to JSON: %v", fieldName, err)
+		}
+	}
+
+	if len(rawBytes) == 0 {
+		return fmt.Errorf("%s is empty", fieldName)
+	}
+
+	// Verify parseable as valid JSON
+	if !json.Valid(rawBytes) {
+		return fmt.Errorf("%s is not valid JSON: %s", fieldName, truncateForError(rawBytes))
+	}
+
+	// Verify compact: compact the original and compare (preserves key order)
+	var buf bytes.Buffer
+	if err := schemas.Compact(&buf, rawBytes); err != nil {
+		return fmt.Errorf("%s failed to compact: %v", fieldName, err)
+	}
+	if !bytes.Equal(rawBytes, buf.Bytes()) {
+		return fmt.Errorf("%s is not compact JSON.\nGot:      %s\nExpected: %s", fieldName, truncateForError(rawBytes), truncateForError(buf.Bytes()))
+	}
+
+	return nil
+}
+
+// truncateForError truncates long byte slices for readable error messages
+func truncateForError(b []byte) string {
+	const maxLen = 200
+	if len(b) <= maxLen {
+		return string(b)
+	}
+	return string(b[:maxLen]) + "... (truncated)"
+}
+
+// ValidateExtraFieldsRaw validates rawRequest and rawResponse on BifrostResponseExtraFields
+func ValidateExtraFieldsRaw(extraFields schemas.BifrostResponseExtraFields) []error {
+	var errs []error
+	if err := ValidateRawField(extraFields.RawRequest, "RawRequest"); err != nil {
+		errs = append(errs, err)
+	}
+	if err := ValidateRawField(extraFields.RawResponse, "RawResponse"); err != nil {
+		errs = append(errs, err)
+	}
+	return errs
+}

--- a/core/internal/llmtests/response_validation.go
+++ b/core/internal/llmtests/response_validation.go
@@ -38,6 +38,10 @@ type ResponseExpectations struct {
 	ShouldHaveModel      bool // Should have model field
 	ShouldHaveLatency    bool // Should have latency information in ExtraFields
 
+	// Raw request/response expectations
+	ShouldHaveRawRequest  bool // Should have non-nil, compact JSON rawRequest in ExtraFields
+	ShouldHaveRawResponse bool // Should have non-nil, compact JSON rawResponse in ExtraFields
+
 	// Provider-specific expectations
 	ProviderSpecific map[string]interface{} // Provider-specific validation data
 }
@@ -230,6 +234,9 @@ func ValidateSpeechResponse(t *testing.T, response *schemas.BifrostSpeechRespons
 	// Collect metrics
 	collectSpeechResponseMetrics(response, &result)
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	// Log results
 	logValidationResults(t, result, scenarioName)
 
@@ -268,6 +275,9 @@ func ValidateImageGenerationResponse(t *testing.T, response *schemas.BifrostImag
 	// Collect metrics
 	collectImageGenerationResponseMetrics(response, &result)
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	// Log results
 	logValidationResults(t, result, scenarioName)
 
@@ -304,6 +314,9 @@ func ValidateTranscriptionResponse(t *testing.T, response *schemas.BifrostTransc
 
 	// Collect metrics
 	collectTranscriptionResponseMetrics(response, &result)
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	// Log results
 	logValidationResults(t, result, scenarioName)
@@ -342,6 +355,9 @@ func ValidateListModelsResponse(t *testing.T, response *schemas.BifrostListModel
 	// Collect metrics
 	collectListModelsResponseMetrics(response, &result)
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	// Log results
 	logValidationResults(t, result, scenarioName)
 
@@ -379,6 +395,9 @@ func ValidateEmbeddingResponse(t *testing.T, response *schemas.BifrostEmbeddingR
 	// Collect metrics
 	collectEmbeddingResponseMetrics(response, &result)
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	// Log results
 	logValidationResults(t, result, scenarioName)
 
@@ -412,6 +431,10 @@ func ValidateCountTokensResponse(t *testing.T, response *schemas.BifrostCountTok
 
 	validateCountTokensFields(t, response, expectations, &result)
 	collectCountTokensResponseMetrics(response, &result)
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	logValidationResults(t, result, scenarioName)
 
 	return result
@@ -587,6 +610,9 @@ func validateChatTechnicalFields(t *testing.T, response *schemas.BifrostChatResp
 			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
 		}
 	}
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, result)
 
 	// Check cached tokens percentage (for prompt caching tests)
 	if expectations.ProviderSpecific != nil {
@@ -774,6 +800,9 @@ func validateTextCompletionTechnicalFields(t *testing.T, response *schemas.Bifro
 			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
 		}
 	}
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, result)
 }
 
 // collectTextCompletionResponseMetrics collects metrics from the text completion response for analysis
@@ -946,6 +975,9 @@ func validateResponsesTechnicalFields(t *testing.T, response *schemas.BifrostRes
 			result.MetricsCollected["latency_ms"] = response.ExtraFields.Latency
 		}
 	}
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, result)
 }
 
 // collectResponsesResponseMetrics collects metrics from the Responses API response for analysis
@@ -1447,6 +1479,9 @@ func ValidateBatchCreateResponse(t *testing.T, response *schemas.BifrostBatchCre
 	result.MetricsCollected["status"] = response.Status
 	result.MetricsCollected["has_endpoint"] = response.Endpoint != ""
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	logValidationResults(t, result, scenarioName)
 	return result
 }
@@ -1487,6 +1522,9 @@ func ValidateBatchListResponse(t *testing.T, response *schemas.BifrostBatchListR
 	// Collect metrics
 	result.MetricsCollected["batch_count"] = len(response.Data)
 	result.MetricsCollected["has_more"] = response.HasMore
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	logValidationResults(t, result, scenarioName)
 	return result
@@ -1536,6 +1574,9 @@ func ValidateBatchRetrieveResponse(t *testing.T, response *schemas.BifrostBatchR
 	result.MetricsCollected["status"] = response.Status
 	result.MetricsCollected["has_request_counts"] = response.RequestCounts.Total > 0
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	logValidationResults(t, result, scenarioName)
 	return result
 }
@@ -1582,6 +1623,9 @@ func ValidateBatchCancelResponse(t *testing.T, response *schemas.BifrostBatchCan
 	// Collect metrics
 	result.MetricsCollected["batch_id"] = response.ID
 	result.MetricsCollected["status"] = response.Status
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	logValidationResults(t, result, scenarioName)
 	return result
@@ -1630,6 +1674,9 @@ func ValidateBatchResultsResponse(t *testing.T, response *schemas.BifrostBatchRe
 	result.MetricsCollected["batch_id"] = response.BatchID
 	result.MetricsCollected["results_count"] = len(response.Results)
 	result.MetricsCollected["has_more"] = response.HasMore
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	logValidationResults(t, result, scenarioName)
 	return result
@@ -1684,6 +1731,9 @@ func ValidateFileUploadResponse(t *testing.T, response *schemas.BifrostFileUploa
 	result.MetricsCollected["bytes"] = response.Bytes
 	result.MetricsCollected["purpose"] = response.Purpose
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	logValidationResults(t, result, scenarioName)
 	return result
 }
@@ -1724,6 +1774,9 @@ func ValidateFileListResponse(t *testing.T, response *schemas.BifrostFileListRes
 	// Collect metrics
 	result.MetricsCollected["file_count"] = len(response.Data)
 	result.MetricsCollected["has_more"] = response.HasMore
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	logValidationResults(t, result, scenarioName)
 	return result
@@ -1773,6 +1826,9 @@ func ValidateFileRetrieveResponse(t *testing.T, response *schemas.BifrostFileRet
 	result.MetricsCollected["filename"] = response.Filename
 	result.MetricsCollected["bytes"] = response.Bytes
 	result.MetricsCollected["status"] = response.Status
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	logValidationResults(t, result, scenarioName)
 	return result
@@ -1827,6 +1883,9 @@ func ValidateFileDeleteResponse(t *testing.T, response *schemas.BifrostFileDelet
 	result.MetricsCollected["file_id"] = response.ID
 	result.MetricsCollected["deleted"] = response.Deleted
 
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
+
 	logValidationResults(t, result, scenarioName)
 	return result
 }
@@ -1880,6 +1939,9 @@ func ValidateFileContentResponse(t *testing.T, response *schemas.BifrostFileCont
 	result.MetricsCollected["file_id"] = response.FileID
 	result.MetricsCollected["content_length"] = len(response.Content)
 	result.MetricsCollected["content_type"] = response.ContentType
+
+	// Check raw request/response fields
+	validateRawFields(expectations, response.ExtraFields.RawRequest, response.ExtraFields.RawResponse, &result)
 
 	logValidationResults(t, result, scenarioName)
 	return result

--- a/core/internal/llmtests/speech_synthesis.go
+++ b/core/internal/llmtests/speech_synthesis.go
@@ -97,7 +97,7 @@ func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				}
 
 				// Enhanced validation for speech synthesis
-				expectations := SpeechExpectations(tc.expectMinBytes)
+				expectations := ApplyRawExpectations(SpeechExpectations(tc.expectMinBytes), testConfig, false)
 				expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 
 				// Create Speech retry config
@@ -203,7 +203,7 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 				},
 			}
 
-			expectations := SpeechExpectations(5000) // HD should produce substantial audio
+			expectations := ApplyRawExpectations(SpeechExpectations(5000), testConfig, false) // HD should produce substantial audio
 			expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 
 			// Create Speech retry config
@@ -273,7 +273,7 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 						Fallbacks: testConfig.SpeechSynthesisFallbacks,
 					}
 
-					expectations := SpeechExpectations(500)
+					expectations := ApplyRawExpectations(SpeechExpectations(500), testConfig, false)
 					expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 
 					// Use retry framework for voice test

--- a/core/internal/llmtests/test_retry_framework.go
+++ b/core/internal/llmtests/test_retry_framework.go
@@ -1141,8 +1141,8 @@ func ConversationRetryConfig() TestRetryConfig {
 func DefaultSpeechRetryConfig() TestRetryConfig {
 	return TestRetryConfig{
 		MaxAttempts: 10,
-		BaseDelay:   2000 * time.Millisecond,
-		MaxDelay:    10 * time.Second,
+		BaseDelay:   10 * time.Second,
+		MaxDelay:    60 * time.Second,
 		Conditions: []TestRetryCondition{
 			&EmptySpeechCondition{},     // Check for missing audio data
 			&GenericResponseCondition{}, // Catch generic error responses
@@ -1157,8 +1157,8 @@ func DefaultSpeechRetryConfig() TestRetryConfig {
 func SpeechStreamRetryConfig() TestRetryConfig {
 	return TestRetryConfig{
 		MaxAttempts: 10,
-		BaseDelay:   2000 * time.Millisecond,
-		MaxDelay:    10 * time.Second,
+		BaseDelay:   10 * time.Second,
+		MaxDelay:    60 * time.Second,
 		Conditions: []TestRetryCondition{
 			&StreamErrorCondition{}, // Stream-specific errors
 			&EmptySpeechCondition{}, // Check for missing audio data

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
 )
 
 // TestScenarioFunc defines the function signature for test scenario functions
@@ -111,10 +112,21 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunPassthroughExtraParamsTest,
 	}
 
-	// Execute all test scenarios
+	// Execute all test scenarios without raw request/response (default behavior)
 	for _, scenarioFunc := range testScenarios {
 		scenarioFunc(t, client, ctx, testConfig)
 	}
+
+	// Execute all test scenarios WITH raw request/response enabled
+	t.Run("WithRawRequestResponse", func(t *testing.T) {
+		rawCtx := context.WithValue(ctx, schemas.BifrostContextKeySendBackRawRequest, true)
+		rawCtx = context.WithValue(rawCtx, schemas.BifrostContextKeySendBackRawResponse, true)
+		rawConfig := testConfig
+		rawConfig.ExpectRawRequestResponse = true
+		for _, scenarioFunc := range testScenarios {
+			scenarioFunc(t, client, rawCtx, rawConfig)
+		}
+	})
 
 	// Print comprehensive summary based on configuration
 	printTestSummary(t, testConfig)

--- a/core/internal/llmtests/transcription.go
+++ b/core/internal/llmtests/transcription.go
@@ -125,7 +125,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 							"format":   tc.format,
 						},
 					}
-					ttsExpectations := SpeechExpectations(100) // Minimum expected bytes
+					ttsExpectations := ApplyRawExpectations(SpeechExpectations(100), testConfig, false) // Minimum expected bytes
 					ttsExpectations = ModifyExpectationsForProvider(ttsExpectations, testConfig.Provider)
 					speechRetryConfig := SpeechRetryConfig{
 						MaxAttempts: ttsRetryConfig.MaxAttempts,
@@ -192,7 +192,8 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 				}
 
 				// Enhanced validation for transcription
-				expectations := TranscriptionExpectations(10) // Expect at least some content
+				// Note: isMultipartRequest=true because transcription uses multipart form data, not JSON body
+				expectations := ApplyRawExpectations(TranscriptionExpectations(10), testConfig, false, true) // Expect at least some content
 				expectations = ModifyExpectationsForProvider(expectations, testConfig.Provider)
 
 				// Create Transcription retry config
@@ -301,7 +302,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 							"model":    testConfig.TranscriptionModel,
 						},
 					}
-					customExpectations := TranscriptionExpectations(5)
+					customExpectations := ApplyRawExpectations(TranscriptionExpectations(5), testConfig, false, true)
 					customExpectations = ModifyExpectationsForProvider(customExpectations, testConfig.Provider)
 					customTranscriptionRetryConfig := TranscriptionRetryConfig{
 						MaxAttempts: customRetryConfig.MaxAttempts,
@@ -409,7 +410,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 							"format":   format,
 						},
 					}
-					formatExpectations := TranscriptionExpectations(5)
+					formatExpectations := ApplyRawExpectations(TranscriptionExpectations(5), testConfig, false, true)
 					formatExpectations = ModifyExpectationsForProvider(formatExpectations, testConfig.Provider)
 					formatTranscriptionRetryConfig := TranscriptionRetryConfig{
 						MaxAttempts: formatRetryConfig.MaxAttempts,
@@ -503,7 +504,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 					"model":    testConfig.TranscriptionModel,
 				},
 			}
-			advancedExpectations := TranscriptionExpectations(5)
+			advancedExpectations := ApplyRawExpectations(TranscriptionExpectations(5), testConfig, false, true)
 			advancedExpectations = ModifyExpectationsForProvider(advancedExpectations, testConfig.Provider)
 			advancedTranscriptionRetryConfig := TranscriptionRetryConfig{
 				MaxAttempts: advancedRetryConfig.MaxAttempts,
@@ -599,7 +600,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 							"language": lang,
 						},
 					}
-					langExpectations := TranscriptionExpectations(5)
+					langExpectations := ApplyRawExpectations(TranscriptionExpectations(5), testConfig, false, true)
 					langExpectations = ModifyExpectationsForProvider(langExpectations, testConfig.Provider)
 					langTranscriptionRetryConfig := TranscriptionRetryConfig{
 						MaxAttempts: langRetryConfig.MaxAttempts,

--- a/core/internal/llmtests/transcription_stream.go
+++ b/core/internal/llmtests/transcription_stream.go
@@ -97,8 +97,8 @@ func RunTranscriptionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 						"model":    speechSynthesisModel,
 					},
 				}
-				ttsExpectations := SpeechExpectations(100)
-				ttsExpectations = ModifyExpectationsForProvider(ttsExpectations, testConfig.Provider)
+				ttsExpectations := ApplyRawExpectations(SpeechExpectations(100), testConfig, false)
+				ttsExpectations = ModifyExpectationsForProvider(ttsExpectations, speechSynthesisProvider)
 				ttsSpeechRetryConfig := SpeechRetryConfig{
 					MaxAttempts: ttsRetryConfig.MaxAttempts,
 					BaseDelay:   ttsRetryConfig.BaseDelay,

--- a/core/internal/llmtests/utils.go
+++ b/core/internal/llmtests/utils.go
@@ -638,6 +638,8 @@ func GenerateTTSAudioForTest(ctx context.Context, t *testing.T, client *bifrost.
 			"format":   format,
 		},
 	}
+	// Note: Raw request/response validation is skipped here since this is a utility function
+	// without access to testConfig. The tests that use this audio will validate raw fields.
 	expectations := SpeechExpectations(100) // Minimum expected bytes
 	expectations = ModifyExpectationsForProvider(expectations, provider)
 	speechRetryConfig := SpeechRetryConfig{

--- a/core/internal/llmtests/validation_presets.go
+++ b/core/internal/llmtests/validation_presets.go
@@ -2,6 +2,7 @@ package llmtests
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -270,116 +271,130 @@ func ChatAudioExpectations() ResponseExpectations {
 
 // GetExpectationsForScenario returns appropriate validation expectations for a given scenario
 func GetExpectationsForScenario(scenarioName string, testConfig ComprehensiveTestConfig, customParams map[string]interface{}) ResponseExpectations {
+	var expectations ResponseExpectations
+
 	switch scenarioName {
 	case "SimpleChat":
-		return BasicChatExpectations()
+		expectations = BasicChatExpectations()
 
 	case "TextCompletion":
-		return TextCompletionExpectations()
+		expectations = TextCompletionExpectations()
 
 	case "ToolCalls":
 		if toolName, ok := customParams["tool_name"].(string); ok {
 			if args, ok := customParams["required_args"].([]string); ok {
-				return ToolCallExpectations(toolName, args)
+				expectations = ToolCallExpectations(toolName, args)
+				break
 			}
 		}
-		return WeatherToolExpectations() // Default to weather tool
+		expectations = WeatherToolExpectations() // Default to weather tool
 
 	case "MultipleToolCalls":
 		if tools, ok := customParams["tool_names"].([]string); ok {
 			if argsPerTool, ok := customParams["required_args_per_tool"].([][]string); ok {
-				return MultipleToolExpectations(tools, argsPerTool)
+				expectations = MultipleToolExpectations(tools, argsPerTool)
+				break
 			}
 		}
 		// Default to weather and calculator
-		return MultipleToolExpectations(
+		expectations = MultipleToolExpectations(
 			[]string{string(SampleToolTypeWeather), string(SampleToolTypeCalculate)},
 			[][]string{{"location"}, {"expression"}},
 		)
 
 	case "End2EndToolCalling":
-		return ConversationExpectations([]string{"weather", "temperature", "result"})
+		expectations = ConversationExpectations([]string{"weather", "temperature", "result"})
 
 	case "AutomaticFunctionCalling":
-		expectations := WeatherToolExpectations()
+		expectations = WeatherToolExpectations()
 		expectations.ShouldHaveContent = true // Should have follow-up text after tool call
-		return expectations
 
 	case "ImageURL", "ImageBase64":
-		return VisionExpectations([]string{"image", "picture", "see"})
+		expectations = VisionExpectations([]string{"image", "picture", "see"})
 
 	case "MultipleImages":
-		return VisionExpectations([]string{"compare", "similar", "different", "images"})
+		expectations = VisionExpectations([]string{"compare", "similar", "different", "images"})
 
 	case "FileInput":
-		return FileInputExpectations()
+		expectations = FileInputExpectations()
 
 	case "ChatCompletionStream":
-		return StreamingExpectations()
+		expectations = StreamingExpectations()
 
 	case "MultiTurnConversation":
 		if keywords, ok := customParams["context_keywords"].([]string); ok {
-			return ConversationExpectations(keywords)
+			expectations = ConversationExpectations(keywords)
+		} else {
+			expectations = ConversationExpectations([]string{"context", "previous", "mentioned"})
 		}
-		return ConversationExpectations([]string{"context", "previous", "mentioned"})
 
 	case "Embedding":
 		if texts, ok := customParams["input_texts"].([]string); ok {
-			return EmbeddingExpectations(texts)
+			expectations = EmbeddingExpectations(texts)
+		} else {
+			expectations = EmbeddingExpectations([]string{"Hello, world!", "Hi, world!", "Goodnight, moon!"})
 		}
-		return EmbeddingExpectations([]string{"Hello, world!", "Hi, world!", "Goodnight, moon!"})
 
 	case "CountTokens":
-		return CountTokensExpectations()
+		expectations = CountTokensExpectations()
 
 	case "CompleteEnd2End":
-		return ConversationExpectations([]string{"complete", "comprehensive", "full"})
+		expectations = ConversationExpectations([]string{"complete", "comprehensive", "full"})
 
 	case "SpeechSynthesis":
 		if minBytes, ok := customParams["min_audio_bytes"].(int); ok {
-			return SpeechExpectations(minBytes)
+			expectations = SpeechExpectations(minBytes)
+		} else {
+			expectations = SpeechExpectations(500) // Default minimum 500 bytes
 		}
-		return SpeechExpectations(500) // Default minimum 500 bytes
 
 	case "Transcription":
 		if minLength, ok := customParams["min_transcription_length"].(int); ok {
-			return TranscriptionExpectations(minLength)
+			expectations = TranscriptionExpectations(minLength)
+		} else {
+			expectations = TranscriptionExpectations(10) // Default minimum 10 characters
 		}
-		return TranscriptionExpectations(10) // Default minimum 10 characters
 
 	case "Reasoning":
-		expectations := ReasoningExpectations()
-		return expectations
+		expectations = ReasoningExpectations()
 
 	case "ChatAudio":
-		return ChatAudioExpectations()
+		expectations = ChatAudioExpectations()
 
 	case "ProviderSpecific":
-		expectations := BasicChatExpectations()
+		expectations = BasicChatExpectations()
 		expectations.ShouldContainKeywords = []string{"unique", "specific", "capability"}
-		return expectations
 
 	case "ImageGeneration":
 		if minImages, ok := customParams["min_images"].(int); ok {
 			if expectedSize, ok := customParams["expected_size"].(string); ok {
-				return ImageGenerationExpectations(minImages, expectedSize)
+				expectations = ImageGenerationExpectations(minImages, expectedSize)
+				break
 			}
 		}
-		return ImageGenerationExpectations(1, "1024x1024")
+		expectations = ImageGenerationExpectations(1, "1024x1024")
 
 	case "ImageEdit", "ImageVariation":
 		// Reuse image generation expectations since they use the same response structure
 		if minImages, ok := customParams["min_images"].(int); ok {
 			if expectedSize, ok := customParams["expected_size"].(string); ok {
-				return ImageGenerationExpectations(minImages, expectedSize)
+				expectations = ImageGenerationExpectations(minImages, expectedSize)
+				break
 			}
 		}
-		return ImageGenerationExpectations(1, "1024x1024")
+		expectations = ImageGenerationExpectations(1, "1024x1024")
 
 	default:
 		// Default to basic chat expectations
-		return BasicChatExpectations()
+		expectations = BasicChatExpectations()
 	}
+
+	// Apply raw request/response expectations from test config
+	isStreaming := strings.HasSuffix(scenarioName, "Stream") || strings.HasSuffix(scenarioName, "Streaming")
+	isMultipartRequest := scenarioName == "Transcription" || scenarioName == "TranscriptionStream"
+	expectations = ApplyRawExpectations(expectations, testConfig, isStreaming, isMultipartRequest)
+
+	return expectations
 }
 
 // =============================================================================
@@ -433,6 +448,26 @@ func ModifyExpectationsForProvider(expectations ResponseExpectations, provider s
 		// Keep default expectations
 	}
 
+	return expectations
+}
+
+// ApplyRawExpectations applies raw request/response expectations based on test config.
+// Call this after creating expectations directly (SpeechExpectations, TranscriptionExpectations, etc.)
+// when not using GetExpectationsForScenario.
+// Parameters:
+//   - isStreaming: if true, skips RawResponse expectation (streaming has no single response body)
+//   - isMultipartRequest: if true, skips RawRequest expectation (multipart form data can't return raw JSON request)
+func ApplyRawExpectations(expectations ResponseExpectations, testConfig ComprehensiveTestConfig, isStreaming bool, isMultipartRequest ...bool) ResponseExpectations {
+	if testConfig.ExpectRawRequestResponse {
+		// Skip RawRequest for multipart form data requests (like transcription)
+		skipRawRequest := len(isMultipartRequest) > 0 && isMultipartRequest[0]
+		if !skipRawRequest {
+			expectations.ShouldHaveRawRequest = true
+		}
+		if !isStreaming {
+			expectations.ShouldHaveRawResponse = true
+		}
+	}
 	return expectations
 }
 

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -40,7 +40,7 @@ func TestOpenAI(t *testing.T) {
 		ReasoningModel:       "o4-mini", // o4-mini properly returns both reasoning items and message output
 		ImageGenerationModel: "gpt-image-1",
 		ImageEditModel:       "gpt-image-1",
-		ImageVariationModel:  "dall-e-2",
+		ImageVariationModel:  "", // dall-e-2 is deprecated and no other OpenAI model supports image variations
 		VideoGenerationModel: "sora-2",
 		ChatAudioModel:       "gpt-4o-mini-audio-preview",
 		Scenarios: llmtests.TestScenarios{
@@ -72,7 +72,7 @@ func TestOpenAI(t *testing.T) {
 			ImageGenerationStream: true,
 			ImageEdit:             true,
 			ImageEditStream:       true,
-			ImageVariation:        true,
+			ImageVariation:        false, // dall-e-2 is deprecated and no other OpenAI model supports image variations
 			VideoGeneration:       false, // disabled for now because of long running operations
 			VideoRetrieve:         false,
 			VideoRemix:            false,

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -771,11 +771,27 @@ func HandleProviderAPIError(resp *fasthttp.Response, errorResp any) *schemas.Bif
 	// Check for empty response
 	trimmed := strings.TrimSpace(string(decodedBody))
 	if len(trimmed) == 0 {
+		// Provide a more descriptive error message based on HTTP status code
+		var errorMessage string
+		switch statusCode {
+		case 401:
+			errorMessage = "authentication failed: unauthorized (401) - check your API key"
+		case 403:
+			errorMessage = "access forbidden (403) - your API key may not have permission for this operation"
+		case 404:
+			errorMessage = "resource not found (404)"
+		case 429:
+			errorMessage = "rate limit exceeded (429)"
+		case 500, 502, 503, 504:
+			errorMessage = fmt.Sprintf("provider server error (%d)", statusCode)
+		default:
+			errorMessage = fmt.Sprintf("%s (HTTP %d)", schemas.ErrProviderResponseEmpty, statusCode)
+		}
 		return &schemas.BifrostError{
 			IsBifrostError: false,
 			StatusCode:     &statusCode,
 			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderResponseEmpty,
+				Message: errorMessage,
 			},
 			ExtraFields: schemas.BifrostErrorExtraFields{
 				RawResponse: rawErrorResponse,
@@ -849,7 +865,7 @@ func EnrichError(
 
 	if ShouldSendBackRawResponse(ctx, sendBackRawResponse) {
 		if len(responseBody) > 0 {
-			bifrostErr.ExtraFields.RawResponse = json.RawMessage(responseBody)
+			bifrostErr.ExtraFields.RawResponse = compactRawJSON(responseBody)
 		}
 	} else {
 		bifrostErr.ExtraFields.RawResponse = nil
@@ -888,7 +904,7 @@ func HandleProviderResponse[T any](responseBody []byte, response *T, requestBody
 	}
 
 	if sendBackRawResponse {
-		rawResponse = json.RawMessage(responseBody)
+		rawResponse = compactRawJSON(responseBody)
 	}
 
 	// Unmarshal the structured response

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1611,7 +1611,6 @@
       "additionalProperties": false
     },
     "auth_config": {
-      "deprecated": true,
       "type": "object",
       "description": "Authentication configuration. Deprecated: Use governance.auth_config instead.",
       "properties": {


### PR DESCRIPTION
## Summary

Adds comprehensive validation for raw request/response fields in LLM test framework. This ensures that when raw request/response context flags are enabled, the returned data is properly formatted as compact JSON and non-nil.

## Changes

- Added `ExpectRawRequestResponse` configuration flag to enable raw field validation in tests
- Created dedicated validation functions for raw request/response fields that verify JSON validity and compactness
- Enhanced response validation to check raw fields when expectations are set
- Modified streaming tests to properly consolidate all ExtraFields from final response
- Added automatic test execution with raw request/response enabled for comprehensive coverage
- Improved error messages for empty provider responses with more descriptive HTTP status-specific messages
- Updated OpenAI test configuration to disable deprecated image variation model
- Fixed raw response handling to ensure compact JSON format

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Run the comprehensive test suite to validate raw request/response functionality:

```sh
go test ./core/internal/llmtests/... -v
go test ./core/providers/openai/... -v
```

The tests will automatically run twice - once with standard behavior and once with raw request/response validation enabled.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Raw request/response data may contain sensitive information like API keys or user data. This validation ensures the data is properly formatted but doesn't add additional security measures for handling sensitive content.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable