### PR TITLE
docs(postgres): require UTF8 databases for config_store/logs_store and add cross-guide warnings

### DIFF
--- a/docs/architecture/framework/config-store.mdx
+++ b/docs/architecture/framework/config-store.mdx
@@ -82,6 +82,10 @@ if err != nil {
 }
 ```
 
+<Note>
+PostgreSQL databases used by Bifrost stores must be UTF8 encoded. See [PostgreSQL UTF8 Requirement](../../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ### Connection Pool Configuration
 
 For PostgreSQL backends, you can configure the database connection pool to optimize performance based on your workload:

--- a/docs/architecture/framework/log-store.mdx
+++ b/docs/architecture/framework/log-store.mdx
@@ -76,6 +76,10 @@ if err != nil {
 }
 ```
 
+<Note>
+PostgreSQL databases used by Bifrost stores must be UTF8 encoded. See [PostgreSQL UTF8 Requirement](../../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ### Connection Pool Configuration
 
 For PostgreSQL backends, you can configure the database connection pool to optimize performance based on your workload:

--- a/docs/deployment-guides/docker-tuning.mdx
+++ b/docs/deployment-guides/docker-tuning.mdx
@@ -200,6 +200,10 @@ volumes:
 
 ### Production (Multi-Node with PostgreSQL)
 
+<Note>
+If you use PostgreSQL for Bifrost storage, ensure the database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ```yaml
 services:
   bifrost-1:

--- a/docs/deployment-guides/ecs.mdx
+++ b/docs/deployment-guides/ecs.mdx
@@ -18,6 +18,10 @@ This guide assumes you already have:
 - For load balancer: Allow inbound traffic from the load balancer's security group
 </Note>
 
+<Note>
+If you use PostgreSQL for `config_store` or `logs_store`, ensure the target database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ## Deployment Methods
 
 Choose your preferred deployment method:

--- a/docs/deployment-guides/enterprise/on-premise.mdx
+++ b/docs/deployment-guides/enterprise/on-premise.mdx
@@ -149,6 +149,10 @@ cat docker-config.json | base64 -w 0
 
 ### Step 3: Create Bifrost Configuration
 
+<Note>
+If you use PostgreSQL for `config_store` or `logs_store`, ensure the target database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ```yaml
 apiVersion: v1
 kind: Secret

--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -18,6 +18,10 @@ Deploy Bifrost on Kubernetes using the official Helm chart. This is the recommen
 - (Optional) Persistent Volume provisioner
 - (Optional) Ingress controller
 
+<Note>
+If you use PostgreSQL for Bifrost storage, ensure the database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ## Quick Start
 
 ### Add Helm Repository

--- a/docs/deployment-guides/how-to/multinode.mdx
+++ b/docs/deployment-guides/how-to/multinode.mdx
@@ -63,6 +63,10 @@ Bifrost Enterprise includes **P2P clustering** with gossip protocol that automat
 
 Create a `config.json` **without** `config_store` or `logs_store`:
 
+<Note>
+If you use PostgreSQL for `logs_store`, ensure the target database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ```json
 {
   "$schema": "https://www.getbifrost.ai/schema",
@@ -425,4 +429,3 @@ resources:
 | Multinode Enterprise | Use P2P clustering with `config_store` |
 
 For OSS multinode deployments, the shared `config.json` approach provides a simple, reliable way to keep all nodes in sync without the complexity of database synchronization.
-

--- a/docs/deployment-guides/k8s.mdx
+++ b/docs/deployment-guides/k8s.mdx
@@ -25,6 +25,10 @@ See the [Terraform module README](https://github.com/maximhq/bifrost/tree/main/t
 If you are using Postgres/MySQL for config and log store, you can skip the Volume configuration and permission changes sections.
 </Note>
 
+<Note>
+If you use PostgreSQL for `config_store` or `logs_store`, ensure the target database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 <Tabs>
 <Tab title="AWS">
 

--- a/docs/enterprise/clustering.mdx
+++ b/docs/enterprise/clustering.mdx
@@ -1147,6 +1147,10 @@ http {
 
 Production-ready Kubernetes deployment with StatefulSet:
 
+<Note>
+If you use PostgreSQL for `config_store`, ensure the target database is UTF8 encoded. See [PostgreSQL UTF8 Requirement](../quickstart/gateway/setting-up#postgresql-utf8-requirement).
+</Note>
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap

--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -325,6 +325,7 @@ The logging plugin is **automatically enabled** in Gateway mode with SQLite stor
 - **Best for**: High-volume production deployments
 - **Performance**: Excellent concurrent writes and complex queries
 - **Features**: Advanced indexing, partitioning, replication
+- **Requirement**: PostgreSQL database must be UTF8 encoded (see [PostgreSQL UTF8 Requirement](../../quickstart/gateway/setting-up#postgresql-utf8-requirement))
 
 ```json
 {

--- a/docs/quickstart/gateway/setting-up.mdx
+++ b/docs/quickstart/gateway/setting-up.mdx
@@ -188,6 +188,38 @@ If you want database persistence but prefer not to use the UI, note that modifyi
 - **Logs Store**: Stores request logs shown in UI - Optional, can be disabled  
 - **Vector Store**: Used for semantic caching - Optional, can be disabled
 
+## PostgreSQL UTF8 Requirement
+
+If you use PostgreSQL for `config_store` or `logs_store`, the target database must use `UTF8` encoding.
+
+Use `template0` when creating the database so PostgreSQL applies UTF8 and locale settings explicitly:
+
+```sql
+CREATE DATABASE bifrost
+  WITH TEMPLATE template0
+       ENCODING 'UTF8'
+       LC_COLLATE '<your-locale>'
+       LC_CTYPE '<your-locale>';
+```
+
+Use locale names that exist in your Postgres image/host (for example, `en_US.UTF-8`, `C.UTF-8`, or another installed UTF-8 locale).
+
+Verify the database encoding:
+
+```sql
+SELECT datname, pg_encoding_to_char(encoding) AS encoding
+FROM pg_database
+WHERE datname = 'bifrost';
+```
+
+If the database is not UTF8, Bifrost startup/migrations can fail with:
+
+```text
+simple protocol queries must be run with client_encoding=UTF8
+```
+
+If you already created a SQL_ASCII database, create a new UTF8 database and update your Bifrost DB config to point to it.
+
 ---
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Added PostgreSQL UTF8 encoding requirement documentation across all deployment guides and configuration pages. This addresses potential startup failures when using PostgreSQL databases that are not UTF8 encoded.

## Issues
Closes #1895 

## Changes

- Added a new "PostgreSQL UTF8 Requirement" section in the quickstart guide with detailed instructions for creating UTF8 databases and troubleshooting encoding issues
- Added note blocks referencing the UTF8 requirement across all deployment guides (Docker, ECS, Kubernetes, Helm, on-premise) and configuration documentation
- Included specific SQL commands for creating UTF8 databases using `template0` and verifying encoding
- Added troubleshooting information for the common error: "simple protocol queries must be run with client_encoding=UTF8"

## Type of change

- [x] Documentation

## Affected areas

- [x] Docs

## How to test

Verify the documentation renders correctly and all internal links work:

```sh
# Check that all referenced links resolve correctly
# Verify the new PostgreSQL UTF8 Requirement section displays properly
# Test that note blocks render correctly across all deployment guides
```

Test the provided SQL commands against a PostgreSQL instance:

```sql
CREATE DATABASE bifrost
  WITH TEMPLATE template0
       ENCODING 'UTF8'
       LC_COLLATE 'en_US.UTF-8'
       LC_CTYPE 'en_US.UTF-8';

SELECT datname, pg_encoding_to_char(encoding) AS encoding
FROM pg_database
WHERE datname = 'bifrost';
```

## Screenshots/Recordings

N/A - Documentation changes only

## Breaking changes

- [ ] No

## Related issues

- Fixes  #1895

## Security considerations

None - documentation-only changes that help prevent configuration issues.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable