### PR TITLE
removes mocker plugin update while testing plugins

### DIFF
--- a/.github/workflows/scripts/test-all-plugins.sh
+++ b/.github/workflows/scripts/test-all-plugins.sh
@@ -108,14 +108,6 @@ for plugin in "${PLUGINS[@]}"; do
   
   cd "$PLUGIN_DIR"
   
-  # For semanticcache plugin, always use the latest mocker version from source
-  if [ "$plugin" = "semanticcache" ] && [ -f "../mocker/version" ]; then
-    MOCKER_VERSION=$(cat ../mocker/version)
-    echo "📦 Updating mocker dependency to latest version v$MOCKER_VERSION..."
-    go mod edit -require="github.com/maximhq/bifrost/plugins/mocker@v$MOCKER_VERSION"
-    go mod tidy
-  fi
-  
   # Validate build
   echo "🔨 Validating plugin build..."
   if ! go build ./...; then


### PR DESCRIPTION
## Summary

Removes special handling for the semanticcache plugin's mocker dependency version in the test script. The script previously updated the mocker dependency to the latest version specifically for the semanticcache plugin during testing.

## Changes

- Removed conditional logic that checked for the semanticcache plugin and updated its mocker dependency to the latest version from source
- Eliminated the `go mod edit` and `go mod tidy` commands that were modifying the semanticcache plugin's go.mod file during testing

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Plugins

## How to test

Run the plugin test script to verify semanticcache plugin testing works without the special mocker version handling:

```sh
.github/workflows/scripts/test-all-plugins.sh
```

Verify that the semanticcache plugin builds and tests successfully with its existing dependency versions.

## Breaking changes

- [ ] No

## Security considerations

None - this change only affects the CI testing process and removes dependency manipulation during testing.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable