### PR TITLE
chore: update flake.lock to bump nix go version to 1.26.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771488326,
-        "narHash": "sha256-LzurEYF+S+vfzHMWHqfhJfzPSV9TbJmdEn/ZVIatB14=",
+        "lastModified": 1773144721,
+        "narHash": "sha256-1fa382ppXYOqqFIECQ3A1qogn/QLwNFvpjx/WivuNBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5cca0a5046ceb9b438023d2acf2180c6fe48eee",
+        "rev": "fb30d84f085815771af9decacb4b41b841798601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Updates the nixpkgs flake input to a newer revision to incorporate the latest
package updates and security fixes.

## Changes

- Updated nixpkgs flake lock from revision
  `e5cca0a5046ceb9b438023d2acf2180c6fe48eee` to
  `fb30d84f085815771af9decacb4b41b841798601`
- Updated lastModified timestamp from 1771488326 to 1773144721
- Updated narHash to reflect the new nixpkgs state

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the Nix flake builds successfully with the updated nixpkgs:

```sh
# Verify flake evaluation
nix flake check

# Build the project
nix build

# Enter development shell
nix develop
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This update may include security patches from the nixpkgs repository.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

