### PR TITLE
docs(bedrock): how to use arns and deployment mapping

### DIFF
--- a/docs/providers/supported-providers/bedrock.mdx
+++ b/docs/providers/supported-providers/bedrock.mdx
@@ -872,6 +872,54 @@ Set `role_arn` to assume an IAM role before signing requests. AssumeRole require
 
 ## Setup & Configuration
 
+### How to Use ARNs and Application Inference Profiles
+
+When using AWS Bedrock inference profiles or application inference profiles, you must split the configuration correctly to avoid `UnknownOperationException`:
+
+| Field | Purpose |
+|-------|---------|
+| **`arn`** | The ARN prefix (everything before the final `/resource-id`). Required for URL formation when using inference profiles. |
+| **`deployments`** | Map logical model names to the **model ID or inference profile resource ID only** — not the full ARN. |
+
+<Warning>
+**Do not** put the full ARN in the deployments mapping. The resource ID (e.g., `abc12xyz`) goes in `deployments`; the ARN prefix goes in the dedicated `arn` field. Putting the full ARN in `deployments` causes malformed URLs and `UnknownOperationException`.
+</Warning>
+
+**Application inference profiles** — use the resource ID (short alphanumeric suffix) in deployments:
+
+```json
+{
+  "bedrock_key_config": {
+    "access_key": "your-aws-access-key",
+    "secret_key": "your-aws-secret-key",
+    "session_token": "optional-session-token",
+    "region": "eu-west-1",
+    "arn": "arn:aws:bedrock:eu-west-1:123456789012:application-inference-profile",
+    "deployments": {
+      "claude-opus-4-6": "ghi56rst",
+      "claude-sonnet-4-5": "jkl78mno"
+    }
+  }
+}
+```
+
+**Cross-region inference profiles** — use the model identifier (e.g., `us.anthropic.claude-3-5-sonnet-v1:0`) in deployments:
+
+```json
+{
+  "bedrock_key_config": {
+    "access_key": "your-aws-access-key",
+    "secret_key": "your-aws-secret-key",
+    "session_token": "optional-session-token",
+    "region": "us-east-1",
+    "arn": "arn:aws:bedrock:us-east-1:123456789012:inference-profile",
+    "deployments": {
+      "claude-sonnet": "us.anthropic.claude-3-5-sonnet-v1:0"
+    }
+  }
+}
+```
+
 For detailed instructions on setting up AWS Bedrock authentication including credentials, IAM roles, regions, and deployment mapping, see the quickstart guides:
 
 <Tabs>

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -1253,6 +1253,7 @@ curl --location 'http://localhost:8080/api/providers' \
 - In IAM role authentication, if both `access_key` and `secret_key` are empty, Bifrost uses IAM role authentication from the environment.
 - `arn` is required for URL formation - `deployments` mapping is ignored without it.
 - When using `arn` + `deployments`, Bifrost uses model profiles; otherwise forms path with incoming model name directly.
+- **ARN vs deployments**: Put the ARN prefix in `arn` and the model/inference profile resource ID only in `deployments` — never the full ARN in deployments. See [How to Use ARNs and Application Inference Profiles](/providers/supported-providers/bedrock#how-to-use-arns-and-application-inference-profiles) for details.
 
 ### Google Vertex
 

--- a/docs/quickstart/go-sdk/provider-configuration.mdx
+++ b/docs/quickstart/go-sdk/provider-configuration.mdx
@@ -506,6 +506,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
 - In IAM role authentication, if both `AccessKey` and `SecretKey` are empty, Bifrost uses IAM from the environment.
 - `ARN` is required for URL formation - `Deployments` mapping is ignored without it.
 - When using `ARN` + `Deployments`, Bifrost uses model profiles; otherwise forms path with incoming model name directly.
+- **ARN vs Deployments**: Put the ARN prefix in `ARN` and the model/inference profile resource ID only in `Deployments` — never the full ARN in Deployments. See [How to Use ARNs and Application Inference Profiles](/providers/supported-providers/bedrock#how-to-use-arns-and-application-inference-profiles) for details.
 
 </Tab>
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for configuring AWS Bedrock ARNs and application inference profiles to prevent `UnknownOperationException` errors. This addresses common configuration mistakes where users put full ARNs in the deployments mapping instead of just the resource ID.

## Changes

- Added detailed section "How to Use ARNs and Application Inference Profiles" to Bedrock provider documentation
- Included configuration examples for both application inference profiles and cross-region inference profiles
- Added warning about incorrect ARN usage in deployments mapping
- Updated provider configuration notes in Gateway and Go SDK quickstart guides with references to the new documentation
- Clarified the distinction between ARN prefix (goes in `arn` field) and resource ID (goes in `deployments` mapping)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Validate the documentation renders correctly and examples are accurate:

```sh
# Test documentation build
cd docs
npm install
npm run build

# Verify examples match expected Bedrock configuration format
# Test with actual Bedrock inference profiles if available
```

## Screenshots/Recordings

N/A - Documentation only changes

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - documentation only changes that improve configuration clarity.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable