### PR TITLE
fix: record ttft in nanoseconds instead of miliseconds to avoid truncation to 0

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,3 +2,4 @@
 - feat: add DisableAutoToolInject to MCPToolManagerConfig to suppress automatic MCP tool injection per request
 - feat: add Filename field to TranscriptionInput schema to carry original filename through the request pipeline
 - fix: add AudioFilenameFromBytes utility to detect audio format from file headers with mp3 fallback
+- fix: record ttft in nanoseconds instead of milliseconds to avoid truncation to 0

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2464,12 +2464,12 @@ func completeDeferredSpan(ctx *schemas.BifrostContext, result *schemas.BifrostRe
 
 	// Get accumulated response with full data (content, tool calls, reasoning, etc.)
 	// This builds a complete BifrostResponse from all the streaming chunks
-	accumulatedResp, ttftMs, chunkCount := tracer.GetAccumulatedChunks(traceID)
+	accumulatedResp, ttftNs, chunkCount := tracer.GetAccumulatedChunks(traceID)
 
 	// Set TTFT and chunk count attributes regardless of accumulated response availability
 	// (GetAccumulatedChunks may return nil response while still providing valid metrics)
-	if ttftMs > 0 {
-		tracer.SetAttribute(handle, schemas.AttrTimeToFirstToken, ttftMs)
+	if ttftNs > 0 {
+		tracer.SetAttribute(handle, schemas.AttrTimeToFirstToken, ttftNs)
 	}
 	if chunkCount > 0 {
 		tracer.SetAttribute(handle, schemas.AttrTotalChunks, chunkCount)

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -95,7 +95,7 @@ type Tracer interface {
 	// The response is always nil — full content accumulation is handled by the streaming.Accumulator
 	// via ProcessStreamingChunk. Callers should nil-check the response.
 	// Returns nil, 0, 0 if no accumulated data exists.
-	GetAccumulatedChunks(traceID string) (response *BifrostResponse, ttftMs int64, chunkCount int)
+	GetAccumulatedChunks(traceID string) (response *BifrostResponse, ttftNs int64, chunkCount int)
 
 	// CreateStreamAccumulator creates a new stream accumulator for the given trace ID.
 	// This should be called at the start of a streaming request.

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- fix: record ttft in nanoseconds instead of milliseconds to avoid truncation to 0

--- a/framework/tracing/store.go
+++ b/framework/tracing/store.go
@@ -173,7 +173,7 @@ func (s *TraceStore) AppendStreamingChunk(traceID string, chunk *schemas.Bifrost
 
 // GetAccumulatedData returns TTFT and chunk count for a deferred span.
 // Chunks are no longer stored; full content is available via the streaming.Accumulator.
-func (s *TraceStore) GetAccumulatedData(traceID string) (ttftMs int64, chunkCount int) {
+func (s *TraceStore) GetAccumulatedData(traceID string) (ttftNs int64, chunkCount int) {
 	info := s.GetDeferredSpan(traceID)
 	if info == nil {
 		return 0, 0
@@ -181,12 +181,12 @@ func (s *TraceStore) GetAccumulatedData(traceID string) (ttftMs int64, chunkCoun
 	info.mu.Lock()
 	defer info.mu.Unlock()
 
-	// Calculate TTFT in milliseconds
+	// Calculate TTFT in nanoseconds
 	if !info.StartTime.IsZero() && !info.FirstChunkTime.IsZero() {
-		ttftMs = info.FirstChunkTime.Sub(info.StartTime).Milliseconds()
+		ttftNs = info.FirstChunkTime.Sub(info.StartTime).Nanoseconds()
 	}
 
-	return ttftMs, info.ChunkCount
+	return ttftNs, info.ChunkCount
 }
 
 // ReleaseTrace returns the trace and its spans to the pools for reuse

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -176,7 +176,7 @@ func (t *Tracer) PopulateLLMResponseAttributes(handle schemas.SpanHandle, resp *
 	span := trace.GetSpan(h.spanID)
 	if span == nil {
 		return
-	}	
+	}
 	for k, v := range PopulateResponseAttributes(resp) {
 		span.SetAttribute(k, v)
 	}
@@ -241,8 +241,8 @@ func (t *Tracer) AddStreamingChunk(traceID string, response *schemas.BifrostResp
 // in completeDeferredSpan. Full content accumulation for plugins is handled by
 // the embedded streaming.Accumulator via ProcessStreamingChunk.
 func (t *Tracer) GetAccumulatedChunks(traceID string) (*schemas.BifrostResponse, int64, int) {
-	ttftMs, chunkCount := t.store.GetAccumulatedData(traceID)
-	return nil, ttftMs, chunkCount
+	ttftNs, chunkCount := t.store.GetAccumulatedData(traceID)
+	return nil, ttftNs, chunkCount
 }
 
 // CreateStreamAccumulator creates a new stream accumulator for the given trace ID.

--- a/plugins/otel/changelog.md
+++ b/plugins/otel/changelog.md
@@ -1,1 +1,2 @@
 - fix: set responses input messages in gen_ai.input.messages
+- fix: record ttft in nanoseconds instead of milliseconds to avoid truncation to 0

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -416,8 +416,8 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 	// Record streaming latency metrics if available
 	ttft := getFloat64Attr(attrs, schemas.AttrTimeToFirstToken)
 	if ttft > 0 {
-		// Convert from milliseconds to seconds if needed (check the unit)
-		p.metricsExporter.RecordStreamFirstTokenLatency(ctx, ttft/1000.0, otelAttrs...)
+		// Convert from nanoseconds to seconds if needed (check the unit)
+		p.metricsExporter.RecordStreamFirstTokenLatency(ctx, ttft/1e9, otelAttrs...)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixed time-to-first-token (TTFT) measurement precision by recording values in nanoseconds instead of milliseconds to prevent truncation to zero for very fast responses.

## Changes

- Updated TTFT calculation in `TraceStore.GetAccumulatedData()` to use `Nanoseconds()` instead of `Milliseconds()`
- Modified function signatures and variable names throughout the codebase to reflect nanosecond precision (`ttftNs` instead of `ttftMs`)
- Updated OpenTelemetry plugin to convert nanoseconds to seconds (dividing by 1e9 instead of 1000) when recording metrics
- Updated interface definitions in `schemas/tracer.go` to reflect the nanosecond return type

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with very low latency to verify TTFT values are properly recorded:

```sh
# Core/Transports
go version
go test ./...

# Test with streaming requests that have sub-millisecond TTFT
# Verify that TTFT metrics are no longer truncated to 0
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a metrics precision fix with no security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable