### PR TITLE
fix: replace goroutine+channel with DoDeadline in MakeRequestWithContext

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -120,7 +120,7 @@ func MakeRequestWithContext(ctx context.Context, client *fasthttp.Client, req *f
 				IsBifrostError: true,
 				Error: &schemas.ErrorField{
 					Type:    schemas.Ptr(schemas.RequestCancelled),
-					Message: fmt.Sprintf("Request cancelled or timed out by context: %v", ctx.Err()),
+					Message: fmt.Sprintf("request cancelled or timed out by context: %v", ctx.Err()),
 					Error:   ctx.Err(),
 				},
 			}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -96,84 +96,87 @@ func getLogger() schemas.Logger {
 
 var UnsupportedSpeechStreamModels = []string{"tts-1", "tts-1-hd"}
 
-// MakeRequestWithContext makes a request with a context and returns the latency and error.
-// IMPORTANT: This function does NOT truly cancel the underlying fasthttp network request if the
-// context is done. The fasthttp client call will continue in its goroutine until it completes
-// or times out based on its own settings. This function merely stops *waiting* for the
-// fasthttp call and returns an error related to the context.
+// defaultRequestTimeout is a safety-net fallback used only when the context has no deadline.
+// In normal operation, callers always set a deadline via NetworkConfig.DefaultRequestTimeoutInSeconds
+// (default 30s), so this 5-minute ceiling should rarely be reached.
+const defaultRequestTimeout = 5 * time.Minute
+
+// MakeRequestWithContext makes a request with a context deadline and returns the latency and error.
+// Uses DoDeadline to avoid goroutine leaks and use-after-free on context cancellation.
+// The deadline is derived from the context; if no deadline is set, defaultRequestTimeout is used.
+//
+// Note: DoDeadline does not observe ctx.Done() for cancel-only (no-deadline) contexts.
+// This is an intentional tradeoff — the previous goroutine+select pattern caused goroutine
+// leaks and use-after-free when contexts cancelled before requests completed. In practice,
+// all provider requests have deadlines set by the caller, so this limitation doesn't apply.
 // Returns the request latency and any error that occurred.
 func MakeRequestWithContext(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) (time.Duration, *schemas.BifrostError) {
 	startTime := time.Now()
-	errChan := make(chan error, 1)
 
-	go func() {
-		// client.Do is a blocking call.
-		// It will send an error (or nil for success) to errChan when it completes.
-		errChan <- client.Do(req, resp)
-	}()
+	// Derive deadline from context, or use a default timeout
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(defaultRequestTimeout)
+	}
 
-	select {
-	case <-ctx.Done():
-		// Context was cancelled (e.g., deadline exceeded or manual cancellation).
-		// Calculate latency even for cancelled requests
-		latency := time.Since(startTime)
-		return latency, &schemas.BifrostError{
-			IsBifrostError: true,
-			Error: &schemas.ErrorField{
-				Type:    schemas.Ptr(schemas.RequestCancelled),
-				Message: fmt.Sprintf("Request cancelled or timed out by context: %v", ctx.Err()),
-				Error:   ctx.Err(),
-			},
+	err := client.DoDeadline(req, resp, deadline)
+	latency := time.Since(startTime)
+
+	if err != nil {
+		// Check if the context was cancelled while the request was in flight
+		if ctx.Err() != nil {
+			return latency, &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: fmt.Sprintf("Request cancelled or timed out by context: %v", ctx.Err()),
+					Error:   ctx.Err(),
+				},
+			}
 		}
-	case err := <-errChan:
-		// The fasthttp.Do call completed.
-		// Calculate latency for both successful and failed requests
-		latency := time.Since(startTime)
-		if err != nil {
-			if errors.Is(err, context.Canceled) {
-				return latency, &schemas.BifrostError{
-					IsBifrostError: false,
-					Error: &schemas.ErrorField{
-						Type:    schemas.Ptr(schemas.RequestCancelled),
-						Message: schemas.ErrRequestCancelled,
-						Error:   err,
-					},
-				}
-			}
-			// Check for timeout errors first before checking net.OpError to avoid misclassification
-			if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
-				return latency, NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, "")
-			}
-			// Check if error implements net.Error and has Timeout() == true
-			var netErr net.Error
-			if errors.As(err, &netErr) && netErr.Timeout() {
-				return latency, NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, "")
-			}
-			// Check for DNS lookup and network errors after timeout checks
-			var opErr *net.OpError
-			var dnsErr *net.DNSError
-			if errors.As(err, &opErr) || errors.As(err, &dnsErr) {
-				return latency, &schemas.BifrostError{
-					IsBifrostError: false,
-					Error: &schemas.ErrorField{
-						Message: schemas.ErrProviderNetworkError,
-						Error:   err,
-					},
-				}
-			}
-			// The HTTP request itself failed (e.g., connection error, fasthttp timeout).
+		if errors.Is(err, context.Canceled) {
 			return latency, &schemas.BifrostError{
 				IsBifrostError: false,
 				Error: &schemas.ErrorField{
-					Message: schemas.ErrProviderDoRequest,
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
 					Error:   err,
 				},
 			}
 		}
-		// HTTP request was successful from fasthttp's perspective (err is nil).
-		// The caller should check resp.StatusCode() for HTTP-level errors (4xx, 5xx).
-		return latency, nil
+		// Check for timeout errors first before checking net.OpError to avoid misclassification
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return latency, NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, "")
+		}
+		// Check if error implements net.Error and has Timeout() == true
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return latency, NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, "")
+		}
+		// Check for DNS lookup and network errors after timeout checks
+		var opErr *net.OpError
+		var dnsErr *net.DNSError
+		if errors.As(err, &opErr) || errors.As(err, &dnsErr) {
+			return latency, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Message: schemas.ErrProviderNetworkError,
+					Error:   err,
+				},
+			}
+		}
+		// The HTTP request itself failed (e.g., connection error, fasthttp timeout).
+		return latency, &schemas.BifrostError{
+			IsBifrostError: false,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderDoRequest,
+				Error:   err,
+			},
+		}
 	}
+	// HTTP request was successful from fasthttp's perspective (err is nil).
+	// The caller should check resp.StatusCode() for HTTP-level errors (4xx, 5xx).
+	return latency, nil
 }
 
 // Deprecated: ConfigureRetry is now handled internally by ConfigureDialer.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -125,6 +125,9 @@ func MakeRequestWithContext(ctx context.Context, client *fasthttp.Client, req *f
 				},
 			}
 		}
+		// Handles edge cases where the error chain contains context.Canceled but the
+		// parent context is still valid (e.g., a nested/derived context was cancelled).
+		// IsBifrostError is false since this may indicate a transient provider-side issue.
 		if errors.Is(err, context.Canceled) {
 			return latency, &schemas.BifrostError{
 				IsBifrostError: false,

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -96,30 +96,21 @@ func getLogger() schemas.Logger {
 
 var UnsupportedSpeechStreamModels = []string{"tts-1", "tts-1-hd"}
 
-// defaultRequestTimeout is a safety-net fallback used only when the context has no deadline.
-// In normal operation, callers always set a deadline via NetworkConfig.DefaultRequestTimeoutInSeconds
-// (default 30s), so this 5-minute ceiling should rarely be reached.
-const defaultRequestTimeout = 5 * time.Minute
-
 // MakeRequestWithContext makes a request with a context deadline and returns the latency and error.
-// Uses DoDeadline to avoid goroutine leaks and use-after-free on context cancellation.
-// The deadline is derived from the context; if no deadline is set, defaultRequestTimeout is used.
-//
-// Note: DoDeadline does not observe ctx.Done() for cancel-only (no-deadline) contexts.
-// This is an intentional tradeoff — the previous goroutine+select pattern caused goroutine
-// leaks and use-after-free when contexts cancelled before requests completed. In practice,
-// all provider requests have deadlines set by the caller, so this limitation doesn't apply.
+// When the context carries a deadline, DoDeadline is used to avoid goroutine leaks and
+// use-after-free on context cancellation. When no deadline is set (e.g. long-running
+// requests), it falls back to client.Do which respects the client's own timeout settings.
 // Returns the request latency and any error that occurred.
 func MakeRequestWithContext(ctx context.Context, client *fasthttp.Client, req *fasthttp.Request, resp *fasthttp.Response) (time.Duration, *schemas.BifrostError) {
 	startTime := time.Now()
 
-	// Derive deadline from context, or use a default timeout
+	var err error
 	deadline, ok := ctx.Deadline()
-	if !ok {
-		deadline = time.Now().Add(defaultRequestTimeout)
+	if ok {
+		err = client.DoDeadline(req, resp, deadline)
+	} else {
+		err = client.Do(req, resp)
 	}
-
-	err := client.DoDeadline(req, resp, deadline)
 	latency := time.Since(startTime)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes a goroutine leak and potential use-after-free in `MakeRequestWithContext` by replacing the goroutine+channel pattern with `client.DoDeadline`.

The previous implementation spawned a goroutine calling `client.Do(req, resp)` and used `select` to race it against `ctx.Done()`. When the context cancelled first, the goroutine continued running and could write to `resp` after the caller had already returned — causing use-after-free of the response buffer.

## Changes

* Replace `client.Do` in a goroutine with `client.DoDeadline(req, resp, deadline)` — synchronous, no goroutine needed
* Derive deadline from `ctx.Deadline()`, falling back to a 5-minute safety-net timeout
* Preserve all existing error classification (timeout, cancellation, DNS, network errors)
* Add `ctx.Err()` check after `DoDeadline` returns to detect in-flight cancellation

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [ ] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

## How to test

```bash
(cd core && go build ./... && go vet ./providers/utils/...)
```

The fix is in the request execution path — all existing provider tests exercise this code:
```bash
make test-core PROVIDER=openai
```

To verify goroutine leak is fixed, send requests with short timeouts and confirm goroutine count stabilizes (previously it would grow unbounded under cancellation).

## Screenshots/Recordings

N/A

## Breaking changes

* [ ] Yes
* [x] No

## Security considerations

Eliminates use-after-free of fasthttp response buffers when contexts cancel during in-flight requests.

## Checklist

* [x] I read docs/contributing/README.md and followed the guidelines
* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable