### PR TITLE
fixed baseApi for new token sync

### DIFF
--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -2,26 +2,13 @@ import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { BifrostErrorResponse } from "@/lib/types/config";
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { createBaseQueryWithRefresh } from "@enterprise/lib/store/utils/baseQueryWithRefresh";
-import { clearOAuthStorage, getAccessToken } from "@enterprise/lib/store/utils/tokenManager";
+import { clearOAuthStorage } from "@enterprise/lib/store/utils/tokenManager";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
-// Helper function to get token from storage
-// Enterprise: use access_token from enterprise tokenManager for Authorization header
-// Non-enterprise: return null — auth is handled via HTTPOnly cookies (credentials: "include")
+// Auth tokens are now stored in HTTP-only cookies (set by server)
+// No client-side token needed — handled by credentials: "include"
 export const getTokenFromStorage = (): Promise<string | null> => {
-	if (typeof window === "undefined") {
-		return Promise.resolve(null);
-	}
-	try {
-		if (IS_ENTERPRISE) {
-			// Enterprise OAuth login - use tokenManager
-			return getAccessToken();
-		}
-		// Non-enterprise: cookie-based auth, no token needed in header
-		return Promise.resolve(null);
-	} catch (error) {
-		return Promise.resolve(null);
-	}
+	return Promise.resolve(null);
 };
 
 // Helper function to set auth token


### PR DESCRIPTION
### TL;DR

Simplified authentication to use HTTP-only cookies for both enterprise and non-enterprise modes instead of client-side token management.

### What changed?

- Removed enterprise-specific OAuth token retrieval logic from `getTokenFromStorage()`
- The function now always returns `null` since authentication is handled server-side via HTTP-only cookies
- Removed import of `getAccessToken` from the enterprise token manager
- Updated comments to reflect that auth tokens are now stored in HTTP-only cookies set by the server

### How to test?

1. Test authentication flows in both enterprise and non-enterprise modes
2. Verify that API requests still work correctly with cookie-based authentication
3. Confirm that the `credentials: "include"` setting properly sends cookies with requests
4. Test that authentication persists across browser sessions

### Why make this change?

This change standardizes authentication across both enterprise and non-enterprise deployments by moving token storage from client-side JavaScript to secure HTTP-only cookies, improving security by preventing client-side access to authentication tokens.