### PR TITLE
feat: session stickiness in key selection

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 
 	"github.com/maximhq/bifrost/core/mcp"
@@ -81,6 +82,7 @@ type Bifrost struct {
 	mcpInitOnce         sync.Once                           // Ensures MCP manager is initialized only once
 	dropExcessRequests  atomic.Bool                         // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
 	keySelector         schemas.KeySelector                 // Custom key selector function
+	kvStore             schemas.KVStore                     // optional KV store for session stickiness (nil = disabled)
 }
 
 // ProviderQueue wraps a provider's request channel with lifecycle management
@@ -200,6 +202,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 		keySelector:    config.KeySelector,
 		oauth2Provider: config.OAuth2Provider,
 		logger:         config.Logger,
+		kvStore:        config.KVStore,
 	}
 	bifrost.tracer.Store(&tracerWrapper{tracer: tracer})
 	if config.LLMPlugins == nil {
@@ -6074,13 +6077,119 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 		return supportedKeys[0], nil
 	}
 
+	// Session stickiness: on the first request for a session ID, the randomly
+	// selected key is persisted in the KV store. Subsequent requests reuse it as
+	// long as the key remains valid. The sticky-key lookup/selection in this block
+	// occurs before executeRequestWithRetries, so the same sticky key is
+	// intentionally applied for the entire session including all retry attempts—
+	// the selected key is persisted in KV and reused across retries rather than
+	// re-selected on each attempt.
+	sessionID := ""
+	if ctx != nil {
+		if id, ok := ctx.Value(schemas.BifrostContextKeySessionID).(string); ok && id != "" {
+			sessionID = id
+		}
+	}
+
+	fallbackIndex := 0
+	if ctx != nil {
+		fallbackIndex, _ = ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int)
+	}
+	stickinessActive := sessionID != "" && bifrost.kvStore != nil && fallbackIndex == 0
+
+	if stickinessActive {
+		kvKey := buildSessionKey(providerKey, sessionID, model)
+		ttl, _ := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration)
+		if ttl <= 0 {
+			ttl = schemas.DefaultSessionStickyTTL
+		}
+
+		// Try to retrieve existing cached key
+		if cachedKey, found, stale := getCachedKeyFromStore(bifrost.kvStore, kvKey, supportedKeys); found {
+			// Refresh TTL so active sessions do not expire.
+			err := bifrost.kvStore.SetWithTTL(kvKey, cachedKey.ID, ttl)
+			if err != nil {
+				bifrost.logger.Warn("error setting session cache for provider=%s key_id=%s: %s", providerKey, cachedKey.ID, err.Error())
+			}
+			return cachedKey, nil
+		} else if stale {
+			if _, err := bifrost.kvStore.Delete(kvKey); err != nil {
+				bifrost.logger.Warn("error deleting stale session cache for provider=%s: %s", providerKey, err.Error())
+			}
+		}
+
+		// No cached key found (or stale entry deleted), select a new one
+		selectedKey, err := bifrost.keySelector(ctx, supportedKeys, providerKey, model)
+		if err != nil {
+			return schemas.Key{}, err
+		}
+
+		// Atomically set the key only if not already set (first-write-wins)
+		wasSet, err := bifrost.kvStore.SetNXWithTTL(kvKey, selectedKey.ID, ttl)
+		if err != nil {
+			bifrost.logger.Warn("error setting session cache for provider=%s key_id=%s: %s", providerKey, selectedKey.ID, err.Error())
+			return selectedKey, nil
+		}
+
+		if wasSet {
+			return selectedKey, nil
+		}
+
+		// Another concurrent request won the race, re-read the current key
+		if currentKey, found, stale := getCachedKeyFromStore(bifrost.kvStore, kvKey, supportedKeys); found {
+			return currentKey, nil
+		} else if stale {
+			if _, err := bifrost.kvStore.Delete(kvKey); err != nil {
+				bifrost.logger.Warn("error deleting stale session cache for provider=%s: %s", providerKey, err.Error())
+			}
+			return selectedKey, nil
+		}
+
+		// Fallback: if we can't read the current key, use what we selected
+		// (shouldn't happen in normal operation, but defensive)
+		return selectedKey, nil
+	}
+
 	selectedKey, err := bifrost.keySelector(ctx, supportedKeys, providerKey, model)
 	if err != nil {
 		return schemas.Key{}, err
 	}
 
 	return selectedKey, nil
+}
 
+// getCachedKeyFromStore retrieves a key ID from the KV store and looks it up in supportedKeys.
+// Returns the matching Key, found (true if key exists in supportedKeys), and stale (true if
+// KV contains an ID but it is not in supportedKeys—caller should delete before SetNXWithTTL).
+func getCachedKeyFromStore(kvStore schemas.KVStore, kvKey string, supportedKeys []schemas.Key) (schemas.Key, bool, bool) {
+	raw, err := kvStore.Get(kvKey)
+	if err != nil {
+		return schemas.Key{}, false, false
+	}
+
+	var cachedKeyID string
+	switch v := raw.(type) {
+	case string:
+		cachedKeyID = v
+	case []byte:
+		var s string
+		if err := sonic.Unmarshal(v, &s); err == nil {
+			cachedKeyID = s
+		} else {
+			cachedKeyID = string(v)
+		}
+	}
+
+	if cachedKeyID != "" {
+		for _, k := range supportedKeys {
+			if k.ID == cachedKeyID {
+				return k, true, false
+			}
+		}
+		return schemas.Key{}, false, true
+	}
+
+	return schemas.Key{}, false, false
 }
 
 func WeightedRandomKeySelector(ctx *schemas.BifrostContext, keys []schemas.Key, providerKey schemas.ModelProvider, model string) (schemas.Key, error) {

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -302,7 +302,7 @@ func TestExecuteRequestWithRetries_RetryableConditions(t *testing.T) {
 // Test calculateBackoff - exponential growth (base calculations without jitter)
 func TestCalculateBackoff_ExponentialGrowth(t *testing.T) {
 	config := createTestConfig(5, 100*time.Millisecond, 5*time.Second)
-	
+
 	// Test the base exponential calculation by checking that results fall within expected ranges
 	// Since we can't easily mock rand.Float64, we'll test the bounds instead
 	testCases := []struct {
@@ -671,6 +671,180 @@ func (ma *MockAccount) GetKeysForProvider(ctx context.Context, provider schemas.
 		return keys, nil
 	}
 	return nil, fmt.Errorf("no keys for provider %s", provider)
+}
+
+func (ma *MockAccount) SetKeysForProvider(provider schemas.ModelProvider, keys []schemas.Key) {
+	ma.mu.Lock()
+	defer ma.mu.Unlock()
+	ma.keys[provider] = keys
+}
+
+// mockKVStore implements schemas.KVStore for session stickiness tests.
+type mockKVStore struct {
+	mu   sync.RWMutex
+	data map[string]struct {
+		value any
+		ttl   time.Duration
+	}
+}
+
+func newMockKVStore() *mockKVStore {
+	return &mockKVStore{data: make(map[string]struct {
+		value any
+		ttl   time.Duration
+	})}
+}
+
+func (m *mockKVStore) Get(key string) (any, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if e, ok := m.data[key]; ok {
+		return e.value, nil
+	}
+	return nil, fmt.Errorf("key not found")
+}
+
+func (m *mockKVStore) SetWithTTL(key string, value any, ttl time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.data[key] = struct {
+		value any
+		ttl   time.Duration
+	}{value: value, ttl: ttl}
+	return nil
+}
+
+func (m *mockKVStore) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.data[key]; ok {
+		return false, nil
+	}
+	m.data[key] = struct {
+		value any
+		ttl   time.Duration
+	}{value: value, ttl: ttl}
+	return true, nil
+}
+
+func (m *mockKVStore) Delete(key string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.data[key]; ok {
+		delete(m.data, key)
+		return true, nil
+	}
+	return false, nil
+}
+
+// Test selectKeyFromProviderForModel with session stickiness
+func TestSelectKeyFromProviderForModel_SessionStickiness(t *testing.T) {
+	kvStore := newMockKVStore()
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 5, 1000)
+	// Use 2 keys so we hit the keySelector path (single key returns early)
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{
+		{ID: "key-a", Name: "Key A", Value: *schemas.NewEnvVar("sk-a"), Weight: 1},
+		{ID: "key-b", Name: "Key B", Value: *schemas.NewEnvVar("sk-b"), Weight: 1},
+	})
+
+	var keySelectorCalls int
+	deterministicSelector := func(ctx *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+		keySelectorCalls++
+		return keys[0], nil // always return first key
+	}
+
+	ctx := context.Background()
+	bifrost, err := Init(ctx, schemas.BifrostConfig{
+		Account:     account,
+		Logger:      NewDefaultLogger(schemas.LogLevelError),
+		KVStore:     kvStore,
+		KeySelector: deterministicSelector,
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bfCtx.SetValue(schemas.BifrostContextKeySessionID, "sess-123")
+
+	// First call: cache miss, keySelector runs, key stored
+	key1, err := bifrost.selectKeyFromProviderForModel(bfCtx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil {
+		t.Fatalf("first selectKeyFromProviderForModel: %v", err)
+	}
+	if key1.ID != "key-a" {
+		t.Errorf("first call: expected key-a, got %s", key1.ID)
+	}
+	if keySelectorCalls != 1 {
+		t.Errorf("first call: expected 1 keySelector call, got %d", keySelectorCalls)
+	}
+
+	// Verify kvstore was written
+	kvKey := buildSessionKey(schemas.OpenAI, "sess-123", "gpt-4")
+	if raw, err := kvStore.Get(kvKey); err != nil || raw != "key-a" {
+		t.Errorf("kvstore after first call: expected key-a, got %v (err=%v)", raw, err)
+	}
+
+	// Second call: cache hit, same key returned, keySelector NOT called
+	key2, err := bifrost.selectKeyFromProviderForModel(bfCtx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil {
+		t.Fatalf("second selectKeyFromProviderForModel: %v", err)
+	}
+	if key2.ID != "key-a" {
+		t.Errorf("second call: expected key-a (sticky), got %s", key2.ID)
+	}
+	if keySelectorCalls != 1 {
+		t.Errorf("second call: keySelector should not run (cache hit), got %d calls", keySelectorCalls)
+	}
+}
+
+// Test selectKeyFromProviderForModel - no stickiness when session ID absent
+func TestSelectKeyFromProviderForModel_NoStickinessWithoutSessionID(t *testing.T) {
+	kvStore := newMockKVStore()
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 5, 1000)
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{
+		{ID: "key-a", Name: "Key A", Value: *schemas.NewEnvVar("sk-a"), Weight: 1},
+		{ID: "key-b", Name: "Key B", Value: *schemas.NewEnvVar("sk-b"), Weight: 1},
+	})
+
+	var keySelectorCalls int
+	deterministicSelector := func(ctx *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+		keySelectorCalls++
+		return keys[0], nil
+	}
+
+	ctx := context.Background()
+	bifrost, err := Init(ctx, schemas.BifrostConfig{
+		Account:     account,
+		Logger:      NewDefaultLogger(schemas.LogLevelError),
+		KVStore:     kvStore,
+		KeySelector: deterministicSelector,
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	// No session ID set
+
+	for i := 0; i < 2; i++ {
+		key, err := bifrost.selectKeyFromProviderForModel(bfCtx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+		if err != nil {
+			t.Fatalf("selectKeyFromProviderForModel call %d: %v", i+1, err)
+		}
+		if key.ID != "key-a" {
+			t.Fatalf("call %d: expected key-a, got %s", i+1, key.ID)
+		}
+	}
+	if keySelectorCalls != 2 {
+		t.Errorf("expected 2 keySelector calls without a session id, got %d", keySelectorCalls)
+	}
+	// KVStore should not have a sticky entry for an empty session id
+	if _, err := kvStore.Get(buildSessionKey(schemas.OpenAI, "", "gpt-4")); err == nil {
+		t.Error("kvstore should not have a sticky entry for an empty session id")
+	}
 }
 
 // Test UpdateProvider functionality

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -28,6 +28,7 @@ type BifrostConfig struct {
 	DropExcessRequests bool        // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
 	MCPConfig          *MCPConfig  // MCP (Model Context Protocol) configuration for tool integration
 	KeySelector        KeySelector // Custom key selector function
+	KVStore            KVStore     // shared KV store for clustering/session stickiness; nil = disabled
 }
 
 // ModelProvider represents the different AI model providers supported by Bifrost.
@@ -238,6 +239,8 @@ const (
 	BifrostContextKeyDeferredUsage                       BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
 	BifrostContextKeyDeferredLargePayloadMetadata        BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
 	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
+	BifrostContextKeySessionID                           BifrostContextKey = "bifrost-session-id"                         // string session ID for the request (session stickiness)
+	BifrostContextKeySessionTTL                          BifrostContextKey = "bifrost-session-ttl"                        // time.Duration session TTL for the request (session stickiness)
 )
 
 const (

--- a/core/schemas/kvstore.go
+++ b/core/schemas/kvstore.go
@@ -1,0 +1,17 @@
+package schemas
+
+import "time"
+
+// KVStore is a minimal interface for a key-value store used by Bifrost internals.
+// The concrete implementation (e.g. framework/kvstore.Store) is injected by the
+// caller and must satisfy this interface. Passing nil disables KV-backed features.
+type KVStore interface {
+	Get(key string) (any, error)
+	SetWithTTL(key string, value any, ttl time.Duration) error
+	SetNXWithTTL(key string, value any, ttl time.Duration) (bool, error)
+	Delete(key string) (bool, error)
+}
+
+const (
+	DefaultSessionStickyTTL = time.Hour
+)

--- a/core/utils.go
+++ b/core/utils.go
@@ -3,6 +3,8 @@ package bifrost
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -479,4 +481,20 @@ func sanitizeSpanName(name string) string {
 // IsCodemodeTool returns true if the given tool name is a codemode tool.
 func IsCodemodeTool(toolName string) bool {
 	return mcp.IsCodeModeTool(toolName)
+}
+
+// hashSHA256 returns a deterministic hex-encoded SHA-256 hash of the input.
+func hashSHA256(value string) string {
+	h := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(h[:])
+}
+
+func buildSessionKey(providerKey schemas.ModelProvider, sessionID string, model string) string {
+	// Hash session ID to prevent PII leakage and ensure bounded key size
+	hashedSessionID := hashSHA256(sessionID)
+	discriminator := model
+	if discriminator == "" {
+		discriminator = "__modelless__"
+	}
+	return "session:" + string(providerKey) + ":" + hashedSessionID + ":" + hashSHA256(discriminator)
 }

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -13,6 +13,8 @@ Bifrost provides request options that control behavior, enable features, and pas
 | `BifrostContextKeyVirtualKey` | `x-bf-vk` | `string` | Virtual key identifier for governance |
 | `BifrostContextKeyAPIKeyName` | `x-bf-api-key` | `string` | Explicit API key name selection |
 | `BifrostContextKeyAPIKeyID` | `x-bf-api-key-id` | `string` | Explicit API key ID selection (takes priority over name) |
+| `BifrostContextKeySessionID` | `x-bf-session-id` | `string` | Session ID for key stickiness (requires KV store) |
+| `BifrostContextKeySessionTTL` | `x-bf-session-ttl` | `time.Duration` | Session-to-key cache TTL (duration string or seconds) |
 | `BifrostContextKeyRequestID` | `x-request-id` | `string` | Custom request ID for tracking |
 | `BifrostContextKeySendBackRawResponse` | `x-bf-send-back-raw-response` | `bool` | Include raw provider response |
 | `BifrostContextKeyPassthroughExtraParams` | `x-bf-passthrough-extra-params` | `bool` | Enable passthrough for extra parameters |
@@ -141,6 +143,86 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
 ```go
 ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyName, "premium-key")
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+```
+</Tab>
+</Tabs>
+
+### Session Stickiness (Session ID)
+
+**Context Key:** `BifrostContextKeySessionID`  
+**Header:** `x-bf-session-id`  
+**Type:** `string`  
+**Required:** No
+
+Bind a session to a specific API key so that requests with the same session ID consistently use the same key. Useful for predictable rate-limit buckets, cost attribution per user, and consistent model routing per session.
+
+On the first request for a session ID, Bifrost selects a key and caches the binding in the KV store. Subsequent requests with the same session ID reuse the cached key as long as it remains valid.
+
+**Retry and Fallback Behavior:**
+- **Retries**: Session stickiness persists across retry attempts. If a request fails and is retried, the same sticky key is used.
+- **Fallbacks**: When falling back to a different provider (e.g., from OpenAI to Anthropic), session stickiness is disabled and a new key is selected for the fallback provider. This ensures availability when the primary provider's keys are exhausted or failing.
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-session-id: user-123-session-abc' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeySessionID, "user-123-session-abc")
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+```
+</Tab>
+</Tabs>
+
+### Session TTL
+
+**Context Key:** `BifrostContextKeySessionTTL`  
+**Header:** `x-bf-session-ttl`  
+**Type:** `time.Duration` (header value: duration string like `"30m"` or `"1h"`, or seconds as integer)  
+**Required:** No
+
+Optional. Controls how long the session-to-key binding is cached. If not set, Bifrost uses 1 hour. The TTL is refreshed on each request so active sessions do not expire.
+
+Accepts duration strings (`"30s"`, `"5m"`, `"1h"`) or plain numbers (treated as seconds).
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-session-id: user-123-session-abc' \
+--header 'x-bf-session-ttl: 30m' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeySessionID, "user-123-session-abc")
+ctx = context.WithValue(ctx, schemas.BifrostContextKeySessionTTL, 30*time.Minute)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
     Provider: schemas.OpenAI,

--- a/docs/quickstart/go-sdk/context-keys.mdx
+++ b/docs/quickstart/go-sdk/context-keys.mdx
@@ -75,6 +75,24 @@ Skip the key selection process entirely and pass an empty key to the provider. U
 ctx := context.WithValue(ctx, schemas.BifrostContextKeySkipKeySelection, true)
 ```
 
+### Session Stickiness (Session ID)
+
+Bind a session to a specific API key so that requests with the same session ID consistently use the same key. Useful for predictable rate-limit buckets, cost attribution per user, and consistent model routing per session.
+
+On the first request for a session ID, Bifrost selects a key (via weighted random) and caches the binding in the KV store. Subsequent requests with the same session ID reuse the cached key as long as it remains valid. If the cached key is no longer in the supported set (disabled, removed, or model support changed), Bifrost re-selects and overwrites the cache.
+
+```go
+ctx := context.WithValue(ctx, schemas.BifrostContextKeySessionID, "user-123-session-abc")
+```
+
+### Session TTL
+
+Optional. Controls how long the session-to-key binding is cached. If not set, Bifrost uses `DefaultSessionStickyTTL` (1 hour). The TTL is refreshed on each request so active sessions do not expire.
+
+```go
+ctx := context.WithValue(ctx, schemas.BifrostContextKeySessionTTL, 30*time.Minute)
+```
+
 ### Request ID
 
 Set a custom request ID for tracking and correlation.
@@ -301,6 +319,8 @@ func makeRequest(client *bifrost.Bifrost) {
 | `BifrostContextKeyFallbackIndex` | `int` | Read | Current fallback index |
 | `BifrostContextKeyStreamEndIndicator` | `bool` | Read | Stream completion flag |
 | `BifrostContextKeySkipKeySelection` | `bool` | Set | Skip key selection |
+| `BifrostContextKeySessionID` | `string` | Set | Session ID for key stickiness (requires KV store) |
+| `BifrostContextKeySessionTTL` | `time.Duration` | Set | TTL for session-to-key cache (default: 1 hour) |
 | `BifrostContextKeyExtraHeaders` | `map[string][]string` | Set | Custom request headers |
 | `BifrostContextKeyURLPath` | `string` | Set | Custom URL path suffix |
 | `BifrostContextKeyUseRawRequestBody` | `bool` | Set | Use raw request body |

--- a/framework/kvstore/kvstore.go
+++ b/framework/kvstore/kvstore.go
@@ -151,6 +151,56 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	return nil
 }
 
+// SetNXWithTTL atomically sets a value with TTL only if the key does not exist.
+// Returns true if the key was set, false if the key already existed.
+// ttl=0 means no expiration.
+func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, error) {
+	if err := s.validateMutable(key, ttl); err != nil {
+		return false, err
+	}
+
+	now := time.Now().UnixNano()
+	var expiresAt int64
+	if ttl > 0 {
+		expiresAt = now + int64(ttl)
+	}
+
+	var valueJSON []byte
+	var err error
+
+	if s.delegate != nil {
+		valueJSON, err = sonic.Marshal(value)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	s.mu.Lock()
+	
+	// Check if key exists and is not expired
+	if existing, ok := s.data[key]; ok {
+		if !isExpired(existing, now) {
+			s.mu.Unlock()
+			return false, nil // Key already exists
+		}
+		// Key exists but is expired, allow overwrite
+	}
+	
+	// Key doesn't exist or is expired, set it
+	s.data[key] = entry{
+		value:     value,
+		writtenAt: now,
+		expiresAt: expiresAt,
+	}
+	s.mu.Unlock()
+
+	if s.delegate != nil {
+		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	}
+
+	return true, nil
+}
+
 // SetRemote applies a remotely-gossiped entry without triggering OnSet.
 // writtenAt and expiresAt must be absolute Unix nanosecond timestamps.
 // If the local entry was written more recently than writtenAt the update is

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -312,20 +312,20 @@ type Config struct {
 }
 
 var DefaultClientConfig = configstore.ClientConfig{
-	DropExcessRequests:      false,
-	PrometheusLabels:        []string{},
-	InitialPoolSize:         schemas.DefaultInitialPoolSize,
-	EnableLogging:           true,
-	DisableContentLogging:   false,
-	EnforceAuthOnInference:  false,
-	AllowDirectKeys:         false,
-	AllowedOrigins:          []string{"*"},
-	AllowedHeaders:          []string{},
-	MaxRequestBodySizeMB:    100,
-	MCPAgentDepth:           10,
-	MCPToolExecutionTimeout: 30,
-	MCPCodeModeBindingLevel: string(schemas.CodeModeBindingLevelServer),
-	EnableLiteLLMFallbacks:  false,
+	DropExcessRequests:              false,
+	PrometheusLabels:                []string{},
+	InitialPoolSize:                 schemas.DefaultInitialPoolSize,
+	EnableLogging:                   true,
+	DisableContentLogging:           false,
+	EnforceAuthOnInference:          false,
+	AllowDirectKeys:                 false,
+	AllowedOrigins:                  []string{"*"},
+	AllowedHeaders:                  []string{},
+	MaxRequestBodySizeMB:            100,
+	MCPAgentDepth:                   10,
+	MCPToolExecutionTimeout:         30,
+	MCPCodeModeBindingLevel:         string(schemas.CodeModeBindingLevelServer),
+	EnableLiteLLMFallbacks:          false,
 	HideDeletedVirtualKeysInFilters: false,
 }
 
@@ -442,6 +442,10 @@ func loadConfigFromFile(ctx context.Context, config *Config, data []byte) (*Conf
 	}
 	// Initialize stores from config file
 	if err = initStoresFromFile(ctx, config, &configData); err != nil {
+		return nil, err
+	}
+	// Initialize kvstore
+	if err := initKVStore(config); err != nil {
 		return nil, err
 	}
 	// From now on, config store gets priority if enabled and we find data.
@@ -1959,6 +1963,9 @@ func loadConfigFromDefaults(ctx context.Context, config *Config, configDBPath, l
 	if err = initDefaultFrameworkConfig(ctx, config); err != nil {
 		return nil, err
 	}
+	if err := initKVStore(config); err != nil {
+		return nil, err
+	}
 	// Sync encryption: encrypt any plaintext rows written during config loading
 	syncEncryption(ctx, config)
 	return config, nil
@@ -2552,6 +2559,19 @@ func (c *Config) GetAsyncJobResultTTL() int {
 // GetKVStore returns the shared in-memory kvstore instance.
 func (c *Config) GetKVStore() *kvstore.Store {
 	return c.KVStore
+}
+
+// initKVStore initializes the kvstore for the config
+func initKVStore(config *Config) error {
+	var err error
+	config.KVStore, err = kvstore.New(kvstore.Config{
+		DefaultTTL:      30 * time.Minute,
+		CleanupInterval: 1 * time.Minute,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize kvstore: %w", err)
+	}
+	return nil
 }
 
 // GetLoadedMCPPlugins returns the current snapshot of loaded MCP plugins.

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -72,6 +72,10 @@ const (
 //   - Any header starting with 'x-bf-eh-' is collected and added to the map stored under schemas.BifrostContextKeyExtraHeaders
 //   - The prefix is stripped, the remainder is lower-cased, and duplicate names append values
 //   - This allows callers to send arbitrary context metadata without needing to extend the public schema
+//
+// 8. Session Stickiness Headers:
+//   - x-bf-session-id: Session identifier for key binding (reuse same key across requests)
+//   - x-bf-session-ttl: Per-request TTL override (duration string e.g. "30m" or seconds integer)
 
 // Parameters:
 //   - ctx: The FastHTTP request context containing the original headers
@@ -87,7 +91,8 @@ const (
 //	bifrostCtx, cancel := ConvertToBifrostContext(fastCtx, true, nil)
 //	defer cancel() // Ensure cleanup
 //	// bifrostCtx now contains propagated header values including Prometheus metrics,
-//	// Maxim tracing data, MCP filters, governance keys, API keys, cache settings, and extra headers
+//	// Maxim tracing data, MCP filters, governance keys, API keys, cache settings,
+//	// session stickiness, and extra headers
 
 func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, headerFilterConfig *configstoreTables.GlobalHeaderFilterConfig) (*schemas.BifrostContext, context.CancelFunc) {
 	// Reuse a shared request-scoped context when available.
@@ -336,6 +341,29 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, hea
 		if keyStr == "x-bf-cache-no-store" {
 			if valueStr := string(value); valueStr == "true" {
 				bifrostCtx.SetValue(semanticcache.CacheNoStoreKey, true)
+			}
+			return true
+		}
+		// Session stickiness: session ID for key binding
+		if keyStr == "x-bf-session-id" {
+			if valueStr := strings.TrimSpace(string(value)); valueStr != "" {
+				bifrostCtx.SetValue(schemas.BifrostContextKeySessionID, valueStr)
+			}
+			return true
+		}
+		// Session stickiness: per-request TTL override (duration string or seconds integer)
+		if keyStr == "x-bf-session-ttl" {
+			valueStr := strings.TrimSpace(string(value))
+			var ttlDuration time.Duration
+			var err error
+			if ttlDuration, err = time.ParseDuration(valueStr); err != nil {
+				if seconds, parseErr := strconv.Atoi(valueStr); parseErr == nil && seconds > 0 {
+					ttlDuration = time.Duration(seconds) * time.Second
+					err = nil
+				}
+			}
+			if err == nil && ttlDuration > 0 {
+				bifrostCtx.SetValue(schemas.BifrostContextKeySessionTTL, ttlDuration)
 			}
 			return true
 		}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
-	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	dynamicPlugins "github.com/maximhq/bifrost/framework/plugins"
@@ -1122,14 +1121,9 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config %v", err)
 	}
-	s.Config.KVStore, err = kvstore.New(kvstore.Config{
-		DefaultTTL:      30 * time.Minute,
-		CleanupInterval: 1 * time.Minute,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to initialize kvstore: %w", err)
+	if s.Config.KVStore != nil {
+		integrations.RegisterKVDecoders(s.Config.KVStore)
 	}
-	integrations.RegisterKVDecoders(s.Config.KVStore)
 	// Initialize WebSocket handler early so plugins can wire event broadcasters during Init.
 	// Log callbacks are registered later in RegisterAPIRoutes when logging plugin is available.
 	s.WebSocketHandler = handlers.NewWebSocketHandler(s.Ctx, s.Config.ClientConfig.AllowedOrigins)
@@ -1210,6 +1204,7 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		MCPConfig:          mcpConfig,
 		OAuth2Provider:     s.Config.OAuthProvider,
 		Logger:             logger,
+		KVStore:            s.Config.KVStore,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize bifrost: %v", err)


### PR DESCRIPTION
## Summary

Implements session stickiness functionality that allows requests with the same session ID to consistently use the same API key across multiple requests, improving user experience by maintaining consistent behavior within a session.

## Changes

- Added `KVStore` field to `BifrostConfig` and `Bifrost` struct for persistent session storage
- Enhanced `selectKeyFromProviderForModel` to check for cached key selection based on session ID before falling back to the key selector
- Added session context keys (`BifrostContextKeySessionID`, `BifrostContextKeySessionTTL`) for session management
- Implemented session key caching with TTL refresh for active sessions
- Added HTTP headers `x-bf-session-id` and `x-bf-session-ttl` for session configuration
- Session stickiness is bypassed on retries to prevent infinite loops with failed keys
- Added `KVStore` interface with `Get`, `SetWithTTL`, and `Delete` methods
- Integrated KV store initialization in the HTTP transport configuration

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

Test session stickiness by sending requests with the same session ID:

```sh
# Send multiple requests with the same session ID
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-bf-session-id: test-session-123" \
  -H "x-bf-session-ttl: 30m" \
  -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}'

# Verify the same key is used across requests by checking logs or response patterns
```

Run the test suite:
```sh
go test ./core -v -run TestSelectKeyFromProviderForModel_SessionStickiness
go test ./...
```

New configuration: Session stickiness is automatically enabled when a KV store is available and session headers are provided.

## Breaking changes

- [ ] No

The feature is opt-in via headers and backward compatible.

## Security considerations

- Session IDs are stored in the KV store but contain no sensitive data (only key IDs)
- TTL ensures sessions expire automatically
- No PII is stored in the session cache

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable