### PR TITLE
feat: add a prompt repository with folder, prompt, version, and session schemas, along with the backend.

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -296,6 +296,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddBedrockAssumeRoleColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4116,5 +4119,140 @@ func migrationAddBedrockAssumeRoleColumns(ctx context.Context, db *gorm.DB) erro
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running bedrock assume role columns migration: %s", err.Error())
 	}
+	return nil
+}
+
+// migrationAddPromptRepoTables adds the prompt repository tables (folders, prompts, versions, sessions)
+func migrationAddPromptRepoTables(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_prompt_repo_tables",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			// Create folders table
+			if !migrator.HasTable(&tables.TableFolder{}) {
+				if err := migrator.CreateTable(&tables.TableFolder{}); err != nil {
+					return err
+				}
+			}
+
+			// Create prompts table
+			if !migrator.HasTable(&tables.TablePrompt{}) {
+				if err := migrator.CreateTable(&tables.TablePrompt{}); err != nil {
+					return err
+				}
+			}
+
+			// Create prompt_versions table
+			if !migrator.HasTable(&tables.TablePromptVersion{}) {
+				if err := migrator.CreateTable(&tables.TablePromptVersion{}); err != nil {
+					return err
+				}
+			}
+
+			// Create prompt_version_messages table
+			if !migrator.HasTable(&tables.TablePromptVersionMessage{}) {
+				if err := migrator.CreateTable(&tables.TablePromptVersionMessage{}); err != nil {
+					return err
+				}
+			}
+
+			// Create prompt_sessions table
+			if !migrator.HasTable(&tables.TablePromptSession{}) {
+				if err := migrator.CreateTable(&tables.TablePromptSession{}); err != nil {
+					return err
+				}
+			}
+
+			// Create prompt_session_messages table
+			if !migrator.HasTable(&tables.TablePromptSessionMessage{}) {
+				if err := migrator.CreateTable(&tables.TablePromptSessionMessage{}); err != nil {
+					return err
+				}
+			}
+
+			// Apply schema updates (indexes, constraints) to existing tables
+			if err := tx.AutoMigrate(
+				&tables.TablePromptVersion{},
+				&tables.TablePromptSession{},
+			); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			// Drop tables in reverse order (respecting foreign key constraints)
+			if err := migrator.DropTable(&tables.TablePromptSessionMessage{}); err != nil {
+				return err
+			}
+			if err := migrator.DropTable(&tables.TablePromptSession{}); err != nil {
+				return err
+			}
+			if err := migrator.DropTable(&tables.TablePromptVersionMessage{}); err != nil {
+				return err
+			}
+			if err := migrator.DropTable(&tables.TablePromptVersion{}); err != nil {
+				return err
+			}
+			if err := migrator.DropTable(&tables.TablePrompt{}); err != nil {
+				return err
+			}
+			if err := migrator.DropTable(&tables.TableFolder{}); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running prompt repo tables migration: %s", err.Error())
+	}
+
+	// Add prompt_id column to prompt message tables
+	m = migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_prompt_id_to_prompt_message_tables",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			if !migrator.HasColumn(&tables.TablePromptVersionMessage{}, "prompt_id") {
+				if err := migrator.AddColumn(&tables.TablePromptVersionMessage{}, "PromptID"); err != nil {
+					return err
+				}
+			}
+
+			if !migrator.HasColumn(&tables.TablePromptSessionMessage{}, "prompt_id") {
+				if err := migrator.AddColumn(&tables.TablePromptSessionMessage{}, "PromptID"); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			if migrator.HasColumn(&tables.TablePromptVersionMessage{}, "prompt_id") {
+				if err := migrator.DropColumn(&tables.TablePromptVersionMessage{}, "prompt_id"); err != nil {
+					return err
+				}
+			}
+			if migrator.HasColumn(&tables.TablePromptSessionMessage{}, "prompt_id") {
+				if err := migrator.DropColumn(&tables.TablePromptSessionMessage{}, "prompt_id"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add_prompt_id_to_prompt_message_tables migration: %s", err.Error())
+	}
+
 	return nil
 }

--- a/framework/configstore/prompts.go
+++ b/framework/configstore/prompts.go
@@ -1,0 +1,480 @@
+package configstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"gorm.io/gorm"
+)
+
+// isUniqueConstraintError checks if the error is a unique constraint violation (SQLite or PostgreSQL)
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "duplicate key value violates unique constraint")
+}
+
+// ============================================================================
+// Prompt Repository - Folders
+// ============================================================================
+
+// GetFolders gets all folders
+func (s *RDBConfigStore) GetFolders(ctx context.Context) ([]tables.TableFolder, error) {
+	var folders []tables.TableFolder
+	if err := s.db.WithContext(ctx).
+		Order("created_at DESC").
+		Find(&folders).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []tables.TableFolder{}, nil
+		}
+		return nil, err
+	}
+
+	// Get prompts count for each folder
+	for i := range folders {
+		var count int64
+		if err := s.db.WithContext(ctx).Model(&tables.TablePrompt{}).Where("folder_id = ?", folders[i].ID).Count(&count).Error; err != nil {
+			return nil, err
+		}
+		folders[i].PromptsCount = int(count)
+	}
+
+	return folders, nil
+}
+
+// GetFolderByID gets a folder by ID
+func (s *RDBConfigStore) GetFolderByID(ctx context.Context, id string) (*tables.TableFolder, error) {
+	var folder tables.TableFolder
+	if err := s.db.WithContext(ctx).
+		First(&folder, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &folder, nil
+}
+
+// CreateFolder creates a new folder
+func (s *RDBConfigStore) CreateFolder(ctx context.Context, folder *tables.TableFolder) error {
+	return s.db.WithContext(ctx).Create(folder).Error
+}
+
+// UpdateFolder updates a folder
+func (s *RDBConfigStore) UpdateFolder(ctx context.Context, folder *tables.TableFolder) error {
+	res := s.db.WithContext(ctx).Where("id = ?", folder.ID).Save(folder)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeleteFolder deletes a folder (child prompts, versions, sessions and messages are cascade-deleted by the DB)
+func (s *RDBConfigStore) DeleteFolder(ctx context.Context, id string) error {
+	result := s.db.WithContext(ctx).Delete(&tables.TableFolder{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ============================================================================
+// Prompt Repository - Prompts
+// ============================================================================
+
+// GetPrompts gets all prompts, optionally filtered by folder ID
+func (s *RDBConfigStore) GetPrompts(ctx context.Context, folderID *string) ([]tables.TablePrompt, error) {
+	var prompts []tables.TablePrompt
+	query := s.db.WithContext(ctx).
+		Preload("Folder").
+		Order("created_at DESC")
+
+	if folderID != nil {
+		query = query.Where("folder_id = ?", *folderID)
+	}
+
+	if err := query.Find(&prompts).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []tables.TablePrompt{}, nil
+		}
+		return nil, err
+	}
+
+	// Get latest version for each prompt
+	for i := range prompts {
+		var latestVersion tables.TablePromptVersion
+		if err := s.db.WithContext(ctx).
+			Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+			Where("prompt_id = ? AND is_latest = ?", prompts[i].ID, true).
+			First(&latestVersion).Error; err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, err
+			}
+		} else {
+			prompts[i].LatestVersion = &latestVersion
+		}
+	}
+
+	return prompts, nil
+}
+
+// GetPromptByID gets a prompt by ID with latest version
+func (s *RDBConfigStore) GetPromptByID(ctx context.Context, id string) (*tables.TablePrompt, error) {
+	var prompt tables.TablePrompt
+	if err := s.db.WithContext(ctx).
+		Preload("Folder").
+		First(&prompt, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+
+	// Get latest version
+	var latestVersion tables.TablePromptVersion
+	if err := s.db.WithContext(ctx).
+		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Where("prompt_id = ? AND is_latest = ?", prompt.ID, true).
+		First(&latestVersion).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	} else {
+		prompt.LatestVersion = &latestVersion
+	}
+
+	return &prompt, nil
+}
+
+// CreatePrompt creates a new prompt
+func (s *RDBConfigStore) CreatePrompt(ctx context.Context, prompt *tables.TablePrompt) error {
+	return s.db.WithContext(ctx).Create(prompt).Error
+}
+
+// UpdatePrompt updates a prompt
+func (s *RDBConfigStore) UpdatePrompt(ctx context.Context, prompt *tables.TablePrompt) error {
+	// Use Select to explicitly include FolderID so GORM writes NULL when it's nil
+	res := s.db.WithContext(ctx).
+		Model(prompt).
+		Where("id = ?", prompt.ID).
+		Select("Name", "FolderID", "UpdatedAt").
+		Updates(prompt)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeletePrompt deletes a prompt (child versions, sessions and messages are cascade-deleted by the DB)
+func (s *RDBConfigStore) DeletePrompt(ctx context.Context, id string) error {
+	result := s.db.WithContext(ctx).Delete(&tables.TablePrompt{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ============================================================================
+// Prompt Repository - Versions
+// ============================================================================
+
+// GetPromptVersions gets all versions for a prompt
+func (s *RDBConfigStore) GetPromptVersions(ctx context.Context, promptID string) ([]tables.TablePromptVersion, error) {
+	var versions []tables.TablePromptVersion
+	if err := s.db.WithContext(ctx).
+		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Where("prompt_id = ?", promptID).
+		Order("version_number DESC").
+		Find(&versions).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []tables.TablePromptVersion{}, nil
+		}
+		return nil, err
+	}
+	return versions, nil
+}
+
+// GetPromptVersionByID gets a version by ID
+func (s *RDBConfigStore) GetPromptVersionByID(ctx context.Context, id uint) (*tables.TablePromptVersion, error) {
+	var version tables.TablePromptVersion
+	if err := s.db.WithContext(ctx).
+		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Preload("Prompt").
+		First(&version, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &version, nil
+}
+
+// GetLatestPromptVersion gets the latest version for a prompt
+func (s *RDBConfigStore) GetLatestPromptVersion(ctx context.Context, promptID string) (*tables.TablePromptVersion, error) {
+	var version tables.TablePromptVersion
+	if err := s.db.WithContext(ctx).
+		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Where("prompt_id = ? AND is_latest = ?", promptID, true).
+		First(&version).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &version, nil
+}
+
+// CreatePromptVersion creates a new version and marks it as latest.
+// Retries on unique constraint conflict (concurrent version_number allocation).
+func (s *RDBConfigStore) CreatePromptVersion(ctx context.Context, version *tables.TablePromptVersion) error {
+	const maxRetries = 3
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			// Get the next version number
+			var maxVersionNumber int
+			if err := tx.Model(&tables.TablePromptVersion{}).
+				Where("prompt_id = ?", version.PromptID).
+				Select("COALESCE(MAX(version_number), 0)").
+				Scan(&maxVersionNumber).Error; err != nil {
+				return err
+			}
+			version.VersionNumber = maxVersionNumber + 1
+
+			// Mark all existing versions as not latest
+			if err := tx.Model(&tables.TablePromptVersion{}).
+				Where("prompt_id = ?", version.PromptID).
+				Update("is_latest", false).Error; err != nil {
+				return err
+			}
+
+			// Mark new version as latest
+			version.IsLatest = true
+
+			// Reset IDs and set order index on messages before create (GORM will auto-create associations)
+			for i := range version.Messages {
+				version.Messages[i].ID = 0
+				version.Messages[i].PromptID = version.PromptID
+				version.Messages[i].OrderIndex = i
+			}
+
+			// Create the version (GORM auto-creates associated messages)
+			if err := tx.Create(version).Error; err != nil {
+				return err
+			}
+
+			return nil
+		})
+		if err == nil {
+			return nil
+		}
+		// Retry on unique constraint conflict, otherwise return immediately
+		if !isUniqueConstraintError(err) {
+			return err
+		}
+	}
+	return fmt.Errorf("failed to create prompt version after %d retries due to concurrent version_number conflict", maxRetries)
+}
+
+// DeletePromptVersion deletes a version
+func (s *RDBConfigStore) DeletePromptVersion(ctx context.Context, id uint) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Get the version to check if it's latest
+		var version tables.TablePromptVersion
+		if err := tx.First(&version, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		// Delete version (messages are cascade-deleted by the DB)
+		if err := tx.Delete(&tables.TablePromptVersion{}, "id = ?", id).Error; err != nil {
+			return err
+		}
+
+		// If this was the latest version, mark the previous one as latest
+		if version.IsLatest {
+			var prevVersion tables.TablePromptVersion
+			if err := tx.Where("prompt_id = ?", version.PromptID).
+				Order("version_number DESC").
+				First(&prevVersion).Error; err != nil {
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					return err
+				}
+			} else {
+				if err := tx.Model(&prevVersion).Update("is_latest", true).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
+// ============================================================================
+// Prompt Repository - Sessions
+// ============================================================================
+
+// GetPromptSessions gets all sessions for a prompt
+func (s *RDBConfigStore) GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error) {
+	var sessions []tables.TablePromptSession
+	if err := s.db.WithContext(ctx).
+		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Preload("Version").
+		Where("prompt_id = ?", promptID).
+		Order("created_at DESC").
+		Find(&sessions).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return []tables.TablePromptSession{}, nil
+		}
+		return nil, err
+	}
+	return sessions, nil
+}
+
+// GetPromptSessionByID gets a session by ID
+func (s *RDBConfigStore) GetPromptSessionByID(ctx context.Context, id uint) (*tables.TablePromptSession, error) {
+	var session tables.TablePromptSession
+	if err := s.db.WithContext(ctx).
+		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
+		Preload("Prompt").
+		Preload("Version").
+		First(&session, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &session, nil
+}
+
+// CreatePromptSession creates a new session
+func (s *RDBConfigStore) CreatePromptSession(ctx context.Context, session *tables.TablePromptSession) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Verify version belongs to the same prompt if set
+		if session.VersionID != nil {
+			var version tables.TablePromptVersion
+			if err := tx.First(&version, "id = ?", *session.VersionID).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return fmt.Errorf("version not found")
+				}
+				return err
+			}
+			if version.PromptID != session.PromptID {
+				return fmt.Errorf("version does not belong to the specified prompt")
+			}
+		}
+
+		// Save messages and clear from session to prevent GORM auto-creating them
+		msgs := session.Messages
+		session.Messages = nil
+
+		// Create the session without associated messages
+		if err := tx.Create(session).Error; err != nil {
+			return err
+		}
+
+		// Create messages with fresh IDs
+		for i := range msgs {
+			msgs[i].ID = 0 // Ensure new auto-increment ID
+			msgs[i].PromptID = session.PromptID
+			msgs[i].SessionID = session.ID
+			msgs[i].OrderIndex = i
+			if err := tx.Create(&msgs[i]).Error; err != nil {
+				return err
+			}
+		}
+
+		session.Messages = msgs
+		return nil
+	})
+}
+
+// UpdatePromptSession updates a session and its messages
+func (s *RDBConfigStore) UpdatePromptSession(ctx context.Context, session *tables.TablePromptSession) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Verify version belongs to the same prompt if set
+		if session.VersionID != nil {
+			var version tables.TablePromptVersion
+			if err := tx.First(&version, "id = ?", *session.VersionID).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return fmt.Errorf("version not found")
+				}
+				return err
+			}
+			if version.PromptID != session.PromptID {
+				return fmt.Errorf("version does not belong to the specified prompt")
+			}
+		}
+
+		// Update the session
+		res := tx.Where("id = ?", session.ID).Save(session)
+		if res.Error != nil {
+			return res.Error
+		}
+		if res.RowsAffected == 0 {
+			return ErrNotFound
+		}
+
+		// Delete old messages
+		if err := tx.Where("session_id = ?", session.ID).Delete(&tables.TablePromptSessionMessage{}).Error; err != nil {
+			return err
+		}
+
+		// Create new messages
+		for i := range session.Messages {
+			session.Messages[i].PromptID = session.PromptID
+			session.Messages[i].SessionID = session.ID
+			session.Messages[i].OrderIndex = i
+			session.Messages[i].ID = 0 // Reset ID for new creation
+			if err := tx.Create(&session.Messages[i]).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}
+
+// RenamePromptSession updates only the name of a session
+func (s *RDBConfigStore) RenamePromptSession(ctx context.Context, id uint, name string) error {
+	result := s.db.WithContext(ctx).Model(&tables.TablePromptSession{}).Where("id = ?", id).Update("name", name)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// DeletePromptSession deletes a session (messages are cascade-deleted by the DB)
+func (s *RDBConfigStore) DeletePromptSession(ctx context.Context, id uint) error {
+	result := s.db.WithContext(ctx).Delete(&tables.TablePromptSession{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -225,6 +225,35 @@ type ConfigStore interface {
 	// Not found retry wrapper
 	RetryOnNotFound(ctx context.Context, fn func(ctx context.Context) (any, error), maxRetries int, retryDelay time.Duration) (any, error)
 
+	// Prompt Repository - Folders
+	GetFolders(ctx context.Context) ([]tables.TableFolder, error)
+	GetFolderByID(ctx context.Context, id string) (*tables.TableFolder, error)
+	CreateFolder(ctx context.Context, folder *tables.TableFolder) error
+	UpdateFolder(ctx context.Context, folder *tables.TableFolder) error
+	DeleteFolder(ctx context.Context, id string) error
+
+	// Prompt Repository - Prompts
+	GetPrompts(ctx context.Context, folderID *string) ([]tables.TablePrompt, error)
+	GetPromptByID(ctx context.Context, id string) (*tables.TablePrompt, error)
+	CreatePrompt(ctx context.Context, prompt *tables.TablePrompt) error
+	UpdatePrompt(ctx context.Context, prompt *tables.TablePrompt) error
+	DeletePrompt(ctx context.Context, id string) error
+
+	// Prompt Repository - Versions
+	GetPromptVersions(ctx context.Context, promptID string) ([]tables.TablePromptVersion, error)
+	GetPromptVersionByID(ctx context.Context, id uint) (*tables.TablePromptVersion, error)
+	GetLatestPromptVersion(ctx context.Context, promptID string) (*tables.TablePromptVersion, error)
+	CreatePromptVersion(ctx context.Context, version *tables.TablePromptVersion) error
+	DeletePromptVersion(ctx context.Context, id uint) error
+
+	// Prompt Repository - Sessions
+	GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error)
+	GetPromptSessionByID(ctx context.Context, id uint) (*tables.TablePromptSession, error)
+	CreatePromptSession(ctx context.Context, session *tables.TablePromptSession) error
+	UpdatePromptSession(ctx context.Context, session *tables.TablePromptSession) error
+	RenamePromptSession(ctx context.Context, id uint, name string) error
+	DeletePromptSession(ctx context.Context, id uint) error
+
 	// DB returns the underlying database connection.
 	DB() *gorm.DB
 

--- a/framework/configstore/tables/folders.go
+++ b/framework/configstore/tables/folders.go
@@ -1,0 +1,22 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"time"
+)
+
+// TableFolder represents a generic folder that can contain prompts
+type TableFolder struct {
+	ID          string  `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Name        string  `gorm:"type:varchar(255);not null" json:"name"`
+	Description *string `gorm:"type:text" json:"description,omitempty"`
+	CreatedAt   time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"not null" json:"updated_at"`
+	ConfigHash  string    `gorm:"type:varchar(64)" json:"-"`
+
+	// Virtual fields (not stored in DB)
+	PromptsCount int `gorm:"-" json:"prompts_count,omitempty"`
+}
+
+// TableName for TableFolder
+func (TableFolder) TableName() string { return "folders" }

--- a/framework/configstore/tables/promptSessions.go
+++ b/framework/configstore/tables/promptSessions.go
@@ -1,0 +1,90 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// TablePromptSession represents a mutable working draft/session for a prompt
+// Sessions belong to a prompt and can optionally be based on a specific version
+type TablePromptSession struct {
+	ID              uint                `gorm:"primaryKey;autoIncrement" json:"id"`
+	PromptID        string              `gorm:"type:varchar(36);not null;index" json:"prompt_id"`
+	Prompt          *TablePrompt        `gorm:"foreignKey:PromptID" json:"prompt,omitempty"`
+	VersionID       *uint               `gorm:"index" json:"version_id,omitempty"` // Optional - session may or may not be based on a version
+	Version         *TablePromptVersion `gorm:"foreignKey:VersionID;constraint:OnDelete:SET NULL" json:"version,omitempty"`
+	Name            string              `gorm:"type:varchar(255)" json:"name"`
+	ModelParamsJSON *string             `gorm:"type:text;column:model_params_json" json:"-"`
+	ModelParams     ModelParams         `gorm:"-" json:"model_params"`
+	Provider        string              `gorm:"type:varchar(100)" json:"provider"`
+	Model           string              `gorm:"type:varchar(100)" json:"model"`
+	CreatedAt       time.Time           `gorm:"not null" json:"created_at"`
+	UpdatedAt       time.Time           `gorm:"not null" json:"updated_at"`
+
+	// Relationships
+	Messages []TablePromptSessionMessage `gorm:"foreignKey:SessionID;constraint:OnDelete:CASCADE" json:"messages,omitempty"`
+}
+
+// TableName for TablePromptSession
+func (TablePromptSession) TableName() string { return "prompt_sessions" }
+
+// BeforeSave GORM hook to serialize JSON fields
+func (s *TablePromptSession) BeforeSave(tx *gorm.DB) error {
+	data, err := json.Marshal(s.ModelParams)
+	if err != nil {
+		return err
+	}
+	paramsStr := string(data)
+	s.ModelParamsJSON = &paramsStr
+	return nil
+}
+
+// AfterFind GORM hook to deserialize JSON fields
+func (s *TablePromptSession) AfterFind(tx *gorm.DB) error {
+	if s.ModelParamsJSON != nil && *s.ModelParamsJSON != "" {
+		dec := json.NewDecoder(strings.NewReader(*s.ModelParamsJSON))
+		dec.UseNumber()
+		if err := dec.Decode(&s.ModelParams); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TablePromptSessionMessage represents a message in a mutable prompt session
+type TablePromptSessionMessage struct {
+	ID          uint                `gorm:"primaryKey;autoIncrement" json:"id"`
+	PromptID    string              `gorm:"type:varchar(36);not null;index" json:"prompt_id"`
+	SessionID   uint                `gorm:"not null;index;uniqueIndex:idx_session_order" json:"session_id"`
+	Session     *TablePromptSession `gorm:"foreignKey:SessionID" json:"-"`
+	OrderIndex  int                 `gorm:"not null;uniqueIndex:idx_session_order" json:"order_index"`
+	MessageJSON string              `gorm:"type:text;not null;column:message_json" json:"-"`
+	Message     PromptMessage       `gorm:"-" json:"message"`
+}
+
+// TableName for TablePromptSessionMessage
+func (TablePromptSessionMessage) TableName() string { return "prompt_session_messages" }
+
+// BeforeSave GORM hook to serialize JSON fields
+func (m *TablePromptSessionMessage) BeforeSave(tx *gorm.DB) error {
+	data, err := json.Marshal(m.Message)
+	if err != nil {
+		return err
+	}
+	m.MessageJSON = string(data)
+	return nil
+}
+
+// AfterFind GORM hook to deserialize JSON fields
+func (m *TablePromptSessionMessage) AfterFind(tx *gorm.DB) error {
+	if m.MessageJSON != "" {
+		if err := json.Unmarshal([]byte(m.MessageJSON), &m.Message); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/framework/configstore/tables/promptVersions.go
+++ b/framework/configstore/tables/promptVersions.go
@@ -1,0 +1,99 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// TablePromptVersion represents an immutable version of a prompt
+// Once created, a version cannot be modified - to make changes, create a new version
+type TablePromptVersion struct {
+	ID              uint         `gorm:"primaryKey;autoIncrement" json:"id"`
+	PromptID        string       `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_prompt_version" json:"prompt_id"`
+	Prompt          *TablePrompt `gorm:"foreignKey:PromptID" json:"prompt,omitempty"`
+	VersionNumber   int          `gorm:"not null;uniqueIndex:idx_prompt_version" json:"version_number"`
+	CommitMessage   string       `gorm:"type:text" json:"commit_message"`
+	ModelParamsJSON *string      `gorm:"type:text;column:model_params_json" json:"-"`
+	ModelParams     ModelParams  `gorm:"-" json:"model_params"`
+	Provider        string       `gorm:"type:varchar(100)" json:"provider"`
+	Model           string       `gorm:"type:varchar(100)" json:"model"`
+	IsLatest        bool         `gorm:"not null;default:false" json:"is_latest"`
+	CreatedAt       time.Time    `gorm:"not null" json:"created_at"`
+	// No UpdatedAt - versions are immutable
+
+	// Relationships
+	Messages []TablePromptVersionMessage `gorm:"foreignKey:VersionID;constraint:OnDelete:CASCADE" json:"messages,omitempty"`
+}
+
+// TableName for TablePromptVersion
+func (TablePromptVersion) TableName() string { return "prompt_versions" }
+
+// ModelParams represents model configuration parameters as a flexible map
+// so that any provider-specific params (response_format, seed, logprobs, etc.) are preserved.
+type ModelParams map[string]interface{}
+
+// BeforeSave GORM hook to serialize JSON fields
+func (v *TablePromptVersion) BeforeSave(tx *gorm.DB) error {
+	data, err := json.Marshal(v.ModelParams)
+	if err != nil {
+		return err
+	}
+	paramsStr := string(data)
+	v.ModelParamsJSON = &paramsStr
+	return nil
+}
+
+// AfterFind GORM hook to deserialize JSON fields
+func (v *TablePromptVersion) AfterFind(tx *gorm.DB) error {
+	if v.ModelParamsJSON != nil && *v.ModelParamsJSON != "" {
+		dec := json.NewDecoder(strings.NewReader(*v.ModelParamsJSON))
+		dec.UseNumber()
+		if err := dec.Decode(&v.ModelParams); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// TablePromptVersionMessage represents a message in an immutable prompt version
+type TablePromptVersionMessage struct {
+	ID          uint                `gorm:"primaryKey;autoIncrement" json:"id"`
+	PromptID    string              `gorm:"type:varchar(36);not null;index" json:"prompt_id"`
+	VersionID   uint                `gorm:"not null;index;uniqueIndex:idx_version_order" json:"version_id"`
+	Version     *TablePromptVersion `gorm:"foreignKey:VersionID" json:"-"`
+	OrderIndex  int                 `gorm:"not null;uniqueIndex:idx_version_order" json:"order_index"`
+	MessageJSON string              `gorm:"type:text;not null;column:message_json" json:"-"`
+	Message     PromptMessage       `gorm:"-" json:"message"`
+}
+
+// TableName for TablePromptVersionMessage
+func (TablePromptVersionMessage) TableName() string { return "prompt_version_messages" }
+
+// PromptMessage is a raw JSON message stored in the database.
+// The frontend handles serialization/deserialization of the message format.
+// The backend treats it as opaque JSON to remain format-agnostic and backward-compatible.
+type PromptMessage = json.RawMessage
+
+// BeforeSave GORM hook to serialize JSON fields
+func (m *TablePromptVersionMessage) BeforeSave(tx *gorm.DB) error {
+	data, err := json.Marshal(m.Message)
+	if err != nil {
+		return err
+	}
+	m.MessageJSON = string(data)
+	return nil
+}
+
+// AfterFind GORM hook to deserialize JSON fields
+func (m *TablePromptVersionMessage) AfterFind(tx *gorm.DB) error {
+	if m.MessageJSON != "" {
+		if err := json.Unmarshal([]byte(m.MessageJSON), &m.Message); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/framework/configstore/tables/prompts.go
+++ b/framework/configstore/tables/prompts.go
@@ -1,0 +1,27 @@
+// Package tables provides tables for the configstore
+package tables
+
+import (
+	"time"
+)
+
+// TablePrompt represents a prompt entity that can have multiple versions and sessions
+type TablePrompt struct {
+	ID        string       `gorm:"type:varchar(36);primaryKey" json:"id"`
+	Name      string       `gorm:"type:varchar(255);not null" json:"name"`
+	FolderID  *string      `gorm:"type:varchar(36);index" json:"folder_id,omitempty"`
+	Folder    *TableFolder `gorm:"foreignKey:FolderID;constraint:OnDelete:CASCADE" json:"folder,omitempty"`
+	CreatedAt time.Time    `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time    `gorm:"not null" json:"updated_at"`
+	ConfigHash string      `gorm:"type:varchar(64)" json:"-"`
+
+	// Relationships
+	Versions []TablePromptVersion `gorm:"foreignKey:PromptID;constraint:OnDelete:CASCADE" json:"versions,omitempty"`
+	Sessions []TablePromptSession `gorm:"foreignKey:PromptID;constraint:OnDelete:CASCADE" json:"sessions,omitempty"`
+
+	// Virtual fields (not stored in DB)
+	LatestVersion *TablePromptVersion `gorm:"-" json:"latest_version,omitempty"`
+}
+
+// TableName for TablePrompt
+func (TablePrompt) TableName() string { return "prompts" }


### PR DESCRIPTION
## Summary

Adds a complete prompt repository system to the configstore, enabling users to organize, version, and manage AI prompts with folders, immutable versions, and mutable working sessions.

## Changes

- **Database schema**: Added 6 new tables for folders, prompts, versions, sessions, and their associated messages
- **Migration system**: Created `migrationAddPromptRepoTables` to handle table creation and schema updates
- **CRUD operations**: Implemented full CRUD functionality for all prompt repository entities
- **Version management**: Automatic version numbering with latest version tracking
- **Cascade deletion**: Proper cleanup of related entities when deleting folders or prompts
- **JSON serialization**: Model parameters and messages stored as flexible JSON for provider compatibility
- **Transaction safety**: All multi-table operations wrapped in database transactions

Key design decisions:
- Versions are immutable once created (git-like versioning)
- Sessions are mutable working drafts that can be based on specific versions
- Messages stored as opaque JSON to remain format-agnostic
- Folders are optional for prompt organization

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# Test database migrations
go test ./framework/configstore -v -run TestMigrations

# Test prompt repository functionality
go test ./framework/configstore -v -run TestPrompt
```

The migration will automatically run on application startup, creating the new tables. Test CRUD operations through the ConfigStore interface methods.

## Screenshots/Recordings

N/A - Backend database changes only

## Breaking changes

- [ ] Yes
- [x] No

This is purely additive - no existing functionality is modified.

## Related issues

N/A

## Security considerations

- All database operations use parameterized queries to prevent SQL injection
- Proper foreign key constraints ensure referential integrity
- Transaction rollbacks prevent partial state corruption

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable