### PR TITLE
fix(semanticcache): nil check on message Content before accessing fields

### DIFF
--- a/plugins/semanticcache/plugin_nil_content_test.go
+++ b/plugins/semanticcache/plugin_nil_content_test.go
@@ -1,0 +1,168 @@
+package semanticcache
+
+import (
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestExtractTextForEmbedding_NilContent verifies that extractTextForEmbedding
+// does not panic when chat messages have nil Content (e.g., assistant tool-call messages).
+func TestExtractTextForEmbedding_NilContent(t *testing.T) {
+	plugin := &Plugin{
+		config: &Config{},
+	}
+
+	tests := []struct {
+		name    string
+		request *schemas.BifrostRequest
+	}{
+		{
+			name: "ChatRequest with nil Content in assistant tool-call message",
+			request: &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Provider: schemas.OpenAI,
+					Model:    "gpt-4o-mini",
+					Input: []schemas.ChatMessage{
+						{
+							Role: schemas.ChatMessageRoleUser,
+							Content: &schemas.ChatMessageContent{
+								ContentStr: bifrost.Ptr("Call the get_weather function"),
+							},
+						},
+						{
+							Role:    schemas.ChatMessageRoleAssistant,
+							Content: nil, // tool-call message with no content
+							ChatAssistantMessage: &schemas.ChatAssistantMessage{
+								ToolCalls: []schemas.ChatAssistantMessageToolCall{
+									{
+										ID:   bifrost.Ptr("call_123"),
+										Type: bifrost.Ptr("function"),
+										Function: schemas.ChatAssistantMessageToolCallFunction{
+											Name:      bifrost.Ptr("get_weather"),
+											Arguments: `{"location": "San Francisco"}`,
+										},
+									},
+								},
+							},
+						},
+					},
+					Params: &schemas.ChatParameters{
+						Temperature:         bifrost.Ptr(0.7),
+						MaxCompletionTokens: bifrost.Ptr(100),
+					},
+				},
+			},
+		},
+		{
+			name: "ChatRequest where all messages have nil Content",
+			request: &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Provider: schemas.OpenAI,
+					Model:    "gpt-4o-mini",
+					Input: []schemas.ChatMessage{
+						{
+							Role:    schemas.ChatMessageRoleAssistant,
+							Content: nil,
+						},
+					},
+					Params: &schemas.ChatParameters{
+						Temperature:         bifrost.Ptr(0.7),
+						MaxCompletionTokens: bifrost.Ptr(100),
+					},
+				},
+			},
+		},
+		{
+			name: "ResponsesRequest with nil Content",
+			request: &schemas.BifrostRequest{
+				RequestType:      schemas.ResponsesRequest,
+				ResponsesRequest: createResponsesRequestWithNilContent(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This should not panic
+			text, hash, err := plugin.extractTextForEmbedding(tt.request)
+			// We don't care about the error — the important thing is no panic
+			t.Logf("text=%q, hash=%q, err=%v", text, hash, err)
+		})
+	}
+}
+
+// TestGetNormalizedInputForCaching_NilContent verifies that getNormalizedInputForCaching
+// does not panic when chat messages have nil Content.
+func TestGetNormalizedInputForCaching_NilContent(t *testing.T) {
+	plugin := &Plugin{
+		config: &Config{},
+	}
+
+	request := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o-mini",
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentStr: bifrost.Ptr("Call the get_weather function"),
+					},
+				},
+				{
+					Role:    schemas.ChatMessageRoleAssistant,
+					Content: nil,
+					ChatAssistantMessage: &schemas.ChatAssistantMessage{
+						ToolCalls: []schemas.ChatAssistantMessageToolCall{
+							{
+								ID:   bifrost.Ptr("call_123"),
+								Type: bifrost.Ptr("function"),
+								Function: schemas.ChatAssistantMessageToolCallFunction{
+									Name:      bifrost.Ptr("get_weather"),
+									Arguments: `{"location": "San Francisco"}`,
+								},
+							},
+						},
+					},
+				},
+			},
+			Params: &schemas.ChatParameters{
+				Temperature:         bifrost.Ptr(0.7),
+				MaxCompletionTokens: bifrost.Ptr(100),
+			},
+		},
+	}
+
+	// This should not panic
+	result := plugin.getNormalizedInputForCaching(request)
+	t.Logf("result type: %T", result)
+}
+
+// createResponsesRequestWithNilContent builds a BifrostResponsesRequest with a nil Content message for testing.
+func createResponsesRequestWithNilContent() *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: bifrost.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: bifrost.Ptr("Hello"),
+				},
+			},
+			{
+				Role:    bifrost.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+				Content: nil,
+			},
+		},
+		Params: &schemas.ResponsesParameters{
+			Temperature:     bifrost.Ptr(0.7),
+			MaxOutputTokens: bifrost.Ptr(100),
+		},
+	}
+}

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -198,21 +198,24 @@ func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest) (stri
 		var textParts []string
 		for _, msg := range reqInput {
 			// Extract content as string
+			// Content can be nil for messages like assistant tool-call messages
 			var content string
-			if msg.Content.ContentStr != nil {
-				content = *msg.Content.ContentStr
-			} else if msg.Content.ContentBlocks != nil {
-				// For content blocks, extract text parts
-				var blockTexts []string
-				for _, block := range msg.Content.ContentBlocks {
-					if block.Text != nil {
-						blockTexts = append(blockTexts, *block.Text)
+			if msg.Content != nil {
+				if msg.Content.ContentStr != nil {
+					content = *msg.Content.ContentStr
+				} else if msg.Content.ContentBlocks != nil {
+					// For content blocks, extract text parts
+					var blockTexts []string
+					for _, block := range msg.Content.ContentBlocks {
+						if block.Text != nil {
+							blockTexts = append(blockTexts, *block.Text)
+						}
+						if block.ImageURLStruct != nil && block.ImageURLStruct.URL != "" {
+							attachments = append(attachments, block.ImageURLStruct.URL)
+						}
 					}
-					if block.ImageURLStruct != nil && block.ImageURLStruct.URL != "" {
-						attachments = append(attachments, block.ImageURLStruct.URL)
-					}
+					content = strings.Join(blockTexts, " ")
 				}
-				content = strings.Join(blockTexts, " ")
 			}
 
 			if content != "" {
@@ -245,24 +248,27 @@ func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest) (stri
 		var textParts []string
 		for _, msg := range reqInput {
 			// Extract content as string
+			// Content can be nil for messages like assistant tool-call messages
 			var content string
-			if msg.Content.ContentStr != nil {
-				content = normalizeText(*msg.Content.ContentStr)
-			} else if msg.Content.ContentBlocks != nil {
-				// For content blocks, extract text parts
-				var blockTexts []string
-				for _, block := range msg.Content.ContentBlocks {
-					if block.Text != nil {
-						blockTexts = append(blockTexts, normalizeText(*block.Text))
+			if msg.Content != nil {
+				if msg.Content.ContentStr != nil {
+					content = normalizeText(*msg.Content.ContentStr)
+				} else if msg.Content.ContentBlocks != nil {
+					// For content blocks, extract text parts
+					var blockTexts []string
+					for _, block := range msg.Content.ContentBlocks {
+						if block.Text != nil {
+							blockTexts = append(blockTexts, normalizeText(*block.Text))
+						}
+						if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
+							attachments = append(attachments, *block.ResponsesInputMessageContentBlockImage.ImageURL)
+						}
+						if block.ResponsesInputMessageContentBlockFile != nil && block.ResponsesInputMessageContentBlockFile.FileURL != nil {
+							attachments = append(attachments, *block.ResponsesInputMessageContentBlockFile.FileURL)
+						}
 					}
-					if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
-						attachments = append(attachments, *block.ResponsesInputMessageContentBlockImage.ImageURL)
-					}
-					if block.ResponsesInputMessageContentBlockFile != nil && block.ResponsesInputMessageContentBlockFile.FileURL != nil {
-						attachments = append(attachments, *block.ResponsesInputMessageContentBlockFile.FileURL)
-					}
+					content = strings.Join(blockTexts, " ")
 				}
-				content = strings.Join(blockTexts, " ")
 			}
 
 			role := ""
@@ -535,20 +541,23 @@ func (plugin *Plugin) getNormalizedInputForCaching(req *schemas.BifrostRequest) 
 			normalizedMsg := schemas.DeepCopyChatMessage(msg)
 
 			// Normalize message content
-			if msg.Content.ContentStr != nil {
-				normalizedContent := normalizeText(*msg.Content.ContentStr)
-				normalizedMsg.Content.ContentStr = &normalizedContent
-			} else if msg.Content.ContentBlocks != nil {
-				// Create a copy of content blocks with normalized text
-				normalizedBlocks := make([]schemas.ChatContentBlock, len(msg.Content.ContentBlocks))
-				for i, block := range msg.Content.ContentBlocks {
-					normalizedBlocks[i] = block
-					if block.Text != nil {
-						normalizedText := normalizeText(*block.Text)
-						normalizedBlocks[i].Text = &normalizedText
+			// Content can be nil for messages like assistant tool-call messages
+			if msg.Content != nil {
+				if msg.Content.ContentStr != nil {
+					normalizedContent := normalizeText(*msg.Content.ContentStr)
+					normalizedMsg.Content.ContentStr = &normalizedContent
+				} else if msg.Content.ContentBlocks != nil {
+					// Create a copy of content blocks with normalized text
+					normalizedBlocks := make([]schemas.ChatContentBlock, len(msg.Content.ContentBlocks))
+					for i, block := range msg.Content.ContentBlocks {
+						normalizedBlocks[i] = block
+						if block.Text != nil {
+							normalizedText := normalizeText(*block.Text)
+							normalizedBlocks[i].Text = &normalizedText
+						}
 					}
+					normalizedMsg.Content.ContentBlocks = normalizedBlocks
 				}
-				normalizedMsg.Content.ContentBlocks = normalizedBlocks
 			}
 
 			normalizedMessages = append(normalizedMessages, normalizedMsg)


### PR DESCRIPTION
## Summary

Fix nil pointer dereference panic in the semantic cache plugin when processing messages with nil `Content` (e.g., assistant tool-call messages). This causes Bifrost pods to crash-loop when proxying LLM requests that include tool use conversation history.

## Changes

- Added `msg.Content != nil` guard in `extractTextForEmbedding` for both `ChatRequest` and `ResponsesRequest` paths
- Added `msg.Content != nil` guard in `getNormalizedInputForCaching` for the `ChatRequest` path
- The `ResponsesRequest` normalization path already had this guard — the fix makes the other paths consistent
- Added unit tests that reproduce the panic and verify the fix

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

### Reproduce

Send a multi-turn Anthropic `/v1/messages` request through Bifrost where the conversation history includes an assistant message with `tool_use` content blocks. The semantic cache plugin must be active, and caching must be triggered (either via `x-bf-cache-key` header or `DefaultCacheKey` in the plugin config).

```python
from anthropic import AsyncAnthropic
import asyncio

client = AsyncAnthropic(
    api_key="<your-key>",
    base_url="http://<bifrost-host>/anthropic",
    default_headers={"x-bf-cache-key": "test", "x-bf-cache-type": "direct"},
)

async def main():
    resp = await client.messages.create(
        model="claude-sonnet-4-20250514",
        max_tokens=100,
        tools=[{
            "name": "get_weather",
            "description": "Get weather",
            "input_schema": {
                "type": "object",
                "properties": {"location": {"type": "string"}},
                "required": ["location"],
            },
        }],
        messages=[
            {"role": "user", "content": "What is the weather in SF?"},
            {"role": "assistant", "content": [
                {"type": "tool_use", "id": "toolu_01A", "name": "get_weather", "input": {"location": "SF"}}
            ]},
            {"role": "user", "content": [
                {"type": "tool_result", "tool_use_id": "toolu_01A", "content": "72F sunny"}
            ]},
        ],
    )
    print(resp.content[0].text)

asyncio.run(main())
```

### Root cause

Bifrost's Anthropic provider converts `tool_use` content blocks into `ResponsesMessage{Type: FunctionCall}` with no `Content` field (nil). When the semantic cache plugin iterates over these messages in `extractTextForEmbedding`, it accesses `msg.Content.ContentStr` without checking if `Content` is nil, causing a panic.

### Results

**Without fix**: `panic: runtime error: invalid memory address or nil pointer dereference` at `utils.go:249`
**With fix**: Request succeeds normally

### Panic stack trace (reproduced locally and observed in production)

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103db1514]

goroutine 3132 [running]:
github.com/maximhq/bifrost/plugins/semanticcache.(*Plugin).extractTextForEmbedding(...)
    plugins/semanticcache/utils.go:249
github.com/maximhq/bifrost/plugins/semanticcache.(*Plugin).performDirectSearch(...)
    plugins/semanticcache/search.go:26
github.com/maximhq/bifrost/plugins/semanticcache.(*Plugin).PreLLMHook(...)
    plugins/semanticcache/main.go:431
```

### Unit tests

```sh
cd plugins/semanticcache
go test -run "TestExtractTextForEmbedding_NilContent|TestGetNormalizedInputForCaching_NilContent" -v
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A — discovered in production when using Bifrost as an Anthropic proxy for requests with tool use (spreadsheet processing with LlamaIndex FunctionAgent).

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable