### PR TITLE
fix: remove auto-creation of plugins in updatePlugin handler

### DIFF
--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -297,30 +297,15 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Empty 'name' parameter not allowed")
 		return
 	}
-	var plugin *configstoreTables.TablePlugin
-	var err error
 	// Check if plugin exists
-	_, err = h.configStore.GetPlugin(ctx, name)
-	if err != nil {
-		// If doesn't exist, create it
+	if _, err := h.configStore.GetPlugin(ctx, name); err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
-			plugin = &configstoreTables.TablePlugin{
-				Name:     name,
-				Enabled:  false,
-				Config:   map[string]any{},
-				Path:     nil,
-				IsCustom: false,
-			}
-			if err := h.configStore.CreatePlugin(ctx, plugin); err != nil {
-				logger.Error("failed to create plugin: %v", err)
-				SendError(ctx, 500, "Failed to create plugin")
-				return
-			}
-		} else {
-			logger.Error("failed to get plugin: %v", err)
-			SendError(ctx, 500, "Failed to update plugin")
+			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found")
 			return
 		}
+		logger.Error("failed to get plugin: %v", err)
+		SendError(ctx, 500, "Failed to update plugin")
+		return
 	}
 
 	// Unmarshalling the request body
@@ -352,7 +337,7 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to update plugin")
 		return
 	}
-	plugin, err = h.configStore.GetPlugin(ctx, name)
+	plugin, err := h.configStore.GetPlugin(ctx, name)
 	if err != nil {
 		if errors.Is(err, configstore.ErrNotFound) {
 			SendError(ctx, fasthttp.StatusNotFound, "Plugin not found")
@@ -364,7 +349,7 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	}
 	// We reload the plugin if its enabled, otherwise we stop it
 	if request.Enabled {
-		if err := h.pluginsLoader.ReloadPlugin(ctx, name, request.Path, request.Config); err != nil {			
+		if err := h.pluginsLoader.ReloadPlugin(ctx, name, request.Path, request.Config); err != nil {
 			logger.Error("failed to load plugin: %v", err)
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Plugin updated in database but failed to load: %v", err))
 			return
@@ -374,7 +359,7 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		if err := h.pluginsLoader.RemovePlugin(ctx, name); err != nil {
 			if !errors.Is(err, plugins.ErrPluginNotFound) {
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Plugin updated in database but failed to stop: %v", err))
-				return	
+				return
 			}
 			// If not found then we don't need to do anything
 		}


### PR DESCRIPTION
## Summary

Removes automatic plugin creation behavior from the `updatePlugin` endpoint. Previously, the endpoint would create a new plugin if it didn't exist during an update operation. Now it returns a 404 error when attempting to update a non-existent plugin.

## Changes

- Removed automatic plugin creation logic that would create a default plugin with `Enabled: false` when updating a non-existent plugin
- Changed error handling to return `404 Not Found` instead of creating the plugin
- Simplified variable declarations by moving them to their usage points
- Fixed minor whitespace formatting issues

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the plugin update endpoint behavior:

```sh
# Test updating a non-existent plugin - should return 404
curl -X PUT http://localhost:8080/api/plugins/nonexistent-plugin \
  -H "Content-Type: application/json" \
  -d '{"enabled": true, "config": {}}'

# Expected: 404 Not Found response

# Test updating an existing plugin - should work normally
curl -X PUT http://localhost:8080/api/plugins/existing-plugin \
  -H "Content-Type: application/json" \
  -d '{"enabled": true, "config": {}}'

# Expected: 200 OK with updated plugin data
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

This is a breaking change for clients that relied on the automatic plugin creation behavior when calling the update endpoint. Clients should now use the create plugin endpoint first, then update the plugin separately.

## Related issues

N/A

## Security considerations

This change improves API consistency by preventing unintended plugin creation through the update endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable