### PR TITLE
feat: add weighted routing targets for probabilistic routing rules

### DIFF
--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -573,6 +573,30 @@ TableKey:
 
 # Routing Rules schemas
 
+RoutingTarget:
+  type: object
+  description: A single weighted routing target within a routing rule
+  required:
+    - weight
+  properties:
+    provider:
+      type: string
+      description: Target provider (omit or empty to use the incoming request provider)
+      nullable: true
+    model:
+      type: string
+      description: Target model (omit or empty to use the incoming request model)
+      nullable: true
+    key_id:
+      type: string
+      description: UUID of the API key to pin for this target (omit for load-balanced key selection)
+      nullable: true
+    weight:
+      type: number
+      format: double
+      description: Probability weight for this target (must be > 0; all target weights in a rule must sum to 1, e.g. 0.7 + 0.3 = 1.0)
+      example: 0.5
+
 RoutingRule:
   type: object
   description: CEL-based routing rule for intelligent request routing
@@ -592,18 +616,11 @@ RoutingRule:
     cel_expression:
       type: string
       description: CEL (Common Expression Language) expression for matching
-    provider:
-      type: string
-      description: Target provider (empty string uses incoming request provider)
-      nullable: true
-    model:
-      type: string
-      description: Target model (empty string uses incoming request model)
-      nullable: true
-    key_id:
-      type: string
-      description: UUID of the API key to pin for this rule (omit or empty for load-balanced key selection)
-      nullable: true
+    targets:
+      type: array
+      description: Weighted routing targets; weights must sum to 1; target is selected probabilistically at request time
+      items:
+        $ref: '#/RoutingTarget'
     fallbacks:
       type: array
       items:
@@ -672,18 +689,11 @@ CreateRoutingRuleRequest:
     cel_expression:
       type: string
       description: CEL expression for matching
-    provider:
-      type: string
-      description: Target provider (optional, empty uses incoming)
-      nullable: true
-    model:
-      type: string
-      description: Target model (optional, empty uses incoming)
-      nullable: true
-    key_id:
-      type: string
-      description: UUID of the API key to pin for this rule (optional, omit for load-balanced key selection)
-      nullable: true
+    targets:
+      type: array
+      description: Weighted routing targets; weights must sum to 1; target is selected probabilistically at request time
+      items:
+        $ref: '#/RoutingTarget'
     fallbacks:
       type: array
       items:
@@ -727,7 +737,7 @@ CreateRoutingRuleRequest:
 
 UpdateRoutingRuleRequest:
   type: object
-  description: Request to update a routing rule
+  description: Request to update a routing rule (all fields optional; providing `targets` replaces all existing targets)
   properties:
     name:
       type: string
@@ -737,16 +747,11 @@ UpdateRoutingRuleRequest:
       type: boolean
     cel_expression:
       type: string
-    provider:
-      type: string
-      nullable: true
-    model:
-      type: string
-      nullable: true
-    key_id:
-      type: string
-      description: UUID of the API key to pin (send empty string to clear)
-      nullable: true
+    targets:
+      type: array
+      description: Replaces all existing targets when provided; weights must sum to 1
+      items:
+        $ref: '#/RoutingTarget'
     fallbacks:
       type: array
       items:

--- a/docs/providers/routing-rules.mdx
+++ b/docs/providers/routing-rules.mdx
@@ -234,8 +234,7 @@ Access routing rules from the dashboard:
 - **Description** (optional): Internal notes
 - **Enabled**: Toggle rule on/off
 - **CEL Expression**: Visual or manual expression builder
-- **Provider** (required): Target provider if matched
-- **Model** (optional): Target model if matched (empty = use original)
+- **Targets** (required): One or more weighted routing targets — each has Provider, Model, API Key (all optional), and Weight (%). Weights must sum to 1. When multiple targets are defined, one is selected probabilistically at request time.
 - **Fallbacks** (optional): Array of fallback providers
 - **Scope**: Where rule applies (global, customer, team, virtual_key)
 - **Scope ID**: Required if scope is not global
@@ -273,9 +272,11 @@ GET /api/governance/routing-rules
       "description": "Route premium users to fast provider",
       "enabled": true,
       "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-      "provider": "openai",
-      "model": "gpt-4o",
-      "fallbacks": ["azure/gpt-4o", "groq/gpt-3.5-turbo"],
+      "targets": [
+        { "provider": "openai", "model": "gpt-4o", "weight": 0.7 },
+        { "provider": "azure",  "model": "gpt-4o", "weight": 0.3 }
+      ],
+      "fallbacks": ["groq/gpt-3.5-turbo"],
       "scope": "global",
       "scope_id": null,
       "priority": 10,
@@ -306,8 +307,9 @@ Content-Type: application/json
   "description": "When budget is high, route to cheaper provider",
   "enabled": true,
   "cel_expression": "budget_used > 85",
-  "provider": "groq",
-  "model": "",
+  "targets": [
+    { "provider": "groq", "weight": 1 }
+  ],
   "fallbacks": ["openai/gpt-4o"],
   "scope": "team",
   "scope_id": "team-uuid-456",
@@ -369,9 +371,11 @@ Define routing rules in your `config.json` file under the governance configurati
         "description": "Route premium users to fast provider",
         "enabled": true,
         "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-        "provider": "openai",
-        "model": "gpt-4o",
-        "fallbacks": ["azure/gpt-4o", "groq/gpt-3.5-turbo"],
+        "targets": [
+          { "provider": "openai", "model": "gpt-4o", "weight": 0.7 },
+          { "provider": "azure",  "model": "gpt-4o", "weight": 0.3 }
+        ],
+        "fallbacks": ["groq/gpt-3.5-turbo"],
         "scope": "global",
         "scope_id": null,
         "priority": 10
@@ -382,8 +386,9 @@ Define routing rules in your `config.json` file under the governance configurati
         "description": "Route to cheaper provider when budget is high",
         "enabled": true,
         "cel_expression": "budget_used > 85",
-        "provider": "groq",
-        "model": "llama-2-70b",
+        "targets": [
+          { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+        ],
         "fallbacks": [],
         "scope": "team",
         "scope_id": "team-ml-ops",
@@ -400,9 +405,11 @@ Define routing rules in your `config.json` file under the governance configurati
 - **description** (string, optional): Internal documentation
 - **enabled** (boolean): Whether rule is active
 - **cel_expression** (string): CEL expression for rule matching
-- **provider** (string, optional): Target provider if matched (empty string = use incoming request provider)
-- **model** (string, optional): Target model if matched (empty string = use incoming request model)
-- **key_id** (string, optional): UUID of the API key to pin for this rule — bypasses load-balanced key selection and always uses this key. Omit to use the normal key selection logic.
+- **targets** (array, required): One or more routing targets. Each target has:
+  - `provider` (string, optional): Target provider — omit to use the incoming request provider
+  - `model` (string, optional): Target model — omit to use the incoming request model
+  - `key_id` (string, optional): UUID of the API key to pin — omit for load-balanced key selection
+  - `weight` (number, required): Probability weight — all weights in a rule must sum to 1 (e.g. 0.7 + 0.3 = 1.0)
 - **fallbacks** (array[string]): Fallback providers in "provider/model" format
 - **scope** (string): Scope level - "global", "customer", "team", or "virtual_key"
 - **scope_id** (string, optional): ID of scoped entity (null for global scope)
@@ -421,8 +428,9 @@ Routes are automatically loaded on startup from the `config.json` governance sec
         "name": "Premium Tier Fast Track",
         "enabled": true,
         "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-        "provider": "openai",
-        "model": "gpt-4o",
+        "targets": [
+          { "provider": "openai", "model": "gpt-4o", "weight": 1 }
+        ],
         "fallbacks": ["azure/gpt-4o"],
         "scope": "global",
         "priority": 0
@@ -432,8 +440,9 @@ Routes are automatically loaded on startup from the `config.json` governance sec
         "name": "Budget Exhaustion Fallback",
         "enabled": true,
         "cel_expression": "budget_used > 90",
-        "provider": "groq",
-        "model": "llama-2-70b",
+        "targets": [
+          { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+        ],
         "fallbacks": [],
         "scope": "global",
         "priority": 5
@@ -443,8 +452,9 @@ Routes are automatically loaded on startup from the `config.json` governance sec
         "name": "ML Team Anthropic Route",
         "enabled": true,
         "cel_expression": "team_name == \"ml-research\"",
-        "provider": "anthropic",
-        "model": "claude-3-opus-20240229",
+        "targets": [
+          { "provider": "anthropic", "model": "claude-3-opus-20240229", "weight": 1 }
+        ],
         "fallbacks": ["bedrock/claude-3-opus"],
         "scope": "team",
         "scope_id": "team-ml-research",
@@ -477,8 +487,9 @@ Route requests based on customer tier using headers:
 {
   "name": "Premium Tier Fast Track",
   "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-  "provider": "openai",
-  "model": "gpt-4o",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o", "weight": 1 }
+  ],
   "fallbacks": ["azure/gpt-4o"],
   "scope": "global",
   "priority": 10
@@ -493,8 +504,9 @@ Route to cheaper provider when budget is exhausted:
 {
   "name": "Budget Exhaustion Fallback",
   "cel_expression": "budget_used > 90",
-  "provider": "groq",
-  "model": "llama-2-70b",
+  "targets": [
+    { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+  ],
   "fallbacks": [],
   "scope": "global",
   "priority": 5
@@ -509,8 +521,9 @@ Route team-specific requests to their preferred provider:
 {
   "name": "ML Team Anthropic Preference",
   "cel_expression": "team_name == \"ml-research\"",
-  "provider": "anthropic",
-  "model": "claude-3-opus-20240229",
+  "targets": [
+    { "provider": "anthropic", "model": "claude-3-opus-20240229", "weight": 1 }
+  ],
   "fallbacks": ["bedrock/claude-3-opus"],
   "scope": "team",
   "scope_id": "team-ml-research-uuid",
@@ -526,29 +539,33 @@ Combine multiple criteria for sophisticated routing:
 {
   "name": "Production Premium Route",
   "cel_expression": "headers[\"x-environment\"] == \"production\" && headers[\"x-priority\"] == \"high\" && tokens_used < 75",
-  "provider": "openai",
-  "model": "gpt-4o",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o", "weight": 1 }
+  ],
   "fallbacks": ["azure/gpt-4o"],
   "scope": "global",
   "priority": 5
 }
 ```
 
-### Use Case 5: A/B Testing
+### Use Case 5: Probabilistic A/B Testing
 
-Route percentage of traffic using request patterns:
+Split traffic across providers or models by weight for canary deployments or cost optimization:
 
 ```json
 {
-  "name": "A/B Test New Model",
-  "cel_expression": "headers[\"x-user-id\"].contains(\"test-\") || headers[\"x-ab-test\"] == \"new-model\"",
-  "provider": "openai",
-  "model": "gpt-4o-mini",
-  "fallbacks": ["openai/gpt-4o"],
+  "name": "Split Traffic OpenAI vs Groq",
+  "cel_expression": "true",
+  "targets": [
+    { "provider": "openai", "model": "gpt-4o",        "weight": 0.7 },
+    { "provider": "groq",   "model": "llama-3.1-70b", "weight": 0.3 }
+  ],
   "scope": "global",
   "priority": 15
 }
 ```
+
+Each request matching this rule has a 70% chance of going to OpenAI and a 30% chance of going to Groq. Weights must always sum to 1.
 
 ### Use Case 6: Regional Routing
 
@@ -558,8 +575,9 @@ Route based on region headers:
 {
   "name": "EU Data Residency",
   "cel_expression": "headers[\"x-region\"] == \"eu\"",
-  "provider": "azure",
-  "model": "gpt-4o",
+  "targets": [
+    { "provider": "azure", "model": "gpt-4o", "weight": 1 }
+  ],
   "fallbacks": [],
   "scope": "global",
   "priority": 0
@@ -577,9 +595,10 @@ Routing Rules run **BEFORE** governance provider selection and can override it:
 **If a routing rule matches:**
 ```
 1. Routing Rules → CEL expression evaluation (first-match-wins)
-2. Rule matches → provider/model/fallbacks overridden
-3. Governance provider_configs → SKIPPED
-4. Load Balancing → selects best key
+2. Rule matches → target selected probabilistically from targets array
+3. provider/model/key_id/fallbacks overridden from selected target
+4. Governance provider_configs → SKIPPED
+5. Load Balancing → selects best key (unless key_id was pinned)
 ```
 
 **If no routing rule matches:**
@@ -812,7 +831,7 @@ Enable debug logging to see routing rule evaluation:
 [RoutingEngine] Rule rule-1 evaluation result: matched=false
 [RoutingEngine] Evaluating rule: id=rule-2, name=Budget Fallback, expression=budget_used>80
 [RoutingEngine] Rule rule-2 evaluation result: matched=true
-[RoutingEngine] Rule matched! Decision: provider=groq, model=gpt-3.5-turbo, fallbacks=[azure/gpt-4o]
+[RoutingEngine] Rule matched! Selected target: provider=groq, model=gpt-3.5-turbo (weight=100), fallbacks=[azure/gpt-4o]
 ```
 
 ---
@@ -830,23 +849,26 @@ curl -X POST http://localhost:8080/api/governance/routing-rules \
     "description": "Switch to cheaper provider when budget >85%",
     "enabled": true,
     "cel_expression": "budget_used > 85",
-    "provider": "groq",
-    "model": "llama-2-70b",
+    "targets": [
+      { "provider": "groq", "model": "llama-2-70b", "weight": 1 }
+    ],
     "fallbacks": ["openai/gpt-3.5-turbo"],
     "scope": "global",
     "priority": 10
   }'
 ```
 
-#### Create Header-Based Rule
+#### Create Probabilistic Split Rule
 ```bash
 curl -X POST http://localhost:8080/api/governance/routing-rules \
   -H "Content-Type: application/json" \
   -d '{
-    "name": "Premium Tier Route",
+    "name": "Premium Tier Split",
     "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-    "provider": "openai",
-    "model": "gpt-4o",
+    "targets": [
+      { "provider": "openai", "model": "gpt-4o",   "weight": 0.7 },
+      { "provider": "azure",  "model": "gpt-4o",   "weight": 0.3 }
+    ],
     "scope": "global",
     "priority": 5
   }'
@@ -861,9 +883,14 @@ curl -X POST http://localhost:8080/api/governance/routing-rules \
     "description": "Always use the dedicated production key for premium requests",
     "enabled": true,
     "cel_expression": "headers[\"x-tier\"] == \"premium\"",
-    "provider": "openai",
-    "model": "gpt-4o",
-    "key_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "targets": [
+      {
+        "provider": "openai",
+        "model": "gpt-4o",
+        "key_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "weight": 1
+      }
+    ],
     "scope": "global",
     "priority": 5
   }'

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,2 @@
+- feat: add `routing_targets` table with 1:many relationship to `routing_rules`; migrates existing single-target rules to the new table with `weight=100`; drops legacy `provider`, `model`, `key_id` columns from `routing_rules`
 - feat: add `key_id` column to `routing_rules` table

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -870,11 +870,23 @@ func GenerateRoutingRuleHash(r tables.TableRoutingRule) (string, error) {
 	// Hash CelExpression
 	hash.Write([]byte(r.CelExpression))
 
-	// Hash Provider
-	hash.Write([]byte(r.Provider))
-
-	// Hash Model
-	hash.Write([]byte(r.Model))
+	// Hash Targets (sorted by ID for determinism)
+	for _, t := range r.Targets {
+		if t.Provider != nil {
+			hash.Write([]byte(*t.Provider))
+		}
+		if t.Model != nil {
+			hash.Write([]byte(*t.Model))
+		}
+		if t.KeyID != nil {
+			hash.Write([]byte(*t.KeyID))
+		}
+		data, err := sonic.Marshal(t.Weight)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
 
 	// Hash Fallbacks: use DB string when set, else marshal ParsedFallbacks (config-origin)
 	if r.Fallbacks != nil {

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -299,6 +299,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddKeyIDToRoutingRules(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddRoutingTargetsTable(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4122,22 +4125,121 @@ func migrationAddBedrockAssumeRoleColumns(ctx context.Context, db *gorm.DB) erro
 	return nil
 }
 
+// legacyRoutingRuleColumns is a migration-only struct that represents the old routing_rules
+// schema before provider/model/key_id were moved to the routing_targets table.
+// GORM's SQLite DropColumn/AddColumn need a real struct (not a string table name) to
+// reconstruct the table correctly, so we keep this stub around for migration use only.
+type legacyRoutingRuleColumns struct {
+	Provider string  `gorm:"column:provider;type:varchar(255)"`
+	Model    string  `gorm:"column:model;type:varchar(255)"`
+	KeyID    *string `gorm:"column:key_id;type:varchar(255)"`
+}
+
+func (legacyRoutingRuleColumns) TableName() string { return "routing_rules" }
+
+// migrationAddRoutingTargetsTable creates the routing_targets table and seeds one target row per
+// existing routing rule, migrating the legacy provider/model/key_id columns.
+// After seeding, the legacy columns are dropped from routing_rules.
+func migrationAddRoutingTargetsTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_routing_targets_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// 1. Create routing_targets table
+			if !mg.HasTable(&tables.TableRoutingTarget{}) {
+				if err := mg.CreateTable(&tables.TableRoutingTarget{}); err != nil {
+					return fmt.Errorf("failed to create routing_targets table: %w", err)
+				}
+			}
+
+			// 2. Seed one target per existing routing rule (idempotent).
+			// Only possible when the legacy columns still exist (i.e. upgrading from an older schema).
+			// On a fresh database AutoMigrate creates routing_rules without these columns, so skip seeding.
+			type legacyRule struct {
+				ID       string
+				Provider string
+				Model    string
+				KeyID    *string
+			}
+			if mg.HasColumn("routing_rules", "provider") {
+			var rows []legacyRule
+			if err := tx.Table("routing_rules").Select("id, provider, model, key_id").Scan(&rows).Error; err != nil {
+				return fmt.Errorf("failed to scan routing_rules for seeding: %w", err)
+			}
+			for _, row := range rows {
+				var count int64
+				if err := tx.Table("routing_targets").Where("rule_id = ?", row.ID).Count(&count).Error; err != nil {
+					return fmt.Errorf("failed to count targets for rule %s: %w", row.ID, err)
+				}
+				if count > 0 {
+					continue // already seeded
+				}
+				target := tables.TableRoutingTarget{
+					RuleID: row.ID,
+					Weight: 1.0,
+					KeyID:  row.KeyID,
+				}
+				if row.Provider != "" {
+					p := row.Provider
+					target.Provider = &p
+				}
+				if row.Model != "" {
+					m := row.Model
+					target.Model = &m
+				}
+				if err := tx.Create(&target).Error; err != nil {
+					return fmt.Errorf("failed to seed target for rule %s: %w", row.ID, err)
+				}
+			}
+			} // end if mg.HasColumn("routing_rules", "provider")
+
+			// 3. Drop legacy single-target columns from routing_rules.
+			// Must use the struct form (not string) so SQLite can reconstruct the table correctly.
+			legacyModel := &legacyRoutingRuleColumns{}
+			for _, col := range []string{"provider", "model", "key_id"} {
+				if mg.HasColumn("routing_rules", col) {
+					if err := mg.DropColumn(legacyModel, col); err != nil {
+						return fmt.Errorf("failed to drop column %s from routing_rules: %w", col, err)
+					}
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			mg := tx.WithContext(ctx).Migrator()
+			if mg.HasTable(&tables.TableRoutingTarget{}) {
+				return mg.DropTable(&tables.TableRoutingTarget{})
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running routing_targets_table migration: %s", err.Error())
+	}
+	return nil
+}
+
 // migrationAddKeyIDToRoutingRules adds the key_id column to the routing_rules table
 // to allow routing rules to pin a specific API key by its UUID.
+// NOTE: key_id was later moved to the routing_targets table, so TableRoutingRule no longer
+// has this field. We use string-based column operations to avoid struct field lookup failures.
 func migrationAddKeyIDToRoutingRules(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
 		ID: "add_key_id_to_routing_rules",
 		Migrate: func(tx *gorm.DB) error {
 			mg := tx.WithContext(ctx).Migrator()
-			if !mg.HasColumn(&tables.TableRoutingRule{}, "key_id") {
-				return mg.AddColumn(&tables.TableRoutingRule{}, "key_id")
+			if !mg.HasColumn("routing_rules", "key_id") {
+				return mg.AddColumn(&legacyRoutingRuleColumns{}, "key_id")
 			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {
 			mg := tx.WithContext(ctx).Migrator()
-			if mg.HasColumn(&tables.TableRoutingRule{}, "key_id") {
-				return mg.DropColumn(&tables.TableRoutingRule{}, "key_id")
+			if mg.HasColumn("routing_rules", "key_id") {
+				return mg.DropColumn(&legacyRoutingRuleColumns{}, "key_id")
 			}
 			return nil
 		},

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2341,7 +2341,7 @@ func (s *RDBConfigStore) UpdateRateLimitUsage(ctx context.Context, id string, to
 // GetRoutingRules retrieves all routing rules from the database.
 func (s *RDBConfigStore) GetRoutingRules(ctx context.Context) ([]tables.TableRoutingRule, error) {
 	var rules []tables.TableRoutingRule
-	if err := s.db.WithContext(ctx).Order("priority ASC, created_at DESC").Find(&rules).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Targets").Order("priority ASC, created_at DESC").Find(&rules).Error; err != nil {
 		return nil, err
 	}
 	return rules, nil
@@ -2350,7 +2350,7 @@ func (s *RDBConfigStore) GetRoutingRules(ctx context.Context) ([]tables.TableRou
 // GetRoutingRulesByScope retrieves routing rules by scope and scope ID, ordered by priority ASC.
 func (s *RDBConfigStore) GetRoutingRulesByScope(ctx context.Context, scope string, scopeID string) ([]tables.TableRoutingRule, error) {
 	var rules []tables.TableRoutingRule
-	query := s.db.WithContext(ctx)
+	query := s.db.WithContext(ctx).Preload("Targets")
 
 	if scope == "global" {
 		query = query.Where("scope = ?", "global")
@@ -2369,7 +2369,7 @@ func (s *RDBConfigStore) GetRoutingRulesByScope(ctx context.Context, scope strin
 // GetRoutingRule retrieves a specific routing rule by ID.
 func (s *RDBConfigStore) GetRoutingRule(ctx context.Context, id string) (*tables.TableRoutingRule, error) {
 	var rule tables.TableRoutingRule
-	if err := s.db.WithContext(ctx).Where("id = ?", id).First(&rule).Error; err != nil {
+	if err := s.db.WithContext(ctx).Preload("Targets").Where("id = ?", id).First(&rule).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -2426,10 +2426,22 @@ func (s *RDBConfigStore) CreateRoutingRule(ctx context.Context, rule *tables.Tab
 		return fmt.Errorf("routing rule with priority %d already exists for scope '%s'", rule.Priority, rule.Scope)
 	}
 
-	if err := database.WithContext(ctx).Create(rule).Error; err != nil {
-		return s.parseGormError(err)
-	}
-	return nil
+	return s.parseGormError(database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		targets := rule.Targets
+		rule.Targets = nil
+		if err := tx.Omit("Targets").Create(rule).Error; err != nil {
+			return err
+		}
+		rule.Targets = targets
+
+		for i := range rule.Targets {
+			rule.Targets[i].RuleID = rule.ID
+			if err := tx.Create(&rule.Targets[i]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
 }
 
 // UpdateRoutingRule updates an existing routing rule in the database.
@@ -2463,17 +2475,37 @@ func (s *RDBConfigStore) UpdateRoutingRule(ctx context.Context, rule *tables.Tab
 		return fmt.Errorf("routing rule with priority %d already exists for scope '%s'", rule.Priority, rule.Scope)
 	}
 
-	if err := database.WithContext(ctx).Save(rule).Error; err != nil {
-		return s.parseGormError(err)
-	}
-	return nil
+	return s.parseGormError(database.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		targets := rule.Targets
+		rule.Targets = nil
+		if err := tx.Omit("Targets").Save(rule).Error; err != nil {
+			return err
+		}
+		rule.Targets = targets
+
+		if err := tx.Where("rule_id = ?", rule.ID).Delete(&tables.TableRoutingTarget{}).Error; err != nil {
+			return err
+		}
+		for i := range rule.Targets {
+			rule.Targets[i].RuleID = rule.ID
+			if err := tx.Create(&rule.Targets[i]).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
 }
 
-// DeleteRoutingRule deletes a routing rule from the database.
+// DeleteRoutingRule deletes a routing rule and its targets from the database.
 func (s *RDBConfigStore) DeleteRoutingRule(ctx context.Context, id string, tx ...*gorm.DB) error {
 	database := s.db
 	if len(tx) > 0 && tx[0] != nil {
 		database = tx[0]
+	}
+
+	// Delete targets first
+	if err := database.WithContext(ctx).Where("rule_id = ?", id).Delete(&tables.TableRoutingTarget{}).Error; err != nil {
+		return s.parseGormError(err)
 	}
 
 	result := database.WithContext(ctx).Delete(&tables.TableRoutingRule{}, "id = ?", id)

--- a/framework/configstore/tables/routing_rules.go
+++ b/framework/configstore/tables/routing_rules.go
@@ -18,12 +18,11 @@ type TableRoutingRule struct {
 	Enabled       bool   `gorm:"not null;default:true" json:"enabled"`
 	CelExpression string `gorm:"type:text;not null" json:"cel_expression"`
 
-	// Routing Target (output)
-	Provider        string   `gorm:"type:varchar(255);not null" json:"provider"` // Primary provider (e.g., "openai", "azure")
-	Model           string   `gorm:"type:varchar(255)" json:"model"`             // Optional model override, empty = use original
-	KeyID           *string  `gorm:"type:varchar(255)" json:"key_id,omitempty"` // Optional: pin a specific API key by its UUID
-	Fallbacks       *string  `gorm:"type:text" json:"-"`                         // JSON array of fallback chains
-	ParsedFallbacks []string `gorm:"-" json:"fallbacks"`                         // Parsed fallbacks from JSON
+	// Routing Targets (output) — 1:many relationship; weights must sum to 1
+	Targets []TableRoutingTarget `gorm:"foreignKey:RuleID" json:"targets,omitempty"`
+
+	Fallbacks       *string  `gorm:"type:text" json:"-"`           // JSON array of fallback chains
+	ParsedFallbacks []string `gorm:"-" json:"fallbacks,omitempty"` // Parsed fallbacks from JSON
 
 	Query       *string        `gorm:"type:text" json:"-"`
 	ParsedQuery map[string]any `gorm:"-" json:"query,omitempty"`
@@ -80,3 +79,17 @@ func (r *TableRoutingRule) AfterFind(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// TableRoutingTarget represents a weighted routing target for probabilistic routing.
+// Multiple targets can be associated with a single routing rule; weights determine
+// the probability of each target being selected and must sum to 100 across all targets in a rule.
+type TableRoutingTarget struct {
+	RuleID   string  `gorm:"type:varchar(255);not null;index" json:"rule_id"`
+	Provider *string `gorm:"type:varchar(255)" json:"provider,omitempty"`          // nil = use incoming provider
+	Model    *string `gorm:"type:varchar(255)" json:"model,omitempty"`             // nil = use incoming model
+	KeyID    *string `gorm:"type:varchar(255)" json:"key_id,omitempty"`            // nil = no key pin
+	Weight   float64 `gorm:"type:decimal(5,4);not null;default:1" json:"weight"` // must sum to 1 across all targets in a rule
+}
+
+// TableName for TableRoutingTarget
+func (TableRoutingTarget) TableName() string { return "routing_targets" }

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,1 +1,2 @@
+- feat: routing rules now support multiple weighted targets for probabilistic routing
 - feat: routing rules now support `key_id` field to pin a specific API key for matched requests, bypassing load-balanced key selection

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"regexp"
 	"strings"
 
@@ -138,23 +139,25 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → no match", rule.Name, rule.CelExpression))
 			}
 
-			// If rule matched, return routing decision
+			// If rule matched, select a target probabilistically and return routing decision
 			if matched {
-				// Use incoming provider/model if rule's are empty
-				provider := rule.Provider
-				if provider == "" {
-					provider = string(routingCtx.Provider)
+				target := selectWeightedTarget(rule.Targets)
+
+				provider := string(routingCtx.Provider)
+				if target.Provider != nil && *target.Provider != "" {
+					provider = *target.Provider
 				}
 
-				model := rule.Model
-				if model == "" {
-					model = routingCtx.Model
+				model := routingCtx.Model
+				if target.Model != nil && *target.Model != "" {
+					model = *target.Model
 				}
 
 				keyID := ""
-				if rule.KeyID != nil {
-					keyID = *rule.KeyID
+				if target.KeyID != nil {
+					keyID = *target.KeyID
 				}
+
 				decision := &RoutingDecision{
 					Provider:        provider,
 					Model:           model,
@@ -167,8 +170,8 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 				ctx.SetValue(schemas.BifrostContextKeyGovernanceRoutingRuleID, rule.ID)
 				ctx.SetValue(schemas.BifrostContextKeyGovernanceRoutingRuleName, rule.Name)
 
-				re.logger.Debug("[RoutingEngine] Rule matched! Decision: provider=%s, model=%s, fallbacks=%v", provider, model, rule.ParsedFallbacks)
-				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → matched, routing to provider=%s, model=%s, fallbacks=%v", rule.Name, rule.CelExpression, provider, model, rule.ParsedFallbacks))
+				re.logger.Debug("[RoutingEngine] Rule matched! Selected target (weight=%.2f): provider=%s, model=%s, fallbacks=%v", target.Weight, provider, model, rule.ParsedFallbacks)
+				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → matched, selected target (weight=%.2f): provider=%s, model=%s, fallbacks=%v", rule.Name, rule.CelExpression, target.Weight, provider, model, rule.ParsedFallbacks))
 				return decision, nil
 			}
 
@@ -178,6 +181,34 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 	// No rule matched - return nil decision (caller should use default routing)
 	re.logger.Debug("[RoutingEngine] No routing rule matched, using default routing")
 	return nil, nil
+}
+
+// selectWeightedTarget picks one target from the slice using weighted random selection.
+// Each target's Weight contributes proportionally to its probability of being chosen.
+// Weights do not need to be normalised to 100; the function normalises internally.
+// If the slice is empty, a zero-value target is returned (caller uses incoming provider/model).
+func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) configstoreTables.TableRoutingTarget {
+	if len(targets) == 0 {
+		return configstoreTables.TableRoutingTarget{}
+	}
+	if len(targets) == 1 {
+		return targets[0]
+	}
+
+	total := 0.0
+	for _, t := range targets {
+		total += t.Weight
+	}
+
+	r := rand.Float64() * total
+	cumulative := 0.0
+	for _, t := range targets {
+		cumulative += t.Weight
+		if r < cumulative {
+			return t
+		}
+	}
+	return targets[len(targets)-1]
 }
 
 // buildScopeChain builds the scope evaluation chain based on organizational hierarchy

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -236,11 +236,12 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 
 	// Store the rule
@@ -279,11 +280,12 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Model:         "gpt-4o",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(globalRule))
 
@@ -292,12 +294,13 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 		ID:            "2",
 		Name:          "VK Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "virtual_key",
-		ScopeID:       bifrost.Ptr("vk-123"),
-		Priority:      10,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "virtual_key",
+		ScopeID:  bifrost.Ptr("vk-123"),
+		Priority: 10,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(vkRule))
 
@@ -341,11 +344,12 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 		ID:            "1",
 		Name:          "Low Priority",
 		CelExpression: "true",
-		Provider:      "openai",
-		Model:         "gpt-4o",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      10,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 10,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule1))
 
@@ -354,11 +358,12 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 		ID:            "2",
 		Name:          "High Priority",
 		CelExpression: "true",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule2))
 
@@ -388,11 +393,12 @@ func TestResolveRoutingWithFallback_RuleMatches(t *testing.T) {
 		ID:            "1",
 		Name:          "Test Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -453,11 +459,12 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 		ID:            "1",
 		Name:          "Disabled Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       false,
-		Scope:         "global",
-		Priority:      10,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  false,
+		Scope:    "global",
+		Priority: 10,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(disabledRule))
 
@@ -466,11 +473,12 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 		ID:            "2",
 		Name:          "Enabled Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Model:         "gpt-4o",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(enabledRule))
 
@@ -502,11 +510,12 @@ func TestEvaluateRoutingRules_ComplexExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Complex Rule",
 		CelExpression: "model == 'gpt-4o' && headers['x-tier'] == 'premium'",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -545,11 +554,12 @@ func TestEvaluateRoutingRules_NilVirtualKey(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		CelExpression: "true",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -581,11 +591,12 @@ func TestEvaluateRoutingRules_MissingHeaderGracefully(t *testing.T) {
 		ID:            "1",
 		Name:          "Header Check Rule",
 		CelExpression: "headers[\"x-custom-header\"] == \"premium\"",
-		Provider:      "azure",
-		Model:         "gpt-4-turbo",
-		Enabled:       true,
-		Scope:         "global",
-		Priority:      0,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 100},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
 	}
 	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
 
@@ -621,8 +632,10 @@ func TestCompileAndCacheProgram_ValidExpression_Routing(t *testing.T) {
 		ID:            "1",
 		Name:          "Test Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -646,8 +659,10 @@ func TestCompileAndCacheProgram_EmptyExpression_Routing(t *testing.T) {
 		ID:            "1",
 		Name:          "Default Rule",
 		CelExpression: "",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -666,8 +681,10 @@ func TestCompileAndCacheProgram_InvalidExpression_Routing(t *testing.T) {
 		ID:            "1",
 		Name:          "Invalid Rule",
 		CelExpression: "model == gpt-4o'", // Missing opening quote
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	_, err = store.GetRoutingProgram(rule)
@@ -697,8 +714,10 @@ func TestCompileAndCacheProgram_ListExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "List Rule",
 		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -717,8 +736,10 @@ func TestCompileAndCacheProgram_RegexExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Regex Rule",
 		CelExpression: "model.matches('^gpt-4.*')",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -737,8 +758,10 @@ func TestCompileAndCacheProgram_HeaderExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Header Rule",
 		CelExpression: "headers['x-tier'] == 'premium'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -757,8 +780,10 @@ func TestCompileAndCacheProgram_RateLimitExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Rate Limit Rule",
 		CelExpression: "tokens_used >= 80.0",
-		Provider:      "azure",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -777,8 +802,10 @@ func TestCompileAndCacheProgram_BudgetExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Budget Rule",
 		CelExpression: "budget_used < 100.0",
-		Provider:      "azure",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -797,8 +824,10 @@ func TestCompileAndCacheProgram_ComplexExpression(t *testing.T) {
 		ID:            "1",
 		Name:          "Complex Rule",
 		CelExpression: "model == 'gpt-4o' && team_name == 'premium' && tokens_used >= 80.0",
-		Provider:      "azure",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -850,8 +879,10 @@ func TestEvaluateCELExpression_TrueResult(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -879,8 +910,10 @@ func TestEvaluateCELExpression_FalseResult(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -908,8 +941,10 @@ func TestEvaluateCELExpression_ListMembership(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)
@@ -944,8 +979,10 @@ func TestEvaluateCELExpression_HeaderAccess(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:            "1",
 		CelExpression: "headers['x-tier'] == 'premium'",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -353,13 +354,14 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 
 	// Create a global routing rule
 	rule1 := &configstoreTables.TableRoutingRule{
-		ID:              "1",
-		Name:            "Global Rule",
-		Description:     "Test global routing rule",
-		Enabled:         true,
-		CelExpression:   "model == 'gpt-4o'",
-		Provider:        "openai",
-		Model:           "gpt-4",
+		ID:            "1",
+		Name:          "Global Rule",
+		Description:   "Test global routing rule",
+		Enabled:       true,
+		CelExpression: "model == 'gpt-4o'",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4"), Weight: 100},
+		},
 		Fallbacks:       nil,
 		ParsedFallbacks: []string{"azure/gpt-4-turbo"},
 		Scope:           "global",
@@ -372,13 +374,14 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 	// Create a team-scoped routing rule
 	teamID := "team-123"
 	rule2 := &configstoreTables.TableRoutingRule{
-		ID:              "2",
-		Name:            "Team Rule",
-		Description:     "Test team routing rule",
-		Enabled:         true,
-		CelExpression:   "model in ['gpt-4o', 'gpt-4-turbo']",
-		Provider:        "azure",
-		Model:           "",
+		ID:            "2",
+		Name:          "Team Rule",
+		Description:   "Test team routing rule",
+		Enabled:       true,
+		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("azure"), Weight: 100},
+		},
 		Fallbacks:       nil,
 		ParsedFallbacks: []string{"groq/mixtral-8x7b"},
 		Scope:           "team",
@@ -647,8 +650,10 @@ func TestCompileAndCacheProgram(t *testing.T) {
 		ID:            "rule-1",
 		Name:          "Test Rule",
 		CelExpression: "model == 'gpt-4o' && tokens_used < 80.0",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	// First compilation
@@ -675,8 +680,10 @@ func TestCompileAndCacheProgram_InvalidExpression(t *testing.T) {
 		ID:            "rule-invalid",
 		Name:          "Invalid Rule",
 		CelExpression: "model == gpt-4o'", // Syntax error
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	_, err = store.GetRoutingProgram(rule)
@@ -697,9 +704,11 @@ func TestCompileAndCacheProgram_CacheInvalidation(t *testing.T) {
 		ID:            "rule-update",
 		Name:          "Update Rule",
 		CelExpression: "model == 'gpt-4o'",
-		Provider:      "openai",
-		Enabled:       true,
-		Scope:         "global",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
+		Scope:   "global",
 	}
 
 	// Compile and cache
@@ -728,9 +737,11 @@ func TestCompileAndCacheProgram_CacheInvalidationOnDelete(t *testing.T) {
 		ID:            "rule-delete",
 		Name:          "Delete Rule",
 		CelExpression: "provider == 'openai'",
-		Provider:      "openai",
-		Enabled:       true,
-		Scope:         "global",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
+		Scope:   "global",
 	}
 
 	// Compile and cache
@@ -754,8 +765,10 @@ func TestCompileAndCacheProgram_EmptyExpression(t *testing.T) {
 		ID:            "rule-empty",
 		Name:          "Empty Rule",
 		CelExpression: "",
-		Provider:      "openai",
-		Enabled:       true,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openai")},
+		},
+		Enabled: true,
 	}
 
 	program, err := store.GetRoutingProgram(rule)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -120,36 +121,42 @@ type UpdateBudgetRequest struct {
 	ResetDuration *string  `json:"reset_duration,omitempty"`
 }
 
+// RoutingTarget represents a single weighted routing target within a rule.
+// All fields except Weight are optional; nil means "use the incoming request's value".
+// Weights across all targets in a rule must sum to 1 (e.g. 0.7 + 0.3 = 1.0).
+type RoutingTarget struct {
+	Provider *string `json:"provider,omitempty"` // nil = use incoming provider
+	Model    *string `json:"model,omitempty"`    // nil = use incoming model
+	KeyID    *string `json:"key_id,omitempty"`   // nil = no key pin
+	Weight   float64 `json:"weight"`             // must be > 0; all weights must sum to 1
+}
+
 // CreateRoutingRuleRequest represents the request body for creating a routing rule
 type CreateRoutingRuleRequest struct {
-	Name          string         `json:"name" validate:"required"`
-	Description   string         `json:"description,omitempty"`
-	Enabled       bool           `json:"enabled,omitempty"`
-	CelExpression string         `json:"cel_expression"`
-	Provider      string         `json:"provider,omitempty"` // Optional; empty uses incoming request provider
-	Model         string         `json:"model,omitempty"`    // Optional; empty uses incoming request model
-	KeyID         string         `json:"key_id,omitempty"`   // Optional; pins a specific API key by UUID
-	Fallbacks     []string       `json:"fallbacks,omitempty"`
-	Scope         string         `json:"scope,omitempty"` // Defaults to "global" if not provided
-	ScopeID       *string        `json:"scope_id,omitempty"`
-	Query         map[string]any `json:"query,omitempty"`
-	Priority      int            `json:"priority,omitempty"` // Defaults to 0 if not provided
+	Name          string          `json:"name" validate:"required"`
+	Description   string          `json:"description,omitempty"`
+	Enabled       bool            `json:"enabled,omitempty"`
+	CelExpression string          `json:"cel_expression"`
+	Targets       []RoutingTarget `json:"targets"` // Required; weights must sum to 1
+	Fallbacks     []string        `json:"fallbacks,omitempty"`
+	Scope         string          `json:"scope,omitempty"` // Defaults to "global" if not provided
+	ScopeID       *string         `json:"scope_id,omitempty"`
+	Query         map[string]any  `json:"query,omitempty"`
+	Priority      int             `json:"priority,omitempty"` // Defaults to 0 if not provided
 }
 
 // UpdateRoutingRuleRequest represents the request body for updating a routing rule
 type UpdateRoutingRuleRequest struct {
-	Name          *string        `json:"name,omitempty"`
-	Description   *string        `json:"description,omitempty"`
-	Enabled       *bool          `json:"enabled,omitempty"`
-	CelExpression *string        `json:"cel_expression,omitempty"`
-	Provider      *string        `json:"provider,omitempty"`
-	Model         *string        `json:"model,omitempty"`
-	KeyID         *string        `json:"key_id,omitempty"` // Optional; pins a specific API key by UUID; send "" to clear
-	Fallbacks     []string       `json:"fallbacks,omitempty"`
-	Query         map[string]any `json:"query,omitempty"`
-	Priority      *int           `json:"priority,omitempty"`
-	Scope         *string        `json:"scope,omitempty"`
-	ScopeID       *string        `json:"scope_id,omitempty"`
+	Name          *string         `json:"name,omitempty"`
+	Description   *string         `json:"description,omitempty"`
+	Enabled       *bool           `json:"enabled,omitempty"`
+	CelExpression *string         `json:"cel_expression,omitempty"`
+	Targets       []RoutingTarget `json:"targets,omitempty"` // If provided, replaces all existing targets; weights must sum to 1
+	Fallbacks     []string        `json:"fallbacks,omitempty"`
+	Query         map[string]any  `json:"query,omitempty"`
+	Priority      *int            `json:"priority,omitempty"`
+	Scope         *string         `json:"scope,omitempty"`
+	ScopeID       *string         `json:"scope_id,omitempty"`
 }
 
 // CreateRateLimitRequest represents the request body for creating a rate limit using flexible approach
@@ -2644,6 +2651,16 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Validate targets
+	if len(req.Targets) == 0 {
+		SendError(ctx, 400, "at least one target is required")
+		return
+	}
+	if err := validateRoutingTargets(req.Targets); err != nil {
+		SendError(ctx, 400, err.Error())
+		return
+	}
+
 	// Set defaults
 	scope := req.Scope
 	if scope == "" {
@@ -2656,29 +2673,29 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	priority := req.Priority
-	if priority == 0 && req.Priority == 0 { // Default to 0
-		priority = 0
-	}
-
-	var keyID *string
-	if req.KeyID != "" {
-		keyID = &req.KeyID
+	// Build targets
+	ruleID := uuid.NewString()
+	targets := make([]configstoreTables.TableRoutingTarget, 0, len(req.Targets))
+	for _, t := range req.Targets {
+		targets = append(targets, configstoreTables.TableRoutingTarget{
+			Provider: t.Provider,
+			Model:    t.Model,
+			KeyID:    t.KeyID,
+			Weight:   t.Weight,
+		})
 	}
 
 	// Create routing rule
 	rule := &configstoreTables.TableRoutingRule{
-		ID:              uuid.NewString(),
+		ID:              ruleID,
 		Name:            req.Name,
 		Description:     req.Description,
 		Enabled:         req.Enabled,
 		CelExpression:   req.CelExpression,
-		Provider:        req.Provider,
-		Model:           req.Model,
-		KeyID:           keyID,
+		Targets:         targets,
 		Scope:           scope,
 		ScopeID:         req.ScopeID,
-		Priority:        priority,
+		Priority:        req.Priority,
 		ParsedFallbacks: req.Fallbacks,
 		ParsedQuery:     req.Query,
 	}
@@ -2736,18 +2753,21 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 	if req.CelExpression != nil {
 		rule.CelExpression = *req.CelExpression
 	}
-	if req.Provider != nil {
-		rule.Provider = *req.Provider
-	}
-	if req.Model != nil {
-		rule.Model = *req.Model
-	}
-	if req.KeyID != nil {
-		if *req.KeyID == "" {
-			rule.KeyID = nil
-		} else {
-			rule.KeyID = req.KeyID
+	if len(req.Targets) > 0 {
+		if err := validateRoutingTargets(req.Targets); err != nil {
+			SendError(ctx, 400, err.Error())
+			return
 		}
+		newTargets := make([]configstoreTables.TableRoutingTarget, 0, len(req.Targets))
+		for _, t := range req.Targets {
+			newTargets = append(newTargets, configstoreTables.TableRoutingTarget{
+				Provider: t.Provider,
+				Model:    t.Model,
+				KeyID:    t.KeyID,
+				Weight:   t.Weight,
+			})
+		}
+		rule.Targets = newTargets
 	}
 	if req.Priority != nil {
 		rule.Priority = *req.Priority
@@ -2813,4 +2833,19 @@ func (h *GovernanceHandler) deleteRoutingRule(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Routing rule deleted successfully",
 	})
+}
+
+// validateRoutingTargets checks that all weights are positive and sum to 1.
+func validateRoutingTargets(targets []RoutingTarget) error {
+	total := 0.0
+	for _, t := range targets {
+		if t.Weight <= 0 {
+			return fmt.Errorf("each target weight must be greater than 0")
+		}
+		total += t.Weight
+	}
+	if math.Abs(total-1.0) > 0.001 {
+		return fmt.Errorf("target weights must sum to 1, got %.4f", total)
+	}
+	return nil
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,4 +1,5 @@
 - feat: adds option to select specific API key for routing rules
+- feat: adds support for multiple weighted routing targets for probabilistic routing
 - fix: preserve original audio filename in transcription requests
 - fix: async jobs stuck in "processing" on marshal failure now correctly transition to "failed"
 - feat: adds attachment support in Maxim plugin

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -22,8 +22,15 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
-import { X, Save, AlertCircle, Plus, Trash2 } from "lucide-react";
-import { RoutingRule, RoutingRuleFormData, DEFAULT_ROUTING_RULE_FORM_DATA, ROUTING_RULE_SCOPES } from "@/lib/types/routingRules";
+import { X, Save, Plus, Trash2 } from "lucide-react";
+import {
+	RoutingRule,
+	RoutingRuleFormData,
+	RoutingTargetFormData,
+	DEFAULT_ROUTING_RULE_FORM_DATA,
+	DEFAULT_ROUTING_TARGET,
+	ROUTING_RULE_SCOPES,
+} from "@/lib/types/routingRules";
 import {
 	useCreateRoutingRuleMutation,
 	useUpdateRoutingRuleMutation,
@@ -83,7 +90,8 @@ export function RoutingRuleSheet({
 	const [createRoutingRule, { isLoading: isCreating }] = useCreateRoutingRuleMutation();
 	const [updateRoutingRule, { isLoading: isUpdating }] = useUpdateRoutingRuleMutation();
 
-	// State to track the query structure for the rule builder
+	// State for targets and query (managed outside react-hook-form for complex nested structures)
+	const [targets, setTargets] = useState<RoutingTargetFormData[]>([{ ...DEFAULT_ROUTING_TARGET }]);
 	const [query, setQuery] = useState<RuleGroupType>(defaultQuery);
 	const [builderKey, setBuilderKey] = useState(0);
 
@@ -103,25 +111,14 @@ export function RoutingRuleSheet({
 	const enabled = watch("enabled");
 	const scope = watch("scope");
 	const scopeId = watch("scope_id");
-	const provider = watch("provider");
-	const model = watch("model");
-	const keyId = watch("key_id");
 	const fallbacks = watch("fallbacks");
 
-	// Get available providers from configured providers, fallback to providers in rules
+	// Get available providers from configured providers
 	const availableProviders = providersData.length > 0
 		? providersData.map((p) => p.name)
 		: Array.from(
-			new Set([...rules.map((r) => r.provider).filter((p) => p !== "")]),
-		);
-
-	// Get keys for the selected provider
-	const availableKeys = provider
-		? (providersData.find((p) => p.name === provider)?.keys ?? [])
-		: [];
-	const availableModels = Array.from(
-		new Set([...rules.map((r) => r.model).filter((m) => m !== "" && m !== undefined)]),
-	) as string[];
+			new Set(rules.flatMap((r) => r.targets?.map((t) => t.provider).filter(Boolean) ?? []))
+		) as string[];
 
 	// Initialize form data when editing rule changes
 	useEffect(() => {
@@ -130,14 +127,22 @@ export function RoutingRuleSheet({
 			setValue("name", editingRule.name);
 			setValue("description", editingRule.description);
 			setValue("cel_expression", editingRule.cel_expression);
-			setValue("provider", editingRule.provider);
-			setValue("model", editingRule.model || "");
-			setValue("key_id", editingRule.key_id || "");
 			setValue("fallbacks", editingRule.fallbacks || []);
 			setValue("scope", editingRule.scope);
 			setValue("scope_id", editingRule.scope_id || "");
 			setValue("priority", editingRule.priority);
 			setValue("enabled", editingRule.enabled);
+			// Restore targets
+			if (editingRule.targets && editingRule.targets.length > 0) {
+				setTargets(editingRule.targets.map((t) => ({
+					provider: t.provider || "",
+					model: t.model || "",
+					key_id: t.key_id || "",
+					weight: t.weight,
+				})));
+			} else {
+				setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
+			}
 			// Restore the query object if it exists, otherwise use default
 			if (editingRule.query) {
 				setQuery(editingRule.query);
@@ -147,6 +152,7 @@ export function RoutingRuleSheet({
 			setBuilderKey((prev) => prev + 1);
 		} else {
 			reset();
+			setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 			setQuery(defaultQuery);
 			setBuilderKey((prev) => prev + 1);
 		}
@@ -160,6 +166,21 @@ export function RoutingRuleSheet({
 		[setValue],
 	);
 
+	const addTarget = () => {
+		const remaining = 1 - targets.reduce((sum, t) => sum + (t.weight || 0), 0);
+		setTargets((prev) => [...prev, { ...DEFAULT_ROUTING_TARGET, weight: Math.max(0, parseFloat(remaining.toFixed(4))) }]);
+	};
+
+	const removeTarget = (index: number) => {
+		setTargets((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const updateTarget = (index: number, field: keyof RoutingTargetFormData, value: string | number) => {
+		setTargets((prev) => prev.map((t, i) => i === index ? { ...t, [field]: value } : t));
+	};
+
+	const totalWeight = targets.reduce((sum, t) => sum + (t.weight || 0), 0);
+
 	const onSubmit = (data: RoutingRuleFormData) => {
 		// Validate scope_id is required when scope is not global
 		if (data.scope !== "global" && !data.scope_id?.trim()) {
@@ -167,19 +188,33 @@ export function RoutingRuleSheet({
 			return;
 		}
 
+		// Validate targets
+		if (targets.length === 0) {
+			toast.error("At least one routing target is required");
+			return;
+		}
+		for (const t of targets) {
+			if (t.weight <= 0) {
+				toast.error("Each target weight must be greater than 0");
+				return;
+			}
+		}
+		if (Math.abs(totalWeight - 1) > 0.001) {
+			toast.error(`Target weights must sum to 1, current total: ${totalWeight.toFixed(4)}`);
+			return;
+		}
+
 		// Validate regex patterns in routing rules
 		const regexErrors = validateRoutingRules(query);
 		if (regexErrors.length > 0) {
-			const errorMessage = regexErrors.join("\n");
-			toast.error(`Invalid regex pattern:\n${errorMessage}`);
+			toast.error(`Invalid regex pattern:\n${regexErrors.join("\n")}`);
 			return;
 		}
 
 		// Validate rate limit and budget rules
 		const rateLimitErrors = validateRateLimitAndBudgetRules(query);
 		if (rateLimitErrors.length > 0) {
-			const errorMessage = rateLimitErrors.join("\n");
-			toast.error(`Invalid rule configuration:\n${errorMessage}`);
+			toast.error(`Invalid rule configuration:\n${rateLimitErrors.join("\n")}`);
 			return;
 		}
 
@@ -193,9 +228,12 @@ export function RoutingRuleSheet({
 			name: data.name,
 			description: data.description,
 			cel_expression: data.cel_expression,
-			provider: data.provider,
-			model: data.model,
-			key_id: data.key_id || undefined,
+			targets: targets.map((t) => ({
+				provider: t.provider || undefined,
+				model: t.model || undefined,
+				key_id: t.key_id || undefined,
+				weight: t.weight,
+			})),
 			fallbacks: validFallbacks,
 			scope: data.scope,
 			scope_id: data.scope === "global" ? undefined : (data.scope_id || undefined),
@@ -219,6 +257,7 @@ export function RoutingRuleSheet({
 						: "Routing rule created successfully",
 				);
 				reset();
+				setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 				setQuery(defaultQuery);
 				setBuilderKey((prev) => prev + 1);
 				onOpenChange(false);
@@ -231,6 +270,7 @@ export function RoutingRuleSheet({
 
 	const handleCancel = () => {
 		reset();
+		setTargets([{ ...DEFAULT_ROUTING_TARGET }]);
 		setQuery(defaultQuery);
 		setBuilderKey((prev) => prev + 1);
 		onOpenChange(false);
@@ -400,7 +440,7 @@ export function RoutingRuleSheet({
 							initialQuery={query}
 							onChange={handleQueryChange}
 							providers={availableProviders}
-							models={availableModels}
+							models={[]}
 							allowCustomModels={true}
 						/>
 					</div>
@@ -412,117 +452,50 @@ export function RoutingRuleSheet({
 
 					<Separator />
 
-					{/* Routing Target */}
+					{/* Routing Targets */}
 					<div className="space-y-3">
-						<Label>Routing Target</Label>
-						<p className="text-muted-foreground text-xs">Leave provider or model empty to use the incoming request value</p>
-						<div className="grid grid-cols-2 gap-4">
-							<div className="space-y-2">
-								<Label htmlFor="provider" className="text-sm">
-									Provider
-								</Label>
-								<div className="flex gap-2">
-									<Select value={provider} onValueChange={(value) => { setValue("provider", value); setValue("key_id", ""); }}>
-										<SelectTrigger className="flex-1">
-											<SelectValue placeholder="Select provider (optional)" />
-										</SelectTrigger>
-										<SelectContent>
-											{availableProviders.map((provider) => (
-												<SelectItem key={provider} value={provider}>
-													<div className="flex items-center gap-2">
-														<RenderProviderIcon
-															provider={provider as ProviderIconType}
-															size="sm"
-															className="h-4 w-4"
-														/>
-														<span>{getProviderLabel(provider)}</span>
-													</div>
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									{provider && (
-										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											onClick={() => { setValue("provider", ""); setValue("key_id", ""); }}
-											className="h-9 px-2"
-											title="Clear provider selection"
-										>
-											<X className="h-4 w-4" />
-										</Button>
-									)}
-								</div>
-								{errors.provider && <p className="text-destructive text-sm">{errors.provider.message}</p>}
+						<div className="flex items-center justify-between">
+							<div>
+								<Label>Routing Targets</Label>
+								<p className="text-muted-foreground text-xs mt-0.5">
+									Weights must sum to 1. Leave provider or model empty to use the incoming request value.
+								</p>
 							</div>
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={addTarget}
+								className="gap-2 shrink-0"
+							>
+								<Plus className="h-4 w-4" />
+								Add Target
+							</Button>
+						</div>
 
-							<div className="space-y-2">
-								<Label htmlFor="model" className="text-sm">
-									Model
-								</Label>
-								<div className="flex gap-2">
-									<div className="flex-1">
-										<ModelMultiselect
-											provider={provider || undefined}
-											value={model}
-											onChange={(value) => setValue("model", value)}
-											placeholder="Search for a model... (optional)"
-											isSingleSelect
-											loadModelsOnEmptyProvider
-										/>
-									</div>
-									{model && (
-										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											onClick={() => setValue("model", "")}
-											className="h-9 px-2"
-											title="Clear model selection"
-										>
-											<X className="h-4 w-4" />
-										</Button>
-									)}
-								</div>
-								{errors.model && <p className="text-destructive text-sm">{errors.model.message}</p>}
-							</div>
+						<div className="space-y-3">
+							{targets.map((target, index) => (
+								<TargetRow
+									key={index}
+									target={target}
+									index={index}
+									availableProviders={availableProviders}
+									providersData={providersData}
+									showRemove={targets.length > 1}
+									onUpdate={updateTarget}
+									onRemove={removeTarget}
+								/>
+							))}
+						</div>
+
+						{/* Weight sum indicator */}
+						<div className={`flex items-center justify-end gap-2 text-xs font-medium ${Math.abs(totalWeight - 1) > 0.001 ? "text-destructive" : "text-muted-foreground"}`}>
+							Total weight: {totalWeight.toFixed(4)}
+							{Math.abs(totalWeight - 1) > 0.001 && (
+								<span className="text-destructive">(must equal 1)</span>
+							)}
 						</div>
 					</div>
-
-					{/* Key Selector - only shown when a provider is selected */}
-					{provider && availableKeys.length > 0 && (
-						<div className="space-y-2">
-							<Label className="text-sm">API Key</Label>
-							<p className="text-muted-foreground text-xs">Pin a specific key for this provider. Leave unset to use load-balanced key selection.</p>
-							<div className="flex gap-2">
-								<Select value={keyId || ""} onValueChange={(value) => setValue("key_id", value)}>
-									<SelectTrigger className="flex-1">
-										<SelectValue placeholder="Select key (optional)" />
-									</SelectTrigger>
-									<SelectContent>
-										{availableKeys.map((key) => (
-											<SelectItem key={key.id} value={key.id}>
-												{key.name}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-								{keyId && (
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										onClick={() => setValue("key_id", "")}
-										className="h-9 px-2"
-										title="Clear key selection"
-									>
-										<X className="h-4 w-4" />
-									</Button>
-								)}
-							</div>
-						</div>
-					)}
 
 					{/* Fallbacks */}
 					<div className="space-y-3">
@@ -635,5 +608,157 @@ export function RoutingRuleSheet({
 				</form>
 			</SheetContent>
 		</Sheet>
+	);
+}
+
+interface TargetRowProps {
+	target: RoutingTargetFormData;
+	index: number;
+	availableProviders: string[];
+	providersData: Array<{ name: string; keys: Array<{ id: string; name: string }> }>;
+	showRemove: boolean;
+	onUpdate: (index: number, field: keyof RoutingTargetFormData, value: string | number) => void;
+	onRemove: (index: number) => void;
+}
+
+function TargetRow({ target, index, availableProviders, providersData, showRemove, onUpdate, onRemove }: TargetRowProps) {
+	const availableKeys = target.provider
+		? (providersData.find((p) => p.name === target.provider)?.keys ?? [])
+		: [];
+
+	return (
+		<div className="rounded-lg border p-3 space-y-3">
+			<div className="flex items-center justify-between">
+				<span className="text-sm font-medium text-muted-foreground">Target {index + 1}</span>
+				<div className="flex items-center gap-2">
+					<div className="flex items-center gap-1.5">
+						<Label className="text-xs text-muted-foreground shrink-0">Weight (0–1)</Label>
+						<Input
+							type="number"
+							min={0.001}
+							max={1}
+							step={0.001}
+							value={target.weight}
+							onChange={(e) => onUpdate(index, "weight", parseFloat(e.target.value) || 0)}
+							className="h-8 w-24 text-sm"
+						/>
+					</div>
+					{showRemove && (
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={() => onRemove(index)}
+							className="h-8 w-8 p-0"
+						>
+							<Trash2 className="h-3.5 w-3.5" />
+						</Button>
+					)}
+				</div>
+			</div>
+
+			<div className="grid grid-cols-2 gap-3">
+				<div className="space-y-1.5">
+					<Label className="text-xs">Provider</Label>
+					<div className="flex gap-1.5">
+						<Select
+							value={target.provider}
+							onValueChange={(value) => {
+								onUpdate(index, "provider", value);
+								onUpdate(index, "key_id", "");
+							}}
+						>
+							<SelectTrigger className="flex-1 h-9 text-sm">
+								<SelectValue placeholder="Incoming (optional)" />
+							</SelectTrigger>
+							<SelectContent>
+								{availableProviders.map((prov) => (
+									<SelectItem key={prov} value={prov}>
+										<div className="flex items-center gap-2">
+											<RenderProviderIcon
+												provider={prov as ProviderIconType}
+												size="sm"
+												className="h-4 w-4"
+											/>
+											<span>{getProviderLabel(prov)}</span>
+										</div>
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						{target.provider && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => { onUpdate(index, "provider", ""); onUpdate(index, "key_id", ""); }}
+								className="h-9 w-9 p-0"
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						)}
+					</div>
+				</div>
+
+				<div className="space-y-1.5">
+					<Label className="text-xs">Model</Label>
+					<div className="flex gap-1.5">
+						<div className="flex-1">
+							<ModelMultiselect
+								provider={target.provider || undefined}
+								value={target.model}
+								onChange={(value) => onUpdate(index, "model", value)}
+								placeholder="Incoming (optional)"
+								isSingleSelect
+								loadModelsOnEmptyProvider
+								className="!h-9 !min-h-9"
+							/>
+						</div>
+						{target.model && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => onUpdate(index, "model", "")}
+								className="h-9 w-9 p-0"
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						)}
+					</div>
+				</div>
+			</div>
+
+			{target.provider && availableKeys.length > 0 && (
+				<div className="space-y-1.5">
+					<Label className="text-xs">API Key <span className="text-muted-foreground">(optional — leave unset for load-balanced selection)</span></Label>
+					<div className="flex gap-1.5">
+						<Select value={target.key_id || ""} onValueChange={(value) => onUpdate(index, "key_id", value)}>
+							<SelectTrigger className="flex-1 h-9 text-sm">
+								<SelectValue placeholder="Select key (optional)" />
+							</SelectTrigger>
+							<SelectContent>
+								{availableKeys.map((key) => (
+									<SelectItem key={key.id} value={key.id}>
+										{key.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						{target.key_id && (
+							<Button
+								type="button"
+								variant="outline"
+								size="sm"
+								onClick={() => onUpdate(index, "key_id", "")}
+								className="h-9 w-9 p-0"
+							>
+								<X className="h-3.5 w-3.5" />
+							</Button>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
 	);
 }

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -34,6 +34,7 @@ import { toast } from "sonner";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage } from "@/lib/store";
+import { RoutingTarget } from "@/lib/types/routingRules";
 
 interface RoutingRulesTableProps {
 	rules: RoutingRule[] | undefined;
@@ -66,8 +67,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 					<TableHeader>
 						<TableRow>
 							<TableHead>Name</TableHead>
-							<TableHead>Provider</TableHead>
-							<TableHead>Model</TableHead>
+							<TableHead>Targets</TableHead>
 							<TableHead>Scope</TableHead>
 							<TableHead className="text-right">Priority</TableHead>
 							<TableHead>Expression</TableHead>
@@ -78,7 +78,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 					<TableBody>
 						{[...Array(5)].map((_, i) => (
 							<TableRow key={i}>
-								<TableCell colSpan={8} className="h-10">
+								<TableCell colSpan={7} className="h-10">
 									<div className="h-2 w-32 bg-muted rounded animate-pulse" />
 								</TableCell>
 							</TableRow>
@@ -109,8 +109,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 					<TableHeader>
 						<TableRow className="bg-muted/50">
 							<TableHead className="font-semibold">Name</TableHead>
-							<TableHead className="font-semibold">Provider</TableHead>
-							<TableHead className="font-semibold">Model</TableHead>
+							<TableHead className="font-semibold">Targets</TableHead>
 							<TableHead className="font-semibold">Scope</TableHead>
 							<TableHead className="text-right font-semibold">Priority</TableHead>
 							<TableHead className="font-semibold">Expression</TableHead>
@@ -130,17 +129,7 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 									</div>
 								</TableCell>
 								<TableCell>
-									<div className="flex items-center gap-2">
-										<RenderProviderIcon
-											provider={rule.provider as ProviderIconType}
-											size="sm"
-											className="h-4 w-4"
-										/>
-										<span className="text-sm">{getProviderLabel(rule.provider || "-")}</span>
-									</div>
-								</TableCell>
-								<TableCell className="text-sm">
-									<span className="font-mono">{rule.model || "-"}</span>
+									<TargetsSummary targets={rule.targets || []} />
 								</TableCell>
 								<TableCell>
 									<Badge variant="secondary">{getScopeLabel(rule.scope)}</Badge>
@@ -200,5 +189,38 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 				</AlertDialogContent>
 			</AlertDialog>
 		</>
+	);
+}
+
+function TargetsSummary({ targets }: { targets: RoutingTarget[] }) {
+	if (!targets || targets.length === 0) {
+		return <span className="text-muted-foreground text-sm">-</span>;
+	}
+
+	const first = targets[0];
+	const label = [
+		first.provider ? getProviderLabel(first.provider) : "Any",
+		first.model || "Any model",
+	].join(" / ");
+
+	return (
+		<div className="flex flex-col gap-1">
+			<div className="flex items-center gap-1.5">
+				{first.provider && (
+					<RenderProviderIcon
+						provider={first.provider as ProviderIconType}
+						size="sm"
+						className="h-4 w-4 shrink-0"
+					/>
+				)}
+				<span className="text-sm truncate max-w-[160px]">{label}</span>
+				{targets.length === 1 && (
+					<span className="text-xs text-muted-foreground shrink-0">{first.weight}</span>
+				)}
+			</div>
+			{targets.length > 1 && (
+				<span className="text-xs text-muted-foreground">+{targets.length - 1} more target{targets.length > 2 ? "s" : ""} (probabilistic)</span>
+			)}
+		</div>
 	);
 }

--- a/ui/lib/types/routingRules.ts
+++ b/ui/lib/types/routingRules.ts
@@ -5,14 +5,19 @@
 
 import { RuleGroupType } from "react-querybuilder";
 
+export interface RoutingTarget {
+	provider?: string;
+	model?: string;
+	key_id?: string;
+	weight: number;
+}
+
 export interface RoutingRule {
 	id: string;
 	name: string;
 	description: string;
 	cel_expression: string;
-	provider: string;
-	model?: string;
-	key_id?: string;
+	targets: RoutingTarget[];
 	fallbacks?: string[];
 	scope: "global" | "team" | "customer" | "virtual_key";
 	scope_id?: string;
@@ -27,9 +32,7 @@ export interface CreateRoutingRuleRequest {
 	name: string;
 	description?: string;
 	cel_expression?: string;
-	provider?: string;
-	model?: string;
-	key_id?: string;
+	targets: RoutingTarget[];
 	fallbacks?: string[];
 	scope: string;
 	scope_id?: string;
@@ -50,14 +53,18 @@ export interface GetRoutingRuleResponse {
 	rule: RoutingRule;
 }
 
+export interface RoutingTargetFormData {
+	provider: string;
+	model: string;
+	key_id: string;
+	weight: number;
+}
+
 export interface RoutingRuleFormData {
 	id?: string;
 	name: string;
 	description: string;
 	cel_expression: string;
-	provider: string;
-	model: string;
-	key_id: string;
 	fallbacks: string[];
 	scope: string;
 	scope_id: string;
@@ -81,13 +88,17 @@ export const ROUTING_RULE_SCOPES = [
 	{ value: RoutingRuleScope.VirtualKey, label: "Virtual Key" },
 ];
 
+export const DEFAULT_ROUTING_TARGET: RoutingTargetFormData = {
+	provider: "",
+	model: "",
+	key_id: "",
+	weight: 1,
+};
+
 export const DEFAULT_ROUTING_RULE_FORM_DATA: RoutingRuleFormData = {
 	name: "",
 	description: "",
 	cel_expression: "",
-	provider: "",
-	model: "",
-	key_id: "",
 	fallbacks: [],
 	scope: RoutingRuleScope.Global,
 	scope_id: "",


### PR DESCRIPTION
## Summary

Adds support for multiple weighted routing targets to routing rules, enabling probabilistic routing where requests can be distributed across multiple providers/models based on configurable weights. This replaces the previous single-target approach with a more flexible system that supports A/B testing, canary deployments, and cost optimization strategies.

## Changes

- **Database schema**: Added `routing_targets` table with 1:many relationship to `routing_rules`; migrated existing single-target rules to the new table with `weight=1.0`; removed legacy `provider`, `model`, `key_id` columns from `routing_rules`
- **API changes**: Updated routing rule endpoints to accept `targets` array instead of single `provider`/`model`/`key_id` fields; added weight validation requiring targets to sum to 1
- **Routing engine**: Implemented probabilistic target selection using weighted random selection when multiple targets are defined
- **UI updates**: Redesigned routing rule form to support multiple targets with weight configuration, visual weight sum validation, and improved target management
- **Documentation**: Updated all examples and API documentation to reflect the new multi-target structure

Key design decisions:
- Weights must sum to 1.0 for validation clarity and probabilistic accuracy
- Migration preserves existing single-target rules by creating one target with weight=1.0
- Empty provider/model fields continue to mean "use incoming request value"
- First-match-wins rule evaluation remains unchanged, only target selection within a matched rule is probabilistic

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

### Core/Transports
```sh
go version
go test ./...

# Test routing rule creation with multiple targets
curl -X POST http://localhost:8080/api/governance/routing-rules \
  -H "Content-Type: application/json" \
  -d '{
    "name": "A/B Test Rule",
    "cel_expression": "headers[\"x-tier\"] == \"premium\"",
    "targets": [
      { "provider": "openai", "model": "gpt-4o", "weight": 0.7 },
      { "provider": "azure", "model": "gpt-4o", "weight": 0.3 }
    ],
    "scope": "global"
  }'
```

### UI
```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

### Migration testing
Start with an existing database containing routing rules, then upgrade to verify:
- Existing rules are migrated to the new targets table
- Legacy columns are removed
- Rules continue to function with weight=1.0

### Probabilistic routing validation
Create a rule with multiple targets and send multiple requests to verify distribution matches configured weights.

## Screenshots/Recordings

The UI now shows a redesigned routing rule form with:
- Multiple target configuration with provider/model/key/weight fields
- Real-time weight sum validation
- Add/remove target buttons
- Compact target summary in the rules table showing "Provider / Model" with probabilistic indicator for multi-target rules

## Breaking changes

- [x] Yes
- [ ] No

**API Breaking Changes:**
- `POST /api/governance/routing-rules` now requires `targets` array instead of `provider`/`model`/`key_id` fields
- `PUT /api/governance/routing-rules/{id}` uses `targets` array for updates
- `GET /api/governance/routing-rules` response includes `targets` array instead of single target fields

**Migration Instructions:**
- Database migration runs automatically on startup, converting existing rules
- Update API clients to use `targets` array format
- Configuration files need to be updated to use the new structure:

```json
// Old format
{
  "provider": "openai",
  "model": "gpt-4o",
  "key_id": "uuid"
}

// New format  
{
  "targets": [
    {
      "provider": "openai",
      "model": "gpt-4o", 
      "key_id": "uuid",
      "weight": 1.0
    }
  ]
}
```

## Related issues

Enables advanced routing scenarios like A/B testing, canary deployments, and cost optimization through traffic splitting.

## Security considerations

- API key pinning moved to target level, maintaining same security model
- Weight validation prevents malformed rules that could cause routing failures
- Migration preserves existing key assignments

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable