### PR TITLE
fix: makefile shell compatibility and gzip reader panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ install-junit-viewer: ## Install junit-viewer for HTML report generation (if not
 				echo "$(YELLOW)You can install it manually: npm install -g junit-viewer$(NC)"; \
 				exit 0; \
 			fi; \
-		fi \
+		fi; \
 	else \
 		echo "$(YELLOW)CI environment detected, skipping junit-viewer installation$(NC)"; \
 	fi
@@ -350,7 +350,7 @@ test: install-gotestsum ## Run tests for bifrost-http
 			echo ""; \
 			echo "$(YELLOW)junit-viewer not installed. Install with: make install-junit-viewer$(NC)"; \
 			echo "$(CYAN)JUnit XML report: $(TEST_REPORTS_DIR)/bifrost-http.xml$(NC)"; \
-		fi \
+		fi; \
 	else \
 		echo ""; \
 		echo "$(CYAN)JUnit XML report: $(TEST_REPORTS_DIR)/bifrost-http.xml$(NC)"; \
@@ -398,7 +398,7 @@ test-core: install-gotestsum $(if $(DEBUG),install-delve) ## Run core tests (Usa
 				cd core/providers/$(PROVIDER) && GOWORK=off gotestsum \
 					--format=$(GOTESTSUM_FORMAT) \
 					--junitfile=../../../$$REPORT_FILE \
-					-- -v -run "^Test$${PROVIDER_TEST_NAME}$$/.*Tests/$$CLEAN_TESTCASE$$" || TEST_FAILED=1; \
+					-- -v -timeout 20m -run "^Test$${PROVIDER_TEST_NAME}$$/.*Tests/$$CLEAN_TESTCASE$$" || TEST_FAILED=1; \
 			fi; \
 			cd ../../..; \
 			$(MAKE) cleanup-junit-xml REPORT_FILE=$$REPORT_FILE; \
@@ -426,7 +426,7 @@ test-core: install-gotestsum $(if $(DEBUG),install-delve) ## Run core tests (Usa
 				cd core/providers/$(PROVIDER) && GOWORK=off gotestsum \
 					--format=$(GOTESTSUM_FORMAT) \
 					--junitfile=../../../$$REPORT_FILE \
-					-- -v -run ".*$(PATTERN).*" || TEST_FAILED=1; \
+					-- -v -timeout 20m -run ".*$(PATTERN).*" || TEST_FAILED=1; \
 			fi; \
 			cd ../../..; \
 			$(MAKE) cleanup-junit-xml REPORT_FILE=$$REPORT_FILE; \
@@ -454,7 +454,7 @@ test-core: install-gotestsum $(if $(DEBUG),install-delve) ## Run core tests (Usa
 				cd core/providers/$(PROVIDER) && GOWORK=off gotestsum \
 					--format=$(GOTESTSUM_FORMAT) \
 					--junitfile=../../../$$REPORT_FILE \
-					-- -v -run "^Test$${PROVIDER_TEST_NAME}$$" || TEST_FAILED=1; \
+					-- -v -timeout 20m -run "^Test$${PROVIDER_TEST_NAME}$$" || TEST_FAILED=1; \
 			fi; \
 			cd ../../..; \
 			$(MAKE) cleanup-junit-xml REPORT_FILE=$$REPORT_FILE; \
@@ -473,7 +473,7 @@ test-core: install-gotestsum $(if $(DEBUG),install-delve) ## Run core tests (Usa
 				echo ""; \
 				echo "$(CYAN)JUnit XML report: $$REPORT_FILE$(NC)"; \
 			fi; \
-		fi \
+		fi; \
 	else \
 		if [ -n "$(TESTCASE)" ]; then \
 			echo "$(RED)Error: TESTCASE requires PROVIDER to be specified$(NC)"; \
@@ -489,7 +489,7 @@ test-core: install-gotestsum $(if $(DEBUG),install-delve) ## Run core tests (Usa
 				cd core && GOWORK=off gotestsum \
 					--format=$(GOTESTSUM_FORMAT) \
 					--junitfile=../$$REPORT_FILE \
-					-- -v -run ".*$(PATTERN).*" ./providers/... || TEST_FAILED=1; \
+					-- -v -timeout 20m -run ".*$(PATTERN).*" ./providers/... || TEST_FAILED=1; \
 			fi; \
 		else \
 			REPORT_FILE="$(TEST_REPORTS_DIR)/core-all.xml"; \

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -777,10 +777,9 @@ func AcquireGzipReader(r io.Reader) (*gzip.Reader, error) {
 		if err := gz.Reset(r); err == nil {
 			return gz, nil
 		}
-		// Reset failed; close before re-pooling so we don't retain a partially
-		// initialized reader state between pool borrowers.
-		_ = gz.Close()
-		gzipReaderPool.Put(gz)
+		// Reset failed; discard the reader. After a failed Reset the internal
+		// decompressor may be nil, making Close() panic (Go 1.26+).
+		// Do not re-pool — let GC reclaim it.
 	}
 	return gzip.NewReader(r)
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771488326,
-        "narHash": "sha256-LzurEYF+S+vfzHMWHqfhJfzPSV9TbJmdEn/ZVIatB14=",
+        "lastModified": 1773144721,
+        "narHash": "sha256-1fa382ppXYOqqFIECQ3A1qogn/QLwNFvpjx/WivuNBc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5cca0a5046ceb9b438023d2acf2180c6fe48eee",
+        "rev": "fb30d84f085815771af9decacb4b41b841798601",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Fixes Makefile shell compatibility issues with zsh and a nil pointer dereference
panic in the pooled gzip reader when handling invalid gzip-encoded responses.

## Changes

- Fix `fi \` → `fi; \` in Makefile for zsh compatibility (bash tolerates the
  missing semicolon, zsh does not)
- Add `-timeout 20m` to `test-core` gotestsum invocations to prevent Go's
  default 10-minute timeout from killing long-running provider test suites
  (e.g., Gemini speech synthesis tests with `WithRawRequestResponse` doubling
  execution time)
- Fix `AcquireGzipReader` panic: after a failed `gz.Reset()` on invalid gzip
  data, `gz.Close()` panics because the internal decompressor is nil (Go 1.26+).
  Discard the reader instead of attempting to close and re-pool it

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Verify gzip reader fix
go test -v -run "TestHandleProviderAPIError_RawResponseIncluded" ./core/providers/utils/

# Verify Makefile works in zsh
make test-core PROVIDER=gemini TESTCASE=TestChatCompletion
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [x] I read docs/contributing/README.md and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
