### PR TITLE
fix: remove unreachable code after t.Skip() in cross-provider tests

### DIFF
--- a/core/internal/llmtests/cross_provider_test.go
+++ b/core/internal/llmtests/cross_provider_test.go
@@ -9,7 +9,6 @@ import (
 func TestCrossProviderScenarios(t *testing.T) {
 	t.Parallel()
 	t.Skip("Skipping cross provider scenarios test")
-	return
 
 	client, ctx, cancel, err := SetupTest()
 	if err != nil {
@@ -115,7 +114,6 @@ func TestCrossProviderScenarios(t *testing.T) {
 func TestCrossProviderConsistency(t *testing.T) {
 	t.Parallel()
 	t.Skip("Skipping cross provider consistency test")
-	return
 
 	client, ctx, cancel, err := SetupTest()
 	if err != nil {


### PR DESCRIPTION
## Summary

Removes redundant `return` statements after `t.Skip()` calls that trigger `go vet` unreachable code warnings.

`t.Skip()` calls `runtime.Goexit()`, so any code after it is unreachable.

## Changes

* Remove `return` after `t.Skip()` in `TestCrossProviderScenarios` (line 12)
* Remove `return` after `t.Skip()` in `TestCrossProviderConsistency` (line 118)

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [ ] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

## How to test

```bash
cd core && go vet ./internal/llmtests/...
```

Before: `unreachable code` warnings. After: clean.

## Breaking changes

* [ ] Yes
* [x] No

## Checklist

* [x] I read docs/contributing/README.md and followed the guidelines
* [x] I verified builds succeed (Go and UI)