### PR TITLE
adds changelog for cli

### DIFF
--- a/.github/workflows/npx-publish.yml
+++ b/.github/workflows/npx-publish.yml
@@ -4,7 +4,10 @@ name: NPX Package Publish
 on:
   push:
     branches:
-      - main    
+      - main
+    paths:
+      - 'npx/bifrost/package.json'
+      - 'npx/bifrost-cli/package.json'
 
 # Prevent concurrent runs for the same trigger
 concurrency:

--- a/cli/changelog.md
+++ b/cli/changelog.md
@@ -1,0 +1,1 @@
+- ✨ hello world


### PR DESCRIPTION
## Summary

Optimizes the NPX package publishing workflow to only trigger when package.json files are modified and adds initial changelog entry for the CLI.

## Changes

- Added path filters to the NPX publish workflow to only run when `npx/bifrost/package.json` or `npx/bifrost-cli/package.json` are modified
- Added initial "hello world" entry to the CLI changelog

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the workflow only triggers on package.json changes by:

1. Push a change to main that doesn't modify the specified package.json files - workflow should not run
2. Push a change that modifies `npx/bifrost/package.json` or `npx/bifrost-cli/package.json` - workflow should trigger

```sh
# Test workflow trigger behavior
git push origin main  # Should not trigger if no package.json changes
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

None - this only affects CI workflow triggers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable