### PR TITLE
fix: tool call indexes in chat completions stream

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,3 +2,4 @@
 - feat: add DisableAutoToolInject to MCPToolManagerConfig to suppress automatic MCP tool injection per request
 - feat: add Filename field to TranscriptionInput schema to carry original filename through the request pipeline
 - fix: add AudioFilenameFromBytes utility to detect audio format from file headers with mp3 fallback
+- fix: streaming tool call indices for multiple parallel tool calls in chat completions stream

--- a/core/internal/llmtests/multiple_tool_calls.go
+++ b/core/internal/llmtests/multiple_tool_calls.go
@@ -2,8 +2,11 @@ package llmtests
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -187,5 +190,328 @@ func RunMultipleToolCallsTest(t *testing.T, client *bifrost.Bifrost, ctx context
 		}
 
 		t.Logf("🎉 Both Chat Completions and Responses APIs passed MultipleToolCalls test!")
+	})
+
+	// Streaming Chat Completions with multiple tool calls (validates sequential indices 0, 1, 2, ...)
+	t.Run("MultipleToolCallsStreamingChatCompletions", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		chatMessages := []schemas.ChatMessage{
+			CreateBasicChatMessage("I need to know the weather in London and also calculate 15 * 23. Can you help with both in a single request?"),
+		}
+		chatWeatherTool := GetSampleChatTool(SampleToolTypeWeather)
+		chatCalculatorTool := GetSampleChatTool(SampleToolTypeCalculate)
+
+		request := &schemas.BifrostChatRequest{
+			Provider: testConfig.Provider,
+			Model:    testConfig.ChatModel,
+			Input:    chatMessages,
+			Params: &schemas.ChatParameters{
+				MaxCompletionTokens: bifrost.Ptr(200),
+				Tools:               []schemas.ChatTool{*chatWeatherTool, *chatCalculatorTool},
+			},
+			Fallbacks: testConfig.Fallbacks,
+		}
+
+		retryConfig := MultiToolRetryConfig(2, []string{"weather", "calculate"})
+		retryContext := TestRetryContext{
+			ScenarioName: "MultipleToolCallsStreamingChatCompletions",
+			ExpectedBehavior: map[string]interface{}{
+				"expected_tool_count": 2,
+				"should_handle_both":  true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+				"model":    testConfig.ChatModel,
+			},
+		}
+
+		responseChannel, err := WithStreamRetry(t, retryConfig, retryContext, func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+			return client.ChatCompletionStreamRequest(bfCtx, request)
+		})
+
+		RequireNoError(t, err, "Chat completion stream with multiple tools failed")
+		if responseChannel == nil {
+			t.Fatal("Response channel should not be nil")
+		}
+
+		accumulator := NewStreamingToolCallAccumulator()
+		var responseCount int
+
+		for response := range responseChannel {
+			if response == nil || response.BifrostChatResponse == nil {
+				t.Fatal("Streaming response should not be nil")
+			}
+			responseCount++
+
+			if response.BifrostChatResponse.Choices != nil {
+				for _, choice := range response.BifrostChatResponse.Choices {
+					if choice.ChatStreamResponseChoice != nil && choice.ChatStreamResponseChoice.Delta != nil {
+						delta := choice.ChatStreamResponseChoice.Delta
+						if len(delta.ToolCalls) > 0 {
+							for _, toolCall := range delta.ToolCalls {
+								accumulator.AccumulateChatToolCall(choice.Index, toolCall)
+							}
+						}
+					}
+				}
+			}
+
+			if responseCount > 500 {
+				break
+			}
+		}
+
+		if responseCount == 0 {
+			t.Fatal("Should receive at least one streaming response")
+		}
+
+		finalToolCalls := accumulator.GetFinalChatToolCalls()
+
+		if len(finalToolCalls) == 0 {
+			t.Fatal("❌ No tool calls found in streaming response")
+		}
+
+		if len(finalToolCalls) < 2 {
+			t.Fatalf("❌ Expected at least 2 tool calls, got %d", len(finalToolCalls))
+		}
+
+		toolsFound := make(map[string]bool)
+		for i, tc := range finalToolCalls {
+			if tc.Index != i {
+				t.Fatalf("❌ Tool call %d has index %d, expected %d", i, tc.Index, i)
+			}
+			toolsFound[tc.Name] = true
+		}
+
+		for _, expected := range []string{"weather", "calculate"} {
+			if !toolsFound[expected] {
+				t.Fatalf("❌ Expected tool '%s' not found. Found: %v", expected, getKeysFromMap(toolsFound))
+			}
+		}
+
+		if err := validateStreamingToolCalls(finalToolCalls, "Chat Completions"); err != nil {
+			t.Fatalf("❌ %v", err)
+		}
+		t.Logf("✅ MultipleToolCallsStreamingChatCompletions passed with %d tool calls", len(finalToolCalls))
+	})
+
+	// Streaming Responses API with multiple tool calls
+	t.Run("MultipleToolCallsStreamingResponses", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		responsesMessages := []schemas.ResponsesMessage{
+			CreateBasicResponsesMessage("I need to know the weather in London and also calculate 15 * 23. Can you help with both in a single request?"),
+		}
+		responsesWeatherTool := GetSampleResponsesTool(SampleToolTypeWeather)
+		responsesCalculatorTool := GetSampleResponsesTool(SampleToolTypeCalculate)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: testConfig.Provider,
+			Model:    testConfig.ChatModel,
+			Input:    responsesMessages,
+			Params: &schemas.ResponsesParameters{
+				Tools: []schemas.ResponsesTool{*responsesWeatherTool, *responsesCalculatorTool},
+			},
+			Fallbacks: testConfig.Fallbacks,
+		}
+
+		retryConfig := MultiToolRetryConfig(2, []string{"weather", "calculate"})
+		retryContext := TestRetryContext{
+			ScenarioName: "MultipleToolCallsStreamingResponses",
+			ExpectedBehavior: map[string]interface{}{
+				"expected_tool_count": 2,
+				"should_handle_both":  true,
+			},
+			TestMetadata: map[string]interface{}{
+				"provider": testConfig.Provider,
+				"model":    testConfig.ChatModel,
+			},
+		}
+
+		validationResult := WithResponsesStreamValidationRetry(t, retryConfig, retryContext,
+			func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				return client.ResponsesStreamRequest(bfCtx, request)
+			},
+			func(responseChannel chan *schemas.BifrostStreamChunk) ResponsesStreamValidationResult {
+				accumulator := NewStreamingToolCallAccumulator()
+				var responseCount int
+				streamCtx, cancel := context.WithTimeout(ctx, 200*time.Second)
+				defer cancel()
+
+				for {
+					select {
+					case response, ok := <-responseChannel:
+						if !ok {
+							goto streamComplete
+						}
+						if response == nil {
+							return ResponsesStreamValidationResult{
+								Passed: false,
+								Errors: []string{"❌ Streaming response should not be nil"},
+							}
+						}
+						responseCount++
+
+						if response.BifrostResponsesStreamResponse == nil {
+							errMsg := fmt.Sprintf("❌ Unexpected non-response chunk at chunk %d", responseCount)
+							if response.BifrostError != nil {
+								errMsg += fmt.Sprintf(" - error: %s", GetErrorMessage(response.BifrostError))
+							}
+							return ResponsesStreamValidationResult{
+								Passed: false,
+								Errors: []string{errMsg},
+							}
+						}
+
+						streamResp := response.BifrostResponsesStreamResponse
+						switch streamResp.Type {
+						case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta:
+							var arguments *string
+							if streamResp.Delta != nil {
+								arguments = streamResp.Delta
+							} else if streamResp.Arguments != nil {
+								arguments = streamResp.Arguments
+							}
+							if arguments != nil {
+								var callID, name, itemID *string
+								if streamResp.ItemID != nil {
+									itemID = streamResp.ItemID
+								}
+								if streamResp.Item != nil && streamResp.Item.ResponsesToolMessage != nil {
+									callID = streamResp.Item.ResponsesToolMessage.CallID
+									name = streamResp.Item.ResponsesToolMessage.Name
+								}
+								if streamResp.Item != nil && streamResp.Item.ID != nil {
+									itemID = streamResp.Item.ID
+								}
+								accumulator.AccumulateResponsesToolCall(callID, name, arguments, itemID)
+							}
+						case schemas.ResponsesStreamResponseTypeOutputItemAdded:
+							if streamResp.Item != nil && streamResp.Item.Type != nil &&
+								*streamResp.Item.Type == schemas.ResponsesMessageTypeFunctionCall {
+								var callID, name, itemID *string
+								if streamResp.Item.ID != nil {
+									itemID = streamResp.Item.ID
+								}
+								if streamResp.Item.ResponsesToolMessage != nil {
+									callID = streamResp.Item.ResponsesToolMessage.CallID
+									name = streamResp.Item.ResponsesToolMessage.Name
+									if streamResp.Item.ResponsesToolMessage.Arguments != nil {
+										accumulator.AccumulateResponsesToolCall(callID, name, streamResp.Item.ResponsesToolMessage.Arguments, itemID)
+									}
+								}
+								if streamResp.Item.ResponsesToolMessage == nil || streamResp.Item.ResponsesToolMessage.Arguments == nil {
+									accumulator.AccumulateResponsesToolCall(callID, name, nil, itemID)
+								}
+							}
+						case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDone:
+							if streamResp.Arguments != nil {
+								var callID, name, itemID *string
+								if streamResp.ItemID != nil {
+									itemID = streamResp.ItemID
+								}
+								if streamResp.Item != nil && streamResp.Item.ResponsesToolMessage != nil {
+									callID = streamResp.Item.ResponsesToolMessage.CallID
+									name = streamResp.Item.ResponsesToolMessage.Name
+								}
+								if streamResp.Item != nil && streamResp.Item.ID != nil {
+									itemID = streamResp.Item.ID
+								}
+								accumulator.AccumulateResponsesToolCall(callID, name, streamResp.Arguments, itemID)
+							}
+						}
+
+						if responseCount > 500 {
+							return ResponsesStreamValidationResult{
+								Passed: false,
+								Errors: []string{"❌ Received too many streaming chunks"},
+							}
+						}
+
+					case <-streamCtx.Done():
+						return ResponsesStreamValidationResult{
+							Passed:       false,
+							Errors:       []string{"❌ Timeout waiting for responses streaming response"},
+							ReceivedData: responseCount > 0,
+						}
+					}
+				}
+
+			streamComplete:
+				if responseCount == 0 {
+					return ResponsesStreamValidationResult{
+						Passed:       false,
+						Errors:       []string{"❌ Stream closed without receiving any data"},
+						ReceivedData: false,
+					}
+				}
+
+				finalToolCalls := accumulator.GetFinalResponsesToolCalls()
+
+				if len(finalToolCalls) == 0 {
+					return ResponsesStreamValidationResult{
+						Passed:       false,
+						Errors:       []string{"❌ No tool calls found in streaming response"},
+						ReceivedData: responseCount > 0,
+					}
+				}
+
+				if len(finalToolCalls) < 2 {
+					return ResponsesStreamValidationResult{
+						Passed:       false,
+						Errors:       []string{fmt.Sprintf("❌ Expected at least 2 tool calls, got %d", len(finalToolCalls))},
+						ReceivedData: responseCount > 0,
+					}
+				}
+
+				toolsFound := make(map[string]bool)
+				var validationErrors []string
+				for i, tc := range finalToolCalls {
+					if tc.Name == "" || tc.Arguments == "" {
+						validationErrors = append(validationErrors, fmt.Sprintf("Tool call %d missing required fields", i))
+					}
+					toolsFound[tc.Name] = true
+				}
+
+				for _, expected := range []string{"weather", "calculate"} {
+					if !toolsFound[expected] {
+						validationErrors = append(validationErrors, fmt.Sprintf("Expected tool '%s' not found. Found: %v", expected, getKeysFromMap(toolsFound)))
+					}
+				}
+
+				if len(validationErrors) > 0 {
+					return ResponsesStreamValidationResult{
+						Passed:       false,
+						Errors:       validationErrors,
+						ReceivedData: responseCount > 0,
+					}
+				}
+
+				if err := validateStreamingToolCalls(finalToolCalls, "Responses API"); err != nil {
+					return ResponsesStreamValidationResult{
+						Passed:       false,
+						Errors:       []string{fmt.Sprintf("❌ %v", err)},
+						ReceivedData: responseCount > 0,
+					}
+				}
+				return ResponsesStreamValidationResult{
+					Passed:       true,
+					ReceivedData: responseCount > 0,
+				}
+			})
+
+		if !validationResult.Passed {
+			allErrors := append(validationResult.Errors, validationResult.StreamErrors...)
+			t.Fatalf("❌ MultipleToolCallsStreamingResponses failed: %s", strings.Join(allErrors, "; "))
+		}
+
+		t.Logf("✅ MultipleToolCallsStreamingResponses passed")
 	})
 }

--- a/core/internal/llmtests/tool_calls_streaming.go
+++ b/core/internal/llmtests/tool_calls_streaming.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/stretchr/testify/require"
 )
 
 // StreamingToolCallAccumulator accumulates tool call fragments from streaming responses
@@ -185,9 +185,18 @@ func (acc *StreamingToolCallAccumulator) AccumulateResponsesToolCall(callID *str
 
 // GetFinalChatToolCalls returns the final accumulated tool calls for Chat Completions
 func (acc *StreamingToolCallAccumulator) GetFinalChatToolCalls() []ToolCallInfo {
+	keys := make([]int, 0, len(acc.ChatToolCalls))
+	for k := range acc.ChatToolCalls {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+
 	var result []ToolCallInfo
-	for _, toolCall := range acc.ChatToolCalls {
-		info := ToolCallInfo{}
+	for _, key := range keys {
+		toolCall := acc.ChatToolCalls[key]
+		info := ToolCallInfo{
+			Index: key,
+		}
 		if toolCall.ID != nil {
 			info.ID = *toolCall.ID
 		}
@@ -343,7 +352,9 @@ func RunToolCallsStreamingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			}
 		}
 
-		validateStreamingToolCalls(t, finalToolCalls, "Chat Completions")
+		if err := validateStreamingToolCalls(finalToolCalls, "Chat Completions"); err != nil {
+			t.Fatalf("❌ %v", err)
+		}
 		t.Logf("✅ Chat Completions streaming with tools test completed successfully")
 	})
 
@@ -713,7 +724,13 @@ func RunToolCallsStreamingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 					}
 				}
 
-				validateStreamingToolCalls(t, finalToolCalls, "Responses API")
+				if err := validateStreamingToolCalls(finalToolCalls, "Responses API"); err != nil {
+					return ResponsesStreamValidationResult{
+						Passed:       false,
+						Errors:       []string{fmt.Sprintf("❌ %v", err)},
+						ReceivedData: responseCount > 0,
+					}
+				}
 				return ResponsesStreamValidationResult{
 					Passed:       true,
 					ReceivedData: responseCount > 0,
@@ -734,52 +751,31 @@ func RunToolCallsStreamingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 	})
 }
 
-// validateStreamingToolCalls validates that all tool calls have ID, name, and arguments
-func validateStreamingToolCalls(t *testing.T, toolCalls []ToolCallInfo, apiName string) {
+// validateStreamingToolCalls validates that all tool calls have ID, name, and arguments.
+func validateStreamingToolCalls(toolCalls []ToolCallInfo, apiName string) error {
 	if len(toolCalls) == 0 {
-		t.Fatalf("❌ %s: No tool calls found in streaming response", apiName)
+		return fmt.Errorf("%s: no tool calls found in streaming response", apiName)
 	}
-
-	t.Logf("📊 %s: Found %d tool call(s) in streaming response", apiName, len(toolCalls))
 
 	for i, toolCall := range toolCalls {
-		// Validate ID
 		if toolCall.ID == "" {
-			t.Fatalf("❌ %s: Tool call %d missing ID", apiName, i)
-		} else {
-			t.Logf("✅ %s: Tool call %d has ID: %s", apiName, i, toolCall.ID)
+			return fmt.Errorf("%s: tool call %d missing ID", apiName, i)
 		}
-
-		// Validate name
 		if toolCall.Name == "" {
-			t.Fatalf("❌ %s: Tool call %d missing name", apiName, i)
-		} else {
-			t.Logf("✅ %s: Tool call %d has name: %s", apiName, i, toolCall.Name)
+			return fmt.Errorf("%s: tool call %d missing name", apiName, i)
 		}
-
-		// Validate arguments
 		if toolCall.Arguments == "" {
-			t.Fatalf("❌ %s: Tool call %d missing arguments", apiName, i)
-		} else {
-			// Try to parse arguments as JSON to ensure they're valid
-			var args map[string]interface{}
-			if err := json.Unmarshal([]byte(toolCall.Arguments), &args); err != nil {
-				t.Logf("⚠️ %s: Tool call %d arguments are not valid JSON: %v", apiName, i, err)
-				// Don't fail on this - some providers might send partial JSON during streaming
-				// But we should at least have some content
-				if strings.TrimSpace(toolCall.Arguments) == "" {
-					t.Fatalf("❌ %s: Tool call %d has empty arguments", apiName, i)
-				}
-			} else {
-				t.Logf("✅ %s: Tool call %d has valid JSON arguments: %s", apiName, i, toolCall.Arguments)
+			return fmt.Errorf("%s: tool call %d missing arguments", apiName, i)
+		}
+		// Try to parse arguments as JSON to ensure they're valid
+		var args map[string]interface{}
+		if err := json.Unmarshal([]byte(toolCall.Arguments), &args); err != nil {
+			// Don't fail on invalid JSON - some providers might send partial JSON during streaming
+			// But we should at least have some content
+			if strings.TrimSpace(toolCall.Arguments) == "" {
+				return fmt.Errorf("%s: tool call %d has empty arguments", apiName, i)
 			}
 		}
-
-		// All three must be present for the test to pass
-		require.NotEmpty(t, toolCall.ID, "%s: Tool call %d must have an ID", apiName, i)
-		require.NotEmpty(t, toolCall.Name, "%s: Tool call %d must have a name", apiName, i)
-		require.NotEmpty(t, toolCall.Arguments, "%s: Tool call %d must have arguments", apiName, i)
 	}
-
-	t.Logf("✅ %s: All tool calls have ID, name, and arguments present", apiName)
+	return nil
 }

--- a/core/internal/llmtests/utils.go
+++ b/core/internal/llmtests/utils.go
@@ -89,11 +89,11 @@ func GetProviderVoice(provider schemas.ModelProvider, voiceType string) string {
 type SampleToolType string
 
 const (
-	SampleToolTypeWeather              SampleToolType = "weather"
-	SampleToolTypeCalculate            SampleToolType = "calculate"
-	SampleToolTypeTime                 SampleToolType = "time"
-	SampleToolTypePingWithEmpty        SampleToolType = "ping_empty"
-	SampleToolTypePingWithNil          SampleToolType = "ping_nil"
+	SampleToolTypeWeather       SampleToolType = "weather"
+	SampleToolTypeCalculate     SampleToolType = "calculate"
+	SampleToolTypeTime          SampleToolType = "time"
+	SampleToolTypePingWithEmpty SampleToolType = "ping_empty"
+	SampleToolTypePingWithNil   SampleToolType = "ping_nil"
 )
 
 var SampleToolFunctions = map[SampleToolType]*schemas.ChatToolFunction{
@@ -396,6 +396,7 @@ type ToolCallInfo struct {
 	Name      string
 	Arguments string
 	ID        string
+	Index     int // OpenAI tool_calls index (0, 1, 2, ...); -1 when not available
 }
 
 // GetChatContent returns the string content from a BifrostChatResponse
@@ -503,8 +504,9 @@ func ExtractChatToolCalls(response *schemas.BifrostChatResponse) []ToolCallInfo 
 	for _, choice := range response.Choices {
 		if choice.Message.ChatAssistantMessage != nil && choice.Message.ChatAssistantMessage.ToolCalls != nil {
 			for _, toolCall := range choice.Message.ChatAssistantMessage.ToolCalls {
-				info := ToolCallInfo{
-					ID: *toolCall.ID,
+				info := ToolCallInfo{}
+				if toolCall.ID != nil {
+					info.ID = *toolCall.ID
 				}
 				if toolCall.Function.Name != nil {
 					info.Name = *toolCall.Function.Name

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -693,6 +693,9 @@ func HandleAnthropicChatCompletionStreaming(
 			structuredOutputToolName = toolName
 		}
 
+		// Per-response tool-call index state
+		streamState := NewAnthropicStreamState()
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -837,7 +840,7 @@ func HandleAnthropicChatCompletionStreaming(
 				}
 			}
 
-			response, bifrostErr, isLastChunk := event.ToBifrostChatCompletionStream(ctx, structuredOutputToolName)
+			response, bifrostErr, isLastChunk := event.ToBifrostChatCompletionStream(ctx, structuredOutputToolName, streamState)
 			if bifrostErr != nil {
 				bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
 					RequestType:    schemas.ChatCompletionStreamRequest,
@@ -1805,24 +1808,6 @@ func (provider *AnthropicProvider) BatchResults(ctx *schemas.BifrostContext, key
 	}
 
 	return nil, lastErr
-}
-
-// splitJSONL splits JSONL content into individual lines.
-func splitJSONL(data []byte) [][]byte {
-	var lines [][]byte
-	start := 0
-	for i, b := range data {
-		if b == '\n' {
-			if i > start {
-				lines = append(lines, data[start:i])
-			}
-			start = i + 1
-		}
-	}
-	if start < len(data) {
-		lines = append(lines, data[start:])
-	}
-	return lines
 }
 
 // Embedding is not supported by the Anthropic provider.

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -682,8 +682,27 @@ func ToAnthropicChatResponse(bifrostResp *schemas.BifrostChatResponse) *Anthropi
 	return anthropicResp
 }
 
+// AnthropicStreamState tracks per-stream tool call index state.
+type AnthropicStreamState struct {
+	nextToolCallIndex         int
+	contentBlockToToolCallIdx map[int]int
+}
+
+// NewAnthropicStreamState returns an initialised stream state for one streaming response.
+func NewAnthropicStreamState() *AnthropicStreamState {
+	return &AnthropicStreamState{
+		contentBlockToToolCallIdx: make(map[int]int),
+	}
+}
+
 // ToBifrostChatCompletionStream converts an Anthropic stream event to a Bifrost Chat Completion Stream response
-func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.BifrostContext, structuredOutputToolName string) (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
+func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.BifrostContext, structuredOutputToolName string, state *AnthropicStreamState) (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
+	if state == nil {
+		state = NewAnthropicStreamState()
+	} else if state.contentBlockToToolCallIdx == nil {
+		state.contentBlockToToolCallIdx = make(map[int]int)
+	}
+
 	switch chunk.Type {
 	case AnthropicStreamEventTypeMessageStart:
 		return nil, nil, false
@@ -700,6 +719,11 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 				return nil, nil, false
 			}
 
+			// Assign the next sequential tool-call index
+			toolCallIdx := state.nextToolCallIndex
+			state.contentBlockToToolCallIdx[*chunk.Index] = toolCallIdx
+			state.nextToolCallIndex++
+
 			// Create streaming response with tool call metadata
 			streamResponse := &schemas.BifrostChatResponse{
 				Object: "chat.completion.chunk",
@@ -710,8 +734,9 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 							Delta: &schemas.ChatStreamResponseChoiceDelta{
 								ToolCalls: []schemas.ChatAssistantMessageToolCall{
 									{
-										Type: schemas.Ptr(string(schemas.ChatToolTypeFunction)),
-										ID:   chunk.ContentBlock.ID,
+										Index: uint16(toolCallIdx),
+										Type:  schemas.Ptr(string(schemas.ChatToolTypeFunction)),
+										ID:    chunk.ContentBlock.ID,
 										Function: schemas.ChatAssistantMessageToolCallFunction{
 											Name:      chunk.ContentBlock.Name,
 											Arguments: "", // Empty arguments initially, will be filled by subsequent deltas
@@ -773,6 +798,10 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 						}
 						return streamResponse, nil, false
 					}
+
+					// Resolve which tool-call this delta belongs to via the content-block index.
+					toolCallIdx := state.contentBlockToToolCallIdx[*chunk.Index]
+
 					// Create streaming response for tool input delta
 					streamResponse := &schemas.BifrostChatResponse{
 						Object: "chat.completion.chunk",
@@ -783,7 +812,8 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 									Delta: &schemas.ChatStreamResponseChoiceDelta{
 										ToolCalls: []schemas.ChatAssistantMessageToolCall{
 											{
-												Type: func() *string { s := "function"; return &s }(),
+												Index: uint16(toolCallIdx),
+												Type:  schemas.Ptr(string(schemas.ChatToolTypeFunction)),
 												Function: schemas.ChatAssistantMessageToolCallFunction{
 													Arguments: *chunk.Delta.PartialJSON,
 												},

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1073,6 +1073,8 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		var structuredOutputBuilder strings.Builder
 		var isAccumulatingStructuredOutput bool
 
+		streamState := NewBedrockStreamState()
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -1215,7 +1217,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 					}
 				}
 
-				response, bifrostErr, _ := streamEvent.ToBifrostChatCompletionStream()
+				response, bifrostErr, _ := streamEvent.ToBifrostChatCompletionStream(streamState)
 				if bifrostErr != nil {
 					bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
 						RequestType:    schemas.ChatCompletionStreamRequest,

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -267,7 +267,26 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(ctx context.Conte
 	return bifrostResponse, nil
 }
 
-func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
+// BedrockStreamState tracks per-stream tool call index state.
+type BedrockStreamState struct {
+	nextToolCallIndex         int
+	contentBlockToToolCallIdx map[int]int
+}
+
+// NewBedrockStreamState returns initialised stream state for one streaming response.
+func NewBedrockStreamState() *BedrockStreamState {
+	return &BedrockStreamState{
+		contentBlockToToolCallIdx: make(map[int]int),
+	}
+}
+
+func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream(state *BedrockStreamState) (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
+	if state == nil {
+		state = NewBedrockStreamState()
+	} else if state.contentBlockToToolCallIdx == nil {
+		state.contentBlockToToolCallIdx = make(map[int]int)
+	}
+
 	// event with metrics/usage is the last and with stop reason is the second last
 	switch {
 	case chunk.Role != nil:
@@ -291,16 +310,16 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 	case chunk.Start != nil && chunk.Start.ToolUse != nil:
 		toolUseStart := chunk.Start.ToolUse
 
-		// Determine the tool call index from ContentBlockIndex
-		// ContentBlockIndex identifies which content block this tool call belongs to
-		var toolCallIndex uint16
+		toolCallIdx := 0
 		if chunk.ContentBlockIndex != nil {
-			toolCallIndex = uint16(*chunk.ContentBlockIndex)
+			toolCallIdx = state.nextToolCallIndex
+			state.contentBlockToToolCallIdx[*chunk.ContentBlockIndex] = toolCallIdx
+			state.nextToolCallIndex++
 		}
 
 		// Create tool call structure for start event
 		var toolCall schemas.ChatAssistantMessageToolCall
-		toolCall.Index = toolCallIndex
+		toolCall.Index = uint16(toolCallIdx)
 		toolCall.ID = schemas.Ptr(toolUseStart.ToolUseID)
 		toolCall.Type = schemas.Ptr("function")
 		toolCall.Function.Name = schemas.Ptr(toolUseStart.Name)
@@ -349,16 +368,14 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifro
 			// Handle tool use delta
 			toolUseDelta := chunk.Delta.ToolUse
 
-			// Determine the tool call index from ContentBlockIndex
-			// This must match the index used in the corresponding Start event
-			var toolCallIndex uint16
+			toolCallIdx := 0
 			if chunk.ContentBlockIndex != nil {
-				toolCallIndex = uint16(*chunk.ContentBlockIndex)
+				toolCallIdx = state.contentBlockToToolCallIdx[*chunk.ContentBlockIndex]
 			}
 
 			// Create tool call structure
 			var toolCall schemas.ChatAssistantMessageToolCall
-			toolCall.Index = toolCallIndex
+			toolCall.Index = uint16(toolCallIdx)
 			toolCall.Type = schemas.Ptr("function")
 
 			// For streaming, we need to accumulate tool use data

--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -509,6 +509,10 @@ func (chunk *CohereStreamEvent) ToBifrostChatCompletionStream() (*schemas.Bifros
 			cohereToolCall := chunk.Delta.Message.ToolCalls.CohereToolCallObject
 			toolCall := schemas.ChatAssistantMessageToolCall{}
 
+			if chunk.Index != nil {
+				toolCall.Index = uint16(*chunk.Index)
+			}
+
 			if cohereToolCall.ID != nil {
 				toolCall.ID = cohereToolCall.ID
 			}

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -271,11 +271,25 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	return bifrostResp
 }
 
+// GeminiStreamState tracks tool-call index across streaming chunks.
+type GeminiStreamState struct {
+	nextToolCallIndex int
+}
+
+// NewGeminiStreamState returns initialised stream state for one streaming response.
+func NewGeminiStreamState() *GeminiStreamState {
+	return &GeminiStreamState{}
+}
+
 // ToBifrostChatCompletionStream converts a Gemini streaming response to a Bifrost Chat Completion Stream response
 // Returns the response, error (if any), and a boolean indicating if this is the last chunk
-func (response *GenerateContentResponse) ToBifrostChatCompletionStream() (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
+func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *GeminiStreamState) (*schemas.BifrostChatResponse, *schemas.BifrostError, bool) {
 	if response == nil {
 		return nil, nil, false
+	}
+
+	if state == nil {
+		state = NewGeminiStreamState()
 	}
 
 	// Handle empty candidates (filtered/malformed responses)
@@ -360,8 +374,11 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream() (*schem
 					callID = fmt.Sprintf("%s%s%s", callID, thoughtSignatureSeparator, encoded)
 				}
 
+				toolCallIdx := state.nextToolCallIndex
+				state.nextToolCallIndex++
+
 				toolCall := schemas.ChatAssistantMessageToolCall{
-					Index: uint16(len(toolCalls)),
+					Index: uint16(toolCallIdx),
 					Type:  schemas.Ptr(string(schemas.ChatToolTypeFunction)),
 					ID:    &callID,
 					Function: schemas.ChatAssistantMessageToolCallFunction{

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -511,6 +511,8 @@ func HandleGeminiChatCompletionStream(
 		var responseID string
 		var modelName string
 
+		streamState := NewGeminiStreamState()
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -573,7 +575,7 @@ func HandleGeminiChatCompletionStream(
 			}
 
 			// Convert to Bifrost stream response
-			response, bifrostErr, isLastChunk := geminiResponse.ToBifrostChatCompletionStream()
+			response, bifrostErr, isLastChunk := geminiResponse.ToBifrostChatCompletionStream(streamState)
 			if bifrostErr != nil {
 				bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
 					RequestType:    schemas.ChatCompletionStreamRequest,

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -170,7 +170,7 @@ func TestEmptyCandidatesRegression(t *testing.T) {
 			var bifrostResp *schemas.BifrostChatResponse
 
 			if tt.isStream {
-				bifrostResp, _, _ = tt.response.ToBifrostChatCompletionStream()
+				bifrostResp, _, _ = tt.response.ToBifrostChatCompletionStream(gemini.NewGeminiStreamState())
 			} else {
 				bifrostResp = tt.response.ToBifrostChatResponse()
 			}
@@ -274,7 +274,7 @@ func TestThoughtSignatureInToolCalls(t *testing.T) {
 			var bifrostResp *schemas.BifrostChatResponse
 
 			if tt.isStream {
-				bifrostResp, _, _ = tt.response.ToBifrostChatCompletionStream()
+				bifrostResp, _, _ = tt.response.ToBifrostChatCompletionStream(gemini.NewGeminiStreamState())
 			} else {
 				bifrostResp = tt.response.ToBifrostChatResponse()
 			}

--- a/core/providers/xai/xai_test.go
+++ b/core/providers/xai/xai_test.go
@@ -27,7 +27,7 @@ func TestXAI(t *testing.T) {
 		ChatModel:            "grok-4-0709",
 		ReasoningModel:       "grok-3-mini",
 		TextModel:            "grok-3",
-		VisionModel:          "grok-2-vision-1212",
+		VisionModel:          "grok-4-1-fast-reasoning",
 		EmbeddingModel:       "", // XAI doesn't support embedding
 		ImageGenerationModel: "grok-2-image",
 		Scenarios: llmtests.TestScenarios{

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,3 +2,4 @@
 - fix: async jobs stuck in "processing" on marshal failure now correctly transition to "failed"
 - feat: adds attachment support in Maxim plugin
 - feat: add x-bf-api-key-id header support for explicit key selection by ID, with priority over x-bf-api-key name selection
+- fix: streaming tool call indices for multiple parallel tool calls in chat completions stream


### PR DESCRIPTION
## Summary

Fixed streaming tool call indices for multiple parallel tool calls in chat completions stream. Previously, tool call indices were not properly sequenced (0, 1, 2, ...) when multiple tools were called in parallel during streaming responses.  
  
fixes #1961

## Changes

- Added stream state tracking for tool call indices across all providers (Anthropic, Bedrock, Gemini, Cohere)
- Implemented `AnthropicStreamState`, `BedrockStreamState`, and `GeminiStreamState` to maintain sequential tool call indexing
- Updated streaming response handlers to assign proper sequential indices (0, 1, 2, ...) for multiple parallel tool calls
- Added comprehensive test coverage for streaming multiple tool calls in both Chat Completions and Responses APIs
- Enhanced test utilities with streaming tool call accumulator and validation functions

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the multiple tool calls streaming tests to validate proper index sequencing:

```sh
# Core/Transports
go version
go test ./...

# Specifically test multiple tool calls streaming
go test -v ./core/internal/llmtests -run TestMultipleToolCallsStreaming
```

The tests validate that:

- Tool call indices are properly sequenced (0, 1, 2, ...)
- Multiple tools (weather, calculate) are called in parallel
- Streaming responses maintain correct tool call metadata

## Screenshots/Recordings

N/A - Backend streaming API fix

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes streaming tool call index sequencing for multiple parallel tool calls

## Security considerations

No security implications - internal streaming response formatting fix

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable