### PR TITLE
updated breaking change notice on 1.4.11

### DIFF
--- a/docs/changelogs/v1.4.11.mdx
+++ b/docs/changelogs/v1.4.11.mdx
@@ -24,6 +24,10 @@ description: "v1.4.11 changelog - 2026-03-06"
 - **Helm Graceful Shutdown** — Added graceful shutdown and HPA stabilization for streaming connections (thanks [@Edward-Upton](https://github.com/Edward-Upton)!)
 - **Logstore Sonic Serialization** — Replaced encoding/json with sonic for logstore serialization (thanks [@davidrudduck](https://github.com/davidrudduck)!)
 
+<Danger>
+**Breaking change**: If authentication is enabled, the `/metrics` endpoint now requires bearer authentication in the request header. This change was made based on recent pentest feedback.
+</Danger>
+
 ## 🐞 Fixed
 
 - **Codex Compatibility** — Fixed fallback handling and request decompression for Codex compatibility


### PR DESCRIPTION
## Summary

Added documentation for a breaking change in v1.4.11 where the `/metrics` endpoint now requires bearer authentication when authentication is enabled.

## Changes

- Added a breaking change notice to the v1.4.11 changelog documenting that the `/metrics` endpoint now requires bearer authentication in the request header when authentication is enabled
- This change was implemented based on recent penetration testing feedback to improve security

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the changelog renders correctly and the breaking change notice is prominently displayed.

```sh
# Verify documentation builds
cd docs
npm install
npm run build
```

## Screenshots/Recordings

N/A - Documentation change only

## Breaking changes

- [x] Yes
- [ ] No

The `/metrics` endpoint now requires bearer authentication when authentication is enabled. Users will need to include proper authentication headers when accessing metrics endpoints in authenticated environments.

## Related issues

N/A

## Security considerations

This change improves security by requiring authentication for metrics endpoints, preventing unauthorized access to potentially sensitive monitoring data.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable