### PR TITLE
feat(providers): allow storing raw request/response without returning them to clients

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4382,18 +4382,10 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 					// Run post hooks on the stream message
 					processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, streamMsg.BifrostError)
 
-					streamResponse := &schemas.BifrostStreamChunk{}
-					if processedResponse != nil {
-						streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
-						streamResponse.BifrostChatResponse = processedResponse.ChatResponse
-						streamResponse.BifrostResponsesStreamResponse = processedResponse.ResponsesStreamResponse
-						streamResponse.BifrostSpeechStreamResponse = processedResponse.SpeechStreamResponse
-						streamResponse.BifrostTranscriptionStreamResponse = processedResponse.TranscriptionStreamResponse
-						streamResponse.BifrostImageGenerationStreamResponse = processedResponse.ImageGenerationStreamResponse
-					}
-					if processedError != nil {
-						streamResponse.BifrostError = processedError
-					}
+					// Build the client-facing chunk via the shared helper, which strips raw
+					// request/response fields when in logging-only mode without mutating the
+					// shared processedResponse or processedError objects.
+					streamResponse := providerUtils.BuildClientStreamChunk(ctx, processedResponse, processedError)
 
 					// Send the processed message to the output stream
 					outputStream <- streamResponse

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4737,6 +4737,20 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		}
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
 
+		// When store_raw_request_response is enabled and neither send_back_raw_* flag is
+		// active (on the config or pre-set in the request context), set the logging-only
+		// context flag. ShouldSendBackRaw* functions honour this flag so providers capture
+		// raw payloads for PostLLMHook plugins without modifying the user's SendBack flags.
+		// The existing stripping logic (non-streaming: bifrost.go; streaming: utils.go)
+		// removes the payloads before the response reaches the client.
+		if config.StoreRawRequestResponse {
+			existingSendBackReq, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool)
+			existingSendBackResp, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool)
+			if !config.SendBackRawRequest && !existingSendBackReq && !config.SendBackRawResponse && !existingSendBackResp {
+				req.Context.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			}
+		}
+
 		key := schemas.Key{}
 		var keys []schemas.Key
 		if providerRequiresKey(baseProvider, config.CustomProviderConfig) {

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4737,20 +4737,27 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		}
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
 
-		// When store_raw_request_response is enabled and neither send_back_raw_* flag is
-		// active (on the config or pre-set in the request context), set the logging-only
-		// context flag. ShouldSendBackRaw* functions honour this flag so providers capture
-		// raw payloads for PostLLMHook plugins without modifying the user's SendBack flags.
-		// The existing stripping logic (non-streaming: bifrost.go; streaming: utils.go)
-		// removes the payloads before the response reaches the client.
-		// Always set the flag explicitly (true or false) so stale values from a previous
-		// provider attempt cannot leak into a fallback attempt on a reused context.
+		// Determine whether this provider attempt should capture raw payloads.
+		// logging-only mode (store_raw_request_response=true, send_back_raw_*=false):
+		//   sets BifrostContextKeySendBackRaw* = true so providers capture via the unified
+		//   ShouldSendBackRaw* path, and sets BifrostContextKeyRawRequestResponseForLogging
+		//   so the payload is stripped before the response reaches the client.
+		// full send-back mode (send_back_raw_request/response=true):
+		//   BifrostContextKeySendBackRaw* are set as before; stripping flag stays false.
+		// Always set both flags explicitly so stale values from a previous provider
+		// attempt (e.g. first attempt was logging-only, fallback is full send-back)
+		// cannot leak into the new attempt on a reused context.
 		existingSendBackReq, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool)
 		existingSendBackResp, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool)
 		loggingOnly := config.StoreRawRequestResponse &&
 			!config.SendBackRawRequest && !existingSendBackReq &&
 			!config.SendBackRawResponse && !existingSendBackResp
 		req.Context.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, loggingOnly)
+		if loggingOnly {
+			// Enable capture via the standard flags so ShouldSendBackRaw* needs only one check.
+			req.Context.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
+			req.Context.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+		}
 
 		key := schemas.Key{}
 		var keys []schemas.Key

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4743,13 +4743,14 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		// raw payloads for PostLLMHook plugins without modifying the user's SendBack flags.
 		// The existing stripping logic (non-streaming: bifrost.go; streaming: utils.go)
 		// removes the payloads before the response reaches the client.
-		if config.StoreRawRequestResponse {
-			existingSendBackReq, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool)
-			existingSendBackResp, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool)
-			if !config.SendBackRawRequest && !existingSendBackReq && !config.SendBackRawResponse && !existingSendBackResp {
-				req.Context.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
-			}
-		}
+		// Always set the flag explicitly (true or false) so stale values from a previous
+		// provider attempt cannot leak into a fallback attempt on a reused context.
+		existingSendBackReq, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool)
+		existingSendBackResp, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool)
+		loggingOnly := config.StoreRawRequestResponse &&
+			!config.SendBackRawRequest && !existingSendBackReq &&
+			!config.SendBackRawResponse && !existingSendBackResp
+		req.Context.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, loggingOnly)
 
 		key := schemas.Key{}
 		var keys []schemas.Key

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -1170,3 +1170,4 @@ func TestUpdateProvider_ProviderSliceIntegrity(t *testing.T) {
 		}
 	})
 }
+

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1659,40 +1659,15 @@ func SendInProgressEventResponsesChunk(ctx *schemas.BifrostContext, postHookRunn
 	ProcessAndSendResponse(ctx, postHookRunner, bifrostResponse, responseChan)
 }
 
-// ProcessAndSendResponse handles post-hook processing and sends the response to the channel.
-// This utility reduces code duplication across streaming implementations by encapsulating
-// the common pattern of running post hooks, handling errors, and sending responses with
-// proper context cancellation handling.
-// It also completes the deferred LLM span when the final chunk is sent (StreamEndIndicator is true).
-func ProcessAndSendResponse(
-	ctx *schemas.BifrostContext,
-	postHookRunner schemas.PostHookRunner,
-	response *schemas.BifrostResponse,
-	responseChan chan *schemas.BifrostStreamChunk,
-) {
-	// Accumulate chunk for tracing (common for all providers)
-	if tracer, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer); ok && tracer != nil {
-		if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
-			tracer.AddStreamingChunk(traceID, response)
-		}
-	}
-
-	// Run post hooks on the response (note: accumulated chunks above contain pre-hook data)
-	processedResponse, processedError := postHookRunner(ctx, response, nil)
-
-	if HandleStreamControlSkip(processedError) {
-		// Even if skipping, complete the deferred span if this is the final chunk
-		if isFinalChunk := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator); isFinalChunk != nil {
-			if final, ok := isFinalChunk.(bool); ok && final {
-				completeDeferredSpan(ctx, processedResponse, processedError)
-			}
-		}
-		return
-	}
-
-	streamResponse := &schemas.BifrostStreamChunk{}
-	// Determine once whether raw fields must be stripped from the client-facing chunk.
+// BuildClientStreamChunk constructs a BifrostStreamChunk from post-hook results.
+// It never mutates the shared processedResponse or processedError objects — when in
+// logging-only mode (BifrostContextKeyRawRequestResponseForLogging) it shallow-copies
+// each inner response struct and the BifrostError, nils only the raw fields on those
+// copies, and returns them as the outgoing chunk. This is safe for concurrent PostLLMHook
+// goroutines that still hold references to the originals.
+func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.BifrostResponse, processedError *schemas.BifrostError) *schemas.BifrostStreamChunk {
 	dropRaw, _ := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool)
+	streamResponse := &schemas.BifrostStreamChunk{}
 	if processedResponse != nil {
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
 		streamResponse.BifrostChatResponse = processedResponse.ChatResponse
@@ -1752,6 +1727,41 @@ func ProcessAndSendResponse(
 			streamResponse.BifrostError = processedError
 		}
 	}
+	return streamResponse
+}
+
+// ProcessAndSendResponse handles post-hook processing and sends the response to the channel.
+// This utility reduces code duplication across streaming implementations by encapsulating
+// the common pattern of running post hooks, handling errors, and sending responses with
+// proper context cancellation handling.
+// It also completes the deferred LLM span when the final chunk is sent (StreamEndIndicator is true).
+func ProcessAndSendResponse(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	response *schemas.BifrostResponse,
+	responseChan chan *schemas.BifrostStreamChunk,
+) {
+	// Accumulate chunk for tracing (common for all providers)
+	if tracer, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer); ok && tracer != nil {
+		if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
+			tracer.AddStreamingChunk(traceID, response)
+		}
+	}
+
+	// Run post hooks on the response (note: accumulated chunks above contain pre-hook data)
+	processedResponse, processedError := postHookRunner(ctx, response, nil)
+
+	if HandleStreamControlSkip(processedError) {
+		// Even if skipping, complete the deferred span if this is the final chunk
+		if isFinalChunk := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator); isFinalChunk != nil {
+			if final, ok := isFinalChunk.(bool); ok && final {
+				completeDeferredSpan(ctx, processedResponse, processedError)
+			}
+		}
+		return
+	}
+
+	streamResponse := BuildClientStreamChunk(ctx, processedResponse, processedError)
 
 	select {
 	case responseChan <- streamResponse:
@@ -1792,61 +1802,7 @@ func ProcessAndSendBifrostError(
 		return
 	}
 
-	streamResponse := &schemas.BifrostStreamChunk{}
-	// Determine once whether raw fields must be stripped from the client-facing chunk.
-	dropRaw, _ := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool)
-	if processedResponse != nil {
-		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
-		streamResponse.BifrostChatResponse = processedResponse.ChatResponse
-		streamResponse.BifrostResponsesStreamResponse = processedResponse.ResponsesStreamResponse
-		streamResponse.BifrostSpeechStreamResponse = processedResponse.SpeechStreamResponse
-		streamResponse.BifrostTranscriptionStreamResponse = processedResponse.TranscriptionStreamResponse
-		// Strip raw fields from client-facing copies without mutating the shared objects
-		// that PostLLMHook goroutines may still be reading.
-		if dropRaw {
-			if streamResponse.BifrostTextCompletionResponse != nil {
-				cp := *streamResponse.BifrostTextCompletionResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
-				streamResponse.BifrostTextCompletionResponse = &cp
-			}
-			if streamResponse.BifrostChatResponse != nil {
-				cp := *streamResponse.BifrostChatResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
-				streamResponse.BifrostChatResponse = &cp
-			}
-			if streamResponse.BifrostResponsesStreamResponse != nil {
-				cp := *streamResponse.BifrostResponsesStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
-				streamResponse.BifrostResponsesStreamResponse = &cp
-			}
-			if streamResponse.BifrostSpeechStreamResponse != nil {
-				cp := *streamResponse.BifrostSpeechStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
-				streamResponse.BifrostSpeechStreamResponse = &cp
-			}
-			if streamResponse.BifrostTranscriptionStreamResponse != nil {
-				cp := *streamResponse.BifrostTranscriptionStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
-				streamResponse.BifrostTranscriptionStreamResponse = &cp
-			}
-		}
-	}
-	if processedError != nil {
-		if dropRaw {
-			// Strip raw fields from a client-facing copy without mutating the shared error object.
-			errCopy := *processedError
-			errCopy.ExtraFields.RawRequest = nil
-			errCopy.ExtraFields.RawResponse = nil
-			streamResponse.BifrostError = &errCopy
-		} else {
-			streamResponse.BifrostError = processedError
-		}
-	}
+	streamResponse := BuildClientStreamChunk(ctx, processedResponse, processedError)
 
 	select {
 	case responseChan <- streamResponse:

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1594,15 +1594,12 @@ type RequestMetadata struct {
 // ShouldSendBackRawRequest checks if the raw request should be captured.
 // Context overrides are intentionally restricted to asymmetric behavior: a context value can only
 // promote false→true and will not override a true config to false, avoiding accidental suppression.
-// When store_raw_request_response is enabled (logging-only mode), this also returns true so that
-// providers capture the raw payload for PostLLMHook plugins; the payload is stripped before
-// the response is returned to the client.
+// Both full send-back mode and logging-only mode (store_raw_request_response) set
+// BifrostContextKeySendBackRawRequest=true in the request context so a single flag is checked here.
+// In logging-only mode the payload is stripped before the response reaches the client.
 func ShouldSendBackRawRequest(ctx context.Context, defaultSendBackRawRequest bool) bool {
 	if sendBackRawRequest, ok := ctx.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok && sendBackRawRequest {
 		return sendBackRawRequest
-	}
-	if loggingOnly, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && loggingOnly {
-		return true
 	}
 	return defaultSendBackRawRequest
 }
@@ -1610,15 +1607,12 @@ func ShouldSendBackRawRequest(ctx context.Context, defaultSendBackRawRequest boo
 // ShouldSendBackRawResponse checks if the raw response should be captured.
 // Context overrides are intentionally restricted to asymmetric behavior: a context value can only
 // promote false→true and will not override a true config to false, avoiding accidental suppression.
-// When store_raw_request_response is enabled (logging-only mode), this also returns true so that
-// providers capture the raw payload for PostLLMHook plugins; the payload is stripped before
-// the response is returned to the client.
+// Both full send-back mode and logging-only mode (store_raw_request_response) set
+// BifrostContextKeySendBackRawResponse=true in the request context so a single flag is checked here.
+// In logging-only mode the payload is stripped before the response reaches the client.
 func ShouldSendBackRawResponse(ctx context.Context, defaultSendBackRawResponse bool) bool {
 	if sendBackRawResponse, ok := ctx.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok && sendBackRawResponse {
 		return sendBackRawResponse
-	}
-	if loggingOnly, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && loggingOnly {
-		return true
 	}
 	return defaultSendBackRawResponse
 }

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1691,29 +1691,66 @@ func ProcessAndSendResponse(
 	}
 
 	streamResponse := &schemas.BifrostStreamChunk{}
+	// Determine once whether raw fields must be stripped from the client-facing chunk.
+	dropRaw, _ := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool)
 	if processedResponse != nil {
-		// Strip raw data from streaming chunks when only captured for internal logging
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
-			extraField := processedResponse.GetExtraFields()
-			if extraField != nil {
-				extraField.RawRequest = nil
-				extraField.RawResponse = nil
-			}
-		}
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
 		streamResponse.BifrostChatResponse = processedResponse.ChatResponse
 		streamResponse.BifrostResponsesStreamResponse = processedResponse.ResponsesStreamResponse
 		streamResponse.BifrostSpeechStreamResponse = processedResponse.SpeechStreamResponse
 		streamResponse.BifrostTranscriptionStreamResponse = processedResponse.TranscriptionStreamResponse
 		streamResponse.BifrostImageGenerationStreamResponse = processedResponse.ImageGenerationStreamResponse
+		// Strip raw fields from client-facing copies without mutating the shared objects
+		// that PostLLMHook goroutines may still be reading.
+		if dropRaw {
+			if streamResponse.BifrostTextCompletionResponse != nil {
+				cp := *streamResponse.BifrostTextCompletionResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostTextCompletionResponse = &cp
+			}
+			if streamResponse.BifrostChatResponse != nil {
+				cp := *streamResponse.BifrostChatResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostChatResponse = &cp
+			}
+			if streamResponse.BifrostResponsesStreamResponse != nil {
+				cp := *streamResponse.BifrostResponsesStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostResponsesStreamResponse = &cp
+			}
+			if streamResponse.BifrostSpeechStreamResponse != nil {
+				cp := *streamResponse.BifrostSpeechStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostSpeechStreamResponse = &cp
+			}
+			if streamResponse.BifrostTranscriptionStreamResponse != nil {
+				cp := *streamResponse.BifrostTranscriptionStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostTranscriptionStreamResponse = &cp
+			}
+			if streamResponse.BifrostImageGenerationStreamResponse != nil {
+				cp := *streamResponse.BifrostImageGenerationStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostImageGenerationStreamResponse = &cp
+			}
+		}
 	}
 	if processedError != nil {
-		// Strip raw data from streaming error chunks when only captured for internal logging
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
-			processedError.ExtraFields.RawRequest = nil
-			processedError.ExtraFields.RawResponse = nil
+		if dropRaw {
+			// Strip raw fields from a client-facing copy without mutating the shared error object.
+			errCopy := *processedError
+			errCopy.ExtraFields.RawRequest = nil
+			errCopy.ExtraFields.RawResponse = nil
+			streamResponse.BifrostError = &errCopy
+		} else {
+			streamResponse.BifrostError = processedError
 		}
-		streamResponse.BifrostError = processedError
 	}
 
 	select {
@@ -1756,28 +1793,59 @@ func ProcessAndSendBifrostError(
 	}
 
 	streamResponse := &schemas.BifrostStreamChunk{}
+	// Determine once whether raw fields must be stripped from the client-facing chunk.
+	dropRaw, _ := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool)
 	if processedResponse != nil {
-		// Strip raw data from streaming chunks when only captured for internal logging
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
-			extraField := processedResponse.GetExtraFields()
-			if extraField != nil {
-				extraField.RawRequest = nil
-				extraField.RawResponse = nil
-			}
-		}
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
 		streamResponse.BifrostChatResponse = processedResponse.ChatResponse
 		streamResponse.BifrostResponsesStreamResponse = processedResponse.ResponsesStreamResponse
 		streamResponse.BifrostSpeechStreamResponse = processedResponse.SpeechStreamResponse
 		streamResponse.BifrostTranscriptionStreamResponse = processedResponse.TranscriptionStreamResponse
+		// Strip raw fields from client-facing copies without mutating the shared objects
+		// that PostLLMHook goroutines may still be reading.
+		if dropRaw {
+			if streamResponse.BifrostTextCompletionResponse != nil {
+				cp := *streamResponse.BifrostTextCompletionResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostTextCompletionResponse = &cp
+			}
+			if streamResponse.BifrostChatResponse != nil {
+				cp := *streamResponse.BifrostChatResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostChatResponse = &cp
+			}
+			if streamResponse.BifrostResponsesStreamResponse != nil {
+				cp := *streamResponse.BifrostResponsesStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostResponsesStreamResponse = &cp
+			}
+			if streamResponse.BifrostSpeechStreamResponse != nil {
+				cp := *streamResponse.BifrostSpeechStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostSpeechStreamResponse = &cp
+			}
+			if streamResponse.BifrostTranscriptionStreamResponse != nil {
+				cp := *streamResponse.BifrostTranscriptionStreamResponse
+				cp.ExtraFields.RawRequest = nil
+				cp.ExtraFields.RawResponse = nil
+				streamResponse.BifrostTranscriptionStreamResponse = &cp
+			}
+		}
 	}
 	if processedError != nil {
-		// Strip raw data from streaming error chunks when only captured for internal logging
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
-			processedError.ExtraFields.RawRequest = nil
-			processedError.ExtraFields.RawResponse = nil
+		if dropRaw {
+			// Strip raw fields from a client-facing copy without mutating the shared error object.
+			errCopy := *processedError
+			errCopy.ExtraFields.RawRequest = nil
+			errCopy.ExtraFields.RawResponse = nil
+			streamResponse.BifrostError = &errCopy
+		} else {
+			streamResponse.BifrostError = processedError
 		}
-		streamResponse.BifrostError = processedError
 	}
 
 	select {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1591,20 +1591,34 @@ type RequestMetadata struct {
 	RequestType schemas.RequestType
 }
 
-// ShouldSendBackRawRequest checks if the raw request should be sent back.
+// ShouldSendBackRawRequest checks if the raw request should be captured.
 // Context overrides are intentionally restricted to asymmetric behavior: a context value can only
 // promote false→true and will not override a true config to false, avoiding accidental suppression.
+// When store_raw_request_response is enabled (logging-only mode), this also returns true so that
+// providers capture the raw payload for PostLLMHook plugins; the payload is stripped before
+// the response is returned to the client.
 func ShouldSendBackRawRequest(ctx context.Context, defaultSendBackRawRequest bool) bool {
 	if sendBackRawRequest, ok := ctx.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok && sendBackRawRequest {
 		return sendBackRawRequest
 	}
+	if loggingOnly, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && loggingOnly {
+		return true
+	}
 	return defaultSendBackRawRequest
 }
 
-// ShouldSendBackRawResponse checks if the raw response should be sent back, and returns it if it exists.
+// ShouldSendBackRawResponse checks if the raw response should be captured.
+// Context overrides are intentionally restricted to asymmetric behavior: a context value can only
+// promote false→true and will not override a true config to false, avoiding accidental suppression.
+// When store_raw_request_response is enabled (logging-only mode), this also returns true so that
+// providers capture the raw payload for PostLLMHook plugins; the payload is stripped before
+// the response is returned to the client.
 func ShouldSendBackRawResponse(ctx context.Context, defaultSendBackRawResponse bool) bool {
 	if sendBackRawResponse, ok := ctx.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok && sendBackRawResponse {
 		return sendBackRawResponse
+	}
+	if loggingOnly, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && loggingOnly {
+		return true
 	}
 	return defaultSendBackRawResponse
 }
@@ -1684,6 +1698,14 @@ func ProcessAndSendResponse(
 
 	streamResponse := &schemas.BifrostStreamChunk{}
 	if processedResponse != nil {
+		// Strip raw data from streaming chunks when only captured for internal logging
+		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
+			extraField := processedResponse.GetExtraFields()
+			if extraField != nil {
+				extraField.RawRequest = nil
+				extraField.RawResponse = nil
+			}
+		}
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
 		streamResponse.BifrostChatResponse = processedResponse.ChatResponse
 		streamResponse.BifrostResponsesStreamResponse = processedResponse.ResponsesStreamResponse
@@ -1692,6 +1714,11 @@ func ProcessAndSendResponse(
 		streamResponse.BifrostImageGenerationStreamResponse = processedResponse.ImageGenerationStreamResponse
 	}
 	if processedError != nil {
+		// Strip raw data from streaming error chunks when only captured for internal logging
+		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
+			processedError.ExtraFields.RawRequest = nil
+			processedError.ExtraFields.RawResponse = nil
+		}
 		streamResponse.BifrostError = processedError
 	}
 
@@ -1736,6 +1763,14 @@ func ProcessAndSendBifrostError(
 
 	streamResponse := &schemas.BifrostStreamChunk{}
 	if processedResponse != nil {
+		// Strip raw data from streaming chunks when only captured for internal logging
+		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
+			extraField := processedResponse.GetExtraFields()
+			if extraField != nil {
+				extraField.RawRequest = nil
+				extraField.RawResponse = nil
+			}
+		}
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
 		streamResponse.BifrostChatResponse = processedResponse.ChatResponse
 		streamResponse.BifrostResponsesStreamResponse = processedResponse.ResponsesStreamResponse
@@ -1743,6 +1778,11 @@ func ProcessAndSendBifrostError(
 		streamResponse.BifrostTranscriptionStreamResponse = processedResponse.TranscriptionStreamResponse
 	}
 	if processedError != nil {
+		// Strip raw data from streaming error chunks when only captured for internal logging
+		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
+			processedError.ExtraFields.RawRequest = nil
+			processedError.ExtraFields.RawResponse = nil
+		}
 		streamResponse.BifrostError = processedError
 	}
 

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1092,7 +1092,8 @@ func TestParseAndSetRawRequest_SSEStreamingChunks(t *testing.T) {
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk verifies
 // that when BifrostContextKeyRawRequestResponseForLogging is set, ProcessAndSendResponse
 // strips RawRequest and RawResponse from the outgoing stream chunk, while leaving other
-// ExtraFields intact.
+// ExtraFields intact. It also verifies that the original BifrostResponse is not mutated
+// (shared object safety for PostLLMHook goroutines).
 func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk(t *testing.T) {
 	rawReq := json.RawMessage(`{"model":"gpt-4","messages":[]}`)
 	rawResp := json.RawMessage(`{"id":"chatcmpl-001"}`)
@@ -1154,6 +1155,17 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 				if hasRawResp {
 					t.Error("expected RawResponse to be nil (stripped) in chunk, but it was present")
 				}
+				// Critical: the original shared object must NOT have been mutated.
+				if response.ChatResponse.ExtraFields.RawRequest == nil {
+					t.Error("original BifrostResponse.ChatResponse.ExtraFields.RawRequest was mutated (nil); shared object must be preserved")
+				}
+				if response.ChatResponse.ExtraFields.RawResponse == nil {
+					t.Error("original BifrostResponse.ChatResponse.ExtraFields.RawResponse was mutated (nil); shared object must be preserved")
+				}
+				// The chunk must be a copy, not the same pointer as the original.
+				if chunk.BifrostChatResponse == response.ChatResponse {
+					t.Error("chunk.BifrostChatResponse is the same pointer as the original; it must be a copy to avoid data races")
+				}
 			} else {
 				if !hasRawReq {
 					t.Error("expected RawRequest to be present in chunk, but it was nil")
@@ -1168,7 +1180,8 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk verifies
 // that when BifrostContextKeyRawRequestResponseForLogging is set, raw data is stripped
-// from BifrostError payloads embedded in stream chunks.
+// from BifrostError payloads embedded in stream chunks, without mutating the shared
+// BifrostError object (shared object safety for PostLLMHook goroutines).
 func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(t *testing.T) {
 	rawReq := json.RawMessage(`{"model":"gpt-4"}`)
 	rawResp := json.RawMessage(`{"error":"rate limit exceeded"}`)
@@ -1231,6 +1244,17 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(
 				}
 				if hasRawResp {
 					t.Error("expected RawResponse to be nil (stripped) in error chunk, but it was present")
+				}
+				// Critical: the original shared BifrostError must NOT have been mutated.
+				if bifrostErr.ExtraFields.RawRequest == nil {
+					t.Error("original BifrostError.ExtraFields.RawRequest was mutated (nil); shared object must be preserved")
+				}
+				if bifrostErr.ExtraFields.RawResponse == nil {
+					t.Error("original BifrostError.ExtraFields.RawResponse was mutated (nil); shared object must be preserved")
+				}
+				// The chunk must hold a copy, not the same pointer as the original.
+				if chunk.BifrostError == bifrostErr {
+					t.Error("chunk.BifrostError is the same pointer as the original; it must be a copy to avoid data races")
 				}
 			} else {
 				if !hasRawReq {

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1089,6 +1089,64 @@ func TestParseAndSetRawRequest_SSEStreamingChunks(t *testing.T) {
 	}
 }
 
+// TestBuildClientStreamChunk_ImageGenerationStripping verifies that
+// BuildClientStreamChunk correctly handles BifrostImageGenerationStreamResponse:
+// strips raw fields when in logging-only mode and never mutates the original.
+func TestBuildClientStreamChunk_ImageGenerationStripping(t *testing.T) {
+	rawReq := json.RawMessage(`{"model":"dall-e-3"}`)
+	rawResp := json.RawMessage(`{"data":[{"url":"https://example.com/img.png"}]}`)
+
+	imgResp := &schemas.BifrostImageGenerationStreamResponse{
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RawRequest:  rawReq,
+			RawResponse: rawResp,
+		},
+	}
+
+	response := &schemas.BifrostResponse{ImageGenerationStreamResponse: imgResp}
+
+	t.Run("logging-only: raw fields stripped from image gen chunk, original preserved", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+
+		chunk := BuildClientStreamChunk(ctx, response, nil)
+		if chunk.BifrostImageGenerationStreamResponse == nil {
+			t.Fatal("expected BifrostImageGenerationStreamResponse in chunk")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawRequest != nil {
+			t.Error("expected RawRequest stripped from chunk, but it was present")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawResponse != nil {
+			t.Error("expected RawResponse stripped from chunk, but it was present")
+		}
+		// Original must not be mutated.
+		if imgResp.ExtraFields.RawRequest == nil {
+			t.Error("original BifrostImageGenerationStreamResponse.ExtraFields.RawRequest was mutated")
+		}
+		if imgResp.ExtraFields.RawResponse == nil {
+			t.Error("original BifrostImageGenerationStreamResponse.ExtraFields.RawResponse was mutated")
+		}
+		if chunk.BifrostImageGenerationStreamResponse == imgResp {
+			t.Error("chunk contains same pointer as original; it must be a copy")
+		}
+	})
+
+	t.Run("no logging flag: raw fields preserved in image gen chunk", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+		chunk := BuildClientStreamChunk(ctx, response, nil)
+		if chunk.BifrostImageGenerationStreamResponse == nil {
+			t.Fatal("expected BifrostImageGenerationStreamResponse in chunk")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawRequest == nil {
+			t.Error("expected RawRequest present in chunk, but it was nil")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawResponse == nil {
+			t.Error("expected RawResponse present in chunk, but it was nil")
+		}
+	})
+}
+
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk verifies
 // that when BifrostContextKeyRawRequestResponseForLogging is set, ProcessAndSendResponse
 // strips RawRequest and RawResponse from the outgoing stream chunk, while leaving other

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1248,22 +1248,21 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(
 // whether providers should capture the raw request body. It covers:
 //   - Default (no context flags): returns the provider default
 //   - BifrostContextKeySendBackRawRequest=true in context: always returns true
-//   - BifrostContextKeyRawRequestResponseForLogging=true in context: returns true (logging-only mode)
-//   - Both flags set simultaneously: returns true
+//   - Logging-only mode: requestWorker sets BifrostContextKeySendBackRawRequest=true,
+//     so the function sees a single flag (no second check needed).
 func TestShouldSendBackRawRequest(t *testing.T) {
 	tests := []struct {
-		name           string
+		name            string
 		contextSendBack bool
-		contextLogging  bool
 		providerDefault bool
 		want            bool
 	}{
 		{
-			name: "provider default false, no context flags",
+			name: "provider default false, no context flag",
 			want: false,
 		},
 		{
-			name:            "provider default true, no context flags",
+			name:            "provider default true, no context flag",
 			providerDefault: true,
 			want:            true,
 		},
@@ -1273,20 +1272,17 @@ func TestShouldSendBackRawRequest(t *testing.T) {
 			want:            true,
 		},
 		{
-			name:           "context LoggingOnly=true returns true (capture for plugins)",
-			contextLogging: true,
-			want:           true,
-		},
-		{
-			name:            "context LoggingOnly=true overrides provider default false",
-			contextLogging:  true,
-			providerDefault: false,
+			name:            "context SendBack=true with provider default true",
+			contextSendBack: true,
+			providerDefault: true,
 			want:            true,
 		},
 		{
-			name:            "both context flags set returns true",
+			// requestWorker sets BifrostContextKeySendBackRawRequest=true in logging-only
+			// mode so a single flag covers both full send-back and logging-only cases.
+			name:            "logging-only: context SendBack=true set by requestWorker",
 			contextSendBack: true,
-			contextLogging:  true,
+			providerDefault: false,
 			want:            true,
 		},
 	}
@@ -1296,9 +1292,6 @@ func TestShouldSendBackRawRequest(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			if tt.contextSendBack {
 				ctx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
-			}
-			if tt.contextLogging {
-				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
 			}
 
 			got := ShouldSendBackRawRequest(ctx, tt.providerDefault)
@@ -1314,16 +1307,15 @@ func TestShouldSendBackRawResponse(t *testing.T) {
 	tests := []struct {
 		name            string
 		contextSendBack bool
-		contextLogging  bool
 		providerDefault bool
 		want            bool
 	}{
 		{
-			name: "provider default false, no context flags",
+			name: "provider default false, no context flag",
 			want: false,
 		},
 		{
-			name:            "provider default true, no context flags",
+			name:            "provider default true, no context flag",
 			providerDefault: true,
 			want:            true,
 		},
@@ -1333,20 +1325,17 @@ func TestShouldSendBackRawResponse(t *testing.T) {
 			want:            true,
 		},
 		{
-			name:           "context LoggingOnly=true returns true (capture for plugins)",
-			contextLogging: true,
-			want:           true,
-		},
-		{
-			name:            "context LoggingOnly=true overrides provider default false",
-			contextLogging:  true,
-			providerDefault: false,
+			name:            "context SendBack=true with provider default true",
+			contextSendBack: true,
+			providerDefault: true,
 			want:            true,
 		},
 		{
-			name:            "both context flags set returns true",
+			// requestWorker sets BifrostContextKeySendBackRawResponse=true in logging-only
+			// mode so a single flag covers both full send-back and logging-only cases.
+			name:            "logging-only: context SendBack=true set by requestWorker",
 			contextSendBack: true,
-			contextLogging:  true,
+			providerDefault: false,
 			want:            true,
 		},
 	}
@@ -1356,9 +1345,6 @@ func TestShouldSendBackRawResponse(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			if tt.contextSendBack {
 				ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
-			}
-			if tt.contextLogging {
-				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
 			}
 
 			got := ShouldSendBackRawResponse(ctx, tt.providerDefault)

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1088,3 +1088,283 @@ func TestParseAndSetRawRequest_SSEStreamingChunks(t *testing.T) {
 		t.Errorf("Expected raw_request.model=gpt-4, got %v", rawParsed["model"])
 	}
 }
+
+// TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk verifies
+// that when BifrostContextKeyRawRequestResponseForLogging is set, ProcessAndSendResponse
+// strips RawRequest and RawResponse from the outgoing stream chunk, while leaving other
+// ExtraFields intact.
+func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk(t *testing.T) {
+	rawReq := json.RawMessage(`{"model":"gpt-4","messages":[]}`)
+	rawResp := json.RawMessage(`{"id":"chatcmpl-001"}`)
+
+	tests := []struct {
+		name           string
+		loggingOnly    bool
+		expectStripped bool
+	}{
+		{
+			name:           "logging-only flag set: raw data stripped from chunk",
+			loggingOnly:    true,
+			expectStripped: true,
+		},
+		{
+			name:           "logging-only flag not set: raw data preserved in chunk",
+			loggingOnly:    false,
+			expectStripped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			if tt.loggingOnly {
+				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			}
+
+			response := &schemas.BifrostResponse{
+				ChatResponse: &schemas.BifrostChatResponse{
+					ID:    "chatcmpl-001",
+					Model: "gpt-4",
+					ExtraFields: schemas.BifrostResponseExtraFields{
+						RawRequest:  rawReq,
+						RawResponse: rawResp,
+					},
+				},
+			}
+
+			passThrough := func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+				return resp, err
+			}
+
+			responseChan := make(chan *schemas.BifrostStreamChunk, 1)
+			ProcessAndSendResponse(ctx, passThrough, response, responseChan)
+
+			chunk := <-responseChan
+			if chunk.BifrostChatResponse == nil {
+				t.Fatal("expected non-nil BifrostChatResponse in stream chunk")
+			}
+
+			hasRawReq := chunk.BifrostChatResponse.ExtraFields.RawRequest != nil
+			hasRawResp := chunk.BifrostChatResponse.ExtraFields.RawResponse != nil
+
+			if tt.expectStripped {
+				if hasRawReq {
+					t.Error("expected RawRequest to be nil (stripped) in chunk, but it was present")
+				}
+				if hasRawResp {
+					t.Error("expected RawResponse to be nil (stripped) in chunk, but it was present")
+				}
+			} else {
+				if !hasRawReq {
+					t.Error("expected RawRequest to be present in chunk, but it was nil")
+				}
+				if !hasRawResp {
+					t.Error("expected RawResponse to be present in chunk, but it was nil")
+				}
+			}
+		})
+	}
+}
+
+// TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk verifies
+// that when BifrostContextKeyRawRequestResponseForLogging is set, raw data is stripped
+// from BifrostError payloads embedded in stream chunks.
+func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(t *testing.T) {
+	rawReq := json.RawMessage(`{"model":"gpt-4"}`)
+	rawResp := json.RawMessage(`{"error":"rate limit exceeded"}`)
+
+	tests := []struct {
+		name           string
+		loggingOnly    bool
+		expectStripped bool
+	}{
+		{
+			name:           "logging-only flag set: raw data stripped from error chunk",
+			loggingOnly:    true,
+			expectStripped: true,
+		},
+		{
+			name:           "logging-only flag not set: raw data preserved in error chunk",
+			loggingOnly:    false,
+			expectStripped: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			if tt.loggingOnly {
+				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			}
+
+			// Use a postHookRunner that converts the response to a BifrostError with raw data
+			bifrostErr := &schemas.BifrostError{
+				IsBifrostError: false,
+				StatusCode:     schemas.Ptr(429),
+				Error:          &schemas.ErrorField{Message: "rate limit exceeded"},
+				ExtraFields: schemas.BifrostErrorExtraFields{
+					RawRequest:  rawReq,
+					RawResponse: rawResp,
+				},
+			}
+
+			errorRunner := func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+				return nil, bifrostErr
+			}
+
+			responseChan := make(chan *schemas.BifrostStreamChunk, 1)
+			ProcessAndSendResponse(ctx, errorRunner, &schemas.BifrostResponse{
+				ChatResponse: &schemas.BifrostChatResponse{ID: "chatcmpl-001"},
+			}, responseChan)
+
+			chunk := <-responseChan
+			if chunk.BifrostError == nil {
+				t.Fatal("expected non-nil BifrostError in stream chunk")
+			}
+
+			hasRawReq := chunk.BifrostError.ExtraFields.RawRequest != nil
+			hasRawResp := chunk.BifrostError.ExtraFields.RawResponse != nil
+
+			if tt.expectStripped {
+				if hasRawReq {
+					t.Error("expected RawRequest to be nil (stripped) in error chunk, but it was present")
+				}
+				if hasRawResp {
+					t.Error("expected RawResponse to be nil (stripped) in error chunk, but it was present")
+				}
+			} else {
+				if !hasRawReq {
+					t.Error("expected RawRequest to be present in error chunk, but it was nil")
+				}
+				if !hasRawResp {
+					t.Error("expected RawResponse to be present in error chunk, but it was nil")
+				}
+			}
+		})
+	}
+}
+
+// TestShouldSendBackRawRequest verifies that ShouldSendBackRawRequest correctly resolves
+// whether providers should capture the raw request body. It covers:
+//   - Default (no context flags): returns the provider default
+//   - BifrostContextKeySendBackRawRequest=true in context: always returns true
+//   - BifrostContextKeyRawRequestResponseForLogging=true in context: returns true (logging-only mode)
+//   - Both flags set simultaneously: returns true
+func TestShouldSendBackRawRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		contextSendBack bool
+		contextLogging  bool
+		providerDefault bool
+		want            bool
+	}{
+		{
+			name: "provider default false, no context flags",
+			want: false,
+		},
+		{
+			name:            "provider default true, no context flags",
+			providerDefault: true,
+			want:            true,
+		},
+		{
+			name:            "context SendBack=true overrides provider default false",
+			contextSendBack: true,
+			want:            true,
+		},
+		{
+			name:           "context LoggingOnly=true returns true (capture for plugins)",
+			contextLogging: true,
+			want:           true,
+		},
+		{
+			name:            "context LoggingOnly=true overrides provider default false",
+			contextLogging:  true,
+			providerDefault: false,
+			want:            true,
+		},
+		{
+			name:            "both context flags set returns true",
+			contextSendBack: true,
+			contextLogging:  true,
+			want:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			if tt.contextSendBack {
+				ctx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
+			}
+			if tt.contextLogging {
+				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			}
+
+			got := ShouldSendBackRawRequest(ctx, tt.providerDefault)
+			if got != tt.want {
+				t.Errorf("ShouldSendBackRawRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldSendBackRawResponse mirrors TestShouldSendBackRawRequest for the response side.
+func TestShouldSendBackRawResponse(t *testing.T) {
+	tests := []struct {
+		name            string
+		contextSendBack bool
+		contextLogging  bool
+		providerDefault bool
+		want            bool
+	}{
+		{
+			name: "provider default false, no context flags",
+			want: false,
+		},
+		{
+			name:            "provider default true, no context flags",
+			providerDefault: true,
+			want:            true,
+		},
+		{
+			name:            "context SendBack=true overrides provider default false",
+			contextSendBack: true,
+			want:            true,
+		},
+		{
+			name:           "context LoggingOnly=true returns true (capture for plugins)",
+			contextLogging: true,
+			want:           true,
+		},
+		{
+			name:            "context LoggingOnly=true overrides provider default false",
+			contextLogging:  true,
+			providerDefault: false,
+			want:            true,
+		},
+		{
+			name:            "both context flags set returns true",
+			contextSendBack: true,
+			contextLogging:  true,
+			want:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			if tt.contextSendBack {
+				ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+			}
+			if tt.contextLogging {
+				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			}
+
+			got := ShouldSendBackRawResponse(ctx, tt.providerDefault)
+			if got != tt.want {
+				t.Errorf("ShouldSendBackRawResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -451,8 +451,9 @@ type ProviderConfig struct {
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
 	Logger               Logger                    `json:"-"`
 	ProxyConfig          *ProxyConfig              `json:"proxy_config,omitempty"` // Proxy configuration
-	SendBackRawRequest   bool                      `json:"send_back_raw_request"`  // Send raw request back in the bifrost response (default: false)
-	SendBackRawResponse  bool                      `json:"send_back_raw_response"` // Send raw response back in the bifrost response (default: false)
+	SendBackRawRequest        bool                      `json:"send_back_raw_request"`         // Send raw request back in the bifrost response (default: false)
+	SendBackRawResponse       bool                      `json:"send_back_raw_response"`        // Send raw response back in the bifrost response (default: false)
+	StoreRawRequestResponse   bool                      `json:"store_raw_request_response"`    // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
 	CustomProviderConfig *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
 	PricingOverrides     []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
 }

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -254,6 +254,7 @@ type ProviderConfig struct {
 	ProxyConfig              *schemas.ProxyConfig              `json:"proxy_config,omitempty"`                // Proxy configuration
 	SendBackRawRequest       bool                              `json:"send_back_raw_request"`                 // Include raw request in BifrostResponse
 	SendBackRawResponse      bool                              `json:"send_back_raw_response"`                // Include raw response in BifrostResponse
+	StoreRawRequestResponse  bool                              `json:"store_raw_request_response"`            // Capture raw request/response for internal logging only; strip from API responses returned to clients
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
 	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`           // Provider-level pricing overrides
 	ConfigHash               string                            `json:"config_hash,omitempty"`                 // Hash of config.json version, used for change detection
@@ -273,6 +274,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		ConcurrencyAndBufferSize: p.ConcurrencyAndBufferSize,
 		SendBackRawRequest:       p.SendBackRawRequest,
 		SendBackRawResponse:      p.SendBackRawResponse,
+		StoreRawRequestResponse:  p.StoreRawRequestResponse,
 		CustomProviderConfig:     p.CustomProviderConfig,
 		PricingOverrides:         p.PricingOverrides,
 		ConfigHash:               p.ConfigHash,
@@ -460,6 +462,11 @@ func (p *ProviderConfig) GenerateConfigHash(providerName string) (string, error)
 	// Hash SendBackRawResponse
 	if p.SendBackRawResponse {
 		hash.Write([]byte("sendBackRawResponse"))
+	}
+
+	// Hash StoreRawRequestResponse
+	if p.StoreRawRequestResponse {
+		hash.Write([]byte("storeRawRequestResponse"))
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -325,6 +325,31 @@ func migrationAddStoreRawRequestResponseColumn(ctx context.Context, db *gorm.DB)
 					return err
 				}
 			}
+			// Backfill config_hash for existing providers so they don't appear
+			// dirty after upgrade. StoreRawRequestResponse is now part of the
+			// hash input; rows written before this migration have stale hashes.
+			var providers []tables.TableProvider
+			if err := tx.Find(&providers).Error; err != nil {
+				return fmt.Errorf("failed to fetch providers for hash backfill: %w", err)
+			}
+			for _, provider := range providers {
+				providerConfig := ProviderConfig{
+					NetworkConfig:            provider.NetworkConfig,
+					ConcurrencyAndBufferSize: provider.ConcurrencyAndBufferSize,
+					ProxyConfig:              provider.ProxyConfig,
+					SendBackRawRequest:       provider.SendBackRawRequest,
+					SendBackRawResponse:      provider.SendBackRawResponse,
+					StoreRawRequestResponse:  provider.StoreRawRequestResponse,
+					CustomProviderConfig:     provider.CustomProviderConfig,
+				}
+				hash, err := providerConfig.GenerateConfigHash(provider.Name)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for provider %s: %w", provider.Name, err)
+				}
+				if err := tx.Model(&provider).Update("config_hash", hash).Error; err != nil {
+					return fmt.Errorf("failed to update hash for provider %s: %w", provider.Name, err)
+				}
+			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -296,6 +296,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddBedrockAssumeRoleColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddStoreRawRequestResponseColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddPricingRefactorColumns(ctx, db); err != nil {
 		return err
 	}
@@ -307,6 +310,35 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	}
 	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
 		return err
+	}
+	return nil
+}
+
+func migrationAddStoreRawRequestResponseColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_store_raw_request_response_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableProvider{}, "store_raw_request_response") {
+				if err := migrator.AddColumn(&tables.TableProvider{}, "store_raw_request_response"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if err := migrator.DropColumn(&tables.TableProvider{}, "store_raw_request_response"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while running add store raw request response column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -248,6 +248,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			ProxyConfig:              providerConfig.ProxyConfig,
 			SendBackRawRequest:       providerConfig.SendBackRawRequest,
 			SendBackRawResponse:      providerConfig.SendBackRawResponse,
+			StoreRawRequestResponse:  providerConfig.StoreRawRequestResponse,
 			CustomProviderConfig:     providerConfig.CustomProviderConfig,
 			PricingOverrides:         providerConfig.PricingOverrides,
 			ConfigHash:               providerConfig.ConfigHash,
@@ -418,6 +419,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 	dbProvider.ProxyConfig = configCopy.ProxyConfig
 	dbProvider.SendBackRawRequest = configCopy.SendBackRawRequest
 	dbProvider.SendBackRawResponse = configCopy.SendBackRawResponse
+	dbProvider.StoreRawRequestResponse = configCopy.StoreRawRequestResponse
 	dbProvider.CustomProviderConfig = configCopy.CustomProviderConfig
 	dbProvider.PricingOverrides = configCopy.PricingOverrides
 	dbProvider.ConfigHash = configCopy.ConfigHash
@@ -556,6 +558,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		ProxyConfig:              configCopy.ProxyConfig,
 		SendBackRawRequest:       configCopy.SendBackRawRequest,
 		SendBackRawResponse:      configCopy.SendBackRawResponse,
+		StoreRawRequestResponse:  configCopy.StoreRawRequestResponse,
 		CustomProviderConfig:     configCopy.CustomProviderConfig,
 		PricingOverrides:         configCopy.PricingOverrides,
 		ConfigHash:               configCopy.ConfigHash,
@@ -714,6 +717,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 			ProxyConfig:              dbProvider.ProxyConfig,
 			SendBackRawRequest:       dbProvider.SendBackRawRequest,
 			SendBackRawResponse:      dbProvider.SendBackRawResponse,
+			StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
 			CustomProviderConfig:     dbProvider.CustomProviderConfig,
 			PricingOverrides:         dbProvider.PricingOverrides,
 			ConfigHash:               dbProvider.ConfigHash,
@@ -762,6 +766,7 @@ func (s *RDBConfigStore) GetProviderConfig(ctx context.Context, provider schemas
 		ProxyConfig:              dbProvider.ProxyConfig,
 		SendBackRawRequest:       dbProvider.SendBackRawRequest,
 		SendBackRawResponse:      dbProvider.SendBackRawResponse,
+		StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
 		CustomProviderConfig:     dbProvider.CustomProviderConfig,
 		PricingOverrides:         dbProvider.PricingOverrides,
 		ConfigHash:               dbProvider.ConfigHash,

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -24,6 +24,7 @@ type TableProvider struct {
 	PricingOverridesJSON     string    `gorm:"type:text" json:"-"`                                // JSON serialized []schemas.ProviderPricingOverride
 	SendBackRawRequest       bool      `json:"send_back_raw_request"`
 	SendBackRawResponse      bool      `json:"send_back_raw_response"`
+	StoreRawRequestResponse  bool      `json:"store_raw_request_response"`
 	CreatedAt                time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt                time.Time `gorm:"index;not null" json:"updated_at"`
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1170,7 +1170,8 @@
                   "budget_id": { "type": "string" },
                   "rate_limit_id": { "type": "string" },
                   "send_back_raw_request": { "type": "boolean" },
-                  "send_back_raw_response": { "type": "boolean" }
+                  "send_back_raw_response": { "type": "boolean" },
+                  "store_raw_request_response": { "type": "boolean" }
                 },
                 "required": ["name"]
               }
@@ -2191,6 +2192,10 @@
         },
         "send_back_raw_response": {
           "type": "boolean"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for plugins only; stripped before returning to client"
         },
         "custom_provider_config": {
           "type": "object",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -249,6 +249,7 @@ bifrost:
     #     password: ""
     #     ca_cert_pem: ""               # PEM-encoded CA cert for SSL-intercepting proxies
     #   send_back_raw_response: false   # Include raw response in BifrostResponse
+  #   store_raw_request_response: false # Capture raw payloads for plugins only; not returned to client
     #
     # anthropic:
     #   keys:

--- a/transports/bifrost-http/lib/validator.go
+++ b/transports/bifrost-http/lib/validator.go
@@ -8,9 +8,30 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
+
+// localSchemaCandidates lists paths (relative to CWD) where config.schema.json may be found
+// when running from a source checkout. Checked in order before falling back to the remote URL.
+var localSchemaCandidates = []string{
+	"config.schema.json",         // running from transports/
+	"../config.schema.json",      // running from transports/bifrost-http/
+	"transports/config.schema.json", // running from repo root
+}
+
+// tryLoadLocalSchema attempts to read config.schema.json from known local paths.
+// Returns nil if none are found.
+func tryLoadLocalSchema() []byte {
+	for _, p := range localSchemaCandidates {
+		data, err := os.ReadFile(p)
+		if err == nil {
+			return data
+		}
+	}
+	return nil
+}
 
 // ValidateConfigSchema validates config data against the JSON schema.
 // Returns nil if valid, or a formatted error describing all validation failures.
@@ -19,6 +40,10 @@ func ValidateConfigSchema(data []byte, schemaOverride ...[]byte) error {
 	var configSchemaJSONBytes []byte
 	if len(schemaOverride) > 0 && len(schemaOverride[0]) > 0 {
 		configSchemaJSONBytes = schemaOverride[0]
+	} else if localSchema := tryLoadLocalSchema(); localSchema != nil {
+		// Prefer the local schema file from the source checkout when available.
+		// This avoids validating against a potentially stale remote schema.
+		configSchemaJSONBytes = localSchema
 	} else {
 		// Pulling config.schema from https://www.getbifrost.ai/schema
 		configSchemaJSON, err := http.Get("https://www.getbifrost.ai/schema")

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -554,6 +554,10 @@
               "send_back_raw_response": {
                 "type": "boolean",
                 "description": "Include raw response in BifrostResponse"
+              },
+              "store_raw_request_response": {
+                "type": "boolean",
+                "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
               }
             },
             "required": ["name"]
@@ -2242,6 +2246,10 @@
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
         },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         },
@@ -2285,6 +2293,10 @@
         "send_back_raw_response": {
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
@@ -2330,6 +2342,10 @@
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
         },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         },
@@ -2374,6 +2390,10 @@
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
         },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
         },
@@ -2417,6 +2437,10 @@
         "send_back_raw_response": {
           "type": "boolean",
           "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"

--- a/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
@@ -133,11 +133,12 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 									<div className="space-y-0.5">
 										<FormLabel>Store Raw Request/Response</FormLabel>
 										<p className="text-muted-foreground text-xs">
-											Capture the raw provider request and response for internal logging only; the data is not exposed in API responses returned to clients
+											Capture the raw provider request and response for internal logging. Raw payloads are not returned to clients unless send_back_raw_request or send_back_raw_response are also enabled.
 										</p>
 									</div>
 									<FormControl>
 										<Switch
+											data-testid="provider-debugging-store-raw-request-response-switch"
 											size="md"
 											checked={field.value}
 											disabled={!hasUpdateProviderAccess}

--- a/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
@@ -28,6 +28,7 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 		defaultValues: {
 			send_back_raw_request: provider.send_back_raw_request ?? false,
 			send_back_raw_response: provider.send_back_raw_response ?? false,
+			store_raw_request_response: provider.store_raw_request_response ?? false,
 		},
 	});
 
@@ -39,14 +40,16 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 		form.reset({
 			send_back_raw_request: provider.send_back_raw_request ?? false,
 			send_back_raw_response: provider.send_back_raw_response ?? false,
+			store_raw_request_response: provider.store_raw_request_response ?? false,
 		});
-	}, [form, provider.name, provider.send_back_raw_request, provider.send_back_raw_response]);
+	}, [form, provider.name, provider.send_back_raw_request, provider.send_back_raw_response, provider.store_raw_request_response]);
 
 	const onSubmit = (data: DebuggingFormSchema) => {
 		const updatedProvider: ModelProvider = {
 			...provider,
 			send_back_raw_request: data.send_back_raw_request,
 			send_back_raw_response: data.send_back_raw_response,
+			store_raw_request_response: data.store_raw_request_response,
 		};
 		updateProvider(updatedProvider)
 			.unwrap()
@@ -113,6 +116,34 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 											onCheckedChange={(checked) => {
 												field.onChange(checked);
 												form.trigger("send_back_raw_response");
+											}}
+										/>
+									</FormControl>
+								</div>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={form.control}
+						name="store_raw_request_response"
+						render={({ field }) => (
+							<FormItem>
+								<div className="flex items-center justify-between space-x-2">
+									<div className="space-y-0.5">
+										<FormLabel>Store Raw Request/Response</FormLabel>
+										<p className="text-muted-foreground text-xs">
+											Capture the raw provider request and response for internal logging only; the data is not exposed in API responses returned to clients
+										</p>
+									</div>
+									<FormControl>
+										<Switch
+											size="md"
+											checked={field.value}
+											disabled={!hasUpdateProviderAccess}
+											onCheckedChange={(checked) => {
+												field.onChange(checked);
+												form.trigger("store_raw_request_response");
 											}}
 										/>
 									</FormControl>

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -303,6 +303,7 @@ export interface ModelProviderConfig {
 	proxy_config?: ProxyConfig;
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
+	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	pricing_overrides?: ProviderPricingOverride[];
 	status?: "unknown" | "success" | "list_models_failed";
@@ -331,6 +332,7 @@ export interface AddProviderRequest {
 	proxy_config?: ProxyConfig;
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
+	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	pricing_overrides?: ProviderPricingOverride[];
 }
@@ -343,6 +345,7 @@ export interface UpdateProviderRequest {
 	proxy_config: ProxyConfig;
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
+	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
 	pricing_overrides?: ProviderPricingOverride[];
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -512,6 +512,7 @@ export const modelProviderConfigSchema = z.object({
 	proxy_config: proxyConfigSchema.optional(),
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
+	store_raw_request_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
@@ -529,6 +530,7 @@ export const formModelProviderConfigSchema = z.object({
 	proxy_config: proxyConfigSchema.optional(),
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
+	store_raw_request_response: z.boolean().optional(),
 	custom_provider_config: formCustomProviderConfigSchema.optional(),
 	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
@@ -547,6 +549,7 @@ export const addProviderRequestSchema = z.object({
 	proxy_config: proxyConfigSchema.optional(),
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
+	store_raw_request_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
@@ -559,6 +562,7 @@ export const updateProviderRequestSchema = z.object({
 	proxy_config: proxyConfigSchema,
 	send_back_raw_request: z.boolean().optional(),
 	send_back_raw_response: z.boolean().optional(),
+	store_raw_request_response: z.boolean().optional(),
 	custom_provider_config: customProviderConfigSchema.optional(),
 	pricing_overrides: z.array(providerPricingOverrideSchema).optional(),
 });
@@ -642,6 +646,7 @@ export const performanceFormSchema = z.object({
 export const debuggingFormSchema = z.object({
 	send_back_raw_request: z.boolean(),
 	send_back_raw_response: z.boolean(),
+	store_raw_request_response: z.boolean(),
 });
 
 export type DebuggingFormSchema = z.infer<typeof debuggingFormSchema>;


### PR DESCRIPTION
## Summary

This PR introduces a new provider debugging option `store_raw_request_response` that allows Bifrost to capture raw provider request and response payloads for internal debugging and logging without returning them to API clients.

Currently, enabling raw payload debugging requires `send_back_raw_request` or `send_back_raw_response`, which exposes raw provider payloads in API responses. This change adds a logging-only mode where raw payloads can be captured internally while ensuring they are stripped before the response is returned to the client.

This allows safer debugging and observability without exposing provider payloads to downstream consumers.

---

## Changes

* Added new provider configuration option `store_raw_request_response`
* Introduced logging-only context flag to capture raw request/response payloads internally
* Updated raw payload handling logic to support logging-only mode
* Ensured raw payloads are stripped from API responses when:

  * `store_raw_request_response = true`
  * `send_back_raw_request = false`
  * `send_back_raw_response = false`
* Added tests validating logging-only behavior and raw payload stripping
* Propagated the new configuration through:

  * provider schema and config structs
  * config store
  * JSON configuration schema
  * UI types and validation
* Added a debugging toggle in the provider configuration UI

Design considerations:

* Existing behavior using `send_back_raw_request` and `send_back_raw_response` remains unchanged
* Logging-only mode captures raw payloads internally for plugins and observability
* API responses returned to clients remain clean

---

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [ ] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [x] UI (Next.js)
* [ ] Docs

---

## How to test

### Build the project

```sh
cd core
go build ./...
```

### Run the server

```sh
/tmp/bifrost-server -app-dir /tmp/bifrost-data -port 8080
```

Provider configuration example:

```json
{
  "providers": {
    "openai": {
      "keys": [
        {
          "name": "demo-key",
          "value": "sk-demo-key",
          "weight": 1
        }
      ],
      "network_config": {
        "base_url": "http://127.0.0.1:9999"
      },
      "store_raw_request_response": true,
      "send_back_raw_request": false,
      "send_back_raw_response": false
    }
  }
}
```

### Send a request through Bifrost

```sh
curl -s http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"openai/gpt-4","messages":[{"role":"user","content":"Hello, Bifrost!"}]}'
```

### Expected result

The API response contains normal completion data and metadata in `extra_fields`, but **does not include `raw_request` or `raw_response` fields**, demonstrating that raw payloads are captured internally but not returned to the client.

---

## Screenshots / Recordings

Example request sent through Bifrost with `store_raw_request_response=true` and `send_back_raw_* = false`.

<img width="1557" height="797" alt="Screenshot 2026-03-07 144139" src="https://github.com/user-attachments/assets/ecab1921-8a75-422e-b8db-34d92bce2005" />


The response returned to the client contains standard completion data and metadata but **does not expose raw provider payloads**.

---

## Breaking changes

* [ ] Yes
* [x] No

This change is backward compatible. Existing behavior using `send_back_raw_request` and `send_back_raw_response` remains unchanged.

---

## Related issues

Closes #1958

---

## Security considerations

This feature improves security by allowing raw payload capture for debugging and logging while preventing exposure of provider request and response payloads to API clients.

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable
