### PR TITLE
fixed discord link

### DIFF
--- a/docs/contributing/adding-a-configstore.mdx
+++ b/docs/contributing/adding-a-configstore.mdx
@@ -69,4 +69,4 @@ Make sure to properly handle errors during:
 
 ## Getting Help
 
-If you need help, please reach out to the Bifrost team on [Discord](https://getmax.im/bifrost-discord).
+If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/WJzTeWDEsX).

--- a/docs/contributing/adding-a-configstore.mdx
+++ b/docs/contributing/adding-a-configstore.mdx
@@ -69,4 +69,4 @@ Make sure to properly handle errors during:
 
 ## Getting Help
 
-If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/WJzTeWDEsX).
+If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/exN5KAydbU).

--- a/docs/contributing/adding-a-logstore.mdx
+++ b/docs/contributing/adding-a-logstore.mdx
@@ -74,4 +74,4 @@ Make sure to properly handle errors during:
 
 ## Getting Help
 
-If you need help, please reach out to the Bifrost team on [Discord](https://getmax.im/bifrost-discord).
+If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/WJzTeWDEsX).

--- a/docs/contributing/adding-a-logstore.mdx
+++ b/docs/contributing/adding-a-logstore.mdx
@@ -74,4 +74,4 @@ Make sure to properly handle errors during:
 
 ## Getting Help
 
-If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/WJzTeWDEsX).
+If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/exN5KAydbU).

--- a/docs/contributing/adding-a-vectorstore.mdx
+++ b/docs/contributing/adding-a-vectorstore.mdx
@@ -111,4 +111,4 @@ Make sure to properly handle errors during:
 
 ## Getting Help
 
-If you need help, please reach out to the Bifrost team on [Discord](https://getmax.im/bifrost-discord).
+If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/WJzTeWDEsX).

--- a/docs/contributing/adding-a-vectorstore.mdx
+++ b/docs/contributing/adding-a-vectorstore.mdx
@@ -111,4 +111,4 @@ Make sure to properly handle errors during:
 
 ## Getting Help
 
-If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/WJzTeWDEsX).
+If you need help, please reach out to the Bifrost team on [Discord](https://discord.gg/exN5KAydbU).

--- a/docs/contributing/setting-up-repo.mdx
+++ b/docs/contributing/setting-up-repo.mdx
@@ -379,7 +379,7 @@ ls transports/bifrost-http/.air.toml
 - **Check logs**: Development logs appear in your terminal
 - **Verify prerequisites**: Ensure Go, Node.js, and make are properly installed
 - **Clean build**: Run `make clean` and try again
-- **Discord**: Join our [Discord community](https://discord.gg/bifrost) for real-time help
+- **Discord**: Join our [Discord community](https://discord.gg/exN5KAydbU) for real-time help
 
 ## Next Steps
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,7 @@
     "links": [
       {
         "label": "Discord",
-        "href": "https://discord.gg/WJzTeWDEsX",
+        "href": "https://discord.gg/exN5KAydbU",
         "icon": "discord"
       },
       {
@@ -43,7 +43,7 @@
         {
           "anchor": "Discord",
           "icon": "discord",
-          "href": "https://discord.gg/WJzTeWDEsX"
+          "href": "https://discord.gg/exN5KAydbU"
         },
         {
           "anchor": "Try Enterprise",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,7 +22,7 @@
     "links": [
       {
         "label": "Discord",
-        "href": "https://getmax.im/bifrost-discord",
+        "href": "https://discord.gg/WJzTeWDEsX",
         "icon": "discord"
       },
       {
@@ -43,7 +43,7 @@
         {
           "anchor": "Discord",
           "icon": "discord",
-          "href": "https://getmax.im/bifrost-discord"
+          "href": "https://discord.gg/WJzTeWDEsX"
         },
         {
           "anchor": "Try Enterprise",

--- a/docs/plugins/building-dynamic-binary.mdx
+++ b/docs/plugins/building-dynamic-binary.mdx
@@ -702,6 +702,6 @@ Now that you have a dynamically linked Bifrost binary:
 3. **[Example plugins](https://github.com/maximhq/bifrost/tree/main/examples/plugins)** - Study working examples
 
 <Note>
-For questions or issues with dynamic builds and plugins, visit our [GitHub Discussions](https://github.com/maximhq/bifrost/discussions) or [Discord community](https://discord.gg/bifrost).
+For questions or issues with dynamic builds and plugins, visit our [GitHub Discussions](https://github.com/maximhq/bifrost/discussions) or [Discord community](https://discord.gg/exN5KAydbU).
 </Note>
 

--- a/docs/plugins/migration-guide.mdx
+++ b/docs/plugins/migration-guide.mdx
@@ -458,7 +458,7 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 
 ## Need Help?
 
-- **Discord Community**: [Join our Discord](https://discord.gg/WJzTeWDEsX)
+- **Discord Community**: [Join our Discord](https://discord.gg/exN5KAydbU)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
 - **Writing Plugins Guide**: [Full plugin documentation](./writing-plugin)
 

--- a/docs/plugins/migration-guide.mdx
+++ b/docs/plugins/migration-guide.mdx
@@ -458,7 +458,7 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 
 ## Need Help?
 
-- **Discord Community**: [Join our Discord](https://getmax.im/bifrost-discord)
+- **Discord Community**: [Join our Discord](https://discord.gg/WJzTeWDEsX)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
 - **Writing Plugins Guide**: [Full plugin documentation](./writing-plugin)
 

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -957,6 +957,6 @@ go version -m my-plugin.so
 
 ## Need Help?
 
-- **Discord Community**: [Join our Discord](https://getmax.im/bifrost-discord)
+- **Discord Community**: [Join our Discord](https://discord.gg/WJzTeWDEsX)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
 - **Documentation**: [Browse all docs](/)

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -957,6 +957,6 @@ go version -m my-plugin.so
 
 ## Need Help?
 
-- **Discord Community**: [Join our Discord](https://discord.gg/WJzTeWDEsX)
+- **Discord Community**: [Join our Discord](https://discord.gg/exN5KAydbU)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
 - **Documentation**: [Browse all docs](/)

--- a/docs/plugins/writing-wasm-plugin.mdx
+++ b/docs/plugins/writing-wasm-plugin.mdx
@@ -1326,6 +1326,6 @@ wasm-objdump -x plugin.wasm | grep -A 20 "Export"
 
 ## Need Help?
 
-- **Discord Community**: [Join our Discord](https://getmax.im/bifrost-discord)
+- **Discord Community**: [Join our Discord](https://discord.gg/WJzTeWDEsX)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
 - **Documentation**: [Browse all docs](/)

--- a/docs/plugins/writing-wasm-plugin.mdx
+++ b/docs/plugins/writing-wasm-plugin.mdx
@@ -1326,6 +1326,6 @@ wasm-objdump -x plugin.wasm | grep -A 20 "Export"
 
 ## Need Help?
 
-- **Discord Community**: [Join our Discord](https://discord.gg/WJzTeWDEsX)
+- **Discord Community**: [Join our Discord](https://discord.gg/exN5KAydbU)
 - **GitHub Issues**: [Report bugs or request features](https://github.com/maximhq/bifrost/issues)
 - **Documentation**: [Browse all docs](/)

--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from "react";
 const externalLinks = [
 	{
 		title: "Discord Server",
-		url: "https://discord.gg/WJzTeWDEsX",
+		url: "https://discord.gg/exN5KAydbU",
 		icon: DiscordLogoIcon,
 	},
 	{

--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from "react";
 const externalLinks = [
 	{
 		title: "Discord Server",
-		url: "https://getmax.im/bifrost-discord",
+		url: "https://discord.gg/WJzTeWDEsX",
 		icon: DiscordLogoIcon,
 	},
 	{

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -106,7 +106,7 @@ const MCPIcon = ({ className }: { className?: string }) => (
 const externalLinks = [
 	{
 		title: "Discord Server",
-		url: "https://discord.gg/WJzTeWDEsX",
+		url: "https://discord.gg/exN5KAydbU",
 		icon: DiscordLogoIcon,
 	},
 	{

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -106,7 +106,7 @@ const MCPIcon = ({ className }: { className?: string }) => (
 const externalLinks = [
 	{
 		title: "Discord Server",
-		url: "https://getmax.im/bifrost-discord",
+		url: "https://discord.gg/WJzTeWDEsX",
 		icon: DiscordLogoIcon,
 	},
 	{


### PR DESCRIPTION
## Summary

There were multiple bad discord links across the repo, this fixes it. 

There were three discord links:
- https://getmax.im/bifrost-discord This one was broken
- https://discord.gg/exN5KAydbU this one works
- https://discord.gg/bifrost this appears to go to something completely different, yikes!

I coalesced everything to the second one. It would be nice if the repo had a variable everything could reference, but this is a good start.


<br class="Apple-interchange-newline">

<br class="Apple-interchange-newline">

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

https://github.com/maximhq/bifrost/issues/2017

## Security considerations

I'm concerned about the previous bad Bifrost discord links! This should help prevent people from ending up in the wrong discord, and build the community.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


