### PR TITLE
feat: enrich HTTP access logs with model and error message

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -66,6 +67,43 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 					Str("http.user_agent", string(ctx.Request.Header.UserAgent()))
 				if traceID, ok := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
 					logBuilder = logBuilder.Str("trace_id", traceID)
+				}
+				// Extract model from request body for JSON inference endpoints only
+				if strings.HasPrefix(string(ctx.RequestURI()), "/v1/") {
+					if ct := string(ctx.Request.Header.ContentType()); strings.HasPrefix(ct, "application/json") {
+						if body := ctx.PostBody(); len(body) > 0 {
+							var partial struct {
+								Model string `json:"model"`
+							}
+							if json.Unmarshal(body, &partial) == nil && partial.Model != "" {
+								logBuilder = logBuilder.Str("model", partial.Model)
+							}
+						}
+					}
+				}
+				// Extract error message from JSON response body on 4xx/5xx
+				if statusCode >= 400 {
+					if ct := string(ctx.Response.Header.Peek("Content-Type")); strings.HasPrefix(ct, "application/json") {
+						if respBody := ctx.Response.Body(); len(respBody) > 0 {
+							const maxErrorBodyBytes = 4096
+							if len(respBody) > maxErrorBodyBytes {
+								respBody = respBody[:maxErrorBodyBytes]
+							}
+							var errResp struct {
+								Error struct {
+									Message string `json:"message"`
+								} `json:"error"`
+							}
+							if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
+								msg := errResp.Error.Message
+								const maxErrorMessageLen = 256
+								if len(msg) > maxErrorMessageLen {
+									msg = msg[:maxErrorMessageLen]
+								}
+								logBuilder = logBuilder.Str("error", msg)
+							}
+						}
+					}
 				}
 				logBuilder.Send()
 			}()

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -97,8 +97,9 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 							if json.Unmarshal(respBody, &errResp) == nil && errResp.Error.Message != "" {
 								msg := errResp.Error.Message
 								const maxErrorMessageLen = 256
-								if len(msg) > maxErrorMessageLen {
-									msg = msg[:maxErrorMessageLen]
+								runes := []rune(msg)
+								if len(runes) > maxErrorMessageLen {
+									msg = string(runes[:maxErrorMessageLen])
 								}
 								logBuilder = logBuilder.Str("error", msg)
 							}


### PR DESCRIPTION
## Summary

- Adds `model` field to the HTTP access log (extracted from JSON request body on inference endpoints)
- Adds `error` field on 4xx/5xx responses (extracted from BifrostError response body)
- Uses lightweight partial JSON unmarshalling with stdlib `encoding/json`, fails silently on non-JSON bodies

## Motivation

When debugging inference errors (e.g. `400 model should be in provider/model format`), the current access log only shows the status code and trace ID. Operators must then query the LogStore database or reproduce the issue to find which model was requested and what error was returned.

With this change, a single `kubectl logs` or log aggregator query gives the full picture:

```json
{"level":"warn","http.method":"POST","http.target":"/v1/chat/completions",
 "http.status_code":400,"http.request_duration_ms":0,
 "model":"openai/claude-sonnet",
 "error":"model should be in provider/model format",
 "trace_id":"abc123","message":"request completed"}
```

## Changes

- `transports/bifrost-http/handlers/middlewares.go`: 23 lines added to the `CorsMiddleware` defer block
- New import: `encoding/json` (stdlib only, no new dependencies)

## Test plan

- [ ] Verify `model` field appears in access log for `/v1/chat/completions` POST requests
- [ ] Verify `error` field appears on 400/401/500 responses
- [ ] Verify no regression on non-JSON endpoints (health, static, websocket)
- [ ] Verify no performance impact — `json.Unmarshal` on partial struct is O(n) single-pass, only runs in the defer (after response is sent)