### PR TITLE
feat: add a prompt management UI with a playground, versioning, and deployment features

### DIFF
--- a/ui/components/prompts/components/alerts.tsx
+++ b/ui/components/prompts/components/alerts.tsx
@@ -1,0 +1,63 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { usePromptContext } from "../context";
+
+export function DeleteFolderDialog() {
+	const { deleteFolderDialog, setDeleteFolderDialog, isDeletingFolder, handleDeleteFolder } = usePromptContext();
+
+	return (
+		<AlertDialog open={deleteFolderDialog.open}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete Folder</AlertDialogTitle>
+					<AlertDialogDescription>
+						Are you sure you want to delete &quot;{deleteFolderDialog.folder?.name}&quot;? This will also delete all prompts, versions, and
+						sessions in this folder. This action cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={() => setDeleteFolderDialog({ open: false })} disabled={isDeletingFolder}>
+						Cancel
+					</AlertDialogCancel>
+					<AlertDialogAction onClick={handleDeleteFolder} disabled={isDeletingFolder}>
+						{isDeletingFolder ? "Deleting..." : "Delete"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}
+
+export function DeletePromptDialog() {
+	const { deletePromptDialog, setDeletePromptDialog, isDeletingPrompt, handleDeletePrompt } = usePromptContext();
+
+	return (
+		<AlertDialog open={deletePromptDialog.open}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete Prompt</AlertDialogTitle>
+					<AlertDialogDescription>
+						Are you sure you want to delete &quot;{deletePromptDialog.prompt?.name}&quot;? This will also delete all versions and sessions.
+						This action cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={() => setDeletePromptDialog({ open: false })} disabled={isDeletingPrompt}>
+						Cancel
+					</AlertDialogCancel>
+					<AlertDialogAction onClick={handleDeletePrompt} disabled={isDeletingPrompt}>
+						{isDeletingPrompt ? "Deleting..." : "Delete"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/ui/components/prompts/components/emptyState.tsx
+++ b/ui/components/prompts/components/emptyState.tsx
@@ -1,0 +1,20 @@
+import { Button } from "@/components/ui/button";
+import { usePromptContext } from "../context";
+
+export function EmptyState() {
+	const { setPromptSheet } = usePromptContext();
+
+	return (
+		<div className="text-muted-foreground flex h-full items-center justify-center">
+			<div className="text-center">
+				<p className="text-lg font-medium">No prompt selected</p>
+				<p className="text-sm">
+					Select a prompt from the sidebar or{" "}
+					<Button variant="link" className="h-auto p-0 text-sm" onClick={() => setPromptSheet({ open: true })}>
+						create a new one
+					</Button>
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/assistantMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/assistantMessageView.tsx
@@ -1,0 +1,106 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Message, SerializedMessage } from "@/lib/message";
+import { InfoIcon, PencilIcon, XIcon } from "lucide-react";
+import { Markdown } from "@/components/ui/markdown";
+import { useEffect, useRef, useState } from "react";
+import MessageRoleSwitcher from "./messageRoleSwitcher";
+
+export function AssistantMessageView({
+	message,
+	disabled,
+	isStreaming,
+	onChange,
+	onRemove,
+}: {
+	message: Message;
+	disabled?: boolean;
+	isStreaming?: boolean;
+	onChange: (serialized: SerializedMessage) => void;
+	onRemove?: () => void;
+}) {
+	const [editMode, setEditMode] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const content = message.content;
+	const isEmpty = !content;
+	const usage = message.usage;
+
+	useEffect(() => {
+		const handleClick = (e: MouseEvent) => {
+			if (!containerRef.current?.contains(e.target as Node)) {
+				setEditMode(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClick);
+		return () => document.removeEventListener("mousedown", handleClick);
+	}, []);
+
+	const handleRoleChange = (role: string) => {
+		const clone = message.clone();
+		clone.role = role as any;
+		onChange(clone.serialized);
+	};
+
+	return (
+		<div className="group hover:border-border focus-within:border-border rounded-lg border border-transparent px-3 py-2 transition-colors" ref={containerRef}>
+			<div className="mb-1 flex items-center">
+				<MessageRoleSwitcher role={message.role ?? ""} disabled={disabled} onRoleChange={handleRoleChange} />
+				<div className="ml-auto flex items-center gap-0.5 h-5">
+					{usage && (
+						<Tooltip>
+							<TooltipTrigger className="p-1 hover:bg-muted focus:bg-muted focus:opacity-100 rounded-sm">
+								<InfoIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 " />
+							</TooltipTrigger>
+							<TooltipContent side="bottom">
+								<div className="flex flex-col gap-0.5 text-xs tabular-nums">
+									<span>Input: {usage.prompt_tokens} tokens</span>
+									<span>Output: {usage.completion_tokens} tokens</span>
+									<span>Total: {usage.total_tokens} tokens</span>
+								</div>
+							</TooltipContent>
+						</Tooltip>
+					)}
+					{!disabled && !isStreaming && (
+						<button type="button" aria-label="Edit message" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+						</button>
+					)}
+					{!disabled && onRemove && (
+						<button type="button" aria-label="Delete message" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+						</button>
+					)}
+				</div>
+			</div>
+
+			<div>
+				{isStreaming && isEmpty ? (
+					<div className="flex items-center gap-1 py-1">
+						<span className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full opacity-60" style={{ animationDelay: "0ms" }} />
+						<span className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full opacity-60" style={{ animationDelay: "150ms" }} />
+						<span className="bg-muted-foreground h-2 w-2 animate-bounce rounded-full opacity-60" style={{ animationDelay: "300ms" }} />
+					</div>
+				) : editMode ? (
+					<Textarea
+						autoFocus
+						value={content}
+						className="text-muted-foreground dark:bg-transparent min-h-[20px] resize-none rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+						disabled={disabled}
+						onChange={(e) => {
+							const clone = message.clone();
+							clone.content = e.target.value;
+							onChange(clone.serialized);
+						}}
+						onBlur={() => {
+							if (content.trim().length > 0) setEditMode(false);
+						}}
+					/>
+				) : isEmpty ? (
+					<div className="text-muted-foreground min-h-[20px] text-sm italic">Enter assistant message...</div>
+				) : (
+					<Markdown content={content} isStreaming={isStreaming} className="text-muted-foreground" />
+				)}
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/attachmentViews.tsx
+++ b/ui/components/prompts/components/messagesView/attachmentViews.tsx
@@ -1,0 +1,35 @@
+import { MessageContent } from "@/lib/message";
+import { Mic, FileIcon, XIcon } from "lucide-react";
+
+export function AttachmentBadge({ attachment, onRemove }: { attachment: MessageContent; onRemove: () => void }) {
+	const isImage = attachment.type === "image_url";
+	const isAudio = attachment.type === "input_audio";
+
+	return (
+		<div className="group/att bg-muted/50 relative flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs">
+			{isImage && attachment.image_url?.url ? (
+				<>
+					<img src={attachment.image_url.url} alt="attachment" className="h-8 w-8 rounded object-cover" />
+					<span className="text-muted-foreground max-w-[100px] truncate">Image</span>
+				</>
+			) : isAudio ? (
+				<>
+					<Mic className="text-muted-foreground h-3.5 w-3.5" />
+					<span className="text-muted-foreground max-w-[100px] truncate">{attachment.input_audio?.format?.toUpperCase() || "Audio"}</span>
+				</>
+			) : (
+				<>
+					<FileIcon className="text-muted-foreground h-3.5 w-3.5" />
+					<span className="text-muted-foreground max-w-[120px] truncate">{attachment.file?.filename || "File"}</span>
+				</>
+			)}
+			<button
+				onClick={onRemove}
+				className="text-muted-foreground hover:bg-destructive/20 hover:text-destructive ml-0.5 rounded-full p-0.5"
+				type="button"
+			>
+				<XIcon className="h-3 w-3" />
+			</button>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/errorMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/errorMessageView.tsx
@@ -1,0 +1,25 @@
+import { Message } from "@/lib/message";
+import { AlertCircle, XIcon } from "lucide-react";
+
+export default function ErrorMessageView({ message, disabled, onRemove }: { message: Message; disabled?: boolean; onRemove?: () => void }) {
+	return (
+		<div className="group hover:border-destructive/30 focus-within:border-destructive/30 rounded-lg border border-transparent px-3 py-2 transition-colors">
+			<div className="mb-1 flex items-center h-5">
+				<span className="text-destructive flex items-center gap-1 py-0.5 text-xs font-medium uppercase">
+					<AlertCircle className="h-3 w-3" />
+					Error
+				</span>
+				<div className="ml-auto">
+					{!disabled && onRemove && (
+						<button type="button" aria-label="Delete message" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+						</button>
+					)}
+				</div>
+			</div>
+			<div className="bg-destructive/10 rounded-md px-2.5 py-1.5">
+				<p className="text-muted-foreground text-sm whitespace-pre-wrap">{message.content}</p>
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/messageRoleSwitcher.tsx
+++ b/ui/components/prompts/components/messagesView/messageRoleSwitcher.tsx
@@ -1,0 +1,45 @@
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import { cn } from "@/lib/utils";
+import { ChevronDown } from "lucide-react";
+
+const AVAILABLE_ROLES = [
+	{ value: "system", label: "System" },
+	{ value: "user", label: "User" },
+	{ value: "assistant", label: "Assistant" },
+	{ value: "tool", label: "Tool" },
+] as const;
+
+export default function MessageRoleSwitcher({
+	role,
+	disabled,
+	onRoleChange,
+	restrictedRoles,
+}: {
+	role: string;
+	disabled?: boolean;
+	onRoleChange: (role: string) => void;
+	restrictedRoles?: (typeof AVAILABLE_ROLES)[number]["value"][];
+}) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild disabled={disabled}>
+				<button
+					className={cn(
+						"-ml-1.5 flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-medium uppercase",
+						!disabled && "hover:bg-muted cursor-pointer",
+					)}
+				>
+					{role}
+					<ChevronDown className="h-3 w-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" />
+				</button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="start">
+				{AVAILABLE_ROLES.filter((r) => r.value !== role && (!restrictedRoles || !restrictedRoles.includes(r.value))).map((option) => (
+					<DropdownMenuItem key={option.value} onSelect={() => onRoleChange(option.value)}>
+						{option.label.toUpperCase()}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/ui/components/prompts/components/messagesView/rootMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/rootMessageView.tsx
@@ -1,0 +1,147 @@
+import { Message, MessageType, SerializedMessage } from "@/lib/message";
+import { useCallback, useEffect, useRef } from "react";
+import { usePromptContext } from "../../context";
+import { SystemMessageView } from "./systemMessageView";
+import { UserMessageView } from "./userMessageView";
+import { AssistantMessageView } from "./assistantMessageView";
+import ToolResultMessageView from "./toolCallResultView";
+import ToolCallMessageView from "./toolCallView";
+import ErrorMessageView from "./errorMessageView";
+
+export function MessagesView() {
+	const { messages, setMessages: onUpdateMessages, isStreaming, supportsVision, handleSubmitToolResult } = usePromptContext();
+	const messagesEndRef = useRef<HTMLDivElement>(null);
+	const prevLengthRef = useRef(messages.length);
+	const prevLastIdRef = useRef(messages[messages.length - 1]?.id);
+
+	useEffect(() => {
+		const lastId = messages[messages.length - 1]?.id;
+		const shouldScroll = messages.length !== prevLengthRef.current || lastId !== prevLastIdRef.current;
+		prevLengthRef.current = messages.length;
+		prevLastIdRef.current = lastId;
+		if (shouldScroll) {
+			messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+		}
+	}, [messages, isStreaming]);
+
+	const handleMessageChange = useCallback(
+		(index: number, serialized: SerializedMessage) => {
+			const newMessages = [...messages];
+			newMessages[index] = Message.deserialize(serialized);
+			onUpdateMessages(newMessages);
+		},
+		[messages, onUpdateMessages],
+	);
+
+	const handleRemoveMessage = useCallback(
+		(index: number) => {
+			const newMessages = messages.filter((_, i) => i !== index);
+			onUpdateMessages(newMessages.length > 0 ? newMessages : [Message.system("")]);
+		},
+		[messages, onUpdateMessages],
+	);
+
+	const lastMessage = messages[messages.length - 1];
+	const isLastMessageStreaming = isStreaming && lastMessage?.type === MessageType.CompletionResult;
+
+	return (
+		<div className="space-y-1 p-4">
+			{messages.map((msg, index) => {
+				const isStreamingMsg = isLastMessageStreaming && index === messages.length - 1;
+				const canRemove = index > 0;
+
+				switch (msg.type) {
+					case MessageType.CompletionError:
+						return (
+							<ErrorMessageView
+								key={msg.id}
+								message={msg}
+								disabled={isStreaming}
+								onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+							/>
+						);
+					case MessageType.ToolResult:
+						return (
+							<ToolResultMessageView
+								key={msg.id}
+								message={msg}
+								disabled={isStreaming}
+								onChange={(s) => handleMessageChange(index, s)}
+								onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+							/>
+						);
+					case MessageType.CompletionResult:
+						if (msg.toolCalls) {
+							const respondedIds = new Set<string>();
+							for (let i = index + 1; i < messages.length; i++) {
+								const m = messages[i];
+								if (m.type === MessageType.ToolResult && m.toolCallId) {
+									respondedIds.add(m.toolCallId);
+								} else {
+									break;
+								}
+							}
+							return (
+								<ToolCallMessageView
+									key={msg.id}
+									message={msg}
+									disabled={isStreaming}
+									onChange={(s) => handleMessageChange(index, s)}
+									onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+									onSubmitToolResult={(toolCallId, content) => handleSubmitToolResult(index, toolCallId, content)}
+									respondedToolCallIds={respondedIds}
+								/>
+							);
+						}
+						return (
+							<AssistantMessageView
+								key={msg.id}
+								message={msg}
+								disabled={isStreaming}
+								isStreaming={isStreamingMsg}
+								onChange={(s) => handleMessageChange(index, s)}
+								onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+							/>
+						);
+					default: {
+						const role = msg.role;
+						if (role === "system") {
+							return (
+								<SystemMessageView
+									key={msg.id}
+									message={msg}
+									disabled={isStreaming}
+									onChange={(s) => handleMessageChange(index, s)}
+									onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+								/>
+							);
+						}
+						if (role === "user") {
+							return (
+								<UserMessageView
+									key={msg.id}
+									message={msg}
+									disabled={isStreaming}
+									supportsVision={supportsVision}
+									onChange={(s) => handleMessageChange(index, s)}
+									onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+								/>
+							);
+						}
+						return (
+							<AssistantMessageView
+								key={msg.id}
+								message={msg}
+								disabled={isStreaming}
+								isStreaming={isStreamingMsg}
+								onChange={(s) => handleMessageChange(index, s)}
+								onRemove={canRemove ? () => handleRemoveMessage(index) : undefined}
+							/>
+						);
+					}
+				}
+			})}
+			<div ref={messagesEndRef} />
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/systemMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/systemMessageView.tsx
@@ -1,0 +1,82 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Message, SerializedMessage } from "@/lib/message";
+import { PencilIcon, XIcon } from "lucide-react";
+import { Markdown } from "@/components/ui/markdown";
+import { useEffect, useRef, useState } from "react";
+import MessageRoleSwitcher from "./messageRoleSwitcher";
+
+export function SystemMessageView({
+	message,
+	disabled,
+	onChange,
+	onRemove,
+}: {
+	message: Message;
+	disabled?: boolean;
+	onChange: (serialized: SerializedMessage) => void;
+	onRemove?: () => void;
+}) {
+	const [editMode, setEditMode] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const content = message.content;
+	const isEmpty = !content;
+
+	useEffect(() => {
+		const handleClick = (e: MouseEvent) => {
+			if (!containerRef.current?.contains(e.target as Node)) {
+				setEditMode(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClick);
+		return () => document.removeEventListener("mousedown", handleClick);
+	}, []);
+
+	const handleRoleChange = (role: string) => {
+		const clone = message.clone();
+		clone.role = role as any;
+		onChange(clone.serialized);
+	};
+
+	return (
+		<div className="group hover:border-border focus-within:border-border rounded-lg border border-transparent px-3 py-2 transition-colors" ref={containerRef}>
+			<div className="mb-1 flex items-center">
+				<MessageRoleSwitcher role={message.role ?? ""} disabled={disabled} onRoleChange={handleRoleChange} />
+				<div className="ml-auto flex items-center gap-0.5 h-5">
+					{!disabled && (
+						<button type="button" aria-label="Edit message" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+						</button>
+					)}
+					{!disabled && onRemove && (
+						<button type="button" aria-label="Delete message" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+						</button>
+					)}
+				</div>
+			</div>
+
+			<div>
+				{editMode ? (
+					<Textarea
+						autoFocus
+						value={content}
+						className="text-muted-foreground dark:bg-transparent min-h-[20px] resize-none rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+						disabled={disabled}
+						onChange={(e) => {
+							const clone = message.clone();
+							clone.content = e.target.value;
+							onChange(clone.serialized);
+						}}
+						onBlur={() => {
+							if (content.trim().length > 0) setEditMode(false);
+						}}
+					/>
+				) : isEmpty ? (
+					<div className="text-muted-foreground min-h-[20px] text-sm italic">Enter system message...</div>
+				) : (
+					<Markdown content={content} className="text-muted-foreground" />
+				)}
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/toolCallResultView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallResultView.tsx
@@ -1,0 +1,80 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Message, MessageRole, SerializedMessage } from "@/lib/message";
+import { PencilIcon, XIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import MessageRoleSwitcher from "./messageRoleSwitcher";
+
+export default function ToolResultMessageView({
+	message,
+	disabled,
+	onChange,
+	onRemove,
+}: {
+	message: Message;
+	disabled?: boolean;
+	onChange: (serialized: SerializedMessage) => void;
+	onRemove?: () => void;
+}) {
+	const [editMode, setEditMode] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const content = message.content;
+
+	useEffect(() => {
+		const handleClick = (e: MouseEvent) => {
+			if (!containerRef.current?.contains(e.target as Node)) {
+				setEditMode(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClick);
+		return () => document.removeEventListener("mousedown", handleClick);
+	}, []);
+
+	const handleRoleChange = (role: string) => {
+		const clone = message.clone();
+		clone.role = role as any;
+		onChange(clone.serialized);
+	};
+
+	return (
+		<div className="group hover:border-border focus-within:border-border rounded-lg border border-transparent px-3 py-2 transition-colors" ref={containerRef}>
+			<div className="mb-1 flex items-center">
+				<MessageRoleSwitcher role={message.role ?? MessageRole.ASSISTANT} disabled={disabled} onRoleChange={handleRoleChange} />
+				<div className="ml-auto flex items-center gap-0.5 overflow-x-auto max-w-1/2 h-5">
+					{message.toolCallId && (
+						<span className="text-muted-foreground ml-4 truncate font-mono text-xs">{message.toolCallId}</span>
+					)}
+					{!disabled && (
+						<button type="button" aria-label="Edit message" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+						</button>
+					)}
+					{!disabled && onRemove && (
+						<button type="button" aria-label="Delete message" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+						</button>
+					)}
+				</div>
+			</div>
+			<div>
+				{editMode ? (
+					<Textarea
+						autoFocus
+						value={content}
+						className="text-muted-foreground min-h-[20px] resize-none rounded-none border-0 bg-transparent p-0 font-mono text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent"
+						disabled={disabled}
+						onChange={(e) => {
+							const clone = message.clone();
+							clone.content = e.target.value;
+							onChange(clone.serialized);
+						}}
+						onBlur={() => setEditMode(false)}
+					/>
+				) : (
+					<div className="text-muted-foreground min-h-[20px] font-mono text-sm whitespace-pre-wrap">
+						{content || <span className="text-muted-foreground italic">Enter tool result...</span>}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -1,0 +1,105 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Message, SerializedMessage } from "@/lib/message";
+import { Wrench, XIcon } from "lucide-react";
+import { useState } from "react";
+import MessageRoleSwitcher from "./messageRoleSwitcher";
+
+export default function ToolCallMessageView({
+	message,
+	disabled,
+	onChange,
+	onRemove,
+	onSubmitToolResult,
+	respondedToolCallIds,
+}: {
+	message: Message;
+	disabled?: boolean;
+	onChange: (serialized: SerializedMessage) => void;
+	onRemove?: () => void;
+	onSubmitToolResult?: (toolCallId: string, content: string) => void;
+	respondedToolCallIds?: Set<string>;
+}) {
+	const toolCalls = message.toolCalls ?? [];
+	const [responses, setResponses] = useState<Record<string, string>>({});
+
+	const handleRoleChange = (role: string) => {
+		const clone = message.clone();
+		clone.role = role as any;
+		onChange(clone.serialized);
+	};
+
+	const handleResponseChange = (toolCallId: string, value: string) => {
+		setResponses((prev) => ({ ...prev, [toolCallId]: value }));
+	};
+
+	const handleSubmitResponse = (toolCallId: string) => {
+		const content = responses[toolCallId]?.trim();
+		if (!content || !onSubmitToolResult) return;
+		onSubmitToolResult(toolCallId, content);
+		setResponses((prev) => {
+			const next = { ...prev };
+			delete next[toolCallId];
+			return next;
+		});
+	};
+
+	return (
+		<div className="group hover:border-border focus-within:border-border rounded-lg border border-transparent px-3 py-2 transition-colors">
+			<div className="mb-1 flex items-center">
+				<MessageRoleSwitcher role={message.role ?? ""} disabled={disabled} onRoleChange={handleRoleChange} />
+				<div className="ml-auto h-5">
+					{!disabled && onRemove && (
+							<button type="button" aria-label="Delete message" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+						</button>
+					)}
+				</div>
+			</div>
+			<div className="space-y-2">
+				{toolCalls.map((tc) => {
+					let formattedArgs = tc.function.arguments;
+					try {
+						formattedArgs = JSON.stringify(JSON.parse(tc.function.arguments), null, 2);
+					} catch {
+						// keep raw string if not valid JSON
+					}
+					return (
+						<div key={tc.id} className="bg-muted/50 rounded-md border px-3 py-2">
+							<div className="flex items-center gap-2">
+								<Wrench className="text-muted-foreground h-3 w-3 shrink-0" />
+								<span className="font-mono text-xs font-medium shrink-0 mr-4">{tc.function.name}</span>
+								<span className="text-muted-foreground ml-auto font-mono text-[10px] truncate">{tc.id}</span>
+							</div>
+							{formattedArgs && (
+								<pre className="text-muted-foreground mt-2 overflow-x-auto rounded bg-black/5 p-2 text-xs leading-relaxed dark:bg-white/5">{formattedArgs}</pre>
+							)}
+							{!disabled && onSubmitToolResult && !respondedToolCallIds?.has(tc.id) && (
+								<div className="mt-2 border-t pt-2">
+									<div className="text-muted-foreground mb-1 text-[10px] font-semibold uppercase tracking-wide">Response</div>
+									<div className="flex items-end gap-2">
+										<Textarea
+											placeholder="Enter tool response..."
+											value={responses[tc.id] ?? ""}
+											onChange={(e) => handleResponseChange(tc.id, e.target.value)}
+											className="min-h-[36px] resize-none font-mono text-xs"
+											rows={2}
+										/>
+										<Button
+											variant="secondary"
+											size="sm"
+											disabled={!responses[tc.id]?.trim()}
+											onClick={() => handleSubmitResponse(tc.id)}
+										>
+											Submit
+										</Button>
+									</div>
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/messagesView/userMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/userMessageView.tsx
@@ -1,0 +1,279 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Message, SerializedMessage, type MessageContent } from "@/lib/message";
+import { FileIcon, Mic, Paperclip, PencilIcon, XIcon } from "lucide-react";
+import { Markdown } from "@/components/ui/markdown";
+import { useCallback, useEffect, useRef, useState } from "react";
+import MessageRoleSwitcher from "./messageRoleSwitcher";
+import { fileToAttachment } from "../../utils/attachment";
+
+export function UserMessageView({
+	message,
+	disabled,
+	supportsVision,
+	onChange,
+	onRemove,
+}: {
+	message: Message;
+	disabled?: boolean;
+	supportsVision?: boolean;
+	onChange: (serialized: SerializedMessage) => void;
+	onRemove?: () => void;
+}) {
+	const [editMode, setEditMode] = useState(false);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const messageRef = useRef(message);
+	messageRef.current = message;
+	const content = message.content;
+	const isEmpty = !content;
+	const messageAttachments = message.attachments;
+	const canAttach = supportsVision && !disabled;
+
+	useEffect(() => {
+		const handleClick = (e: MouseEvent) => {
+			if (!containerRef.current?.contains(e.target as Node)) {
+				setEditMode(false);
+			}
+		};
+		document.addEventListener("mousedown", handleClick);
+		return () => document.removeEventListener("mousedown", handleClick);
+	}, []);
+
+	const handleRoleChange = (role: string) => {
+		const clone = message.clone();
+		clone.role = role as any;
+		onChange(clone.serialized);
+	};
+
+	const addAttachments = useCallback(
+		(newAttachments: MessageContent[]) => {
+			const latest = messageRef.current;
+			const clone = latest.clone();
+			clone.attachments = [...latest.attachments, ...newAttachments];
+			onChange(clone.serialized);
+		},
+		[onChange],
+	);
+
+	const handleRemoveAttachment = useCallback(
+		(index: number) => {
+			const clone = message.clone();
+			clone.attachments = message.attachments.filter((_, i) => i !== index);
+			onChange(clone.serialized);
+		},
+		[message, onChange],
+	);
+
+	const handleFileSelect = useCallback(
+		async (e: React.ChangeEvent<HTMLInputElement>) => {
+			const files = e.target.files;
+			if (!files) return;
+			const attachments: MessageContent[] = [];
+			for (const file of Array.from(files)) {
+				const att = await fileToAttachment(file);
+				if (att) attachments.push(att);
+			}
+			if (attachments.length > 0) addAttachments(attachments);
+			e.target.value = "";
+		},
+		[addAttachments],
+	);
+
+	// Drag & drop state
+	const [isDragging, setIsDragging] = useState(false);
+	const dragCounterRef = useRef(0);
+
+	const handleDragEnter = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		dragCounterRef.current++;
+		if (e.dataTransfer.types.includes("Files")) setIsDragging(true);
+	}, []);
+
+	const handleDragLeave = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		dragCounterRef.current--;
+		if (dragCounterRef.current === 0) setIsDragging(false);
+	}, []);
+
+	const handleDragOver = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+	}, []);
+
+	const handleDrop = useCallback(
+		async (e: React.DragEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			dragCounterRef.current = 0;
+			setIsDragging(false);
+			const files = e.dataTransfer.files;
+			if (!files || files.length === 0) return;
+			const attachments: MessageContent[] = [];
+			for (const file of Array.from(files)) {
+				const att = await fileToAttachment(file);
+				if (att) attachments.push(att);
+			}
+			if (attachments.length > 0) addAttachments(attachments);
+		},
+		[addAttachments],
+	);
+
+	return (
+		<div
+			className="group relative hover:border-border focus-within:border-border rounded-lg border border-transparent px-3 py-2 transition-colors"
+			ref={containerRef}
+			{...(canAttach
+				? {
+						onDragEnter: handleDragEnter,
+						onDragLeave: handleDragLeave,
+						onDragOver: handleDragOver,
+						onDrop: handleDrop,
+					}
+				: {})}
+		>
+			{canAttach && isDragging && (
+				<div className="bg-background/80 border-primary absolute inset-0 z-50 flex items-center justify-center rounded-lg border-2 border-dashed backdrop-blur-sm">
+					<div className="text-primary flex flex-col items-center gap-1">
+						<Paperclip className="h-5 w-5" />
+						<span className="text-xs font-medium">Drop files to attach</span>
+					</div>
+				</div>
+			)}
+			<div className="mb-1 flex items-center">
+				<MessageRoleSwitcher role={message.role ?? ""} disabled={disabled} onRoleChange={handleRoleChange} />
+				<div className="ml-auto flex items-center gap-0.5 h-5">
+					{canAttach && (
+						<>
+							<input
+								ref={fileInputRef}
+								type="file"
+								multiple
+								accept="image/*,audio/*,.pdf,.txt,.csv,.json,.xml,.doc,.docx"
+								className="hidden"
+								onChange={handleFileSelect}
+							/>
+							<button type="button" aria-label="Attach file" onClick={() => fileInputRef.current?.click()} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+								<Paperclip className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+							</button>
+						</>
+					)}
+					{!disabled && (
+						<button type="button" aria-label="Edit message" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+						</button>
+					)}
+					{!disabled && onRemove && (
+						<button type="button" aria-label="Delete message" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
+							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+						</button>
+					)}
+				</div>
+			</div>
+
+			<div>
+				{editMode ? (
+					<Textarea
+						autoFocus
+						value={content}
+						className="text-muted-foreground dark:bg-transparent min-h-[20px] resize-none rounded-none border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0"
+						disabled={disabled}
+						onChange={(e) => {
+							const clone = message.clone();
+							clone.content = e.target.value;
+							onChange(clone.serialized);
+						}}
+						onBlur={() => {
+							if (content.trim().length > 0) setEditMode(false);
+						}}
+					/>
+				) : isEmpty && messageAttachments.length === 0 ? (
+					<div className="text-muted-foreground min-h-[20px] text-sm italic">Enter user message...</div>
+				) : (
+					<Markdown content={content} className="text-muted-foreground" />
+				)}
+			</div>
+
+			{messageAttachments.length > 0 && (
+				<AttachmentDisplay attachments={messageAttachments} editable={canAttach} onRemoveAttachment={handleRemoveAttachment} />
+			)}
+		</div>
+	);
+}
+
+function AttachmentDisplay({
+	attachments,
+	editable,
+	onRemoveAttachment,
+}: {
+	attachments: MessageContent[];
+	editable?: boolean;
+	onRemoveAttachment?: (index: number) => void;
+}) {
+	if (attachments.length === 0) return null;
+
+	return (
+		<div className="mt-2 flex flex-wrap gap-2">
+			{attachments.map((att, i) => {
+				if (att.type === "image_url" && att.image_url?.url) {
+					return (
+						<div key={i} className="group/att relative">
+							{/* eslint-disable-next-line @next/next/no-img-element */}
+							<img src={att.image_url.url} alt="attached image" className="max-h-48 max-w-xs rounded-md border object-contain" />
+							{editable && onRemoveAttachment && (
+								<button
+									onClick={() => onRemoveAttachment(i)}
+									className="bg-background/80 text-muted-foreground hover:bg-destructive/20 hover:text-destructive absolute -top-1.5 -right-1.5 rounded-full border p-0.5 opacity-0 transition-opacity group-hover/att:opacity-100"
+								>
+									<XIcon className="h-3 w-3" />
+								</button>
+							)}
+						</div>
+					);
+				}
+
+				if (att.type === "input_audio") {
+					const format = att.input_audio?.format || "wav";
+					const dataUrl = `data:audio/${format};base64,${att.input_audio?.data || ""}`;
+					return (
+						<div key={i} className="group/att bg-muted/30 relative flex items-center gap-2 rounded-md border px-3 py-2">
+							<Mic className="text-muted-foreground h-4 w-4" />
+							<audio controls className="h-8 max-w-[200px]">
+								<source src={dataUrl} type={`audio/${format}`} />
+							</audio>
+							{editable && onRemoveAttachment && (
+								<button
+									onClick={() => onRemoveAttachment(i)}
+									className="bg-background/80 text-muted-foreground hover:bg-destructive/20 hover:text-destructive absolute -top-1.5 -right-1.5 rounded-full border p-0.5 opacity-0 transition-opacity group-hover/att:opacity-100"
+								>
+									<XIcon className="h-3 w-3" />
+								</button>
+							)}
+						</div>
+					);
+				}
+
+				if (att.type === "file") {
+					return (
+						<div key={i} className="group/att bg-muted/30 text-muted-foreground relative flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm">
+							<FileIcon className="h-4 w-4 shrink-0" />
+							<span className="max-w-[200px] truncate">{att.file?.filename || "File"}</span>
+							{att.file?.file_type && <span className="text-xs opacity-60">{att.file.file_type}</span>}
+							{editable && onRemoveAttachment && (
+								<button
+									onClick={() => onRemoveAttachment(i)}
+									className="bg-background/80 text-muted-foreground hover:bg-destructive/20 hover:text-destructive absolute -top-1.5 -right-1.5 rounded-full border p-0.5 opacity-0 transition-opacity group-hover/att:opacity-100"
+								>
+									<XIcon className="h-3 w-3" />
+								</button>
+							)}
+						</div>
+					);
+				}
+
+				return null;
+			})}
+		</div>
+	);
+}

--- a/ui/components/prompts/components/newMessageInputView.tsx
+++ b/ui/components/prompts/components/newMessageInputView.tsx
@@ -1,0 +1,243 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Message, type MessageContent } from "@/lib/message";
+import { Loader2, Paperclip, Play, Plus } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePromptContext } from "../context";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import MessageRoleSwitcher from "./messagesView/messageRoleSwitcher";
+import { fileToAttachment } from "../utils/attachment";
+import { AttachmentBadge } from "./messagesView/attachmentViews";
+
+export function NewMessageInputView() {
+	const { messages, setMessages: onUpdateMessages, handleSendMessage: onSendMessage, isStreaming, supportsVision } = usePromptContext();
+	const [userInput, setUserInput] = useState("");
+	const [inputRole, setInputRole] = useState<string>("user");
+	const [attachments, setAttachments] = useState<MessageContent[]>([]);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const userInputRef = useRef<HTMLTextAreaElement>(null);
+
+	const handleAddMessage = useCallback(() => {
+		if (isStreaming) return;
+		const input = userInput.trim();
+		const currentAttachments = attachments.length > 0 ? [...attachments] : undefined;
+		if (!input && !currentAttachments) return;
+		setUserInput("");
+		setAttachments([]);
+		let msg: Message;
+		if (inputRole === "user") {
+			msg = Message.request(input, 0, currentAttachments);
+		} else if (inputRole === "system") {
+			msg = Message.system(input);
+		} else {
+			msg = Message.response(input);
+		}
+		onUpdateMessages([...messages, msg]);
+	}, [userInput, attachments, isStreaming, inputRole, onUpdateMessages, messages]);
+
+	const handleRun = useCallback(async () => {
+		if (isStreaming) return;
+		const input = userInput.trim();
+		const currentAttachments = attachments.length > 0 ? [...attachments] : undefined;
+		if (input || currentAttachments) {
+			setUserInput("");
+			setAttachments([]);
+		}
+		let pendingMessage: Message | undefined;
+		if (input || currentAttachments) {
+			if (inputRole === "system") {
+				pendingMessage = Message.system(input);
+			} else if (inputRole === "user") {
+				pendingMessage = Message.request(input, 0, currentAttachments);
+			} else {
+				pendingMessage = Message.response(input);
+			}
+		}
+		await onSendMessage(pendingMessage);
+		setTimeout(() => {
+			userInputRef.current?.focus();
+		}, 100);
+	}, [userInput, attachments, isStreaming, inputRole, onSendMessage]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter" && !e.shiftKey) {
+				e.preventDefault();
+				handleRun();
+			}
+		},
+		[handleAddMessage, handleRun],
+	);
+
+	const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = e.target.files;
+		if (!files) return;
+
+		for (const file of Array.from(files)) {
+			const attachment = await fileToAttachment(file);
+			if (attachment) {
+				setAttachments((prev) => [...prev, attachment]);
+			}
+		}
+
+		// Reset input so re-selecting the same file triggers onChange
+		e.target.value = "";
+	}, []);
+
+	const handleRemoveAttachment = useCallback((index: number) => {
+		setAttachments((prev) => prev.filter((_, i) => i !== index));
+	}, []);
+
+	const handlePaste = useCallback(
+		async (e: React.ClipboardEvent) => {
+			if (!supportsVision) return;
+			const items = e.clipboardData?.items;
+			if (!items) return;
+
+			for (const item of Array.from(items)) {
+				if (item.type.startsWith("image/")) {
+					e.preventDefault();
+					const file = item.getAsFile();
+					if (file) {
+						const attachment = await fileToAttachment(file);
+						if (attachment) {
+							setAttachments((prev) => [...prev, attachment]);
+						}
+					}
+				}
+			}
+		},
+		[supportsVision],
+	);
+
+	const [isDragging, setIsDragging] = useState(false);
+	const dragCounterRef = useRef(0);
+
+	const handleDragEnter = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		dragCounterRef.current++;
+		if (e.dataTransfer.types.includes("Files")) {
+			setIsDragging(true);
+		}
+	}, []);
+
+	const handleDragLeave = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		dragCounterRef.current--;
+		if (dragCounterRef.current === 0) {
+			setIsDragging(false);
+		}
+	}, []);
+
+	const handleDragOver = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+	}, []);
+
+	const handleDrop = useCallback(async (e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		dragCounterRef.current = 0;
+		setIsDragging(false);
+
+		const files = e.dataTransfer.files;
+		if (!files || files.length === 0) return;
+
+		for (const file of Array.from(files)) {
+			const attachment = await fileToAttachment(file);
+			if (attachment) {
+				setAttachments((prev) => [...prev, attachment]);
+			}
+		}
+	}, []);
+
+	return (
+		<div
+			className="group relative max-h-[500px] shrink-0 overflow-y-auto border-t px-4 py-2"
+			{...(supportsVision
+				? {
+						onDragEnter: handleDragEnter,
+						onDragLeave: handleDragLeave,
+						onDragOver: handleDragOver,
+						onDrop: handleDrop,
+					}
+				: {})}
+		>
+			{supportsVision && isDragging && (
+				<div className="bg-background/80 border-primary absolute inset-0 z-50 flex items-center justify-center rounded-lg border-2 border-dashed backdrop-blur-sm">
+					<div className="text-primary flex flex-col items-center gap-1">
+						<Paperclip className="h-5 w-5" />
+						<span className="text-xs font-medium">Drop files to attach</span>
+					</div>
+				</div>
+			)}
+			<div className="mb-1 flex items-center">
+				<MessageRoleSwitcher role={inputRole} disabled={isStreaming} onRoleChange={(role) => { setInputRole(role); if (role !== "user") setAttachments([]); }} restrictedRoles={["system", "tool"]} />
+				{supportsVision && inputRole === "user" && (
+					<div className="ml-auto">
+						<input
+							ref={fileInputRef}
+							type="file"
+							multiple
+							accept="image/*,audio/*,.pdf,.txt,.csv,.json,.xml,.doc,.docx"
+							className="hidden"
+							onChange={handleFileSelect}
+						/>
+						<button type="button" aria-label="Attach file" onClick={() => fileInputRef.current?.click()} className="rounded-sm p-1 hover:bg-muted focus:bg-muted">
+							<Paperclip className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+						</button>
+					</div>
+				)}
+			</div>
+			{attachments.length > 0 && (
+				<div className="mb-2 flex flex-wrap gap-2">
+					{attachments.map((att, index) => (
+						<AttachmentBadge key={index} attachment={att} onRemove={() => handleRemoveAttachment(index)} />
+					))}
+				</div>
+			)}
+			<div className="relative">
+				<Textarea
+					placeholder="Type a message..."
+					value={userInput}
+					ref={userInputRef}
+					onChange={(e) => setUserInput(e.target.value)}
+					onKeyDown={handleKeyDown}
+					onPaste={handlePaste}
+					className="text-muted-foreground min-h-[60px] resize-none rounded-none border-0 bg-transparent p-0 pr-16 text-sm shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent"
+					disabled={isStreaming}
+				/>
+				<div className="absolute right-0 bottom-0 flex items-center gap-1">
+					<Button
+						onClick={handleAddMessage}
+						disabled={isStreaming}
+						variant={"ghost"}
+						className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded px-1.5 py-1 text-xs disabled:pointer-events-none disabled:opacity-50"
+					>
+						<Plus className="h-3.5 w-3.5" />
+						Add
+					</Button>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								onClick={handleRun}
+								disabled={isStreaming}
+								variant={"ghost"}
+								className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded px-1.5 py-1 text-xs disabled:pointer-events-none disabled:opacity-50"
+							>
+								{isStreaming ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
+								Run
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="top">
+							<span>Run prompt</span>
+							<kbd className="bg-primary-foreground/20 ml-1.5 rounded px-1 py-0.5 font-mono text-[10px]">↵</kbd>
+						</TooltipContent>
+					</Tooltip>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/ui/components/prompts/components/promptsViewHeader.tsx
+++ b/ui/components/prompts/components/promptsViewHeader.tsx
@@ -1,0 +1,336 @@
+import { Button } from "@/components/ui/button";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { SplitButton } from "@/components/ui/splitButton";
+import { DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdownMenu";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Check, ChevronDown, GitCommit, PencilIcon, Save, Trash2 } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { parseAsInteger, useQueryStates } from "nuqs";
+import { useCreateSessionMutation, useGetSessionsQuery, useGetVersionsQuery, useRenameSessionMutation } from "@/lib/store/apis/promptsApi";
+import { Message, MessageRole } from "@/lib/message";
+import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/store";
+import { usePromptContext } from "../context";
+import { ModelParams, PromptSession } from "@/lib/types/prompts";
+import { Input } from "@/components/ui/input";
+
+export default function PromptsViewHeader() {
+	const {
+		selectedPrompt,
+		messages,
+		setMessages: onMessagesChange,
+		setCommitSheet,
+		apiKeyId,
+		modelParams,
+		provider,
+		model,
+		hasChanges,
+		isStreaming,
+	} = usePromptContext();
+
+	const [sessionsOpen, setSessionsOpen] = useState(false);
+
+	const onSessionSaved = useCallback(
+		(session: PromptSession) => {
+			setCommitSheet({ open: true, session });
+		},
+		[setCommitSheet],
+	);
+	// UI state — persisted in URL query params
+	const [{ sessionId: selectedSessionId, versionId: selectedVersionId }, setUrlState] = useQueryStates(
+		{
+			sessionId: parseAsInteger,
+			versionId: parseAsInteger,
+		},
+		{ history: "replace" },
+	);
+
+	// Fetch versions and sessions for selected prompt
+	const { data: versionsData } = useGetVersionsQuery(selectedPrompt?.id ?? "", { skip: !selectedPrompt?.id });
+	const { data: sessionsData } = useGetSessionsQuery(selectedPrompt?.id ?? "", { skip: !selectedPrompt?.id });
+
+	// Mutations
+	const [createSession, { isLoading: isCreatingSession }] = useCreateSessionMutation();
+	const [renameSession] = useRenameSessionMutation();
+
+	const versions = versionsData?.versions ?? [];
+	const sessions = sessionsData?.sessions ?? [];
+
+	const handleSelectVersion = useCallback(
+		(versionId: number) => {
+			setUrlState({ versionId, sessionId: null });
+		},
+		[setUrlState],
+	);
+
+	// Build model_params with api_key_id for persistence
+	const buildSaveParams = useCallback((): ModelParams => {
+		const params = { ...modelParams };
+		if (apiKeyId && apiKeyId !== "__auto__") {
+			params.api_key_id = apiKeyId;
+		}
+		return params;
+	}, [modelParams, apiKeyId]);
+
+	const handleSaveSession = useCallback(async () => {
+		if (!selectedPrompt || !hasChanges) return;
+		try {
+			const result = await createSession({
+				promptId: selectedPrompt.id,
+				data: {
+					messages: Message.serializeAll(messages),
+					model_params: buildSaveParams(),
+					provider,
+					model,
+				},
+			}).unwrap();
+			setUrlState({ sessionId: result.session.id, versionId: null });
+			toast.success("Session saved");
+		} catch (err) {
+			toast.error("Failed to save session", { description: getErrorMessage(err) });
+		}
+	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, createSession, setUrlState, hasChanges]);
+
+	// Cmd+S / Ctrl+S to save session
+	useHotkeys(
+		"mod+s",
+		() => handleSaveSession(),
+		{
+			preventDefault: true,
+			enableOnFormTags: ["input", "textarea", "select"],
+			enabled: !!selectedPrompt && !isCreatingSession,
+		},
+		[handleSaveSession, selectedPrompt, isCreatingSession],
+	);
+
+	const handleCommitVersion = useCallback(async () => {
+		if (!selectedPrompt) return;
+		try {
+			// Always create a new session with current state before committing
+			const result = await createSession({
+				promptId: selectedPrompt.id,
+				data: {
+					messages: Message.serializeAll(messages),
+					model_params: buildSaveParams(),
+					provider,
+					model,
+				},
+			}).unwrap();
+			setUrlState({ sessionId: result.session.id });
+			onSessionSaved(result.session);
+		} catch (err) {
+			toast.error("Failed to save session", { description: getErrorMessage(err) });
+		}
+	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, createSession, setUrlState, onSessionSaved]);
+
+	const handleRenameSession = useCallback(
+		async (sessionId: number, name: string) => {
+			if (!selectedPrompt) return;
+			try {
+				await renameSession({ id: sessionId, promptId: selectedPrompt.id, data: { name } }).unwrap();
+			} catch (err) {
+				toast.error("Failed to rename session", { description: getErrorMessage(err) });
+			}
+		},
+		[selectedPrompt?.id, renameSession],
+	);
+
+	const handleClearConversation = useCallback(() => {
+		const firstMsg = messages[0];
+		if (firstMsg?.role === MessageRole.SYSTEM) {
+			onMessagesChange([firstMsg]);
+		} else {
+			onMessagesChange([Message.system("")]);
+		}
+	}, [messages]);
+
+	return (
+		<div className="flex items-center justify-between border-b px-4 py-3">
+			<h3 className="truncate font-semibold">{selectedPrompt?.name || "Playground"}</h3>
+			<div className="flex shrink-0 items-center gap-4">
+				{messages.length > 1 && (
+					<Button variant="ghost" size="sm" onClick={handleClearConversation} disabled={isStreaming}>
+						<Trash2 className="h-4 w-4" />
+						Clear
+					</Button>
+				)}
+				<div className="inline-flex items-center">
+					<Button
+						variant="outline"
+						className="rounded-r-none border bg-transparent"
+						onClick={handleSaveSession}
+						disabled={isCreatingSession || !hasChanges || isStreaming}
+					>
+						<Save className="h-4 w-4" />
+						Save Session
+					</Button>
+					<Popover open={sessionsOpen} onOpenChange={setSessionsOpen}>
+						<PopoverTrigger asChild>
+							<Button variant="outline" className="h-[30px] w-8 rounded-l-none border border-l-0 bg-transparent p-0">
+								<ChevronDown className="h-4 w-4" />
+							</Button>
+						</PopoverTrigger>
+						<PopoverContent className="w-72 p-0" align="end">
+							<Command>
+								<CommandInput placeholder="Search sessions..." />
+								<CommandList>
+									<CommandEmpty>No sessions found.</CommandEmpty>
+									<CommandGroup>
+										{sessions.map((session) => (
+											<SessionItem
+												key={session.id}
+												session={session}
+												isSelected={selectedSessionId === session.id}
+												onSelect={() => {
+													setUrlState({ sessionId: session.id, versionId: null });
+													setSessionsOpen(false);
+												}}
+												onRename={(name) => handleRenameSession(session.id, name)}
+											/>
+										))}
+									</CommandGroup>
+								</CommandList>
+							</Command>
+						</PopoverContent>
+					</Popover>
+				</div>
+				<SplitButton
+					onClick={handleCommitVersion}
+					disabled={isCreatingSession || isStreaming}
+					dropdownContent={{
+						className: "w-64 max-h-72 overflow-y-auto",
+						children: (
+							<>
+								<DropdownMenuLabel>Versions</DropdownMenuLabel>
+								<DropdownMenuSeparator />
+								{versions.length === 0 ? (
+									<div className="text-muted-foreground px-2 py-3 text-center text-sm">No versions yet</div>
+								) : (
+									versions.map((version) => (
+										<DropdownMenuItem
+											key={version.id}
+											onClick={() => handleSelectVersion(version.id)}
+											className="flex items-center justify-between gap-2"
+										>
+											<div className="flex min-w-0 flex-col">
+												<span className="truncate text-sm">
+													v{version.version_number}
+													{version.is_latest && <span className="text-primary ml-1.5 text-xs">(latest)</span>}
+												</span>
+												<span className="text-muted-foreground truncate text-xs">{version.commit_message || "No commit message"}</span>
+												<span className="text-muted-foreground text-xs">{new Date(version.created_at).toLocaleString()}</span>
+											</div>
+											{selectedVersionId === version.id && <Check className="text-primary h-4 w-4 shrink-0" />}
+										</DropdownMenuItem>
+									))
+								)}
+							</>
+						),
+					}}
+					variant={"outline"}
+					dropdownTrigger={{
+						className: "bg-transparent",
+					}}
+					button={{
+						className: "bg-transparent",
+					}}
+				>
+					<GitCommit className="h-4 w-4" />
+					Commit Version
+				</SplitButton>
+			</div>
+		</div>
+	);
+}
+
+function formatSessionDate(dateStr: string): string {
+	const date = new Date(dateStr);
+	const month = date.toLocaleString("en-US", { month: "short" });
+	const day = date.getDate();
+	const hours = date.getHours();
+	const minutes = date.getMinutes().toString().padStart(2, "0");
+	const ampm = hours >= 12 ? "pm" : "am";
+	const displayHours = (hours % 12 || 12).toString().padStart(2, "0");
+	return `${month} ${day}, ${displayHours}:${minutes}${ampm}`;
+}
+
+function SessionItem({
+	session,
+	isSelected,
+	onSelect,
+	onRename,
+}: {
+	session: PromptSession;
+	isSelected: boolean;
+	onSelect: () => void;
+	onRename: (name: string) => void;
+}) {
+	const [isEditing, setIsEditing] = useState(false);
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const handleRenameSubmit = () => {
+		const newName = inputRef.current?.value.trim() ?? "";
+		if (!newName || newName === session.name) {
+			setIsEditing(false);
+			return;
+		}
+		onRename(newName);
+		setIsEditing(false);
+	};
+
+	const dateLabel = formatSessionDate(session.created_at);
+
+	if (isEditing) {
+		return (
+			<div className="px-2 py-1.5" onKeyDown={(e) => e.stopPropagation()}>
+				<Input
+					ref={inputRef}
+					defaultValue={session.name}
+					placeholder="Session name"
+					className="h-7 text-sm"
+					autoFocus
+					onKeyDown={(e) => {
+						if (e.key === "Enter") handleRenameSubmit();
+						if (e.key === "Escape") setIsEditing(false);
+					}}
+					onBlur={handleRenameSubmit}
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<CommandItem
+			value={`${session.id}-${dateLabel}-${session.name}`}
+			onSelect={onSelect}
+			className="group/item flex items-center justify-between gap-2"
+		>
+			<div className="flex min-w-0 flex-col">
+				<span className="truncate text-sm">
+					<span className="text-muted-foreground">{dateLabel}</span>
+					{session.name && <span className="ml-1.5">{session.name}</span>}
+				</span>
+			</div>
+			<div className="flex shrink-0 items-center gap-1">
+				<button
+					type="button"
+					aria-label="Rename session"
+					onPointerDown={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+					}}
+					onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						setIsEditing(true);
+					}}
+					className="rounded-sm p-1 hover:bg-muted focus:bg-muted opacity-0 transition-opacity group-hover/item:opacity-100 focus:opacity-100"
+				>
+					<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 cursor-pointer" />
+				</button>
+				{isSelected && <Check className="text-primary h-4 w-4" />}
+			</div>
+		</CommandItem>
+	);
+}

--- a/ui/components/prompts/components/sheets.tsx
+++ b/ui/components/prompts/components/sheets.tsx
@@ -1,0 +1,42 @@
+import { usePromptContext } from "../context";
+import { FolderSheet } from "../sheets/folderSheet";
+import { PromptSheet } from "../sheets/promptSheet";
+import { CommitVersionSheet } from "../sheets/commitVersionSheet";
+
+export function PromptSheets() {
+	const { folderSheet, setFolderSheet, promptSheet, setPromptSheet, commitSheet, setCommitSheet, setUrlState } = usePromptContext();
+
+	return (
+		<>
+			<FolderSheet
+				open={folderSheet.open}
+				onOpenChange={(open) => setFolderSheet({ ...folderSheet, open })}
+				folder={folderSheet.folder}
+				onSaved={() => {}}
+			/>
+
+			<PromptSheet
+				open={promptSheet.open}
+				onOpenChange={(open) => setPromptSheet({ ...promptSheet, open })}
+				prompt={promptSheet.prompt}
+				folderId={promptSheet.folderId}
+				onSaved={(newPromptId) => {
+					if (newPromptId) {
+						setUrlState({ promptId: newPromptId, sessionId: null, versionId: null });
+					}
+				}}
+			/>
+
+			{commitSheet.session && (
+				<CommitVersionSheet
+					open={commitSheet.open}
+					onOpenChange={(open) => setCommitSheet({ ...commitSheet, open })}
+					session={commitSheet.session}
+					onCommitted={(versionId) => {
+						setUrlState({ versionId, sessionId: null });
+					}}
+				/>
+			)}
+		</>
+	);
+}

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import { getErrorMessage } from "@/lib/store";
+import {
+	useCreateSessionMutation,
+	useDeleteFolderMutation,
+	useDeletePromptMutation,
+	useGetFoldersQuery,
+	useGetPromptsQuery,
+	useGetPromptVersionQuery,
+	useGetSessionsQuery,
+	useGetVersionsQuery,
+	useUpdatePromptMutation,
+} from "@/lib/store/apis/promptsApi";
+import { useGetModelDatasheetQuery } from "@/lib/store/apis/providersApi";
+import { Message, MessageRole, MessageType } from "@/lib/message";
+import { Folder, ModelParams, Prompt, PromptSession, PromptVersion } from "@/lib/types/prompts";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { toast } from "sonner";
+import { executePrompt } from "./utils/executor";
+
+interface PromptContextValue {
+	// Data
+	folders: Folder[];
+	prompts: Prompt[];
+	selectedPrompt?: Prompt;
+	sessions: PromptSession[];
+	selectedSession?: PromptSession;
+	selectedVersion?: PromptVersion;
+
+	// Loading states
+	foldersLoading: boolean;
+	promptsLoading: boolean;
+	foldersError: unknown;
+	promptsError: unknown;
+	isLoadingPlayground: boolean;
+	isStreaming: boolean;
+
+	// URL state
+	selectedPromptId: string | null;
+	selectedSessionId: number | null;
+	selectedVersionId: number | null;
+	setUrlState: (state: { promptId?: string | null; sessionId?: number | null; versionId?: number | null }) => void;
+
+	// Playground state
+	messages: Message[];
+	setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+	provider: string;
+	setProvider: React.Dispatch<React.SetStateAction<string>>;
+	model: string;
+	setModel: React.Dispatch<React.SetStateAction<string>>;
+	modelParams: ModelParams;
+	setModelParams: React.Dispatch<React.SetStateAction<ModelParams>>;
+	apiKeyId: string;
+	setApiKeyId: React.Dispatch<React.SetStateAction<string>>;
+
+	// Sheet states
+	folderSheet: { open: boolean; folder?: Folder };
+	setFolderSheet: React.Dispatch<React.SetStateAction<{ open: boolean; folder?: Folder }>>;
+	promptSheet: { open: boolean; prompt?: Prompt; folderId?: string };
+	setPromptSheet: React.Dispatch<React.SetStateAction<{ open: boolean; prompt?: Prompt; folderId?: string }>>;
+	commitSheet: { open: boolean; session?: PromptSession };
+	setCommitSheet: React.Dispatch<React.SetStateAction<{ open: boolean; session?: PromptSession }>>;
+
+	// Delete dialog states
+	deleteFolderDialog: { open: boolean; folder?: Folder };
+	setDeleteFolderDialog: React.Dispatch<React.SetStateAction<{ open: boolean; folder?: Folder }>>;
+	deletePromptDialog: { open: boolean; prompt?: Prompt };
+	setDeletePromptDialog: React.Dispatch<React.SetStateAction<{ open: boolean; prompt?: Prompt }>>;
+
+	// Mutation loading states
+	isDeletingFolder: boolean;
+	isDeletingPrompt: boolean;
+
+	// Model capabilities
+	supportsVision: boolean;
+
+	// Diff detection
+	hasChanges: boolean;
+
+	// Handlers
+	handleSelectPrompt: (id: string) => void;
+	handleMovePrompt: (promptId: string, folderId: string | null) => Promise<void>;
+	handleDeleteFolder: () => Promise<void>;
+	handleDeletePrompt: () => Promise<void>;
+	handleSendMessage: (pendingMessage?: Message) => Promise<void>;
+	handleSubmitToolResult: (afterIndex: number, toolCallId: string, content: string) => Promise<void>;
+}
+
+const PromptContext = createContext<PromptContextValue | null>(null);
+
+export function usePromptContext() {
+	const context = useContext(PromptContext);
+	if (!context) {
+		throw new Error("usePromptContext must be used within a PromptProvider");
+	}
+	return context;
+}
+
+export function PromptProvider({ children }: { children: ReactNode }) {
+	// API queries
+	const { data: foldersData, isLoading: foldersLoading, error: foldersError } = useGetFoldersQuery();
+	const { data: promptsData, isLoading: promptsLoading, error: promptsError } = useGetPromptsQuery();
+
+	// Mutations
+	const [deleteFolder, { isLoading: isDeletingFolder }] = useDeleteFolderMutation();
+	const [deletePrompt, { isLoading: isDeletingPrompt }] = useDeletePromptMutation();
+	const [updatePrompt] = useUpdatePromptMutation();
+	const [createSession] = useCreateSessionMutation();
+
+	// UI state — persisted in URL query params
+	const [{ promptId: selectedPromptId, sessionId: selectedSessionId, versionId: selectedVersionId }, setUrlState] = useQueryStates(
+		{
+			promptId: parseAsString,
+			sessionId: parseAsInteger,
+			versionId: parseAsInteger,
+		},
+		{ history: "replace" },
+	);
+
+	// Sheet states
+	const [folderSheet, setFolderSheet] = useState<{ open: boolean; folder?: Folder }>({ open: false });
+	const [promptSheet, setPromptSheet] = useState<{ open: boolean; prompt?: Prompt; folderId?: string }>({ open: false });
+	const [commitSheet, setCommitSheet] = useState<{ open: boolean; session?: PromptSession }>({ open: false });
+
+	// Delete dialog states
+	const [deleteFolderDialog, setDeleteFolderDialog] = useState<{ open: boolean; folder?: Folder }>({ open: false });
+	const [deletePromptDialog, setDeletePromptDialog] = useState<{ open: boolean; prompt?: Prompt }>({ open: false });
+
+	// Playground state
+	const [messages, setMessagesRaw] = useState<Message[]>([Message.system("")]);
+	const setMessages = useCallback<React.Dispatch<React.SetStateAction<Message[]>>>((action) => {
+		setMessagesRaw((prev) => {
+			const next = typeof action === "function" ? action(prev) : action;
+			return next.map((msg, i) => msg.withIndex(i));
+		});
+	}, []);
+	const [provider, setProvider] = useState("openai");
+	const [model, setModel] = useState("gpt-4o");
+	const [modelParams, setModelParams] = useState<ModelParams>({});
+	const [apiKeyId, setApiKeyId] = useState("__auto__");
+	const [isStreaming, setIsStreaming] = useState(false);
+	const activeRunRef = useRef<symbol | null>(null);
+
+	// Fetch model datasheet for capabilities
+	const { data: datasheetData } = useGetModelDatasheetQuery(model, { skip: !model });
+	const supportsVision = datasheetData?.supports_vision ?? false;
+
+	// Derived data
+	const folders = useMemo(() => foldersData?.folders ?? [], [foldersData]);
+	const prompts = useMemo(() => promptsData?.prompts ?? [], [promptsData]);
+	const selectedPrompt = useMemo(() => prompts.find((p) => p.id === selectedPromptId), [prompts, selectedPromptId]);
+
+	// Fetch versions and sessions for selected prompt
+	const { data: versionsData } = useGetVersionsQuery(selectedPromptId ?? "", { skip: !selectedPromptId });
+	const { data: sessionsData, isLoading: isSessionsLoading } = useGetSessionsQuery(selectedPromptId ?? "", { skip: !selectedPromptId });
+
+	// Filter sessions to current prompt — RTK Query may briefly return stale cached data from the previous prompt
+	const sessions = useMemo(() => {
+		const all = sessionsData?.sessions ?? [];
+		if (!selectedPromptId) return [];
+		return all.filter((s) => s.prompt_id === selectedPromptId);
+	}, [sessionsData, selectedPromptId]);
+	const selectedSession = useMemo(() => sessions.find((s) => s.id === selectedSessionId), [sessions, selectedSessionId]);
+
+	// Fetch full version data (with messages) when a version is selected
+	const { currentData: selectedVersionData, isLoading: isVersionLoading } = useGetPromptVersionQuery(selectedVersionId ?? 0, {
+		skip: !selectedVersionId,
+	});
+	const selectedVersion = selectedVersionData?.version;
+
+	// Show loader only on initial fetch, not on cache refetches (avoids flicker on save)
+	const isLoadingPlayground = !!(
+		selectedPromptId &&
+		(isSessionsLoading ||
+			(selectedVersionId && isVersionLoading) ||
+			// Sessions loaded but auto-select hasn't happened yet
+			(sessions.length > 0 && !selectedSessionId && !selectedVersionId))
+	);
+
+	// Load session or version data when selection changes
+	useEffect(() => {
+		// Don't reset state while waiting for data that hasn't arrived yet
+		if (selectedSessionId && !selectedSession) return;
+		if (selectedVersionId && !selectedVersion) return;
+
+		const loadFromParams = (params: ModelParams, prov: string, mod: string) => {
+			const { api_key_id, ...rest } = params || ({} as ModelParams);
+			setModelParams(rest);
+			setApiKeyId(api_key_id || "__auto__");
+			setProvider(prov || "openai");
+			setModel(mod || "gpt-4o");
+		};
+
+		if (selectedSession) {
+			const raw = (selectedSession.messages ?? []).map((m) => m.message);
+			const loaded = Message.fromLegacyAll(raw);
+			setMessages(loaded.length > 0 ? loaded : [Message.system("")]);
+			loadFromParams(selectedSession.model_params, selectedSession.provider, selectedSession.model);
+		} else if (selectedVersion) {
+			const raw = (selectedVersion.messages ?? []).map((m) => m.message);
+			const loaded = Message.fromLegacyAll(raw);
+			setMessages(loaded.length > 0 ? loaded : [Message.system("")]);
+			loadFromParams(selectedVersion.model_params, selectedVersion.provider, selectedVersion.model);
+		} else if (selectedPrompt?.latest_version) {
+			// Only fall back to latest_version after sessions have settled
+			// to avoid racing with the session auto-select effect
+			if (isSessionsLoading) return;
+			const version = selectedPrompt.latest_version;
+			const raw = (version.messages ?? []).map((m) => m.message);
+			const loaded = Message.fromLegacyAll(raw);
+			setMessages(loaded.length > 0 ? loaded : [Message.system("")]);
+			loadFromParams(version.model_params, version.provider, version.model);
+			if (sessions.length === 0) {
+				setUrlState({ versionId: version.id });
+			}
+		} else {
+			setMessages([Message.system("")]);
+			setProvider("openai");
+			setModel("gpt-4o");
+			setModelParams({});
+			setApiKeyId("__auto__");
+		}
+	}, [selectedSession, selectedVersion, selectedPrompt, selectedSessionId, selectedVersionId, setUrlState, isSessionsLoading, sessions.length]);
+
+	// Auto-select the most recent session when sessions load and none is selected
+	useEffect(() => {
+		if (sessions.length > 0 && !selectedSessionId && !selectedVersionId) {
+			setUrlState({ sessionId: sessions[0].id });
+		}
+	}, [selectedPromptId, sessions, selectedSessionId, selectedVersionId, setUrlState]);
+
+	// Diff detection — compare current playground state against the loaded session/version
+	const hasChanges = useMemo(() => {
+		let refMessages: any[] | undefined;
+		let refParams: ModelParams | undefined;
+		let refProvider: string | undefined;
+		let refModel: string | undefined;
+
+		if (selectedSession) {
+			refMessages = selectedSession.messages?.map((m) => m.message) ?? [];
+			refParams = selectedSession.model_params;
+			refProvider = selectedSession.provider;
+			refModel = selectedSession.model;
+		} else if (selectedVersion) {
+			refMessages = selectedVersion.messages?.map((m) => m.message) ?? [];
+			refParams = selectedVersion.model_params;
+			refProvider = selectedVersion.provider;
+			refModel = selectedVersion.model;
+		} else {
+			// No reference to compare against — always allow save
+			return true;
+		}
+
+		// Quick string checks first
+		if (provider !== refProvider) return true;
+		if (model !== refModel) return true;
+
+		// Compare api_key_id
+		const { api_key_id: refApiKeyId, ...refParamsRest } = refParams || ({} as ModelParams);
+		const currentApiKeyId = apiKeyId !== "__auto__" ? apiKeyId : undefined;
+		if (currentApiKeyId !== (refApiKeyId || undefined)) return true;
+
+		// Compare model params (excluding api_key_id)
+		if (JSON.stringify(modelParams, Object.keys(modelParams).sort()) !== JSON.stringify(refParamsRest, Object.keys(refParamsRest).sort()))
+			return true;
+
+		// Compare messages (most expensive — do last)
+		const currentSerialized = Message.serializeAll(messages);
+		if (JSON.stringify(currentSerialized) !== JSON.stringify(refMessages)) return true;
+
+		return false;
+	}, [selectedSession, selectedVersion, provider, model, modelParams, apiKeyId, messages]);
+
+	// Handlers
+	const handleSelectPrompt = useCallback(
+		(id: string) => {
+			setMessages([Message.system("")]);
+			setProvider("openai");
+			setModel("gpt-4o");
+			setModelParams({});
+			setApiKeyId("__auto__");
+			setUrlState({ promptId: id, sessionId: null, versionId: null });
+		},
+		[setUrlState],
+	);
+
+	const handleMovePrompt = useCallback(
+		async (promptId: string, folderId: string | null) => {
+			try {
+				await updatePrompt({ id: promptId, data: { folder_id: folderId } }).unwrap();
+				toast.success("Prompt moved successfully");
+			} catch (err) {
+				toast.error(getErrorMessage(err) || "Failed to move prompt");
+			}
+		},
+		[updatePrompt],
+	);
+
+	const handleDeleteFolder = useCallback(async () => {
+		if (!deleteFolderDialog.folder) return;
+
+		try {
+			await deleteFolder(deleteFolderDialog.folder.id).unwrap();
+			toast.success("Folder deleted");
+			setDeleteFolderDialog({ open: false });
+			if (selectedPrompt?.folder_id === deleteFolderDialog.folder.id) {
+				setUrlState({ promptId: null, sessionId: null, versionId: null });
+			}
+		} catch (err) {
+			toast.error("Failed to delete folder", { description: getErrorMessage(err) });
+		}
+	}, [deleteFolderDialog.folder, deleteFolder, selectedPrompt, setUrlState]);
+
+	const handleDeletePrompt = useCallback(async () => {
+		if (!deletePromptDialog.prompt) return;
+
+		try {
+			await deletePrompt(deletePromptDialog.prompt.id).unwrap();
+			toast.success("Prompt deleted");
+			setDeletePromptDialog({ open: false });
+			if (selectedPromptId === deletePromptDialog.prompt.id) {
+				setUrlState({ promptId: null, sessionId: null, versionId: null });
+			}
+		} catch (err) {
+			toast.error("Failed to delete prompt", { description: getErrorMessage(err) });
+		}
+	}, [deletePromptDialog.prompt, deletePrompt, selectedPromptId, setUrlState]);
+
+	const handleSendMessage = useCallback(
+		async (pendingMessage?: Message) => {
+			const runToken = Symbol();
+			activeRunRef.current = runToken;
+			const isActive = () => activeRunRef.current === runToken;
+
+			setIsStreaming(true);
+			await executePrompt(messages, pendingMessage, { provider, model, modelParams, apiKeyId }, {
+				onStreamingStart: (allMessages, placeholder) => {
+					if (!isActive()) return;
+					setMessages([...allMessages, placeholder]);
+				},
+				onStreamChunk: (content) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const updated = [...prev];
+						const last = updated[updated.length - 1];
+						const clone = last.clone();
+						clone.content = content;
+						updated[updated.length - 1] = clone;
+						return updated;
+					});
+				},
+				onComplete: (content, usage) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const updated = [...prev];
+						updated[updated.length - 1] = Message.response(content, 0, usage);
+						return updated;
+					});
+				},
+				onToolCallComplete: (content, toolCalls, usage) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const updated = [...prev];
+						updated[updated.length - 1] = Message.toolCallResponse(content, toolCalls, 0, usage);
+						return updated;
+					});
+				},
+				onEmptyResponse: () => {
+					if (!isActive()) return;
+					setMessages((prev) => prev.slice(0, -1));
+				},
+				onError: (error) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const withoutPlaceholder = prev.slice(0, -1);
+						return [...withoutPlaceholder, Message.error(error)];
+					});
+				},
+				onFinally: () => {
+					if (!isActive()) return;
+					setIsStreaming(false);
+				},
+			});
+		},
+		[messages, provider, model, modelParams, apiKeyId],
+	);
+
+	const handleSubmitToolResult = useCallback(
+		async (afterIndex: number, toolCallId: string, content: string) => {
+			const runToken = Symbol();
+			activeRunRef.current = runToken;
+			const isActive = () => activeRunRef.current === runToken;
+
+			const toolResultMsg = new Message(
+				crypto.randomUUID(),
+				0,
+				MessageType.ToolResult,
+				{
+					role: MessageRole.TOOL,
+					content,
+					tool_call_id: toolCallId,
+				},
+			);
+			const newMessages = [...messages];
+			// Insert after any existing tool results that follow the assistant message
+			let insertAt = afterIndex + 1;
+			while (insertAt < newMessages.length && newMessages[insertAt].type === MessageType.ToolResult) {
+				insertAt++;
+			}
+			newMessages.splice(insertAt, 0, toolResultMsg);
+			setMessages(newMessages);
+
+			// Execute with the updated messages
+			setIsStreaming(true);
+			await executePrompt(newMessages, undefined, { provider, model, modelParams, apiKeyId }, {
+				onStreamingStart: (allMessages, placeholder) => {
+					if (!isActive()) return;
+					setMessages([...allMessages, placeholder]);
+				},
+				onStreamChunk: (content) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const updated = [...prev];
+						const last = updated[updated.length - 1];
+						const clone = last.clone();
+						clone.content = content;
+						updated[updated.length - 1] = clone;
+						return updated;
+					});
+				},
+				onComplete: (content, usage) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const updated = [...prev];
+						updated[updated.length - 1] = Message.response(content, 0, usage);
+						return updated;
+					});
+				},
+				onToolCallComplete: (content, toolCalls, usage) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const updated = [...prev];
+						updated[updated.length - 1] = Message.toolCallResponse(content, toolCalls, 0, usage);
+						return updated;
+					});
+				},
+				onEmptyResponse: () => {
+					if (!isActive()) return;
+					setMessages((prev) => prev.slice(0, -1));
+				},
+				onError: (error) => {
+					if (!isActive()) return;
+					setMessages((prev) => {
+						const withoutPlaceholder = prev.slice(0, -1);
+						return [...withoutPlaceholder, Message.error(error)];
+					});
+				},
+				onFinally: () => {
+					if (!isActive()) return;
+					setIsStreaming(false);
+				},
+			});
+		},
+		[messages, provider, model, modelParams, apiKeyId],
+	);
+
+	const value: PromptContextValue = {
+		folders,
+		prompts,
+		selectedPrompt,
+		sessions,
+		selectedSession,
+		selectedVersion,
+		foldersLoading,
+		promptsLoading,
+		foldersError,
+		promptsError,
+		isLoadingPlayground,
+		isStreaming,
+		selectedPromptId,
+		selectedSessionId,
+		selectedVersionId,
+		setUrlState,
+		messages,
+		setMessages,
+		provider,
+		setProvider,
+		model,
+		setModel,
+		modelParams,
+		setModelParams,
+		apiKeyId,
+		setApiKeyId,
+		folderSheet,
+		setFolderSheet,
+		promptSheet,
+		setPromptSheet,
+		commitSheet,
+		setCommitSheet,
+		deleteFolderDialog,
+		setDeleteFolderDialog,
+		deletePromptDialog,
+		setDeletePromptDialog,
+		isDeletingFolder,
+		isDeletingPrompt,
+		supportsVision,
+		hasChanges,
+		handleSelectPrompt,
+		handleMovePrompt,
+		handleDeleteFolder,
+		handleDeletePrompt,
+		handleSendMessage,
+		handleSubmitToolResult,
+	};
+
+	return <PromptContext.Provider value={value}>{children}</PromptContext.Provider>;
+}

--- a/ui/components/prompts/fragments/playgroundPanel.tsx
+++ b/ui/components/prompts/fragments/playgroundPanel.tsx
@@ -1,0 +1,17 @@
+import { ScrollArea } from "@/components/ui/scrollArea";
+import { useRef } from "react";
+import { MessagesView } from "../components/messagesView/rootMessageView";
+import { NewMessageInputView } from "../components/newMessageInputView";
+
+export function PlaygroundPanel() {
+	const scrollAreaRef = useRef<HTMLDivElement>(null);
+
+	return (
+		<div className="custom-scrollbar relative flex h-full flex-col overscroll-none">
+			<ScrollArea className="flex-1 overflow-y-auto" ref={scrollAreaRef} viewportClassName="no-table">
+				<MessagesView />
+			</ScrollArea>
+			<NewMessageInputView />
+		</div>
+	);
+}

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -1,0 +1,276 @@
+import { Combobox, ComboboxInput, ComboboxContent, ComboboxList, ComboboxItem, ComboboxGroup, ComboboxLabel, ComboboxSeparator, ComboboxSelect } from '@/components/ui/combobox'
+import { Label } from '@/components/ui/label'
+import { ScrollArea } from '@/components/ui/scrollArea'
+import { Separator } from '@/components/ui/separator'
+import ModelParameters from '@/components/ui/custom/modelParameters'
+import { ModelParams } from '@/lib/types/prompts'
+import { getProviderLabel } from '@/lib/constants/logs'
+import { useGetAllKeysQuery, useGetProvidersQuery, useLazyGetModelsQuery } from '@/lib/store/apis/providersApi'
+import { useGetVirtualKeysQuery } from '@/lib/store'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ModelProviderName } from '@/lib/types/config'
+import type { DBKey, VirtualKey } from '@/lib/types/governance'
+import { usePromptContext } from '../context'
+
+export function SettingsPanel() {
+  const {
+    provider,
+    setProvider,
+    model,
+    setModel: onModelChange,
+    modelParams,
+    setModelParams: onModelParamsChange,
+    apiKeyId,
+    
+    setApiKeyId,
+  } = usePromptContext()
+
+  const onProviderChange = useCallback((p: string) => {
+    setProvider(p)
+    setApiKeyId('__auto__')
+    onModelChange('')
+    onModelParamsChange({} as ModelParams)
+  }, [setProvider, setApiKeyId, onModelChange, onModelParamsChange])
+
+  const onApiKeyIdChange = useCallback((id: string) => {
+    setApiKeyId(id)
+  }, [setApiKeyId])
+  // Dynamic providers
+  const { data: providers } = useGetProvidersQuery()
+  const configuredProviders = useMemo(
+    () => (providers ?? []).filter((p) => p.keys && p.keys.length > 0),
+    [providers]
+  )
+
+  // Ensure current provider always has a label-resolved option (even before providers query loads)
+  const providerOptions = useMemo(() => {
+    const opts = configuredProviders.map((p) => ({ label: getProviderLabel(p.name), value: p.name }))
+    if (provider && !opts.find((o) => o.value === provider)) {
+      opts.unshift({ label: getProviderLabel(provider), value: provider as ModelProviderName })
+    }
+    return opts
+  }, [configuredProviders, provider])
+
+  // Get keys from the provider config (has models[] per key)
+  const selectedProvider = useMemo(
+    () => configuredProviders.find((p) => p.name === provider),
+    [configuredProviders, provider]
+  )
+  const providerKeyConfigs = useMemo(() => selectedProvider?.keys ?? [], [selectedProvider])
+
+  // Keys for the API Key selector (from /api/keys endpoint, provider-filtered)
+  const { data: allKeys } = useGetAllKeysQuery()
+  const providerKeys = useMemo(
+    () => (allKeys ?? []).filter((k) => k.provider === provider),
+    [allKeys, provider]
+  )
+
+  // Virtual keys filtered by selected provider
+  const { data: virtualKeysData } = useGetVirtualKeysQuery()
+  const providerVirtualKeys = useMemo(() => {
+    const vks = virtualKeysData?.virtual_keys ?? []
+    return vks.filter((vk) => {
+      if (!vk.is_active) return false
+      // No provider configs means all providers are allowed (wildcard)
+      if (!vk.provider_configs || vk.provider_configs.length === 0) return true
+      // Check if selected provider is in the configured providers
+      return vk.provider_configs.some((pc) => pc.provider === provider)
+    })
+  }, [virtualKeysData, provider])
+
+  // Fallback: fetch all models for this provider (used when any key has no models restriction)
+  const [fetchModels, { data: modelsData }] = useLazyGetModelsQuery()
+  useEffect(() => {
+    if (provider) {
+      fetchModels({ provider, limit: 100, unfiltered: true })
+    }
+  }, [provider, fetchModels])
+  const allProviderModels = useMemo(
+    () => (modelsData?.models ?? []).map((m) => m.name),
+    [modelsData]
+  )
+
+  // Build model list based on key selection
+  const availableModels = useMemo(() => {
+    if (apiKeyId !== '__auto__') {
+      // Specific key selected — find it in provider config
+      const key = providerKeyConfigs.find((k) => k.id === apiKeyId)
+      if (key?.models && key.models.length > 0) {
+        return key.models
+      }
+      // Key has no model restriction → show all
+      return allProviderModels
+    }
+
+    // Auto mode — blend models from all keys
+    // If any key has empty models (no restriction), show all models
+    const hasUnrestrictedKey = providerKeyConfigs.some(
+      (k) => !k.models || k.models.length === 0
+    )
+    if (hasUnrestrictedKey || providerKeyConfigs.length === 0) {
+      return allProviderModels
+    }
+
+    // All keys have specific models — show unique union
+    const modelSet = new Set<string>()
+    for (const k of providerKeyConfigs) {
+      for (const m of k.models ?? []) {
+        modelSet.add(m)
+      }
+    }
+    return Array.from(modelSet)
+  }, [apiKeyId, providerKeyConfigs, allProviderModels])
+
+  const handleModelParamsChange = useCallback(
+    (params: Record<string, any>) => {
+      onModelParamsChange(params as ModelParams)
+    },
+    [onModelParamsChange]
+  )
+
+  return (
+    <div className="flex h-full flex-col">
+      <ScrollArea className="grow overflow-y-auto" viewportClassName='no-table'>
+        <div className="space-y-6 p-4">
+          {/* Provider Selector */}
+          <div className="flex flex-col gap-2">
+            <Label className="text-muted-foreground text-xs font-medium uppercase">Provider</Label>
+            <ComboboxSelect
+              options={providerOptions}
+              value={provider}
+              onValueChange={(v) => v && onProviderChange(v)}
+              placeholder="Select provider"
+              hideClear
+            />
+          </div>
+
+          {/* Model Selector */}
+          <div className="flex flex-col gap-2">
+            <Label className="text-muted-foreground text-xs font-medium uppercase">Model</Label>
+            <ComboboxSelect
+              options={availableModels.map((m) => ({ label: m, value: m }))}
+              value={model}
+              onValueChange={(v) => v && onModelChange(v)}
+              placeholder="Select model"
+              hideClear
+            />
+          </div>
+
+          {/* API Key / Virtual Key Selector */}
+          {(providerKeys.length > 0 || providerVirtualKeys.length > 0) && (
+            <div className="flex flex-col gap-2">
+              <Label className="text-muted-foreground text-xs font-medium uppercase">API Key</Label>
+              <ApiKeyCombobox
+                providerKeys={providerKeys}
+                virtualKeys={providerVirtualKeys}
+                value={apiKeyId}
+                onValueChange={(v) => onApiKeyIdChange(v ?? '__auto__')}
+              />
+            </div>
+          )}
+
+          <Separator />
+
+          {/* Model Parameters */}
+          <div className="flex flex-col gap-4">
+            <Label className="text-muted-foreground text-xs font-medium uppercase">Model Parameters</Label>
+            <ModelParameters
+              model={model}
+              config={modelParams}
+              onChange={handleModelParamsChange}
+              hideFields={['promptTools']}
+            />
+          </div>
+        </div>
+      </ScrollArea>
+
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Grouped API Key + Virtual Key combobox
+// ---------------------------------------------------------------------------
+
+function ApiKeyCombobox({
+  providerKeys,
+  virtualKeys,
+  value,
+  onValueChange,
+}: {
+  providerKeys: DBKey[]
+  virtualKeys: VirtualKey[]
+  value: string
+  onValueChange: (v: string | null) => void
+}) {
+  const [query, setQuery] = useState('')
+
+  const allOptions = useMemo(() => {
+    const apiKeyOpts = providerKeys.map((k) => ({ label: k.name, value: k.key_id, group: 'api' as const }))
+    const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: vk.value, group: 'virtual' as const }))
+    return [{ label: 'Auto (default)', value: '__auto__', group: 'api' as const }, ...apiKeyOpts, ...vkOpts]
+  }, [providerKeys, virtualKeys])
+
+  const filtered = useMemo(() => {
+    if (!query) return allOptions
+    const q = query.toLowerCase()
+    return allOptions.filter((o) => o.label.toLowerCase().includes(q))
+  }, [allOptions, query])
+
+  const filteredApiKeys = useMemo(() => filtered.filter((o) => o.group === 'api'), [filtered])
+  const filteredVirtualKeys = useMemo(() => filtered.filter((o) => o.group === 'virtual'), [filtered])
+
+  const getLabel = useCallback(
+    (val: string | null) => allOptions.find((o) => o.value === val)?.label ?? val ?? '',
+    [allOptions]
+  )
+
+  return (
+    <Combobox
+      value={value}
+      onValueChange={(v) => onValueChange(v)}
+      onOpenChange={(open) => { if (open) setQuery('') }}
+      onInputValueChange={(v) => setQuery(v)}
+      filter={null}
+      itemToStringLabel={getLabel}
+    >
+      <ComboboxInput
+        placeholder="Select API key"
+        showClear={value !== '__auto__'}
+        showTrigger
+      />
+      <ComboboxContent>
+        <ComboboxList>
+          {filteredApiKeys.length > 0 && (
+            <ComboboxGroup>
+              <ComboboxLabel>API Keys</ComboboxLabel>
+              {filteredApiKeys.map((o) => (
+                <ComboboxItem key={o.value} value={o.value}>
+                  {o.label}
+                </ComboboxItem>
+              ))}
+            </ComboboxGroup>
+          )}
+          {filteredApiKeys.length > 0 && filteredVirtualKeys.length > 0 && (
+            <ComboboxSeparator />
+          )}
+          {filteredVirtualKeys.length > 0 && (
+            <ComboboxGroup>
+              <ComboboxLabel>Virtual Keys</ComboboxLabel>
+              {filteredVirtualKeys.map((o) => (
+                <ComboboxItem key={o.value} value={o.value}>
+                  {o.label}
+                </ComboboxItem>
+              ))}
+            </ComboboxGroup>
+          )}
+          {filtered.length === 0 && (
+            <div className="text-muted-foreground py-6 text-center text-sm">
+              No results found.
+            </div>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  )
+}

--- a/ui/components/prompts/fragments/sidebar.tsx
+++ b/ui/components/prompts/fragments/sidebar.tsx
@@ -1,0 +1,470 @@
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scrollArea";
+import { cn } from "@/lib/utils";
+import { Folder, Prompt } from "@/lib/types/prompts";
+import {
+	ChevronDown,
+	ChevronRight,
+	FileText,
+	Folder as FolderIcon,
+	FolderOpen,
+	MoreHorizontal,
+	Pencil,
+	Plus,
+	PlusIcon,
+	Search,
+	Trash2,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import { DragDropProvider, useDraggable, useDroppable } from "@dnd-kit/react";
+import { usePromptContext } from "../context";
+
+export function PromptSidebar() {
+	const {
+		folders,
+		prompts,
+		selectedPromptId,
+		handleSelectPrompt: onSelectPrompt,
+		setFolderSheet,
+		setDeleteFolderDialog,
+		setPromptSheet,
+		setDeletePromptDialog,
+		handleMovePrompt: onMovePrompt,
+	} = usePromptContext();
+
+	const onCreateFolder = useCallback(() => setFolderSheet({ open: true }), [setFolderSheet]);
+	const onEditFolder = useCallback((folder: Folder) => setFolderSheet({ open: true, folder }), [setFolderSheet]);
+	const onDeleteFolder = useCallback((folder: Folder) => setDeleteFolderDialog({ open: true, folder }), [setDeleteFolderDialog]);
+	const onCreatePrompt = useCallback((folderId?: string) => setPromptSheet({ open: true, folderId }), [setPromptSheet]);
+	const onEditPrompt = useCallback((prompt: Prompt) => setPromptSheet({ open: true, prompt }), [setPromptSheet]);
+	const onDeletePrompt = useCallback((prompt: Prompt) => setDeletePromptDialog({ open: true, prompt }), [setDeletePromptDialog]);
+	const pathname = usePathname();
+	const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set());
+	const [searchQuery, setSearchQuery] = useState("");
+	const [dragOverTarget, setDragOverTarget] = useState<string | null>(null);
+
+	// Auto-expand the folder containing the selected prompt
+	useEffect(() => {
+		if (!selectedPromptId) return;
+		const prompt = prompts.find((p) => p.id === selectedPromptId);
+		if (prompt?.folder_id) {
+			setExpandedFolders((prev) => {
+				if (prev.has(prompt.folder_id!)) return prev;
+				const next = new Set(prev);
+				next.add(prompt.folder_id!);
+				return next;
+			});
+		}
+	}, [selectedPromptId, prompts]);
+
+	const toggleFolder = useCallback((folderId: string) => {
+		setExpandedFolders((prev) => {
+			const next = new Set(prev);
+			if (next.has(folderId)) {
+				next.delete(folderId);
+			} else {
+				next.add(folderId);
+			}
+			return next;
+		});
+	}, []);
+
+	// Group prompts by folder, root prompts have no folder_id
+	const { promptsByFolder, rootPrompts } = useMemo(() => {
+		const map = new Map<string, Prompt[]>();
+		const root: Prompt[] = [];
+		for (const prompt of prompts) {
+			if (!prompt.folder_id) {
+				root.push(prompt);
+			} else {
+				const list = map.get(prompt.folder_id) || [];
+				list.push(prompt);
+				map.set(prompt.folder_id, list);
+			}
+		}
+		return { promptsByFolder: map, rootPrompts: root };
+	}, [prompts]);
+
+	// Filter folders and prompts based on search
+	const filteredData = useMemo(() => {
+		if (!searchQuery.trim()) {
+			return { folders, promptsByFolder, rootPrompts };
+		}
+
+		const query = searchQuery.toLowerCase();
+		const matchedFolderIds = new Set<string>();
+		const filteredPromptsByFolder = new Map<string, Prompt[]>();
+		const filteredRootPrompts: Prompt[] = [];
+
+		for (const prompt of prompts) {
+			if (prompt.name.toLowerCase().includes(query)) {
+				if (!prompt.folder_id) {
+					filteredRootPrompts.push(prompt);
+				} else {
+					matchedFolderIds.add(prompt.folder_id);
+					const list = filteredPromptsByFolder.get(prompt.folder_id) || [];
+					list.push(prompt);
+					filteredPromptsByFolder.set(prompt.folder_id, list);
+				}
+			}
+		}
+
+		const filteredFolders = folders.filter((folder) => folder.name.toLowerCase().includes(query) || matchedFolderIds.has(folder.id));
+
+		return { folders: filteredFolders, promptsByFolder: filteredPromptsByFolder, rootPrompts: filteredRootPrompts };
+	}, [folders, prompts, promptsByFolder, rootPrompts, searchQuery]);
+
+	const getPromptHref = useCallback(
+		(promptId: string) => {
+			return `${pathname}?promptId=${encodeURIComponent(promptId)}`;
+		},
+		[pathname],
+	);
+
+	// Prompt lookup for drag events
+	const promptMap = useMemo(() => {
+		const map = new Map<string, Prompt>();
+		for (const p of prompts) map.set(p.id, p);
+		return map;
+	}, [prompts]);
+
+	return (
+		<DragDropProvider
+			onDragOver={(event) => {
+				const targetId = event.operation.target?.id as string | undefined;
+				setDragOverTarget(targetId ?? null);
+			}}
+			onDragEnd={(event) => {
+				setDragOverTarget(null);
+				if (event.canceled || !onMovePrompt) return;
+
+				const sourceId = event.operation.source?.id as string | undefined;
+				const targetId = event.operation.target?.id as string | undefined;
+				if (!sourceId || !targetId) return;
+
+				const promptId = sourceId.startsWith("prompt-") ? sourceId.slice(7) : null;
+				if (!promptId) return;
+
+				const prompt = promptMap.get(promptId);
+				if (!prompt) return;
+
+				let targetFolderId: string | null = null;
+				if (targetId === "root-drop-zone") {
+					targetFolderId = null;
+				} else if (targetId.startsWith("folder-")) {
+					targetFolderId = targetId.slice(7);
+				} else {
+					return;
+				}
+				if ((prompt.folder_id ?? null) === targetFolderId) return;
+				onMovePrompt(promptId, targetFolderId);
+			}}
+		>
+			<div className="flex h-full flex-col">
+				{/* Search */}
+				<div className="flex items-center gap-2 border-b p-3">
+					<div className="relative grow">
+						<Search className="text-muted-foreground absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
+						<Input
+							placeholder="Search prompts..."
+							value={searchQuery}
+							onChange={(e) => setSearchQuery(e.target.value)}
+							className="h-8 pl-8"
+						/>
+					</div>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button variant="outline" className="h-8 w-8 shrink-0 bg-transparent" aria-label="Create prompt or folder">
+								<PlusIcon className="h-3.5 w-3.5" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end">
+							<DropdownMenuItem
+								onClick={(e) => {
+									e.stopPropagation();
+									onCreatePrompt();
+								}}
+							>
+								New Prompt
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={(e) => {
+									e.stopPropagation();
+									onCreateFolder();
+								}}
+							>
+								New Folder
+							</DropdownMenuItem>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</div>
+
+				{/* Tree content */}
+				<ScrollArea className="grow overflow-y-auto" viewportClassName="no-table viewport-table-height-full">
+					<div className="flex h-full flex-col p-2">
+						{filteredData.folders.length === 0 && filteredData.rootPrompts.length === 0 ? (
+							<div className="text-muted-foreground py-8 text-center text-sm">{searchQuery ? "No results found" : "No prompts yet"}</div>
+						) : (
+							<>
+								{filteredData.folders.map((folder) => (
+									<DroppableFolder
+										key={folder.id}
+										folder={folder}
+										prompts={filteredData.promptsByFolder.get(folder.id) || promptsByFolder.get(folder.id) || []}
+										isExpanded={expandedFolders.has(folder.id) || !!searchQuery}
+										isDragOver={dragOverTarget === `folder-${folder.id}`}
+										selectedPromptId={selectedPromptId}
+										onToggle={() => toggleFolder(folder.id)}
+										onSelectPrompt={onSelectPrompt}
+										getPromptHref={getPromptHref}
+										onEdit={() => onEditFolder(folder)}
+										onDelete={() => onDeleteFolder(folder)}
+										onCreatePrompt={() => onCreatePrompt(folder.id)}
+										onEditPrompt={onEditPrompt}
+										onDeletePrompt={onDeletePrompt}
+									/>
+								))}
+								<RootDropZone
+									isDragOver={dragOverTarget === "root-drop-zone"}
+									rootPrompts={filteredData.rootPrompts}
+									selectedPromptId={selectedPromptId}
+									getPromptHref={getPromptHref}
+									onSelectPrompt={onSelectPrompt}
+									onEditPrompt={onEditPrompt}
+									onDeletePrompt={onDeletePrompt}
+								/>
+							</>
+						)}
+					</div>
+				</ScrollArea>
+			</div>
+		</DragDropProvider>
+	);
+}
+
+interface RootDropZoneProps {
+	isDragOver: boolean;
+	rootPrompts: Prompt[];
+	selectedPromptId?: string | null;
+	getPromptHref: (promptId: string) => string;
+	onSelectPrompt: (promptId: string) => void;
+	onEditPrompt: (prompt: Prompt) => void;
+	onDeletePrompt: (prompt: Prompt) => void;
+}
+
+function RootDropZone({
+	isDragOver,
+	rootPrompts,
+	selectedPromptId,
+	getPromptHref,
+	onSelectPrompt,
+	onEditPrompt,
+	onDeletePrompt,
+}: RootDropZoneProps) {
+	const { ref } = useDroppable({ id: "root-drop-zone" });
+
+	return (
+		<div ref={ref} className={cn("min-h-[8px] grow rounded-md transition-colors", isDragOver && "bg-primary/10 ring-primary/30 ring-1")}>
+			{rootPrompts.map((prompt) => (
+				<DraggablePromptItem
+					key={prompt.id}
+					prompt={prompt}
+					isSelected={selectedPromptId === prompt.id}
+					href={getPromptHref(prompt.id)}
+					onSelect={() => onSelectPrompt(prompt.id)}
+					onEdit={() => onEditPrompt(prompt)}
+					onDelete={() => onDeletePrompt(prompt)}
+				/>
+			))}
+		</div>
+	);
+}
+
+interface DroppableFolderProps {
+	folder: Folder;
+	prompts: Prompt[];
+	isExpanded: boolean;
+	isDragOver: boolean;
+	selectedPromptId?: string | null;
+	onToggle: () => void;
+	onSelectPrompt: (promptId: string) => void;
+	getPromptHref: (promptId: string) => string;
+	onEdit: () => void;
+	onDelete: () => void;
+	onCreatePrompt: () => void;
+	onEditPrompt: (prompt: Prompt) => void;
+	onDeletePrompt: (prompt: Prompt) => void;
+}
+
+function DroppableFolder({
+	folder,
+	prompts,
+	isExpanded,
+	isDragOver,
+	selectedPromptId,
+	onToggle,
+	onSelectPrompt,
+	getPromptHref,
+	onEdit,
+	onDelete,
+	onCreatePrompt,
+	onEditPrompt,
+	onDeletePrompt,
+}: DroppableFolderProps) {
+	const { ref } = useDroppable({ id: `folder-${folder.id}` });
+
+	return (
+		<div ref={ref} className="mb-1">
+			<div
+				className={cn(
+					"hover:bg-muted/50 group relative flex cursor-pointer items-center gap-1 rounded-md px-2 py-1.5 transition-colors",
+					isDragOver && "bg-primary/10 ring-primary/30 ring-1",
+				)}
+				onClick={onToggle}
+			>
+				<button className="flex shrink-0 items-center" aria-label="Toggle folder">
+					{isExpanded ? (
+						<ChevronDown className="text-muted-foreground h-4 w-4" />
+					) : (
+						<ChevronRight className="text-muted-foreground h-4 w-4" />
+					)}
+				</button>
+				{isExpanded ? (
+					<FolderOpen className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+				) : (
+					<FolderIcon className="text-muted-foreground mr-2 h-4 w-4 shrink-0" />
+				)}
+				<span className="flex-1 truncate text-sm font-medium">{folder.name}</span>
+				<span className="text-muted-foreground mr-1 shrink-0 text-xs">{prompts.length}</span>
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()} className="bg-card absolute top-1/2 right-2 -translate-y-1/2">
+						<Button variant="ghost" size="icon" className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100" aria-label="Folder actions">
+							<MoreHorizontal className="h-4 w-4" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end">
+						<DropdownMenuItem
+							onClick={(e) => {
+								e.stopPropagation();
+								onCreatePrompt();
+							}}
+						>
+							<Plus className="mr-2 h-4 w-4" />
+							New Prompt
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							onClick={(e) => {
+								e.stopPropagation();
+								onEdit();
+							}}
+						>
+							<Pencil className="mr-2 h-4 w-4" />
+							Edit Folder
+						</DropdownMenuItem>
+						<DropdownMenuItem
+							className="text-destructive"
+							onClick={(e) => {
+								e.stopPropagation();
+								onDelete();
+							}}
+						>
+							<Trash2 className="mr-2 h-4 w-4" />
+							Delete Folder
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+
+			{isExpanded && (
+				<div className="ml-4 border-l pl-2">
+					{prompts.length === 0 ? (
+						<div className="text-muted-foreground py-2 pl-4 text-xs">{isDragOver ? "Drop here" : "No prompts"}</div>
+					) : (
+						prompts.map((prompt) => (
+							<DraggablePromptItem
+								key={prompt.id}
+								prompt={prompt}
+								isSelected={selectedPromptId === prompt.id}
+								href={getPromptHref(prompt.id)}
+								onSelect={() => onSelectPrompt(prompt.id)}
+								onEdit={() => onEditPrompt(prompt)}
+								onDelete={() => onDeletePrompt(prompt)}
+							/>
+						))
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+interface DraggablePromptItemProps {
+	prompt: Prompt;
+	isSelected: boolean;
+	href: string;
+	onSelect: () => void;
+	onEdit: () => void;
+	onDelete: () => void;
+}
+
+function DraggablePromptItem({ prompt, isSelected, href, onSelect, onEdit, onDelete }: DraggablePromptItemProps) {
+	const { ref, isDragging } = useDraggable({ id: `prompt-${prompt.id}` });
+
+	return (
+		<div
+			ref={ref}
+			className={cn(
+				"group flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5",
+				isSelected ? "bg-primary/10 text-primary" : "hover:bg-muted/50",
+				isDragging && "opacity-50",
+			)}
+			onClick={(e) => {
+				// Don't navigate if this was a drag
+				if (isDragging) return;
+				onSelect();
+			}}
+		>
+			<FileText className="h-4 w-4 shrink-0" />
+			<span className="flex-1 truncate text-sm">{prompt.name}</span>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+					<Button variant="ghost" size="icon" className="h-6 w-6 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 group-focus-within:opacity-100" aria-label="Prompt actions">
+						<MoreHorizontal className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem
+						className="cursor-pointer"
+						onClick={(e) => {
+							e.stopPropagation();
+							onEdit();
+						}}
+					>
+						<Pencil className="h-4 w-4" />
+						Rename
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						className="text-destructive hover:text-destructive cursor-pointer"
+						onClick={(e) => {
+							e.stopPropagation();
+							onDelete();
+						}}
+					>
+						<Trash2 className="text-destructive h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/ui/components/prompts/promptsView.tsx
+++ b/ui/components/prompts/promptsView.tsx
@@ -1,0 +1,73 @@
+import FullPageLoader from "@/components/fullPageLoader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { PromptSidebar } from "./fragments/sidebar";
+import { PlaygroundPanel } from "./fragments/playgroundPanel";
+import { SettingsPanel } from "./fragments/settingsPanel";
+import { DeleteFolderDialog, DeletePromptDialog } from "./components/alerts";
+import { PromptSheets } from "./components/sheets";
+import { EmptyState } from "./components/emptyState";
+import PromptsViewHeader from "./components/promptsViewHeader";
+import { usePromptContext } from "./context";
+
+export default function PromptsView() {
+	const { foldersLoading, promptsLoading, foldersError, promptsError, isLoadingPlayground, selectedPromptId } = usePromptContext();
+
+	if (foldersLoading || promptsLoading) {
+		return <FullPageLoader />;
+	}
+	
+	if (foldersError || promptsError) {
+		return (
+			<div className="no-padding-parent no-border-parent p-4">
+				<Alert variant="destructive">
+					<AlertCircle className="h-4 w-4" />
+					<AlertDescription>Failed to load prompt repository</AlertDescription>
+				</Alert>
+			</div>
+		);
+	}
+
+	return (
+		<div className="no-padding-parent no-border-parent bg-background h-[calc(100dvh_-_18px)] w-full">
+			<DeleteFolderDialog />
+			<DeletePromptDialog />
+			<PromptSheets />
+
+			<ResizablePanelGroup direction="horizontal" className="h-full">
+				<ResizablePanel defaultSize={20} className="bg-card mr-1 overflow-hidden rounded-r-md rounded-br-none">
+					<PromptSidebar />
+				</ResizablePanel>
+
+				<ResizableHandle className="mr-1 bg-transparent" />
+
+				<ResizablePanel defaultSize={80} minSize={50} className="bg-card overflow-hidden rounded-md rounded-bl-none">
+					{selectedPromptId ? (
+						<div className="flex h-full flex-col">
+							<PromptsViewHeader />
+
+							{isLoadingPlayground ? (
+								<div className="flex flex-1 items-center justify-center">
+									<Loader2 className="text-muted-foreground h-5 w-5 animate-spin" />
+								</div>
+							) : (
+								<ResizablePanelGroup direction="horizontal" className="flex-1">
+									<ResizablePanel defaultSize={70} minSize={40}>
+										<PlaygroundPanel />
+									</ResizablePanel>
+									<ResizableHandle />
+									<ResizablePanel defaultSize={30} minSize={20}>
+										<SettingsPanel />
+									</ResizablePanel>
+								</ResizablePanelGroup>
+							)}
+						</div>
+					) : (
+						<EmptyState />
+					)}
+				</ResizablePanel>
+			</ResizablePanelGroup>
+		</div>
+	);
+}

--- a/ui/components/prompts/sheets/commitVersionSheet.tsx
+++ b/ui/components/prompts/sheets/commitVersionSheet.tsx
@@ -1,0 +1,104 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet'
+import { getErrorMessage } from '@/lib/store'
+import { useCommitSessionMutation } from '@/lib/store/apis/promptsApi'
+import { PromptSession } from '@/lib/types/prompts'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+
+interface CommitVersionFormData {
+  commitMessage: string
+}
+
+interface CommitVersionSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  session: PromptSession
+  onCommitted: (versionId: number) => void
+}
+
+export function CommitVersionSheet({ open, onOpenChange, session, onCommitted }: CommitVersionSheetProps) {
+  const [commitSession, { isLoading }] = useCommitSessionMutation()
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<CommitVersionFormData>({
+    defaultValues: { commitMessage: '' },
+  })
+
+  useEffect(() => {
+    if (open) {
+      reset({ commitMessage: '' })
+    }
+  }, [open, reset])
+
+  async function onSubmit(data: CommitVersionFormData) {
+    try {
+      const result = await commitSession({
+        id: session.id,
+        promptId: session.prompt_id,
+        data: { commit_message: data.commitMessage.trim() },
+      }).unwrap()
+      toast.success('Version committed')
+      reset()
+      onCommitted(result.version.id)
+      onOpenChange(false)
+    } catch (err) {
+      toast.error('Failed to commit version', {
+        description: getErrorMessage(err),
+      })
+    }
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className='p-8' onOpenAutoFocus={(e) => { e.preventDefault(); document.getElementById("commitMessage")?.focus(); }}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <SheetHeader className='flex flex-col items-start'>
+            <SheetTitle>Commit as Version</SheetTitle>
+            <SheetDescription>
+              Create a new immutable version from the current session. Versions cannot be modified after creation.
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-6 space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="commitMessage">Commit Message</Label>
+              <Input
+                id="commitMessage"
+                placeholder="Added system message for better context..."
+                {...register('commitMessage', {
+                  required: 'Commit message is required',
+                  validate: (v) => v.trim().length > 0 || 'Commit message cannot be blank',
+                })}
+                autoFocus
+              />
+              {errors.commitMessage ? (
+                <p className="text-destructive text-xs">{errors.commitMessage.message}</p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  Describe what changed in this version (e.g., "Added error handling instructions")
+                </p>
+              )}
+            </div>
+          </div>
+
+          <SheetFooter className="mt-6 p-0 flex flex-row items-center justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Committing...' : 'Commit Version'}
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/ui/components/prompts/sheets/folderSheet.tsx
+++ b/ui/components/prompts/sheets/folderSheet.tsx
@@ -1,0 +1,123 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { getErrorMessage } from "@/lib/store";
+import { useCreateFolderMutation, useUpdateFolderMutation } from "@/lib/store/apis/promptsApi";
+import { Folder } from "@/lib/types/prompts";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+interface FolderFormData {
+	name: string;
+	description: string;
+}
+
+interface FolderSheetProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	folder?: Folder;
+	onSaved: () => void;
+}
+
+export function FolderSheet({ open, onOpenChange, folder, onSaved }: FolderSheetProps) {
+	const [createFolder, { isLoading: isCreating }] = useCreateFolderMutation();
+	const [updateFolder, { isLoading: isUpdating }] = useUpdateFolderMutation();
+
+	const isLoading = isCreating || isUpdating;
+	const isEditing = !!folder;
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<FolderFormData>({
+		defaultValues: { name: "", description: "" },
+	});
+
+	useEffect(() => {
+		if (open) {
+			reset({
+				name: folder?.name ?? "",
+				description: folder?.description ?? "",
+			});
+		}
+	}, [open, folder, reset]);
+
+	async function onSubmit(data: FolderFormData) {
+		try {
+			if (isEditing) {
+				await updateFolder({
+					id: folder.id,
+					data: { name: data.name.trim(), description: data.description.trim() || undefined },
+				}).unwrap();
+				toast.success("Folder updated");
+			} else {
+				await createFolder({
+					name: data.name.trim(),
+					description: data.description.trim() || undefined,
+				}).unwrap();
+				toast.success("Folder created");
+			}
+			onSaved();
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(`Failed to ${isEditing ? "update" : "create"} folder`, {
+				description: getErrorMessage(err),
+			});
+		}
+	}
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent className="p-8" onOpenAutoFocus={(e) => { e.preventDefault(); document.getElementById("name")?.focus(); }}>
+				<form onSubmit={handleSubmit(onSubmit)}>
+					<SheetHeader className="flex flex-col items-start">
+						<SheetTitle>{isEditing ? "Edit Folder" : "Create Folder"}</SheetTitle>
+						<SheetDescription>
+							{isEditing ? "Update the folder name and description." : "Create a new folder to organize your prompts."}
+						</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-4">
+						<div className="space-y-2">
+							<Label htmlFor="name">Name</Label>
+							<Input
+								id="name"
+								placeholder="My Prompts"
+								{...register("name", {
+									required: "Folder name is required",
+									validate: (v) => v.trim().length > 0 || "Folder name cannot be blank",
+								})}
+								autoFocus
+							/>
+							{errors.name && <p className="text-destructive text-xs">{errors.name.message}</p>}
+						</div>
+
+						<div className="space-y-2">
+							<Label htmlFor="description">Description (optional)</Label>
+							<Textarea
+								id="description"
+								placeholder="Prompts for customer support use cases..."
+								className="resize-none"
+								{...register("description")}
+							/>
+						</div>
+					</div>
+
+					<SheetFooter className="mt-6 flex flex-row items-center justify-end gap-2 p-0">
+						<Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={isLoading}>
+							{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+						</Button>
+					</SheetFooter>
+				</form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/components/prompts/sheets/promptSheet.tsx
+++ b/ui/components/prompts/sheets/promptSheet.tsx
@@ -1,0 +1,108 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Sheet, SheetContent, SheetDescription, SheetFooter, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { getErrorMessage } from "@/lib/store";
+import { useCreatePromptMutation, useUpdatePromptMutation } from "@/lib/store/apis/promptsApi";
+import { Prompt } from "@/lib/types/prompts";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+interface PromptFormData {
+	name: string;
+}
+
+interface PromptSheetProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	prompt?: Prompt;
+	folderId?: string;
+	onSaved: (promptId?: string) => void;
+}
+
+export function PromptSheet({ open, onOpenChange, prompt, folderId, onSaved }: PromptSheetProps) {
+	const [createPrompt, { isLoading: isCreating }] = useCreatePromptMutation();
+	const [updatePrompt, { isLoading: isUpdating }] = useUpdatePromptMutation();
+
+	const isLoading = isCreating || isUpdating;
+	const isEditing = !!prompt;
+
+	const {
+		register,
+		handleSubmit,
+		reset,
+		formState: { errors },
+	} = useForm<PromptFormData>({
+		defaultValues: { name: "" },
+	});
+
+	useEffect(() => {
+		if (open) {
+			reset({ name: prompt?.name ?? "" });
+		}
+	}, [open, prompt, reset]);
+
+	async function onSubmit(data: PromptFormData) {
+		try {
+			if (isEditing) {
+				await updatePrompt({
+					id: prompt.id,
+					data: { name: data.name.trim() },
+				}).unwrap();
+				toast.success("Prompt updated");
+				onSaved();
+			} else {
+				const result = await createPrompt({
+					name: data.name.trim(),
+					...(folderId ? { folder_id: folderId } : {}),
+				}).unwrap();
+				toast.success("Prompt created");
+				onSaved(result.prompt.id);
+			}
+			onOpenChange(false);
+		} catch (err) {
+			toast.error(`Failed to ${isEditing ? "update" : "create"} prompt`, {
+				description: getErrorMessage(err),
+			});
+		}
+	}
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			<SheetContent className="p-8" onOpenAutoFocus={(e) => { e.preventDefault(); document.getElementById("name")?.focus(); }}>
+				<form onSubmit={handleSubmit(onSubmit)}>
+					<SheetHeader className="flex flex-col items-start">
+						<SheetTitle>{isEditing ? "Rename Prompt" : "Create Prompt"}</SheetTitle>
+						<SheetDescription>{isEditing ? "Update the prompt name." : folderId ? "Create a new prompt in this folder." : "Create a new prompt."}</SheetDescription>
+					</SheetHeader>
+
+					<div className="mt-6 space-y-4">
+						<div className="space-y-2">
+							<Label htmlFor="name">Name</Label>
+							<Input
+								id="name"
+								placeholder="Customer Support Assistant"
+								{...register("name", {
+									required: "Prompt name is required",
+									validate: (v) => v.trim().length > 0 || "Prompt name cannot be blank",
+								})}
+								autoFocus
+							/>
+							{errors.name && <p className="text-destructive text-xs">{errors.name.message}</p>}
+						</div>
+					</div>
+
+					<SheetFooter className="mt-6 flex flex-row items-center justify-end gap-2 p-0">
+						<Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={isLoading}>
+							{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+						</Button>
+					</SheetFooter>
+				</form>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/components/prompts/utils/attachment.ts
+++ b/ui/components/prompts/utils/attachment.ts
@@ -1,0 +1,42 @@
+import { MessageContent } from "@/lib/message";
+
+export function fileToBase64(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result as string);
+		reader.onerror = reject;
+		reader.readAsDataURL(file);
+	});
+}
+
+export async function fileToAttachment(file: File): Promise<MessageContent | null> {
+	if (file.type.startsWith("image/")) {
+		const dataUrl = await fileToBase64(file);
+		return {
+			type: "image_url",
+			image_url: { url: dataUrl, detail: "auto" },
+		};
+	}
+
+	if (file.type.startsWith("audio/")) {
+		const dataUrl = await fileToBase64(file);
+		// Extract base64 data and format from data URL
+		const base64Data = dataUrl.split(",")[1] || "";
+		const format = file.name.split(".").pop() || file.type.split("/")[1] || "wav";
+		return {
+			type: "input_audio",
+			input_audio: { data: base64Data, format },
+		};
+	}
+
+	// Generic file — API expects full data URL with MIME prefix
+	const dataUrl = await fileToBase64(file);
+	return {
+		type: "file",
+		file: {
+			file_data: dataUrl,
+			filename: file.name,
+			file_type: file.type || "application/octet-stream",
+		},
+	};
+}

--- a/ui/components/prompts/utils/executor.ts
+++ b/ui/components/prompts/utils/executor.ts
@@ -1,0 +1,179 @@
+import { Message, type CompletionUsage, type ToolCall } from "@/lib/message";
+import { getErrorMessage } from "@/lib/store";
+import type { ModelParams } from "@/lib/types/prompts";
+
+export interface ExecutionConfig {
+	provider: string;
+	model: string;
+	modelParams: ModelParams;
+	apiKeyId: string;
+}
+
+function getBaseUrl() {
+	if(process.env.NODE_ENV === "development") {
+		return "http://localhost:8080";
+	} else {
+		return "";
+	}
+}
+
+export interface ExecutionCallbacks {
+	onStreamingStart: (allMessages: Message[], placeholder: Message) => void;
+	onStreamChunk: (content: string) => void;
+	onComplete: (content: string, usage?: CompletionUsage) => void;
+	onToolCallComplete: (content: string, toolCalls: ToolCall[], usage?: CompletionUsage) => void;
+	onEmptyResponse: () => void;
+	onError: (error: string) => void;
+	onFinally: () => void;
+}
+
+export async function executePrompt(
+	currentMessages: Message[],
+	pendingMessage: Message | undefined,
+	config: ExecutionConfig,
+	callbacks: ExecutionCallbacks,
+) {
+	let allMessages: Message[];
+	if (pendingMessage) {
+		allMessages = [...currentMessages, pendingMessage];
+	} else {
+		allMessages = [...currentMessages];
+	}
+
+	const placeholder = Message.response("");
+	callbacks.onStreamingStart(allMessages, placeholder);
+
+	try {
+		const headers: Record<string, string> = { "Content-Type": "application/json" };
+		if (config.apiKeyId && config.apiKeyId !== "__auto__") {
+			if (config.apiKeyId.startsWith("sk-bf-")) {
+				headers["Authorization"] = `Bearer ${config.apiKeyId}`;
+			} else {
+				headers["x-bf-api-key-id"] = config.apiKeyId;
+			}
+		}
+
+		const { api_key_id: _, ...requestParams } = config.modelParams;
+		const response = await fetch(`${getBaseUrl()}/v1/chat/completions`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({
+				model: `${config.provider}/${config.model}`,
+				messages: Message.toAPIMessages(allMessages),
+				...requestParams,
+				stream: requestParams.stream ?? true,
+			}),
+		});
+
+		if (!response.ok) {
+			let errorMessage = `HTTP error! status: ${response.status}`;
+			try {
+				const data = await response.json();
+				errorMessage = data.error?.error || data.error?.message || errorMessage;
+			} catch (error) {
+				console.error("Failed to parse error response:", error);
+			}
+			throw new Error(errorMessage);
+		}
+
+		const contentType = response.headers.get("content-type") || "";
+		const isStreamResponse = contentType.includes("text/event-stream");
+
+		if (!isStreamResponse) {
+			const data = await response.json();
+			const content = data.choices?.[0]?.message?.content ?? "";
+			const toolCalls = data.choices?.[0]?.message?.tool_calls as ToolCall[] | undefined;
+			const usage = data.usage as CompletionUsage | undefined;
+			if (toolCalls && toolCalls.length > 0) {
+				callbacks.onToolCallComplete(content, toolCalls, usage);
+			} else if (content) {
+				callbacks.onComplete(content, usage);
+			} else {
+				callbacks.onEmptyResponse();
+			}
+		} else {
+			const reader = response.body?.getReader();
+			if (!reader) throw new Error("No response body");
+
+			const decoder = new TextDecoder();
+			let assistantContent = "";
+			let streamUsage: CompletionUsage | undefined;
+			const toolCallsMap = new Map<number, ToolCall>();
+			let buffer = "";
+
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+
+				buffer += decoder.decode(value, { stream: true });
+				const lines = buffer.split("\n");
+				// Keep the last (potentially incomplete) line in the buffer
+				buffer = lines.pop() ?? "";
+
+				for (const line of lines) {
+					const trimmed = line.trim();
+					if (!trimmed.startsWith("data: ")) continue;
+					const data = trimmed.slice(6);
+					if (data === "[DONE]") continue;
+
+					try {
+						const parsed = JSON.parse(data);
+						const delta = parsed.choices?.[0]?.delta;
+
+						if (parsed.usage) {
+							streamUsage = parsed.usage as CompletionUsage;
+						}
+
+						const content = delta?.content;
+						if (content) {
+							assistantContent += content;
+							callbacks.onStreamChunk(assistantContent);
+						}
+
+						const deltaToolCalls = delta?.tool_calls as Array<{
+							index: number;
+							id?: string;
+							type?: string;
+							function?: { name?: string; arguments?: string };
+						}>;
+						if (deltaToolCalls) {
+							for (const dtc of deltaToolCalls) {
+								const idx = dtc.index;
+								const existing = toolCallsMap.get(idx);
+								if (existing) {
+									if (dtc.function?.arguments) {
+										existing.function.arguments += dtc.function.arguments;
+									}
+								} else {
+									toolCallsMap.set(idx, {
+										type: "function",
+										id: dtc.id ?? "",
+										function: {
+											name: dtc.function?.name ?? "",
+											arguments: dtc.function?.arguments ?? "",
+										},
+									});
+								}
+							}
+						}
+					} catch {
+						// Ignore parse errors
+					}
+				}
+			}
+
+			const toolCalls = Array.from(toolCallsMap.values());
+			if (toolCalls.length > 0) {
+				callbacks.onToolCallComplete(assistantContent, toolCalls, streamUsage);
+			} else if (assistantContent) {
+				callbacks.onComplete(assistantContent, streamUsage);
+			} else {
+				callbacks.onEmptyResponse();
+			}
+		}
+	} catch (err) {
+		callbacks.onError(getErrorMessage(err));
+	} finally {
+		callbacks.onFinally();
+	}
+}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -24,6 +24,7 @@ import {
 	Network,
 	PanelLeftClose,
 	Puzzle,
+	Router,
 	ScrollText,
 	Search,
 	SearchCheck,
@@ -32,6 +33,7 @@ import {
 	ShieldCheck,
 	ShieldUser,
 	Shuffle,
+	SquareTerminal,
 	Telescope,
 	ToolCase,
 	TrendingUp,
@@ -300,9 +302,14 @@ const SidebarItemView = ({
 									}`}
 									onClick={(e) => (subItem.hasAccess === false ? undefined : handleSubItemClick(subItem, e))}
 								>
-									<div className="flex items-center gap-2">
+									<div className="flex w-full items-center gap-2">
 										{SubItemIcon && <SubItemIcon className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`} />}
 										<span className={`text-sm ${isSubItemActive ? "font-medium" : "font-normal"}`}>{subItem.title}</span>
+										{subItem.tag && (
+											<Badge variant="secondary" className="text-muted-foreground leading-normal text-[10px] py-0 font-medium">
+												{subItem.tag}
+											</Badge>
+										)}
 									</div>
 								</SidebarMenuSubButton>
 							</SidebarMenuSubItem>
@@ -616,8 +623,24 @@ export default function AppSidebar() {
 				url: "/workspace/prompt-repo",
 				icon: FolderGit,
 				description: "Prompt repository",
-				// Public access intentional — feature is "coming soon" with no sensitive data; RBAC will be added at GA
 				hasAccess: true,
+				subItems: [
+					{
+						title: "Prompts",
+						url: "/workspace/prompt-repo/prompts",
+						icon: SquareTerminal,
+						description: "Manage prompts",
+						hasAccess: true,
+						tag: "Beta",
+					},
+					{
+						title: "Deployments",
+						url: "/workspace/prompt-repo/deployments",
+						icon: Router,
+						description: "Manage deployment",
+						hasAccess: true,
+					},
+				],
 			},
 			{
 				title: "Evals",


### PR DESCRIPTION
## Summary

Adds a comprehensive prompt management interface with a playground for testing prompts, version control, and session management. This provides users with a visual interface to create, organize, and iterate on prompts with real-time testing capabilities.

## Changes

- Added complete prompt repository UI with folder-based organization and drag-and-drop functionality
- Implemented interactive playground with message composition, streaming responses, and tool call support
- Added version control system for prompts with commit messages and immutable versions
- Created session management for saving and restoring prompt states
- Built comprehensive message handling for different roles (system, user, assistant, tool)
- Added file attachment support for vision-enabled models (images, audio, documents)
- Implemented model parameter configuration with provider-specific settings
- Added context provider for state management across the prompt interface
- Created reusable components for alerts, sheets, and message views
- Added drag-and-drop file upload with preview capabilities
- Implemented keyboard shortcuts (Cmd+S for saving, Enter for execution)
- Added support for tool calls and tool result handling
- Created attachment handling utilities for various file types

## Type of change

- [x] Feature

## Affected areas

- [x] UI (Next.js)

## How to test

Navigate to the prompt repository section and verify:

1. **Folder Management**: Create, edit, and delete folders for organizing prompts
2. **Prompt Creation**: Create new prompts and organize them within folders
3. **Playground Functionality**: 
   - Test message composition with different roles
   - Verify streaming responses work correctly
   - Test file attachments (images, audio, documents) if using vision-enabled models
4. **Version Control**: Save sessions and commit them as immutable versions
5. **Drag and Drop**: Move prompts between folders and upload files via drag-and-drop
6. **Model Configuration**: Switch between providers and models, adjust parameters
7. **Tool Calls**: Test prompts that generate tool calls and provide tool results

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A - This is a new feature addition

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- File uploads are handled client-side and converted to base64 for API transmission
- API key selection respects existing virtual key and provider configurations
- No sensitive data is exposed in the UI beyond what's already available in the system

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable