### PR TITLE
forward SSE errors as is vs sending back 200

### DIFF
--- a/core/internal/llmtests/stream_error_status_code.go
+++ b/core/internal/llmtests/stream_error_status_code.go
@@ -1,0 +1,129 @@
+package llmtests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunStreamErrorStatusCodeTest validates that pre-stream errors from providers carry
+// the correct HTTP status code in BifrostError.StatusCode. This is critical because
+// the HTTP transport layer (sendStreamError) relies on this field to propagate the
+// provider's actual status code to clients, rather than always returning 200 OK.
+//
+// The test sends a streaming request with a deliberately invalid model name.
+// All providers (OpenAI, Anthropic, Bedrock) return 4xx status codes for such errors,
+// and Bifrost must preserve those codes through the error chain.
+func RunStreamErrorStatusCodeTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.CompletionStream {
+		t.Logf("Completion stream not supported for provider %s, skipping stream error status code test", testConfig.Provider)
+		return
+	}
+
+	t.Run("StreamErrorStatusCode", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		// Use a model name that is guaranteed to not exist across all providers.
+		// This triggers a pre-stream validation error (400/404) rather than an in-stream error.
+		invalidModel := "bifrost-nonexistent-model-for-testing-12345"
+
+		// Test with Chat Completion stream (most universally supported stream type)
+		t.Run("ChatCompletionStream", func(t *testing.T) {
+			messages := []schemas.ChatMessage{
+				CreateBasicChatMessage("Hello"),
+			}
+
+			request := &schemas.BifrostChatRequest{
+				Provider: testConfig.Provider,
+				Model:    invalidModel,
+				Input:    messages,
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: bifrost.Ptr(10),
+				},
+			}
+
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			stream, bifrostErr := client.ChatCompletionStreamRequest(bfCtx, request)
+
+			// We expect an error — the model doesn't exist
+			if bifrostErr == nil {
+				// If somehow no error, drain the stream and fail
+				if stream != nil {
+					for range stream {
+					}
+				}
+				t.Fatal("❌ Expected error for invalid model in stream request, but got nil")
+			}
+
+			// Core assertion: the error must carry a provider HTTP status code
+			if bifrostErr.StatusCode == nil {
+				t.Fatalf("❌ BifrostError.StatusCode is nil for provider %s — provider status code was not propagated. Error: %s",
+					testConfig.Provider, GetErrorMessage(bifrostErr))
+			}
+
+			statusCode := *bifrostErr.StatusCode
+
+			// The status code should be a 4xx client error (invalid model → 400, 404, or similar)
+			if statusCode < 400 || statusCode >= 600 {
+				t.Fatalf("❌ Expected 4xx/5xx status code for invalid model, got %d. Error: %s",
+					statusCode, GetErrorMessage(bifrostErr))
+			}
+
+			// Should not be a Bifrost-generated error — it should come from the provider
+			if bifrostErr.IsBifrostError {
+				// Some providers may have bifrost-level validation that catches invalid models
+				// before reaching the provider. Log but don't fail.
+				t.Logf("⚠️  Error is a Bifrost error (not provider error) with status %d — this may indicate model validation happened before the provider call", statusCode)
+			}
+
+			t.Logf("✅ Stream error for invalid model returned status code %d (provider: %s)", statusCode, testConfig.Provider)
+			t.Logf("   Error message: %s", GetErrorMessage(bifrostErr))
+		})
+
+		// Also test Responses stream if supported (Anthropic uses a different path)
+		t.Run("ResponsesStream", func(t *testing.T) {
+			messages := []schemas.ResponsesMessage{
+				CreateBasicResponsesMessage("Hello"),
+			}
+
+			request := &schemas.BifrostResponsesRequest{
+				Provider: testConfig.Provider,
+				Model:    invalidModel,
+				Input:    messages,
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: bifrost.Ptr(10),
+				},
+			}
+
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			stream, bifrostErr := client.ResponsesStreamRequest(bfCtx, request)
+
+			if bifrostErr == nil {
+				if stream != nil {
+					for range stream {
+					}
+				}
+				t.Fatal("❌ Expected error for invalid model in responses stream request, but got nil")
+			}
+
+			if bifrostErr.StatusCode == nil {
+				t.Fatalf("❌ BifrostError.StatusCode is nil for provider %s responses stream — provider status code was not propagated. Error: %s",
+					testConfig.Provider, GetErrorMessage(bifrostErr))
+			}
+
+			statusCode := *bifrostErr.StatusCode
+
+			if statusCode < 400 || statusCode >= 600 {
+				t.Fatalf("❌ Expected 4xx/5xx status code for invalid model in responses stream, got %d. Error: %s",
+					statusCode, GetErrorMessage(bifrostErr))
+			}
+
+			t.Logf("✅ Responses stream error for invalid model returned status code %d (provider: %s)", statusCode, testConfig.Provider)
+		})
+	})
+}

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -111,6 +111,7 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunContainerFileDeleteTest,
 		RunContainerFileUnsupportedTest,
 		RunPassthroughExtraParamsTest,
+		RunStreamErrorStatusCodeTest,
 	}
 
 	// Execute all test scenarios without raw request/response (default behavior)
@@ -221,6 +222,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"ContainerFileDelete", testConfig.Scenarios.ContainerFileDelete},
 		{"ContainerFileUnsupported", !testConfig.Scenarios.ContainerFileCreate && !testConfig.Scenarios.ContainerFileList && !testConfig.Scenarios.ContainerFileRetrieve && !testConfig.Scenarios.ContainerFileContent && !testConfig.Scenarios.ContainerFileDelete},
 		{"PassThroughExtraParams", testConfig.Scenarios.PassThroughExtraParams},
+		{"StreamErrorStatusCode", testConfig.Scenarios.CompletionStream},
 	}
 
 	supported := 0

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -3,7 +3,6 @@ package integrations
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -140,7 +139,9 @@ func extractExactPath(ctx *fasthttp.RequestCtx) string {
 	return string(out)
 }
 
-// sendStreamError sends an error in streaming format using the stream error converter if available
+// sendStreamError sends an error response for a streaming request that failed before streaming started.
+// It propagates the provider's HTTP status code and returns a JSON error body (not SSE format),
+// since no streaming has begun and clients should receive a standard error response.
 func (g *GenericRouter) sendStreamError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, config RouteConfig, bifrostErr *schemas.BifrostError) {
 	// Forward provider response headers from context so streaming error responses include them
 	if bifrostCtx != nil {
@@ -151,27 +152,30 @@ func (g *GenericRouter) sendStreamError(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 		}
 	}
 
-	var errorResponse interface{}
-
-	// Use stream error converter if available, otherwise fallback to regular error converter
-	if config.StreamConfig != nil && config.StreamConfig.ErrorConverter != nil {
-		errorResponse = config.StreamConfig.ErrorConverter(bifrostCtx, bifrostErr)
+	// Set the HTTP status code from the provider error
+	if bifrostErr.StatusCode != nil {
+		ctx.SetStatusCode(*bifrostErr.StatusCode)
 	} else {
-		errorResponse = config.ErrorConverter(bifrostCtx, bifrostErr)
-	}
-
-	errorJSON, err := sonic.Marshal(map[string]interface{}{
-		"error": errorResponse,
-	})
-	if err != nil {
-		log.Printf("Failed to marshal error for SSE: %v", err)
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+	}
+	ctx.SetContentType("application/json")
+
+	// Always use the route-level ErrorConverter (not StreamConfig.ErrorConverter) because
+	// sendStreamError returns JSON, not SSE. StreamConfig.ErrorConverter is designed for
+	// in-stream SSE errors (e.g., Anthropic's returns a raw SSE string that would be
+	// double-escaped by JSON marshaling).
+	errorResponse := config.ErrorConverter(bifrostCtx, bifrostErr)
+
+	errorJSON, err := sonic.Marshal(errorResponse)
+	if err != nil {
+		g.logger.Error("failed to marshal error response", "err", err, "path", extractExactPath(ctx))
+		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetContentType("text/plain; charset=utf-8")
+		ctx.SetBodyString(fmt.Sprintf("failed to encode error response: %v", err))
 		return
 	}
 
-	if _, err := fmt.Fprintf(ctx, "data: %s\n\n", errorJSON); err != nil {
-		log.Printf("Failed to write SSE error: %v", err)
-	}
+	ctx.SetBody(errorJSON)
 }
 
 // sendError sends an error response with the appropriate status code and JSON body.
@@ -200,6 +204,7 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 		// Log the marshal failure and return a plain text error
 		g.logger.Error("failed to marshal error response", "err", err, "path", extractExactPath(ctx))
 		ctx.SetStatusCode(fasthttp.StatusInternalServerError)
+		ctx.SetContentType("text/plain; charset=utf-8")
 		ctx.SetBodyString(fmt.Sprintf("failed to encode error response: %v", err))
 		return
 	}

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -1,0 +1,277 @@
+package integrations
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// testLogger implements schemas.Logger for testing (all no-ops)
+type testLogger struct{}
+
+func (t *testLogger) Debug(msg string, args ...any) {}
+func (t *testLogger) Info(msg string, args ...any)  {}
+func (t *testLogger) Warn(msg string, args ...any)  {}
+func (t *testLogger) Error(msg string, args ...any) {}
+func (t *testLogger) Fatal(msg string, args ...any) {}
+func (t *testLogger) SetLevel(level schemas.LogLevel) {}
+func (t *testLogger) SetOutputType(outputType schemas.LoggerOutputType) {}
+func (t *testLogger) LogHTTPRequest(level schemas.LogLevel, msg string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+var _ schemas.Logger = (*testLogger)(nil)
+
+func ptr(i int) *int {
+	return &i
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func newTestGenericRouter() *GenericRouter {
+	return NewGenericRouter(nil, &mockHandlerStore{}, nil, &testLogger{})
+}
+
+func newTestBifrostContext() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+// TestSendStreamError_PropagatesProviderStatusCode verifies that sendStreamError
+// sets the HTTP status code from the provider's BifrostError.StatusCode field.
+// All three providers (OpenAI, Anthropic, Bedrock) return actual HTTP error codes
+// for pre-stream errors, so Bifrost must propagate them faithfully.
+func TestSendStreamError_PropagatesProviderStatusCode(t *testing.T) {
+	tests := []struct {
+		name               string
+		statusCode         *int
+		expectedStatusCode int
+	}{
+		{
+			name:               "provider 400 - Bedrock ValidationException / OpenAI invalid_request_error",
+			statusCode:         ptr(400),
+			expectedStatusCode: 400,
+		},
+		{
+			name:               "provider 429 - rate limiting (all providers)",
+			statusCode:         ptr(429),
+			expectedStatusCode: 429,
+		},
+		{
+			name:               "provider 503 - Bedrock ServiceUnavailableException",
+			statusCode:         ptr(503),
+			expectedStatusCode: 503,
+		},
+		{
+			name:               "provider 529 - Anthropic overloaded_error",
+			statusCode:         ptr(529),
+			expectedStatusCode: 529,
+		},
+		{
+			name:               "nil StatusCode defaults to 500",
+			statusCode:         nil,
+			expectedStatusCode: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := newTestGenericRouter()
+			ctx := &fasthttp.RequestCtx{}
+			bifrostCtx := newTestBifrostContext()
+
+			bifrostErr := &schemas.BifrostError{
+				StatusCode: tt.statusCode,
+				Error: &schemas.ErrorField{
+					Message: "test error",
+				},
+			}
+
+			config := RouteConfig{
+				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+					return err
+				},
+			}
+
+			router.sendStreamError(ctx, bifrostCtx, config, bifrostErr)
+
+			assert.Equal(t, tt.expectedStatusCode, ctx.Response.StatusCode())
+			assert.Equal(t, "application/json", string(ctx.Response.Header.ContentType()))
+
+			body := string(ctx.Response.Body())
+			assert.True(t, sonic.Valid(ctx.Response.Body()), "response body should be valid JSON, got: %s", body)
+			assert.False(t, strings.HasPrefix(body, "data: "), "response should not be SSE format")
+		})
+	}
+}
+
+// TestSendStreamError_OpenAIErrorFormat verifies the response body matches the
+// OpenAI error format. OpenAI's ErrorConverter returns *schemas.BifrostError directly,
+// which serializes to {"is_bifrost_error":false,"status_code":400,"error":{...}}.
+func TestSendStreamError_OpenAIErrorFormat(t *testing.T) {
+	router := newTestGenericRouter()
+	ctx := &fasthttp.RequestCtx{}
+	bifrostCtx := newTestBifrostContext()
+
+	bifrostErr := &schemas.BifrostError{
+		IsBifrostError: false,
+		StatusCode:     ptr(400),
+		Error: &schemas.ErrorField{
+			Type:    strPtr("invalid_request_error"),
+			Message: "content is empty",
+		},
+	}
+
+	config := RouteConfig{
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router.sendStreamError(ctx, bifrostCtx, config, bifrostErr)
+
+	assert.Equal(t, 400, ctx.Response.StatusCode())
+
+	// Unmarshal and verify the structure
+	var result map[string]interface{}
+	err := sonic.Unmarshal(ctx.Response.Body(), &result)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "is_bifrost_error")
+	assert.Contains(t, result, "status_code")
+	assert.Contains(t, result, "error")
+	assert.Equal(t, false, result["is_bifrost_error"])
+
+	errorObj, ok := result["error"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "invalid_request_error", errorObj["type"])
+	assert.Equal(t, "content is empty", errorObj["message"])
+}
+
+// TestSendStreamError_AnthropicErrorFormat verifies the response body matches the
+// Anthropic error format: {"type":"error","error":{"type":"...","message":"..."}}.
+// Critically, it also verifies that the StreamConfig.ErrorConverter (which returns
+// raw SSE strings) is NOT used — sendStreamError must use the route-level ErrorConverter.
+func TestSendStreamError_AnthropicErrorFormat(t *testing.T) {
+	router := newTestGenericRouter()
+	ctx := &fasthttp.RequestCtx{}
+	bifrostCtx := newTestBifrostContext()
+
+	bifrostErr := &schemas.BifrostError{
+		StatusCode: ptr(429),
+		Error: &schemas.ErrorField{
+			Type:    strPtr("rate_limit_error"),
+			Message: "rate limited",
+		},
+	}
+
+	config := RouteConfig{
+		// Route-level: returns JSON-marshallable *AnthropicMessageError
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return anthropic.ToAnthropicChatCompletionError(err)
+		},
+		// Stream-level: returns raw SSE string — should NOT be used by sendStreamError
+		StreamConfig: &StreamConfig{
+			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+				return anthropic.ToAnthropicResponsesStreamError(err)
+			},
+		},
+	}
+
+	router.sendStreamError(ctx, bifrostCtx, config, bifrostErr)
+
+	assert.Equal(t, 429, ctx.Response.StatusCode())
+	assert.Equal(t, "application/json", string(ctx.Response.Header.ContentType()))
+
+	body := string(ctx.Response.Body())
+
+	// Must NOT contain SSE markers — that would mean StreamConfig.ErrorConverter was used
+	assert.NotContains(t, body, "event: error", "response should not contain SSE event markers")
+
+	// Unmarshal and verify Anthropic error structure
+	var result anthropic.AnthropicMessageError
+	err := sonic.Unmarshal(ctx.Response.Body(), &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, "error", result.Type)
+	assert.Equal(t, "rate_limit_error", result.Error.Type)
+	assert.Equal(t, "rate limited", result.Error.Message)
+}
+
+// TestSendStreamError_BedrockErrorFormat verifies the response body matches the
+// Bedrock error format: {"__type":"ValidationException","message":"..."}.
+func TestSendStreamError_BedrockErrorFormat(t *testing.T) {
+	router := newTestGenericRouter()
+	ctx := &fasthttp.RequestCtx{}
+	bifrostCtx := newTestBifrostContext()
+
+	bifrostErr := &schemas.BifrostError{
+		StatusCode: ptr(400),
+		Error: &schemas.ErrorField{
+			Code:    strPtr("ValidationException"),
+			Message: "validation error",
+		},
+	}
+
+	config := RouteConfig{
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return bedrock.ToBedrockError(err)
+		},
+	}
+
+	router.sendStreamError(ctx, bifrostCtx, config, bifrostErr)
+
+	assert.Equal(t, 400, ctx.Response.StatusCode())
+
+	// Unmarshal and verify Bedrock error structure
+	var result bedrock.BedrockError
+	err := sonic.Unmarshal(ctx.Response.Body(), &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ValidationException", result.Type)
+	assert.Equal(t, "validation error", result.Message)
+}
+
+// TestSendStreamError_ForwardsProviderHeaders verifies that provider response headers
+// stored in the BifrostContext are forwarded to the HTTP response. This ensures
+// clients receive provider-specific headers (e.g., x-amzn-requestid for Bedrock,
+// x-request-id for Anthropic) even in error scenarios.
+func TestSendStreamError_ForwardsProviderHeaders(t *testing.T) {
+	router := newTestGenericRouter()
+	ctx := &fasthttp.RequestCtx{}
+	bifrostCtx := newTestBifrostContext()
+
+	// Set provider response headers on the context
+	bifrostCtx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{
+		"x-amzn-requestid": "req-123",
+		"x-amzn-errortype": "ValidationException",
+	})
+
+	bifrostErr := &schemas.BifrostError{
+		StatusCode: ptr(400),
+		Error: &schemas.ErrorField{
+			Message: "validation error",
+		},
+	}
+
+	config := RouteConfig{
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return err
+		},
+	}
+
+	router.sendStreamError(ctx, bifrostCtx, config, bifrostErr)
+
+	assert.Equal(t, 400, ctx.Response.StatusCode())
+	assert.Equal(t, "req-123", string(ctx.Response.Header.Peek("x-amzn-requestid")))
+	assert.Equal(t, "ValidationException", string(ctx.Response.Header.Peek("x-amzn-errortype")))
+}


### PR DESCRIPTION
## Summary

Fixed the `sendStreamError` function to return proper HTTP error responses instead of Server-Sent Events (SSE) format when streaming requests fail before streaming begins.

## Issues

Closes #1911

## Changes

- Updated `sendStreamError` to set appropriate HTTP status codes from provider errors
- Changed response format from SSE (`data: {...}\n\n`) to standard JSON error response
- Set proper `application/json` content type for error responses
- Replaced `log.Printf` with structured logging using the router's logger
- Removed unnecessary error wrapping that was adding an extra `error` field
- Improved error handling when JSON marshaling fails

The key insight is that when a streaming request fails before any streaming starts, clients expect a standard HTTP error response, not an SSE-formatted message.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming endpoints that fail before streaming begins to verify they return proper HTTP error responses:

```sh
# Core/Transports
go version
go test ./...

# Test streaming endpoints with invalid requests
curl -i -X POST http://localhost:8080/streaming-endpoint \
  -H "Content-Type: application/json" \
  -d '{"invalid": "request"}'

# Verify response has proper HTTP status code and JSON content-type
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change improves error handling without affecting authentication or data exposure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable