### PR TITLE
adds proxy override fixes

### DIFF
--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -162,6 +162,11 @@ type ProxyConfig struct {
 	CACertPEM string    `json:"ca_cert_pem"` // PEM-encoded CA certificate to trust for TLS connections through the proxy
 }
 
+// IsRedactedValue returns true if the value is redacted.
+func (pc *ProxyConfig) IsRedactedValue(value string) bool {
+	return value == "<REDACTED>" || value == "********"
+}
+
 // Redacted returns a redacted copy of the proxy configuration.
 func (pc *ProxyConfig) Redacted() *ProxyConfig {
 	// Create redacted config with same structure but redacted values
@@ -171,10 +176,10 @@ func (pc *ProxyConfig) Redacted() *ProxyConfig {
 		Username: pc.Username,
 	}
 	if pc.Password != "" {
-		redactedConfig.Password = "********"
+		redactedConfig.Password = "<REDACTED>"
 	}
 	if pc.CACertPEM != "" {
-		redactedConfig.CACertPEM = "********"
+		redactedConfig.CACertPEM = "<REDACTED>"
 	}
 	return &redactedConfig
 }

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -449,6 +449,16 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 
 	config.ConcurrencyAndBufferSize = &payload.ConcurrencyAndBufferSize
 	config.NetworkConfig = &nc
+	// Merge proxy config - preserve secrets if redacted values were sent back
+	if payload.ProxyConfig != nil && oldConfigRaw.ProxyConfig != nil {
+		if payload.ProxyConfig.IsRedactedValue(payload.ProxyConfig.Password) {
+			payload.ProxyConfig.Password = oldConfigRaw.ProxyConfig.Password			
+		}
+		if payload.ProxyConfig.IsRedactedValue(payload.ProxyConfig.CACertPEM) {
+			payload.ProxyConfig.CACertPEM = oldConfigRaw.ProxyConfig.CACertPEM
+		}
+	}
+
 	config.ProxyConfig = payload.ProxyConfig
 	config.CustomProviderConfig = payload.CustomProviderConfig
 	config.PricingOverrides = payload.PricingOverrides


### PR DESCRIPTION
## Summary

Fixes proxy configuration updates to preserve sensitive values when redacted placeholders are sent from the UI. This prevents accidental clearing of passwords and CA certificates during provider configuration updates.

## Changes

- Added logic to detect redacted proxy configuration values (`********`) in update payloads
- Preserves existing `Password` and `CACertPEM` values from the original configuration when redacted placeholders are received
- Ensures sensitive proxy credentials are maintained during provider updates when the UI sends back masked values

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test proxy configuration updates with sensitive values:

1. Configure a provider with proxy settings including password and CA certificate
2. Update the provider configuration through the UI
3. Verify that proxy credentials are preserved and not cleared by redacted values

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security by preventing accidental clearing of sensitive proxy credentials (passwords and CA certificates) during configuration updates. The fix ensures that redacted values displayed in the UI don't overwrite actual stored credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable