### PR TITLE
change liveness probe to use health in helm-chart

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.11
+version: 2.0.12
 appVersion: "1.4.11"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,13 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.11
+**Latest Version:** 2.0.12
 
 ## Changelog
+
+### v2.0.12
+
+- Fixed health probe paths to use `/health` instead of `/metrics`
 
 ### v2.0.11
 

--- a/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
+++ b/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
@@ -230,7 +230,7 @@ resources:
 # Probes
 livenessProbe:
   httpGet:
-    path: /metrics
+    path: /health
     port: http
   initialDelaySeconds: 30
   periodSeconds: 30
@@ -239,7 +239,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /metrics
+    path: /health
     port: http
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -87,7 +87,7 @@ resources:
 
 livenessProbe:
   httpGet:
-    path: /metrics
+    path: /health
     port: http
   initialDelaySeconds: 30
   periodSeconds: 30
@@ -96,7 +96,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /metrics
+    path: /health
     port: http
   initialDelaySeconds: 10
   periodSeconds: 10

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.11
+    created: "2026-03-06T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.12.tgz
+    version: 2.0.12
+  - apiVersion: v2
+    appVersion: 1.4.11
     created: "2026-03-05T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
     digest: ""

--- a/recipes/values-local-k8s.yaml
+++ b/recipes/values-local-k8s.yaml
@@ -137,7 +137,7 @@ resources:
 # Probes
 livenessProbe:
   httpGet:
-    path: /metrics
+    path: /health
     port: http
   initialDelaySeconds: 30
   periodSeconds: 30
@@ -146,7 +146,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /metrics
+    path: /health
     port: http
   initialDelaySeconds: 10
   periodSeconds: 10


### PR DESCRIPTION
## Summary

Fixed health probe paths in Bifrost Helm chart to use the correct `/health` endpoint instead of `/metrics` for both liveness and readiness probes.

## Issues

Closes #1955



## Changes

- Updated liveness and readiness probe paths from `/metrics` to `/health` in all Helm chart configuration files
- Bumped chart version from 2.0.11 to 2.0.12
- Updated chart index and documentation to reflect the new version

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Deploy the updated Helm chart and verify that health probes are working correctly:

```sh
# Deploy the chart
helm upgrade --install bifrost ./helm-charts/bifrost

# Check pod status and probe health
kubectl get pods
kubectl describe pod <bifrost-pod-name>

# Verify the health endpoint is accessible
kubectl port-forward <bifrost-pod-name> 8080:8080
curl http://localhost:8080/health
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves the reliability of health checks by using the proper health endpoint, which could prevent false positive health check failures.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable