### PR TITLE
fix(logging): avoid loading raw_request/raw_response in log list queries

### DIFF
--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -226,9 +226,12 @@ func (s *RDBLogStore) SearchLogs(ctx context.Context, filters SearchFilters, pag
 		orderClause = "timestamp " + direction
 	}
 
-	// Execute main query with sorting and pagination
+	// Execute main query with sorting and pagination.
+	// Omit large raw_request/raw_response blobs from the list — they are only
+	// needed when a user opens the detail view for a single log entry, where
+	// they are fetched via the dedicated GET /api/logs/:id endpoint.
 	var logs []Log
-	mainQuery := baseQuery.Order(orderClause)
+	mainQuery := baseQuery.Order(orderClause).Omit("raw_request", "raw_response")
 
 	if pagination.Limit > 0 {
 		mainQuery = mainQuery.Limit(pagination.Limit)
@@ -865,7 +868,7 @@ func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFil
 
 	var results []struct {
 		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
-		Latency        float64 `gorm:"column:latency"`
+		Latency         float64 `gorm:"column:latency"`
 	}
 
 	var selectClause string
@@ -1207,7 +1210,7 @@ func (s *RDBLogStore) GetProviderLatencyHistogram(ctx context.Context, filters S
 	var results []struct {
 		BucketTimestamp int64   `gorm:"column:bucket_timestamp"`
 		Provider        string  `gorm:"column:provider"`
-		Latency        float64 `gorm:"column:latency"`
+		Latency         float64 `gorm:"column:latency"`
 	}
 
 	var selectClause string

--- a/framework/logstore/sqlite.go
+++ b/framework/logstore/sqlite.go
@@ -36,6 +36,7 @@ func newSqliteLogStore(ctx context.Context, config *SQLiteConfig, logger schemas
 		return nil, err
 	}
 	logger.Debug("db opened for logstore")
+
 	s := &RDBLogStore{db: db, logger: logger}
 	// Run migrations
 	if err := triggerMigrations(ctx, db); err != nil {

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -652,6 +652,11 @@ func (p *LoggerPlugin) SearchLogs(ctx context.Context, filters logstore.SearchFi
 	return p.store.SearchLogs(ctx, filters, pagination)
 }
 
+// GetLog retrieves a single log entry by ID including all fields (raw_request, raw_response).
+func (p *LoggerPlugin) GetLog(ctx context.Context, id string) (*logstore.Log, error) {
+	return p.store.FindByID(ctx, id)
+}
+
 // GetStats calculates statistics for logs matching the given filters
 func (p *LoggerPlugin) GetStats(ctx context.Context, filters logstore.SearchFilters) (*logstore.SearchStats, error) {
 	return p.store.GetStats(ctx, filters)

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -21,6 +21,9 @@ type KeyPair struct {
 
 // LogManager defines the main interface that combines all logging functionality
 type LogManager interface {
+	// GetLog retrieves a single log entry by ID (includes all fields, including raw_request/raw_response)
+	GetLog(ctx context.Context, id string) (*logstore.Log, error)
+
 	// Search searches for log entries based on filters and pagination
 	Search(ctx context.Context, filters *logstore.SearchFilters, pagination *logstore.PaginationOptions) (*logstore.SearchResult, error)
 
@@ -101,6 +104,10 @@ type LogManager interface {
 // PluginLogManager implements LogManager interface wrapping the plugin
 type PluginLogManager struct {
 	plugin *LoggerPlugin
+}
+
+func (p *PluginLogManager) GetLog(ctx context.Context, id string) (*logstore.Log, error) {
+	return p.plugin.GetLog(ctx, id)
 }
 
 func (p *PluginLogManager) Search(ctx context.Context, filters *logstore.SearchFilters, pagination *logstore.PaginationOptions) (*logstore.SearchResult, error) {

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -45,6 +46,7 @@ func NewLoggingHandler(logManager logging.LogManager, redactedKeysManager Redact
 func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	// LLM Log retrieval with filtering, search, and pagination
 	r.GET("/api/logs", lib.ChainMiddlewares(h.getLogs, middlewares...))
+	r.GET("/api/logs/{id}", lib.ChainMiddlewares(h.getLogByID, middlewares...))
 	r.GET("/api/logs/stats", lib.ChainMiddlewares(h.getLogsStats, middlewares...))
 	r.GET("/api/logs/histogram", lib.ChainMiddlewares(h.getLogsHistogram, middlewares...))
 	r.GET("/api/logs/histogram/tokens", lib.ChainMiddlewares(h.getLogsTokenHistogram, middlewares...))
@@ -239,6 +241,27 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, result)
+}
+
+// getLogByID handles GET /api/logs/{id} - Get a single log entry by ID including raw_request and raw_response
+func (h *LoggingHandler) getLogByID(ctx *fasthttp.RequestCtx) {
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || id == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "log id is required")
+		return
+	}
+
+	log, err := h.logManager.GetLog(ctx, id)
+	if err != nil {
+		if errors.Is(err, logstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "log not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get log: %v", err))
+		return
+	}
+
+	SendJSON(ctx, log)
 }
 
 // getLogsStats handles GET /api/logs/stats - Get statistics for logs with filtering

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -76,9 +76,10 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 
 	if (!log) return null;
 
-	// Merge raw fields from the dedicated single-log fetch (list query omits them for performance)
-	const rawRequest = fullLog?.raw_request ?? log.raw_request;
-	const rawResponse = fullLog?.raw_response ?? log.raw_response;
+	// Merge raw fields from the dedicated single-log fetch (list query omits them for performance).
+	// Guard against stale data: only use fullLog if it belongs to the currently opened log entry.
+	const rawRequest = fullLog?.id === log.id ? fullLog.raw_request : log.raw_request;
+	const rawResponse = fullLog?.id === log.id ? fullLog.raw_response : log.raw_response;
 
 	const isContainer = isContainerOperation(log.object);
 

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+import { useLazyGetLogByIdQuery } from "@/lib/store/apis/logsApi";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -64,7 +66,19 @@ const isContainerOperation = (object: string) => {
 };
 
 export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDetailSheetProps) {
+	const [fetchLog, { data: fullLog }] = useLazyGetLogByIdQuery();
+
+	useEffect(() => {
+		if (open && log?.id) {
+			fetchLog(log.id);
+		}
+	}, [open, log?.id, fetchLog]);
+
 	if (!log) return null;
+
+	// Merge raw fields from the dedicated single-log fetch (list query omits them for performance)
+	const rawRequest = fullLog?.raw_request ?? log.raw_request;
+	const rawResponse = fullLog?.raw_response ?? log.raw_response;
 
 	const isContainer = isContainerOperation(log.object);
 
@@ -611,7 +625,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								</CollapsibleBox>
 							</>
 						)}
-						{log.raw_request && (
+						{rawRequest && (
 							<>
 								<div className="mt-4 w-full text-left text-sm font-medium">
 									Raw Request sent to <span className="font-medium capitalize">{log.provider}</span>
@@ -620,9 +634,9 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									title="Raw Request"
 									onCopy={() => {
 										try {
-											return JSON.stringify(JSON.parse(log.raw_request || ""), null, 2);
+											return JSON.stringify(JSON.parse(rawRequest || ""), null, 2);
 										} catch {
-											return log.raw_request || "";
+											return rawRequest || "";
 										}
 									}}
 								>
@@ -633,9 +647,9 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 										wrap={true}
 										code={(() => {
 											try {
-												return JSON.stringify(JSON.parse(log.raw_request || ""), null, 2);
+												return JSON.stringify(JSON.parse(rawRequest || ""), null, 2);
 											} catch {
-												return log.raw_request || "";
+												return rawRequest || "";
 											}
 										})()}
 										lang="json"
@@ -645,7 +659,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 								</CollapsibleBox>
 							</>
 						)}
-						{log.raw_response && (
+						{rawResponse && (
 							<>
 								<div className="mt-4 w-full text-left text-sm font-medium">
 									Raw Response from <span className="font-medium capitalize">{log.provider}</span>
@@ -654,9 +668,9 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									title="Raw Response"
 									onCopy={() => {
 										try {
-											return JSON.stringify(JSON.parse(log.raw_response || ""), null, 2);
+											return JSON.stringify(JSON.parse(rawResponse || ""), null, 2);
 										} catch {
-											return log.raw_response || "";
+											return rawResponse || "";
 										}
 									}}
 								>
@@ -667,9 +681,9 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 										wrap={true}
 										code={(() => {
 											try {
-												return JSON.stringify(JSON.parse(log.raw_response || ""), null, 2);
+												return JSON.stringify(JSON.parse(rawResponse || ""), null, 2);
 											} catch {
-												return log.raw_response || "";
+												return rawResponse || "";
 											}
 										})()}
 										lang="json"

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -328,7 +328,7 @@ export const logsApi = baseApi.injectEndpoints({
 
 		// Get a single log entry by ID (includes raw_request and raw_response)
 		getLogById: builder.query<LogEntry, string>({
-			query: (id) => `/logs/${id}`,
+			query: (id) => `/logs/${encodeURIComponent(id)}`,
 			providesTags: (result, error, id) => [{ type: "Logs", id }],
 		}),
 	}),

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -325,6 +325,12 @@ export const logsApi = baseApi.injectEndpoints({
 			}),
 			invalidatesTags: ["Logs"],
 		}),
+
+		// Get a single log entry by ID (includes raw_request and raw_response)
+		getLogById: builder.query<LogEntry, string>({
+			query: (id) => `/logs/${id}`,
+			providesTags: (result, error, id) => [{ type: "Logs", id }],
+		}),
 	}),
 });
 
@@ -355,4 +361,5 @@ export const {
 	useLazyGetAvailableFilterDataQuery,
 	useDeleteLogsMutation,
 	useRecalculateLogCostsMutation,
+	useLazyGetLogByIdQuery,
 } = logsApi;


### PR DESCRIPTION
## Summary

When **raw request and response logging** is enabled, the logs list endpoint (`GET /api/logs`) returns the full `raw_request` and `raw_response` fields for every log entry. These fields can be quite large for long running prompts or tool-heavy responses.

Because of this, the **Logs** and **Dashboard** pages can become very slow or appear to load indefinitely when many logs contain large raw payloads.

This change avoids loading those fields in the list query and instead fetches them only when a specific log entry is opened.

---

## Changes

* Updated the logs list query to omit `raw_request` and `raw_response`.
* Added a new endpoint to fetch a single log entry with the full raw payload:

```
GET /api/logs/{id}
```

* Updated the UI to lazily fetch the full log when opening the log detail sheet.
* Removed `SetMaxOpenConns(1)` from the SQLite configuration since WAL mode already supports concurrent reads.

This keeps the logs list lightweight while still allowing the full raw request/response to be inspected when needed.

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [x] Plugins
* [x] UI (Next.js)
* [ ] Providers/Integrations
* [ ] Docs

---

## How to test

Run tests:

```sh
go test ./...
```

Build UI:

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

### Manual validation

1. Enable **Raw request and response logging** for a provider.
2. Send a prompt that generates logs with large raw payloads.
3. Open:

```
Observability → Logs
Observability → Dashboard
```

Expected behavior:

* Logs page loads normally
* Dashboard loads normally
* Opening a log entry still shows the raw request and response

---

## Screenshots / Recordings

Logs page loading normally with raw logging enabled:

<img width="1912" height="974" alt="Screenshot 2026-03-05 142400" src="https://github.com/user-attachments/assets/e084af46-b000-4967-abf4-a248325a5ac9" />


---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #1764

---

## Security considerations

No changes to authentication or access control. Raw payloads remain accessible through the existing log detail view.

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [ ] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable
