### PR TITLE
feat: add image size and aspect ratio configuration for Gemini provider

### DIFF
--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -303,6 +303,8 @@ func convertImagenFormatToSize(sampleImageSize *string, aspectRatio *string) str
 			baseSize = 1024
 		case "2k":
 			baseSize = 2048
+		case "4k":
+			baseSize = 4096
 		}
 	}
 
@@ -403,6 +405,17 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
+
+		// Handle size conversion
+		if bifrostReq.Params.Size != nil && strings.ToLower(*bifrostReq.Params.Size) != "auto" {
+			imageSize, aspectRatio := convertSizeToImagenFormat(*bifrostReq.Params.Size)
+			if imageSize != "" && aspectRatio != "" {
+				geminiReq.GenerationConfig.ImageConfig = &GeminiImageConfig{
+					ImageSize:   imageSize,
+					AspectRatio: aspectRatio,
+				}
+			}
+		}
 
 		// Handle extra parameters
 		if bifrostReq.Params.ExtraParams != nil {
@@ -626,7 +639,7 @@ func convertOutputFormatToMimeType(outputFormat string) string {
 }
 
 // convertSizeToImagenFormat converts standard size format (e.g., "1024x1024") to Imagen format
-// Returns (imageSize, aspectRatio) where imageSize is "1k", "2k" and aspectRatio is one of:
+// Returns (imageSize, aspectRatio) where imageSize is "1k", "2k", "4k" and aspectRatio is one of:
 // "1:1", "3:4", "4:3", "9:16", or "16:9"
 func convertSizeToImagenFormat(size string) (string, string) {
 	// Parse size string (format: "WIDTHxHEIGHT")
@@ -651,6 +664,8 @@ func convertSizeToImagenFormat(size string) (string, string) {
 		imageSize = "1k"
 	} else if width <= 2048 && height <= 2048 {
 		imageSize = "2k"
+	} else if width <= 4096 && height <= 4096 {
+		imageSize = "4k"
 	}
 
 	// Calculate aspect ratio

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -848,6 +848,18 @@ type GenerationConfig struct {
 	TopK *int `json:"topK,omitempty"`
 	// Optional. If specified, nucleus sampling will be used.
 	TopP *float64 `json:"topP,omitempty"`
+	// Optional. Image generation configuration.
+	ImageConfig *GeminiImageConfig `json:"imageConfig,omitempty"`
+}
+
+// GeminiImageConfig represents image generation configuration within GenerationConfig.
+type GeminiImageConfig struct {
+	// AspectRatio controls the aspect ratio of generated images.
+	// Valid values: "1:1", "3:4", "4:3", "9:16", "16:9"
+	AspectRatio string `json:"aspectRatio,omitempty"`
+	// ImageSize controls the resolution of generated images.
+	// Valid values: "1k", "2k", "4k"
+	ImageSize string `json:"imageSize,omitempty"`
 }
 
 // ModelSelectionConfig represents configuration for model selection.

--- a/transports/bifrost-http/integrations/cursor.go
+++ b/transports/bifrost-http/integrations/cursor.go
@@ -1057,6 +1057,6 @@ func NewCursorRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, log
 	routes = append(routes, CreateCohereRouteConfigs("/cursor")...)
 
 	return &CursorRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
 }


### PR DESCRIPTION
## Summary

Adds support for 4K image generation and proper size/aspect ratio configuration for Gemini's image generation API. This enhancement allows users to generate higher resolution images and ensures size parameters are properly converted to Gemini's Imagen format.

## Changes

- Added `ImageConfig` struct to handle image generation configuration with `AspectRatio` and `ImageSize` fields
- Extended `convertSizeToImagenFormat` function to support 4K resolution (up to 4096x4096 pixels)
- Integrated size parameter handling in `ToGeminiImageGenerationRequest` to automatically convert standard size formats to Gemini's format
- Updated `GenerationConfig` to include optional `ImageConfig` field
- Fixed constructor call in cursor router to match updated signature

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test image generation with various size parameters to ensure proper conversion to Gemini format:

```sh
# Core/Transports
go version
go test ./...

# Test with different image sizes
curl -X POST /v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "A beautiful landscape",
    "size": "4096x4096",
    "provider": "gemini"
  }'

# Test with standard sizes
curl -X POST /v1/images/generations \
  -H "Content-Type: application/json" \
  -d '{
    "prompt": "A portrait",
    "size": "1024x1024",
    "provider": "gemini"
  }'
```

Verify that size parameters are correctly converted to Gemini's imageSize ("1k", "2k", "4k") and aspectRatio formats.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects image generation configuration parameters.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable