### PR TITLE
feat: add TLS configuration support for all providers

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -97,6 +97,7 @@ func NewAnthropicProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.anthropic.com"

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -179,6 +179,7 @@ func NewAzureProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*A
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	return &AzureProvider{
 		logger:              logger,
 		client:              client,

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -37,6 +37,7 @@ func NewCerebrasProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.cerebras.ai"

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -111,6 +111,7 @@ func NewCohereProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	// Setting proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Pre-warm response pools
 	for i := 0; i < config.ConcurrencyAndBufferSize.Concurrency; i++ {
 		cohereResponsePool.Put(&CohereChatResponse{})

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -46,6 +46,7 @@ func NewElevenlabsProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.elevenlabs.io"

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -68,6 +68,7 @@ func NewGeminiProvider(config *schemas.ProviderConfig, logger schemas.Logger) *G
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -42,6 +42,7 @@ func NewGroqProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*Gr
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.groq.com/openai"

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -85,6 +85,7 @@ func NewHuggingFaceProvider(config *schemas.ProviderConfig, logger schemas.Logge
 
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = defaultInferenceBaseURL
 	}

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -47,6 +47,7 @@ func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.mistral.ai"

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -40,6 +40,7 @@ func NewNebiusProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.tokenfactory.nebius.com"

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -44,6 +44,7 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
 	// BaseURL is required for Ollama

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -54,6 +54,7 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.openai.com"

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -40,6 +40,7 @@ func NewOpenRouterProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://openrouter.ai/api"

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -38,6 +38,7 @@ func NewParasailProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.parasail.io"

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -40,6 +40,7 @@ func NewPerplexityProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {
 		config.NetworkConfig.BaseURL = "https://api.perplexity.ai"

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -48,6 +48,7 @@ func NewReplicateProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
 	if config.NetworkConfig.BaseURL == "" {

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -38,6 +38,8 @@ func NewRunwayProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 
 	// Configure proxy if provided
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
+	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 
 	// Set default BaseURL if not provided
 	if config.NetworkConfig.BaseURL == "" {

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -44,6 +44,7 @@ func NewSGLProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*SGL
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
 	// BaseURL is required for SGLang

--- a/core/providers/utils/tls_test.go
+++ b/core/providers/utils/tls_test.go
@@ -1,0 +1,171 @@
+package utils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// testLogger is a minimal logger for tests that implements schemas.Logger.
+type testLogger struct{}
+
+func (testLogger) Debug(string, ...any)                   {}
+func (testLogger) Info(string, ...any)                    {}
+func (testLogger) Warn(string, ...any)                    {}
+func (testLogger) Error(string, ...any)                   {}
+func (testLogger) Fatal(string, ...any)                   {}
+func (testLogger) SetLevel(schemas.LogLevel)              {}
+func (testLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+// validTestCertPEM returns a minimal valid PEM-encoded CA certificate for testing.
+func validTestCertPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	block := &pem.Block{Type: "CERTIFICATE", Bytes: certDER}
+	return string(pem.EncodeToMemory(block))
+}
+
+func TestConfigureTLS_ReturnsUnchangedWhenNeitherSet(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+
+	result := ConfigureTLS(client, schemas.NetworkConfig{}, logger)
+
+	if result != client {
+		t.Error("ConfigureTLS should return the same client when neither InsecureSkipVerify nor CACertPEM is set")
+	}
+	if client.TLSConfig != nil {
+		t.Error("TLSConfig should remain nil when no TLS options are set")
+	}
+}
+
+func TestConfigureTLS_SetsInsecureSkipVerify(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+
+	result := ConfigureTLS(client, schemas.NetworkConfig{InsecureSkipVerify: true}, logger)
+
+	if result != client {
+		t.Error("ConfigureTLS should return the same client")
+	}
+	if client.TLSConfig == nil {
+		t.Fatal("TLSConfig should be set when InsecureSkipVerify is true")
+	}
+	if !client.TLSConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be true")
+	}
+}
+
+func TestConfigureTLS_AppliesCACertPEM(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+	caPEM := validTestCertPEM(t)
+
+	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: caPEM}, logger)
+
+	if result != client {
+		t.Error("ConfigureTLS should return the same client")
+	}
+	if client.TLSConfig == nil {
+		t.Fatal("TLSConfig should be set when CACertPEM is provided")
+	}
+	if client.TLSConfig.RootCAs == nil {
+		t.Error("RootCAs should be set when CACertPEM is provided")
+	}
+}
+
+func TestConfigureTLS_HandlesInvalidCACertPEM(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+
+	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: "not-valid-pem"}, logger)
+
+	if result != client {
+		t.Error("ConfigureTLS should return the same client even when CACertPEM is invalid")
+	}
+	// Invalid PEM logs warning and skips RootCAs; TLSConfig may still be set with MinVersion
+	if client.TLSConfig != nil && client.TLSConfig.RootCAs != nil {
+		t.Error("RootCAs should not be set when CACertPEM is invalid")
+	}
+}
+
+func TestConfigureTLS_MergesWithExistingTLSConfig(t *testing.T) {
+	// Simulate client that already has TLSConfig from ConfigureProxy
+	existingRootCAs, _ := x509.SystemCertPool()
+	if existingRootCAs == nil {
+		existingRootCAs = x509.NewCertPool()
+	}
+	client := &fasthttp.Client{
+		TLSConfig: &tls.Config{
+			RootCAs:    existingRootCAs,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	logger := testLogger{}
+	caPEM := validTestCertPEM(t)
+
+	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: caPEM}, logger)
+
+	if result != client {
+		t.Error("ConfigureTLS should return the same client")
+	}
+	if client.TLSConfig == nil {
+		t.Fatal("TLSConfig should remain set")
+	}
+	if client.TLSConfig.RootCAs == nil {
+		t.Error("RootCAs should be set (merged with existing)")
+	}
+}
+
+func TestConfigureTLS_InsecureSkipVerifyAndCACertPEM(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+	caPEM := validTestCertPEM(t)
+
+	result := ConfigureTLS(client, schemas.NetworkConfig{
+		InsecureSkipVerify: true,
+		CACertPEM:          caPEM,
+	}, logger)
+
+	if result != client {
+		t.Error("ConfigureTLS should return the same client")
+	}
+	if client.TLSConfig == nil {
+		t.Fatal("TLSConfig should be set")
+	}
+	if !client.TLSConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should be true when both options are set")
+	}
+	if client.TLSConfig.RootCAs == nil {
+		t.Error("RootCAs should be set when CACertPEM is provided")
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -323,6 +323,46 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 	}, nil
 }
 
+// ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
+// It merges with any existing TLSConfig (e.g., from ConfigureProxy).
+func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
+	if !networkConfig.InsecureSkipVerify && networkConfig.CACertPEM == "" {
+		return client
+	}
+
+	tlsConfig := client.TLSConfig
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	} else {
+		tlsConfig = tlsConfig.Clone()
+	}
+
+	if networkConfig.InsecureSkipVerify {
+		logger.Warn("insecure_skip_verify is enabled for provider — TLS certificate verification is disabled. Not recommended for production.")
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	if networkConfig.CACertPEM != "" {
+		caTLSConfig, err := createTLSConfigWithCA(networkConfig.CACertPEM)
+		if err != nil {
+			logger.Warn("Failed to configure custom CA certificate for provider: %v", err)
+		} else {
+			if tlsConfig.RootCAs != nil {
+				tlsConfig.RootCAs = tlsConfig.RootCAs.Clone()
+				// Merge: append network CA to existing pool (e.g. from proxy)
+				if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(networkConfig.CACertPEM)) {
+					logger.Warn("Failed to append CA certificate to existing TLS config")
+				}
+			} else {
+				tlsConfig.RootCAs = caTLSConfig.RootCAs
+			}
+		}
+	}
+
+	client.TLSConfig = tlsConfig
+	return client
+}
+
 // hopByHopHeaders are HTTP/1.1 headers that must not be forwarded by proxies.
 var hopByHopHeaders = map[string]bool{
 	"connection":          true,

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -78,6 +78,7 @@ func NewVertexProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	}
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	return &VertexProvider{
 		logger:              logger,
 		client:              client,

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -40,6 +40,7 @@ func NewVLLMProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*VL
 
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
 	// BaseURL is optional when keys have vllm_key_config with per-key URLs

--- a/core/providers/xai/xai.go
+++ b/core/providers/xai/xai.go
@@ -38,6 +38,7 @@ func NewXAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*XAI
 	// Configure proxy and retry policy
 	client = providerUtils.ConfigureProxy(client, config.ProxyConfig, logger)
 	client = providerUtils.ConfigureDialer(client)
+	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
 	if config.NetworkConfig.BaseURL == "" {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -53,6 +53,8 @@ type NetworkConfig struct {
 	MaxRetries                     int               `json:"max_retries"`                        // Maximum number of retries
 	RetryBackoffInitial            time.Duration     `json:"retry_backoff_initial"`              // Initial backoff duration (stored as nanoseconds, JSON as milliseconds)
 	RetryBackoffMax                time.Duration     `json:"retry_backoff_max"`                  // Maximum backoff duration (stored as nanoseconds, JSON as milliseconds)
+	InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`     // Disables TLS certificate verification for provider connections
+	CACertPEM                      string            `json:"ca_cert_pem,omitempty"`              // PEM-encoded CA certificate to trust for provider endpoint connections
 }
 
 // UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
@@ -67,6 +69,8 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		MaxRetries                     int               `json:"max_retries"`
 		RetryBackoffInitial            int64             `json:"retry_backoff_initial"` // milliseconds in JSON
 		RetryBackoffMax                int64             `json:"retry_backoff_max"`     // milliseconds in JSON
+		InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`
+		CACertPEM                      string            `json:"ca_cert_pem,omitempty"`
 	}
 
 	var alias NetworkConfigAlias
@@ -79,6 +83,8 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	nc.ExtraHeaders = alias.ExtraHeaders
 	nc.DefaultRequestTimeoutInSeconds = alias.DefaultRequestTimeoutInSeconds
 	nc.MaxRetries = alias.MaxRetries
+	nc.InsecureSkipVerify = alias.InsecureSkipVerify
+	nc.CACertPEM = alias.CACertPEM
 
 	// Convert milliseconds to time.Duration (nanoseconds)
 	// Only convert if value is greater than 0
@@ -104,6 +110,8 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		MaxRetries                     int               `json:"max_retries"`
 		RetryBackoffInitial            int64             `json:"retry_backoff_initial"` // milliseconds in JSON
 		RetryBackoffMax                int64             `json:"retry_backoff_max"`     // milliseconds in JSON
+		InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`
+		CACertPEM                      string            `json:"ca_cert_pem,omitempty"`
 	}
 
 	alias := NetworkConfigAlias{
@@ -114,9 +122,23 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		// Convert time.Duration (nanoseconds) to milliseconds
 		RetryBackoffInitial: int64(nc.RetryBackoffInitial / time.Millisecond),
 		RetryBackoffMax:     int64(nc.RetryBackoffMax / time.Millisecond),
+		InsecureSkipVerify:  nc.InsecureSkipVerify,
+		CACertPEM:           nc.CACertPEM,
 	}
 
 	return json.Marshal(alias)
+}
+
+// Redacted returns a redacted copy of the network configuration with CACertPEM masked.
+func (nc *NetworkConfig) Redacted() *NetworkConfig {
+	if nc == nil {
+		return nil
+	}
+	redacted := *nc
+	if nc.CACertPEM != "" {
+		redacted.CACertPEM = "<REDACTED>"
+	}
+	return &redacted
 }
 
 // DefaultNetworkConfig is the default network configuration for provider connections.

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1,6 +1,7 @@
 package schemas
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -253,4 +254,28 @@ func TestSonic_ChatTool_ToolFunctionParametersPreservesOrder(t *testing.T) {
 	require.NoError(t, err)
 	paramOutputKeys := ExtractTopLevelKeyOrder(paramOutput)
 	assert.Equal(t, "$defs", paramOutputKeys[0], "parameters should have $defs first")
+}
+
+// TestNetworkConfig_TLSFieldsRoundTrip verifies that insecure_skip_verify and ca_cert_pem
+// round-trip correctly through JSON marshaling (used by config.json).
+func TestNetworkConfig_TLSFieldsRoundTrip(t *testing.T) {
+	nc := NetworkConfig{
+		BaseURL:                        "https://example.com",
+		DefaultRequestTimeoutInSeconds: 60,
+		MaxRetries:                     3,
+		InsecureSkipVerify:             true,
+		CACertPEM:                      "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
+	}
+
+	data, err := json.Marshal(nc)
+	require.NoError(t, err)
+
+	var decoded NetworkConfig
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, nc.InsecureSkipVerify, decoded.InsecureSkipVerify, "insecure_skip_verify should round-trip")
+	assert.Equal(t, nc.CACertPEM, decoded.CACertPEM, "ca_cert_pem should round-trip")
+	assert.Contains(t, string(data), `"insecure_skip_verify":true`)
+	assert.Contains(t, string(data), `"ca_cert_pem"`)
 }

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -31,6 +31,12 @@ NetworkConfig:
       type: integer
       format: int64
       description: Maximum backoff duration in milliseconds
+    insecure_skip_verify:
+      type: boolean
+      description: Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments.
+    ca_cert_pem:
+      type: string
+      description: PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)
 
 ConcurrencyAndBufferSize:
   type: object

--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -322,6 +322,63 @@ When a full URL (with scheme and host) is provided in `request_path_overrides`, 
 
 In this example, instead of using OpenAI's default `/v1/chat/completions` path, requests will be sent to `https://custom-endpoint.example.com/api/v2/chat`.
 
+### TLS for Self-Signed or Internal Certificates
+
+When connecting to providers with HTTPS endpoints that use self-signed certificates or internal CAs (e.g., air-gapped environments, internal services), you can configure TLS in `network_config`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `insecure_skip_verify` | boolean | Disable TLS certificate verification. Use only for trusted internal environments. **Not recommended for production.** |
+| `ca_cert_pem` | string | PEM-encoded CA certificate to trust for provider connections. Use when the endpoint uses a custom CA. |
+
+These options are mutually exclusive. Do not set `insecure_skip_verify: true` together with `ca_cert_pem`; provider config validation rejects that combination.
+
+**Option 1: Skip verification (air-gapped / self-signed)**
+
+```json
+{
+    "my-air-gapped-provider": {
+        "keys": [{ "name": "key-1", "value": "env.API_KEY", "models": [], "weight": 1.0 }],
+        "network_config": {
+            "base_url": "https://internal-llm.example.com",
+            "insecure_skip_verify": true
+        },
+        "custom_provider_config": {
+            "base_provider_type": "openai",
+            "allowed_requests": {
+                "chat_completion": true,
+                "chat_completion_stream": true
+            }
+        }
+    }
+}
+```
+
+**Option 2: Custom CA certificate (preferred when you have the CA)**
+
+```json
+{
+    "my-internal-provider": {
+        "keys": [{ "name": "key-1", "value": "env.API_KEY", "models": [], "weight": 1.0 }],
+        "network_config": {
+            "base_url": "https://internal-llm.example.com",
+            "ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
+        },
+        "custom_provider_config": {
+            "base_provider_type": "openai",
+            "allowed_requests": {
+                "chat_completion": true,
+                "chat_completion_stream": true
+            }
+        }
+    }
+}
+```
+
+<Warning>
+Using `insecure_skip_verify` disables all certificate verification and is insecure. Prefer `ca_cert_pem` when you have the CA certificate. Only use `insecure_skip_verify` in trusted, isolated environments (e.g., air-gapped networks).
+</Warning>
+
 ## Use Cases
 
 ### 1. Environment-Specific Configurations

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -146,6 +146,10 @@ Each key in a provider needs to have a unique name.
 **Kubernetes DNS (only for custom endpoint):** When running in Kubernetes, use fully qualified domain names (FQDN) like `http://<service>.<namespace>.svc.cluster.local:8000` for cross-namespace custom endpoints. Short names like `http://<service>:8000` only work within the same namespace.
 </Tip>
 
+<Tip>
+**Air-gapped or self-signed certificates:** If your custom provider uses HTTPS with a self-signed or internal CA certificate, add `"insecure_skip_verify": true` or `"ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"` to `network_config`. See [Custom Providers - TLS](../../providers/custom-providers#tls-for-self-signed-or-internal-certificates) for details.
+</Tip>
+
 ## Making Requests
 
 Once providers are configured, you can make requests to any specific provider. This example shows how to send a request directly to OpenAI's GPT-4o Mini model. Bifrost handles the provider-specific API formatting automatically.

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -264,8 +264,12 @@ type ProviderConfig struct {
 // Redacted returns a redacted copy of the provider configuration.
 func (p *ProviderConfig) Redacted() *ProviderConfig {
 	// Create redacted config with same structure but redacted values
+	var redactedNetworkConfig *schemas.NetworkConfig
+	if p.NetworkConfig != nil {
+		redactedNetworkConfig = p.NetworkConfig.Redacted()
+	}
 	redactedConfig := ProviderConfig{
-		NetworkConfig:            p.NetworkConfig,
+		NetworkConfig:            redactedNetworkConfig,
 		ConcurrencyAndBufferSize: p.ConcurrencyAndBufferSize,
 		SendBackRawRequest:       p.SendBackRawRequest,
 		SendBackRawResponse:      p.SendBackRawResponse,

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -448,6 +448,10 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 	}
 
 	config.ConcurrencyAndBufferSize = &payload.ConcurrencyAndBufferSize
+	// Merge network config - restore ca_cert_pem if the redacted placeholder was sent back
+	if oldConfigRaw.NetworkConfig != nil && (nc.CACertPEM == "<REDACTED>" || nc.CACertPEM == "********") {
+		nc.CACertPEM = oldConfigRaw.NetworkConfig.CACertPEM
+	}
 	config.NetworkConfig = &nc
 	// Merge proxy config - preserve secrets if redacted values were sent back
 	if payload.ProxyConfig != nil && oldConfigRaw.ProxyConfig != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1939,6 +1939,14 @@
           "type": "integer",
           "minimum": 0,
           "description": "Maximum retry backoff in milliseconds"
+        },
+        "insecure_skip_verify": {
+          "type": "boolean",
+          "description": "Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments."
+        },
+        "ca_cert_pem": {
+          "type": "string",
+          "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)"
         }
       },
       "additionalProperties": false

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -4,6 +4,8 @@ import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { DefaultNetworkConfig } from "@/lib/constants/config";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
@@ -70,6 +72,8 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				max_retries: provider.network_config?.max_retries ?? DefaultNetworkConfig.max_retries,
 				retry_backoff_initial: provider.network_config?.retry_backoff_initial ?? DefaultNetworkConfig.retry_backoff_initial,
 				retry_backoff_max: provider.network_config?.retry_backoff_max ?? DefaultNetworkConfig.retry_backoff_max,
+				insecure_skip_verify: provider.network_config?.insecure_skip_verify ?? DefaultNetworkConfig.insecure_skip_verify,
+				ca_cert_pem: provider.network_config?.ca_cert_pem ?? DefaultNetworkConfig.ca_cert_pem,
 			},
 		},
 	});
@@ -99,6 +103,8 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				max_retries: data.network_config?.max_retries ?? 0,
 				retry_backoff_initial: data.network_config?.retry_backoff_initial ?? 500,
 				retry_backoff_max: data.network_config?.retry_backoff_max ?? 10000,
+				insecure_skip_verify: data.network_config?.insecure_skip_verify ?? false,
+				ca_cert_pem: data.network_config?.ca_cert_pem?.trim() || undefined,
 			},
 		};
 		updateProvider(updatedProvider)
@@ -125,6 +131,8 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				max_retries: provider.network_config?.max_retries ?? DefaultNetworkConfig.max_retries,
 				retry_backoff_initial: provider.network_config?.retry_backoff_initial ?? DefaultNetworkConfig.retry_backoff_initial,
 				retry_backoff_max: provider.network_config?.retry_backoff_max ?? DefaultNetworkConfig.retry_backoff_max,
+				insecure_skip_verify: provider.network_config?.insecure_skip_verify ?? DefaultNetworkConfig.insecure_skip_verify,
+				ca_cert_pem: provider.network_config?.ca_cert_pem ?? DefaultNetworkConfig.ca_cert_pem,
 			},
 		});
 	}, [form, provider.name, provider.network_config]);
@@ -302,6 +310,55 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 								</FormItem>
 							)}
 						/>
+						<div className="space-y-4 rounded-lg border p-4">
+							<h4 className="text-sm font-medium">TLS / Certificate</h4>
+							<FormField
+								control={form.control}
+								name="network_config.insecure_skip_verify"
+								render={({ field }) => (
+									<FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+										<div className="space-y-0.5">
+											<FormLabel>Skip TLS verification</FormLabel>
+											<FormDescription>
+												Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments.
+											</FormDescription>
+										</div>
+										<FormControl>
+											<Switch
+												checked={field.value ?? false}
+												onCheckedChange={field.onChange}
+												disabled={!hasUpdateProviderAccess}
+												data-testid="network-config-insecure-skip-verify"
+											/>
+										</FormControl>
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={form.control}
+								name="network_config.ca_cert_pem"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
+										<FormControl>
+											<Textarea
+												placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+												className="font-mono text-xs"
+												rows={6}
+												{...field}
+												value={field.value || ""}
+												disabled={!hasUpdateProviderAccess}
+												data-testid="network-config-ca-cert-pem"
+											/>
+										</FormControl>
+										<FormDescription>
+											PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)
+										</FormDescription>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
 					</div>
 				</div>
 

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -81,6 +81,8 @@ export const DefaultNetworkConfig = {
 	max_retries: 0,
 	retry_backoff_initial: 1000,
 	retry_backoff_max: 10000,
+	insecure_skip_verify: false,
+	ca_cert_pem: "",
 } satisfies NetworkConfig;
 
 export const DefaultPerformanceConfig = {

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -154,6 +154,8 @@ export interface NetworkConfig {
 	max_retries: number;
 	retry_backoff_initial: number; // Duration in milliseconds
 	retry_backoff_max: number; // Duration in milliseconds
+	insecure_skip_verify?: boolean;
+	ca_cert_pem?: string;
 }
 
 // ConcurrencyAndBufferSize matching Go's schemas.ConcurrencyAndBufferSize

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -225,6 +225,8 @@ export const networkConfigSchema = z
 		max_retries: z.number().min(0, "Max retries must be greater than 0").max(10, "Max retries must be less than 10"),
 		retry_backoff_initial: z.number().min(100),
 		retry_backoff_max: z.number().min(1000),
+		insecure_skip_verify: z.boolean().optional(),
+		ca_cert_pem: z.string().optional(),
 	})
 	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
 		message: "retry_backoff_initial must be <= retry_backoff_max",
@@ -262,6 +264,8 @@ export const networkFormConfigSchema = z
 			.number("Retry backoff max must be a number")
 			.min(100, "Retry backoff max must be at least 100ms")
 			.max(1000000, "Retry backoff max must be at most 1000000ms"),
+		insecure_skip_verify: z.boolean().optional(),
+		ca_cert_pem: z.string().optional(),
 	})
 	.refine((d) => d.retry_backoff_initial <= d.retry_backoff_max, {
 		message: "Initial backoff must be less than or equal to max backoff",


### PR DESCRIPTION
## Summary

Adds TLS configuration support for provider connections, enabling secure communication with endpoints using self-signed certificates or internal CAs. This is essential for air-gapped environments and internal services that don't use publicly trusted certificates.

## Changes

- Added `insecure_skip_verify` and `ca_cert_pem` fields to `NetworkConfig` schema with proper JSON marshaling/unmarshaling
- Implemented `ConfigureTLS` utility function that merges TLS settings with existing client configuration (e.g., from proxy settings)
- Integrated TLS configuration across all 24 provider implementations by adding `ConfigureTLS` calls after proxy and dialer setup
- Added comprehensive test coverage for TLS configuration scenarios including certificate validation and config merging
- Updated OpenAPI documentation and UI forms to expose TLS settings with appropriate warnings about security implications
- Enhanced documentation with examples for both `insecure_skip_verify` and `ca_cert_pem` usage patterns

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] UI (Next.js)
- [x] Docs

## How to test

Test TLS configuration with a custom provider:

```sh
# Core/Transports
go version
go test ./core/providers/utils/...
go test ./core/schemas/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Example configuration for testing with self-signed certificates:

```json
{
  "my-internal-provider": {
    "keys": [{"name": "key-1", "value": "your-api-key", "models": [], "weight": 1.0}],
    "network_config": {
      "base_url": "https://internal-llm.example.com",
      "ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
    }
  }
}
```

## Screenshots/Recordings

https://www.loom.com/share/696c21f92f5a4dd8918c342583991662

## Breaking changes

- [ ] Yes
- [x] No

New optional fields in `NetworkConfig` maintain backward compatibility.

## Related issues

Closes #1900 

## Security considerations

- `insecure_skip_verify` disables all TLS certificate verification and should only be used in trusted, isolated environments
- `ca_cert_pem` provides a secure alternative by allowing custom CA trust without disabling verification
- Added prominent warnings in UI and documentation about production security implications
- TLS settings are properly merged with existing proxy configurations to maintain security layers

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable