### PR TITLE
test case fixes

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -941,6 +941,24 @@ append_dynamic_columns_postgres() {
     echo "UPDATE mcp_tool_logs SET metadata = '' WHERE id = 'mcp-log-migration-001';" >> "$output_file"
     echo "UPDATE mcp_tool_logs SET metadata = '' WHERE id = 'mcp-log-migration-002';" >> "$output_file"
   fi
+
+  # -------------------------------------------------------------------------
+  # v1.4.10 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  # config_keys Bedrock assume-role columns (added in v1.4.10)
+  if column_exists_postgres "config_keys" "bedrock_role_arn"; then
+    echo "UPDATE config_keys SET bedrock_role_arn = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+    echo "UPDATE config_keys SET bedrock_role_arn = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+  fi
+  if column_exists_postgres "config_keys" "bedrock_external_id"; then
+    echo "UPDATE config_keys SET bedrock_external_id = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+    echo "UPDATE config_keys SET bedrock_external_id = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+  fi
+  if column_exists_postgres "config_keys" "bedrock_role_session_name"; then
+    echo "UPDATE config_keys SET bedrock_role_session_name = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+    echo "UPDATE config_keys SET bedrock_role_session_name = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+  fi
 }
 
 # Append dynamic column UPDATEs for columns that may not exist in older schemas (SQLite)
@@ -1171,6 +1189,26 @@ append_dynamic_columns_sqlite() {
   # mcp_tool_logs.metadata (added in v1.4.8)
   echo "UPDATE mcp_tool_logs SET metadata = '' WHERE id = 'mcp-log-migration-001';" >> "$output_file"
   echo "UPDATE mcp_tool_logs SET metadata = '' WHERE id = 'mcp-log-migration-002';" >> "$output_file"
+
+  # -------------------------------------------------------------------------
+  # v1.4.10 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  if [ -f "$config_db" ]; then
+    # config_keys Bedrock assume-role columns (added in v1.4.10)
+    if column_exists_sqlite "$config_db" "config_keys" "bedrock_role_arn"; then
+      echo "UPDATE config_keys SET bedrock_role_arn = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET bedrock_role_arn = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "config_keys" "bedrock_external_id"; then
+      echo "UPDATE config_keys SET bedrock_external_id = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET bedrock_external_id = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "config_keys" "bedrock_role_session_name"; then
+      echo "UPDATE config_keys SET bedrock_role_session_name = NULL WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET bedrock_role_session_name = NULL WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+  fi
 }
 
 # ============================================================================

--- a/core/internal/llmtests/speech_synthesis.go
+++ b/core/internal/llmtests/speech_synthesis.go
@@ -112,7 +112,7 @@ func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 
 				
 				speechResponse, bifrostErr := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "SpeechSynthesis_"+tc.name, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-					requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+					requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 					return client.SpeechRequest(requestCtx, request)
 				})
 
@@ -219,7 +219,7 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 			
 
 			speechResponse, bifrostErr := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "SpeechSynthesis_HD", func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-				requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 				return client.SpeechRequest(requestCtx, request)
 			})
 			if bifrostErr != nil {
@@ -301,7 +301,7 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 
 					
 					speechResponse, bifrostErr := WithSpeechTestRetry(t, voiceSpeechRetryConfig, voiceRetryContext, expectations, "SpeechSynthesis_VoiceType_"+voiceType, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-						requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+						requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 						return client.SpeechRequest(requestCtx, request)
 					})
 

--- a/core/internal/llmtests/speech_synthesis_stream.go
+++ b/core/internal/llmtests/speech_synthesis_stream.go
@@ -118,7 +118,7 @@ func RunSpeechSynthesisStreamTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				
 
 				responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-					requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+					requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 					return client.SpeechStreamRequest(requestCtx, request)
 				})
 
@@ -307,9 +307,8 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 				},
 			}
 
-			
 			responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-				requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 				return client.SpeechStreamRequest(requestCtx, request)
 			})
 
@@ -462,7 +461,7 @@ func RunSpeechSynthesisStreamAdvancedTest(t *testing.T, client *bifrost.Bifrost,
 						retryContext,
 						func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {							
 							accumulatedAudio.Reset() // Reset buffer on retry
-							requestCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+							requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 							return client.SpeechStreamRequest(requestCtx, request)
 						},
 						func(responseChannel chan *schemas.BifrostStreamChunk) SpeechStreamValidationResult {

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -17,8 +17,11 @@ import (
 )
 
 const (
-	// defaultLimit is the default limit used for pagination and batch operations
+	// BatchLimit is the default limit used for pagination and batch operations
 	BatchLimit = 100
+	// RedisMaxSearchResults is the maximum number of results Redis Search returns in a single query.
+	// This is the default MAXSEARCHRESULTS configuration in Redis Search.
+	RedisMaxSearchResults = 10000
 )
 
 type RedisConfig struct {
@@ -232,24 +235,15 @@ func (s *RedisStore) GetAll(ctx context.Context, namespace string, queries []Que
 	// Build Redis query from the provided queries
 	redisQuery := buildRedisQuery(queries, s.getNamespaceFieldTypes(namespace))
 
-	// Build FT.SEARCH command
-	args := []interface{}{
-		"FT.SEARCH", namespace,
-		redisQuery,
-	}
-
-	// Add RETURN only if specific fields were requested
-	if len(selectFields) > 0 {
-		args = append(args, "RETURN", len(selectFields))
-		for _, field := range selectFields {
-			args = append(args, field)
-		}
-	}
-
-	// Add LIMIT clause - use large limit for "all" (limit=0)
-	searchLimit := limit
+	// When limit=0 (get all), use internal pagination to avoid exceeding Redis MAXSEARCHRESULTS
 	if limit == 0 {
-		searchLimit = math.MaxInt32 // Use large limit to get all results
+		return s.getAllWithPagination(ctx, namespace, redisQuery, queries, selectFields)
+	}
+
+	// For explicit limit, cap to Redis maximum and use single query with cursor support
+	searchLimit := limit
+	if searchLimit > RedisMaxSearchResults {
+		searchLimit = RedisMaxSearchResults
 	}
 
 	// Add OFFSET for pagination if cursor is provided
@@ -258,49 +252,15 @@ func (s *RedisStore) GetAll(ctx context.Context, namespace string, queries []Que
 		return nil, nil, err
 	}
 
-	args = append(args, "LIMIT", offset, int(searchLimit), "DIALECT", "2")
-
-	// Execute search. Some Valkey builds are stricter about query parsing.
-	result := s.client.Do(ctx, args...)
-	if result.Err() != nil {
-		errMsg := strings.ToLower(result.Err().Error())
-		// Fallback 1: retry without explicit DIALECT for compatibility.
-		if isQuerySyntaxError(errMsg) {
-			s.logger.Debug(fmt.Sprintf("FT.SEARCH DIALECT fallback triggered for namespace %s: %s", namespace, result.Err()))
-			compatArgs := make([]interface{}, 0, len(args)-2)
-			for i := 0; i < len(args); i++ {
-				if i+1 < len(args) && args[i] == "DIALECT" {
-					i++ // skip dialect version
-					continue
-				}
-				compatArgs = append(compatArgs, args[i])
-			}
-			result = s.client.Do(ctx, compatArgs...)
-		}
-		// Fallback 2: scan keys and filter in-process if search parser is incompatible.
-		if result.Err() != nil {
-			errMsg = strings.ToLower(result.Err().Error())
-			if isQuerySyntaxError(errMsg) {
-				s.logger.Debug(fmt.Sprintf("FT.SEARCH scan fallback triggered for namespace %s: %s", namespace, result.Err()))
-				return s.getAllByScan(ctx, namespace, queries, selectFields, cursor, limit)
-			}
-			return nil, nil, fmt.Errorf("failed to search: %w", result.Err())
-		}
-	}
-
-	// Parse search results
-	results, err := s.parseSearchResults(result.Val(), namespace, selectFields)
+	results, err := s.executeSearch(ctx, namespace, redisQuery, queries, selectFields, offset, int(searchLimit))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse search results: %w", err)
+		return nil, nil, err
 	}
 
 	// Implement cursor-based pagination using OFFSET
 	var nextCursor *string = nil
 	if cursor != nil && *cursor != "" {
-		// If we have a cursor, we've already applied pagination
-		// Check if there might be more results
 		if len(results) == int(limit) && limit > 0 {
-			// There might be more results, create next cursor
 			offset, err := strconv.ParseInt(*cursor, 10, 64)
 			if err == nil {
 				nextOffset := offset + limit
@@ -309,12 +269,91 @@ func (s *RedisStore) GetAll(ctx context.Context, namespace string, queries []Que
 			}
 		}
 	} else if len(results) == int(limit) && limit > 0 {
-		// First page and we got exactly the limit, there might be more
 		nextCursorStr := strconv.FormatInt(limit, 10)
 		nextCursor = &nextCursorStr
 	}
 
 	return results, nextCursor, nil
+}
+
+// getAllWithPagination fetches all matching results using internal pagination to avoid
+// exceeding Redis Search's MAXSEARCHRESULTS limit (default 10,000).
+func (s *RedisStore) getAllWithPagination(ctx context.Context, namespace string, redisQuery string, queries []Query, selectFields []string) ([]SearchResult, *string, error) {
+	var allResults []SearchResult
+	offset := 0
+
+	for {
+		pageResults, err := s.executeSearch(ctx, namespace, redisQuery, queries, selectFields, offset, RedisMaxSearchResults)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if len(pageResults) == 0 {
+			break
+		}
+
+		allResults = append(allResults, pageResults...)
+
+		if len(pageResults) < RedisMaxSearchResults {
+			break
+		}
+		offset += len(pageResults)
+	}
+
+	return allResults, nil, nil
+}
+
+// executeSearch performs a single FT.SEARCH query with the given offset and limit.
+func (s *RedisStore) executeSearch(ctx context.Context, namespace string, redisQuery string, queries []Query, selectFields []string, offset int, searchLimit int) ([]SearchResult, error) {
+	args := []interface{}{
+		"FT.SEARCH", namespace,
+		redisQuery,
+	}
+
+	if len(selectFields) > 0 {
+		args = append(args, "RETURN", len(selectFields))
+		for _, field := range selectFields {
+			args = append(args, field)
+		}
+	}
+
+	args = append(args, "LIMIT", offset, searchLimit, "DIALECT", "2")
+
+	result := s.client.Do(ctx, args...)
+	if result.Err() != nil {
+		errMsg := strings.ToLower(result.Err().Error())
+		if isQuerySyntaxError(errMsg) {
+			s.logger.Debug(fmt.Sprintf("FT.SEARCH DIALECT fallback triggered for namespace %s: %s", namespace, result.Err()))
+			compatArgs := make([]interface{}, 0, len(args)-2)
+			for i := 0; i < len(args); i++ {
+				if i+1 < len(args) && args[i] == "DIALECT" {
+					i++
+					continue
+				}
+				compatArgs = append(compatArgs, args[i])
+			}
+			result = s.client.Do(ctx, compatArgs...)
+		}
+		if result.Err() != nil {
+			errMsg = strings.ToLower(result.Err().Error())
+			if isQuerySyntaxError(errMsg) {
+				s.logger.Debug(fmt.Sprintf("FT.SEARCH scan fallback triggered for namespace %s: %s", namespace, result.Err()))
+				scanResults, _, scanErr := s.getAllByScan(ctx, namespace, queries, selectFields, nil, int64(searchLimit))
+				if scanErr != nil {
+					return nil, scanErr
+				}
+				return scanResults, nil
+			}
+			return nil, fmt.Errorf("failed to search: %w", result.Err())
+		}
+	}
+
+	results, err := s.parseSearchResults(result.Val(), namespace, selectFields)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse search results: %w", err)
+	}
+
+	return results, nil
 }
 
 func (s *RedisStore) getAllByScan(ctx context.Context, namespace string, queries []Query, selectFields []string, cursor *string, limit int64) ([]SearchResult, *string, error) {


### PR DESCRIPTION
## Summary

This PR adds support for Bedrock assume-role configuration columns in migration tests and fixes context propagation issues in speech synthesis tests. It also improves Redis vector store pagination to handle large result sets more efficiently.

## Changes

- Added migration test support for new Bedrock assume-role columns (`bedrock_role_arn`, `bedrock_external_id`, `bedrock_role_session_name`) in both PostgreSQL and SQLite configurations
- Fixed context propagation in speech synthesis tests by passing the test context instead of creating new background contexts
- Enhanced Redis vector store pagination to handle Redis Search's MAXSEARCHRESULTS limit (10,000) by implementing internal pagination for unlimited queries
- Added proper offset-based cursor pagination for Redis vector store queries with explicit limits

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the migration test changes and Redis pagination improvements:

```sh
# Test migration scripts
./.github/workflows/scripts/run-migration-tests.sh

# Test speech synthesis with proper context
go test ./core/internal/llmtests -run TestSpeechSynthesis

# Test Redis vector store pagination
go test ./framework/vectorstore -run TestRedisStore

# Run full test suite
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The Bedrock assume-role columns handle AWS IAM role configuration which involves security credentials, but the migration tests properly null out test values to avoid any credential exposure.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable