### PR TITLE
fixed cli publish flows

### DIFF
--- a/.github/workflows/npx-publish.yml
+++ b/.github/workflows/npx-publish.yml
@@ -94,14 +94,30 @@ jobs:
         if: steps.check-bifrost.outputs.changed == 'true'
         working-directory: npx/bifrost
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ steps.extract-version.outputs.version }}"
           echo "Publishing @maximhq/bifrost@${VERSION} to npm..."
           if npm view @maximhq/bifrost@"${VERSION}" version >/dev/null 2>&1; then
             echo "@maximhq/bifrost@${VERSION} already exists on npm. Skipping publish."
+            exit 0
+          fi
+          
+          # Try OIDC (Trusted Publishing) first - no token needed
+          echo "Attempting publish with OIDC (Trusted Publishing)..."
+          if npm publish --provenance --access public 2>&1; then
+            echo "Published successfully with OIDC!"
+            exit 0
+          fi
+          
+          # Fallback to NPM_TOKEN if OIDC fails
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "OIDC failed, falling back to NPM_TOKEN..."
+            export NODE_AUTH_TOKEN="$NPM_TOKEN"
+            npm publish --access public
           else
-            npm publish --provenance --access public
+            echo "OIDC failed and no NPM_TOKEN available"
+            exit 1
           fi
 
       - name: Configure Git
@@ -185,14 +201,30 @@ jobs:
         if: steps.check-cli.outputs.changed == 'true'
         working-directory: npx/bifrost-cli
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${{ steps.extract-version.outputs.version }}"
           echo "Publishing @maximhq/bifrost-cli@${VERSION} to npm..."
           if npm view @maximhq/bifrost-cli@"${VERSION}" version >/dev/null 2>&1; then
             echo "@maximhq/bifrost-cli@${VERSION} already exists on npm. Skipping publish."
+            exit 0
+          fi
+          
+          # Try OIDC (Trusted Publishing) first - no token needed
+          echo "Attempting publish with OIDC (Trusted Publishing)..."
+          if npm publish --provenance --access public 2>&1; then
+            echo "Published successfully with OIDC!"
+            exit 0
+          fi
+          
+          # Fallback to NPM_TOKEN if OIDC fails
+          if [ -n "$NPM_TOKEN" ]; then
+            echo "OIDC failed, falling back to NPM_TOKEN..."
+            export NODE_AUTH_TOKEN="$NPM_TOKEN"
+            npm publish --access public
           else
-            npm publish --provenance --access public
+            echo "OIDC failed and no NPM_TOKEN available"
+            exit 1
           fi
 
       - name: Configure Git

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,12 +1,11 @@
 name: Release CLI
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "CLI version to release (e.g., 1.0.0)"
-        required: true
-        type: string
+  push:
+    branches:
+      - main
+    paths:
+      - 'cli/**'
 
 # Prevent concurrent runs
 concurrency:
@@ -14,7 +13,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      tag_exists: ${{ steps.check-tag.outputs.exists }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Get version from file
+        id: get-version
+        run: echo "version=$(cat cli/version)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check-tag
+        run: |
+          if git rev-parse "cli/v${{ steps.get-version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
   test-cli:
+    needs: [check-version]
+    if: needs.check-version.outputs.tag_exists == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -35,7 +61,8 @@ jobs:
         run: go test ./...
 
   release-cli:
-    needs: [test-cli]
+    needs: [check-version, test-cli]
+    if: needs.check-version.outputs.tag_exists == 'false'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -67,4 +94,4 @@ jobs:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        run: ./.github/workflows/scripts/release-cli.sh "${{ inputs.version }}"
+        run: ./.github/workflows/scripts/release-cli.sh "${{ needs.check-version.outputs.version }}"


### PR DESCRIPTION
## Summary

Enhances npm publishing workflow with OIDC (Trusted Publishing) support and automates CLI releases to trigger on code changes rather than manual dispatch.

## Changes

- **NPM Publishing**: Implements OIDC (Trusted Publishing) as the primary authentication method with automatic fallback to NPM_TOKEN for both `@maximhq/bifrost` and `@maximhq/bifrost-cli` packages
- **CLI Release Automation**: Converts CLI release workflow from manual `workflow_dispatch` to automatic triggering on pushes to main branch affecting `cli/**` paths
- **Version Management**: Adds automatic version detection from `cli/version` file and prevents duplicate releases by checking for existing git tags
- **Error Handling**: Improves publish logic with proper exit codes and clearer error messages when both OIDC and token authentication fail

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Plugins
- [x] Docs

## How to test

Validate the npm publishing workflow:
```sh
# Test OIDC publishing (requires GitHub Actions environment)
npm publish --provenance --access public

# Test fallback token authentication
export NODE_AUTH_TOKEN="your-npm-token"
npm publish --access public
```

Validate CLI release automation:
```sh
# Make changes to cli/ directory and push to main
echo "1.0.1" > cli/version
git add cli/version
git commit -m "bump cli version"
git push origin main

# Verify workflow triggers and version detection
gh workflow list
gh run list --workflow="Release CLI"
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

- OIDC (Trusted Publishing) eliminates the need for long-lived NPM tokens in most cases, improving security posture
- NPM_TOKEN is now used as a fallback mechanism only, reducing token exposure
- Automatic CLI releases require proper branch protection and review processes to prevent unauthorized releases

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable