### PR TITLE
observability v2

### DIFF
--- a/ui/app/workspace/dashboard/components/providerLatencyChart.tsx
+++ b/ui/app/workspace/dashboard/components/providerLatencyChart.tsx
@@ -162,10 +162,10 @@ export function ProviderLatencyChart({ data, chartType, startTime, endTime, sele
 						{mode === "single" ? (
 							<>
 								<Tooltip content={<SingleProviderTooltip provider={selectedProvider} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-								<Bar dataKey="avg_latency" fill={LATENCY_COLORS.avg} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
-								<Bar dataKey="p90_latency" fill={LATENCY_COLORS.p90} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
-								<Bar dataKey="p95_latency" fill={LATENCY_COLORS.p95} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
-								<Bar dataKey="p99_latency" fill={LATENCY_COLORS.p99} fillOpacity={0.9} barSize={8} radius={[2, 2, 0, 0]} />
+								<Bar dataKey="avg_latency" fill={LATENCY_COLORS.avg} fillOpacity={0.9} barSize={30} radius={[2, 2, 0, 0]} />
+								<Bar dataKey="p90_latency" fill={LATENCY_COLORS.p90} fillOpacity={0.9} barSize={30} radius={[2, 2, 0, 0]} />
+								<Bar dataKey="p95_latency" fill={LATENCY_COLORS.p95} fillOpacity={0.9} barSize={30} radius={[2, 2, 0, 0]} />
+								<Bar dataKey="p99_latency" fill={LATENCY_COLORS.p99} fillOpacity={0.9} barSize={30} radius={[2, 2, 0, 0]} />
 							</>
 						) : (
 							<>
@@ -176,7 +176,7 @@ export function ProviderLatencyChart({ data, chartType, startTime, endTime, sele
 										dataKey={`provider_${idx}`}
 										fill={getModelColor(idx)}
 										fillOpacity={0.9}
-										barSize={8}
+										barSize={30}
 										radius={[2, 2, 0, 0]}
 									/>
 								))}


### PR DESCRIPTION
## Summary

Increased the bar width in the provider latency chart to improve visual clarity and readability of latency metrics.

## Changes

- Increased `barSize` from 8 to 30 pixels for all latency bars (avg, p90, p95, p99) in single provider mode
- Increased `barSize` from 8 to 30 pixels for provider comparison bars in multi-provider mode
- This change makes the latency data more visually prominent and easier to read in the dashboard

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the workspace dashboard and verify that the provider latency chart displays with wider, more visible bars for both single provider and multi-provider views.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

None - this is a visual styling change only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable