### PR TITLE
feat: Add a model parameters table and an API endpoint with in-memory caching

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -4254,5 +4254,32 @@ func migrationAddPromptRepoTables(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("error while running add_prompt_id_to_prompt_message_tables migration: %s", err.Error())
 	}
 
+	m = migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_parameters_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasTable(&tables.TableModelParameters{}) {
+				if err := migrator.CreateTable(&tables.TableModelParameters{}); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasTable(&tables.TableModelParameters{}) {
+				if err := migrator.DropTable(&tables.TableModelParameters{}); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add_model_parameters_table migration: %s", err.Error())
+	}
+
 	return nil
 }

--- a/framework/configstore/prompts.go
+++ b/framework/configstore/prompts.go
@@ -320,7 +320,7 @@ func (s *RDBConfigStore) DeletePromptVersion(ctx context.Context, id uint) error
 					return err
 				}
 			} else {
-				if err := tx.Model(&prevVersion).Update("is_latest", true).Error; err != nil {
+				if err := tx.Model(&prevVersion).UpdateColumn("is_latest", true).Error; err != nil {
 					return err
 				}
 			}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1260,6 +1260,49 @@ func (s *RDBConfigStore) DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) 
 	return txDB.WithContext(ctx).Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&tables.TableModelPricing{}).Error
 }
 
+// MODEL PARAMETERS METHODS
+
+// GetModelParameters retrieves model parameters for a specific model.
+func (s *RDBConfigStore) GetModelParameters(ctx context.Context, model string) (*tables.TableModelParameters, error) {
+	var params tables.TableModelParameters
+	if err := s.db.WithContext(ctx).Where("model = ?", model).First(&params).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &params, nil
+}
+
+// UpsertModelParameters inserts or updates model parameters for a specific model.
+func (s *RDBConfigStore) UpsertModelParameters(ctx context.Context, params *tables.TableModelParameters, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.db
+	}
+	db := txDB.WithContext(ctx)
+
+	var existing tables.TableModelParameters
+	err := db.Where("model = ?", params.Model).First(&existing).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if err := db.Create(params).Error; err != nil {
+				return s.parseGormError(err)
+			}
+			return nil
+		}
+		return s.parseGormError(err)
+	}
+
+	params.ID = existing.ID
+	if err := db.Save(params).Error; err != nil {
+		return s.parseGormError(err)
+	}
+	return nil
+}
+
 // PLUGINS METHODS
 
 func (s *RDBConfigStore) GetPlugins(ctx context.Context) ([]*tables.TablePlugin, error) {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -177,6 +177,10 @@ type ConfigStore interface {
 	UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error
 	DeleteModelPrices(ctx context.Context, tx ...*gorm.DB) error
 
+	// Model parameters
+	GetModelParameters(ctx context.Context, model string) (*tables.TableModelParameters, error)
+	UpsertModelParameters(ctx context.Context, params *tables.TableModelParameters, tx ...*gorm.DB) error
+
 	// Key management
 	GetKeysByIDs(ctx context.Context, ids []string) ([]tables.TableKey, error)
 	GetKeysByProvider(ctx context.Context, provider string) ([]tables.TableKey, error)

--- a/framework/configstore/tables/modelparameters.go
+++ b/framework/configstore/tables/modelparameters.go
@@ -1,0 +1,13 @@
+package tables
+
+// TableModelParameters stores model parameters and capabilities data
+// synced from the external datasheet API. Each row holds one model's
+// full parameter/capability JSON blob.
+type TableModelParameters struct {
+	ID    uint   `gorm:"primaryKey;autoIncrement" json:"id"`
+	Model string `gorm:"type:varchar(255);not null;uniqueIndex:idx_model_params_model" json:"model"`
+	Data  string `gorm:"type:text;not null" json:"data"` // Raw JSON blob
+}
+
+// TableName sets the table name
+func (TableModelParameters) TableName() string { return "governance_model_parameters" }

--- a/framework/configstore/tables/promptVersions.go
+++ b/framework/configstore/tables/promptVersions.go
@@ -38,12 +38,14 @@ type ModelParams map[string]interface{}
 
 // BeforeSave GORM hook to serialize JSON fields
 func (v *TablePromptVersion) BeforeSave(tx *gorm.DB) error {
-	data, err := json.Marshal(v.ModelParams)
-	if err != nil {
-		return err
+	if v.ModelParams != nil {
+		data, err := json.Marshal(v.ModelParams)
+		if err != nil {
+			return err
+		}
+		paramsStr := string(data)
+		v.ModelParamsJSON = &paramsStr
 	}
-	paramsStr := string(data)
-	v.ModelParamsJSON = &paramsStr
 	return nil
 }
 

--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -3,10 +3,13 @@ package modelcatalog
 import "time"
 
 const (
-	DefaultPricingSyncInterval = 24 * time.Hour
-	ConfigLastPricingSyncKey   = "LastModelPricingSync"
-	DefaultPricingURL          = "https://getbifrost.ai/datasheet"
-	DefaultPricingTimeout      = 45 * time.Second
+	DefaultPricingSyncInterval    = 24 * time.Hour
+	ConfigLastPricingSyncKey      = "LastModelPricingSync"
+	ConfigLastParamsSyncKey       = "LastModelParametersSync"
+	DefaultPricingURL             = "https://getbifrost.ai/datasheet"
+	DefaultModelParametersURL     = "https://getbifrost.ai/datasheet/model-parameters"
+	DefaultPricingTimeout         = 45 * time.Second
+	DefaultModelParametersTimeout = 45 * time.Second
 )
 
 // Config is the model pricing configuration.

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -3,6 +3,7 @@ package modelcatalog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -45,6 +46,10 @@ type ModelCatalog struct {
 	modelPool           map[schemas.ModelProvider][]string
 	unfilteredModelPool map[schemas.ModelProvider][]string // model pool without allowed models filtering
 	baseModelIndex      map[string]string                  // model string → canonical base model name
+
+	// In-memory cache for model parameters (keyed by model name)
+	modelParametersData map[string]json.RawMessage
+	paramsMu            sync.RWMutex
 
 	// Background sync worker
 	syncTicker *time.Ticker
@@ -126,6 +131,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		modelPool:              make(map[schemas.ModelProvider][]string),
 		unfilteredModelPool:    make(map[schemas.ModelProvider][]string),
 		baseModelIndex:         make(map[string]string),
+		modelParametersData:    make(map[string]json.RawMessage),
 		done:                   make(chan struct{}),
 		shouldSyncPricingFunc:  shouldSyncPricingFunc,
 		distributedLockManager: configstore.NewDistributedLockManager(configStore, logger, configstore.WithDefaultTTL(30*time.Second)),
@@ -139,6 +145,10 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			}
 			if err := mc.syncPricing(ctx); err != nil {
 				return nil, fmt.Errorf("failed to sync pricing data: %w", err)
+			}
+			// Sync model parameters into memory
+			if err := mc.syncModelParameters(ctx); err != nil {
+				mc.logger.Warn("failed to sync model parameters data: %v", err)
 			}
 		} else {
 			lock, err := mc.distributedLockManager.NewLock("model_catalog_pricing_sync")
@@ -156,11 +166,19 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			if err := mc.syncPricing(ctx); err != nil {
 				return nil, fmt.Errorf("failed to sync pricing data: %w", err)
 			}
+			// Sync model parameters into memory
+			if err := mc.syncModelParameters(ctx); err != nil {
+				mc.logger.Warn("failed to sync model parameters data: %v", err)
+			}
 		}
 	} else {
 		// Load pricing data from config memory
 		if err := mc.loadPricingIntoMemory(ctx); err != nil {
 			return nil, fmt.Errorf("failed to load pricing data from config memory: %w", err)
+		}
+		// Sync model parameters into memory
+		if err := mc.syncModelParameters(ctx); err != nil {
+			mc.logger.Warn("failed to sync model parameters data: %v", err)
 		}
 	}
 
@@ -210,6 +228,11 @@ func (mc *ModelCatalog) ReloadPricing(ctx context.Context, config *Config) error
 		return fmt.Errorf("failed to sync pricing data: %w", err)
 	}
 
+	// Also sync model parameters
+	if err := mc.syncModelParameters(ctx); err != nil {
+		mc.logger.Warn("failed to sync model parameters during reload: %v", err)
+	}
+
 	return nil
 }
 
@@ -234,6 +257,12 @@ func (mc *ModelCatalog) ForceReloadPricing(ctx context.Context) error {
 
 	// Rebuild model pool from updated pricing data
 	mc.populateModelPoolFromPricingData()
+
+	// Also sync model parameters
+	if err := mc.syncModelParameters(ctx); err != nil {
+		mc.logger.Warn("failed to sync model parameters during force reload: %v", err)
+	}
+
 	return nil
 }
 
@@ -520,6 +549,17 @@ func (mc *ModelCatalog) IsSameModel(model1, model2 string) bool {
 	return mc.GetBaseModelName(model1) == mc.GetBaseModelName(model2)
 }
 
+// GetModelParametersData returns the raw JSON model parameters for a specific model (thread-safe)
+func (mc *ModelCatalog) GetModelParametersData(model string) json.RawMessage {
+	mc.paramsMu.RLock()
+	defer mc.paramsMu.RUnlock()
+	data, ok := mc.modelParametersData[model]
+	if !ok {
+		return nil
+	}
+	return data
+}
+
 // DeleteModelDataForProvider deletes all model data from the pool for a given provider
 func (mc *ModelCatalog) DeleteModelDataForProvider(provider schemas.ModelProvider) {
 	mc.mu.Lock()
@@ -774,6 +814,7 @@ func NewTestCatalog(baseModelIndex map[string]string) *ModelCatalog {
 		unfilteredModelPool: make(map[schemas.ModelProvider][]string),
 		baseModelIndex:      baseModelIndex,
 		pricingData:         make(map[string]configstoreTables.TableModelPricing),
+		modelParametersData: make(map[string]json.RawMessage),
 		compiledOverrides:   make(map[schemas.ModelProvider][]compiledProviderPricingOverride),
 		done:                make(chan struct{}),
 	}

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -224,6 +224,9 @@ func (mc *ModelCatalog) syncTick(ctx context.Context) {
 		if err := mc.checkAndSyncPricing(ctx); err != nil {
 			mc.logger.Error("background pricing sync failed: %v", err)
 		}
+		if err := mc.checkAndSyncModelParameters(ctx); err != nil {
+			mc.logger.Error("background model parameters sync failed: %v", err)
+		}
 		return
 	}
 	lock, err := mc.distributedLockManager.NewLock("model_catalog_pricing_sync")
@@ -238,6 +241,9 @@ func (mc *ModelCatalog) syncTick(ctx context.Context) {
 	defer lock.Unlock(ctx)
 	if err := mc.checkAndSyncPricing(ctx); err != nil {
 		mc.logger.Error("background pricing sync failed: %v", err)
+	}
+	if err := mc.checkAndSyncModelParameters(ctx); err != nil {
+		mc.logger.Error("background model parameters sync failed: %v", err)
 	}
 }
 
@@ -257,3 +263,123 @@ func (mc *ModelCatalog) syncWorker(ctx context.Context) {
 		}
 	}
 }
+
+// --- Model Parameters sync ---
+
+// checkAndSyncModelParameters determines if model parameters data needs to be synced and performs the sync if needed.
+func (mc *ModelCatalog) checkAndSyncModelParameters(ctx context.Context) error {
+	if mc.configStore == nil {
+		return nil
+	}
+
+	needsSync, reason := mc.shouldSyncModelParameters(ctx)
+	if needsSync {
+		mc.logger.Debug("model parameters sync needed: %s", reason)
+		return mc.syncModelParameters(ctx)
+	}
+
+	return nil
+}
+
+// shouldSyncModelParameters determines if model parameters data should be synced
+func (mc *ModelCatalog) shouldSyncModelParameters(ctx context.Context) (bool, string) {
+	config, err := mc.configStore.GetConfig(ctx, ConfigLastParamsSyncKey)
+	if err != nil {
+		return true, "no previous model parameters sync record found"
+	}
+
+	lastSync, err := time.Parse(time.RFC3339, config.Value)
+	if err != nil {
+		mc.logger.Warn("invalid last model parameters sync timestamp: %v", err)
+		return true, "corrupted sync timestamp"
+	}
+
+	if time.Since(lastSync) >= mc.getPricingSyncInterval() {
+		return true, "sync interval elapsed"
+	}
+
+	return false, "sync not needed"
+}
+
+// syncModelParameters syncs model parameters data from URL into memory cache
+func (mc *ModelCatalog) syncModelParameters(ctx context.Context) error {
+	mc.logger.Debug("model-parameters-sync: starting model parameters synchronization")
+
+	paramsData, err := mc.loadModelParametersFromURL(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load model parameters from URL: %w", err)
+	}
+
+	// Persist to database if config store is available
+	if mc.configStore != nil {
+		err = mc.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+			for model, data := range paramsData {
+				params := &configstoreTables.TableModelParameters{
+					Model: model,
+					Data:  string(data),
+				}
+				if err := mc.configStore.UpsertModelParameters(ctx, params, tx); err != nil {
+					return fmt.Errorf("failed to upsert model parameters for model %s: %w", model, err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("model-parameters-sync: failed to sync model parameters to database: %w", err)
+		}
+	}
+
+	// Update in-memory cache
+	mc.paramsMu.Lock()
+	mc.modelParametersData = paramsData
+	mc.paramsMu.Unlock()
+
+	// Update last sync time if config store is available
+	if mc.configStore != nil {
+		config := &configstoreTables.TableGovernanceConfig{
+			Key:   ConfigLastParamsSyncKey,
+			Value: time.Now().Format(time.RFC3339),
+		}
+		if err := mc.configStore.UpdateConfig(ctx, config); err != nil {
+			mc.logger.Warn("model-parameters-sync: failed to update last model parameters sync time: %v", err)
+		}
+	}
+
+	mc.logger.Info("model-parameters-sync: successfully synced %d model parameters records", len(paramsData))
+	return nil
+}
+
+// loadModelParametersFromURL loads model parameters data from the remote URL
+func (mc *ModelCatalog) loadModelParametersFromURL(ctx context.Context) (map[string]json.RawMessage, error) {
+	client := &http.Client{}
+	client.Timeout = DefaultModelParametersTimeout
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, DefaultModelParametersURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download model parameters data: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download model parameters data: HTTP %d", resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read model parameters response: %w", err)
+	}
+
+	var paramsData map[string]json.RawMessage
+	if err := json.Unmarshal(data, &paramsData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal model parameters data: %w", err)
+	}
+
+	mc.logger.Debug("model-parameters-sync: successfully downloaded and parsed %d model parameters records", len(paramsData))
+	return paramsData, nil
+}
+
+

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -97,6 +97,7 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.DELETE("/api/providers/{provider}", lib.ChainMiddlewares(h.deleteProvider, middlewares...))
 	r.GET("/api/keys", lib.ChainMiddlewares(h.listKeys, middlewares...))
 	r.GET("/api/models", lib.ChainMiddlewares(h.listModels, middlewares...))
+	r.GET("/api/models/parameters", lib.ChainMiddlewares(h.getModelParameters, middlewares...))
 	r.GET("/api/models/base", lib.ChainMiddlewares(h.listBaseModels, middlewares...))
 }
 
@@ -696,6 +697,33 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, response)
+}
+
+// getModelParameters handles GET /api/models/parameters - Get model parameters for a specific model
+// Query parameters:
+//   - model: The model name to get parameters for (required)
+func (h *ProviderHandler) getModelParameters(ctx *fasthttp.RequestCtx) {
+	modelParam := string(ctx.QueryArgs().Peek("model"))
+	if modelParam == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "model query parameter is required")
+		return
+	}
+
+	modelCatalog := h.inMemoryStore.ModelCatalog
+	if modelCatalog == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "model catalog not available")
+		return
+	}
+
+	data := modelCatalog.GetModelParametersData(modelParam)
+	if data == nil {
+		SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("no parameters found for model %s", modelParam))
+		return
+	}
+
+	ctx.SetContentType("application/json")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	ctx.SetBody(data)
 }
 
 // filterModelsByKeys filters models based on key-level model restrictions

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -841,6 +841,15 @@ func (m *MockConfigStore) DeleteModelPrices(ctx context.Context, tx ...*gorm.DB)
 	return nil
 }
 
+// Model parameters
+func (m *MockConfigStore) GetModelParameters(ctx context.Context, model string) (*tables.TableModelParameters, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) UpsertModelParameters(ctx context.Context, params *tables.TableModelParameters, tx ...*gorm.DB) error {
+	return nil
+}
+
 // Provider methods
 func (m *MockConfigStore) GetProvider(ctx context.Context, provider schemas.ModelProvider) (*tables.TableProvider, error) {
 	return nil, nil

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -12,7 +12,7 @@ import {
 	useGetVersionsQuery,
 	useUpdatePromptMutation,
 } from "@/lib/store/apis/promptsApi";
-import { useGetModelDatasheetQuery } from "@/lib/store/apis/providersApi";
+import { useGetModelParametersQuery } from "@/lib/store/apis/providersApi";
 import { Message, MessageRole, MessageType } from "@/lib/message";
 import { Folder, ModelParams, Prompt, PromptSession, PromptVersion } from "@/lib/types/prompts";
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
@@ -144,7 +144,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	const activeRunRef = useRef<symbol | null>(null);
 
 	// Fetch model datasheet for capabilities
-	const { data: datasheetData } = useGetModelDatasheetQuery(model, { skip: !model });
+	const { data: datasheetData } = useGetModelParametersQuery(model, { skip: !model });
 	const supportsVision = datasheetData?.supports_vision ?? false;
 
 	// Derived data

--- a/ui/components/ui/custom/modelParameters/index.tsx
+++ b/ui/components/ui/custom/modelParameters/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useGetModelDatasheetQuery } from '@/lib/store/apis/providersApi'
+import { useGetModelParametersQuery } from '@/lib/store/apis/providersApi'
 import { Parameter, ParameterType } from './types'
 import ParameterFieldView from './paramFieldView'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -37,16 +37,16 @@ export default function ModelParameters({
   disabled,
   hideFields,
 }: ModelParametersProps) {
-  const { data, isLoading, isError } = useGetModelDatasheetQuery(model, {
+  const { data, isLoading, isError } = useGetModelParametersQuery(model, {
     skip: !model,
   })
 
   // Ensure parameters belong to the current model (RTK Query may briefly return stale cached data)
   const datasheetModel = data?.base_model
   const parameters = useMemo(() => {
-    if (!data?.model_parameters || datasheetModel !== model) return []
+    if (!data?.model_parameters || isLoading) return []
     return data.model_parameters.filter((p) => SUPPORTED_TYPES.has(p.type))
-  }, [data, datasheetModel, model])
+  }, [data, isLoading])
 
   // Clear config when switching models — values stay undefined until the user explicitly sets them
   const prevModelRef = useRef(model)

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -64,6 +64,30 @@ export interface ListBaseModelsResponse {
 	total: number;
 }
 
+const DEFAULT_MODEL_PARAMETERS: ModelDatasheetResponse = {
+	mode: "chat",
+	base_model: "default",
+	model_parameters: [
+		{
+			id: "temperature",
+			label: "Temperature",
+			helpText:
+				"What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
+			type: "number",
+			default: 1,
+			range: { min: 0, max: 2, step: 0.01 },
+		},
+		{
+			id: "max_tokens",
+			label: "Max Tokens",
+			helpText: "The maximum number of tokens that can be generated in the Result.",
+			type: "number",
+			default: 4096,
+			range: { min: 1, max: 8192, step: 1 },
+		},
+	],
+};
+
 export const providersApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Get all providers
@@ -174,19 +198,19 @@ export const providersApi = baseApi.injectEndpoints({
 			providesTags: ["BaseModels"],
 		}),
 
-		// Get model datasheet (parameters, capabilities) from external API
-		getModelDatasheet: builder.query<ModelDatasheetResponse, string>({
-			queryFn: async (model) => {
-				try {
-					const res = await fetch(`https://getbifrost.ai/datasheet-extended?model=${encodeURIComponent(model)}`);
-					if (!res.ok) {
-						return { error: { status: res.status, data: `Failed to fetch datasheet for ${model}` } };
+		// Get model parameters (parameters, capabilities) from local API
+		// Falls back to default parameters if the API returns an error (e.g. model not found)
+		getModelParameters: builder.query<ModelDatasheetResponse, string>({
+			queryFn: async (model, _queryApi, _extraOptions, baseQuery) => {
+				const result = await baseQuery(`/models/parameters?model=${encodeURIComponent(model)}`);
+				if (result.error) {
+					// If the model is not found, return the default parameters
+					if ((result.error as any)?.status === 404) {
+						return { data: DEFAULT_MODEL_PARAMETERS };
 					}
-					const data = await res.json();
-					return { data };
-				} catch (err) {
-					return { error: { status: "FETCH_ERROR", data: String(err) } };
+					return { error: result.error };
 				}
+				return { data: result.data as ModelDatasheetResponse };
 			},
 		}),
 	}),
@@ -206,6 +230,6 @@ export const {
 	useLazyGetAllKeysQuery,
 	useLazyGetModelsQuery,
 	useLazyGetBaseModelsQuery,
-	useGetModelDatasheetQuery,
-	useLazyGetModelDatasheetQuery,
+	useGetModelParametersQuery,
+	useLazyGetModelParametersQuery,
 } = providersApi;


### PR DESCRIPTION
## Summary

Adds model parameters storage and synchronization functionality to the framework. This enables storing and retrieving model-specific parameters and capabilities data from an external API, with local caching and database persistence.

## Changes

- Added `TableModelParameters` database table to store model parameters as JSON blobs
- Implemented CRUD operations for model parameters in the config store
- Added background synchronization of model parameters from external API endpoint
- Created new HTTP endpoint `/api/models/parameters` to retrieve model parameters
- Updated UI to use local model parameters API instead of external datasheet API
- Added fallback to default parameters when model-specific data is unavailable

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Validate the model parameters functionality:

```sh
# Core/Transports
go version
go test ./...

# Test the new API endpoint
curl "http://localhost:8080/api/models/parameters?model=gpt-4"

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

The system will automatically sync model parameters from `https://getbifrost.ai/datasheet/model-parameters` on startup and every 24 hours.

## Screenshots/Recordings

N/A - Backend functionality with API changes

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- Model parameters are fetched from external API endpoint over HTTPS
- No sensitive data is stored in model parameters
- Standard database security practices apply for the new table

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable