### PR TITLE
compilation fixes

### DIFF
--- a/plugins/semanticcache/plugin_conversation_config_test.go
+++ b/plugins/semanticcache/plugin_conversation_config_test.go
@@ -290,7 +290,7 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	WaitForCache(setup.Plugin)
+	WaitForCache(setup1.Plugin)
 
 	response2, err2 := setup1.Client.ChatCompletionRequest(ctx1, request2)
 	if err2 != nil {
@@ -324,7 +324,7 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
-	WaitForCache(setup.Plugin)
+	WaitForCache(setup2.Plugin)
 
 	response4, err4 := setup2.Client.ChatCompletionRequest(ctx2, request2)
 	if err4 != nil {


### PR DESCRIPTION
## Summary

Fixed incorrect variable references in the semantic cache plugin test that were causing test failures by using the wrong plugin instances for cache waiting operations.

## Changes

- Corrected `WaitForCache(setup.Plugin)` to `WaitForCache(setup1.Plugin)` in the first test case
- Corrected `WaitForCache(setup.Plugin)` to `WaitForCache(setup2.Plugin)` in the second test case
- Ensures the cache waiting operations use the correct plugin instances that correspond to their respective test setups

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the semantic cache plugin tests to verify the fix:

```sh
go test ./plugins/semanticcache/... -v
```

The `TestExcludeSystemPromptComparison` test should now pass without variable reference errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a test-only fix with no runtime security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable