### PR TITLE
fix: prevent panic in WeightedRandomKeySelector when all keys have zero weight

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5945,6 +5945,11 @@ func WeightedRandomKeySelector(ctx *schemas.BifrostContext, keys []schemas.Key, 
 		totalWeight += int(key.Weight * 100) // Convert float to int for better performance
 	}
 
+	// If all keys have zero weight, fall back to uniform random selection
+	if totalWeight == 0 {
+		return keys[rand.Intn(len(keys))], nil
+	}
+
 	// Use global thread-safe random (Go 1.20+) - no allocation, no syscall
 	randomValue := rand.Intn(totalWeight)
 

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
+- fix: prevent panic in WeightedRandomKeySelector when all keys have zero weight by falling back to uniform random selection
 - feat: add Filename field to TranscriptionInput schema to carry original filename through the request pipeline
 - fix: add AudioFilenameFromBytes utility to detect audio format from file headers with mp3 fallback

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+- fix: prevent panic in key selection when all keys have zero weight
 - fix: preserve original audio filename in transcription requests
 - fix: async jobs stuck in "processing" on marshal failure now correctly transition to "failed"
 - feat: adds attachment support in Maxim plugin


### PR DESCRIPTION
## Summary

Fixes a panic in `WeightedRandomKeySelector` that occurs when all keys have zero weight by adding a fallback to uniform random selection.

## Changes

- Added zero weight check in `WeightedRandomKeySelector` before attempting weighted selection
- When `totalWeight` equals zero, the function now falls back to uniform random selection using `rand.Intn(len(keys))`
- This prevents division by zero or invalid range errors that would cause panics

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the fix by creating a scenario where all keys have zero weight and verify the selector doesn't panic:

```sh
# Core/Transports
go version
go test ./...

# Test specific scenario with zero weights
go test -run TestWeightedRandomKeySelector -v
```

Create test cases with keys that all have `Weight: 0.0` to ensure uniform random selection occurs without panics.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a defensive programming fix that improves system stability.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable