### PR TITLE
fixed test-core test cases for new flows

### DIFF
--- a/core/internal/llmtests/stream_error_status_code.go
+++ b/core/internal/llmtests/stream_error_status_code.go
@@ -28,11 +28,12 @@ func RunStreamErrorStatusCodeTest(t *testing.T, client *bifrost.Bifrost, ctx con
 	// which means invalid models fail BEFORE reaching the provider API.
 	// Since no HTTP request is made, there's no provider status code to propagate.
 	deploymentBasedProviders := map[schemas.ModelProvider]bool{
-		schemas.Azure:     true,
-		schemas.Bedrock:   true,
-		schemas.Vertex:    true,
-		schemas.Replicate: true,
-		schemas.VLLM:      true,
+		schemas.Azure:       true,
+		schemas.Bedrock:     true,
+		schemas.Vertex:      true,
+		schemas.Replicate:   true,
+		schemas.VLLM:        true,
+		schemas.HuggingFace: true,
 	}
 	if deploymentBasedProviders[testConfig.Provider] {
 		t.Logf("Skipping StreamErrorStatusCode for %s (deployment-based key selection validates models before API call)", testConfig.Provider)

--- a/core/internal/llmtests/validation_presets.go
+++ b/core/internal/llmtests/validation_presets.go
@@ -391,7 +391,9 @@ func GetExpectationsForScenario(scenarioName string, testConfig ComprehensiveTes
 
 	// Apply raw request/response expectations from test config
 	isStreaming := strings.HasSuffix(scenarioName, "Stream") || strings.HasSuffix(scenarioName, "Streaming")
-	isMultipartRequest := scenarioName == "Transcription" || scenarioName == "TranscriptionStream"
+	isMultipartRequest := scenarioName == "Transcription" || scenarioName == "TranscriptionStream" ||
+		scenarioName == "ImageEdit" || scenarioName == "ImageEditStream" ||
+		scenarioName == "ImageVariation"
 	expectations = ApplyRawExpectations(expectations, testConfig, isStreaming, isMultipartRequest)
 
 	return expectations

--- a/core/providers/openai/errors_test.go
+++ b/core/providers/openai/errors_test.go
@@ -47,9 +47,10 @@ func TestParseOpenAIError_FallbackMessageWhenBodyIsEmpty(t *testing.T) {
 	if errResp == nil || errResp.Error == nil {
 		t.Fatal("expected non-nil error response")
 	}
-	// HandleProviderAPIError returns ErrProviderResponseEmpty for empty bodies.
-	if errResp.Error.Message != schemas.ErrProviderResponseEmpty {
-		t.Fatalf("expected empty-response message, got %q", errResp.Error.Message)
+	// HandleProviderAPIError returns ErrProviderResponseEmpty with HTTP status for empty bodies.
+	expectedMsg := schemas.ErrProviderResponseEmpty + " (HTTP 400)"
+	if errResp.Error.Message != expectedMsg {
+		t.Fatalf("expected %q, got %q", expectedMsg, errResp.Error.Message)
 	}
 }
 


### PR DESCRIPTION
## Summary

Updates test configurations and error handling to properly support HuggingFace provider and improve multipart request detection for image operations.

## Changes

- Added HuggingFace to the list of deployment-based providers that skip stream error status code tests since model validation occurs before API calls
- Extended multipart request detection to include ImageEdit, ImageEditStream, and ImageVariation scenarios alongside existing Transcription scenarios
- Updated OpenAI error test to expect HTTP status code appended to empty response error messages

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the changes by running the test suite and verifying HuggingFace provider behavior:

```sh
# Core/Transports
go version
go test ./...

# Specifically test the affected areas
go test ./core/internal/llmtests/...
go test ./core/providers/openai/...
```

Test with HuggingFace provider to ensure stream error status code tests are properly skipped and image operation scenarios are handled correctly.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - these are test configuration and error handling improvements.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable