### PR TITLE
fixed cli actions condition

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'cli/**'
-
+    
 # Prevent concurrent runs
 concurrency:
   group: release-cli


### PR DESCRIPTION
## Summary

Remove path-based filtering from the CLI release workflow to trigger releases on any push to main branch, not just changes to the `cli/` directory.

## Changes

- Removed `paths: - 'cli/**'` filter from the GitHub Actions workflow trigger
- The workflow will now run on every push to main branch regardless of which files are modified

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)

## How to test

Push any change to the main branch and verify the release-cli workflow triggers:

```sh
# Verify workflow runs on any main branch push
git push origin main
# Check GitHub Actions tab to confirm workflow execution
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this only affects when the release workflow triggers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable