### PR TITLE
feat: add API key selection by ID with priority over name selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,8 @@ ctx.WithValue(key, value)    // Chainable variant
 
 **User-settable keys** (plugins and handlers can set these):
 - `BifrostContextKeyVirtualKey` (`x-bf-vk`) — Virtual key for governance
-- `BifrostContextKeyAPIKeyName` (`x-bf-api-key`) — Explicit key selection
+- `BifrostContextKeyAPIKeyName` (`x-bf-api-key`) — Explicit key selection by name
+- `BifrostContextKeyAPIKeyID` (`x-bf-api-key-id`) — Explicit key selection by ID (takes priority over name)
 - `BifrostContextKeyRequestID` — Request ID
 - `BifrostContextKeyExtraHeaders` — Extra headers to forward to provider
 - `BifrostContextKeyURLPath` — Custom URL path for provider

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5931,20 +5931,28 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 		return schemas.Key{}, fmt.Errorf("no keys found that support model: %s", model)
 	}
 
-	var requestedKeyName string
+	// Key ID takes priority over key name when both are present
 	if ctx != nil {
-		if keyName, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyName).(string); ok {
-			requestedKeyName = strings.TrimSpace(keyName)
-		}
-	}
-
-	if requestedKeyName != "" {
-		for _, key := range supportedKeys {
-			if key.Name == requestedKeyName {
-				return key, nil
+		if keyID, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyID).(string); ok {
+			if keyID = strings.TrimSpace(keyID); keyID != "" {
+				for _, key := range supportedKeys {
+					if key.ID == keyID {
+						return key, nil
+					}
+				}
+				return schemas.Key{}, fmt.Errorf("no key found with id %q for provider: %v", keyID, providerKey)
 			}
 		}
-		return schemas.Key{}, fmt.Errorf("no key found with name %q for provider: %v", requestedKeyName, providerKey)
+		if keyName, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyName).(string); ok {
+			if keyName = strings.TrimSpace(keyName); keyName != "" {
+				for _, key := range supportedKeys {
+					if key.Name == keyName {
+						return key, nil
+					}
+				}
+				return schemas.Key{}, fmt.Errorf("no key found with name %q for provider: %v", keyName, providerKey)
+			}
+		}
 	}
 
 	if len(supportedKeys) == 1 {

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,4 @@
+- feat: add BifrostContextKeyAPIKeyID for explicit key selection by ID, with priority over key name selection
+- feat: add DisableAutoToolInject to MCPToolManagerConfig to suppress automatic MCP tool injection per request
+- feat: add Filename field to TranscriptionInput schema to carry original filename through the request pipeline
+- fix: add AudioFilenameFromBytes utility to detect audio format from file headers with mp3 fallback

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -152,9 +152,10 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeySessionToken                        BifrostContextKey = "bifrost-session-token"                 // string (session token for authentication - set by auth middleware)
+	BifrostContextKeySessionToken                        BifrostContextKey = "bifrost-session-token"                // string (session token for authentication - set by auth middleware)
 	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                              // string
 	BifrostContextKeyAPIKeyName                          BifrostContextKey = "x-bf-api-key"                         // string (explicit key name selection)
+	BifrostContextKeyAPIKeyID                            BifrostContextKey = "x-bf-api-key-id"                      // string (explicit key ID selection, takes priority over name)
 	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                           // string
 	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"                  // string
 	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"                   // Key struct
@@ -233,10 +234,8 @@ const (
 	BifrostContextKeyLargePayloadPrefetchSize            BifrostContextKey = "bifrost-large-payload-prefetch-size"        // int (set by enterprise - DO NOT SET THIS MANUALLY)) prefetch buffer size for metadata extraction from large responses
 	BifrostContextKeyDeferredUsage                       BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
 	BifrostContextKeyDeferredLargePayloadMetadata        BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
-	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                  // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
-)
+	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
 
-const (
 	// DefaultLargePayloadRequestThresholdBytes is the default request-size heuristic
 	// used by transport guards when no enterprise threshold is present on context.
 	DefaultLargePayloadRequestThresholdBytes = 10 * 1024 * 1024 // 10MB

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -13,6 +13,7 @@ var NoDeadline time.Time
 var reservedKeys = []any{
 	BifrostContextKeyVirtualKey,
 	BifrostContextKeyAPIKeyName,
+	BifrostContextKeyAPIKeyID,
 	BifrostContextKeyRequestID,
 	BifrostContextKeyFallbackRequestID,
 	BifrostContextKeyDirectKey,

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -211,21 +211,33 @@ For cloud providers with deployment-based routing, Bifrost validates deployment 
 3. Exclude keys without proper deployment mapping
 4. Continue with standard weighted selection
 
-## Custom Key Usage (By Name)
+## Custom Key Usage (By Name or ID)
 
-Bifrost also supports referencing a stored provider key by name instead of sending the raw secret. This can be useful when you want callers to reference logical key names (for example, `openai-key-1`) and let the gateway resolve the actual secret from configured provider keys.
+Bifrost supports referencing a stored provider key by name or by ID instead of sending the raw secret. This can be useful when you want callers to reference logical key names or stable IDs and let the gateway resolve the actual secret from configured provider keys.
 
-How to use:
-- Header: send `x-bf-api-key: <key-name>` on the request. The gateway will look up the named key and use its secret for the upstream provider call.
-- Context (server-side / Go): set the API key name in the Bifrost context so internal callers can request the named key. For example:
+**When both are provided, ID takes priority over name.**
 
-From a client SDK call you can set the name directly on your request context:
+### By ID
+
+- Header: send `x-bf-api-key-id: <key-id>` on the request. The gateway will look up the key with that ID.
+- Context (Go SDK):
 
 ```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyID, "key-uuid-1234")
+```
+
+### By Name
+
+- Header: send `x-bf-api-key: <key-name>` on the request. The gateway will look up the named key and use its secret for the upstream provider call.
+- Context (Go SDK):
+
+```go
+ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyName, "openai-key-1")
 ```
 
-Note: `x-bf-api-key` and the `BifrostContextKeyAPIKeyName` value reference a stored key name (not the raw secret). The gateway will resolve the named key against configured provider keys and apply model filtering, deployment mapping and weighted selection as usual.
+Note: Both mechanisms reference a stored key (not the raw secret). The gateway resolves the key against configured provider keys and applies model filtering and deployment mapping. When an explicit key ID or name is supplied, weighted selection is bypassed and the referenced key is used directly.
 
 ```bash
 # Example: request referencing a stored key name that doesn't exist

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -12,6 +12,7 @@ Bifrost provides request options that control behavior, enable features, and pas
 |-------------|--------|------|-------------|
 | `BifrostContextKeyVirtualKey` | `x-bf-vk` | `string` | Virtual key identifier for governance |
 | `BifrostContextKeyAPIKeyName` | `x-bf-api-key` | `string` | Explicit API key name selection |
+| `BifrostContextKeyAPIKeyID` | `x-bf-api-key-id` | `string` | Explicit API key ID selection (takes priority over name) |
 | `BifrostContextKeyRequestID` | `x-request-id` | `string` | Custom request ID for tracking |
 | `BifrostContextKeySendBackRawResponse` | `x-bf-send-back-raw-response` | `bool` | Include raw provider response |
 | `BifrostContextKeyPassthroughExtraParams` | `x-bf-passthrough-extra-params` | `bool` | Enable passthrough for extra parameters |
@@ -76,11 +77,50 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 Virtual keys can also be passed via `Authorization: Bearer vk-*`, `x-api-key: vk-*`, or `x-goog-api-key: vk-*` headers when the value starts with the virtual key prefix.
 </Note>
 
-### API Key Name Selection
+### API Key Selection
 
-**Context Key:** `BifrostContextKeyAPIKeyName`  
-**Header:** `x-bf-api-key`  
-**Type:** `string`  
+Bifrost supports selecting a specific key by **ID** or **name**. When both are present, ID takes priority.
+
+#### By ID
+
+**Context Key:** `BifrostContextKeyAPIKeyID`
+**Header:** `x-bf-api-key-id`
+**Type:** `string`
+**Required:** No
+
+Explicitly select a key by its unique ID. Takes priority over name selection when both are provided.
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-api-key-id: key-uuid-1234' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyID, "key-uuid-1234")
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+```
+</Tab>
+</Tabs>
+
+#### By Name
+
+**Context Key:** `BifrostContextKeyAPIKeyName`
+**Header:** `x-bf-api-key`
+**Type:** `string`
 **Required:** No
 
 Explicitly select a named API key from your configured keys.

--- a/docs/quickstart/go-sdk/context-keys.mdx
+++ b/docs/quickstart/go-sdk/context-keys.mdx
@@ -34,7 +34,19 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 See [Custom Headers Per Request](./provider-configuration#custom-headers-per-request) for detailed information on header handling and security restrictions.
 </Note>
 
-### API Key Name Selection
+### API Key Selection
+
+Bifrost supports selecting a specific key by **ID** or **name**. When both are present, ID takes priority.
+
+#### By ID
+
+Explicitly select a key by its unique ID.
+
+```go
+ctx := context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyID, "key-uuid-1234")
+```
+
+#### By Name
 
 Explicitly select a named API key from your configured keys.
 
@@ -279,6 +291,7 @@ func makeRequest(client *bifrost.Bifrost) {
 |-----|------|-----------|-------------|
 | `BifrostContextKeyVirtualKey` | `string` | Set | Virtual key identifier |
 | `BifrostContextKeyAPIKeyName` | `string` | Set | Explicit API key name selection |
+| `BifrostContextKeyAPIKeyID` | `string` | Set | Explicit API key ID selection (priority over name) |
 | `BifrostContextKeyRequestID` | `string` | Set | Custom request ID for tracking |
 | `BifrostContextKeyFallbackRequestID` | `string` | Read | Request ID when using fallback |
 | `BifrostContextKeyDirectKey` | `schemas.Key` | Set | Direct key credentials |

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -151,8 +151,9 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, hea
 		// prevent auth/key overrides via x-bf-eh-*
 		"x-api-key":      true,
 		"x-goog-api-key": true,
-		"x-bf-api-key":   true,
-		"x-bf-vk":        true,
+		"x-bf-api-key":    true,
+		"x-bf-api-key-id": true,
+		"x-bf-vk":         true,
 	}
 
 	// shouldAllowHeader determines if a header should be forwarded based on
@@ -276,6 +277,12 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, hea
 		if keyStr == "x-bf-api-key" {
 			if keyName := strings.TrimSpace(string(value)); keyName != "" {
 				bifrostCtx.SetValue(schemas.BifrostContextKeyAPIKeyName, keyName)
+			}
+			return true
+		}
+		if keyStr == "x-bf-api-key-id" {
+			if keyID := strings.TrimSpace(string(value)); keyID != "" {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyAPIKeyID, keyID)
 			}
 			return true
 		}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,4 @@
+- fix: preserve original audio filename in transcription requests
+- fix: async jobs stuck in "processing" on marshal failure now correctly transition to "failed"
+- feat: adds attachment support in Maxim plugin
+- feat: add x-bf-api-key-id header support for explicit key selection by ID, with priority over x-bf-api-key name selection


### PR DESCRIPTION
## Summary

Adds support for explicit API key selection by ID through a new `BifrostContextKeyAPIKeyID` context key and `x-bf-api-key-id` header. When both key ID and key name are provided, the ID takes priority over name-based selection.

## Changes

- Added `BifrostContextKeyAPIKeyID` constant for key selection by ID
- Modified key selection logic in `selectKeyFromProviderForModel` to prioritize ID over name
- Added `x-bf-api-key-id` header support in HTTP transport layer
- Updated documentation to reflect the new key selection options and priority behavior

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Test key selection by ID:
```sh
# Test with key ID header
curl --location 'http://localhost:8080/v1/chat/completions' \
--header 'x-bf-api-key-id: your-key-uuid' \
--header 'Content-Type: application/json' \
--data '{
    "model": "openai/gpt-4o-mini",
    "messages": [{"role": "user", "content": "Hello!"}]
}'

# Test priority: ID should override name when both are present
curl --location 'http://localhost:8080/v1/chat/completions' \
--header 'x-bf-api-key-id: key-uuid-1' \
--header 'x-bf-api-key: key-name-2' \
--header 'Content-Type: application/json' \
--data '{
    "model": "openai/gpt-4o-mini",
    "messages": [{"role": "user", "content": "Hello!"}]
}'
```

Test with Go SDK:
```go
ctx := context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyID, "your-key-uuid")
response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), request)
```

Run standard tests:
```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A - Backend API enhancement

## Breaking changes

- [ ] Yes
- [x] No

This is an additive feature that maintains backward compatibility with existing key name selection.

## Related issues

N/A

## Security considerations

The new key ID selection follows the same security model as existing key name selection. Key IDs are resolved server-side against configured provider keys, maintaining the same access control and validation patterns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable