### PR TITLE
fix: add Bearer token authentication to VLLM provider

### DIFF
--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -140,12 +140,16 @@ func (provider *VLLMProvider) TextCompletionStream(ctx *schemas.BifrostContext, 
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.client,
 		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
-		nil,
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
@@ -186,12 +190,16 @@ func (provider *VLLMProvider) ChatCompletionStream(ctx *schemas.BifrostContext, 
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.client,
 		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
-		nil,
+		authHeader,
 		provider.networkConfig.ExtraHeaders,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
@@ -437,6 +445,9 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 			"Content-Type":  writer.FormDataContentType(),
 			"Accept":        "text/event-stream",
 			"Cache-Control": "no-cache",
+		}
+		if key.Value.GetValue() != "" {
+			headers["Authorization"] = "Bearer " + key.Value.GetValue()
 		}
 
 		// Create HTTP request for streaming


### PR DESCRIPTION
## Summary

Adds authentication support to the VLLM provider by implementing Bearer token authorization for text completion, chat completion, and transcription streaming endpoints.

## Changes

- Added conditional Bearer token authentication to `TextCompletionStream` and `ChatCompletionStream` methods using authorization headers
- Implemented Bearer token support in `TranscriptionStream` by adding Authorization header when API key is present
- Authentication is only applied when a valid API key value is available, maintaining backward compatibility

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the VLLM provider with and without API keys to ensure authentication works correctly:

```sh
# Test core functionality
go test ./core/providers/vllm/...

# Test with API key configured
# Set up VLLM instance with authentication enabled
# Configure API key in provider settings
# Verify streaming endpoints work with Bearer token

# Test without API key
# Ensure backward compatibility with unauthenticated VLLM instances
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

This change maintains backward compatibility by only adding authentication headers when an API key is present.

## Related issues

closes #1920

## Security considerations

- Properly handles API key authentication using Bearer token format
- Only sends authorization headers when API keys are configured
- Maintains secure handling of authentication credentials in streaming requests

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable