### PR TITLE
fix: strip governance model prefix from raw body in Anthropic passthrough

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -686,7 +686,10 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			return
 		}
 		if sendRawRequestBody, ok := (*bifrostCtx).Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && sendRawRequestBody {
-			bifrostReq.SetRawRequestBody(rawBody)
+			// Re-read the body from the context: PreCallback (e.g.
+			// checkAnthropicPassthrough) may have updated it to strip
+			// the provider prefix that the governance plugin added.
+			bifrostReq.SetRawRequestBody(ctx.Request.Body())
 		}
 
 		// Extract and parse fallbacks from the request if present


### PR DESCRIPTION
## Summary

- The governance plugin's load balancer prepends the provider name to the model field (e.g. `anthropic/claude-sonnet-4-6`) for internal routing. `checkAnthropicPassthrough` correctly strips this prefix from the parsed struct, but the **raw HTTP body** — used by passthrough mode to forward requests directly to Anthropic — still contained the prefixed model name. This caused **404 errors from Anthropic's API**, most visibly on `count_tokens` requests from the Claude CLI subprocess.
- The fix strips the provider prefix from the raw body in `checkAnthropicPassthrough` via `stripModelPrefixFromBody()`, and re-reads the body in the router after `PreCallback` runs so the passthrough path gets the corrected model.

### Context

This was identified as the P0 root cause amplifier during an eval debug session. The Claude CLI subprocess calls `/v1/messages/count_tokens` continuously for context management decisions, and the 404s from the prefixed model name caused:
1. **313 failed `count_tokens` calls in 11 minutes** (5-retry bursts every ~7-10s)
2. **Inaccurate compaction threshold estimation** — compaction fired at 172K tokens instead of the intended 167K
3. **Longer compaction silence windows** (45-59s) that triggered connection drops (499s) in production

This supersedes #1866 with a cleaner rebase on current main.

## Test plan

- [ ] Verify `POST /anthropic/v1/messages/count_tokens` with `anthropic/claude-sonnet-4-6` model succeeds (previously returned 404)
- [ ] Verify regular chat completions via passthrough mode still work with prefixed model names
- [ ] Verify non-passthrough requests are unaffected
- [ ] Run `make test-core PROVIDER=anthropic` to check Anthropic integration tests


Made with [Cursor](https://cursor.com)