### PR TITLE
fix: improve context cancellation handling and error differentiation

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4434,11 +4434,15 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	case <-ctx.Done():
 		bifrost.releaseChannelMessage(msg)
 		provider, model, _ := req.GetRequestFields()
+		errType, errMsg := schemas.RequestCancelled, fmt.Sprintf("request cancelled while waiting for provider response: %v", ctx.Err())
+		if ctx.Err() == context.DeadlineExceeded {
+			errType, errMsg = schemas.RequestTimedOut, fmt.Sprintf("request timed out waiting for provider response: %v", ctx.Err())
+		}
 		bifrostErr := &schemas.BifrostError{
 			IsBifrostError: true,
 			Error: &schemas.ErrorField{
-				Type:    schemas.Ptr(schemas.RequestCancelled),
-				Message: fmt.Sprintf("request timed out waiting for provider response: %v", ctx.Err()),
+				Type:    schemas.Ptr(errType),
+				Message: errMsg,
 				Error:   ctx.Err(),
 			},
 			ExtraFields: schemas.BifrostErrorExtraFields{
@@ -4686,6 +4690,33 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			return newBifrostMessageChan(recoveredResp), nil
 		}
 		return nil, &bifrostErrVal
+	case <-ctx.Done():
+		errType, errMsg := schemas.RequestCancelled, fmt.Sprintf("request cancelled while waiting for provider response: %v", ctx.Err())
+		if ctx.Err() == context.DeadlineExceeded {
+			errType, errMsg = schemas.RequestTimedOut, fmt.Sprintf("request timed out waiting for provider response: %v", ctx.Err())
+		}
+		bifrostErr := &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Type:    schemas.Ptr(errType),
+				Message: errMsg,
+				Error:   ctx.Err(),
+			},
+			ExtraFields: schemas.BifrostErrorExtraFields{
+				RequestType:    req.RequestType,
+				Provider:       provider,
+				ModelRequested: model,
+			},
+		}
+		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+		recoveredResp, recoveredErr := pipeline.RunPostLLMHooks(ctx, nil, bifrostErr, preCount)
+		if recoveredErr != nil {
+			return nil, recoveredErr
+		}
+		if recoveredResp != nil {
+			return newBifrostMessageChan(recoveredResp), nil
+		}
+		return nil, bifrostErr
 	}
 }
 
@@ -4725,7 +4756,29 @@ func executeRequestWithRetries[T any](
 			backoff := calculateBackoff(attempts-1, config)
 			logger.Debug("sleeping for %s before retry", backoff)
 
-			time.Sleep(backoff)
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				errType := schemas.RequestCancelled
+				errMsg := fmt.Sprintf("request cancelled during retry backoff: %v", ctx.Err())
+				if ctx.Err() == context.DeadlineExceeded {
+					errType = schemas.RequestTimedOut
+					errMsg = fmt.Sprintf("request timed out during retry backoff: %v", ctx.Err())
+				}
+				return result, &schemas.BifrostError{
+					IsBifrostError: true,
+					Error: &schemas.ErrorField{
+						Type:    schemas.Ptr(errType),
+						Message: errMsg,
+						Error:   ctx.Err(),
+					},
+					ExtraFields: schemas.BifrostErrorExtraFields{
+						RequestType:    requestType,
+						Provider:       providerKey,
+						ModelRequested: model,
+					},
+				}
+			}
 		}
 
 		logger.Debug("attempting %s request for provider %s", requestType, providerKey)
@@ -4902,7 +4955,19 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		}
 	}()
 
-	for req := range pq.queue {
+	for {
+		var req *ChannelMessage
+		select {
+		case <-bifrost.ctx.Done():
+			bifrost.logger.Debug("worker exiting due to context cancellation for provider %s", provider.GetProviderKey())
+			return
+		case r, ok := <-pq.queue:
+			if !ok {
+				return
+			}
+			req = r
+		}
+
 		_, model, _ := req.BifrostRequest.GetRequestFields()
 
 		var result *schemas.BifrostResponse
@@ -5096,11 +5161,13 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				case req.ResponseStream <- stream:
 					// Stream sent successfully
 				case <-req.Context.Done():
-					// Client no longer listening, log and continue
+					// Client no longer listening; release msg since tryStreamRequest already returned
 					bifrost.logger.Debug("Client context cancelled while sending stream response")
+					bifrost.releaseChannelMessage(req)
 				case <-time.After(5 * time.Second):
-					// Timeout to prevent indefinite blocking
+					// Timeout to prevent indefinite blocking; release msg to avoid pool leak
 					bifrost.logger.Warn("Timeout while sending stream response, client may have disconnected")
+					bifrost.releaseChannelMessage(req)
 				}
 			} else {
 				// Send response with context awareness to prevent deadlock

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -1243,3 +1243,40 @@ func TestUpdateProvider_ProviderSliceIntegrity(t *testing.T) {
 	})
 }
 
+// TestRequestWorkerExitsOnContextCancel verifies that requestWorker goroutines
+// clean up when the context passed to Init() is cancelled (without calling Shutdown()).
+func TestRequestWorkerExitsOnContextCancel(t *testing.T) {
+	workerCount := 4
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, workerCount, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	b, err := Init(schemas.NewBifrostContext(ctx, schemas.NoDeadline), schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Failed to initialize Bifrost: %v", err)
+	}
+	cancel()
+
+	wgValue, ok := b.waitGroups.Load(schemas.OpenAI)
+	if !ok {
+		t.Fatal("wait group for OpenAI provider not found")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wgValue.(*sync.WaitGroup).Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		b.Shutdown()
+	case <-time.After(2 * time.Second):
+		t.Fatal("workers did not exit after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

Fixed a goroutine leak in the Bifrost request worker by adding proper context cancellation handling. Previously, request workers would not exit when the context was cancelled, causing goroutines to remain running indefinitely.

## Changes

- Modified the `requestWorker` function to use a `select` statement that listens for both context cancellation and incoming requests from the queue
- Added graceful shutdown logic that exits the worker loop when `bifrost.ctx.Done()` is triggered
- Enhanced `tryStreamRequest` and `executeRequestWithRetries` functions to handle context cancellation with proper error responses
- Added comprehensive test `TestRequestWorkerExitsOnContextCancel` to verify workers properly clean up on context cancellation
- Minor formatting fix (trailing whitespace removal)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the goroutine leak fix by running the new test:

```sh
go test ./core -run TestRequestWorkerExitsOnContextCancel -v
```

Run the full test suite to ensure no regressions:

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #828 

## Security considerations

This change improves resource management by preventing goroutine leaks, which could potentially lead to memory exhaustion in long-running applications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable