### PR TITLE
feat(api): expose model capabilities via /api/models/details

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -565,6 +565,8 @@ paths:
     $ref: './paths/management/providers.yaml#/keys'
   /api/models:
     $ref: './paths/management/providers.yaml#/models'
+  /api/models/details:
+    $ref: './paths/management/providers.yaml#/models-details'
 
   # Plugins
   /api/plugins:

--- a/docs/openapi/paths/management/providers.yaml
+++ b/docs/openapi/paths/management/providers.yaml
@@ -182,8 +182,12 @@ models:
       - name: keys
         in: query
         description: Comma-separated list of key IDs to filter models accessible by those keys
+        style: form
+        explode: false
         schema:
-          type: string
+          type: array
+          items:
+            type: string
       - name: limit
         in: query
         description: Maximum number of results to return (default 5)
@@ -229,8 +233,12 @@ models-details:
       - name: keys
         in: query
         description: Comma-separated list of key IDs to filter models accessible by those keys
+        style: form
+        explode: false
         schema:
-          type: string
+          type: array
+          items:
+            type: string
       - name: limit
         in: query
         description: Maximum number of results to return (default 20)

--- a/docs/openapi/paths/management/providers.yaml
+++ b/docs/openapi/paths/management/providers.yaml
@@ -190,6 +190,12 @@ models:
         schema:
           type: integer
           default: 5
+      - name: unfiltered
+        in: query
+        description: If true, return all models including those filtered out by provider-level restrictions
+        schema:
+          type: boolean
+          default: false
     responses:
       '200':
         description: Successful response
@@ -197,5 +203,52 @@ models:
           application/json:
             schema:
               $ref: '../../schemas/management/providers.yaml#/ListModelsResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+models-details:
+  get:
+    operationId: listModelDetailsManagement
+    summary: List model details
+    description: |
+      Lists available models with capability metadata (context length and token limits),
+      with optional filtering by query, provider, or keys.
+    tags:
+      - Providers
+    parameters:
+      - name: query
+        in: query
+        description: Filter models by name (case-insensitive partial match)
+        schema:
+          type: string
+      - name: provider
+        in: query
+        description: Filter by specific provider name
+        schema:
+          type: string
+      - name: keys
+        in: query
+        description: Comma-separated list of key IDs to filter models accessible by those keys
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Maximum number of results to return (default 20)
+        schema:
+          type: integer
+          default: 20
+      - name: unfiltered
+        in: query
+        description: If true, return all models including those filtered out by provider-level restrictions
+        schema:
+          type: boolean
+          default: false
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/ListModelDetailsResponse'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -360,3 +360,53 @@ ListModelsResponse:
         $ref: '#/ModelResponse'
     total:
       type: integer
+
+ModelDetailsResponse:
+  type: object
+  description: Model details with capability metadata
+  properties:
+    name:
+      type: string
+    provider:
+      type: string
+    context_length:
+      type: integer
+    max_input_tokens:
+      type: integer
+    max_output_tokens:
+      type: integer
+    architecture:
+      $ref: '#/Architecture'
+    accessible_by_keys:
+      type: array
+      items:
+        type: string
+
+Architecture:
+  type: object
+  properties:
+    modality:
+      type: string
+    tokenizer:
+      type: string
+    instruct_type:
+      type: string
+    input_modalities:
+      type: array
+      items:
+        type: string
+    output_modalities:
+      type: array
+      items:
+        type: string
+
+ListModelDetailsResponse:
+  type: object
+  description: List model details response
+  properties:
+    models:
+      type: array
+      items:
+        $ref: '#/ModelDetailsResponse'
+    total:
+      type: integer

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -299,6 +299,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddModelCapabilityColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4281,5 +4284,52 @@ func migrationAddPromptRepoTables(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("error while running add_model_parameters_table migration: %s", err.Error())
 	}
 
+	return nil
+}
+
+// migrationAddModelCapabilityColumns adds capability columns to governance_model_pricing.
+func migrationAddModelCapabilityColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_capability_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			columns := []string{
+				"context_length",
+				"max_input_tokens",
+				"max_output_tokens",
+				"architecture",
+			}
+			for _, column := range columns {
+				if !mg.HasColumn(&tables.TableModelPricing{}, column) {
+					if err := mg.AddColumn(&tables.TableModelPricing{}, column); err != nil {
+						return fmt.Errorf("failed to add %s column: %w", column, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			columns := []string{
+				"context_length",
+				"max_input_tokens",
+				"max_output_tokens",
+				"architecture",
+			}
+			for _, column := range columns {
+				if mg.HasColumn(&tables.TableModelPricing{}, column) {
+					if err := mg.DropColumn(&tables.TableModelPricing{}, column); err != nil {
+						return fmt.Errorf("failed to drop %s column: %w", column, err)
+					}
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running model capability columns migration: %s", err.Error())
+	}
 	return nil
 }

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -1,14 +1,20 @@
 package tables
 
+import "github.com/maximhq/bifrost/core/schemas"
+
 // TableModelPricing represents pricing information for AI models
 type TableModelPricing struct {
-	ID                 uint    `gorm:"primaryKey;autoIncrement" json:"id"`
-	Model              string  `gorm:"type:varchar(255);not null;uniqueIndex:idx_model_provider_mode" json:"model"`
-	BaseModel          string  `gorm:"type:varchar(255);default:null" json:"base_model,omitempty"`
-	Provider           string  `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"provider"`
-	InputCostPerToken  float64 `gorm:"not null" json:"input_cost_per_token"`
-	OutputCostPerToken float64 `gorm:"not null" json:"output_cost_per_token"`
-	Mode               string  `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"mode"`
+	ID                 uint                  `gorm:"primaryKey;autoIncrement" json:"id"`
+	Model              string                `gorm:"type:varchar(255);not null;uniqueIndex:idx_model_provider_mode" json:"model"`
+	BaseModel          string                `gorm:"type:varchar(255);default:null" json:"base_model,omitempty"`
+	Provider           string                `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"provider"`
+	InputCostPerToken  float64               `gorm:"not null" json:"input_cost_per_token"`
+	OutputCostPerToken float64               `gorm:"not null" json:"output_cost_per_token"`
+	Mode               string                `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"mode"`
+	ContextLength      *int                  `gorm:"default:null" json:"context_length,omitempty"`
+	MaxInputTokens     *int                  `gorm:"default:null" json:"max_input_tokens,omitempty"`
+	MaxOutputTokens    *int                  `gorm:"default:null" json:"max_output_tokens,omitempty"`
+	Architecture       *schemas.Architecture `gorm:"type:text;serializer:json;default:null" json:"architecture,omitempty"`
 
 	// Additional pricing for media
 	InputCostPerVideoPerSecond  *float64 `gorm:"default:null" json:"input_cost_per_video_per_second,omitempty"`

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -68,6 +68,11 @@ type PricingEntry struct {
 	OutputCostPerToken float64 `json:"output_cost_per_token"`
 	Provider           string  `json:"provider"`
 	Mode               string  `json:"mode"`
+	// Model capabilities
+	ContextLength   *int                  `json:"context_length,omitempty"`
+	MaxInputTokens  *int                  `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens *int                  `json:"max_output_tokens,omitempty"`
+	Architecture    *schemas.Architecture `json:"architecture,omitempty"`
 	// Additional pricing for media
 	InputCostPerVideoPerSecond *float64 `json:"input_cost_per_video_per_second,omitempty"`
 	InputCostPerAudioPerSecond *float64 `json:"input_cost_per_audio_per_second,omitempty"`
@@ -300,6 +305,44 @@ func (mc *ModelCatalog) GetPricingEntryForModel(model string, provider schemas.M
 			return convertTableModelPricingToPricingData(&pricing)
 		}
 	}
+	return nil
+}
+
+// GetModelCapabilityEntryForModel returns capability metadata for a model/provider pair.
+// Mode precedence is tuned for common request patterns.
+func (mc *ModelCatalog) GetModelCapabilityEntryForModel(model string, provider schemas.ModelProvider) *PricingEntry {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	preferredModes := []schemas.RequestType{
+		schemas.ChatCompletionRequest,
+		schemas.ResponsesRequest,
+		schemas.TextCompletionRequest,
+	}
+
+	for _, mode := range preferredModes {
+		key := makeKey(model, string(provider), normalizeRequestType(mode))
+		pricing, ok := mc.pricingData[key]
+		if ok {
+			return convertTableModelPricingToPricingData(&pricing)
+		}
+	}
+
+	// Fallback to any mode for the same model/provider if preferred modes are absent.
+	// Collect and sort keys for deterministic selection across requests.
+	prefix := model + "|" + string(provider) + "|"
+	var matchingKeys []string
+	for key := range mc.pricingData {
+		if strings.HasPrefix(key, prefix) {
+			matchingKeys = append(matchingKeys, key)
+		}
+	}
+	if len(matchingKeys) > 0 {
+		slices.Sort(matchingKeys)
+		pricing := mc.pricingData[matchingKeys[0]]
+		return convertTableModelPricingToPricingData(&pricing)
+	}
+
 	return nil
 }
 

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -76,6 +76,10 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 		InputCostPerToken:  entry.InputCostPerToken,
 		OutputCostPerToken: entry.OutputCostPerToken,
 		Mode:               entry.Mode,
+		ContextLength:      entry.ContextLength,
+		MaxInputTokens:     entry.MaxInputTokens,
+		MaxOutputTokens:    entry.MaxOutputTokens,
+		Architecture:       entry.Architecture,
 
 		// Additional pricing for media
 		InputCostPerVideoPerSecond:  entry.InputCostPerVideoPerSecond,
@@ -126,6 +130,10 @@ func convertTableModelPricingToPricingData(pricing *configstoreTables.TableModel
 		Mode:                                       pricing.Mode,
 		InputCostPerToken:                          pricing.InputCostPerToken,
 		OutputCostPerToken:                         pricing.OutputCostPerToken,
+		ContextLength:                              pricing.ContextLength,
+		MaxInputTokens:                             pricing.MaxInputTokens,
+		MaxOutputTokens:                            pricing.MaxOutputTokens,
+		Architecture:                               pricing.Architecture,
 		InputCostPerVideoPerSecond:                 pricing.InputCostPerVideoPerSecond,
 		OutputCostPerVideoPerSecond:                pricing.OutputCostPerVideoPerSecond,
 		OutputCostPerSecond:                        pricing.OutputCostPerSecond,

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -639,21 +639,11 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 	// If provider is specified, get models for that provider only
 	if providerParam != "" {
 		provider := schemas.ModelProvider(providerParam)
-		validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
-		var models []string
-		if unfiltered {
-			models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
-		} else {
-			models = h.modelsManager.GetModelsForProvider(provider)
-			// Filter by keys if specified
-			if len(validKeyIDs) > 0 {
-				models = h.filterModelsByKeys(provider, models, validKeyIDs)
-			}
-		}
+		models, modelAccessibleByKeys := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
 		for _, model := range models {
 			entry := ModelResponse{Name: model, Provider: string(provider)}
-			if len(validKeyIDs) > 0 && !unfiltered {
-				entry.AccessibleByKeys = validKeyIDs
+			if keys, ok := modelAccessibleByKeys[model]; ok && len(keys) > 0 {
+				entry.AccessibleByKeys = keys
 			}
 			allModels = append(allModels, entry)
 		}
@@ -667,21 +657,11 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 		// Collect models from all providers
 		for _, provider := range providers {
-			validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
-			var models []string
-			if unfiltered {
-				models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
-			} else {
-				models = h.modelsManager.GetModelsForProvider(provider)
-				// Filter by keys if specified
-				if len(validKeyIDs) > 0 {
-					models = h.filterModelsByKeys(provider, models, validKeyIDs)
-				}
-			}
+			models, modelAccessibleByKeys := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
 			for _, model := range models {
 				entry := ModelResponse{Name: model, Provider: string(provider)}
-				if len(validKeyIDs) > 0 && !unfiltered {
-					entry.AccessibleByKeys = validKeyIDs
+				if keys, ok := modelAccessibleByKeys[model]; ok && len(keys) > 0 {
+					entry.AccessibleByKeys = keys
 				}
 				allModels = append(allModels, entry)
 			}
@@ -788,24 +768,15 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 
 	if providerParam != "" {
 		provider := schemas.ModelProvider(providerParam)
-		validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
-		var models []string
-		if unfiltered {
-			models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
-		} else {
-			models = h.modelsManager.GetModelsForProvider(provider)
-			if len(validKeyIDs) > 0 {
-				models = h.filterModelsByKeys(provider, models, validKeyIDs)
-			}
-		}
+		models, modelAccessibleByKeys := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
 
 		for _, model := range models {
 			details := ModelDetailsResponse{
 				Name:     model,
 				Provider: string(provider),
 			}
-			if len(validKeyIDs) > 0 && !unfiltered {
-				details.AccessibleByKeys = validKeyIDs
+			if keys, ok := modelAccessibleByKeys[model]; ok && len(keys) > 0 {
+				details.AccessibleByKeys = keys
 			}
 			if modelCatalog != nil {
 				capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
@@ -826,23 +797,14 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 		}
 
 		for _, provider := range providers {
-			validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
-			var models []string
-			if unfiltered {
-				models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
-			} else {
-				models = h.modelsManager.GetModelsForProvider(provider)
-				if len(validKeyIDs) > 0 {
-					models = h.filterModelsByKeys(provider, models, validKeyIDs)
-				}
-			}
+			models, modelAccessibleByKeys := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
 			for _, model := range models {
 				details := ModelDetailsResponse{
 					Name:     model,
 					Provider: string(provider),
 				}
-				if len(validKeyIDs) > 0 && !unfiltered {
-					details.AccessibleByKeys = validKeyIDs
+				if keys, ok := modelAccessibleByKeys[model]; ok && len(keys) > 0 {
+					details.AccessibleByKeys = keys
 				}
 				if modelCatalog != nil {
 					capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
@@ -916,53 +878,108 @@ func (h *ProviderHandler) getValidKeyIDsForProvider(provider schemas.ModelProvid
 	return valid
 }
 
-// filterModelsByKeys filters models based on key-level model restrictions
-func (h *ProviderHandler) filterModelsByKeys(provider schemas.ModelProvider, models []string, keyIDs []string) []string {
+// getFilteredModelsForProvider applies provider-level and key-level filters and returns
+// both filtered models and per-model key accessibility.
+func (h *ProviderHandler) getFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
+	validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
+
+	var models []string
+	if unfiltered {
+		models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
+	} else {
+		models = h.modelsManager.GetModelsForProvider(provider)
+	}
+
+	// If caller supplied keys but none are valid for this provider, fail closed.
+	if len(keyIDs) > 0 && len(validKeyIDs) == 0 {
+		return []string{}, map[string][]string{}
+	}
+
+	if len(validKeyIDs) == 0 {
+		return models, nil
+	}
+
+	return h.filterModelsByKeysWithAccessMap(provider, models, validKeyIDs)
+}
+
+// filterModelsByKeysWithAccessMap filters models based on key-level model restrictions
+// and returns exact per-model key IDs that grant access.
+func (h *ProviderHandler) filterModelsByKeysWithAccessMap(provider schemas.ModelProvider, models []string, keyIDs []string) ([]string, map[string][]string) {
 	// Get provider config to access keys
 	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
 	if err != nil {
 		logger.Warn("Failed to get config for provider %s: %v", provider, err)
-		return models
+		return []string{}, map[string][]string{}
 	}
-	// Build a set of allowed models from the specified keys
-	// Track whether we have any unrestricted keys (which grant access to all models)
-	// and whether we have any restricted keys (which limit to specific models)
+
+	keysByID := make(map[string]schemas.Key, len(config.Keys))
+	for _, key := range config.Keys {
+		keysByID[key.ID] = key
+	}
+
 	allowedModels := make(map[string]bool)
+	modelToKeys := make(map[string][]string)
+	modelToKeySeen := make(map[string]map[string]bool)
 	hasRestrictedKey := false
-	hasUnrestrictedKey := false
+	unrestrictedKeyIDs := make([]string, 0, len(keyIDs))
+
 	for _, keyID := range keyIDs {
-		for _, key := range config.Keys {
-			if key.ID == keyID {
-				if len(key.Models) > 0 {
-					// Key has model restrictions - add them to allowedModels
-					hasRestrictedKey = true
-					for _, model := range key.Models {
-						allowedModels[model] = true
-					}
-				} else {
-					// Key has no model restrictions - grants access to all models
-					hasUnrestrictedKey = true
+		key, exists := keysByID[keyID]
+		if !exists {
+			continue
+		}
+
+		if len(key.Models) > 0 {
+			hasRestrictedKey = true
+			for _, model := range key.Models {
+				allowedModels[model] = true
+				if _, ok := modelToKeySeen[model]; !ok {
+					modelToKeySeen[model] = make(map[string]bool)
 				}
-				break
+				if !modelToKeySeen[model][keyID] {
+					modelToKeys[model] = append(modelToKeys[model], keyID)
+					modelToKeySeen[model][keyID] = true
+				}
+			}
+			continue
+		}
+
+		unrestrictedKeyIDs = append(unrestrictedKeyIDs, keyID)
+	}
+
+	accessByModel := make(map[string][]string, len(models))
+
+	// If any key is unrestricted, all models remain visible.
+	if len(unrestrictedKeyIDs) > 0 {
+		for _, model := range models {
+			access := make([]string, 0, len(unrestrictedKeyIDs)+len(modelToKeys[model]))
+			access = append(access, unrestrictedKeyIDs...)
+			if restrictedKeys, ok := modelToKeys[model]; ok {
+				access = append(access, restrictedKeys...)
+			}
+			if len(access) > 0 {
+				accessByModel[model] = access
 			}
 		}
+		return models, accessByModel
 	}
-	// If any key is unrestricted, return all models (union of "all" and restricted subsets is "all")
-	if hasUnrestrictedKey {
-		return models
-	}
-	// If no keys have model restrictions (e.g., unknown key IDs), return all models
+
+	// If no keys have model restrictions, return models unchanged.
 	if !hasRestrictedKey {
-		return models
+		return models, accessByModel
 	}
-	// Filter models based on restrictions from restricted keys only
+
+	// Filter models based on restrictions from restricted keys only.
 	filtered := []string{}
 	for _, model := range models {
 		if allowedModels[model] {
 			filtered = append(filtered, model)
+			if keys, ok := modelToKeys[model]; ok && len(keys) > 0 {
+				accessByModel[model] = keys
+			}
 		}
 	}
-	return filtered
+	return filtered, accessByModel
 }
 
 // ListBaseModelsResponse represents the response for listing base models

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -760,6 +760,10 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 
 	var allModels []ModelDetailsResponse
 	modelCatalog := h.inMemoryStore.ModelCatalog
+	if modelCatalog == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "model catalog not available")
+		return
+	}
 
 	var keyIDs []string
 	if keysParam != "" {
@@ -909,6 +913,10 @@ func (h *ProviderHandler) filterModelsByKeysWithAccessMap(provider schemas.Model
 	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
 	if err != nil {
 		logger.Warn("Failed to get config for provider %s: %v", provider, err)
+		return []string{}, map[string][]string{}
+	}
+	if config == nil || config.Keys == nil {
+		logger.Warn("Missing key config for provider %s while filtering models by key access", provider)
 		return []string{}, map[string][]string{}
 	}
 

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -782,14 +782,12 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 			if keys, ok := modelAccessibleByKeys[model]; ok && len(keys) > 0 {
 				details.AccessibleByKeys = keys
 			}
-			if modelCatalog != nil {
-				capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
-				if capabilities != nil {
-					details.ContextLength = capabilities.ContextLength
-					details.MaxInputTokens = capabilities.MaxInputTokens
-					details.MaxOutputTokens = capabilities.MaxOutputTokens
-					details.Architecture = capabilities.Architecture
-				}
+			capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
+			if capabilities != nil {
+				details.ContextLength = capabilities.ContextLength
+				details.MaxInputTokens = capabilities.MaxInputTokens
+				details.MaxOutputTokens = capabilities.MaxOutputTokens
+				details.Architecture = capabilities.Architecture
 			}
 			allModels = append(allModels, details)
 		}
@@ -810,14 +808,12 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 				if keys, ok := modelAccessibleByKeys[model]; ok && len(keys) > 0 {
 					details.AccessibleByKeys = keys
 				}
-				if modelCatalog != nil {
-					capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
-					if capabilities != nil {
-						details.ContextLength = capabilities.ContextLength
-						details.MaxInputTokens = capabilities.MaxInputTokens
-						details.MaxOutputTokens = capabilities.MaxOutputTokens
-						details.Architecture = capabilities.Architecture
-					}
+				capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
+				if capabilities != nil {
+					details.ContextLength = capabilities.ContextLength
+					details.MaxInputTokens = capabilities.MaxInputTokens
+					details.MaxOutputTokens = capabilities.MaxOutputTokens
+					details.Architecture = capabilities.Architecture
 				}
 				allModels = append(allModels, details)
 			}
@@ -864,6 +860,9 @@ func (h *ProviderHandler) getValidKeyIDsForProvider(provider schemas.ModelProvid
 
 	existing := make(map[string]bool, len(config.Keys))
 	for _, key := range config.Keys {
+		if key.Enabled != nil && !*key.Enabled {
+			continue
+		}
 		existing[key.ID] = true
 	}
 
@@ -922,6 +921,9 @@ func (h *ProviderHandler) filterModelsByKeysWithAccessMap(provider schemas.Model
 
 	keysByID := make(map[string]schemas.Key, len(config.Keys))
 	for _, key := range config.Keys {
+		if key.Enabled != nil && !*key.Enabled {
+			continue
+		}
 		keysByID[key.ID] = key
 	}
 

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -98,6 +98,7 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.GET("/api/keys", lib.ChainMiddlewares(h.listKeys, middlewares...))
 	r.GET("/api/models", lib.ChainMiddlewares(h.listModels, middlewares...))
 	r.GET("/api/models/parameters", lib.ChainMiddlewares(h.getModelParameters, middlewares...))
+	r.GET("/api/models/details", lib.ChainMiddlewares(h.listModelDetails, middlewares...))
 	r.GET("/api/models/base", lib.ChainMiddlewares(h.listBaseModels, middlewares...))
 }
 
@@ -457,7 +458,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	// Merge proxy config - preserve secrets if redacted values were sent back
 	if payload.ProxyConfig != nil && oldConfigRaw.ProxyConfig != nil {
 		if payload.ProxyConfig.IsRedactedValue(payload.ProxyConfig.Password) {
-			payload.ProxyConfig.Password = oldConfigRaw.ProxyConfig.Password			
+			payload.ProxyConfig.Password = oldConfigRaw.ProxyConfig.Password
 		}
 		if payload.ProxyConfig.IsRedactedValue(payload.ProxyConfig.CACertPEM) {
 			payload.ProxyConfig.CACertPEM = oldConfigRaw.ProxyConfig.CACertPEM
@@ -587,6 +588,23 @@ type ListModelsResponse struct {
 	Total  int             `json:"total"`
 }
 
+// ModelDetailsResponse represents a model with capability metadata.
+type ModelDetailsResponse struct {
+	Name             string                `json:"name"`
+	Provider         string                `json:"provider"`
+	ContextLength    *int                  `json:"context_length,omitempty"`
+	MaxInputTokens   *int                  `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens  *int                  `json:"max_output_tokens,omitempty"`
+	Architecture     *schemas.Architecture `json:"architecture,omitempty"`
+	AccessibleByKeys []string              `json:"accessible_by_keys,omitempty"`
+}
+
+// ListModelDetailsResponse represents the response for listing model details.
+type ListModelDetailsResponse struct {
+	Models []ModelDetailsResponse `json:"models"`
+	Total  int                    `json:"total"`
+}
+
 // listModels handles GET /api/models - List models with filtering
 // Query parameters:
 //   - query: Filter models by name (case-insensitive partial match)
@@ -613,25 +631,31 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 	var allModels []ModelResponse
 
+	var keyIDs []string
+	if keysParam != "" {
+		keyIDs = strings.Split(keysParam, ",")
+	}
+
 	// If provider is specified, get models for that provider only
 	if providerParam != "" {
 		provider := schemas.ModelProvider(providerParam)
+		validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
 		var models []string
 		if unfiltered {
 			models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
 		} else {
 			models = h.modelsManager.GetModelsForProvider(provider)
 			// Filter by keys if specified
-			if keysParam != "" {
-				keyIDs := strings.Split(keysParam, ",")
-				models = h.filterModelsByKeys(provider, models, keyIDs)
+			if len(validKeyIDs) > 0 {
+				models = h.filterModelsByKeys(provider, models, validKeyIDs)
 			}
 		}
 		for _, model := range models {
-			allModels = append(allModels, ModelResponse{
-				Name:     model,
-				Provider: string(provider),
-			})
+			entry := ModelResponse{Name: model, Provider: string(provider)}
+			if len(validKeyIDs) > 0 && !unfiltered {
+				entry.AccessibleByKeys = validKeyIDs
+			}
+			allModels = append(allModels, entry)
 		}
 	} else {
 		// Get all providers
@@ -643,23 +667,23 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 		// Collect models from all providers
 		for _, provider := range providers {
+			validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
 			var models []string
 			if unfiltered {
 				models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
 			} else {
 				models = h.modelsManager.GetModelsForProvider(provider)
 				// Filter by keys if specified
-				if keysParam != "" {
-					keyIDs := strings.Split(keysParam, ",")
-					models = h.filterModelsByKeys(provider, models, keyIDs)
+				if len(validKeyIDs) > 0 {
+					models = h.filterModelsByKeys(provider, models, validKeyIDs)
 				}
-
 			}
 			for _, model := range models {
-				allModels = append(allModels, ModelResponse{
-					Name:     model,
-					Provider: string(provider),
-				})
+				entry := ModelResponse{Name: model, Provider: string(provider)}
+				if len(validKeyIDs) > 0 && !unfiltered {
+					entry.AccessibleByKeys = validKeyIDs
+				}
+				allModels = append(allModels, entry)
 			}
 		}
 	}
@@ -728,6 +752,168 @@ func (h *ProviderHandler) getModelParameters(ctx *fasthttp.RequestCtx) {
 	ctx.SetContentType("application/json")
 	ctx.SetStatusCode(fasthttp.StatusOK)
 	ctx.SetBody(data)
+}
+
+// listModelDetails handles GET /api/models/details - List models with capability metadata.
+// Query parameters:
+//   - query: Filter models by name (case-insensitive partial match)
+//   - provider: Filter by specific provider name
+//   - keys: Comma-separated list of key IDs to filter models accessible by those keys
+//   - limit: Maximum number of results to return (default: 20)
+func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
+	queryParam := string(ctx.QueryArgs().Peek("query"))
+	providerParam := string(ctx.QueryArgs().Peek("provider"))
+	keysParam := string(ctx.QueryArgs().Peek("keys"))
+	limitParam := string(ctx.QueryArgs().Peek("limit"))
+	unfilteredParam := string(ctx.QueryArgs().Peek("unfiltered"))
+
+	unfiltered := unfilteredParam == "true"
+
+	// Default is 20 (vs 5 for /api/models) because capability metadata is the primary value here;
+	// clients typically need a richer initial page to display meaningful information.
+	limit := 20
+	if limitParam != "" {
+		if n, err := ctx.QueryArgs().GetUint("limit"); err == nil {
+			limit = n
+		}
+	}
+
+	var allModels []ModelDetailsResponse
+	modelCatalog := h.inMemoryStore.ModelCatalog
+
+	var keyIDs []string
+	if keysParam != "" {
+		keyIDs = strings.Split(keysParam, ",")
+	}
+
+	if providerParam != "" {
+		provider := schemas.ModelProvider(providerParam)
+		validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
+		var models []string
+		if unfiltered {
+			models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
+		} else {
+			models = h.modelsManager.GetModelsForProvider(provider)
+			if len(validKeyIDs) > 0 {
+				models = h.filterModelsByKeys(provider, models, validKeyIDs)
+			}
+		}
+
+		for _, model := range models {
+			details := ModelDetailsResponse{
+				Name:     model,
+				Provider: string(provider),
+			}
+			if len(validKeyIDs) > 0 && !unfiltered {
+				details.AccessibleByKeys = validKeyIDs
+			}
+			if modelCatalog != nil {
+				capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
+				if capabilities != nil {
+					details.ContextLength = capabilities.ContextLength
+					details.MaxInputTokens = capabilities.MaxInputTokens
+					details.MaxOutputTokens = capabilities.MaxOutputTokens
+					details.Architecture = capabilities.Architecture
+				}
+			}
+			allModels = append(allModels, details)
+		}
+	} else {
+		providers, err := h.inMemoryStore.GetAllProviders()
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get providers: %v", err))
+			return
+		}
+
+		for _, provider := range providers {
+			validKeyIDs := h.getValidKeyIDsForProvider(provider, keyIDs)
+			var models []string
+			if unfiltered {
+				models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
+			} else {
+				models = h.modelsManager.GetModelsForProvider(provider)
+				if len(validKeyIDs) > 0 {
+					models = h.filterModelsByKeys(provider, models, validKeyIDs)
+				}
+			}
+			for _, model := range models {
+				details := ModelDetailsResponse{
+					Name:     model,
+					Provider: string(provider),
+				}
+				if len(validKeyIDs) > 0 && !unfiltered {
+					details.AccessibleByKeys = validKeyIDs
+				}
+				if modelCatalog != nil {
+					capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider)
+					if capabilities != nil {
+						details.ContextLength = capabilities.ContextLength
+						details.MaxInputTokens = capabilities.MaxInputTokens
+						details.MaxOutputTokens = capabilities.MaxOutputTokens
+						details.Architecture = capabilities.Architecture
+					}
+				}
+				allModels = append(allModels, details)
+			}
+		}
+	}
+
+	if queryParam != "" {
+		filtered := []ModelDetailsResponse{}
+		queryLower := strings.ToLower(queryParam)
+		queryNormalized := strings.ReplaceAll(strings.ReplaceAll(queryLower, "-", ""), "_", "")
+
+		for _, model := range allModels {
+			modelLower := strings.ToLower(model.Name)
+			modelNormalized := strings.ReplaceAll(strings.ReplaceAll(modelLower, "-", ""), "_", "")
+
+			if strings.Contains(modelLower, queryLower) ||
+				strings.Contains(modelNormalized, queryNormalized) ||
+				fuzzyMatch(modelLower, queryLower) {
+				filtered = append(filtered, model)
+			}
+		}
+		allModels = filtered
+	}
+
+	total := len(allModels)
+	if limit > 0 && limit < len(allModels) {
+		allModels = allModels[:limit]
+	}
+
+	SendJSON(ctx, ListModelDetailsResponse{Models: allModels, Total: total})
+}
+
+// getValidKeyIDsForProvider returns key IDs that exist for the provider config.
+// Input IDs are trimmed and deduplicated while preserving request order.
+func (h *ProviderHandler) getValidKeyIDsForProvider(provider schemas.ModelProvider, keyIDs []string) []string {
+	if len(keyIDs) == 0 {
+		return nil
+	}
+
+	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
+	if err != nil || config == nil {
+		return nil
+	}
+
+	existing := make(map[string]bool, len(config.Keys))
+	for _, key := range config.Keys {
+		existing[key.ID] = true
+	}
+
+	valid := make([]string, 0, len(keyIDs))
+	seen := make(map[string]bool, len(keyIDs))
+	for _, keyID := range keyIDs {
+		trimmed := strings.TrimSpace(keyID)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		if existing[trimmed] {
+			valid = append(valid, trimmed)
+		}
+	}
+	return valid
 }
 
 // filterModelsByKeys filters models based on key-level model restrictions


### PR DESCRIPTION
## Summary

Adds a new `/api/models/details` endpoint that provides model capability metadata including context length, token limits, and architecture information. Also adds an `unfiltered` parameter to the existing `/api/models` endpoint.

## Changes

- Added new `/api/models/details` endpoint with filtering by `query`, `provider`, and `keys`
- Extended model pricing table with capability columns (`context_length`, `max_input_tokens`, `max_output_tokens`, `architecture`)
- Added database migration to add capability columns to `governance_model_pricing` table
- Added `unfiltered` parameter to `/api/models` endpoint to bypass provider-level restrictions
- Enhanced model catalog to retrieve capability metadata with fallback logic across request types
- Added key validation logic to ensure only existing keys are used for model filtering

## Type of Change

- [x] Feature
- [x] Refactor

## Affected Areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Docs

## How to Test
```bash
# Get all model details
curl -X GET "http://localhost:8080/api/models/details"

# Filter by provider
curl -X GET "http://localhost:8080/api/models/details?provider=openai"

# Filter by model name
curl -X GET "http://localhost:8080/api/models/details?query=gpt-4"

# Filter by keys
curl -X GET "http://localhost:8080/api/models/details?keys=key1,key2"

# Test unfiltered parameter on existing endpoint
curl -X GET "http://localhost:8080/api/models?unfiltered=true"

# Run targeted tests
(cd framework && go test ./modelcatalog ./configstore)
(cd transports && go test ./bifrost-http/handlers)
```

## Breaking Changes

None.

## Related issues

Closes #1954 

## Security Considerations

The endpoint follows existing management API auth/middleware behavior. The `unfiltered` parameter is intended to bypass filtering constraints for model listing.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable