### PR TITLE
enterprise v1.3.8 base

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -152,6 +152,7 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
+	BifrostContextKeySessionToken                        BifrostContextKey = "bifrost-session-token"                 // string (session token for authentication - set by auth middleware)
 	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                              // string
 	BifrostContextKeyAPIKeyName                          BifrostContextKey = "x-bf-api-key"                         // string (explicit key name selection)
 	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                           // string

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -382,12 +382,14 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 	})
 }
 
+// middleware is the core authentication middleware that checks if the request should be authenticated or not.
 func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, string) bool) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			authConfig := m.authConfig.Load()
 			if authConfig == nil || !authConfig.IsEnabled {
 				logger.Debug("auth middleware is disabled because auth config is not present or not enabled")
+				ctx.SetUserValue(schemas.BifrostContextKeySessionToken, "")
 				next(ctx)
 				return
 			}
@@ -408,6 +410,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 					if ticket != "" && m.wsTicketStore != nil {
 						sessionToken := m.wsTicketStore.Consume(ticket)
 						if sessionToken != "" && validateSession(ctx, m.store, sessionToken) {
+							ctx.SetUserValue(schemas.BifrostContextKeySessionToken, sessionToken)
 							next(ctx)
 							return
 						}
@@ -418,6 +421,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 					token := string(ctx.Request.URI().QueryArgs().Peek("token"))
 					if token != "" {
 						if validateSession(ctx, m.store, token) {
+							ctx.SetUserValue(schemas.BifrostContextKeySessionToken, token)
 							next(ctx)
 							return
 						}
@@ -427,6 +431,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 					// Fallback: cookie-based WS auth
 					cookieToken := string(ctx.Request.Header.Cookie("token"))
 					if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
+						ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
 						next(ctx)
 						return
 					}
@@ -437,6 +442,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 				// This supports the dashboard which relies on cookies instead of localStorage tokens.
 				cookieToken := string(ctx.Request.Header.Cookie("token"))
 				if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
+					ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
 					next(ctx)
 					return
 				}
@@ -523,6 +529,8 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 					next(ctx)
 					return
 				}
+				// setting up session in the request
+				ctx.SetUserValue(schemas.BifrostContextKeySessionToken, token)
 				// Continue with the next handler
 				next(ctx)
 				return

--- a/transports/bifrost-http/handlers/session.go
+++ b/transports/bifrost-http/handlers/session.go
@@ -209,23 +209,14 @@ func (h *SessionHandler) issueWSTicket(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "WebSocket tickets are not available")
 		return
 	}
-	// Resolve the session token from Authorization header or cookie
-	sessionToken := ""
-	if authHeader := string(ctx.Request.Header.Peek("Authorization")); strings.HasPrefix(authHeader, "Bearer ") {
-		sessionToken = strings.TrimPrefix(authHeader, "Bearer ")
-	}
-	if sessionToken == "" {
-		sessionToken = string(ctx.Request.Header.Cookie("token"))
-	}
-	if sessionToken == "" {
+	sessionToken,ok := ctx.UserValue(schemas.BifrostContextKeySessionToken).(string)
+	if !ok {
 		SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 		return
 	}
-	// Validate session exists and is not expired (defense-in-depth)
-	session, err := h.configStore.GetSession(ctx, sessionToken)
-	if err != nil || session == nil || session.ExpiresAt.Before(time.Now()) {
-		SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
-		return
+	if sessionToken == "" {
+		// This is the case where auth is not configured or not enabled
+		sessionToken = "dummy-session"
 	}
 	ticket, err := h.wsTicketStore.Issue(sessionToken)
 	if err != nil {


### PR DESCRIPTION
## Summary

Refactors session token handling in the authentication middleware to store the session token in the request context, enabling downstream handlers to access it without re-parsing headers or cookies.

## Changes

- Added `BifrostContextKeySessionToken` constant to store session tokens in request context
- Modified authentication middleware to set the session token in context after validation
- Refactored WebSocket ticket issuance to retrieve session token from context instead of parsing Authorization header or cookies directly
- Added fallback to "dummy-session" when authentication is not configured or enabled
- Removed redundant session validation in WebSocket ticket handler since authentication middleware already validates sessions

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that session-based authentication and WebSocket ticket issuance continue to work correctly:

```sh
# Core/Transports
go version
go test ./...

# Test WebSocket ticket endpoint with valid session
curl -H "Authorization: Bearer <valid-session-token>" /api/ws/ticket

# Test WebSocket ticket endpoint with cookie-based auth
curl -b "token=<valid-session-token>" /api/ws/ticket
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change maintains the same security posture by preserving session validation in the authentication middleware. The refactor eliminates duplicate session parsing logic and ensures consistent token handling across handlers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable