### PR TITLE
feat(helm): add graceful shutdown and HPA stabilization for streaming connections

### DIFF
--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
       serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -58,6 +61,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.bifrost.port }}

--- a/helm-charts/bifrost/templates/hpa.yaml
+++ b/helm-charts/bifrost/templates/hpa.yaml
@@ -31,4 +31,8 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -48,6 +48,9 @@ spec:
       serviceAccountName: {{ include "bifrost.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- with .Values.initContainers }}
       initContainers:
         {{- toYaml . | nindent 8 }}
@@ -58,6 +61,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.bifrost.port }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -109,6 +109,20 @@ autoscaling:
   maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
+  # HPA scaling behavior configuration
+  # Controls how quickly the HPA scales up/down to prevent connection disruption
+  behavior:
+    scaleDown:
+      # Stabilization window prevents rapid scale-down oscillation.
+      # The HPA will wait this long after the last scale event before scaling down again.
+      # Important for long-lived streaming connections (e.g. SSE for LLM inference).
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 120
+    scaleUp:
+      stabilizationWindowSeconds: 30
 
 # Additional volumes on the output Deployment definition.
 volumes: []
@@ -121,6 +135,19 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Graceful shutdown configuration for long-lived connections (SSE streaming)
+# When a pod is terminated (e.g. during HPA scale-down), active streaming connections
+# are severed abruptly. This causes clients to lose their SSE stream mid-response.
+# The preStop hook and termination grace period give in-flight requests time to complete.
+terminationGracePeriodSeconds: 60
+lifecycle:
+  preStop:
+    exec:
+      # Sleep allows the pod to be removed from the Service endpoints and load balancer
+      # before the process starts shutting down, preventing new connections from arriving
+      # while existing ones drain.
+      command: ["sh", "-c", "sleep 15"]
 
 # Bifrost specific configuration
 # You can find entire schema at https://getbifrost.ai/schema


### PR DESCRIPTION
## Summary

When the HPA scales Bifrost pods during active SSE streaming sessions (e.g. LLM inference via the Anthropic provider), existing TCP connections are severed abruptly. This causes streaming clients to lose their connection mid-response, often forcing a fallback to slower non-streaming mode with 10–20x higher latency per request.

This PR adds three configurable mechanisms to the Helm chart to mitigate this:

1. **HPA `behavior` section** — Adds a `scaleDown.stabilizationWindowSeconds` (default 300s) and a policy limiting scale-down to 1 pod per 120s, preventing rapid oscillation between replica counts.
2. **`terminationGracePeriodSeconds`** (default 60s) — Gives in-flight streaming requests time to complete before the pod is forcibly killed.
3. **`preStop` lifecycle hook** (default: `sleep 15`) — Allows the pod to be removed from Service endpoints and GCP NEG/load balancer backends before the process starts shutting down, preventing new connections from being routed to a terminating pod.

All values are configurable and the defaults are sensible for production LLM gateway workloads.

## Context: Production incident analysis

We investigated a series of agent executions that became unresponsive after initially working fine. By correlating Bifrost's request logs (from the `logs` table in the Bifrost PostgreSQL database) with Kubernetes events from Loki, we found a consistent pattern across all affected executions:

### The pattern (reproduced across 5 separate executions)

| Phase | Bifrost logs | K8s events |
|-------|-------------|------------|
| **Healthy** | Streaming calls succeed, 1.5–12s latency | Stable pod count |
| **HPA event** | — | Scale up/down, NEG endpoint attach/detach, pod killing |
| **Connection drop** | `client_disconnected` (HTTP 499), switches to non-streaming | Pod killed or NEG rebalanced |
| **Degraded** | Non-streaming calls at 30–68s latency (10–20x slower) | — |
| **Cascading failure** | 300s message timeout → retry loop → execution hangs | — |

### Example: Execution timeline

```
05:04:48 - 05:06:07  14 streaming calls, 1.7–7.4s latency each (healthy)
05:06:06             HPA scales 4→5, NEG endpoint update at 05:06:08
05:06:10             client_disconnected (499) — streaming connection severed
05:06:40 - 05:20:48  22 non-streaming calls, 32–68s latency each (degraded)
```

### Root cause

The Bifrost HPA was scaling **10+ times in a single hour**, bouncing between 3 and 5 replicas based on memory pressure. Each scale-down event kills a pod with potentially active SSE streaming connections. The Kubernetes default `terminationGracePeriodSeconds` (30s) and the lack of a `preStop` hook means:

1. The pod is removed from the Service immediately
2. Existing TCP connections are forcibly reset
3. Clients lose their SSE stream mid-response
4. Client SDKs fall back to non-streaming mode (much slower)

The `preStop` sleep gives the load balancer time to drain the endpoint before the process exits, and the HPA stabilization window prevents the rapid oscillation that triggers this in the first place.

## Changes

- `helm-charts/bifrost/values.yaml` — Added `autoscaling.behavior`, `terminationGracePeriodSeconds`, and `lifecycle` values with documented defaults
- `helm-charts/bifrost/templates/hpa.yaml` — Renders `behavior` section when configured
- `helm-charts/bifrost/templates/deployment.yaml` — Adds `terminationGracePeriodSeconds` and container `lifecycle` hook
- `helm-charts/bifrost/templates/stateful.yaml` — Same changes as deployment (both templates serve Bifrost pods)

## Test plan

- [ ] Verify `helm template` renders correctly with default values (behavior, terminationGracePeriodSeconds, lifecycle all present)
- [ ] Verify `helm template` renders correctly with `autoscaling.enabled: true` (HPA includes behavior section)
- [ ] Verify `helm template` renders correctly with `terminationGracePeriodSeconds` set to `0` or removed (should omit the field)
- [ ] Verify existing deployments upgrade cleanly (no breaking changes — all new fields have defaults)

Made with [Cursor](https://cursor.com)