### PR TITLE
helm: add client.enforceAuthOnInference to bifrost.config

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -215,6 +215,9 @@ false
 {{- if hasKey .Values.bifrost.client "enableLogging" }}
 {{- $_ := set $client "enable_logging" .Values.bifrost.client.enableLogging }}
 {{- end }}
+{{- if hasKey .Values.bifrost.client "enforceAuthOnInference" }}
+{{- $_ := set $client "enforce_auth_on_inference" .Values.bifrost.client.enforceAuthOnInference }}
+{{- end }}
 {{- if hasKey .Values.bifrost.client "enforceGovernanceHeader" }}
 {{- $_ := set $client "enforce_governance_header" .Values.bifrost.client.enforceGovernanceHeader }}
 {{- end }}


### PR DESCRIPTION
## Summary
Exposes `enforce_auth_on_inference` in the generated Bifrost config when `bifrost.client.enforceAuthOnInference` is set in Helm values.

## Change
- In `helm-charts/bifrost/templates/_helpers.tpl`, in the `bifrost.config` client section, added mapping from `enforceAuthOnInference` (camelCase) to `enforce_auth_on_inference` (snake_case) so the Bifrost gateway can be configured via the chart to enforce auth on inference endpoints.

## Usage
```yaml
bifrost:
  client:
    enforceAuthOnInference: true
```

Made with [Cursor](https://cursor.com)