### PR TITLE
feat(tracing): add chat token detail OTEL span attributes

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -216,6 +216,20 @@ const (
 	AttrInputTokens      = "gen_ai.usage.input_tokens"
 	AttrOutputTokens     = "gen_ai.usage.output_tokens"
 	AttrUsageCost        = "gen_ai.usage.cost"
+	// Chat completion usage detail attributes
+	AttrPromptTokenDetailsText        = "gen_ai.usage.prompt_token_details.text_tokens"
+	AttrPromptTokenDetailsAudio       = "gen_ai.usage.prompt_token_details.audio_tokens"
+	AttrPromptTokenDetailsImage       = "gen_ai.usage.prompt_token_details.image_tokens"
+	AttrPromptTokenDetailsCachedRead  = "gen_ai.usage.prompt_token_details.cached_read_tokens"
+	AttrPromptTokenDetailsCachedWrite = "gen_ai.usage.prompt_token_details.cached_write_tokens"
+	AttrCompletionTokenDetailsText    = "gen_ai.usage.completion_token_details.text_tokens"
+	AttrCompletionTokenDetailsAudio   = "gen_ai.usage.completion_token_details.audio_tokens"
+	AttrCompletionTokenDetailsImage   = "gen_ai.usage.completion_token_details.image_tokens"
+	AttrCompletionTokenDetailsReason  = "gen_ai.usage.completion_token_details.reasoning_tokens"
+	AttrCompletionTokenDetailsAccept  = "gen_ai.usage.completion_token_details.accepted_prediction_tokens"
+	AttrCompletionTokenDetailsReject  = "gen_ai.usage.completion_token_details.rejected_prediction_tokens"
+	AttrCompletionTokenDetailsCite    = "gen_ai.usage.completion_token_details.citation_tokens"
+	AttrCompletionTokenDetailsSearch  = "gen_ai.usage.completion_token_details.num_search_queries"
 
 	// Error Attributes
 	AttrError     = "gen_ai.error"

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -242,6 +242,51 @@ func PopulateChatResponseAttributes(resp *schemas.BifrostChatResponse, attrs map
 		attrs[schemas.AttrPromptTokens] = resp.Usage.PromptTokens
 		attrs[schemas.AttrCompletionTokens] = resp.Usage.CompletionTokens
 		attrs[schemas.AttrTotalTokens] = resp.Usage.TotalTokens
+
+		if resp.Usage.PromptTokensDetails != nil {
+			if resp.Usage.PromptTokensDetails.TextTokens > 0 {
+				attrs[schemas.AttrPromptTokenDetailsText] = resp.Usage.PromptTokensDetails.TextTokens
+			}
+			if resp.Usage.PromptTokensDetails.AudioTokens > 0 {
+				attrs[schemas.AttrPromptTokenDetailsAudio] = resp.Usage.PromptTokensDetails.AudioTokens
+			}
+			if resp.Usage.PromptTokensDetails.ImageTokens > 0 {
+				attrs[schemas.AttrPromptTokenDetailsImage] = resp.Usage.PromptTokensDetails.ImageTokens
+			}
+			if resp.Usage.PromptTokensDetails.CachedReadTokens > 0 {
+				attrs[schemas.AttrPromptTokenDetailsCachedRead] = resp.Usage.PromptTokensDetails.CachedReadTokens
+			}
+			if resp.Usage.PromptTokensDetails.CachedWriteTokens > 0 {
+				attrs[schemas.AttrPromptTokenDetailsCachedWrite] = resp.Usage.PromptTokensDetails.CachedWriteTokens
+			}
+		}
+
+		if resp.Usage.CompletionTokensDetails != nil {
+			if resp.Usage.CompletionTokensDetails.TextTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsText] = resp.Usage.CompletionTokensDetails.TextTokens
+			}
+			if resp.Usage.CompletionTokensDetails.AudioTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsAudio] = resp.Usage.CompletionTokensDetails.AudioTokens
+			}
+			if resp.Usage.CompletionTokensDetails.ImageTokens != nil && *resp.Usage.CompletionTokensDetails.ImageTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsImage] = *resp.Usage.CompletionTokensDetails.ImageTokens
+			}
+			if resp.Usage.CompletionTokensDetails.ReasoningTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsReason] = resp.Usage.CompletionTokensDetails.ReasoningTokens
+			}
+			if resp.Usage.CompletionTokensDetails.AcceptedPredictionTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsAccept] = resp.Usage.CompletionTokensDetails.AcceptedPredictionTokens
+			}
+			if resp.Usage.CompletionTokensDetails.RejectedPredictionTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsReject] = resp.Usage.CompletionTokensDetails.RejectedPredictionTokens
+			}
+			if resp.Usage.CompletionTokensDetails.CitationTokens != nil && *resp.Usage.CompletionTokensDetails.CitationTokens > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsCite] = *resp.Usage.CompletionTokensDetails.CitationTokens
+			}
+			if resp.Usage.CompletionTokensDetails.NumSearchQueries != nil && *resp.Usage.CompletionTokensDetails.NumSearchQueries > 0 {
+				attrs[schemas.AttrCompletionTokenDetailsSearch] = *resp.Usage.CompletionTokensDetails.NumSearchQueries
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds support for detailed token usage tracking in chat completion responses by introducing new attribute constants for prompt and completion token breakdowns and implementing logic to populate these attributes when available.

## Changes

- Added 13 new attribute constants in `trace.go` for tracking detailed token usage including text, audio, image, cached, reasoning, prediction, citation tokens and search queries
- Enhanced `PopulateChatResponseAttributes` function to conditionally populate detailed token attributes from `PromptTokensDetails` and `CompletionTokensDetails` when present in the response
- Implemented zero-value checks to only set attributes when token counts are greater than zero
- Added proper nil pointer handling for optional fields like `ImageTokens`, `CitationTokens`, and `NumSearchQueries`

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that detailed token usage attributes are properly populated in traces when chat completion responses include token details.

```sh
# Core/Transports
go version
go test ./...
```

Test with chat completion responses that include `PromptTokensDetails` and `CompletionTokensDetails` to verify the new attributes are correctly set in the trace spans.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #1960

## Security considerations

No security implications - this change only adds observability attributes for token usage tracking.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable