### PR TITLE
feat: add weighted routing targets for probabilistic routing rules with key selection support

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3917,6 +3917,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, i+1)
 		bifrost.logger.Debug(fmt.Sprintf("trying fallback provider %s with model %s", fallback.Provider, fallback.Model))
 		ctx.SetValue(schemas.BifrostContextKeyFallbackRequestID, uuid.New().String())
+		clearCtxForFallback(ctx)
 
 		// Start span for fallback attempt
 		tracer := bifrost.getTracer()
@@ -4030,6 +4031,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 	for i, fallback := range fallbacks {
 		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, i+1)
 		ctx.SetValue(schemas.BifrostContextKeyFallbackRequestID, uuid.New().String())
+		clearCtxForFallback(ctx)
 
 		// Start span for fallback attempt
 		tracer := bifrost.getTracer()
@@ -6058,7 +6060,7 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 						return key, nil
 					}
 				}
-				return schemas.Key{}, fmt.Errorf("no key found with id %q for provider: %v", keyID, providerKey)
+				return schemas.Key{}, fmt.Errorf("no supported key found with id %q for provider: %v and model: %s", keyID, providerKey, model)
 			}
 		}
 		if keyName, ok := ctx.Value(schemas.BifrostContextKeyAPIKeyName).(string); ok {
@@ -6068,7 +6070,7 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 						return key, nil
 					}
 				}
-				return schemas.Key{}, fmt.Errorf("no key found with name %q for provider: %v", keyName, providerKey)
+				return schemas.Key{}, fmt.Errorf("no supported key found with name %q for provider: %v and model: %s", keyName, providerKey, model)
 			}
 		}
 	}

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -221,7 +221,6 @@ func (bc *BifrostContext) SetValue(key, value any) {
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
 		// we silently drop writes for these reserved keys
-
 		return
 	}
 	bc.valuesMu.Lock()
@@ -230,6 +229,20 @@ func (bc *BifrostContext) SetValue(key, value any) {
 		bc.userValues = make(map[any]any)
 	}
 	bc.userValues[key] = value
+}
+
+// ClearValue clears a value from the internal userValues map.
+func (bc *BifrostContext) ClearValue(key any) {
+	// Check if the key is a reserved key
+	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
+		// we silently drop writes for these reserved keys
+		return
+	}
+	bc.valuesMu.Lock()
+	defer bc.valuesMu.Unlock()
+	if bc.userValues != nil {
+		bc.userValues[key] = nil
+	}
 }
 
 // GetAndSetValue gets a value from the internal userValues map and sets it

--- a/core/utils.go
+++ b/core/utils.go
@@ -189,6 +189,12 @@ func newBifrostMessageChan(message *schemas.BifrostResponse) chan *schemas.Bifro
 	return ch
 }
 
+// clearCtxForFallback clears the ctx values which are not applicable for fallback requests.
+func clearCtxForFallback(ctx *schemas.BifrostContext) {
+	ctx.ClearValue(schemas.BifrostContextKeyAPIKeyID)
+	ctx.ClearValue(schemas.BifrostContextKeyAPIKeyName)
+}
+
 var supportedBaseProvidersSet = func() map[schemas.ModelProvider]struct{} {
 	m := make(map[schemas.ModelProvider]struct{}, len(schemas.SupportedBaseProviders))
 	for _, p := range schemas.SupportedBaseProviders {

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -573,6 +573,34 @@ TableKey:
 
 # Routing Rules schemas
 
+RoutingTarget:
+  type: object
+  description: A single weighted routing target within a routing rule
+  required:
+    - weight
+  dependentRequired:
+    key_id:
+      - provider
+  properties:
+    provider:
+      type: string
+      description: Target provider (omit or empty to use the incoming request provider)
+      nullable: true
+    model:
+      type: string
+      description: Target model (omit or empty to use the incoming request model)
+      nullable: true
+    key_id:
+      type: string
+      description: UUID of the API key to pin for this target (omit for load-balanced key selection)
+      nullable: true
+    weight:
+      type: number
+      format: double
+      exclusiveMinimum: 0
+      description: Probability weight for this target (must be > 0; all target weights in a rule must sum to 1, e.g. 0.7 + 0.3 = 1.0)
+      example: 0.5
+
 RoutingRule:
   type: object
   description: CEL-based routing rule for intelligent request routing
@@ -592,14 +620,11 @@ RoutingRule:
     cel_expression:
       type: string
       description: CEL (Common Expression Language) expression for matching
-    provider:
-      type: string
-      description: Target provider (empty string uses incoming request provider)
-      nullable: true
-    model:
-      type: string
-      description: Target model (empty string uses incoming request model)
-      nullable: true
+    targets:
+      type: array
+      description: Weighted routing targets; weights must sum to 1; target is selected probabilistically at request time
+      items:
+        $ref: '#/RoutingTarget'
     fallbacks:
       type: array
       items:
@@ -655,6 +680,7 @@ CreateRoutingRuleRequest:
     - cel_expression
     - scope
     - priority
+    - targets
   properties:
     name:
       type: string
@@ -668,14 +694,12 @@ CreateRoutingRuleRequest:
     cel_expression:
       type: string
       description: CEL expression for matching
-    provider:
-      type: string
-      description: Target provider (optional, empty uses incoming)
-      nullable: true
-    model:
-      type: string
-      description: Target model (optional, empty uses incoming)
-      nullable: true
+    targets:
+      type: array
+      minItems: 1
+      description: Weighted routing targets; weights must sum to 1; target is selected probabilistically at request time
+      items:
+        $ref: '#/RoutingTarget'
     fallbacks:
       type: array
       items:
@@ -719,7 +743,7 @@ CreateRoutingRuleRequest:
 
 UpdateRoutingRuleRequest:
   type: object
-  description: Request to update a routing rule
+  description: Request to update a routing rule (all fields optional; providing `targets` replaces all existing targets)
   properties:
     name:
       type: string
@@ -729,12 +753,12 @@ UpdateRoutingRuleRequest:
       type: boolean
     cel_expression:
       type: string
-    provider:
-      type: string
-      nullable: true
-    model:
-      type: string
-      nullable: true
+    targets:
+      type: array
+      minItems: 1
+      description: Replaces all existing targets when provided; weights must sum to 1
+      items:
+        $ref: '#/RoutingTarget'
     fallbacks:
       type: array
       items:

--- a/docs/providers/routing-rules.mdx
+++ b/docs/providers/routing-rules.mdx
@@ -234,8 +234,7 @@ Access routing rules from the dashboard:
 - **Description** (optional): Internal notes
 - **Enabled**: Toggle rule on/off
 - **CEL Expression**: Visual or manual expression builder
-- **Provider** (required): Target provider if matched
-- **Model** (optional): Target model if matched (empty = use original)
+- **Targets** (required): One or more weighted routing targets — each has Provider (optional), Model (optional), API Key (optional, requires Provider to be set), and Weight (%). Weights must sum to 1. When multiple targets are defined, one is selected probabilistically at request time.
 - **Fallbacks** (optional): Array of fallback providers
 - **Scope**: Where rule applies (global, customer, team, virtual_key)
 - **Scope ID**: Required if scope is not global
@@ -273,9 +272,11 @@ GET /api/governance/routing-rules
       "description": "Route premium users to fast provider",
       "enabled": true,
       "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-      "provider": "openai",
-      "model": "gpt-4o",
-      "fallbacks": ["azure/gpt-4o", "groq/gpt-3.5-turbo"],
+      "targets": [
+        { "provider": "openai", "model": "gpt-4o", "weight": 0.7 },
+        { "provider": "azure",  "model": "gpt-4o", "weight": 0.3 }
+      ],
+      "fallbacks": ["groq/gpt-3.5-turbo"],
       "scope": "global",
       "scope_id": null,
       "priority": 10,
@@ -306,8 +307,9 @@ Content-Type: application/json
   "description": "When budget is high, route to cheaper provider",
   "enabled": true,
   "cel_expression": "budget_used > 85",
-  "provider": "groq",
-  "model": "",
+  "targets": [
+    { "provider": "groq", "weight": 1 }
+  ],
   "fallbacks": ["openai/gpt-4o"],
   "scope": "team",
   "scope_id": "team-uuid-456",
@@ -369,9 +371,11 @@ Define routing rules in your `config.json` file under the governance configurati
         "description": "Route premium users to fast provider",
         "enabled": true,
         "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-        "provider": "openai",
-        "model": "gpt-4o",
-        "fallbacks": ["azure/gpt-4o", "groq/gpt-3.5-turbo"],
+        "targets": [
+          { "provider": "openai", "model": "gpt-4o", "weight": 0.7 },
+          { "provider": "azure",  "model": "gpt-4o", "weight": 0.3 }
+        ],
+        "fallbacks": ["groq/gpt-3.5-turbo"],
         "scope": "global",
         "scope_id": null,
         "priority": 10
@@ -382,8 +386,9 @@ Define routing rules in your `config.json` file under the governance configurati
         "description": "Route to cheaper provider when budget is high",
         "enabled": true,
         "cel_expression": "budget_used > 85",
-        "provider": "groq",
-        "model": "llama-2-70b",
+        "targets": [
+          { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+        ],
         "fallbacks": [],
         "scope": "team",
         "scope_id": "team-ml-ops",
@@ -400,8 +405,11 @@ Define routing rules in your `config.json` file under the governance configurati
 - **description** (string, optional): Internal documentation
 - **enabled** (boolean): Whether rule is active
 - **cel_expression** (string): CEL expression for rule matching
-- **provider** (string, optional): Target provider if matched (empty string = use incoming request provider)
-- **model** (string, optional): Target model if matched (empty string = use incoming request model)
+- **targets** (array, required): One or more routing targets. Each target has:
+  - `provider` (string, optional): Target provider — omit to use the incoming request provider
+  - `model` (string, optional): Target model — omit to use the incoming request model
+  - `key_id` (string, optional): UUID of the API key to pin — requires `provider` to be present; omit for load-balanced key selection
+  - `weight` (number, required): Probability weight — all weights in a rule must sum to 1 (e.g. 0.7 + 0.3 = 1.0)
 - **fallbacks** (array[string]): Fallback providers in "provider/model" format
 - **scope** (string): Scope level - "global", "customer", "team", or "virtual_key"
 - **scope_id** (string, optional): ID of scoped entity (null for global scope)
@@ -420,8 +428,9 @@ Routes are automatically loaded on startup from the `config.json` governance sec
         "name": "Premium Tier Fast Track",
         "enabled": true,
         "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-        "provider": "openai",
-        "model": "gpt-4o",
+        "targets": [
+          { "provider": "openai", "model": "gpt-4o", "weight": 1 }
+        ],
         "fallbacks": ["azure/gpt-4o"],
         "scope": "global",
         "priority": 0
@@ -431,8 +440,9 @@ Routes are automatically loaded on startup from the `config.json` governance sec
         "name": "Budget Exhaustion Fallback",
         "enabled": true,
         "cel_expression": "budget_used > 90",
-        "provider": "groq",
-        "model": "llama-2-70b",
+        "targets": [
+          { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+        ],
         "fallbacks": [],
         "scope": "global",
         "priority": 5
@@ -442,8 +452,9 @@ Routes are automatically loaded on startup from the `config.json` governance sec
         "name": "ML Team Anthropic Route",
         "enabled": true,
         "cel_expression": "team_name == \"ml-research\"",
-        "provider": "anthropic",
-        "model": "claude-3-opus-20240229",
+        "targets": [
+          { "provider": "anthropic", "model": "claude-3-opus-20240229", "weight": 1 }
+        ],
         "fallbacks": ["bedrock/claude-3-opus"],
         "scope": "team",
         "scope_id": "team-ml-research",
@@ -476,8 +487,9 @@ Route requests based on customer tier using headers:
 {
   "name": "Premium Tier Fast Track",
   "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-  "provider": "openai",
-  "model": "gpt-4o",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o", "weight": 1 }
+  ],
   "fallbacks": ["azure/gpt-4o"],
   "scope": "global",
   "priority": 10
@@ -492,8 +504,9 @@ Route to cheaper provider when budget is exhausted:
 {
   "name": "Budget Exhaustion Fallback",
   "cel_expression": "budget_used > 90",
-  "provider": "groq",
-  "model": "llama-2-70b",
+  "targets": [
+    { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+  ],
   "fallbacks": [],
   "scope": "global",
   "priority": 5
@@ -508,8 +521,9 @@ Route team-specific requests to their preferred provider:
 {
   "name": "ML Team Anthropic Preference",
   "cel_expression": "team_name == \"ml-research\"",
-  "provider": "anthropic",
-  "model": "claude-3-opus-20240229",
+  "targets": [
+    { "provider": "anthropic", "model": "claude-3-opus-20240229", "weight": 1 }
+  ],
   "fallbacks": ["bedrock/claude-3-opus"],
   "scope": "team",
   "scope_id": "team-ml-research-uuid",
@@ -525,29 +539,33 @@ Combine multiple criteria for sophisticated routing:
 {
   "name": "Production Premium Route",
   "cel_expression": "headers[\"x-environment\"] == \"production\" && headers[\"x-priority\"] == \"high\" && tokens_used < 75",
-  "provider": "openai",
-  "model": "gpt-4o",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o", "weight": 1 }
+  ],
   "fallbacks": ["azure/gpt-4o"],
   "scope": "global",
   "priority": 5
 }
 ```
 
-### Use Case 5: A/B Testing
+### Use Case 5: Probabilistic A/B Testing
 
-Route percentage of traffic using request patterns:
+Split traffic across providers or models by weight for canary deployments or cost optimization:
 
 ```json
 {
-  "name": "A/B Test New Model",
-  "cel_expression": "headers[\"x-user-id\"].contains(\"test-\") || headers[\"x-ab-test\"] == \"new-model\"",
-  "provider": "openai",
-  "model": "gpt-4o-mini",
-  "fallbacks": ["openai/gpt-4o"],
+  "name": "Split Traffic OpenAI vs Groq",
+  "cel_expression": "true",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o",        "weight": 0.7 },
+    { "provider": "groq",   "model": "llama-3.1-70b", "weight": 0.3 }
+  ],
   "scope": "global",
   "priority": 15
 }
 ```
+
+Each request matching this rule has a 70% chance of going to OpenAI and a 30% chance of going to Groq. Weights must always sum to 1.
 
 ### Use Case 6: Regional Routing
 
@@ -557,8 +575,9 @@ Route based on region headers:
 {
   "name": "EU Data Residency",
   "cel_expression": "headers[\"x-region\"] == \"eu\"",
-  "provider": "azure",
-  "model": "gpt-4o",
+  "targets": [
+    { "provider": "azure", "model": "gpt-4o", "weight": 1 }
+  ],
   "fallbacks": [],
   "scope": "global",
   "priority": 0
@@ -576,9 +595,10 @@ Routing Rules run **BEFORE** governance provider selection and can override it:
 **If a routing rule matches:**
 ```
 1. Routing Rules → CEL expression evaluation (first-match-wins)
-2. Rule matches → provider/model/fallbacks overridden
-3. Governance provider_configs → SKIPPED
-4. Load Balancing → selects best key
+2. Rule matches → target selected probabilistically from targets array
+3. provider/model/key_id/fallbacks overridden from selected target
+4. Governance provider_configs → SKIPPED
+5. Load Balancing → selects best key (unless key_id was pinned)
 ```
 
 **If no routing rule matches:**
@@ -811,7 +831,7 @@ Enable debug logging to see routing rule evaluation:
 [RoutingEngine] Rule rule-1 evaluation result: matched=false
 [RoutingEngine] Evaluating rule: id=rule-2, name=Budget Fallback, expression=budget_used>80
 [RoutingEngine] Rule rule-2 evaluation result: matched=true
-[RoutingEngine] Rule matched! Decision: provider=groq, model=gpt-3.5-turbo, fallbacks=[azure/gpt-4o]
+[RoutingEngine] Rule matched! Selected target: provider=groq, model=gpt-3.5-turbo (weight=1), fallbacks=[azure/gpt-4o]
 ```
 
 ---
@@ -829,23 +849,48 @@ curl -X POST http://localhost:8080/api/governance/routing-rules \
     "description": "Switch to cheaper provider when budget >85%",
     "enabled": true,
     "cel_expression": "budget_used > 85",
-    "provider": "groq",
-    "model": "llama-2-70b",
+    "targets": [
+      { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+    ],
     "fallbacks": ["openai/gpt-3.5-turbo"],
     "scope": "global",
     "priority": 10
   }'
 ```
 
-#### Create Header-Based Rule
+#### Create Probabilistic Split Rule
 ```bash
 curl -X POST http://localhost:8080/api/governance/routing-rules \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Premium Tier Route",
+    "name": "Premium Tier Split",
     "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-    "provider": "openai",
-    "model": "gpt-4o",
+    "targets": [
+      { "provider": "openai", "model": "gpt-4o",   "weight": 0.7 },
+      { "provider": "azure",  "model": "gpt-4o",   "weight": 0.3 }
+    ],
+    "scope": "global",
+    "priority": 5
+  }'
+```
+
+#### Create Rule with Pinned API Key
+```bash
+curl -X POST http://localhost:8080/api/governance/routing-rules \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Pin Production Key for Premium Tier",
+    "description": "Always use the dedicated production key for premium requests",
+    "enabled": true,
+    "cel_expression": "headers[\"x-tier\"] == \"premium\"",
+    "targets": [
+      {
+        "provider": "openai",
+        "model": "gpt-4o",
+        "key_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "weight": 1
+      }
+    ],
     "scope": "global",
     "priority": 5
   }'

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,2 @@
+- feat: add `routing_targets` table with 1:many relationship to `routing_rules`; migrates existing single-target rules to the new table with `weight=1`; drops legacy `provider` and `model` columns from `routing_rules`
+- feat: add per-target `key_id` pinning support in `routing_targets`

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -851,6 +851,24 @@ func GenerateTeamHash(t tables.TableTeam) (string, error) {
 
 // GenerateRoutingRuleHash generates a SHA256 hash for a routing rule.
 // This is used to detect changes to routing rules between config.json and database.
+// routingTargetHashPayload is a canonical struct for hashing a routing target.
+// Used to ensure deterministic hashes regardless of slice order.
+// Fields use plain string (not *string) so nil and "" both marshal to "" and produce the same hash.
+type routingTargetHashPayload struct {
+	Provider string  `json:"provider"`
+	Model    string  `json:"model"`
+	KeyID    string  `json:"key_id"`
+	Weight   float64 `json:"weight"`
+}
+
+// derefStr returns the dereferenced value of s, or "" if s is nil.
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 // Skips: CreatedAt, UpdatedAt (dynamic fields)
 func GenerateRoutingRuleHash(r tables.TableRoutingRule) (string, error) {
 	hash := sha256.New()
@@ -874,11 +892,30 @@ func GenerateRoutingRuleHash(r tables.TableRoutingRule) (string, error) {
 	// Hash CelExpression
 	hash.Write([]byte(r.CelExpression))
 
-	// Hash Provider
-	hash.Write([]byte(r.Provider))
-
-	// Hash Model
-	hash.Write([]byte(r.Model))
+	// Hash Targets: sort by canonical marshaled payload for determinism, then hash each target as a single blob
+	targets := make([]tables.TableRoutingTarget, len(r.Targets))
+	copy(targets, r.Targets)
+	sort.Slice(targets, func(i, j int) bool {
+		pi := routingTargetHashPayload{Provider: derefStr(targets[i].Provider), Model: derefStr(targets[i].Model), KeyID: derefStr(targets[i].KeyID), Weight: targets[i].Weight}
+		pj := routingTargetHashPayload{Provider: derefStr(targets[j].Provider), Model: derefStr(targets[j].Model), KeyID: derefStr(targets[j].KeyID), Weight: targets[j].Weight}
+		di, err := sonic.Marshal(pi)
+		if err != nil {
+			return false
+		}
+		dj, err := sonic.Marshal(pj)
+		if err != nil {
+			return false
+		}
+		return string(di) < string(dj)
+	})
+	for _, t := range targets {
+		payload := routingTargetHashPayload{Provider: derefStr(t.Provider), Model: derefStr(t.Model), KeyID: derefStr(t.KeyID), Weight: t.Weight}
+		data, err := sonic.Marshal(payload)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
 
 	// Hash Fallbacks: use DB string when set, else marshal ParsedFallbacks (config-origin)
 	if r.Fallbacks != nil {

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -296,6 +296,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddBedrockAssumeRoleColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddRoutingTargetsTable(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddPromptRepoTables(ctx, db); err != nil {
 		return err
 	}
@@ -4118,6 +4121,159 @@ func migrationAddBedrockAssumeRoleColumns(ctx context.Context, db *gorm.DB) erro
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running bedrock assume role columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// legacyRoutingRuleColumns is a migration-only struct that represents the old routing_rules
+// schema before provider/model/key_id were moved to the routing_targets table.
+// GORM's SQLite DropColumn/AddColumn need a real struct (not a string table name) to
+// reconstruct the table correctly, so we keep this stub around for migration use only.
+type legacyRoutingRuleColumns struct {
+	Provider string `gorm:"column:provider;type:varchar(255)"`
+	Model    string `gorm:"column:model;type:varchar(255)"`
+}
+
+func (legacyRoutingRuleColumns) TableName() string { return "routing_rules" }
+
+// migrationAddRoutingTargetsTable creates the routing_targets table and seeds one target row per
+// existing routing rule, migrating the legacy provider/model columns.
+// After seeding, the legacy columns are dropped from routing_rules.
+func migrationAddRoutingTargetsTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_routing_targets_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// 1. Create routing_targets table
+			if !mg.HasTable(&tables.TableRoutingTarget{}) {
+				if err := mg.CreateTable(&tables.TableRoutingTarget{}); err != nil {
+					return fmt.Errorf("failed to create routing_targets table: %w", err)
+				}
+			}
+			if !mg.HasConstraint(&tables.TableRoutingRule{}, "Targets") {
+				if err := mg.CreateConstraint(&tables.TableRoutingRule{}, "Targets"); err != nil {
+					return fmt.Errorf("failed to create routing_targets foreign key: %w", err)
+				}
+			}
+
+			// 2. Seed one target per existing routing rule (idempotent).
+			// Only possible when the legacy columns still exist (i.e. upgrading from an older schema).
+			// On a fresh database AutoMigrate creates routing_rules without these columns, so skip seeding.
+			type legacyRule struct {
+				ID       string
+				Provider string
+				Model    string
+			}
+			if mg.HasColumn("routing_rules", "provider") {
+				var rows []legacyRule
+				if err := tx.Table("routing_rules").Select("id, provider, model").Scan(&rows).Error; err != nil {
+					return fmt.Errorf("failed to scan routing_rules for seeding: %w", err)
+				}
+				for _, row := range rows {
+					var count int64
+					if err := tx.Table("routing_targets").Where("rule_id = ?", row.ID).Count(&count).Error; err != nil {
+						return fmt.Errorf("failed to count targets for rule %s: %w", row.ID, err)
+					}
+					if count > 0 {
+						continue // already seeded
+					}
+					target := tables.TableRoutingTarget{
+						RuleID: row.ID,
+						Weight: 1.0,
+					}
+					if row.Provider != "" {
+						p := row.Provider
+						target.Provider = &p
+					}
+					if row.Model != "" {
+						m := row.Model
+						target.Model = &m
+					}
+					if err := tx.Create(&target).Error; err != nil {
+						return fmt.Errorf("failed to seed target for rule %s: %w", row.ID, err)
+					}
+				}
+			} // end if mg.HasColumn("routing_rules", "provider")
+
+			// 3. Drop legacy single-target columns from routing_rules.
+			// Must use the struct form (not string) so SQLite can reconstruct the table correctly.
+			legacyModel := &legacyRoutingRuleColumns{}
+			for _, col := range []string{"provider", "model"} {
+				if mg.HasColumn("routing_rules", col) {
+					if err := mg.DropColumn(legacyModel, col); err != nil {
+						return fmt.Errorf("failed to drop column %s from routing_rules: %w", col, err)
+					}
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			if !mg.HasTable(&tables.TableRoutingTarget{}) {
+				return nil
+			}
+
+			// 1. Add provider and model columns back to routing_rules (before dropping targets)
+			legacyModel := &legacyRoutingRuleColumns{}
+			for _, col := range []string{"provider", "model"} {
+				if !mg.HasColumn("routing_rules", col) {
+					if err := mg.AddColumn(legacyModel, col); err != nil {
+						return fmt.Errorf("failed to add column %s to routing_rules: %w", col, err)
+					}
+				}
+			}
+
+			// 2. Backfill provider/model from routing_targets into routing_rules (join by rule_id)
+			type targetRow struct {
+				RuleID   string
+				Provider *string
+				Model    *string
+			}
+			var targets []targetRow
+			if err := tx.Table("routing_targets").Select("rule_id, provider, model").Order("rule_id").Scan(&targets).Error; err != nil {
+				return fmt.Errorf("failed to scan routing_targets for backfill: %w", err)
+			}
+			ruleData := make(map[string]targetRow)
+			for _, t := range targets {
+				if _, ok := ruleData[t.RuleID]; !ok {
+					ruleData[t.RuleID] = t
+				}
+			}
+			for ruleID, t := range ruleData {
+				provider, model := "", ""
+				if t.Provider != nil {
+					provider = *t.Provider
+				}
+				if t.Model != nil {
+					model = *t.Model
+				}
+				if err := tx.Table("routing_rules").Where("id = ?", ruleID).Updates(map[string]interface{}{
+					"provider": provider,
+					"model":    model,
+				}).Error; err != nil {
+					return fmt.Errorf("failed to backfill routing_rule %s: %w", ruleID, err)
+				}
+			}
+
+			// 3. Drop routing_targets table
+			if mg.HasConstraint(&tables.TableRoutingRule{}, "Targets") {
+				if err := mg.DropConstraint(&tables.TableRoutingRule{}, "Targets"); err != nil {
+					return fmt.Errorf("failed to drop routing_targets foreign key: %w", err)
+				}
+			}
+			if err := mg.DropTable(&tables.TableRoutingTarget{}); err != nil {
+				return fmt.Errorf("failed to drop routing_targets table: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running routing_targets_table migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2445,10 +2445,27 @@ func (s *RDBConfigStore) UpdateRateLimitUsage(ctx context.Context, id string, to
 	return nil
 }
 
+// loadRoutingRulesOrdered loads routing rules with Targets preloaded, using consistent ordering:
+// rules by priority ASC, created_at DESC; targets by weight DESC for deterministic ordering.
+func (s *RDBConfigStore) loadRoutingRulesOrdered(ctx context.Context, dest *[]tables.TableRoutingRule, scopes ...func(*gorm.DB) *gorm.DB) error {
+	q := s.db.WithContext(ctx).
+		Preload("Targets", func(db *gorm.DB) *gorm.DB {
+			return db.Order("weight DESC").
+				Order("COALESCE(provider, '') ASC").
+				Order("COALESCE(model, '') ASC").
+				Order("COALESCE(key_id, '') ASC")
+		}).
+		Order("priority ASC, created_at DESC")
+	for _, scope := range scopes {
+		q = scope(q)
+	}
+	return q.Find(dest).Error
+}
+
 // GetRoutingRules retrieves all routing rules from the database.
 func (s *RDBConfigStore) GetRoutingRules(ctx context.Context) ([]tables.TableRoutingRule, error) {
 	var rules []tables.TableRoutingRule
-	if err := s.db.WithContext(ctx).Order("priority ASC, created_at DESC").Find(&rules).Error; err != nil {
+	if err := s.loadRoutingRulesOrdered(ctx, &rules); err != nil {
 		return nil, err
 	}
 	return rules, nil
@@ -2456,18 +2473,19 @@ func (s *RDBConfigStore) GetRoutingRules(ctx context.Context) ([]tables.TableRou
 
 // GetRoutingRulesByScope retrieves routing rules by scope and scope ID, ordered by priority ASC.
 func (s *RDBConfigStore) GetRoutingRulesByScope(ctx context.Context, scope string, scopeID string) ([]tables.TableRoutingRule, error) {
-	var rules []tables.TableRoutingRule
-	query := s.db.WithContext(ctx)
-
-	if scope == "global" {
-		query = query.Where("scope = ?", "global")
-	} else if scope != "" && scopeID != "" {
-		query = query.Where("scope = ? AND scope_id = ?", scope, scopeID)
-	} else {
-		// If no scope specified, return all
+	if scope != "global" && scopeID == "" {
+		return nil, fmt.Errorf("scopeID is required for non-global scope %q", scope)
 	}
-
-	if err := query.Where("enabled = ?", true).Order("priority ASC").Find(&rules).Error; err != nil {
+	var rules []tables.TableRoutingRule
+	scopeFilter := func(q *gorm.DB) *gorm.DB {
+		if scope == "global" {
+			return q.Where("scope = ?", "global")
+		}
+		return q.Where("scope = ? AND scope_id = ?", scope, scopeID)
+	}
+	if err := s.loadRoutingRulesOrdered(ctx, &rules, scopeFilter, func(q *gorm.DB) *gorm.DB {
+		return q.Where("enabled = ?", true)
+	}); err != nil {
 		return nil, err
 	}
 	return rules, nil
@@ -2475,14 +2493,16 @@ func (s *RDBConfigStore) GetRoutingRulesByScope(ctx context.Context, scope strin
 
 // GetRoutingRule retrieves a specific routing rule by ID.
 func (s *RDBConfigStore) GetRoutingRule(ctx context.Context, id string) (*tables.TableRoutingRule, error) {
-	var rule tables.TableRoutingRule
-	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&rule).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, ErrNotFound
-		}
+	var rules []tables.TableRoutingRule
+	if err := s.loadRoutingRulesOrdered(ctx, &rules, func(q *gorm.DB) *gorm.DB {
+		return q.Where("id = ?", id)
+	}); err != nil {
 		return nil, err
 	}
-	return &rule, nil
+	if len(rules) == 0 {
+		return nil, ErrNotFound
+	}
+	return &rules[0], nil
 }
 
 // GetRedactedRoutingRules retrieves redacted routing rules from the database.
@@ -2533,10 +2553,22 @@ func (s *RDBConfigStore) CreateRoutingRule(ctx context.Context, rule *tables.Tab
 		return fmt.Errorf("routing rule with priority %d already exists for scope '%s'", rule.Priority, rule.Scope)
 	}
 
-	if err := database.WithContext(ctx).Create(rule).Error; err != nil {
-		return s.parseGormError(err)
-	}
-	return nil
+	return s.parseGormError(database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		targets := rule.Targets
+		rule.Targets = nil
+		if err := tx.Omit("Targets").Create(rule).Error; err != nil {
+			return err
+		}
+		rule.Targets = targets
+
+		for i := range rule.Targets {
+			rule.Targets[i].RuleID = rule.ID
+			if err := tx.Create(&rule.Targets[i]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
 }
 
 // UpdateRoutingRule updates an existing routing rule in the database.
@@ -2570,27 +2602,47 @@ func (s *RDBConfigStore) UpdateRoutingRule(ctx context.Context, rule *tables.Tab
 		return fmt.Errorf("routing rule with priority %d already exists for scope '%s'", rule.Priority, rule.Scope)
 	}
 
-	if err := database.WithContext(ctx).Save(rule).Error; err != nil {
-		return s.parseGormError(err)
-	}
-	return nil
+	return s.parseGormError(database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		targets := rule.Targets
+		rule.Targets = nil
+		if err := tx.Omit("Targets").Save(rule).Error; err != nil {
+			return err
+		}
+		rule.Targets = targets
+
+		if err := tx.Where("rule_id = ?", rule.ID).Delete(&tables.TableRoutingTarget{}).Error; err != nil {
+			return err
+		}
+		for i := range rule.Targets {
+			rule.Targets[i].RuleID = rule.ID
+			if err := tx.Create(&rule.Targets[i]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
 }
 
-// DeleteRoutingRule deletes a routing rule from the database.
+// DeleteRoutingRule deletes a routing rule and its targets from the database.
 func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ...*gorm.DB) error {
 	database := s.db
 	if len(tx) > 0 && tx[0] != nil {
 		database = tx[0]
 	}
 
-	result := database.WithContext(ctx).Delete(&tables.TableRoutingRule{}, "id = ?", id)
-	if result.Error != nil {
-		return s.parseGormError(result.Error)
-	}
-	if result.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return s.parseGormError(database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("rule_id = ?", id).Delete(&tables.TableRoutingTarget{}).Error; err != nil {
+			return err
+		}
+		result := tx.Delete(&tables.TableRoutingRule{}, "id = ?", id)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrNotFound
+		}
+		return nil
+	}))
 }
 
 // GetModelConfigs retrieves all model configs from the database.
@@ -2751,7 +2803,7 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 	if err := s.db.WithContext(ctx).Find(&providers).Error; err != nil {
 		return nil, err
 	}
-	if err := s.db.WithContext(ctx).Find(&routingRules).Error; err != nil {
+	if err := s.loadRoutingRulesOrdered(ctx, &routingRules); err != nil {
 		return nil, err
 	}
 	// Fetching governance config for username and password

--- a/framework/configstore/tables/routing_rules.go
+++ b/framework/configstore/tables/routing_rules.go
@@ -18,11 +18,11 @@ type TableRoutingRule struct {
 	Enabled       bool   `gorm:"not null;default:true" json:"enabled"`
 	CelExpression string `gorm:"type:text;not null" json:"cel_expression"`
 
-	// Routing Target (output)
-	Provider        string   `gorm:"type:varchar(255);not null" json:"provider"` // Primary provider (e.g., "openai", "azure")
-	Model           string   `gorm:"type:varchar(255)" json:"model"`             // Optional model override, empty = use original
-	Fallbacks       *string  `gorm:"type:text" json:"-"`                         // JSON array of fallback chains
-	ParsedFallbacks []string `gorm:"-" json:"fallbacks"`                         // Parsed fallbacks from JSON
+	// Routing Targets (output) — 1:many relationship; weights must sum to 1
+	Targets []TableRoutingTarget `gorm:"foreignKey:RuleID;constraint:OnDelete:CASCADE" json:"targets,omitempty"`
+
+	Fallbacks       *string  `gorm:"type:text" json:"-"`           // JSON array of fallback chains
+	ParsedFallbacks []string `gorm:"-" json:"fallbacks,omitempty"` // Parsed fallbacks from JSON
 
 	Query       *string        `gorm:"type:text" json:"-"`
 	ParsedQuery map[string]any `gorm:"-" json:"query,omitempty"`
@@ -79,3 +79,18 @@ func (r *TableRoutingRule) AfterFind(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// TableRoutingTarget represents a weighted routing target for probabilistic routing.
+// Multiple targets can be associated with a single routing rule; weights determine
+// the probability of each target being selected and must sum to 1 across all targets in a rule.
+// The composite (RuleID, Provider, Model, KeyID) is unique to prevent duplicate target configs.
+type TableRoutingTarget struct {
+	RuleID   string  `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_routing_target_config" json:"-"`
+	Provider *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"provider,omitempty"` // nil = use incoming provider
+	Model    *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"model,omitempty"`    // nil = use incoming model
+	KeyID    *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"key_id,omitempty"`   // nil = no key pin
+	Weight   float64 `gorm:"type:double;not null;default:1" json:"weight"` // must sum to 1 across all targets in a rule
+}
+
+// TableName for TableRoutingTarget
+func (TableRoutingTarget) TableName() string { return "routing_targets" }

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,2 @@
+- feat: routing rules now support multiple weighted targets for probabilistic routing
+- feat: target-level key pinning: each entry in `targets[]` can specify `key_id` to pin a specific API key for that target, bypassing load-balanced key selection

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -827,7 +827,12 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 			body["fallbacks"] = decision.Fallbacks
 		}
 
-		p.logger.Debug("[Governance] Applied routing decision: provider=%s, model=%s, fallbacks=%v", decision.Provider, decision.Model, decision.Fallbacks)
+		// Pin specific API key by ID if the routing rule specifies one
+		if decision.KeyID != "" {
+			ctx.SetValue(schemas.BifrostContextKeyAPIKeyID, decision.KeyID)
+		}
+
+		p.logger.Debug("[Governance] Applied routing decision: provider=%s, model=%s, keyID=%s, fallbacks=%v", decision.Provider, decision.Model, decision.KeyID, decision.Fallbacks)
 	}
 
 	return body, decision, nil

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"regexp"
 	"strings"
 
@@ -33,6 +34,7 @@ type ScopeLevel struct {
 type RoutingDecision struct {
 	Provider        string   // Primary provider (e.g., "openai", "azure")
 	Model           string   // Model to use (or empty to use original)
+	KeyID           string   // Optional: pin a specific API key by UUID ("" = no pin)
 	Fallbacks       []string // Fallback chain: ["provider/model", ...]
 	MatchedRuleID   string   // ID of the rule that matched
 	MatchedRuleName string   // Name of the rule that matched
@@ -137,22 +139,34 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → no match", rule.Name, rule.CelExpression))
 			}
 
-			// If rule matched, return routing decision
+			// If rule matched, select a target probabilistically and return routing decision
 			if matched {
-				// Use incoming provider/model if rule's are empty
-				provider := rule.Provider
-				if provider == "" {
-					provider = string(routingCtx.Provider)
+				target, ok := selectWeightedTarget(rule.Targets)
+				if !ok {
+					re.logger.Debug("[RoutingEngine] Rule %s matched but has no valid targets (empty list or all-negative weights), skipping — note: all-zero weights use uniform selection and would not reach here", rule.Name)
+					ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → matched but no valid targets (empty or all-negative weights), skipping", rule.Name, rule.CelExpression))
+					continue
 				}
 
-				model := rule.Model
-				if model == "" {
-					model = routingCtx.Model
+				provider := string(routingCtx.Provider)
+				if target.Provider != nil && *target.Provider != "" {
+					provider = *target.Provider
+				}
+
+				model := routingCtx.Model
+				if target.Model != nil && *target.Model != "" {
+					model = *target.Model
+				}
+
+				keyID := ""
+				if target.KeyID != nil {
+					keyID = *target.KeyID
 				}
 
 				decision := &RoutingDecision{
 					Provider:        provider,
 					Model:           model,
+					KeyID:           keyID,
 					Fallbacks:       rule.ParsedFallbacks,
 					MatchedRuleID:   rule.ID,
 					MatchedRuleName: rule.Name,
@@ -161,8 +175,8 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 				ctx.SetValue(schemas.BifrostContextKeyGovernanceRoutingRuleID, rule.ID)
 				ctx.SetValue(schemas.BifrostContextKeyGovernanceRoutingRuleName, rule.Name)
 
-				re.logger.Debug("[RoutingEngine] Rule matched! Decision: provider=%s, model=%s, fallbacks=%v", provider, model, rule.ParsedFallbacks)
-				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → matched, routing to provider=%s, model=%s, fallbacks=%v", rule.Name, rule.CelExpression, provider, model, rule.ParsedFallbacks))
+				re.logger.Debug("[RoutingEngine] Rule matched! Selected target (weight=%.2f): provider=%s, model=%s, fallbacks=%v", target.Weight, provider, model, rule.ParsedFallbacks)
+				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → matched, selected target (weight=%.2f): provider=%s, model=%s, fallbacks=%v", rule.Name, rule.CelExpression, target.Weight, provider, model, rule.ParsedFallbacks))
 				return decision, nil
 			}
 
@@ -172,6 +186,55 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 	// No rule matched - return nil decision (caller should use default routing)
 	re.logger.Debug("[RoutingEngine] No routing rule matched, using default routing")
 	return nil, nil
+}
+
+// selectWeightedTarget picks one target from the slice using weighted random selection.
+// Each target's Weight contributes proportionally to its probability of being chosen.
+// Weights do not need to be normalised to 100; the function normalises internally.
+// Returns ok=false only when len(targets)==0 or all targets have negative weights (filtered out).
+// When all valid targets have weight==0 the function falls back to uniform random selection
+// and still returns ok=true, so zero-weight targets are valid and handled.
+func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (configstoreTables.TableRoutingTarget, bool) {
+	if len(targets) == 0 {
+		return configstoreTables.TableRoutingTarget{}, false
+	}
+
+	// Filter out negative weights as a precaution against malformed DB data.
+	// Negative weights are blocked at write time by validateRoutingTargets, but
+	// we guard here defensively so a bad row cannot corrupt the cumulative range.
+	valid := make([]configstoreTables.TableRoutingTarget, 0, len(targets))
+	for _, t := range targets {
+		if t.Weight >= 0 {
+			valid = append(valid, t)
+		}
+	}
+	if len(valid) == 0 {
+		return configstoreTables.TableRoutingTarget{}, false
+	}
+
+	total := 0.0
+	for _, t := range valid {
+		total += t.Weight
+	}
+
+	// All weights are 0 — select uniformly at random among valid targets.
+	if total == 0 {
+		return valid[rand.IntN(len(valid))], true
+	}
+
+	if len(valid) == 1 {
+		return valid[0], true
+	}
+
+	r := rand.Float64() * total
+	cumulative := 0.0
+	for _, t := range valid {
+		cumulative += t.Weight
+		if r < cumulative {
+			return t, true
+		}
+	}
+	return valid[len(valid)-1], true
 }
 
 // buildScopeChain builds the scope evaluation chain based on organizational hierarchy

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -236,11 +236,12 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 
 	// Store the rule
@@ -265,6 +266,82 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 	assert.Equal(t, "Global Rule", decision.MatchedRuleName)
 }
 
+// TestEvaluateRoutingRules_MultiTargetDeterministicWithPinnedKey tests weighted target selection
+// with a seeded/stubbed approach: one target carries all the weight (1.0) and the other carries
+// none (0.0). Because selectWeightedTarget accumulates weights and picks the first target whose
+// cumulative sum exceeds the random draw — and rand.Float64()*1.0 always lies in [0,1) — the
+// 1.0-weight target is always chosen regardless of the RNG state.  This gives us fully
+// deterministic selection without modifying production code or reaching for a global-rand seed.
+// The test also verifies that the pinned key_id from the winning target propagates into the
+// RoutingDecision and, when applied the same way governance/main.go does it, into the
+// BifrostContext under BifrostContextKeyAPIKeyID.
+func TestEvaluateRoutingRules_MultiTargetDeterministicWithPinnedKey(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	engine, err := NewRoutingEngine(store, NewMockLogger())
+	require.NoError(t, err)
+
+	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	const pinnedKeyID = "pinned-key-abc-123"
+
+	// Two-target fixture: azure gets weight 1.0 (always wins), openai gets weight 0.0
+	// (included in valid[] per the >= 0 filter but contributes 0 to cumulative, so it can
+	// never be selected).  No RNG seeding is required — the outcome is guaranteed by the
+	// weight distribution alone.
+	rule := &configstoreTables.TableRoutingRule{
+		ID:            "multi-1",
+		Name:          "Multi-Target Rule",
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				Provider: bifrost.Ptr("azure"),
+				Model:    bifrost.Ptr("gpt-4-turbo"),
+				KeyID:    bifrost.Ptr(pinnedKeyID),
+				Weight:   1.0,
+			},
+			{
+				Provider: bifrost.Ptr("openai"),
+				Model:    bifrost.Ptr("gpt-3.5"),
+				Weight:   0.0,
+			},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
+
+	routingCtx := &RoutingContext{
+		Provider:    schemas.OpenAI,
+		Model:       "gpt-4o",
+		Headers:     map[string]string{},
+		QueryParams: map[string]string{},
+	}
+
+	decision, err := engine.EvaluateRoutingRules(bgCtx, routingCtx)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+
+	// The 1.0-weight azure target must always be selected.
+	assert.Equal(t, "azure", decision.Provider)
+	assert.Equal(t, "gpt-4-turbo", decision.Model)
+	assert.Equal(t, "multi-1", decision.MatchedRuleID)
+	assert.Equal(t, "Multi-Target Rule", decision.MatchedRuleName)
+
+	// KeyID must be propagated through the routing decision.
+	assert.Equal(t, pinnedKeyID, decision.KeyID)
+
+	// Simulate the propagation step performed by governance/main.go so that we can
+	// assert the pinned key_id is visible in the BifrostContext.
+	if decision.KeyID != "" {
+		bgCtx.SetValue(schemas.BifrostContextKeyAPIKeyID, decision.KeyID)
+	}
+	ctxKeyID, _ := bgCtx.Value(schemas.BifrostContextKeyAPIKeyID).(string)
+	assert.Equal(t, pinnedKeyID, ctxKeyID)
+}
+
 // TestEvaluateRoutingRules_ScopePrecedence tests virtual_key scope takes precedence over global
 func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
@@ -279,11 +356,12 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Model:         "gpt-4o",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(globalRule))
 
@@ -292,12 +370,13 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 		ID:            "2",
 		Name:          "VK Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "virtual_key",
-		ScopeID:       bifrost.Ptr("vk-123"),
-		Priority:      10,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "virtual_key",
+		ScopeID:  bifrost.Ptr("vk-123"),
+		Priority: 10,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(vkRule))
 
@@ -341,11 +420,12 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 		ID:            "1",
 		Name:          "Low Priority",
 		CelExpression: "true",
-		Provider:      "openai",
-		Model:         "gpt-4o",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      10,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 10,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule1))
 
@@ -354,11 +434,12 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 		ID:            "2",
 		Name:          "High Priority",
 		CelExpression: "true",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule2))
 
@@ -388,11 +469,12 @@ func TestResolveRoutingWithFallback_RuleMatches(t *testing.T) {
 		ID:            "1",
 		Name:          "Test Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -453,11 +535,12 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 		ID:            "1",
 		Name:          "Disabled Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       false,
-		Scope:         "global",
-		Priority:      10,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  false,
+		Scope:    "global",
+		Priority: 10,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(disabledRule))
 
@@ -466,11 +549,12 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 		ID:            "2",
 		Name:          "Enabled Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Model:         "gpt-4o",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(enabledRule))
 
@@ -502,11 +586,12 @@ func TestEvaluateRoutingRules_ComplexExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Complex Rule",
 		CelExpression: "model == 'gpt-4o' && headers['x-tier'] == 'premium'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -545,11 +630,12 @@ func TestEvaluateRoutingRules_NilVirtualKey(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		CelExpression: "true",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -581,11 +667,12 @@ func TestEvaluateRoutingRules_MissingHeaderGracefully(t *testing.T) {
 		ID:            "1",
 		Name:          "Header Check Rule",
 		CelExpression: "headers[\"x-custom-header\"] == \"premium\"",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -621,8 +708,10 @@ func TestCompileAndCacheProgram_ValidExpression_Routing(t *testing.T) {
 		ID:            "1",
 		Name:          "Test Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -646,8 +735,10 @@ func TestCompileAndCacheProgram_EmptyExpression_Routing(t *testing.T) {
 		ID:            "1",
 		Name:          "Default Rule",
 		CelExpression: "",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -666,8 +757,10 @@ func TestCompileAndCacheProgram_InvalidExpression_Routing(t *testing.T) {
 		ID:            "1",
 		Name:          "Invalid Rule",
 		CelExpression: "model == gpt-4o'", // Missing opening quote
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	_, err = store.GetRoutingProgram(rule)
@@ -697,8 +790,10 @@ func TestCompileAndCacheProgram_ListExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "List Rule",
 		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -717,8 +812,10 @@ func TestCompileAndCacheProgram_RegexExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Regex Rule",
 		CelExpression: "model.matches('^gpt-4.*')",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -737,8 +834,10 @@ func TestCompileAndCacheProgram_HeaderExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Header Rule",
 		CelExpression: "headers['x-tier'] == 'premium'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -757,8 +856,10 @@ func TestCompileAndCacheProgram_RateLimitExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Rate Limit Rule",
 		CelExpression: "tokens_used >= 80.0",
-		Provider:      "azure",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -777,8 +878,10 @@ func TestCompileAndCacheProgram_BudgetExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Budget Rule",
 		CelExpression: "budget_used < 100.0",
-		Provider:      "azure",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -797,8 +900,10 @@ func TestCompileAndCacheProgram_ComplexExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Complex Rule",
 		CelExpression: "model == 'gpt-4o' && team_name == 'premium' && tokens_used >= 80.0",
-		Provider:      "azure",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -850,8 +955,10 @@ func TestEvaluateCELExpression_TrueResult(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -879,8 +986,10 @@ func TestEvaluateCELExpression_FalseResult(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -908,8 +1017,10 @@ func TestEvaluateCELExpression_ListMembership(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -944,8 +1055,10 @@ func TestEvaluateCELExpression_HeaderAccess(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "headers['x-tier'] == 'premium'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -353,13 +354,14 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 
 	// Create a global routing rule
 	rule1 := &configstoreTables.TableRoutingRule{
-		ID:              "1",
-		Name:            "Global Rule",
-		Description:     "Test global routing rule",
-		Enabled:         true,
-		CelExpression:   "model == 'gpt-4o'",
-		Provider:        "openai",
-		Model:           "gpt-4",
+		ID:            "1",
+		Name:          "Global Rule",
+		Description:   "Test global routing rule",
+		Enabled:       true,
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4"), Weight: 1.0},
+		},
 		Fallbacks:       nil,
 		ParsedFallbacks: []string{"azure/gpt-4-turbo"},
 		Scope:           "global",
@@ -372,13 +374,14 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 	// Create a team-scoped routing rule
 	teamID := "team-123"
 	rule2 := &configstoreTables.TableRoutingRule{
-		ID:              "2",
-		Name:            "Team Rule",
-		Description:     "Test team routing rule",
-		Enabled:         true,
-		CelExpression:   "model in ['gpt-4o', 'gpt-4-turbo']",
-		Provider:        "azure",
-		Model:           "",
+		ID:            "2",
+		Name:          "Team Rule",
+		Description:   "Test team routing rule",
+		Enabled:       true,
+		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Weight: 1.0},
+		},
 		Fallbacks:       nil,
 		ParsedFallbacks: []string{"groq/mixtral-8x7b"},
 		Scope:           "team",
@@ -647,8 +650,10 @@ func TestCompileAndCacheProgram(t *testing.T) {
 		ID:            "rule-1",
 		Name:          "Test Rule",
 		CelExpression: "model == 'gpt-4o' && tokens_used < 80.0",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	// First compilation
@@ -675,8 +680,10 @@ func TestCompileAndCacheProgram_InvalidExpression(t *testing.T) {
 		ID:            "rule-invalid",
 		Name:          "Invalid Rule",
 		CelExpression: "model == gpt-4o'", // Syntax error
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	_, err = store.GetRoutingProgram(rule)
@@ -697,9 +704,11 @@ func TestCompileAndCacheProgram_CacheInvalidation(t *testing.T) {
 		ID:            "rule-update",
 		Name:          "Update Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
-		Scope:         "global",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
+		Scope:   "global",
 	}
 
 	// Compile and cache
@@ -728,9 +737,11 @@ func TestCompileAndCacheProgram_CacheInvalidationOnDelete(t *testing.T) {
 		ID:            "rule-delete",
 		Name:          "Delete Rule",
 		CelExpression: "provider == 'openai'",
-		Provider:      "openai",
-		Enabled:       true,
-		Scope:         "global",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
+		Scope:   "global",
 	}
 
 	// Compile and cache
@@ -754,8 +765,10 @@ func TestCompileAndCacheProgram_EmptyExpression(t *testing.T) {
 		ID:            "rule-empty",
 		Name:          "Empty Rule",
 		CelExpression: "",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -121,34 +122,42 @@ type UpdateBudgetRequest struct {
 	ResetDuration *string  `json:"reset_duration,omitempty"`
 }
 
+// RoutingTarget represents a single weighted routing target within a rule.
+// All fields except Weight are optional; nil means "use the incoming request's value".
+// Weights across all targets in a rule must sum to 1 (e.g. 0.7 + 0.3 = 1.0).
+type RoutingTarget struct {
+	Provider *string `json:"provider,omitempty"` // nil = use incoming provider
+	Model    *string `json:"model,omitempty"`    // nil = use incoming model
+	KeyID    *string `json:"key_id,omitempty"`   // nil = no key pin
+	Weight   float64 `json:"weight"`             // must be > 0; all weights must sum to 1
+}
+
 // CreateRoutingRuleRequest represents the request body for creating a routing rule
 type CreateRoutingRuleRequest struct {
-	Name          string         `json:"name" validate:"required"`
-	Description   string         `json:"description,omitempty"`
-	Enabled       bool           `json:"enabled,omitempty"`
-	CelExpression string         `json:"cel_expression"`
-	Provider      string         `json:"provider,omitempty"` // Optional; empty uses incoming request provider
-	Model         string         `json:"model,omitempty"`    // Optional; empty uses incoming request model
-	Fallbacks     []string       `json:"fallbacks,omitempty"`
-	Scope         string         `json:"scope,omitempty"` // Defaults to "global" if not provided
-	ScopeID       *string        `json:"scope_id,omitempty"`
-	Query         map[string]any `json:"query,omitempty"`
-	Priority      int            `json:"priority,omitempty"` // Defaults to 0 if not provided
+	Name          string          `json:"name" validate:"required"`
+	Description   string          `json:"description,omitempty"`
+	Enabled       *bool           `json:"enabled,omitempty"` // nil = use DB default (true)
+	CelExpression string          `json:"cel_expression"`
+	Targets       []RoutingTarget `json:"targets"` // Required; weights must sum to 1
+	Fallbacks     []string        `json:"fallbacks,omitempty"`
+	Scope         string          `json:"scope,omitempty"` // Defaults to "global" if not provided
+	ScopeID       *string         `json:"scope_id,omitempty"`
+	Query         map[string]any  `json:"query,omitempty"`
+	Priority      int             `json:"priority,omitempty"` // Defaults to 0 if not provided
 }
 
 // UpdateRoutingRuleRequest represents the request body for updating a routing rule
 type UpdateRoutingRuleRequest struct {
-	Name          *string        `json:"name,omitempty"`
-	Description   *string        `json:"description,omitempty"`
-	Enabled       *bool          `json:"enabled,omitempty"`
-	CelExpression *string        `json:"cel_expression,omitempty"`
-	Provider      *string        `json:"provider,omitempty"`
-	Model         *string        `json:"model,omitempty"`
-	Fallbacks     []string       `json:"fallbacks,omitempty"`
-	Query         map[string]any `json:"query,omitempty"`
-	Priority      *int           `json:"priority,omitempty"`
-	Scope         *string        `json:"scope,omitempty"`
-	ScopeID       *string        `json:"scope_id,omitempty"`
+	Name          *string         `json:"name,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Enabled       *bool           `json:"enabled,omitempty"`
+	CelExpression *string         `json:"cel_expression,omitempty"`
+	Targets       []RoutingTarget `json:"targets,omitempty"` // If provided, replaces all existing targets; weights must sum to 1
+	Fallbacks     []string        `json:"fallbacks,omitempty"`
+	Query         map[string]any  `json:"query,omitempty"`
+	Priority      *int            `json:"priority,omitempty"`
+	Scope         *string         `json:"scope,omitempty"`
+	ScopeID       *string         `json:"scope_id,omitempty"`
 }
 
 // CreateRateLimitRequest represents the request body for creating a rate limit using flexible approach
@@ -2676,35 +2685,64 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Set defaults
+	// Validate targets
+	if len(req.Targets) == 0 {
+		SendError(ctx, 400, "at least one target is required")
+		return
+	}
+	if err := validateRoutingTargets(req.Targets); err != nil {
+		SendError(ctx, 400, err.Error())
+		return
+	}
+
+	// Set defaults and normalize scope/scope_id
 	scope := req.Scope
 	if scope == "" {
 		scope = "global"
 	}
 
-	// Validate scope_id is required when scope is not global
-	if scope != "global" && (req.ScopeID == nil || *req.ScopeID == "") {
+	// Validate scope value before normalization
+	if err := validateRoutingScope(scope); err != nil {
+		SendError(ctx, 400, err.Error())
+		return
+	}
+
+	// Validate: scope_id required for non-global scopes; must be nil/empty for global
+	if scope == "global" {
+		req.ScopeID = nil // normalize: global rules must not have scope_id
+	} else if req.ScopeID == nil || *req.ScopeID == "" {
 		SendError(ctx, 400, "scope_id field is required when scope is not global")
 		return
 	}
 
-	priority := req.Priority
-	if priority == 0 && req.Priority == 0 { // Default to 0
-		priority = 0
+	// Build targets
+	ruleID := uuid.NewString()
+	targets := make([]configstoreTables.TableRoutingTarget, 0, len(req.Targets))
+	for _, t := range req.Targets {
+		targets = append(targets, configstoreTables.TableRoutingTarget{
+			Provider: t.Provider,
+			Model:    t.Model,
+			KeyID:    t.KeyID,
+			Weight:   t.Weight,
+		})
 	}
 
 	// Create routing rule
+	// Handle Enabled: nil means use DB default (true), otherwise use provided value
+	enabled := true // DB default
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
 	rule := &configstoreTables.TableRoutingRule{
-		ID:              uuid.NewString(),
+		ID:              ruleID,
 		Name:            req.Name,
 		Description:     req.Description,
-		Enabled:         req.Enabled,
+		Enabled:         enabled,
 		CelExpression:   req.CelExpression,
-		Provider:        req.Provider,
-		Model:           req.Model,
+		Targets:         targets,
 		Scope:           scope,
 		ScopeID:         req.ScopeID,
-		Priority:        priority,
+		Priority:        req.Priority,
 		ParsedFallbacks: req.Fallbacks,
 		ParsedQuery:     req.Query,
 	}
@@ -2762,11 +2800,25 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 	if req.CelExpression != nil {
 		rule.CelExpression = *req.CelExpression
 	}
-	if req.Provider != nil {
-		rule.Provider = *req.Provider
-	}
-	if req.Model != nil {
-		rule.Model = *req.Model
+	if req.Targets != nil {
+		if len(req.Targets) == 0 {
+			SendError(ctx, 400, "at least one routing target is required")
+			return
+		}
+		if err := validateRoutingTargets(req.Targets); err != nil {
+			SendError(ctx, 400, err.Error())
+			return
+		}
+		newTargets := make([]configstoreTables.TableRoutingTarget, 0, len(req.Targets))
+		for _, t := range req.Targets {
+			newTargets = append(newTargets, configstoreTables.TableRoutingTarget{
+				Provider: t.Provider,
+				Model:    t.Model,
+				KeyID:    t.KeyID,
+				Weight:   t.Weight,
+			})
+		}
+		rule.Targets = newTargets
 	}
 	if req.Priority != nil {
 		rule.Priority = *req.Priority
@@ -2778,6 +2830,11 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 		rule.ParsedFallbacks = req.Fallbacks
 	}
 	if req.Scope != nil && *req.Scope != "" {
+		// Validate scope value before updating
+		if err := validateRoutingScope(*req.Scope); err != nil {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		rule.Scope = *req.Scope
 	}
 	if req.ScopeID != nil {
@@ -2832,4 +2889,64 @@ func (h *GovernanceHandler) deleteRoutingRule(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Routing rule deleted successfully",
 	})
+}
+
+// validRoutingScopes contains the allowed scope values for routing rules
+var validRoutingScopes = map[string]bool{
+	"global":      true,
+	"team":        true,
+	"customer":    true,
+	"virtual_key": true,
+}
+
+// validateRoutingScope validates that the scope value is one of the allowed values
+func validateRoutingScope(scope string) error {
+	if scope == "" {
+		return nil // Empty scope will default to "global" later
+	}
+	if !validRoutingScopes[scope] {
+		return fmt.Errorf("invalid scope %q: must be one of: global, team, customer, virtual_key", scope)
+	}
+	return nil
+}
+
+// validateRoutingTargets checks that all weights are positive, that no two
+// targets share the same (provider, model, key_id) identity, and that all
+// weights sum to 1.
+func validateRoutingTargets(targets []RoutingTarget) error {
+	seen := make(map[string]struct{}, len(targets))
+	total := 0.0
+	for _, t := range targets {
+		if t.Weight < 0 {
+			return fmt.Errorf("each target weight must be positive")
+		}
+		if t.KeyID != nil && *t.KeyID != "" && (t.Provider == nil || *t.Provider == "") {
+			return fmt.Errorf("key_id requires provider to be set")
+		}
+
+		// Canonicalise identity: lowercase provider/model, treat nil == "".
+		provider := ""
+		if t.Provider != nil {
+			provider = strings.ToLower(*t.Provider)
+		}
+		model := ""
+		if t.Model != nil {
+			model = strings.ToLower(*t.Model)
+		}
+		keyID := ""
+		if t.KeyID != nil {
+			keyID = *t.KeyID
+		}
+		key := provider + "|" + model + "|" + keyID
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate target entry: provider=%q model=%q key_id=%q", provider, model, keyID)
+		}
+		seen[key] = struct{}{}
+
+		total += t.Weight
+	}
+	if math.Abs(total-1.0) > 0.001 {
+		return fmt.Errorf("target weights must sum to 1, got %.4f", total)
+	}
+	return nil
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,5 +1,73 @@
+- feat: adds option to select specific API key for routing rules
+- feat: adds support for multiple weighted routing targets for probabilistic routing
+- [breaking change] feat: routing rules no longer support top-level `provider`/`model` fields; replace with a `targets` array — e.g. `"targets": [{"provider": "openai", "model": "gpt-4o", "weight": 1.0}]`
 - fix: preserve original audio filename in transcription requests
 - fix: async jobs stuck in "processing" on marshal failure now correctly transition to "failed"
 - feat: adds attachment support in Maxim plugin
 - feat: add x-bf-api-key-id header support for explicit key selection by ID, with priority over x-bf-api-key name selection
 - fix: streaming tool call indices for multiple parallel tool calls in chat completions stream
+
+## Migration Guide
+
+### Routing Rules — `targets` array (breaking)
+
+Routing rules now route requests via a `targets` array instead of top-level `provider` and `model` fields. This enables weighted probabilistic routing across multiple targets.
+
+#### config.json
+
+Before:
+```json
+{
+  "id": "rule-1",
+  "name": "Route to GPT-4o",
+  "cel_expression": "true",
+  "provider": "openai",
+  "model": "gpt-4o"
+}
+```
+
+After:
+```json
+{
+  "id": "rule-1",
+  "name": "Route to GPT-4o",
+  "cel_expression": "true",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o", "weight": 1.0 }
+  ]
+}
+```
+
+For probabilistic routing across multiple targets, weights must sum to 1:
+```json
+{
+  "id": "rule-2",
+  "name": "Split traffic",
+  "cel_expression": "true",
+  "targets": [
+    { "provider": "openai",    "model": "gpt-4o",          "weight": 0.7 },
+    { "provider": "anthropic", "model": "claude-sonnet-4-6", "weight": 0.3 }
+  ]
+}
+```
+
+To pin a specific API key for a target, add `key_id`:
+```json
+"targets": [
+  { "provider": "openai", "model": "gpt-4o", "key_id": "<key-uuid>", "weight": 1.0 }
+]
+```
+
+#### API
+
+The `POST /api/governance/routing-rules` and `PUT /api/governance/routing-rules/:id` request bodies follow the same shape. On `PUT`, omit `targets` entirely to leave existing targets unchanged — sending `"targets": []` is now a 400 error.
+
+Before:
+```json
+{ "provider": "openai", "model": "gpt-4o" }
+```
+
+After:
+```json
+{ "targets": [{ "provider": "openai", "model": "gpt-4o", "weight": 1.0 }] }
+```

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1373,6 +1373,35 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "routing_target": {
+      "type": "object",
+      "description": "A single weighted routing target within a rule. All fields except weight are optional; omitting provider or model means use the incoming request value. Weights across all targets in a rule must sum to 1.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Target provider name (e.g., 'openai', 'azure'). Omit to use the incoming request provider"
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Target model name. Omit to use the incoming request model"
+        },
+        "key_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Optional API key UUID to pin for this target. Omit for load-balanced key selection"
+        },
+        "weight": {
+          "type": "number",
+          "description": "Probability weight for this target (must be > 0). All weights in a rule must sum to 1",
+          "exclusiveMinimum": 0,
+          "maximum": 1
+        }
+      },
+      "required": ["weight"],
+      "additionalProperties": false
+    },
     "routing_rule": {
       "type": "object",
       "description": "Routing rule for dynamic provider/model selection",
@@ -1398,14 +1427,16 @@
           "type": "string",
           "description": "CEL (Common Expression Language) expression for rule evaluation"
         },
-        "provider": {
-          "type": "string",
-          "description": "Target provider name (e.g., 'openai', 'azure'). Empty means use original provider"
+        "targets": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Weighted routing targets. Weights must sum to 1. Omit provider or model to use the incoming request value.",
+          "items": {
+            "$ref": "#/$defs/routing_target"
+          }
         },
-        "model": {
-          "type": "string",
-          "description": "Target model name. Empty means use original model"
-        },
+        "provider": false,
+        "model": false,
         "fallbacks": {
           "type": "array",
           "description": "Fallback provider chain in order",
@@ -1434,7 +1465,7 @@
           "additionalProperties": true
         }
       },
-      "required": ["id", "name"],
+      "required": ["id", "name", "targets"],
       "additionalProperties": false
     },
     "virtual_key_provider_config": {

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -22,8 +22,15 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
-import { X, Save, AlertCircle, Plus, Trash2 } from "lucide-react";
-import { RoutingRule, RoutingRuleFormData, DEFAULT_ROUTING_RULE_FORM_DATA, ROUTING_RULE_SCOPES } from "@/lib/types/routingRules";
+import { X, Save, Plus, Trash2 } from "lucide-react";
+import {
+	RoutingRule,
+	RoutingRuleFormData,
+	RoutingTargetFormData,
+	DEFAULT_ROUTING_RULE_FORM_DATA,
+	DEFAULT_ROUTING_TARGET,
+	ROUTING_RULE_SCOPES,
+} from "@/lib/types/routingRules";
 import {
 	useCreateRoutingRuleMutation,
 	useUpdateRoutingRuleMutation,
@@ -83,7 +90,8 @@ export function RoutingRuleSheet({
 	const [createRoutingRule, { isLoading: isCreating }] = useCreateRoutingRuleMutation();
 	const [updateRoutingRule, { isLoading: isUpdating }] = useUpdateRoutingRuleMutation();
 
-	// State to track the query structure for the rule builder
+	// State for targets and query (managed outside react-hook-form for complex nested structures)
+	const [targets, setTargets] = useState<RoutingTargetFormData[]>([{ ...DEFAULT_ROUTING_TARGET }]);
 	const [query, setQuery] = useState<RuleGroupType>(defaultQuery);
 	const [builderKey, setBuilderKey] = useState(0);
 
@@ -103,19 +111,19 @@ export function RoutingRuleSheet({
 	const enabled = watch("enabled");
 	const scope = watch("scope");
 	const scopeId = watch("scope_id");
-	const provider = watch("provider");
-	const model = watch("model");
 	const fallbacks = watch("fallbacks");
 
-	// Get available providers from configured providers, fallback to providers in rules
-	const availableProviders = providersData.length > 0
-		? providersData.map((p) => p.name)
-		: Array.from(
-			new Set([...rules.map((r) => r.provider).filter((p) => p !== "")]),
-		);
-	const availableModels = Array.from(
-		new Set([...rules.map((r) => r.model).filter((m) => m !== "" && m !== undefined)]),
-	) as string[];
+	// Get available providers from configured providers, plus any provider already
+	// referenced by the current targets, existing rules' targets, or rules' fallbacks
+	// so edited/removed providers are still visible in the dropdown.
+	const availableProviders = Array.from(
+		new Set([
+			...providersData.map((p) => p.name),
+			...(targets.map((t) => t.provider).filter(Boolean) as string[]),
+			...(rules.flatMap((r) => r.targets?.map((t) => t.provider).filter(Boolean) ?? []) as string[]),
+			...(rules.flatMap((r) => (r.fallbacks ?? []).map((f) => f.split("/")[0]?.trim()).filter(Boolean))),
+		]),
+	);
 
 	// Initialize form data when editing rule changes
 	useEffect(() => {
@@ -124,13 +132,22 @@ export function RoutingRuleSheet({
 			setValue("name", editingRule.name);
 			setValue("description", editingRule.description);
 			setValue("cel_expression", editingRule.cel_expression);
-			setValue("provider", editingRule.provider);
-			setValue("model", editingRule.model || "");
 			setValue("fallbacks", editingRule.fallbacks || []);
 			setValue("scope", editingRule.scope);
 			setValue("scope_id", editingRule.scope_id || "");
 			setValue("priority", editingRule.priority);
 			setValue("enabled", editingRule.enabled);
+			if (editingRule.targets && editingRule.targets.length > 0) {
+				setTargets(editingRule.targets.map((t) => ({
+					...DEFAULT_ROUTING_TARGET,
+					provider: t.provider || "",
+					model: t.model || "",
+					key_id: t.key_id || "",
+					weight: t.weight,
+				})));
+			} else {
+				setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
+			}
 			// Restore the query object if it exists, otherwise use default
 			if (editingRule.query) {
 				setQuery(editingRule.query);
@@ -140,6 +157,7 @@ export function RoutingRuleSheet({
 			setBuilderKey((prev) => prev + 1);
 		} else {
 			reset();
+			setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 			setQuery(defaultQuery);
 			setBuilderKey((prev) => prev + 1);
 		}
@@ -153,6 +171,21 @@ export function RoutingRuleSheet({
 		[setValue],
 	);
 
+	const addTarget = () => {
+		const remaining = 1 - targets.reduce((sum, t) => sum + (t.weight || 0), 0);
+		setTargets((prev) => [...prev, { ...DEFAULT_ROUTING_TARGET, weight: Math.max(0, parseFloat(remaining.toFixed(4))) }]);
+	};
+
+	const removeTarget = (index: number) => {
+		setTargets((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const updateTarget = (index: number, field: keyof RoutingTargetFormData, value: string | number) => {
+		setTargets((prev) => prev.map((t, i) => i === index ? { ...t, [field]: value } : t));
+	};
+
+	const totalWeight = targets.reduce((sum, t) => sum + (t.weight || 0), 0);
+
 	const onSubmit = (data: RoutingRuleFormData) => {
 		// Validate scope_id is required when scope is not global
 		if (data.scope !== "global" && !data.scope_id?.trim()) {
@@ -160,19 +193,33 @@ export function RoutingRuleSheet({
 			return;
 		}
 
+		// Validate targets
+		if (targets.length === 0) {
+			toast.error("At least one routing target is required");
+			return;
+		}
+		for (const t of targets) {
+			if (t.weight <= 0) {
+				toast.error("Each target weight must be greater than 0");
+				return;
+			}
+		}
+		if (Math.abs(totalWeight - 1) > 0.001) {
+			toast.error(`Target weights must sum to 1, current total: ${totalWeight.toFixed(4)}`);
+			return;
+		}
+
 		// Validate regex patterns in routing rules
 		const regexErrors = validateRoutingRules(query);
 		if (regexErrors.length > 0) {
-			const errorMessage = regexErrors.join("\n");
-			toast.error(`Invalid regex pattern:\n${errorMessage}`);
+			toast.error(`Invalid regex pattern:\n${regexErrors.join("\n")}`);
 			return;
 		}
 
 		// Validate rate limit and budget rules
 		const rateLimitErrors = validateRateLimitAndBudgetRules(query);
 		if (rateLimitErrors.length > 0) {
-			const errorMessage = rateLimitErrors.join("\n");
-			toast.error(`Invalid rule configuration:\n${errorMessage}`);
+			toast.error(`Invalid rule configuration:\n${rateLimitErrors.join("\n")}`);
 			return;
 		}
 
@@ -186,8 +233,12 @@ export function RoutingRuleSheet({
 			name: data.name,
 			description: data.description,
 			cel_expression: data.cel_expression,
-			provider: data.provider,
-			model: data.model,
+			targets: targets.map(({ provider, model, key_id, weight }) => ({
+				provider: provider || undefined,
+				model: model || undefined,
+				key_id: key_id || undefined,
+				weight,
+			})),
 			fallbacks: validFallbacks,
 			scope: data.scope,
 			scope_id: data.scope === "global" ? undefined : (data.scope_id || undefined),
@@ -211,6 +262,7 @@ export function RoutingRuleSheet({
 						: "Routing rule created successfully",
 				);
 				reset();
+				setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 				setQuery(defaultQuery);
 				setBuilderKey((prev) => prev + 1);
 				onOpenChange(false);
@@ -223,6 +275,7 @@ export function RoutingRuleSheet({
 
 	const handleCancel = () => {
 		reset();
+		setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 		setQuery(defaultQuery);
 		setBuilderKey((prev) => prev + 1);
 		onOpenChange(false);
@@ -392,7 +445,7 @@ export function RoutingRuleSheet({
 							initialQuery={query}
 							onChange={handleQueryChange}
 							providers={availableProviders}
-							models={availableModels}
+							models={[]}
 							allowCustomModels={true}
 						/>
 					</div>
@@ -404,81 +457,49 @@ export function RoutingRuleSheet({
 
 					<Separator />
 
-					{/* Routing Target */}
+					{/* Routing Targets */}
 					<div className="space-y-3">
-						<Label>Routing Target</Label>
-						<p className="text-muted-foreground text-xs">Leave provider or model empty to use the incoming request value</p>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="space-y-2">
-								<Label htmlFor="provider" className="text-sm">
-									Provider
-								</Label>
-								<div className="flex gap-2">
-									<Select value={provider} onValueChange={(value) => setValue("provider", value)}>
-										<SelectTrigger className="flex-1">
-											<SelectValue placeholder="Select provider (optional)" />
-										</SelectTrigger>
-										<SelectContent>
-											{availableProviders.map((provider) => (
-												<SelectItem key={provider} value={provider}>
-													<div className="flex items-center gap-2">
-														<RenderProviderIcon
-															provider={provider as ProviderIconType}
-															size="sm"
-															className="h-4 w-4"
-														/>
-														<span>{getProviderLabel(provider)}</span>
-													</div>
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									{provider && (
-										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											onClick={() => setValue("provider", "")}
-											className="h-9 px-2"
-											title="Clear provider selection"
-										>
-											<X className="h-4 w-4" />
-										</Button>
-									)}
-								</div>
-								{errors.provider && <p className="text-destructive text-sm">{errors.provider.message}</p>}
+						<div className="flex items-center justify-between">
+							<div>
+								<Label>Routing Targets</Label>
+								<p className="text-muted-foreground text-xs mt-0.5">
+									Weights must sum to 1. Leave provider or model empty to use the incoming request value.
+								</p>
 							</div>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={addTarget}
+								className="gap-2 shrink-0"
+								data-testid="routing-rule-target-add"
+							>
+								<Plus className="h-4 w-4" />
+								Add Target
+							</Button>
+						</div>
 
-							<div className="space-y-2">
-								<Label htmlFor="model" className="text-sm">
-									Model
-								</Label>
-								<div className="flex gap-2">
-									<div className="flex-1">
-										<ModelMultiselect
-											provider={provider || undefined}
-											value={model}
-											onChange={(value) => setValue("model", value)}
-											placeholder="Search for a model... (optional)"
-											isSingleSelect
-											loadModelsOnEmptyProvider
-										/>
-									</div>
-									{model && (
-										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											onClick={() => setValue("model", "")}
-											className="h-9 px-2"
-											title="Clear model selection"
-										>
-											<X className="h-4 w-4" />
-										</Button>
-									)}
-								</div>
-								{errors.model && <p className="text-destructive text-sm">{errors.model.message}</p>}
-							</div>
+						<div className="space-y-3">
+							{targets.map((target, index) => (
+								<TargetRow
+									key={index}
+									target={target}
+									index={index}
+									availableProviders={availableProviders}
+									providersData={providersData}
+									showRemove={targets.length > 1}
+									onUpdate={updateTarget}
+									onRemove={removeTarget}
+								/>
+							))}
+						</div>
+
+						{/* Weight sum indicator */}
+						<div className={`flex items-center justify-end gap-2 text-xs font-medium ${Math.abs(totalWeight - 1) > 0.001 ? "text-destructive" : "text-muted-foreground"}`}>
+							Total weight: {totalWeight.toFixed(4)}
+							{Math.abs(totalWeight - 1) > 0.001 && (
+								<span className="text-destructive">(must equal 1)</span>
+							)}
 						</div>
 					</div>
 
@@ -568,6 +589,7 @@ export function RoutingRuleSheet({
 												size="sm"
 												onClick={handleRemove}
 												className="h-9 px-2"
+												aria-label={`Remove fallback ${index + 1}`}
 											>
 												<Trash2 className="h-4 w-4" />
 											</Button>
@@ -593,5 +615,185 @@ export function RoutingRuleSheet({
 				</form>
 			</SheetContent>
 		</Sheet>
+	);
+}
+
+interface TargetRowProps {
+	target: RoutingTargetFormData;
+	index: number;
+	availableProviders: string[];
+	providersData: Array<{ name: string; keys: Array<{ id: string; name: string }> }>;
+	showRemove: boolean;
+	onUpdate: (index: number, field: keyof RoutingTargetFormData, value: string | number) => void;
+	onRemove: (index: number) => void;
+}
+
+function TargetRow({ target, index, availableProviders, providersData, showRemove, onUpdate, onRemove }: TargetRowProps) {
+	const availableKeys = target.provider
+		? (providersData.find((p) => p.name === target.provider)?.keys ?? [])
+		: [];
+
+	return (
+		<div className="rounded-lg border p-3 space-y-3" data-testid={`routing-target-${index}`}>
+			<div className="flex items-center justify-between">
+				<span className="text-sm font-medium text-muted-foreground">Target {index + 1}</span>
+				<div className="flex items-center gap-2">
+					<div className="flex items-center gap-1.5">
+						<Label htmlFor={`routing-target-${index}-weight-input`} className="text-xs text-muted-foreground shrink-0">Weight</Label>
+						<Input
+							id={`routing-target-${index}-weight-input`}
+							type="number"
+							min={0.001}
+							max={1}
+							step={0.001}
+							value={target.weight}
+							onChange={(e) => onUpdate(index, "weight", parseFloat(e.target.value) || 0)}
+							className="h-8 w-24 text-sm"
+							data-testid={`routing-target-${index}-weight-input`}
+						/>
+					</div>
+					{showRemove && (
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={() => onRemove(index)}
+							className="h-8 w-8 p-0"
+							aria-label={`Remove target ${index + 1}`}
+							data-testid={`routing-target-${index}-remove-button`}
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</Button>
+					)}
+				</div>
+			</div>
+
+			<div className="grid grid-cols-2 gap-3">
+				<div className="space-y-1.5">
+					<Label id={`routing-target-${index}-provider-label`} className="text-xs">Provider</Label>
+					<div className="flex gap-1.5">
+						<Select
+							value={target.provider}
+							onValueChange={(value) => {
+								onUpdate(index, "provider", value);
+								onUpdate(index, "model", "");
+								onUpdate(index, "key_id", "");
+							}}
+						>
+							<SelectTrigger
+								id={`routing-target-${index}-provider-select`}
+								aria-labelledby={`routing-target-${index}-provider-label`}
+								className="flex-1 h-9 text-sm"
+								data-testid={`routing-target-${index}-provider-select`}
+							>
+								<SelectValue placeholder="Incoming (optional)" />
+							</SelectTrigger>
+							<SelectContent>
+								{availableProviders.map((prov) => (
+									<SelectItem key={prov} value={prov}>
+										<div className="flex items-center gap-2">
+											<RenderProviderIcon
+												provider={prov as ProviderIconType}
+												size="sm"
+												className="h-4 w-4"
+											/>
+											<span>{getProviderLabel(prov)}</span>
+										</div>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						{target.provider && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => { onUpdate(index, "provider", ""); onUpdate(index, "model", ""); onUpdate(index, "key_id", ""); }}
+								className="h-9 w-9 p-0"
+								aria-label={`Clear provider for target ${index + 1}`}
+								data-testid={`routing-target-${index}-provider-clear`}
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						)}
+					</div>
+				</div>
+
+				<div className="space-y-1.5">
+					<Label id={`routing-target-${index}-model-label`} className="text-xs">Model</Label>
+					<div className="flex gap-1.5">
+						<div className="flex-1" data-testid={`routing-target-${index}-model-select`}>
+							<ModelMultiselect
+								provider={target.provider || undefined}
+								value={target.model}
+								onChange={(value) => onUpdate(index, "model", value)}
+								placeholder="Incoming (optional)"
+								isSingleSelect
+								loadModelsOnEmptyProvider
+								className="!h-9 !min-h-9"
+								inputId={`routing-target-${index}-model-input`}
+								ariaLabelledBy={`routing-target-${index}-model-label`}
+							/>
+						</div>
+						{target.model && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => onUpdate(index, "model", "")}
+								className="h-9 w-9 p-0"
+								aria-label={`Clear model for target ${index + 1}`}
+								data-testid={`routing-target-${index}-model-clear`}
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{target.provider && (availableKeys.length > 0 || target.key_id) && (
+				<div className="space-y-1.5">
+					<Label id={`routing-target-${index}-apikey-label`} className="text-xs">API Key <span className="text-muted-foreground">(optional — leave unset for load-balanced selection)</span></Label>
+					<div className="flex gap-1.5">
+						<Select value={target.key_id || ""} onValueChange={(value) => onUpdate(index, "key_id", value)}>
+							<SelectTrigger
+								id={`routing-target-${index}-apikey-select`}
+								aria-labelledby={`routing-target-${index}-apikey-label`}
+								className="flex-1 h-9 text-sm"
+								data-testid={`routing-target-${index}-apikey-select`}
+							>
+								<SelectValue placeholder="Select key (optional)" />
+							</SelectTrigger>
+							<SelectContent>
+								{availableKeys.map((key) => (
+									<SelectItem key={key.id} value={key.id}>
+										{key.name}
+									</SelectItem>
+								))}
+								{target.key_id && !availableKeys.some((k) => k.id === target.key_id) && (
+									<SelectItem key={`pinned-${target.key_id}`} value={target.key_id}>
+										(pinned) {target.key_id}
+									</SelectItem>
+								)}
+							</SelectContent>
+						</Select>
+						{target.key_id && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => onUpdate(index, "key_id", "")}
+								className="h-9 w-9 p-0"
+								aria-label={`Clear API key for target ${index + 1}`}
+								data-testid={`routing-target-${index}-apikey-clear`}
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
 	);
 }

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -34,6 +34,7 @@ import { toast } from "sonner";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage } from "@/lib/store";
+import { RoutingTarget } from "@/lib/types/routingRules";
 
 interface RoutingRulesTableProps {
 	rules: RoutingRule[] | undefined;
@@ -66,8 +67,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 					<TableHeader>
 						<TableRow>
 							<TableHead>Name</TableHead>
-							<TableHead>Provider</TableHead>
-							<TableHead>Model</TableHead>
+							<TableHead>Targets</TableHead>
 							<TableHead>Scope</TableHead>
 							<TableHead className="text-right">Priority</TableHead>
 							<TableHead>Expression</TableHead>
@@ -78,7 +78,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 					<TableBody>
 						{[...Array(5)].map((_, i) => (
 							<TableRow key={i}>
-								<TableCell colSpan={8} className="h-10">
+								<TableCell colSpan={7} className="h-10">
 									<div className="h-2 w-32 bg-muted rounded animate-pulse" />
 								</TableCell>
 							</TableRow>
@@ -109,8 +109,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 					<TableHeader>
 						<TableRow className="bg-muted/50">
 							<TableHead className="font-semibold">Name</TableHead>
-							<TableHead className="font-semibold">Provider</TableHead>
-							<TableHead className="font-semibold">Model</TableHead>
+							<TableHead className="font-semibold">Targets</TableHead>
 							<TableHead className="font-semibold">Scope</TableHead>
 							<TableHead className="text-right font-semibold">Priority</TableHead>
 							<TableHead className="font-semibold">Expression</TableHead>
@@ -130,17 +129,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 									</div>
 								</TableCell>
 								<TableCell>
-									<div className="flex items-center gap-2">
-										<RenderProviderIcon
-											provider={rule.provider as ProviderIconType}
-											size="sm"
-											className="h-4 w-4"
-										/>
-										<span className="text-sm">{getProviderLabel(rule.provider || "-")}</span>
-									</div>
-								</TableCell>
-								<TableCell className="text-sm">
-									<span className="font-mono">{rule.model || "-"}</span>
+									<TargetsSummary targets={rule.targets || []} />
 								</TableCell>
 								<TableCell>
 									<Badge variant="secondary">{getScopeLabel(rule.scope)}</Badge>
@@ -200,5 +189,38 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 				</AlertDialogContent>
 			</AlertDialog>
 		</>
+	);
+}
+
+function TargetsSummary({ targets }: { targets: RoutingTarget[] }) {
+	if (!targets || targets.length === 0) {
+		return <span className="text-muted-foreground text-sm">-</span>;
+	}
+
+	const first = targets[0];
+	const label = [
+		first.provider ? getProviderLabel(first.provider) : "Any",
+		first.model || "Any model",
+	].join(" / ");
+
+	return (
+		<div className="flex flex-col gap-1">
+			<div className="flex items-center gap-1.5">
+				{first.provider && (
+					<RenderProviderIcon
+						provider={first.provider as ProviderIconType}
+						size="sm"
+						className="h-4 w-4 shrink-0"
+					/>
+				)}
+				<span className="text-sm truncate max-w-[160px]">{label}</span>
+				{targets.length === 1 && (
+					<span className="text-xs text-muted-foreground shrink-0">{first.weight}</span>
+				)}
+			</div>
+			{targets.length > 1 && (
+				<span className="text-xs text-muted-foreground">+{targets.length - 1} more target{targets.length > 2 ? "s" : ""}</span>
+			)}
+		</div>
 	);
 }

--- a/ui/components/ui/asyncMultiselect.tsx
+++ b/ui/components/ui/asyncMultiselect.tsx
@@ -199,6 +199,11 @@ interface AsyncMultiSelectProps<T> {
 	noOptionsMessage?: () => React.ReactNode;
 	valueContainerClassName?: string;
 	noOptionsMessageClassName?: string;
+
+	/** id for the search input (accessibility) */
+	inputId?: string;
+	/** id of element that labels this control (accessibility) */
+	ariaLabelledBy?: string;
 	views?: {
 		clearIndicator?: (props: ClearIndicatorProps<T>) => React.ReactNode;
 		control?: (props: ControlProps<T>) => React.ReactNode;
@@ -474,6 +479,8 @@ export function AsyncMultiSelect<T>(props: AsyncMultiSelectProps<T>) {
 					SingleValue: CustomSingleValue,
 					ValueContainer: CustomValueContainer,
 				}}
+				inputId={props.inputId}
+				aria-labelledby={props.ariaLabelledBy}
 				{...customOptionProps}
 				{...customDropdownIndicatorProps}
 				{...customComponentsProps}

--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -19,6 +19,10 @@ interface ModelMultiselectPropsBase {
 	 * - `"base_models"`: loads distinct base model names (useful for governance where cross-provider matching is needed)
 	 */
 	loadModelsOnEmptyProvider?: boolean | "base_models";
+	/** id for the search input (accessibility) */
+	inputId?: string;
+	/** id of element that labels this control (accessibility) */
+	ariaLabelledBy?: string;
 }
 
 interface ModelMultiselectPropsSingle extends ModelMultiselectPropsBase {
@@ -219,6 +223,8 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 		<AsyncMultiSelect<ModelOption>
 			isSingleSelect={isSingleSelect}
 			hideSelectedOptions
+			inputId={props.inputId}
+			ariaLabelledBy={props.ariaLabelledBy}
 			value={selectedOptions}
 			onChange={handleChange}
 			reload={loadOptions}

--- a/ui/lib/types/routingRules.ts
+++ b/ui/lib/types/routingRules.ts
@@ -5,13 +5,19 @@
 
 import { RuleGroupType } from "react-querybuilder";
 
+export interface RoutingTarget {
+	provider?: string;
+	model?: string;
+	key_id?: string;
+	weight: number;
+}
+
 export interface RoutingRule {
 	id: string;
 	name: string;
 	description: string;
 	cel_expression: string;
-	provider: string;
-	model?: string;
+	targets: RoutingTarget[];
 	fallbacks?: string[];
 	scope: "global" | "team" | "customer" | "virtual_key";
 	scope_id?: string;
@@ -26,8 +32,7 @@ export interface CreateRoutingRuleRequest {
 	name: string;
 	description?: string;
 	cel_expression?: string;
-	provider?: string;
-	model?: string;
+	targets: RoutingTarget[];
 	fallbacks?: string[];
 	scope: string;
 	scope_id?: string;
@@ -48,13 +53,19 @@ export interface GetRoutingRuleResponse {
 	rule: RoutingRule;
 }
 
+export interface RoutingTargetFormData {
+	provider: string;
+	model: string;
+	key_id: string;
+	weight: number;
+}
+
 export interface RoutingRuleFormData {
 	id?: string;
 	name: string;
 	description: string;
 	cel_expression: string;
-	provider: string;
-	model: string;
+	targets: RoutingTargetFormData[];
 	fallbacks: string[];
 	scope: string;
 	scope_id: string;
@@ -78,12 +89,18 @@ export const ROUTING_RULE_SCOPES = [
 	{ value: RoutingRuleScope.VirtualKey, label: "Virtual Key" },
 ];
 
+export const DEFAULT_ROUTING_TARGET: RoutingTargetFormData = {
+	provider: "",
+	model: "",
+	key_id: "",
+	weight: 1,
+};
+
 export const DEFAULT_ROUTING_RULE_FORM_DATA: RoutingRuleFormData = {
 	name: "",
 	description: "",
 	cel_expression: "",
-	provider: "",
-	model: "",
+	targets: [DEFAULT_ROUTING_TARGET],
 	fallbacks: [],
 	scope: RoutingRuleScope.Global,
 	scope_id: "",


### PR DESCRIPTION
## Summary

Adds support for multiple weighted routing targets and per-target API key pinning to routing rules, enabling probabilistic routing across providers and granular key selection control.

## Changes

- **Breaking**: Replaced single `provider`/`model` fields with `targets` array supporting weighted probabilistic routing
- Added `routing_targets` table with 1:many relationship to `routing_rules` including per-target `key_id` pinning
- Updated routing engine to select targets probabilistically based on weights and set pinned key IDs in Bifrost context
- Enhanced error messages to include model information when key selection fails
- Added comprehensive migration logic to convert existing single-target rules to the new schema
- Updated API endpoints, UI components, and documentation for the new targets-based approach

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

Create routing rules with multiple weighted targets and verify probabilistic selection:

```sh
# Create a probabilistic routing rule
curl -X POST http://localhost:8080/api/governance/routing-rules \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Split Traffic OpenAI vs Groq",
    "cel_expression": "true",
    "targets": [
      { "provider": "openai", "model": "gpt-4o", "weight": 0.7 },
      { "provider": "groq", "model": "llama-3.1-70b", "weight": 0.3 }
    ],
    "scope": "global",
    "priority": 5
  }'

# Create rule with pinned API key
curl -X POST http://localhost:8080/api/governance/routing-rules \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Pin Production Key",
    "cel_expression": "headers[\"x-tier\"] == \"premium\"",
    "targets": [
      {
        "provider": "openai",
        "model": "gpt-4o", 
        "key_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
        "weight": 1.0
      }
    ],
    "scope": "global",
    "priority": 10
  }'

# Test requests to verify routing behavior
for i in {1..10}; do
  curl -X POST http://localhost:8080/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model": "gpt-3.5-turbo", "messages": [{"role": "user", "content": "Hello"}]}'
done

# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

The UI now displays a targets section where users can add multiple weighted routing targets, each with optional provider, model, and API key selection. A weight validation indicator shows the current total and warns when weights don't sum to 1.

## Breaking changes

- [x] Yes
- [ ] No

**Migration Required**: Routing rules now use a `targets` array instead of top-level `provider`/`model` fields. The database migration automatically converts existing rules, but API clients and config files need updates:

**Before:**
```json
{
  "provider": "openai",
  "model": "gpt-4o"
}
```

**After:**
```json
{
  "targets": [
    { "provider": "openai", "model": "gpt-4o", "weight": 1.0 }
  ]
}
```

## Related issues

Enables advanced routing scenarios including A/B testing, canary deployments, cost optimization through provider splitting, and dedicated key usage for specific request types.

## Security considerations

The `key_id` field references existing API keys by UUID, maintaining the existing security model. Probabilistic routing doesn't expose additional information, and key pinning provides more granular control over key usage patterns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable