### PR TITLE
feat: Adds attachment support to Maxim plugin

### DIFF
--- a/plugins/maxim/attachments.go
+++ b/plugins/maxim/attachments.go
@@ -1,0 +1,326 @@
+// Package maxim provides attachment extraction from Bifrost requests for Maxim logging.
+package maxim
+
+import (
+	"encoding/base64"
+	"log"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/maxim-go/logging"
+)
+
+// ExtractAttachmentsFromRequest extracts image_url, file, and input_audio blocks from
+// Chat and Responses API messages and converts them to maxim-go attachment types.
+// Returns a slice of *logging.UrlAttachment or *logging.FileDataAttachment for use with
+// Logger.GenerationAddAttachment.
+func ExtractAttachmentsFromRequest(req *schemas.BifrostRequest) []interface{} {
+	if req == nil {
+		return nil
+	}
+
+	switch req.RequestType {
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+		return extractFromChatRequest(req.ChatRequest)
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
+		return extractFromResponsesRequest(req.ResponsesRequest)
+	default:
+		return nil
+	}
+}
+
+func extractFromChatRequest(cr *schemas.BifrostChatRequest) []interface{} {
+	if cr == nil || cr.Input == nil {
+		return nil
+	}
+
+	var attachments []interface{}
+	for _, msg := range cr.Input {
+		if msg.Content == nil || msg.Content.ContentBlocks == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if att := chatBlockToAttachment(block); att != nil {
+				attachments = append(attachments, att)
+			}
+		}
+	}
+	return attachments
+}
+
+func extractFromResponsesRequest(rr *schemas.BifrostResponsesRequest) []interface{} {
+	if rr == nil || rr.Input == nil {
+		return nil
+	}
+
+	var attachments []interface{}
+	for _, msg := range rr.Input {
+		if msg.Content == nil || msg.Content.ContentBlocks == nil {
+			continue
+		}
+		for _, block := range msg.Content.ContentBlocks {
+			if att := responsesBlockToAttachment(block); att != nil {
+				attachments = append(attachments, att)
+			}
+		}
+	}
+	return attachments
+}
+
+func chatBlockToAttachment(block schemas.ChatContentBlock) interface{} {
+	switch block.Type {
+	case schemas.ChatContentBlockTypeImage:
+		if block.ImageURLStruct != nil && block.ImageURLStruct.URL != "" {
+			return urlToAttachment(block.ImageURLStruct.URL, "image")
+		}
+	case schemas.ChatContentBlockTypeFile:
+		if block.File != nil {
+			return chatFileToAttachment(block.File)
+		}
+	case schemas.ChatContentBlockTypeInputAudio:
+		if block.InputAudio != nil && block.InputAudio.Data != "" {
+			return audioDataToAttachment(block.InputAudio.Data, block.InputAudio.Format)
+		}
+	}
+	return nil
+}
+
+func responsesBlockToAttachment(block schemas.ResponsesMessageContentBlock) interface{} {
+	switch block.Type {
+	case schemas.ResponsesInputMessageContentBlockTypeImage:
+		if block.ImageURL != nil && *block.ImageURL != "" {
+			return urlToAttachment(*block.ImageURL, "image")
+		}
+	case schemas.ResponsesInputMessageContentBlockTypeFile:
+		return responsesFileToAttachment(&block)
+	case schemas.ResponsesInputMessageContentBlockTypeAudio:
+		if block.Audio != nil && block.Audio.Data != "" {
+			format := block.Audio.Format
+			if format == "" {
+				format = "mp3"
+			}
+			return audioDataToAttachment(block.Audio.Data, &format)
+		}
+	}
+	return nil
+}
+
+func responsesFileToAttachment(block *schemas.ResponsesMessageContentBlock) interface{} {
+	if block.FileURL != nil && *block.FileURL != "" {
+		name := "attachment"
+		if block.Filename != nil && *block.Filename != "" {
+			name = *block.Filename
+		}
+		mime := ""
+		if block.FileType != nil {
+			mime = *block.FileType
+		}
+		urlStr := *block.FileURL
+		return &logging.UrlAttachment{
+			BaseAttachmentProps: logging.BaseAttachmentProps{
+				ID:       uuid.New().String(),
+				Name:     name,
+				MimeType: mime,
+				Metadata: map[string]string{"url": urlStr},
+			},
+			Type: logging.AttachmentTypeURL,
+			URL:  urlStr,
+		}
+	}
+	if block.FileData != nil && *block.FileData != "" {
+		data, err := base64.StdEncoding.DecodeString(*block.FileData)
+		if err != nil {
+			log.Printf("%s failed to decode file_data base64: %v", PluginLoggerPrefix, err)
+			return nil
+		}
+		name := "attachment"
+		if block.Filename != nil && *block.Filename != "" {
+			name = *block.Filename
+		}
+		mime := "application/octet-stream"
+		if block.FileType != nil && *block.FileType != "" {
+			mime = *block.FileType
+		}
+		return &logging.FileDataAttachment{
+			BaseAttachmentProps: logging.BaseAttachmentProps{
+				ID:       uuid.New().String(),
+				Name:     name,
+				MimeType: mime,
+			},
+			Type: logging.AttachmentTypeFileData,
+			Data: data,
+		}
+	}
+	return nil
+}
+
+func chatFileToAttachment(f *schemas.ChatInputFile) interface{} {
+	if f.FileURL != nil && *f.FileURL != "" {
+		name := "attachment"
+		if f.Filename != nil && *f.Filename != "" {
+			name = *f.Filename
+		}
+		mime := ""
+		if f.FileType != nil {
+			mime = *f.FileType
+		}
+		urlStr := *f.FileURL
+		return &logging.UrlAttachment{
+			BaseAttachmentProps: logging.BaseAttachmentProps{
+				ID:       uuid.New().String(),
+				Name:     name,
+				MimeType: mime,
+				Metadata: map[string]string{"url": urlStr},
+			},
+			Type: logging.AttachmentTypeURL,
+			URL:  urlStr,
+		}
+	}
+	if f.FileData != nil && *f.FileData != "" {
+		data, err := base64.StdEncoding.DecodeString(*f.FileData)
+		if err != nil {
+			log.Printf("%s failed to decode file_data base64: %v", PluginLoggerPrefix, err)
+			return nil
+		}
+		name := "attachment"
+		if f.Filename != nil && *f.Filename != "" {
+			name = *f.Filename
+		}
+		mime := "application/octet-stream"
+		if f.FileType != nil && *f.FileType != "" {
+			mime = *f.FileType
+		}
+		return &logging.FileDataAttachment{
+			BaseAttachmentProps: logging.BaseAttachmentProps{
+				ID:       uuid.New().String(),
+				Name:     name,
+				MimeType: mime,
+			},
+			Type: logging.AttachmentTypeFileData,
+			Data: data,
+		}
+	}
+	return nil
+}
+
+func audioDataToAttachment(data string, format *string) interface{} {
+	// Data can be base64 or a data URL (data:audio/wav;base64,...)
+	var b64 string
+	if strings.HasPrefix(data, "data:") {
+		idx := strings.Index(data, ";base64,")
+		if idx == -1 {
+			log.Printf("%s invalid audio data URL format", PluginLoggerPrefix)
+			return nil
+		}
+		b64 = data[idx+8:]
+	} else {
+		b64 = data
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		log.Printf("%s failed to decode audio base64: %v", PluginLoggerPrefix, err)
+		return nil
+	}
+
+	mime := "audio/mpeg"
+	if format != nil {
+		switch strings.ToLower(*format) {
+		case "wav":
+			mime = "audio/wav"
+		case "mp3":
+			mime = "audio/mpeg"
+		default:
+			mime = "audio/" + *format
+		}
+	}
+
+	return &logging.FileDataAttachment{
+		BaseAttachmentProps: logging.BaseAttachmentProps{
+			ID:       uuid.New().String(),
+			Name:     "audio." + extFromMime(mime),
+			MimeType: mime,
+		},
+		Type: logging.AttachmentTypeFileData,
+		Data: decoded,
+	}
+}
+
+func urlToAttachment(urlStr string, kind string) interface{} {
+	if strings.HasPrefix(urlStr, "data:") {
+		return dataURLToAttachment(urlStr, kind)
+	}
+	// HTTP/HTTPS URL
+	name := "attachment"
+	if u, err := url.Parse(urlStr); err == nil {
+		if p := path.Base(u.Path); p != "" && p != "." {
+			name = p
+		}
+	}
+	return &logging.UrlAttachment{
+		BaseAttachmentProps: logging.BaseAttachmentProps{
+			ID:       uuid.New().String(),
+			Name:     name,
+			Metadata: map[string]string{"url": urlStr},
+		},
+		Type: logging.AttachmentTypeURL,
+		URL:  urlStr,
+	}
+}
+
+func dataURLToAttachment(dataURL string, kind string) interface{} {
+	// Format: data:image/png;base64,iVBORw0...
+	idx := strings.Index(dataURL, ";base64,")
+	if idx == -1 {
+		log.Printf("%s invalid data URL format", PluginLoggerPrefix)
+		return nil
+	}
+
+	header := dataURL[5:idx] // "image/png" or "image/png;charset=..."
+	mime := strings.Split(header, ";")[0]
+	if mime == "" {
+		mime = "application/octet-stream"
+	}
+
+	b64 := dataURL[idx+8:]
+	decoded, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		log.Printf("%s failed to decode data URL base64: %v", PluginLoggerPrefix, err)
+		return nil
+	}
+
+	name := kind + "." + extFromMime(mime)
+	return &logging.FileDataAttachment{
+		BaseAttachmentProps: logging.BaseAttachmentProps{
+			ID:       uuid.New().String(),
+			Name:     name,
+			MimeType: mime,
+		},
+		Type: logging.AttachmentTypeFileData,
+		Data: decoded,
+	}
+}
+
+func extFromMime(mime string) string {
+	switch mime {
+	case "image/png":
+		return "png"
+	case "image/jpeg", "image/jpg":
+		return "jpg"
+	case "image/gif":
+		return "gif"
+	case "image/webp":
+		return "webp"
+	case "audio/wav":
+		return "wav"
+	case "audio/mpeg":
+		return "mp3"
+	case "application/pdf":
+		return "pdf"
+	default:
+		return "bin"
+	}
+}

--- a/plugins/maxim/attachments_test.go
+++ b/plugins/maxim/attachments_test.go
@@ -1,0 +1,563 @@
+package maxim
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/maxim-go/logging"
+)
+
+// Test URLs and assets from core/internal/llmtests/utils.go for consistency across Bifrost tests.
+var (
+	testFileURL     = "https://www.berkshirehathaway.com/letters/2024ltr.pdf"
+	testImageURL    = "https://pestworldcdn-dcf2a8gbggazaghf.z01.azurefd.net/media/561791/carpenter-ant4.jpg"
+	testImageBase64 = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAAIAAoDASIAAhEBAxEB/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABmX/9k="
+)
+
+func strPtr(s string) *string { return &s }
+
+func responsesUserRole() *schemas.ResponsesMessageRoleType {
+	r := schemas.ResponsesInputMessageRoleUser
+	return &r
+}
+
+func TestExtractAttachmentsFromRequest_ChatImageUrlHttp(t *testing.T) {
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeImage,
+								ImageURLStruct: &schemas.ChatInputImage{
+									URL: testImageURL,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.UrlAttachment); !ok {
+		t.Errorf("expected *logging.UrlAttachment, got %T", attachments[0])
+	}
+	ua := attachments[0].(*logging.UrlAttachment)
+	if ua.URL != testImageURL {
+		t.Errorf("expected URL %q, got %q", testImageURL, ua.URL)
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ChatImageUrlData(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("fake-png-bytes"))
+	dataURL := "data:image/png;base64," + b64
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeImage,
+								ImageURLStruct: &schemas.ChatInputImage{
+									URL: dataURL,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.FileDataAttachment); !ok {
+		t.Errorf("expected *logging.FileDataAttachment, got %T", attachments[0])
+	}
+	fda := attachments[0].(*logging.FileDataAttachment)
+	if string(fda.Data) != "fake-png-bytes" {
+		t.Errorf("expected data 'fake-png-bytes', got %q", string(fda.Data))
+	}
+	if fda.MimeType != "image/png" {
+		t.Errorf("expected mime image/png, got %q", fda.MimeType)
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ChatFileUrl(t *testing.T) {
+	fileURL := testFileURL
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeFile,
+								File: &schemas.ChatInputFile{
+									FileURL:  &fileURL,
+									Filename: strPtr("2024ltr.pdf"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.UrlAttachment); !ok {
+		t.Errorf("expected *logging.UrlAttachment, got %T", attachments[0])
+	}
+	ua := attachments[0].(*logging.UrlAttachment)
+	if ua.URL != fileURL {
+		t.Errorf("expected URL %q, got %q", fileURL, ua.URL)
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ChatFileData(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("pdf content"))
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeFile,
+								File: &schemas.ChatInputFile{
+									FileData: &b64,
+									Filename: strPtr("doc.pdf"),
+									FileType: strPtr("application/pdf"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.FileDataAttachment); !ok {
+		t.Errorf("expected *logging.FileDataAttachment, got %T", attachments[0])
+	}
+	fda := attachments[0].(*logging.FileDataAttachment)
+	if string(fda.Data) != "pdf content" {
+		t.Errorf("expected data 'pdf content', got %q", string(fda.Data))
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ChatInputAudio(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("audio-bytes"))
+	format := "wav"
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeInputAudio,
+								InputAudio: &schemas.ChatInputAudio{
+									Data:   b64,
+									Format: &format,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.FileDataAttachment); !ok {
+		t.Errorf("expected *logging.FileDataAttachment, got %T", attachments[0])
+	}
+	fda := attachments[0].(*logging.FileDataAttachment)
+	if string(fda.Data) != "audio-bytes" {
+		t.Errorf("expected data 'audio-bytes', got %q", string(fda.Data))
+	}
+	if fda.MimeType != "audio/wav" {
+		t.Errorf("expected mime audio/wav, got %q", fda.MimeType)
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ResponsesInputImage(t *testing.T) {
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: responsesUserRole(),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+								ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+									ImageURL: &testImageURL,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.UrlAttachment); !ok {
+		t.Errorf("expected *logging.UrlAttachment, got %T", attachments[0])
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ResponsesInputFile(t *testing.T) {
+	fileURL := testFileURL
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: responsesUserRole(),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeFile,
+								ResponsesInputMessageContentBlockFile: &schemas.ResponsesInputMessageContentBlockFile{
+									FileURL:  &fileURL,
+									Filename: strPtr("2024ltr.pdf"),
+									FileType: strPtr("application/pdf"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.UrlAttachment); !ok {
+		t.Errorf("expected *logging.UrlAttachment, got %T", attachments[0])
+	}
+}
+
+func TestExtractAttachmentsFromRequest_ResponsesInputAudio(t *testing.T) {
+	b64 := base64.StdEncoding.EncodeToString([]byte("mp3-bytes"))
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: responsesUserRole(),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeAudio,
+								Audio: &schemas.ResponsesInputMessageContentBlockAudio{
+									Format: "mp3",
+									Data:   b64,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.FileDataAttachment); !ok {
+		t.Errorf("expected *logging.FileDataAttachment, got %T", attachments[0])
+	}
+	fda := attachments[0].(*logging.FileDataAttachment)
+	if string(fda.Data) != "mp3-bytes" {
+		t.Errorf("expected data 'mp3-bytes', got %q", string(fda.Data))
+	}
+	if fda.MimeType != "audio/mpeg" {
+		t.Errorf("expected mime audio/mpeg, got %q", fda.MimeType)
+	}
+}
+
+func TestExtractAttachmentsFromRequest_NoAttachments(t *testing.T) {
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentStr: strPtr("Hello, world!"),
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 0 {
+		t.Fatalf("expected 0 attachments, got %d", len(attachments))
+	}
+}
+
+func TestExtractAttachmentsFromRequest_TextCompletion(t *testing.T) {
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.TextCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeImage,
+								ImageURLStruct: &schemas.ChatInputImage{
+									URL: "https://example.com/image.png",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 0 {
+		t.Fatalf("expected 0 attachments for text completion, got %d", len(attachments))
+	}
+}
+
+func TestExtractAttachmentsFromRequest_NilRequest(t *testing.T) {
+	attachments := ExtractAttachmentsFromRequest(nil)
+	if attachments != nil {
+		t.Fatalf("expected nil for nil request, got %v", attachments)
+	}
+}
+
+// TestExtractAttachmentsFromRequest_ChatFileDataFromBase64 uses testImageBase64
+// and verifies FileData extraction from base64-encoded content.
+func TestExtractAttachmentsFromRequest_ChatFileDataFromBase64(t *testing.T) {
+	// Extract base64 from data URL (format: data:image/jpeg;base64,...)
+	idx := strings.Index(testImageBase64, ";base64,")
+	if idx == -1 {
+		t.Fatal("invalid testImageBase64 format")
+	}
+	b64 := testImageBase64[idx+8:]
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("failed to decode test image base64: %v", err)
+	}
+	b64ForRequest := base64.StdEncoding.EncodeToString(data)
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentBlocks: []schemas.ChatContentBlock{
+							{
+								Type: schemas.ChatContentBlockTypeFile,
+								File: &schemas.ChatInputFile{
+									FileData: &b64ForRequest,
+									Filename: strPtr("grey_solid.jpg"),
+									FileType: strPtr("image/jpeg"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	attachments := ExtractAttachmentsFromRequest(req)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if _, ok := attachments[0].(*logging.FileDataAttachment); !ok {
+		t.Errorf("expected *logging.FileDataAttachment, got %T", attachments[0])
+	}
+	fda := attachments[0].(*logging.FileDataAttachment)
+	if len(fda.Data) != len(data) {
+		t.Errorf("expected data length %d, got %d", len(data), len(fda.Data))
+	}
+	if fda.MimeType != "image/jpeg" {
+		t.Errorf("expected mime image/jpeg, got %q", fda.MimeType)
+	}
+}
+
+// requireIntegrationEnv skips the test if required env vars for real API calls are not set.
+func requireIntegrationEnv(t *testing.T) {
+	t.Helper()
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("OPENAI_API_KEY not set, skipping integration test")
+	}
+	if os.Getenv("MAXIM_API_KEY") == "" {
+		t.Skip("MAXIM_API_KEY not set, skipping integration test")
+	}
+	if os.Getenv("MAXIM_LOG_REPO_ID") == "" {
+		t.Skip("MAXIM_LOG_REPO_ID not set, skipping integration test")
+	}
+}
+
+// TestVisionWithImageUrl_Integration sends a real OpenAI vision request via Bifrost
+// with the maxim plugin. The plugin extracts the image_url and logs it as an attachment
+// to Maxim. Verify attachments in the Maxim dashboard after the test.
+func TestVisionWithImageUrl_Integration(t *testing.T) {
+	requireIntegrationEnv(t)
+
+	plugin, err := getPlugin()
+	if err != nil {
+		t.Fatalf("failed to get plugin: %v", err)
+	}
+
+	client, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
+		Account:    &BaseAccount{},
+		LLMPlugins: []schemas.LLMPlugin{plugin},
+		Logger:     bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+	})
+	if err != nil {
+		t.Fatalf("failed to init Bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	_, bifrostErr := client.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentBlocks: []schemas.ChatContentBlock{
+						{
+							Type: schemas.ChatContentBlockTypeText,
+							Text: bifrost.Ptr("Describe this image in one sentence."),
+						},
+						{
+							Type: schemas.ChatContentBlockTypeImage,
+							ImageURLStruct: &schemas.ChatInputImage{
+								URL: testImageURL,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionRequest failed: %v", bifrostErr)
+	}
+
+	log.Printf("Vision request with image URL completed. Check Maxim dashboard for trace with attachment.")
+}
+
+// TestVisionWithImageData_Integration fetches testImageURL, encodes it as a data URL,
+// and sends to OpenAI vision via Bifrost. The maxim plugin extracts the data URL and
+// logs it as a FileDataAttachment. Uses a real image (carpenter ant) since OpenAI
+// rejects minimal test images like the grey solid.
+func TestVisionWithImageData_Integration(t *testing.T) {
+	requireIntegrationEnv(t)
+
+	// Fetch real image and encode as data URL (OpenAI rejects minimal grey solid)
+	httpClient := &http.Client{Timeout: 20 * time.Second}
+	resp, err := httpClient.Get(testImageURL)
+
+	if err != nil {
+		t.Skipf("failed to fetch test image: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Skipf("test image URL returned %d", resp.StatusCode)
+	}
+	imgData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Skipf("failed to read test image: %v", err)
+	}
+	dataURL := "data:image/jpeg;base64," + base64.StdEncoding.EncodeToString(imgData)
+
+	plugin, err := getPlugin()
+	if err != nil {
+		t.Fatalf("failed to get plugin: %v", err)
+	}
+
+	client, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
+		Account:    &BaseAccount{},
+		LLMPlugins: []schemas.LLMPlugin{plugin},
+		Logger:     bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+	})
+	if err != nil {
+		t.Fatalf("failed to init Bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	_, bifrostErr := client.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentBlocks: []schemas.ChatContentBlock{
+						{
+							Type: schemas.ChatContentBlockTypeText,
+							Text: bifrost.Ptr("What do you see in this image? One sentence."),
+						},
+						{
+							Type: schemas.ChatContentBlockTypeImage,
+							ImageURLStruct: &schemas.ChatInputImage{
+								URL: dataURL,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionRequest failed: %v", bifrostErr)
+	}
+
+	log.Printf("Vision request with base64 image completed. Check Maxim dashboard for trace with FileData attachment.")
+}

--- a/plugins/maxim/changelog.md
+++ b/plugins/maxim/changelog.md
@@ -1,0 +1,1 @@
+- feat: Adds attachment support [@Rohan](https://github.com/roroghost17)

--- a/plugins/maxim/go.mod
+++ b/plugins/maxim/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/maximhq/bifrost/core v1.4.6
 	github.com/maximhq/bifrost/framework v1.2.25
-	github.com/maximhq/maxim-go v0.1.14
+	github.com/maximhq/maxim-go v0.1.16
 )
 
 require github.com/google/uuid v1.6.0

--- a/plugins/maxim/go.sum
+++ b/plugins/maxim/go.sum
@@ -195,8 +195,8 @@ github.com/maximhq/bifrost/core v1.4.6 h1:fE1r77KaZcwJezfYg8f5a0gCUM8UEK9o3XNm22
 github.com/maximhq/bifrost/core v1.4.6/go.mod h1:1BFmMbnlJniAxQn9dPWHBnwhIW43WZLld2OJy0nnxMw=
 github.com/maximhq/bifrost/framework v1.2.25 h1:fGl+RbD0u4akCsQy3+DYObG0H6YSw1Moqw31fHHSglE=
 github.com/maximhq/bifrost/framework v1.2.25/go.mod h1:EpMS+7kb/w1RtVjUtYh2DniX67WAc1GtoWQ+6WvgMCE=
-github.com/maximhq/maxim-go v0.1.14 h1:NQgpf3aRoD2Kq1GAqeSrLn3rQresn1H6mPP3JJ85qhA=
-github.com/maximhq/maxim-go v0.1.14/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
+github.com/maximhq/maxim-go v0.1.16 h1:07yuTQIatwOCjd9cfM3b6hOBgD6Q8ixu17VA22o0XY0=
+github.com/maximhq/maxim-go v0.1.16/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -435,6 +435,13 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	// Add generation to the effective log repository
 	logger.AddGenerationToTrace(traceID, &generationConfig)
 
+	// Extract and log attachments from message content
+	for _, att := range ExtractAttachmentsFromRequest(req) {
+		if att != nil {
+			logger.GenerationAddAttachment(generationID, att)
+		}
+	}
+
 	if ctx != nil {
 		if _, ok := ctx.Value(TraceIDKey).(string); !ok {
 			ctx.SetValue(TraceIDKey, traceID)
@@ -515,8 +522,9 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 				}
 			}
 
-			// Return if no stream response or it's a delta response
-			if streamResponse == nil || !isFinalChunk {
+			// For streaming: only process on final chunk. Skip intermediate chunks.
+			// When there's an error, streamResponse may be nil but we must still log bifrostErr.
+			if !isFinalChunk {
 				return
 			}
 		}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,3 @@
 - fix: preserve original audio filename in transcription requests
 - fix: async jobs stuck in "processing" on marshal failure now correctly transition to "failed"
+- feat: adds attachment support in Maxim plugin

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.32 // indirect
 	github.com/maximhq/bifrost/plugins/mocker v1.4.25 // indirect
-	github.com/maximhq/maxim-go v0.1.14 // indirect
+	github.com/maximhq/maxim-go v0.1.16 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oapi-codegen/runtime v1.1.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -233,8 +233,7 @@ github.com/maximhq/bifrost/plugins/semanticcache v1.4.24 h1:oS1QNyMPt/418JSys/j9
 github.com/maximhq/bifrost/plugins/semanticcache v1.4.24/go.mod h1:6XnVUg2y2FKlQuvAukMvTqVjhlyTpsUpOXef0G7Z16k=
 github.com/maximhq/bifrost/plugins/telemetry v1.4.26 h1:+4EyCAlJ+rK8hGXDx5QwXmBDGZ5JBD38wdG1T2WuW/g=
 github.com/maximhq/bifrost/plugins/telemetry v1.4.26/go.mod h1:PAUk/49dXCga3J5t/ipm56SDkl3Rm6glP2oJ166Wy98=
-github.com/maximhq/maxim-go v0.1.14 h1:NQgpf3aRoD2Kq1GAqeSrLn3rQresn1H6mPP3JJ85qhA=
-github.com/maximhq/maxim-go v0.1.14/go.mod h1:0+UTWM7UZwNNE5VnljLtr/vpRGtYP8r/2q9WDwlLWFw=
+github.com/maximhq/maxim-go v0.1.16 h1:07yuTQIatwOCjd9cfM3b6hOBgD6Q8ixu17VA22o0XY0=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=


### PR DESCRIPTION
## Summary

Adds attachment support to the Maxim plugin, enabling extraction and logging of image, file, and audio attachments from Chat and Responses API requests to Maxim's logging system.

## Changes

- Added `ExtractAttachmentsFromRequest` function that processes Bifrost requests and extracts attachments from message content blocks
- Supports multiple attachment types: image URLs, data URLs, file URLs, file data (base64), and input audio
- Converts attachments to appropriate Maxim logging types (`UrlAttachment` or `FileDataAttachment`)
- Handles both Chat Completion and Responses API request formats
- Integrated attachment extraction into the plugin's `PreLLMHook` to log attachments before LLM processing
- Added comprehensive test coverage including unit tests and integration tests with real API calls
- Updated maxim-go dependency to v0.1.16 to support attachment logging functionality

## Type of change

- [x] Feature

## Affected areas

- [x] Plugins

## How to test

Run the unit tests to verify attachment extraction logic:

```sh
cd plugins/maxim
go test -v ./...
```

For integration testing with real API calls, set environment variables and run integration tests:

```sh
export OPENAI_API_KEY="your-key"
export MAXIM_API_KEY="your-key" 
export MAXIM_LOG_REPO_ID="your-repo-id"
go test -v -run TestVisionWithImageUrl_Integration
go test -v -run TestVisionWithImageData_Integration
```

The integration tests will send vision requests with image attachments and log them to Maxim. Check the Maxim dashboard to verify attachments appear in the traces.

## Screenshots/Recordings

N/A - This is a backend logging feature without UI changes.

## Breaking changes

- [ ] No

## Related issues

N/A

## Security considerations

- Base64 decoding is performed on user-provided data with proper error handling
- File attachments are processed and logged to Maxim's secure logging infrastructure
- No sensitive data is exposed beyond what's already in the original requests

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable