### PR TITLE
updates waitForCacing for vector store - to fix flakyness of the tests

### DIFF
--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -23,7 +23,7 @@ func TestCacheTypeDirectOnly(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Now test with CacheTypeKey set to direct only
 	ctx2 := CreateContextWithCacheKeyAndType("test-cache-type-direct", CacheTypeDirect)
@@ -56,7 +56,7 @@ func TestCacheTypeSemanticOnly(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test with slightly different wording that should match semantically but not directly
 	similarRequest := CreateBasicChatRequest("Can you explain concepts in machine learning", 0.7, 50)
@@ -103,7 +103,7 @@ func TestCacheTypeDirectWithSemanticFallback(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test exact match (should hit direct cache)
 	ctx2 := CreateContextWithCacheKey("test-cache-type-fallback")
@@ -179,7 +179,7 @@ func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test with direct-only cache type
 	ctx2 := CreateContextWithCacheKeyAndType("test-embedding-cache-type", CacheTypeDirect)
@@ -223,7 +223,7 @@ func TestCacheTypePerformanceCharacteristics(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test direct-only performance
 	ctx2 := CreateContextWithCacheKeyAndType("test-cache-performance", CacheTypeDirect)

--- a/plugins/semanticcache/plugin_conversation_config_test.go
+++ b/plugins/semanticcache/plugin_conversation_config_test.go
@@ -29,7 +29,7 @@ func TestConversationHistoryThresholdBasic(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify it was cached
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request1)
@@ -57,7 +57,7 @@ func TestConversationHistoryThresholdBasic(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}) // Should not cache
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify it was NOT cached
 	t.Log("Verifying conversation exceeding threshold was not cached...")
@@ -93,7 +93,7 @@ func TestConversationHistoryThresholdWithSystemPrompt(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Should not cache (exceeds threshold)
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify not cached
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
@@ -137,7 +137,7 @@ func TestConversationHistoryThresholdWithExcludeSystemPrompt(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request, should not hit cache
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Second request should hit cache (3 non-system messages <= 3 threshold)
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
@@ -198,7 +198,7 @@ func TestConversationHistoryThresholdDifferentValues(t *testing.T) {
 			}
 			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Always fresh first time
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
 			if err2 != nil {
@@ -245,7 +245,7 @@ func TestExcludeSystemPromptBasic(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Testing conversation with different system prompt (should hit cache due to ExcludeSystemPrompt=true)...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request2)
@@ -290,7 +290,7 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	response2, err2 := setup1.Client.ChatCompletionRequest(ctx1, request2)
 	if err2 != nil {
@@ -324,7 +324,7 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	response4, err4 := setup2.Client.ChatCompletionRequest(ctx2, request2)
 	if err4 != nil {
@@ -392,7 +392,7 @@ func TestExcludeSystemPromptWithMultipleSystemMessages(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Testing conversation with different multiple system messages...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request2)
@@ -437,7 +437,7 @@ func TestExcludeSystemPromptWithNoSystemMessages(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Should cache normally
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)

--- a/plugins/semanticcache/plugin_core_test.go
+++ b/plugins/semanticcache/plugin_core_test.go
@@ -44,7 +44,7 @@ func TestSemanticCacheBasicFunctionality(t *testing.T) {
 	t.Logf("Response: %s", *response1.Choices[0].Message.Content.ContentStr)
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical request (should be served from cache)...")
 
@@ -139,7 +139,7 @@ func TestSemanticSearch(t *testing.T) {
 	t.Logf("Response: %s", *response1.Choices[0].Message.Content.ContentStr)
 
 	// Wait for cache to be written (async PostLLMHook needs time to complete)
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Second request - very similar text to test semantic matching
 	secondRequest := CreateBasicChatRequest(
@@ -232,7 +232,7 @@ func TestDirectVsSemanticSearch(t *testing.T) {
 		return // Test will be skipped by retry function
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making exact same request (should hit direct cache)...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, exactRequest)
@@ -310,7 +310,7 @@ func TestNoCacheScenarios(t *testing.T) {
 		return // Test will be skipped by retry function
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Second request with different temperature
 	request2 := CreateBasicChatRequest(basePrompt, 0.9, 50) // Different temperature
@@ -401,7 +401,7 @@ func TestCacheConfiguration(t *testing.T) {
 				return // Test will be skipped by retry function
 			}
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			_, err2 := setup.Client.ChatCompletionRequest(ctx, testRequest)
 			if err2 != nil {

--- a/plugins/semanticcache/plugin_cross_cache_test.go
+++ b/plugins/semanticcache/plugin_cross_cache_test.go
@@ -22,7 +22,7 @@ func TestCrossCacheTypeAccessibility(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test 2: Retrieve with direct-only cache type
 	ctx2 := CreateContextWithCacheKeyAndType("test-cross-cache-access", CacheTypeDirect)
@@ -68,7 +68,7 @@ func TestCacheTypeIsolation(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test 2: Try to retrieve with semantic-only (should miss because no semantic entry)
 	ctx2 := CreateContextWithCacheKeyAndType("test-cache-isolation", CacheTypeSemantic)
@@ -79,7 +79,7 @@ func TestCacheTypeIsolation(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should miss - no semantic cache entry
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test 3: Retrieve with direct-only (should hit)
 	t.Log("Retrieving with CacheTypeKey=direct (should hit)...")
@@ -117,7 +117,7 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test similar request with direct-only (should miss direct, no fallback, but should cache response)
 	similarRequest := CreateBasicChatRequest("Explain machine learning concepts", 0.7, 100)
@@ -130,7 +130,7 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should miss - no direct match, no semantic search
 
-	WaitForCache() // Let the response get cached
+	WaitForCache(setup.Plugin) // Let the response get cached
 
 	// Test same similar request with semantic-only (should hit original entry)
 	ctx3 := CreateContextWithCacheKeyAndType("test-fallback-behavior", CacheTypeSemantic)
@@ -190,7 +190,7 @@ func TestMultipleCacheEntriesPriority(t *testing.T) {
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 	originalContent := *response1.Choices[0].Message.Content.ContentStr
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify it hits cache with default behavior
 	t.Log("Verifying cache hit with default behavior...")
@@ -249,7 +249,7 @@ func TestCrossCacheTypeWithDifferentParameters(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test same parameters with direct-only
 	ctx2 := CreateContextWithCacheKeyAndType("test-cross-cache-params", CacheTypeDirect)
@@ -306,7 +306,7 @@ func TestCacheTypeErrorHandling(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Should work with fallback behavior
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test nil cache type (should use default)
 	ctx2 := CreateContextWithCacheKey("test-cache-error-handling")

--- a/plugins/semanticcache/plugin_default_cache_key_test.go
+++ b/plugins/semanticcache/plugin_default_cache_key_test.go
@@ -34,7 +34,7 @@ func TestDefaultCacheKey_CachesWithoutPerRequestKey(t *testing.T) {
 	// First request should NOT be a cache hit
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical request without per-request cache key (should hit cache)...")
 	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -68,7 +68,7 @@ func TestDefaultCacheKey_PerRequestKeyOverridesDefault(t *testing.T) {
 		return // Test will be skipped by retry function
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify the cache was actually populated with the default key
 	ctxDefault2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
@@ -116,7 +116,7 @@ func TestDefaultCacheKey_EmptyDefault_NoCaching(t *testing.T) {
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical request (should still not cache)...")
 	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)

--- a/plugins/semanticcache/plugin_edge_cases_test.go
+++ b/plugins/semanticcache/plugin_edge_cases_test.go
@@ -56,7 +56,7 @@ func TestParameterVariations(t *testing.T) {
 				return // Test will be skipped by retry function
 			}
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Make second request
 			response2, err2 := setup.Client.ChatCompletionRequest(ctx, tt.request2)
@@ -184,7 +184,7 @@ func TestToolVariations(t *testing.T) {
 		t.Fatalf("Request without tools failed: %v", err1)
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test 2: Request with tools (should NOT cache hit)
 	t.Log("Making request with tools...")
@@ -195,7 +195,7 @@ func TestToolVariations(t *testing.T) {
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test 3: Same request with tools (should cache hit)
 	t.Log("Making same request with tools again...")
@@ -359,7 +359,7 @@ func TestContentVariations(t *testing.T) {
 				return // Skip this test case
 			}
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Make second identical request
 			response2, err2 := setup.Client.ChatCompletionRequest(ctx, tt.request)
@@ -523,7 +523,7 @@ func TestSemanticSimilarityEdgeCases(t *testing.T) {
 			}
 
 			// Wait for cache to be written
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Make second request with similar content
 			request2 := CreateBasicChatRequest(test.prompt2, 0.1, 50) // Same parameters
@@ -602,7 +602,7 @@ func TestErrorHandlingEdgeCases(t *testing.T) {
 			t.Fatalf("First request with valid cache key failed: %v", err)
 		}
 
-		WaitForCache()
+		WaitForCache(setup.Plugin)
 
 		// Now test with invalid key type - should bypass cache
 		ctxInvalidKey := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).WithValue(CacheKey, 12345)

--- a/plugins/semanticcache/plugin_embedding_test.go
+++ b/plugins/semanticcache/plugin_embedding_test.go
@@ -39,7 +39,7 @@ func TestEmbeddingRequestsCaching(t *testing.T) {
 	t.Logf("Response contains %d embeddings", len(response1.Data))
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical embedding request (should be served from cache)...")
 
@@ -115,7 +115,7 @@ func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second different embedding request...")
 	response2, err2 := setup.Client.EmbeddingRequest(ctx, request2)
@@ -146,7 +146,7 @@ func TestEmbeddingRequestsCacheExpiration(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second request before TTL expiration...")
 	response2, err2 := setup.Client.EmbeddingRequest(ctx, embeddingRequest)

--- a/plugins/semanticcache/plugin_image_generation_test.go
+++ b/plugins/semanticcache/plugin_image_generation_test.go
@@ -48,7 +48,7 @@ func TestImageGenerationCacheBasicFunctionality(t *testing.T) {
 	t.Logf("Response: ID=%s, Images=%d", response1.ID, len(response1.Data))
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical request (should be served from cache)...")
 
@@ -161,7 +161,7 @@ func TestImageGenerationSemanticSearch(t *testing.T) {
 	t.Logf("First request completed in %v", duration1)
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Second request - very similar text to test semantic matching
 	secondRequest := CreateImageGenerationRequest(
@@ -260,7 +260,7 @@ func TestImageGenerationDifferentParameters(t *testing.T) {
 		return
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Second request with different size - should NOT be cached
 	request2 := CreateImageGenerationRequest(basePrompt, "1024x1536", "low")
@@ -275,7 +275,7 @@ func TestImageGenerationDifferentParameters(t *testing.T) {
 	// Should NOT be cached (different size)
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ImageGenerationResponse: response2})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Third request with different quality - should NOT be cached
 	request3 := CreateImageGenerationRequest(basePrompt, "1024x1024", "high")
@@ -341,7 +341,7 @@ func TestImageGenerationStreamCaching(t *testing.T) {
 	t.Logf("First streaming request completed in %v with %d chunks", duration1, len(responses1))
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical streaming request (should be served from cache)...")
 

--- a/plugins/semanticcache/plugin_integration_test.go
+++ b/plugins/semanticcache/plugin_integration_test.go
@@ -100,7 +100,7 @@ func TestSemanticCacheBasicFlow(t *testing.T) {
 	}
 
 	// Wait for async caching to complete
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 	t.Log("✅ Response cached successfully")
 
 	// Second request - should be a cache hit
@@ -225,7 +225,7 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 		t.Fatalf("PostLLMHook failed: %v", err)
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 	t.Log("✅ First response cached")
 
 	// Second request with different temperature - should be cache miss
@@ -389,7 +389,7 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 		}
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 	t.Log("✅ Streaming response chunks cached")
 
 	// Test cache retrieval for streaming
@@ -536,7 +536,7 @@ func TestSemanticCache_CustomTTLHandling(t *testing.T) {
 		t.Fatalf("PostLLMHook failed: %v", err)
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("✅ Custom TTL configuration test passed!")
 }
@@ -647,7 +647,7 @@ func TestSemanticCache_ProviderModelCachingFlags(t *testing.T) {
 		t.Fatalf("PostLLMHook failed: %v", err)
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Second request with different provider - should potentially hit cache since provider is not considered
 	request2 := &schemas.BifrostRequest{

--- a/plugins/semanticcache/plugin_no_store_test.go
+++ b/plugins/semanticcache/plugin_no_store_test.go
@@ -22,7 +22,7 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify it got cached
 	t.Log("Verifying normal caching worked...")
@@ -45,7 +45,7 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}) // Fresh request
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify it was NOT cached
 	t.Log("Verifying no-store request was not cached...")
@@ -64,7 +64,7 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response5}) // Fresh request
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify it got cached
 	t.Log("Verifying no-store=false request was cached...")
@@ -95,7 +95,7 @@ func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify not cached
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx1, chatRequest)
@@ -115,7 +115,7 @@ func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response3})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify not cached
 	response4, err4 := setup.Client.EmbeddingRequest(ctx2, embeddingRequest)
@@ -150,7 +150,7 @@ func TestCacheNoStoreWithConversationHistory(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify not cached (same conversation should not hit cache)
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
@@ -181,7 +181,7 @@ func TestCacheNoStoreWithCacheTypes(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Should not be cached
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
@@ -202,7 +202,7 @@ func TestCacheNoStoreWithCacheTypes(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Should not be cached
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
@@ -232,7 +232,7 @@ func TestCacheNoStoreErrorHandling(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Should be cached (invalid value should be ignored)
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
@@ -256,7 +256,7 @@ func TestCacheNoStoreErrorHandling(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Should be cached (nil should be treated as normal caching)
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
@@ -284,7 +284,7 @@ func TestCacheNoStoreReadButNoWrite(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Step 2: Try to read with no-store enabled (should still read from cache)
 	ctx2 := CreateContextWithCacheKeyAndNoStore("test-no-store-read", true)
@@ -311,7 +311,7 @@ func TestCacheNoStoreReadButNoWrite(t *testing.T) {
 	// Should get semantic cache hit (no-store allows reads, just prevents writes)
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, "semantic")
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Step 4: Repeat similar request with no-store (should still get semantic hit)
 	t.Log("Repeating similar request with no-store (should still get semantic hit)...")

--- a/plugins/semanticcache/plugin_normalization_test.go
+++ b/plugins/semanticcache/plugin_normalization_test.go
@@ -101,7 +101,7 @@ func testChatCompletionNormalization(t *testing.T, setup *TestSetup) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test all other variations should hit cache due to normalization
 	for i := 1; i < len(testCases); i++ {
@@ -159,7 +159,7 @@ func testSpeechNormalization(t *testing.T, setup *TestSetup) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{SpeechResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test all other variations should hit cache due to normalization
 	for i := 1; i < len(testCases); i++ {
@@ -253,7 +253,7 @@ func TestChatCompletionContentBlocksNormalization(t *testing.T) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test all other variations should hit cache due to normalization
 	for i := 1; i < len(testCases); i++ {
@@ -291,7 +291,7 @@ func TestNormalizationWithSemanticCache(t *testing.T) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test semantic match with different case (should hit semantic cache after normalization)
 	normalizedRequest := CreateBasicChatRequest("what is machine learning?", 0.5, 50)

--- a/plugins/semanticcache/plugin_responses_test.go
+++ b/plugins/semanticcache/plugin_responses_test.go
@@ -47,7 +47,7 @@ func TestResponsesAPIBasicFunctionality(t *testing.T) {
 	}
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical Responses API request (should be served from cache)...")
 
@@ -143,7 +143,7 @@ func TestResponsesAPIDifferentParameters(t *testing.T) {
 				return // Test will be skipped by retry function
 			}
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Make second request
 			response2, err2 := setup.Client.ResponsesRequest(ctx, tt.request2)
@@ -182,7 +182,7 @@ func TestResponsesAPISemanticMatching(t *testing.T) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Test semantic match with similar but different text
 	semanticRequest := CreateBasicResponsesRequest("Can you explain machine learning concepts?", 0.5, 500)
@@ -223,7 +223,7 @@ func TestResponsesAPIWithInstructions(t *testing.T) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Make identical request
 	request2 := CreateResponsesRequestWithInstructions(
@@ -266,7 +266,7 @@ func TestResponsesAPICacheExpiration(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second Responses request before TTL expiration...")
 	response2, err2 := setup.Client.ResponsesRequest(ctx, responsesRequest)
@@ -331,7 +331,7 @@ func TestResponsesAPINoStoreFlag(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Verify not cached
 	response2, err2 := setup.Client.ResponsesRequest(ctx, responsesRequest)
@@ -361,7 +361,7 @@ func TestResponsesAPIStreaming(t *testing.T) {
 		return // Test will be skipped by retry function
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Make streaming request with same prompt and parameters
 	t.Log("Making streaming Responses request with same prompt...")
@@ -425,7 +425,7 @@ func TestResponsesAPIComplexParameters(t *testing.T) {
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Create identical request
 	request2 := CreateBasicResponsesRequest("Test complex parameters", 0.8, 500)

--- a/plugins/semanticcache/plugin_streaming_test.go
+++ b/plugins/semanticcache/plugin_streaming_test.go
@@ -48,7 +48,7 @@ func TestStreamingCacheBasicFunctionality(t *testing.T) {
 	t.Logf("First streaming request completed in %v with %d chunks", duration1, len(responses1))
 
 	// Wait for cache to be written
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical streaming request (should be served from cache)...")
 
@@ -130,7 +130,7 @@ func TestStreamingVsNonStreaming(t *testing.T) {
 		return // Test will be skipped by retry function
 	}
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	// Make streaming request with same prompt and parameters
 	t.Log("Making streaming request with same prompt...")
@@ -218,7 +218,7 @@ func TestStreamingChunkOrdering(t *testing.T) {
 
 	t.Logf("Original stream had %d chunks", len(originalChunks))
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second streaming request to test cached chunk ordering...")
 	stream2, err2 := setup.Client.ChatCompletionStreamRequest(ctx, testRequest)
@@ -299,7 +299,7 @@ func TestSpeechSynthesisStreaming(t *testing.T) {
 
 	t.Logf("First speech request completed in %v", duration1)
 
-	WaitForCache()
+	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical speech synthesis request...")
 	start2 := time.Now()

--- a/plugins/semanticcache/plugin_vectorstore_test.go
+++ b/plugins/semanticcache/plugin_vectorstore_test.go
@@ -147,7 +147,7 @@ func TestSemanticCache_AllVectorStores_BasicFlow(t *testing.T) {
 			}
 
 			// Wait for async caching to complete
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 			t.Logf("[%s] Response cached successfully", tc.Name)
 
 			// Second request - should be a cache hit
@@ -200,7 +200,7 @@ func TestSemanticCache_AllVectorStores_DirectHashMatch(t *testing.T) {
 			}
 			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Second request with direct-only cache type
 			ctx2 := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
@@ -243,7 +243,7 @@ func TestSemanticCache_AllVectorStores_NamespaceIsolation(t *testing.T) {
 			}
 			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Try with different cache key - should miss
 			ctx2 := CreateContextWithCacheKey(cacheKey2)
@@ -343,7 +343,7 @@ func TestSemanticCache_AllVectorStores_ParameterFiltering(t *testing.T) {
 				t.Fatalf("[%s] PostHook failed: %v", tc.Name, err)
 			}
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 			t.Logf("[%s] First response cached", tc.Name)
 
 			// Second request with different temperature - should be cache miss
@@ -411,7 +411,7 @@ func TestSemanticCache_AllVectorStores_EmbeddingRequest(t *testing.T) {
 			}
 			AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
-			WaitForCache()
+			WaitForCache(setup.Plugin)
 
 			// Second request - should be cache hit
 			ctx2 := CreateContextWithCacheKey(cacheKey)

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -539,8 +539,12 @@ func AssertNoCacheHit(t *testing.T, response *schemas.BifrostResponse) {
 }
 
 // WaitForCache waits for async cache operations to complete
-func WaitForCache() {
-	time.Sleep(2 * time.Second)
+func WaitForCache(plugin schemas.LLMPlugin) {
+	if p, ok := plugin.(*Plugin); ok {
+		p.WaitForPendingOperations()
+	}
+	// Small buffer for Weaviate index consistency
+	time.Sleep(500 * time.Millisecond)
 }
 
 // CreateEmbeddingRequest creates an embedding request for testing


### PR DESCRIPTION
## Summary

Improved semantic cache test reliability by replacing fixed sleep delays with proper synchronization using the plugin's `WaitForPendingOperations()` method.

## Changes

- Updated `WaitForCache()` function to accept a plugin parameter and call `WaitForPendingOperations()` for proper synchronization
- Replaced fixed 2-second sleep with plugin-aware waiting plus a small 500ms buffer for vector store index consistency
- Updated all test files to pass the plugin instance to `WaitForCache()` calls

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache plugin tests to verify improved reliability and reduced test execution time:

```sh
go test ./plugins/semanticcache/... -v
```

The tests should now complete faster and with more consistent results due to proper synchronization instead of arbitrary delays.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a test-only improvement that doesn't affect production code paths.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable