### PR TITLE
semantic cache test case fixes

### DIFF
--- a/.github/workflows/scripts/test-all-plugins.sh
+++ b/.github/workflows/scripts/test-all-plugins.sh
@@ -108,6 +108,14 @@ for plugin in "${PLUGINS[@]}"; do
   
   cd "$PLUGIN_DIR"
   
+  # For semanticcache plugin, always use the latest mocker version from source
+  if [ "$plugin" = "semanticcache" ] && [ -f "../mocker/version" ]; then
+    MOCKER_VERSION=$(cat ../mocker/version)
+    echo "📦 Updating mocker dependency to latest version v$MOCKER_VERSION..."
+    go mod edit -require="github.com/maximhq/bifrost/plugins/mocker@v$MOCKER_VERSION"
+    go mod tidy
+  fi
+  
   # Validate build
   echo "🔨 Validating plugin build..."
   if ! go build ./...; then

--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,11 @@ cleanup-junit-xml: ## Internal: Clean up JUnit XML to remove parent test cases w
 test-plugins: install-gotestsum ## Run plugin tests
 	@echo "$(GREEN)Running plugin tests...$(NC)"
 	@mkdir -p $(TEST_REPORTS_DIR)
-	@cd plugins && find . -name "*.go" -path "*/tests/*" -o -name "*_test.go" | head -1 > /dev/null && \
+	@if [ -f .env ]; then \
+		echo "$(YELLOW)Loading environment variables from .env...$(NC)"; \
+		set -a; . ./.env; set +a; \
+	fi; \
+	cd plugins && find . -name "*.go" -path "*/tests/*" -o -name "*_test.go" | head -1 > /dev/null && \
 		for dir in $$(find . -name "*_test.go" -exec dirname {} \; | sort -u); do \
 			plugin_name=$$(echo $$dir | sed 's|^\./||' | sed 's|/|-|g'); \
 			echo "Testing $$dir..."; \

--- a/core/schemas/json_native.go
+++ b/core/schemas/json_native.go
@@ -5,6 +5,7 @@ package schemas
 import (
 	"bytes"
 	"encoding/json"
+	"reflect"
 
 	"github.com/bytedance/sonic"
 )
@@ -35,4 +36,80 @@ func Compact(dst *bytes.Buffer, src []byte) error {
 // Uses sonic.ConfigStd which has SortMapKeys enabled.
 func MarshalSorted(v interface{}) ([]byte, error) {
 	return sonic.ConfigStd.Marshal(v)
+}
+
+// MarshalDeeplySorted encodes v to JSON with all map keys sorted alphabetically,
+// including nested maps inside OrderedMap and other custom types with MarshalJSON.
+// This ensures fully deterministic output for hashing/caching purposes.
+//
+// Unlike MarshalSorted which relies on sonic's SortMapKeys (which doesn't affect
+// types with custom MarshalJSON like OrderedMap), this function first normalizes
+// the entire structure to plain maps, then marshals with sorted keys.
+func MarshalDeeplySorted(v interface{}) ([]byte, error) {
+	normalized := normalizeForSortedMarshal(v)
+	return sonic.ConfigStd.Marshal(normalized)
+}
+
+// normalizeForSortedMarshal recursively converts OrderedMaps and structs to plain maps
+// so that sonic.ConfigStd.Marshal will sort all keys deterministically.
+func normalizeForSortedMarshal(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	switch val := v.(type) {
+	case *OrderedMap:
+		if val == nil {
+			return nil
+		}
+		result := make(map[string]interface{}, val.Len())
+		val.Range(func(k string, v interface{}) bool {
+			result[k] = normalizeForSortedMarshal(v)
+			return true
+		})
+		return result
+	case OrderedMap:
+		result := make(map[string]interface{}, val.Len())
+		val.Range(func(k string, v interface{}) bool {
+			result[k] = normalizeForSortedMarshal(v)
+			return true
+		})
+		return result
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(val))
+		for k, v := range val {
+			result[k] = normalizeForSortedMarshal(v)
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(val))
+		for i, elem := range val {
+			result[i] = normalizeForSortedMarshal(elem)
+		}
+		return result
+	default:
+		// For structs and other types, marshal to JSON then unmarshal to map
+		// This handles types with custom MarshalJSON that may contain unsorted maps
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Ptr {
+			if rv.IsNil() {
+				return nil
+			}
+			rv = rv.Elem()
+		}
+		if rv.Kind() == reflect.Struct {
+			// Marshal struct to JSON, then unmarshal to map for normalization
+			data, err := sonic.Marshal(v)
+			if err != nil {
+				return v
+			}
+			var m map[string]interface{}
+			if err := sonic.Unmarshal(data, &m); err != nil {
+				return v
+			}
+			// Recursively normalize the resulting map
+			return normalizeForSortedMarshal(m)
+		}
+		return v
+	}
 }

--- a/core/schemas/json_wasm.go
+++ b/core/schemas/json_wasm.go
@@ -40,7 +40,16 @@ func MarshalSorted(v interface{}) ([]byte, error) {
 	return json.Marshal(normalized)
 }
 
-// normalizeForSortedMarshal recursively converts OrderedMaps to plain maps
+// MarshalDeeplySorted encodes v to JSON with all map keys sorted alphabetically,
+// including nested maps inside OrderedMap and other custom types with MarshalJSON.
+// This ensures fully deterministic output for hashing/caching purposes.
+// In WASM builds, this is equivalent to MarshalSorted since both normalize recursively.
+func MarshalDeeplySorted(v interface{}) ([]byte, error) {
+	normalized := normalizeForSortedMarshal(v)
+	return json.Marshal(normalized)
+}
+
+// normalizeForSortedMarshal recursively converts OrderedMaps and structs to plain maps
 // so that json.Marshal will sort their keys (Go 1.12+ sorts map keys).
 func normalizeForSortedMarshal(v interface{}) interface{} {
 	if v == nil {

--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -506,7 +506,10 @@ func (p *MockerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		return req, nil, nil
 	}
 
-	if req.RequestType != schemas.ChatCompletionRequest && req.RequestType != schemas.ResponsesRequest {
+	if req.RequestType != schemas.ChatCompletionRequest &&
+		req.RequestType != schemas.ChatCompletionStreamRequest &&
+		req.RequestType != schemas.ResponsesRequest &&
+		req.RequestType != schemas.ResponsesStreamRequest {
 		return req, nil, nil
 	}
 
@@ -550,15 +553,27 @@ func (p *MockerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	p.ruleHitsMu.Unlock()
 
 	// Generate appropriate mock response based on type
+	var modifiedReq *schemas.BifrostRequest
+	var shortCircuit *schemas.LLMPluginShortCircuit
+	var err error
+
 	switch response.Type {
 	case ResponseTypeSuccess:
-		return p.generateSuccessShortCircuit(req, response, startTime)
+		modifiedReq, shortCircuit, err = p.generateSuccessShortCircuit(req, response, startTime)
 	case ResponseTypeError:
-		return p.generateErrorShortCircuit(req, response)
+		modifiedReq, shortCircuit, err = p.generateErrorShortCircuit(req, response)
+	default:
+		// Fallback: continue with normal flow if response type is unrecognized
+		return req, nil, nil
 	}
 
-	// Fallback: continue with normal flow if response type is unrecognized
-	return req, nil, nil
+	// For streaming requests with a short-circuit response, mark the stream as complete
+	// This is required for plugins like semantic cache that need to know when the stream ends
+	if shortCircuit != nil && shortCircuit.Response != nil && bifrost.IsStreamRequestType(req.RequestType) {
+		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	}
+
+	return modifiedReq, shortCircuit, err
 }
 
 // PostLLMHook processes responses after provider calls
@@ -817,7 +832,7 @@ func (p *MockerPlugin) generateSuccessShortCircuit(req *schemas.BifrostRequest, 
 	// Create mock response with proper structure
 	mockResponse := &schemas.BifrostResponse{}
 
-	if req.RequestType == schemas.ChatCompletionRequest {
+	if req.RequestType == schemas.ChatCompletionRequest || req.RequestType == schemas.ChatCompletionStreamRequest {
 		mockResponse.ChatResponse = &schemas.BifrostChatResponse{
 			Model: model,
 			Usage: &usage,
@@ -836,7 +851,7 @@ func (p *MockerPlugin) generateSuccessShortCircuit(req *schemas.BifrostRequest, 
 				},
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
-				RequestType:    schemas.ChatCompletionRequest,
+				RequestType:    req.RequestType,
 				Provider:       provider,
 				ModelRequested: model,
 				Latency:        int64(time.Since(startTime).Milliseconds()),
@@ -861,6 +876,34 @@ func (p *MockerPlugin) generateSuccessShortCircuit(req *schemas.BifrostRequest, 
 			},
 			ExtraFields: schemas.BifrostResponseExtraFields{
 				RequestType:    schemas.ResponsesRequest,
+				Provider:       provider,
+				ModelRequested: model,
+				Latency:        int64(time.Since(startTime).Milliseconds()),
+			},
+		}
+	} else if req.RequestType == schemas.ResponsesStreamRequest {
+		mockResponse.ResponsesStreamResponse = &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeCompleted,
+			SequenceNumber: 0,
+			Response: &schemas.BifrostResponsesResponse{
+				CreatedAt: int(time.Now().Unix()),
+				Output: []schemas.ResponsesMessage{
+					{
+						Role: bifrost.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: &message,
+						},
+						Type: bifrost.Ptr(schemas.ResponsesMessageTypeMessage),
+					},
+				},
+				Usage: &schemas.ResponsesResponseUsage{
+					InputTokens:  usage.PromptTokens,
+					OutputTokens: usage.CompletionTokens,
+					TotalTokens:  usage.TotalTokens,
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:    schemas.ResponsesStreamRequest,
 				Provider:       provider,
 				ModelRequested: model,
 				Latency:        int64(time.Since(startTime).Milliseconds()),

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -114,8 +114,9 @@ func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest) (string, 
 		hashInput.Params = req.ImageGenerationRequest.Params
 	}
 
-	// Marshal to JSON with sorted keys for deterministic hashing
-	jsonData, err := schemas.MarshalSorted(hashInput)
+	// Marshal to JSON with deeply sorted keys for deterministic hashing
+	// MarshalDeeplySorted handles OrderedMap and nested map[string]interface{} correctly
+	jsonData, err := schemas.MarshalDeeplySorted(hashInput)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal request for hashing: %w", err)
 	}


### PR DESCRIPTION
## Summary

Enhances the mocker plugin to support streaming request types and improves semantic cache deterministic hashing by implementing deeply sorted JSON marshaling for nested structures.

## Changes

- **Mocker plugin streaming support**: Extended `PreLLMHook` to handle `ChatCompletionStreamRequest` and `ResponsesStreamRequest` types, generating appropriate mock responses for streaming scenarios
- **Stream completion signaling**: Added stream end indicator context value when short-circuiting streaming requests to notify downstream plugins
- **Deterministic JSON marshaling**: Implemented `MarshalDeeplySorted` function that recursively normalizes `OrderedMap` and struct types to plain maps before marshaling, ensuring consistent key ordering for hashing
- **Semantic cache hash improvement**: Updated request hash generation to use `MarshalDeeplySorted` instead of `MarshalSorted` for more reliable cache key consistency
- **Test environment loading**: Added `.env` file loading support to plugin tests in Makefile
- **CI dependency management**: Added automatic mocker version updating for semanticcache plugin tests

## Type of change

- [x] Feature
- [x] Bug fix
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Plugins

## How to test

Validate streaming mock responses and cache consistency:

```sh
# Test plugin functionality
make test-plugins

# Test core JSON marshaling
go test ./core/schemas -v

# Test mocker plugin with streaming requests
cd plugins/mocker && go test -v

# Test semantic cache deterministic hashing
cd plugins/semanticcache && go test -v
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - changes focus on response mocking and cache key generation consistency.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable