### PR TITLE
refactor: use direct struct pointer for Anthropic tool InputSchema

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -95,38 +95,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 
 				// Convert function parameters to input_schema
 				if tool.Function.Parameters != nil && (tool.Function.Parameters.Type != "" || tool.Function.Parameters.Properties != nil) {
-					anthropicTool.InputSchema = &schemas.ToolFunctionParameters{
-						Type:                 tool.Function.Parameters.Type,
-						Description:          tool.Function.Parameters.Description,
-						Properties:           tool.Function.Parameters.Properties,
-						Required:             tool.Function.Parameters.Required,
-						Enum:                 tool.Function.Parameters.Enum,
-						AdditionalProperties: tool.Function.Parameters.AdditionalProperties,
-						// JSON Schema definition fields
-						Defs:        tool.Function.Parameters.Defs,
-						Definitions: tool.Function.Parameters.Definitions,
-						Ref:         tool.Function.Parameters.Ref,
-						// Array schema fields
-						Items:    tool.Function.Parameters.Items,
-						MinItems: tool.Function.Parameters.MinItems,
-						MaxItems: tool.Function.Parameters.MaxItems,
-						// Composition fields
-						AnyOf: tool.Function.Parameters.AnyOf,
-						OneOf: tool.Function.Parameters.OneOf,
-						AllOf: tool.Function.Parameters.AllOf,
-						// String validation fields
-						Format:    tool.Function.Parameters.Format,
-						Pattern:   tool.Function.Parameters.Pattern,
-						MinLength: tool.Function.Parameters.MinLength,
-						MaxLength: tool.Function.Parameters.MaxLength,
-						// Number validation fields
-						Minimum: tool.Function.Parameters.Minimum,
-						Maximum: tool.Function.Parameters.Maximum,
-						// Misc fields
-						Title:    tool.Function.Parameters.Title,
-						Default:  tool.Function.Parameters.Default,
-						Nullable: tool.Function.Parameters.Nullable,
-					}
+					anthropicTool.InputSchema = tool.Function.Parameters
 				}
 
 				if tool.CacheControl != nil {


### PR DESCRIPTION
## Summary

Replaces a 30-line field-by-field copy of `ToolFunctionParameters` with direct pointer assignment when building Anthropic tool definitions. Both the source (`tool.Function.Parameters`) and destination (`anthropicTool.InputSchema`) use the same `*schemas.ToolFunctionParameters` type, making the manual copy unnecessary.

This also prevents future bugs where new fields added to `ToolFunctionParameters` would be silently dropped by the Anthropic provider.

## Changes

* Replace field-by-field struct initialization with `anthropicTool.InputSchema = tool.Function.Parameters` in `core/providers/anthropic/chat.go`

## Type of change

* [ ] Bug fix
* [ ] Feature
* [x] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [ ] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

## How to test

```bash
cd core && go build ./providers/anthropic/...
make test-core PROVIDER=anthropic
```

Existing Anthropic provider tests validate tool parameter handling.

## Breaking changes

* [ ] Yes
* [x] No

## Security considerations

No security impact — same data, simplified assignment.

## Checklist

* [x] I read docs/contributing/README.md and followed the guidelines
* [x] I added/updated tests where appropriate
* [x] I verified builds succeed (Go and UI)