### PR TITLE
remove extra headers from restricted keys in BifrostContext

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -24,7 +24,6 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Gemi
 	if bifrostReq.Params != nil {
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		geminiReq.GenerationConfig = convertParamsToGenerationConfig(bifrostReq.Params, []string{}, bifrostReq.Model)
-
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {
 			geminiReq.Tools = convertBifrostToolsToGemini(bifrostReq.Params.Tools)
@@ -60,14 +59,12 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *Gemi
 			}
 		}
 	}
-
 	// Convert chat completion messages to Gemini format
 	contents, systemInstruction := convertBifrostMessagesToGemini(bifrostReq.Input)
 	if systemInstruction != nil {
 		geminiReq.SystemInstruction = systemInstruction
 	}
 	geminiReq.Contents = contents
-
 	return geminiReq
 }
 
@@ -116,7 +113,6 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 				})
 				continue
 			}
-
 			// Handle regular text
 			if part.Text != "" {
 				contentBlocks = append(contentBlocks, schemas.ChatContentBlock{
@@ -133,7 +129,6 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 					})
 				}
 			}
-
 			if part.FunctionCall != nil {
 				function := schemas.ChatAssistantMessageToolCallFunction{
 					Name: &part.FunctionCall.Name,
@@ -262,6 +257,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 		bifrostResp.Choices = append(bifrostResp.Choices, schemas.BifrostResponseChoice{
 			Index:        0,
 			FinishReason: &finishReason,
+			LogProbs:     ConvertGeminiLogprobsResultToBifrost(candidate.LogprobsResult),
 			ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
 				Message: message,
 			},
@@ -271,6 +267,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	// Set usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
 
+	
 	return bifrostResp
 }
 
@@ -456,6 +453,7 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream() (*schem
 	choice := schemas.BifrostResponseChoice{
 		Index:        int(candidate.Index),
 		FinishReason: finishReason,
+		LogProbs:     ConvertGeminiLogprobsResultToBifrost(candidate.LogprobsResult),
 		ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
 			Delta: delta,
 		},

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -985,7 +985,6 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 			}
 		}
 	}
-
 	// Handle response_format to response_schema conversion
 	if params.ResponseFormat != nil {
 		formatMap, ok := (*params.ResponseFormat).(map[string]interface{})
@@ -1006,7 +1005,6 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 			}
 		}
 	}
-
 	if params.ExtraParams != nil {
 		if topK, ok := params.ExtraParams["top_k"]; ok {
 			if val, success := schemas.SafeExtractInt(topK); success {
@@ -1021,7 +1019,21 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 			config.ResponseJSONSchema = responseJsonSchema
 		}
 	}
-
+	// Mapping logprobs to generation config
+	if params.LogProbs != nil {
+		config.ResponseLogprobs = *params.LogProbs
+	}
+	// Mapping top_logprobs to generation config
+	if params.TopLogProbs != nil {
+		topLogProbs := *params.TopLogProbs
+		if topLogProbs > 20 {
+			topLogProbs = 20
+		}
+		if topLogProbs > 0 {
+			config.ResponseLogprobs = true
+			config.Logprobs = schemas.Ptr(int32(topLogProbs))
+		}
+	}
 	return config
 }
 
@@ -2360,4 +2372,40 @@ func downloadImageFromURL(ctx context.Context, imageURL string) (string, error) 
 	imageCopy := append([]byte(nil), body...)
 
 	return encodeBytesToBase64String(imageCopy), nil
+}
+
+// tokenToBytes converts a token string to its UTF-8 byte representation as []int
+func tokenToBytes(token string) []int {
+	bytes := []byte(token)
+	result := make([]int, len(bytes))
+	for i, b := range bytes {
+		result[i] = int(b)
+	}
+	return result
+}
+
+// ConvertGeminiLogprobsResultToBifrost converts a Gemini LogprobsResult to Bifrost BifrostLogProbs
+func ConvertGeminiLogprobsResultToBifrost(result *LogprobsResult) *schemas.BifrostLogProbs {
+	if result == nil || len(result.ChosenCandidates) == 0 {
+		return nil
+	}
+
+	content := make([]schemas.ContentLogProb, len(result.ChosenCandidates))
+	for i, chosen := range result.ChosenCandidates {
+		content[i] = schemas.ContentLogProb{
+			Token:   chosen.Token,
+			LogProb: float64(chosen.LogProbability),
+			Bytes:   tokenToBytes(chosen.Token),
+		}
+		if i < len(result.TopCandidates) && result.TopCandidates[i] != nil {
+			for _, tc := range result.TopCandidates[i].Candidates {
+				content[i].TopLogProbs = append(content[i].TopLogProbs, schemas.LogProb{
+					Token:   tc.Token,
+					LogProb: float64(tc.LogProbability),
+					Bytes:   tokenToBytes(tc.Token),
+				})
+			}
+		}
+	}
+	return &schemas.BifrostLogProbs{Content: content}
 }

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -221,6 +221,7 @@ func (bc *BifrostContext) SetValue(key, value any) {
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
 		// we silently drop writes for these reserved keys
+
 		return
 	}
 	bc.valuesMu.Lock()
@@ -311,7 +312,7 @@ func (bc *BifrostContext) GetRoutingEngineLogs() []RoutingEngineLogEntry {
 	return nil
 }
 
-// AppendToContext appends a value to the context list value.
+// AppendToContextList appends a value to the context list value.
 // Parameters:
 //   - ctx: The Bifrost context
 //   - key: The key to append the value to

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -21,7 +21,6 @@ var reservedKeys = []any{
 	BifrostContextKeyNumberOfRetries,
 	BifrostContextKeyFallbackIndex,
 	BifrostContextKeySkipKeySelection,
-	BifrostContextKeyExtraHeaders,
 	BifrostContextKeyURLPath,
 	BifrostContextKeyDeferTraceCompletion,
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1433,6 +1433,70 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 	return virtualKeys, nil
 }
 
+// GetVirtualKeysPaginated retrieves virtual keys with pagination, filtering, and search support.
+func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params VirtualKeyQueryParams) ([]tables.TableVirtualKey, int64, error) {
+	// Build base query with filters
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableVirtualKey{})
+
+	// Virtual keys are either customer-scoped or team-scoped, never both.
+	// When both filters are provided, use OR to match keys belonging to either.
+	if params.CustomerID != "" && params.TeamID != "" {
+		baseQuery = baseQuery.Where("(customer_id = ? OR team_id = ?)", params.CustomerID, params.TeamID)
+	} else if params.CustomerID != "" {
+		baseQuery = baseQuery.Where("customer_id = ?", params.CustomerID)
+	} else if params.TeamID != "" {
+		baseQuery = baseQuery.Where("team_id = ?", params.TeamID)
+	}
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
+	}
+
+	// Get total count before pagination
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Apply pagination defaults
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	offset := params.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Fetch with preloads and pagination
+	var virtualKeys []tables.TableVirtualKey
+	if err := baseQuery.
+		Preload("Team").
+		Preload("Team.Customer").
+		Preload("Customer").
+		Preload("Budget").
+		Preload("RateLimit").
+		Preload("ProviderConfigs").
+		Preload("ProviderConfigs.Budget").
+		Preload("ProviderConfigs.RateLimit").
+		Preload("ProviderConfigs.Keys", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id, name, key_id, models_json, provider")
+		}).
+		Preload("MCPConfigs").
+		Preload("MCPConfigs.MCPClient").
+		Order("created_at ASC, id ASC").
+		Offset(offset).
+		Limit(limit).
+		Find(&virtualKeys).Error; err != nil {
+		return nil, 0, err
+	}
+	return virtualKeys, totalCount, nil
+}
+
 // GetVirtualKey retrieves a virtual key from the database.
 func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error) {
 	var virtualKey tables.TableVirtualKey

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -14,6 +14,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// VirtualKeyQueryParams holds pagination, filtering, and search parameters for virtual key queries.
+type VirtualKeyQueryParams struct {
+	Limit      int
+	Offset     int
+	Search     string
+	CustomerID string
+	TeamID     string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -71,6 +80,7 @@ type ConfigStore interface {
 
 	// Governance config CRUD
 	GetVirtualKeys(ctx context.Context) ([]tables.TableVirtualKey, error)
+	GetVirtualKeysPaginated(ctx context.Context, params VirtualKeyQueryParams) ([]tables.TableVirtualKey, int64, error)
 	GetRedactedVirtualKeys(ctx context.Context, ids []string) ([]tables.TableVirtualKey, error) // leave ids empty to get all
 	GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error)
 	GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error)

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -414,6 +414,23 @@ func (a *Accumulator) processAccumulatedChatStreamingChunks(requestID string, re
 		}
 		data.FinishReason = lastChunk.FinishReason
 	}
+	// Merge LogProbs from all chunks
+	if len(accumulator.ChatStreamChunks) > 0 {
+		var mergedLogProbs *schemas.BifrostLogProbs
+		for _, chunk := range accumulator.ChatStreamChunks {
+			if chunk.LogProbs != nil {
+				if mergedLogProbs == nil {
+					mergedLogProbs = &schemas.BifrostLogProbs{}
+				}
+				mergedLogProbs.Content = append(mergedLogProbs.Content, chunk.LogProbs.Content...)
+				mergedLogProbs.Refusal = append(mergedLogProbs.Refusal, chunk.LogProbs.Refusal...)
+				if chunk.LogProbs.TextCompletionLogProb != nil {
+					mergedLogProbs.TextCompletionLogProb = chunk.LogProbs.TextCompletionLogProb
+				}
+			}
+		}
+		data.LogProbs = mergedLogProbs
+	}
 	// Accumulate raw response using strings.Builder to avoid O(n^2) string concatenation
 	if len(accumulator.ChatStreamChunks) > 0 {
 		// Sort chunks by chunk index
@@ -470,6 +487,7 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 					Content: deltaCopy,
 				}
 				chunk.FinishReason = choice.FinishReason
+				chunk.LogProbs = choice.LogProbs
 			}
 		}
 		// Extract token usage
@@ -492,6 +510,7 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 				// Deep copy delta to prevent shared data mutation between chunks
 				chunk.Delta = deepCopyChatStreamDelta(choice.ChatStreamResponseChoice.Delta)
 				chunk.FinishReason = choice.FinishReason
+				chunk.LogProbs = choice.LogProbs
 			}
 		}
 		// Extract token usage

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -40,6 +40,7 @@ type AccumulatedData struct {
 	TranscriptionOutput   *schemas.BifrostTranscriptionResponse
 	ImageGenerationOutput *schemas.BifrostImageGenerationResponse
 	FinishReason          *string
+	LogProbs              *schemas.BifrostLogProbs
 	RawResponse           *string
 }
 
@@ -74,6 +75,7 @@ type ChatStreamChunk struct {
 	Timestamp          time.Time                              // When chunk was received
 	Delta              *schemas.ChatStreamResponseChoiceDelta // The actual delta content
 	FinishReason       *string                                // If this is the final chunk
+	LogProbs           *schemas.BifrostLogProbs               // LogProbs if available
 	TokenUsage         *schemas.BifrostLLMUsage               // Token usage if available
 	SemanticCacheDebug *schemas.BifrostCacheDebug             // Semantic cache debug if available
 	Cost               *float64                               // Cost in dollars from pricing plugin
@@ -256,6 +258,7 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 				{
 					Index:        0,
 					FinishReason: p.Data.FinishReason,
+					LogProbs:     p.Data.LogProbs,
 					TextCompletionResponseChoice: &schemas.TextCompletionResponseChoice{
 						Text: &text,
 					},
@@ -300,6 +303,7 @@ func (p *ProcessedStreamResponse) ToBifrostResponse() *schemas.BifrostResponse {
 				{
 					Index:        0,
 					FinishReason: p.Data.FinishReason,
+					LogProbs:     p.Data.LogProbs,
 					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
 						Message: message,
 					},

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -291,8 +292,38 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 		})
 		return
 	}
-	// Preload all relationships for complete information
-	virtualKeys, err := h.configStore.GetVirtualKeys(ctx)
+	// Parse pagination and filter query params
+	params := configstore.VirtualKeyQueryParams{
+		Search:     string(ctx.QueryArgs().Peek("search")),
+		CustomerID: string(ctx.QueryArgs().Peek("customer_id")),
+		TeamID:     string(ctx.QueryArgs().Peek("team_id")),
+	}
+	if limitStr := string(ctx.QueryArgs().Peek("limit")); limitStr != "" {
+		n, err := strconv.Atoi(limitStr)
+		if err != nil {
+			SendError(ctx, 400, "Invalid limit parameter: must be a number")
+			return
+		}
+		if n < 0 {
+			SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
+			return
+		}
+		params.Limit = n
+	}
+	if offsetStr := string(ctx.QueryArgs().Peek("offset")); offsetStr != "" {
+		n, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			SendError(ctx, 400, "Invalid offset parameter: must be a number")
+			return
+		}
+		if n < 0 {
+			SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
+			return
+		}
+		params.Offset = n
+	}
+
+	virtualKeys, totalCount, err := h.configStore.GetVirtualKeysPaginated(ctx, params)
 	if err != nil {
 		logger.Error("failed to retrieve virtual keys: %v", err)
 		SendError(ctx, 500, "Failed to retrieve virtual keys")
@@ -301,6 +332,9 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_keys": virtualKeys,
 		"count":        len(virtualKeys),
+		"total_count":  totalCount,
+		"limit":        params.Limit,
+		"offset":       params.Offset,
 	})
 }
 

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/plugins/governance"
+	"github.com/valyala/fasthttp"
+)
+
+// mockGovernanceManagerForVK embeds the interface so unimplemented methods panic.
+// Only GetGovernanceData is needed for the getVirtualKeys handler path.
+type mockGovernanceManagerForVK struct {
+	GovernanceManager
+}
+
+func (m *mockGovernanceManagerForVK) GetGovernanceData() *governance.GovernanceData {
+	return nil
+}
+
+// mockConfigStoreForVK embeds the interface so unimplemented methods panic.
+// Only GetVirtualKeysPaginated is called in the non-from_memory path.
+type mockConfigStoreForVK struct {
+	configstore.ConfigStore
+}
+
+func (m *mockConfigStoreForVK) GetVirtualKeysPaginated(_ context.Context, _ configstore.VirtualKeyQueryParams) ([]configstoreTables.TableVirtualKey, int64, error) {
+	return nil, 0, nil
+}
+
+// TestGetVirtualKeys_PaginatedEndpoint_ResponseShape verifies the JSON response
+// from the paginated virtual keys endpoint contains all expected fields.
+func TestGetVirtualKeys_PaginatedEndpoint_ResponseShape(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{
+		configStore:       &mockConfigStoreForVK{},
+		governanceManager: &mockGovernanceManagerForVK{},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/governance/virtual-keys?limit=10&offset=0")
+
+	h.getVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse JSON response: %v", err)
+	}
+
+	// Assert expected fields exist with correct types
+	requiredFields := []struct {
+		key      string
+		wantType string
+	}{
+		{"virtual_keys", "array"},
+		{"total_count", "number"},
+		{"count", "number"},
+		{"limit", "number"},
+		{"offset", "number"},
+	}
+
+	for _, f := range requiredFields {
+		val, ok := resp[f.key]
+		if !ok {
+			t.Errorf("response missing required field %q", f.key)
+			continue
+		}
+		switch f.wantType {
+		case "array":
+			if _, ok := val.([]interface{}); !ok {
+				// nil decodes as nil, which is fine — JSON null for empty array
+				if val != nil {
+					t.Errorf("field %q: expected array, got %T", f.key, val)
+				}
+			}
+		case "number":
+			if _, ok := val.(float64); !ok {
+				t.Errorf("field %q: expected number, got %T", f.key, val)
+			}
+		}
+	}
+
+	// Verify no unexpected extra top-level fields
+	allowedKeys := map[string]bool{
+		"virtual_keys": true,
+		"total_count":  true,
+		"count":        true,
+		"limit":        true,
+		"offset":       true,
+	}
+	for key := range resp {
+		if !allowedKeys[key] {
+			t.Errorf("unexpected field %q in response", key)
+		}
+	}
+}
+
+// TestGetVirtualKeys_PaginatedEndpoint_QueryParams verifies query parameters are
+// parsed and reflected in the response.
+func TestGetVirtualKeys_PaginatedEndpoint_QueryParams(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &GovernanceHandler{
+		configStore:       &mockConfigStoreForVK{},
+		governanceManager: &mockGovernanceManagerForVK{},
+	}
+
+	tests := []struct {
+		name       string
+		uri        string
+		wantLimit  float64
+		wantOffset float64
+	}{
+		{
+			name:       "explicit limit and offset",
+			uri:        "/api/governance/virtual-keys?limit=10&offset=5",
+			wantLimit:  10,
+			wantOffset: 5,
+		},
+		{
+			name:       "no params uses defaults",
+			uri:        "/api/governance/virtual-keys",
+			wantLimit:  0,
+			wantOffset: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.SetMethod("GET")
+			ctx.Request.SetRequestURI(tt.uri)
+
+			h.getVirtualKeys(ctx)
+
+			if ctx.Response.StatusCode() != 200 {
+				t.Fatalf("expected status 200, got %d", ctx.Response.StatusCode())
+			}
+
+			var resp map[string]interface{}
+			if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+				t.Fatalf("failed to parse JSON: %v", err)
+			}
+
+			if got := resp["limit"].(float64); got != tt.wantLimit {
+				t.Errorf("limit: got %v, want %v", got, tt.wantLimit)
+			}
+			if got := resp["offset"].(float64); got != tt.wantOffset {
+				t.Errorf("offset: got %v, want %v", got, tt.wantOffset)
+			}
+		})
+	}
+}
+
+// Ensure mockLogger satisfies schemas.Logger (already defined in middlewares_test.go
+// but we reference it here — same package, so no redeclaration needed).
+var _ schemas.Logger = (*mockLogger)(nil)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -680,6 +680,10 @@ func (m *MockConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVir
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetVirtualKeysPaginated(ctx context.Context, params configstore.VirtualKeyQueryParams) ([]tables.TableVirtualKey, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) GetRedactedVirtualKeys(ctx context.Context, ids []string) ([]tables.TableVirtualKey, error) {
 	return nil, nil
 }
@@ -1117,7 +1121,7 @@ func createTestSQLiteConfigStore(t *testing.T, dir string) configstore.ConfigSto
 		Config: &configstore.SQLiteConfig{
 			Path: dbPath,
 		},
-	}, nil)
+	}, &testLogger{})
 	if err != nil {
 		t.Fatalf("failed to create SQLite config store: %v", err)
 	}
@@ -1261,6 +1265,18 @@ func makeVirtualKeyWithTeam(id, name, value, teamID string) tables.TableVirtualK
 		Value:       value,
 		IsActive:    true,
 		TeamID:      &teamID,
+	}
+}
+
+// makeVirtualKeyWithCustomer creates a virtual key with customer association
+func makeVirtualKeyWithCustomer(id, name, value, customerID string) tables.TableVirtualKey {
+	return tables.TableVirtualKey{
+		ID:          id,
+		Name:        name,
+		Description: "Test virtual key with customer",
+		Value:       value,
+		IsActive:    true,
+		CustomerID:  &customerID,
 	}
 }
 
@@ -16073,4 +16089,138 @@ func TestRemoveProvider_SkipDBUpdate(t *testing.T) {
 	if _, exists := cfg.Providers["test-provider"]; exists {
 		t.Fatal("provider should be removed from memory when skipDBUpdate is true")
 	}
+}
+
+// =============================================================================
+// GetVirtualKeysPaginated SQLite Integration Tests
+// =============================================================================
+
+func TestSQLite_GetVirtualKeysPaginated(t *testing.T) {
+	dir := t.TempDir()
+	store := createTestSQLiteConfigStore(t, dir)
+	ctx := context.Background()
+
+	// ID strings for FK references
+	team1 := "team-1"
+	team2 := "team-2"
+	cust1 := "cust-1"
+	cust2 := "cust-2"
+
+	// Create referenced customers and teams first (FK constraints)
+	customers := []tables.TableCustomer{
+		{ID: cust1, Name: "Customer One"},
+		{ID: cust2, Name: "Customer Two"},
+	}
+	for i := range customers {
+		require.NoError(t, store.CreateCustomer(ctx, &customers[i]))
+	}
+	teams := []tables.TableTeam{
+		{ID: team1, Name: "Team One", CustomerID: &cust1},
+		{ID: team2, Name: "Team Two", CustomerID: &cust2},
+	}
+	for i := range teams {
+		require.NoError(t, store.CreateTeam(ctx, &teams[i]))
+	}
+
+	vks := []tables.TableVirtualKey{
+		{ID: "vk-1", Name: "alpha-key", Value: "val-1", IsActive: true, TeamID: &team1},
+		{ID: "vk-2", Name: "beta-key", Value: "val-2", IsActive: true, TeamID: &team2},
+		{ID: "vk-3", Name: "alpha-test", Value: "val-3", IsActive: true, CustomerID: &cust1},
+		{ID: "vk-4", Name: "gamma-key", Value: "val-4", IsActive: true, CustomerID: &cust2},
+		{ID: "vk-5", Name: "delta-key", Value: "val-5", IsActive: true, TeamID: &team1},
+	}
+	for i := range vks {
+		err := store.CreateVirtualKey(ctx, &vks[i])
+		require.NoError(t, err, "failed to seed VK %s", vks[i].ID)
+	}
+
+	t.Run("Pagination", func(t *testing.T) {
+		// First page: limit=2, offset=0
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			Limit: 2, Offset: 0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(5), totalCount)
+		require.Len(t, results, 2)
+
+		// Last page: offset=4
+		results, totalCount, err = store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			Limit: 2, Offset: 4,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(5), totalCount)
+		require.Len(t, results, 1)
+	})
+
+	t.Run("Search", func(t *testing.T) {
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			Search: "alpha",
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(2), totalCount)
+		require.Len(t, results, 2)
+		for _, vk := range results {
+			require.Contains(t, vk.Name, "alpha")
+		}
+	})
+
+	t.Run("CustomerID_filter", func(t *testing.T) {
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			CustomerID: "cust-1",
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), totalCount)
+		require.Len(t, results, 1)
+		require.Equal(t, "vk-3", results[0].ID)
+	})
+
+	t.Run("TeamID_filter", func(t *testing.T) {
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			TeamID: "team-1",
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(2), totalCount)
+		require.Len(t, results, 2)
+		for _, vk := range results {
+			require.NotNil(t, vk.TeamID)
+			require.Equal(t, "team-1", *vk.TeamID)
+		}
+	})
+
+	t.Run("OR_filter_customer_and_team", func(t *testing.T) {
+		// When both customer and team are provided, should return VKs matching either
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			CustomerID: "cust-1",
+			TeamID:     "team-2",
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(2), totalCount)
+		require.Len(t, results, 2)
+		ids := map[string]bool{}
+		for _, vk := range results {
+			ids[vk.ID] = true
+		}
+		require.True(t, ids["vk-2"], "should include team-2 VK")
+		require.True(t, ids["vk-3"], "should include cust-1 VK")
+	})
+
+	t.Run("Default_limit", func(t *testing.T) {
+		// limit=0 should default to 25
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			Limit: 0,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(5), totalCount)
+		require.Len(t, results, 5) // all 5, since <25
+	})
+
+	t.Run("Max_limit_cap", func(t *testing.T) {
+		// limit=200 should be capped to 100
+		results, totalCount, err := store.GetVirtualKeysPaginated(ctx, configstore.VirtualKeyQueryParams{
+			Limit: 200,
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(5), totalCount)
+		require.Len(t, results, 5) // all 5, since <100
+	})
 }

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -8,11 +8,13 @@ import {
 	useGetVirtualKeysQuery,
 } from "@/lib/store"
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import VirtualKeysTable from "@/app/workspace/virtual-keys/views/virtualKeysTable"
+import { useDebouncedValue } from "@/hooks/useDebounce"
 
 const POLLING_INTERVAL = 5000
+const PAGE_SIZE = 25
 
 export default function GovernanceVirtualKeysPage() {
 	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View)
@@ -20,11 +22,29 @@ export default function GovernanceVirtualKeysPage() {
 	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View)
 	const shownErrorsRef = useRef(new Set<string>())
 
+	const [search, setSearch] = useState("")
+	const [customerFilter, setCustomerFilter] = useState("")
+	const [teamFilter, setTeamFilter] = useState("")
+	const [offset, setOffset] = useState(0)
+
+	const debouncedSearch = useDebouncedValue(search, 300)
+
+	// Reset to first page when filters change
+	useEffect(() => {
+		setOffset(0)
+	}, [debouncedSearch, customerFilter, teamFilter])
+
 	const {
 		data: virtualKeysData,
 		error: vkError,
 		isLoading: vkLoading,
-	} = useGetVirtualKeysQuery(undefined, {
+	} = useGetVirtualKeysQuery({
+		limit: PAGE_SIZE,
+		offset,
+		search: debouncedSearch || undefined,
+		customer_id: customerFilter || undefined,
+		team_id: teamFilter || undefined,
+	}, {
 		skip: !hasVirtualKeysAccess,
 		pollingInterval: POLLING_INTERVAL,
 	})
@@ -74,8 +94,18 @@ export default function GovernanceVirtualKeysPage() {
 		<div className="mx-auto w-full max-w-7xl">
 			<VirtualKeysTable
 				virtualKeys={virtualKeysData?.virtual_keys || []}
+				totalCount={virtualKeysData?.total_count || 0}
 				teams={teamsData?.teams || []}
 				customers={customersData?.customers || []}
+				search={search}
+				onSearchChange={setSearch}
+				customerFilter={customerFilter}
+				onCustomerFilterChange={setCustomerFilter}
+				teamFilter={teamFilter}
+				onTeamFilterChange={setTeamFilter}
+				offset={offset}
+				limit={PAGE_SIZE}
+				onOffsetChange={setOffset}
 			/>
 		</div>
 	)

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -13,13 +13,15 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { getErrorMessage, useDeleteVirtualKeyMutation } from "@/lib/store"
 import { Customer, Team, VirtualKey } from "@/lib/types/governance"
 import { cn } from "@/lib/utils"
 import { formatCurrency } from "@/lib/utils/governance"
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
-import { Copy, Edit, Eye, EyeOff, Plus, Trash2 } from "lucide-react"
+import { ChevronLeft, ChevronRight, Copy, Edit, Eye, EyeOff, Plus, Search, Trash2 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { toast } from "sonner"
 import VirtualKeyDetailSheet from "./virtualKeyDetailsSheet"
@@ -28,11 +30,35 @@ import VirtualKeySheet from "./virtualKeySheet"
 
 interface VirtualKeysTableProps {
 	virtualKeys: VirtualKey[];
+	totalCount: number;
 	teams: Team[];
 	customers: Customer[];
+	search: string;
+	onSearchChange: (value: string) => void;
+	customerFilter: string;
+	onCustomerFilterChange: (value: string) => void;
+	teamFilter: string;
+	onTeamFilterChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export default function VirtualKeysTable({ virtualKeys, teams, customers }: VirtualKeysTableProps) {
+export default function VirtualKeysTable({
+	virtualKeys,
+	totalCount,
+	teams,
+	customers,
+	search,
+	onSearchChange,
+	customerFilter,
+	onCustomerFilterChange,
+	teamFilter,
+	onTeamFilterChange,
+	offset,
+	limit,
+	onOffsetChange,
+}: VirtualKeysTableProps) {
   const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false)
   const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null)
   const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
@@ -110,8 +136,10 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers }: Virt
 		toast.success("Copied to clipboard");
 	};
 
-	// Empty state when user has no virtual keys (same pattern as Plugins)
-	if (virtualKeys?.length === 0) {
+	const hasActiveFilters = search || customerFilter || teamFilter;
+
+	// True empty state: no VKs at all (not just filtered to zero)
+	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				{showVirtualKeySheet && (
@@ -154,11 +182,51 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers }: Virt
 					</Button>
 				</div>
 
+				{/* Toolbar: Search + Filters */}
+				<div className="flex items-center gap-3">
+					<div className="relative max-w-sm flex-1">
+						<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+						<Input
+							placeholder="Search by name..."
+							value={search}
+							onChange={(e) => onSearchChange(e.target.value)}
+							className="pl-9"
+							data-testid="vk-search-input"
+						/>
+					</div>
+					<Select value={customerFilter} onValueChange={(val) => onCustomerFilterChange(val === "all" ? "" : val)}>
+						<SelectTrigger className="w-[180px]" data-testid="vk-customer-filter">
+							<SelectValue placeholder="All Customers" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Customers</SelectItem>
+							{customers.map((c) => (
+								<SelectItem key={c.id} value={c.id}>{c.name}</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+					{customerFilter && teamFilter && (
+						<span className="text-muted-foreground text-xs font-medium">or</span>
+					)}
+					<Select value={teamFilter} onValueChange={(val) => onTeamFilterChange(val === "all" ? "" : val)}>
+						<SelectTrigger className="w-[180px]" data-testid="vk-team-filter">
+							<SelectValue placeholder="All Teams" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">All Teams</SelectItem>
+							{teams.map((t) => (
+								<SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
 				<div className="rounded-sm border">
 					<Table data-testid="vk-table">
 						<TableHeader>
 							<TableRow>
 								<TableHead>Name</TableHead>
+								<TableHead>Assigned To</TableHead>
 								<TableHead>Key</TableHead>
 								<TableHead>Budget</TableHead>
 								<TableHead>Status</TableHead>
@@ -166,7 +234,14 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers }: Virt
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{virtualKeys?.map((vk) => {
+							{virtualKeys.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={6} className="h-24 text-center">
+										<span className="text-muted-foreground text-sm">No matching virtual keys found.</span>
+									</TableCell>
+								</TableRow>
+							) : (
+								virtualKeys.map((vk) => {
 									const isRevealed = revealedKeys.has(vk.id);
 									const isExhausted =
 										(vk.budget?.current_usage && vk.budget?.max_limit && vk.budget.current_usage >= vk.budget.max_limit) ||
@@ -186,6 +261,15 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers }: Virt
 										>
 											<TableCell className="max-w-[200px]">
 												<div className="truncate font-medium">{vk.name}</div>
+											</TableCell>
+											<TableCell>
+												{vk.team ? (
+													<Badge variant="outline">Team: {vk.team.name}</Badge>
+												) : vk.customer ? (
+													<Badge variant="outline">Customer: {vk.customer.name}</Badge>
+												) : (
+													<span className="text-muted-foreground text-sm">-</span>
+												)}
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<div className="flex items-center gap-2">
@@ -265,10 +349,42 @@ export default function VirtualKeysTable({ virtualKeys, teams, customers }: Virt
 											</TableCell>
 										</TableRow>
 									);
-								})}
+								})
+							)}
 						</TableBody>
 					</Table>
 				</div>
+
+				{/* Pagination */}
+				{totalCount > 0 && (
+					<div className="flex items-center justify-between px-2">
+						<p className="text-muted-foreground text-sm">
+							Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+						</p>
+						<div className="flex gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={offset === 0}
+								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+								data-testid="vk-pagination-prev-btn"
+							>
+								<ChevronLeft className="mr-1 h-4 w-4" />
+								Previous
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={offset + limit >= totalCount}
+								onClick={() => onOffsetChange(offset + limit)}
+								data-testid="vk-pagination-next-btn"
+							>
+								Next
+								<ChevronRight className="ml-1 h-4 w-4" />
+							</Button>
+						</div>
+					</div>
+				)}
 			</div>
 		</>
 	);

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -13,6 +13,7 @@ import {
 	GetRateLimitsResponse,
 	GetTeamsResponse,
 	GetUsageStatsResponse,
+	GetVirtualKeysParams,
 	GetVirtualKeysResponse,
 	HealthCheckResponse,
 	ModelConfig,
@@ -34,10 +35,16 @@ import { baseApi } from "./baseApi";
 export const governanceApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Virtual Keys
-		getVirtualKeys: builder.query<GetVirtualKeysResponse, { fromMemory?: boolean } | void>({
+		getVirtualKeys: builder.query<GetVirtualKeysResponse, GetVirtualKeysParams | void>({
 			query: (params) => ({
 				url: "/governance/virtual-keys",
-				params: { from_memory: params?.fromMemory ?? false },
+				params: {
+					...(params?.limit && { limit: params.limit }),
+					...(params?.offset !== undefined && { offset: params.offset }),
+					...(params?.search && { search: params.search }),
+					...(params?.customer_id && { customer_id: params.customer_id }),
+					...(params?.team_id && { team_id: params.team_id }),
+				},
 			}),
 			providesTags: ["VirtualKeys"],
 		}),
@@ -53,23 +60,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
-				try {
-					const { data } = await queryFulfilled;
-					const variants = [undefined, { fromMemory: true }] as const;
-					for (const variant of variants) {
-						dispatch(
-							governanceApi.util.updateQueryData("getVirtualKeys", variant, (draft) => {
-								if (!draft.virtual_keys) draft.virtual_keys = [];
-								draft.virtual_keys.unshift(data.virtual_key);
-								draft.count = (draft.count || 0) + 1;
-							}),
-						);
-					}
-				} catch {
-					// Mutation failed, do nothing - error handling bubbled up
-				}
-			},
+			invalidatesTags: ["VirtualKeys"],
 		}),
 
 		updateVirtualKey: builder.mutation<{ message: string; virtual_key: VirtualKey }, { vkId: string; data: UpdateVirtualKeyRequest }>({
@@ -78,30 +69,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			async onQueryStarted({ vkId }, { dispatch, queryFulfilled }) {
-				try {
-					const { data } = await queryFulfilled;
-					const variants = [undefined, { fromMemory: true }] as const;
-					for (const variant of variants) {
-						dispatch(
-							governanceApi.util.updateQueryData("getVirtualKeys", variant, (draft) => {
-								if (!draft.virtual_keys) return;
-								const index = draft.virtual_keys.findIndex((vk) => vk.id === vkId);
-								if (index !== -1) {
-									draft.virtual_keys[index] = data.virtual_key;
-								}
-							}),
-						);
-					}
-					dispatch(
-						governanceApi.util.updateQueryData("getVirtualKey", vkId, (draft) => {
-							draft.virtual_key = data.virtual_key;
-						}),
-					);
-				} catch {
-					// Mutation failed
-				}
-			},
+			invalidatesTags: ["VirtualKeys"],
 		}),
 
 		deleteVirtualKey: builder.mutation<{ message: string }, string>({
@@ -109,23 +77,7 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/virtual-keys/${vkId}`,
 				method: "DELETE",
 			}),
-			async onQueryStarted(vkId, { dispatch, queryFulfilled }) {
-				try {
-					await queryFulfilled;
-					const variants = [undefined, { fromMemory: true }] as const;
-					for (const variant of variants) {
-						dispatch(
-							governanceApi.util.updateQueryData("getVirtualKeys", variant, (draft) => {
-								if (!draft.virtual_keys) return;
-								draft.virtual_keys = draft.virtual_keys.filter((vk) => vk.id !== vkId);
-								draft.count = Math.max(0, (draft.count || 0) - 1);
-							}),
-						);
-					}
-				} catch {
-					// Mutation failed
-				}
-			},
+			invalidatesTags: ["VirtualKeys"],
 		}),
 
 		// Teams

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -228,10 +228,22 @@ export interface ResetUsageRequest {
 	model?: string;
 }
 
+// Query params
+export interface GetVirtualKeysParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+	customer_id?: string;
+	team_id?: string;
+}
+
 // Response types
 export interface GetVirtualKeysResponse {
 	virtual_keys: VirtualKey[];
 	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
 }
 
 export interface GetTeamsResponse {


### PR DESCRIPTION
## Summary

Remove `BifrostContextKeyExtraHeaders` from the reserved context keys list in the Bifrost schema definitions.

## Changes

- Removed `BifrostContextKeyExtraHeaders` from the `reservedKeys` slice in `core/schemas/context.go`
- This indicates that extra headers are no longer considered a reserved context key in the Bifrost system

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the context schema validation works correctly without the extra headers key being reserved.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This change may allow extra headers to be used in contexts where they were previously restricted. Ensure this aligns with the intended security model.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable