### PR TITLE
skips streaming error detector for deployment based providers

### DIFF
--- a/core/internal/llmtests/stream_error_status_code.go
+++ b/core/internal/llmtests/stream_error_status_code.go
@@ -23,6 +23,22 @@ func RunStreamErrorStatusCodeTest(t *testing.T, client *bifrost.Bifrost, ctx con
 		return
 	}
 
+	// Skip providers that perform deployment-based key selection.
+	// These providers validate model→deployment mapping during key selection,
+	// which means invalid models fail BEFORE reaching the provider API.
+	// Since no HTTP request is made, there's no provider status code to propagate.
+	deploymentBasedProviders := map[schemas.ModelProvider]bool{
+		schemas.Azure:     true,
+		schemas.Bedrock:   true,
+		schemas.Vertex:    true,
+		schemas.Replicate: true,
+		schemas.VLLM:      true,
+	}
+	if deploymentBasedProviders[testConfig.Provider] {
+		t.Logf("Skipping StreamErrorStatusCode for %s (deployment-based key selection validates models before API call)", testConfig.Provider)
+		return
+	}
+
 	t.Run("StreamErrorStatusCode", func(t *testing.T) {
 		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
 			t.Parallel()


### PR DESCRIPTION
## Summary

Skip stream error status code tests for providers that use deployment-based key selection. These providers validate model-to-deployment mapping during key selection, causing invalid model requests to fail before reaching the provider API, which prevents testing of provider-specific HTTP status codes.

## Changes

- Added logic to skip `StreamErrorStatusCode` test for Azure, Bedrock, Vertex, Replicate, and VLLM providers
- These providers perform model validation during key selection phase, so invalid models never generate HTTP requests to test status code propagation
- Added explanatory comment describing why deployment-based providers need to be skipped

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the LLM tests to verify that deployment-based providers are properly skipped:

```sh
go test ./core/internal/llmtests/... -v
```

Expected outcome: Azure, Bedrock, Vertex, Replicate, and VLLM providers should log skip messages for StreamErrorStatusCode tests instead of attempting to run them.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects test execution logic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable