### PR TITLE
feat: add threshold-gated streaming request decompression with pooled readers

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.123.0
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/andybalholm/brotli v1.2.0
 	github.com/aws/aws-sdk-go-v2 v1.41.0
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
@@ -16,6 +17,7 @@ require (
 	github.com/bytedance/sonic v1.15.0
 	github.com/google/uuid v1.6.0
 	github.com/hajimehoshi/go-mp3 v0.3.4
+	github.com/klauspost/compress v1.18.2
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
@@ -30,7 +32,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
-	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect
@@ -51,7 +52,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect

--- a/core/providers/utils/decompression.go
+++ b/core/providers/utils/decompression.go
@@ -1,0 +1,192 @@
+package utils
+
+import (
+	"compress/gzip"
+	"compress/zlib"
+	"io"
+	"sync"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
+)
+
+// ---------------------------------------------------------------------------
+// Pooled decompression readers
+//
+// Each encoding gets a sync.Pool with Acquire/Release helpers that follow the
+// same contract:
+//   - Acquire(r io.Reader) returns a ready-to-read decompressor, reusing a
+//     pooled instance when possible, falling back to a fresh allocation.
+//   - Release returns the decompressor to the pool for future reuse.
+//     Callers MUST call Release exactly once after the reader is fully consumed.
+//
+// All pool operations are panic-safe: type assertions use the comma-ok form,
+// Reset calls are wrapped in recover, and nil checks guard every dereference.
+// A corrupt or wrong-typed pooled instance is silently discarded (GC reclaims
+// it) and a fresh allocation takes its place.
+//
+// Gzip, deflate, and brotli readers are stateless between streams — Close (if
+// applicable) then Reset is safe. Zstd decoders run background goroutines so
+// Close is terminal; pooled decoders are reset without closing.
+// ---------------------------------------------------------------------------
+
+// safeReset calls resetFn and recovers from any panic. Returns true on success.
+// A corrupt pooled reader may panic inside Reset; this prevents that from
+// bringing down the server.
+func safeReset(resetFn func() error) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			ok = false
+		}
+	}()
+	return resetFn() == nil
+}
+
+// ---- gzip ----
+
+var gzipReaderPool = sync.Pool{
+	New: func() any {
+		return &gzip.Reader{}
+	},
+}
+
+// AcquireGzipReader gets a gzip.Reader from the pool and resets it to read from r,
+// or creates a new one if the pool is empty or reset fails.
+func AcquireGzipReader(r io.Reader) (*gzip.Reader, error) {
+	if v := gzipReaderPool.Get(); v != nil {
+		if gz, ok := v.(*gzip.Reader); ok {
+			if safeReset(func() error { return gz.Reset(r) }) {
+				return gz, nil
+			}
+		}
+		// Wrong type or reset failed/panicked — discard, let GC reclaim.
+	}
+	return gzip.NewReader(r)
+}
+
+// ReleaseGzipReader closes and returns a gzip.Reader to the pool.
+func ReleaseGzipReader(gz *gzip.Reader) {
+	if gz == nil {
+		return
+	}
+	_ = gz.Close()
+	gzipReaderPool.Put(gz)
+}
+
+// ---- deflate ----
+//
+// HTTP Content-Encoding "deflate" is zlib-wrapped DEFLATE (RFC 1950), NOT raw
+// DEFLATE (RFC 1951). This matches fasthttp's implementation and the HTTP spec
+// (RFC 9110 §8.4.1.2). We use compress/zlib, not compress/flate.
+
+// deflateReader is the interface that zlib readers support for pooling.
+// The concrete type from zlib.NewReader is unexported, but implements Resetter.
+type deflateReader interface {
+	io.ReadCloser
+	Reset(r io.Reader, dict []byte) error
+}
+
+// No New func: zlib.NewReader validates the header eagerly, so it cannot be
+// created with a nil reader. Pooled readers are populated via Release.
+var deflateReaderPool = sync.Pool{}
+
+// AcquireFlateReader gets a zlib (HTTP "deflate") reader from the pool and
+// resets it to read from r, or creates a new one if the pool is empty or
+// reset fails.
+func AcquireFlateReader(r io.Reader) (io.ReadCloser, error) {
+	if v := deflateReaderPool.Get(); v != nil {
+		if dr, ok := v.(deflateReader); ok {
+			if safeReset(func() error { return dr.Reset(r, nil) }) {
+				return dr, nil
+			}
+		}
+	}
+	return zlib.NewReader(r)
+}
+
+// ReleaseFlateReader closes and returns a deflate reader to the pool.
+func ReleaseFlateReader(fr io.ReadCloser) {
+	if fr == nil {
+		return
+	}
+	_ = fr.Close()
+	deflateReaderPool.Put(fr)
+}
+
+// ---- brotli ----
+
+var brotliReaderPool = sync.Pool{
+	New: func() any {
+		return brotli.NewReader(nil)
+	},
+}
+
+// AcquireBrotliReader gets a brotli.Reader from the pool and resets it to read
+// from r, or creates a new one if the pool is empty or reset panics.
+func AcquireBrotliReader(r io.Reader) *brotli.Reader {
+	if v := brotliReaderPool.Get(); v != nil {
+		if br, ok := v.(*brotli.Reader); ok {
+			// brotli.Reset is void (no error), but wrap in safeReset for
+			// consistency: a corrupt pooled reader could panic on Reset.
+			if safeReset(func() error { br.Reset(r); return nil }) {
+				return br
+			}
+		}
+		// Wrong type or reset panicked — discard, let GC reclaim.
+	}
+	return brotli.NewReader(r)
+}
+
+// ReleaseBrotliReader returns a brotli.Reader to the pool.
+// Brotli readers have no Close method; Reset(nil) is sufficient to drop the
+// reference to the underlying reader.
+func ReleaseBrotliReader(br *brotli.Reader) {
+	if br == nil {
+		return
+	}
+	br.Reset(nil)
+	brotliReaderPool.Put(br)
+}
+
+// ---- zstd ----
+
+var zstdDecoderPool = sync.Pool{
+	New: func() any {
+		dec, err := zstd.NewReader(nil, zstd.WithDecoderConcurrency(1))
+		if err != nil {
+			// NewReader(nil) failing is unexpected; return nil so Acquire
+			// falls through to a fresh allocation with the real reader.
+			return nil
+		}
+		return dec
+	},
+}
+
+// AcquireZstdDecoder gets a zstd.Decoder from the pool and resets it to read
+// from r, or creates a new one if the pool is empty or reset fails.
+// Decoders are created with concurrency=1 to minimise goroutine overhead.
+func AcquireZstdDecoder(r io.Reader) (*zstd.Decoder, error) {
+	if v := zstdDecoderPool.Get(); v != nil {
+		if dec, ok := v.(*zstd.Decoder); ok && dec != nil {
+			if safeReset(func() error { return dec.Reset(r) }) {
+				return dec, nil
+			}
+			// Reset failed/panicked — release references before discarding.
+			// Don't call Close (terminal); Reset(nil) is safe per pool contract.
+			_ = dec.Reset(nil)
+		}
+	}
+	return zstd.NewReader(r, zstd.WithDecoderConcurrency(1))
+}
+
+// ReleaseZstdDecoder returns a zstd.Decoder to the pool.
+// Unlike other decoders, zstd.Close() is terminal (stops background goroutines
+// permanently). We only call Reset(nil) to release the source reference, then
+// re-pool. Close is never called on pooled decoders.
+func ReleaseZstdDecoder(dec *zstd.Decoder) {
+	if dec == nil {
+		return
+	}
+	_ = dec.Reset(nil)
+	zstdDecoderPool.Put(dec)
+}

--- a/core/providers/utils/decompression_test.go
+++ b/core/providers/utils/decompression_test.go
@@ -1,0 +1,516 @@
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
+)
+
+const poolTestIterations = 10
+
+var testPayload = []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello world"}]}`)
+
+// ---------------------------------------------------------------------------
+// helpers — one compressor per encoding
+// ---------------------------------------------------------------------------
+
+func compressGzip(data []byte) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(data); err != nil {
+		panic(fmt.Errorf("gzip write: %w", err))
+	}
+	if err := gz.Close(); err != nil {
+		panic(fmt.Errorf("gzip close: %w", err))
+	}
+	return buf.Bytes()
+}
+
+// compressFlate produces zlib-wrapped DEFLATE (RFC 1950) — the correct format
+// for HTTP Content-Encoding "deflate" per RFC 9110 §8.4.1.2.
+func compressFlate(data []byte) []byte {
+	var buf bytes.Buffer
+	w, err := zlib.NewWriterLevel(&buf, zlib.DefaultCompression)
+	if err != nil {
+		panic(fmt.Errorf("zlib new writer: %w", err))
+	}
+	if _, err := w.Write(data); err != nil {
+		panic(fmt.Errorf("zlib write: %w", err))
+	}
+	if err := w.Close(); err != nil {
+		panic(fmt.Errorf("zlib close: %w", err))
+	}
+	return buf.Bytes()
+}
+
+func compressBrotli(data []byte) []byte {
+	var buf bytes.Buffer
+	w := brotli.NewWriter(&buf)
+	if _, err := w.Write(data); err != nil {
+		panic(fmt.Errorf("brotli write: %w", err))
+	}
+	if err := w.Close(); err != nil {
+		panic(fmt.Errorf("brotli close: %w", err))
+	}
+	return buf.Bytes()
+}
+
+func compressZstd(data []byte) []byte {
+	var buf bytes.Buffer
+	enc, err := zstd.NewWriter(&buf)
+	if err != nil {
+		panic(fmt.Errorf("zstd new writer: %w", err))
+	}
+	if _, err := enc.Write(data); err != nil {
+		panic(fmt.Errorf("zstd write: %w", err))
+	}
+	if err := enc.Close(); err != nil {
+		panic(fmt.Errorf("zstd close: %w", err))
+	}
+	return buf.Bytes()
+}
+
+// ---------------------------------------------------------------------------
+// Pool cycle tests — each runs Acquire → ReadAll → Release N times to verify
+// that pooled instances are reused correctly across iterations.
+// ---------------------------------------------------------------------------
+
+func TestAcquireReleaseGzipReader(t *testing.T) {
+	compressed := compressGzip(testPayload)
+	for i := 0; i < poolTestIterations; i++ {
+		gz, err := AcquireGzipReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("iteration %d: AcquireGzipReader error: %v", i, err)
+		}
+		got, err := io.ReadAll(gz)
+		if err != nil {
+			t.Fatalf("iteration %d: ReadAll error: %v", i, err)
+		}
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("iteration %d: got %q, want %q", i, got, testPayload)
+		}
+		ReleaseGzipReader(gz)
+	}
+}
+
+func TestAcquireReleaseFlateReader(t *testing.T) {
+	compressed := compressFlate(testPayload)
+	for i := 0; i < poolTestIterations; i++ {
+		fr, err := AcquireFlateReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("iteration %d: AcquireFlateReader error: %v", i, err)
+		}
+		got, err := io.ReadAll(fr)
+		if err != nil {
+			t.Fatalf("iteration %d: ReadAll error: %v", i, err)
+		}
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("iteration %d: got %q, want %q", i, got, testPayload)
+		}
+		ReleaseFlateReader(fr)
+	}
+}
+
+func TestAcquireReleaseBrotliReader(t *testing.T) {
+	compressed := compressBrotli(testPayload)
+	for i := 0; i < poolTestIterations; i++ {
+		br := AcquireBrotliReader(bytes.NewReader(compressed))
+		got, err := io.ReadAll(br)
+		if err != nil {
+			t.Fatalf("iteration %d: ReadAll error: %v", i, err)
+		}
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("iteration %d: got %q, want %q", i, got, testPayload)
+		}
+		ReleaseBrotliReader(br)
+	}
+}
+
+func TestAcquireReleaseZstdDecoder(t *testing.T) {
+	compressed := compressZstd(testPayload)
+	for i := 0; i < poolTestIterations; i++ {
+		dec, err := AcquireZstdDecoder(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("iteration %d: AcquireZstdDecoder error: %v", i, err)
+		}
+		got, err := io.ReadAll(dec)
+		if err != nil {
+			t.Fatalf("iteration %d: ReadAll error: %v", i, err)
+		}
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("iteration %d: got %q, want %q", i, got, testPayload)
+		}
+		ReleaseZstdDecoder(dec)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Panic-safety tests — verify that corrupt or wrong-typed pooled instances
+// are handled gracefully (no panics, fallback to fresh allocation).
+//
+// Each poison test drains the target pool first so stale values from earlier
+// tests cannot interfere. sync.Pool.Get offers no ordering guarantee, so
+// draining ensures the poisoned value is the only item available.
+// ---------------------------------------------------------------------------
+
+// drainPool removes all previously pooled values so the next Put/Get pair
+// exercises the intended fallback path. Temporarily sets New to nil to ensure
+// Get returns nil when the pool is empty.
+func drainPool(p *sync.Pool) {
+	origNew := p.New
+	p.New = nil
+	for p.Get() != nil {
+	}
+	p.New = origNew
+}
+
+// TestPool_WrongType_NoPanic poisons each pool with a wrong-typed value,
+// then verifies Acquire still succeeds by falling back to a fresh allocation.
+func TestPool_WrongType_NoPanic(t *testing.T) {
+	wrongValue := "not a reader"
+	compressed := compressGzip(testPayload)
+
+	t.Run("gzip", func(t *testing.T) {
+		drainPool(&gzipReaderPool)
+		gzipReaderPool.Put(wrongValue)
+		gz, err := AcquireGzipReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("AcquireGzipReader should fall back, got error: %v", err)
+		}
+		got, _ := io.ReadAll(gz)
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseGzipReader(gz)
+	})
+
+	t.Run("deflate", func(t *testing.T) {
+		drainPool(&deflateReaderPool)
+		deflateReaderPool.Put(wrongValue)
+		fr, err := AcquireFlateReader(bytes.NewReader(compressFlate(testPayload)))
+		if err != nil {
+			t.Fatalf("AcquireFlateReader should fall back, got error: %v", err)
+		}
+		got, _ := io.ReadAll(fr)
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseFlateReader(fr)
+	})
+
+	t.Run("brotli", func(t *testing.T) {
+		drainPool(&brotliReaderPool)
+		brotliReaderPool.Put(wrongValue)
+		br := AcquireBrotliReader(bytes.NewReader(compressBrotli(testPayload)))
+		got, err := io.ReadAll(br)
+		if err != nil {
+			t.Fatalf("ReadAll error: %v", err)
+		}
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseBrotliReader(br)
+	})
+
+	t.Run("zstd", func(t *testing.T) {
+		drainPool(&zstdDecoderPool)
+		zstdDecoderPool.Put(wrongValue)
+		dec, err := AcquireZstdDecoder(bytes.NewReader(compressZstd(testPayload)))
+		if err != nil {
+			t.Fatalf("AcquireZstdDecoder should fall back, got error: %v", err)
+		}
+		got, _ := io.ReadAll(dec)
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseZstdDecoder(dec)
+	})
+}
+
+// TestPool_NilInPool_NoPanic puts an explicit nil into each pool, then
+// verifies Acquire still succeeds by falling back to a fresh allocation.
+func TestPool_NilInPool_NoPanic(t *testing.T) {
+	t.Run("gzip", func(t *testing.T) {
+		drainPool(&gzipReaderPool)
+		gzipReaderPool.Put((*gzip.Reader)(nil))
+		gz, err := AcquireGzipReader(bytes.NewReader(compressGzip(testPayload)))
+		if err != nil {
+			t.Fatalf("should fall back, got error: %v", err)
+		}
+		got, _ := io.ReadAll(gz)
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseGzipReader(gz)
+	})
+
+	t.Run("zstd", func(t *testing.T) {
+		drainPool(&zstdDecoderPool)
+		zstdDecoderPool.Put((*zstd.Decoder)(nil))
+		dec, err := AcquireZstdDecoder(bytes.NewReader(compressZstd(testPayload)))
+		if err != nil {
+			t.Fatalf("should fall back, got error: %v", err)
+		}
+		got, _ := io.ReadAll(dec)
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseZstdDecoder(dec)
+	})
+}
+
+// TestPool_InvalidData_NoPanic verifies that Acquire handles corrupt/invalid
+// compressed data without panicking. The error should surface as a return
+// value or a read error, never a panic.
+func TestPool_InvalidData_NoPanic(t *testing.T) {
+	garbage := []byte("this is not compressed data at all")
+
+	t.Run("gzip", func(t *testing.T) {
+		// gzip.NewReader validates the header immediately, so Acquire returns error.
+		_, err := AcquireGzipReader(bytes.NewReader(garbage))
+		if err == nil {
+			t.Fatal("expected error for invalid gzip data")
+		}
+	})
+
+	t.Run("deflate", func(t *testing.T) {
+		// zlib.NewReader validates the header eagerly, so Acquire returns error.
+		_, err := AcquireFlateReader(bytes.NewReader(garbage))
+		if err == nil {
+			t.Fatal("expected error for invalid deflate (zlib) data")
+		}
+	})
+
+	t.Run("brotli", func(t *testing.T) {
+		// brotli doesn't validate eagerly; error surfaces on Read.
+		br := AcquireBrotliReader(bytes.NewReader(garbage))
+		_, readErr := io.ReadAll(br)
+		if readErr == nil {
+			t.Fatal("expected read error for invalid brotli data")
+		}
+		ReleaseBrotliReader(br)
+	})
+
+	t.Run("zstd", func(t *testing.T) {
+		// zstd.Decoder doesn't validate eagerly; error surfaces on Read.
+		dec, err := AcquireZstdDecoder(bytes.NewReader(garbage))
+		if err != nil {
+			t.Fatalf("AcquireZstdDecoder should not error eagerly: %v", err)
+		}
+		_, readErr := io.ReadAll(dec)
+		if readErr == nil {
+			t.Fatal("expected read error for invalid zstd data")
+		}
+		ReleaseZstdDecoder(dec)
+	})
+}
+
+// TestPool_CorruptPooledInstance_NoPanic simulates a corrupt pooled reader
+// whose Reset panics. Verifies safeReset catches the panic and Acquire
+// falls through to a fresh allocation.
+func TestPool_CorruptPooledInstance_NoPanic(t *testing.T) {
+	t.Run("safeReset_catches_panic", func(t *testing.T) {
+		ok := safeReset(func() error {
+			panic("simulated corrupt reader")
+		})
+		if ok {
+			t.Fatal("safeReset should return false when resetFn panics")
+		}
+	})
+
+	t.Run("gzip_after_corrupt", func(t *testing.T) {
+		// Poison pool with a gzip.Reader that has corrupt internal state:
+		// a zero-value reader that has been closed without ever being used.
+		drainPool(&gzipReaderPool)
+		corrupt := &gzip.Reader{}
+		gzipReaderPool.Put(corrupt)
+
+		// Acquire should recover, discard the corrupt reader, and create fresh.
+		compressed := compressGzip(testPayload)
+		gz, err := AcquireGzipReader(bytes.NewReader(compressed))
+		if err != nil {
+			t.Fatalf("should recover from corrupt pooled reader, got: %v", err)
+		}
+		got, _ := io.ReadAll(gz)
+		if !bytes.Equal(got, testPayload) {
+			t.Errorf("got %q, want %q", got, testPayload)
+		}
+		ReleaseGzipReader(gz)
+	})
+}
+
+// TestRelease_Nil_NoPanic verifies Release functions are safe to call with nil.
+func TestRelease_Nil_NoPanic(t *testing.T) {
+	ReleaseGzipReader(nil)
+	ReleaseFlateReader(nil)
+	ReleaseBrotliReader(nil)
+	ReleaseZstdDecoder(nil)
+}
+
+// TestPool_RecoveryAndReuse verifies that after a corrupt instance is discarded,
+// the pool recovers and subsequent cycles work normally.
+func TestPool_RecoveryAndReuse(t *testing.T) {
+	// Drain then poison all pools with wrong types.
+	drainPool(&gzipReaderPool)
+	drainPool(&deflateReaderPool)
+	drainPool(&brotliReaderPool)
+	drainPool(&zstdDecoderPool)
+	gzipReaderPool.Put("wrong")
+	deflateReaderPool.Put(42)
+	brotliReaderPool.Put(struct{}{})
+	zstdDecoderPool.Put(false)
+
+	// Run a normal Acquire → ReadAll → Release cycle for each.
+	// This verifies the pool recovers: the wrong-typed value is discarded,
+	// a fresh instance is created and released back, making the pool healthy.
+	t.Run("gzip", func(t *testing.T) {
+		compressed := compressGzip(testPayload)
+		for i := 0; i < 3; i++ {
+			gz, err := AcquireGzipReader(bytes.NewReader(compressed))
+			if err != nil {
+				t.Fatalf("iteration %d: %v", i, err)
+			}
+			got, _ := io.ReadAll(gz)
+			if !bytes.Equal(got, testPayload) {
+				t.Errorf("iteration %d: mismatch", i)
+			}
+			ReleaseGzipReader(gz)
+		}
+	})
+
+	t.Run("deflate", func(t *testing.T) {
+		compressed := compressFlate(testPayload)
+		for i := 0; i < 3; i++ {
+			fr, err := AcquireFlateReader(bytes.NewReader(compressed))
+			if err != nil {
+				t.Fatalf("iteration %d: %v", i, err)
+			}
+			got, _ := io.ReadAll(fr)
+			if !bytes.Equal(got, testPayload) {
+				t.Errorf("iteration %d: mismatch", i)
+			}
+			ReleaseFlateReader(fr)
+		}
+	})
+
+	t.Run("brotli", func(t *testing.T) {
+		compressed := compressBrotli(testPayload)
+		for i := 0; i < 3; i++ {
+			br := AcquireBrotliReader(bytes.NewReader(compressed))
+			got, err := io.ReadAll(br)
+			if err != nil {
+				t.Fatalf("iteration %d: %v", i, err)
+			}
+			if !bytes.Equal(got, testPayload) {
+				t.Errorf("iteration %d: mismatch", i)
+			}
+			ReleaseBrotliReader(br)
+		}
+	})
+
+	t.Run("zstd", func(t *testing.T) {
+		compressed := compressZstd(testPayload)
+		for i := 0; i < 3; i++ {
+			dec, err := AcquireZstdDecoder(bytes.NewReader(compressed))
+			if err != nil {
+				t.Fatalf("iteration %d: %v", i, err)
+			}
+			got, _ := io.ReadAll(dec)
+			if !bytes.Equal(got, testPayload) {
+				t.Errorf("iteration %d: mismatch", i)
+			}
+			ReleaseZstdDecoder(dec)
+		}
+	})
+}
+
+// TestPool_EmptyReader_NoPanic verifies Acquire handles an empty reader
+// (zero bytes) without panicking. Gzip/zstd should return an error (no header),
+// deflate/brotli should return empty or error on Read.
+func TestPool_EmptyReader_NoPanic(t *testing.T) {
+	empty := bytes.NewReader(nil)
+
+	t.Run("gzip", func(t *testing.T) {
+		_, err := AcquireGzipReader(empty)
+		if err == nil {
+			t.Fatal("expected error for empty gzip input")
+		}
+	})
+
+	t.Run("deflate", func(t *testing.T) {
+		// zlib.NewReader validates the header eagerly; empty input has no header.
+		_, err := AcquireFlateReader(bytes.NewReader(nil))
+		if err == nil {
+			t.Fatal("expected error for empty deflate (zlib) input")
+		}
+	})
+
+	t.Run("brotli", func(t *testing.T) {
+		br := AcquireBrotliReader(bytes.NewReader(nil))
+		data, _ := io.ReadAll(br)
+		if len(data) != 0 {
+			t.Errorf("expected empty output, got %d bytes", len(data))
+		}
+		ReleaseBrotliReader(br)
+	})
+
+	t.Run("zstd", func(t *testing.T) {
+		dec, err := AcquireZstdDecoder(bytes.NewReader(nil))
+		if err != nil {
+			// Some versions error eagerly, that's fine.
+			return
+		}
+		data, _ := io.ReadAll(dec)
+		// Empty input with no zstd frame yields empty output or read error.
+		_ = data
+		ReleaseZstdDecoder(dec)
+	})
+}
+
+// TestSafeReset verifies safeReset correctly handles panics and errors.
+func TestSafeReset(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ok := safeReset(func() error { return nil })
+		if !ok {
+			t.Fatal("expected true for successful reset")
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		ok := safeReset(func() error { return io.ErrUnexpectedEOF })
+		if ok {
+			t.Fatal("expected false for failed reset")
+		}
+	})
+
+	t.Run("panic_string", func(t *testing.T) {
+		ok := safeReset(func() error { panic("boom") })
+		if ok {
+			t.Fatal("expected false for panicking reset")
+		}
+	})
+
+	t.Run("panic_nil", func(t *testing.T) {
+		ok := safeReset(func() error { panic(nil) })
+		if ok {
+			t.Fatal("expected false for nil panic")
+		}
+	})
+
+	t.Run("panic_error", func(t *testing.T) {
+		ok := safeReset(func() error {
+			panic(fmt.Errorf("internal corruption: %s", strings.Repeat("x", 100)))
+		})
+		if ok {
+			t.Fatal("expected false for error panic")
+		}
+	})
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -802,36 +802,6 @@ func CloneFastHTTPClientConfig(base *fasthttp.Client) *fasthttp.Client {
 	}
 }
 
-// gzipReaderPool reuses gzip.Reader instances across requests to reduce GC pressure.
-var gzipReaderPool = sync.Pool{
-	New: func() any {
-		return &gzip.Reader{}
-	},
-}
-
-// AcquireGzipReader gets a gzip.Reader from the pool and resets it to read from r,
-// or creates a new one if the pool is empty or reset fails.
-func AcquireGzipReader(r io.Reader) (*gzip.Reader, error) {
-	if v := gzipReaderPool.Get(); v != nil {
-		gz := v.(*gzip.Reader)
-		if err := gz.Reset(r); err == nil {
-			return gz, nil
-		}
-		// Reset failed; discard the reader. After a failed Reset the internal
-		// decompressor may be nil, making Close() panic (Go 1.26+).
-		// Do not re-pool — let GC reclaim it.
-	}
-	return gzip.NewReader(r)
-}
-
-// ReleaseGzipReader closes and returns a gzip.Reader to the pool.
-func ReleaseGzipReader(gz *gzip.Reader) {
-	if gz != nil {
-		_ = gz.Close()
-		gzipReaderPool.Put(gz)
-	}
-}
-
 // decompressBodyStreamIfGzip checks Content-Encoding for gzip and wraps the stream
 // with on-the-fly decompression using a pooled gzip.Reader. Clears Content-Encoding
 // header so downstream consumers don't double-decompress. Returns original reader

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -697,31 +697,6 @@ func TestCheckAndDecodeBody_PooledGzip(t *testing.T) {
 	}
 }
 
-// TestAcquireReleaseGzipReader verifies the pool acquire/release cycle works correctly.
-func TestAcquireReleaseGzipReader(t *testing.T) {
-	testData := []byte(`test data for gzip pool`)
-	compressed := gzipCompress(testData)
-
-	for i := 0; i < 10; i++ {
-		reader := bytes.NewReader(compressed)
-		gz, err := AcquireGzipReader(reader)
-		if err != nil {
-			t.Fatalf("iteration %d: AcquireGzipReader() error: %v", i, err)
-		}
-
-		decompressed, err := io.ReadAll(gz)
-		if err != nil {
-			t.Fatalf("iteration %d: ReadAll() error: %v", i, err)
-		}
-
-		if string(decompressed) != string(testData) {
-			t.Errorf("iteration %d: got %q, want %q", i, string(decompressed), string(testData))
-		}
-
-		ReleaseGzipReader(gz)
-	}
-}
-
 // TestCheckAndDecodeBody_Concurrent verifies no data races with concurrent access.
 func TestCheckAndDecodeBody_Concurrent(t *testing.T) {
 	testData := []byte(`{"concurrent":"test"}`)

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -2,8 +2,6 @@ package handlers
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -14,8 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/andybalholm/brotli"
-	"github.com/klauspost/compress/zstd"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/encrypt"
@@ -118,41 +115,120 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 }
 
 // RequestDecompressionMiddleware transparently decompresses compressed request bodies.
-// Request bodies are decompressed with streaming readers before entering handler pipelines.
+// Two paths based on compressed Content-Length:
+//   - Large or chunked (CL > threshold or CL unknown): streaming decompression via
+//     SetBodyStream, avoiding full body materialization. Uses pooled gzip readers
+//     matching the response-side pattern in core/providers/utils.
+//   - Small (CL ≤ threshold): buffered decompression via io.ReadAll + SetBodyRaw,
+//     with decompression bomb protection via MaxRequestBodySizeMB.
 func RequestDecompressionMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
-			if len(ctx.Request.Header.ContentEncoding()) > 0 {
-				maxRequestBodyBytes := 0
-				if config != nil && config.ClientConfig.MaxRequestBodySizeMB > 0 {
-					maxRequestBodyBytes = config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024
-				}
+			if len(ctx.Request.Header.ContentEncoding()) == 0 {
+				next(ctx)
+				return
+			}
 
-				body, err := decodeRequestBodyWithLimit(&ctx.Request, maxRequestBodyBytes)
-				if errors.Is(err, errRequestBodyTooLarge) {
-					SendError(ctx, fasthttp.StatusRequestEntityTooLarge, fmt.Sprintf("decompressed request body exceeds max allowed size of %d bytes", maxRequestBodyBytes))
-					return
-				}
+			if shouldStreamDecompress(config, ctx) {
+				cleanup, applied, err := streamingDecompress(ctx)
 				if err != nil {
 					SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid compressed request body: %v", err))
 					return
 				}
-
-				ctx.Request.SetBodyRaw(body)
-				ctx.Request.Header.Del(fasthttp.HeaderContentEncoding)
-				ctx.Request.Header.Del(fasthttp.HeaderContentLength)
+				if applied {
+					next(ctx)
+					cleanup()
+					return
+				}
+				// No body stream available (StreamRequestBody not enabled) — fall
+				// through to the buffered decompression path below.
 			}
+
+			// Buffered path: small compressed request — materialize fully.
+			maxRequestBodyBytes := 100 * 1024 * 1024 // default 100 MB (matches decodeRequestBodyWithLimit fallback)
+			if config != nil && config.ClientConfig.MaxRequestBodySizeMB > 0 {
+				maxRequestBodyBytes = config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024
+			}
+
+			body, err := decodeRequestBodyWithLimit(&ctx.Request, maxRequestBodyBytes)
+			if errors.Is(err, errRequestBodyTooLarge) {
+				SendError(ctx, fasthttp.StatusRequestEntityTooLarge, fmt.Sprintf("decompressed request body exceeds max allowed size of %d bytes", maxRequestBodyBytes))
+				return
+			}
+			if err != nil {
+				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid compressed request body: %v", err))
+				return
+			}
+
+			ctx.Request.SetBodyRaw(body)
+			ctx.Request.Header.Del(fasthttp.HeaderContentEncoding)
+			ctx.Request.Header.Del(fasthttp.HeaderContentLength)
 			next(ctx)
 		}
 	}
 }
 
+// shouldStreamDecompress returns true when the compressed request body should
+// use streaming decompression rather than full materialization. Uses the
+// config threshold (set by enterprise from LargePayloadConfig.RequestThresholdBytes)
+// or falls back to DefaultLargePayloadRequestThresholdBytes.
+// Chunked requests (unknown size) always stream to be safe.
+func shouldStreamDecompress(config *lib.Config, ctx *fasthttp.RequestCtx) bool {
+	contentLength := ctx.Request.Header.ContentLength()
+	// Chunked transfer encoding: fasthttp reports -1. Size unknown, stream to be safe.
+	if contentLength < 0 {
+		return true
+	}
+	var threshold int64 = schemas.DefaultLargePayloadRequestThresholdBytes
+	if config != nil && config.StreamingDecompressThreshold > 0 {
+		threshold = config.StreamingDecompressThreshold
+	}
+	return int64(contentLength) > threshold
+}
+
+// streamingDecompress wraps the request body stream with a streaming decompression
+// reader, avoiding full body materialization for large compressed requests.
+// Returns (cleanup, applied, err):
+//   - applied=true: body stream was wrapped; caller must invoke cleanup after the
+//     handler chain completes and the body is fully consumed.
+//   - applied=false: no body stream available (StreamRequestBody not enabled on the
+//     server). Caller should fall back to the buffered decompression path.
+func streamingDecompress(ctx *fasthttp.RequestCtx) (cleanup func(), applied bool, err error) {
+	bodyStream := ctx.RequestBodyStream()
+	if bodyStream == nil {
+		return func() {}, false, nil
+	}
+
+	encoding := strings.ToLower(strings.TrimSpace(
+		string(ctx.Request.Header.ContentEncoding()),
+	))
+
+	decompReader, cleanup, err := newDecompressReader(bodyStream, encoding)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ctx.Request.SetBodyStream(decompReader, -1)
+	ctx.Request.Header.Del(fasthttp.HeaderContentEncoding)
+	ctx.Request.Header.Del(fasthttp.HeaderContentLength)
+
+	return cleanup, true, nil
+}
+
 var errRequestBodyTooLarge = errors.New("decompressed request body exceeds max allowed size")
 
 func decodeRequestBodyWithLimit(req *fasthttp.Request, maxRequestBodyBytes int) ([]byte, error) {
-	reader, cleanup, err := requestBodyDecoder(req)
-	if err != nil {
-		return nil, err
+	encoding := strings.ToLower(strings.TrimSpace(string(req.Header.ContentEncoding())))
+	bodyReader := bytes.NewReader(req.Body())
+
+	var reader io.Reader = bodyReader
+	cleanup := func() {}
+	if encoding != "" {
+		var err error
+		reader, cleanup, err = newDecompressReader(bodyReader, encoding)
+		if err != nil {
+			return nil, err
+		}
 	}
 	defer cleanup()
 
@@ -171,33 +247,34 @@ func decodeRequestBodyWithLimit(req *fasthttp.Request, maxRequestBodyBytes int) 
 	return body, nil
 }
 
-func requestBodyDecoder(req *fasthttp.Request) (io.Reader, func(), error) {
-	bodyReader := bytes.NewReader(req.Body())
-	encoding := strings.ToLower(strings.TrimSpace(string(req.Header.ContentEncoding())))
-	if encoding == "" {
-		return bodyReader, func() {}, nil
-	}
-
+// newDecompressReader wraps r with a decompression reader for the given encoding.
+// All encodings use pooled readers from core/providers/utils. The returned cleanup
+// function must be called when the reader is no longer needed.
+func newDecompressReader(r io.Reader, encoding string) (io.Reader, func(), error) {
 	switch encoding {
 	case "gzip":
-		gz, err := gzip.NewReader(bodyReader)
+		gz, err := providerUtils.AcquireGzipReader(r)
 		if err != nil {
-			return nil, func() {}, err
+			return nil, nil, err
 		}
-		return gz, func() { _ = gz.Close() }, nil
+		return gz, func() { providerUtils.ReleaseGzipReader(gz) }, nil
 	case "deflate":
-		zr := flate.NewReader(bodyReader)
-		return zr, func() { _ = zr.Close() }, nil
-	case "br":
-		return brotli.NewReader(bodyReader), func() {}, nil
-	case "zstd":
-		decoder, err := zstd.NewReader(bodyReader, zstd.WithDecoderConcurrency(1))
+		fr, err := providerUtils.AcquireFlateReader(r)
 		if err != nil {
-			return nil, func() {}, err
+			return nil, nil, err
 		}
-		return decoder, func() { decoder.Close() }, nil
+		return fr, func() { providerUtils.ReleaseFlateReader(fr) }, nil
+	case "br":
+		br := providerUtils.AcquireBrotliReader(r)
+		return br, func() { providerUtils.ReleaseBrotliReader(br) }, nil
+	case "zstd":
+		dec, err := providerUtils.AcquireZstdDecoder(r)
+		if err != nil {
+			return nil, nil, err
+		}
+		return dec, func() { providerUtils.ReleaseZstdDecoder(dec) }, nil
 	default:
-		return nil, func() {}, fmt.Errorf("%w: %q", fasthttp.ErrContentEncodingUnsupported, encoding)
+		return nil, nil, fmt.Errorf("%w: %q", fasthttp.ErrContentEncodingUnsupported, encoding)
 	}
 }
 
@@ -314,7 +391,10 @@ func fasthttpToHTTPRequest(ctx *fasthttp.RequestCtx, req *schemas.HTTPRequest) {
 	// Check threshold first (set by RequestThresholdMiddleware before this middleware runs)
 	// because the large-payload-mode flag is only set later inside the handler hook.
 	if threshold, ok := ctx.UserValue(schemas.BifrostContextKeyLargePayloadRequestThreshold).(int64); ok && threshold > 0 {
-		if int64(ctx.Request.Header.ContentLength()) > threshold {
+		cl := int64(ctx.Request.Header.ContentLength())
+		// Skip body copy when CL exceeds threshold OR CL is unknown (streaming/
+		// chunked, e.g. after streaming decompression deletes the header).
+		if cl > threshold || cl < 0 {
 			return
 		}
 	}

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"compress/gzip"
+	cryptoRand "crypto/rand"
 	"encoding/json"
 	"io"
 	"strings"
@@ -1416,6 +1417,293 @@ func TestRequestDecompressionMiddleware_ExactSizeLimit(t *testing.T) {
 
 	if !nextCalled {
 		t.Fatal("next handler was not called — body exactly at limit should pass")
+	}
+}
+
+// --- Streaming decompression path tests ---
+
+func TestShouldStreamDecompress(t *testing.T) {
+	defaultThreshold := int(schemas.DefaultLargePayloadRequestThresholdBytes)
+	tests := []struct {
+		name            string
+		contentLength   int
+		customThreshold int64 // 0 means no custom threshold (use default)
+		want            bool
+	}{
+		{"chunked (CL=-1)", -1, 0, true},
+		{"empty body (CL=0)", 0, 0, false},
+		{"small body", 100, 0, false},
+		{"at default threshold", defaultThreshold, 0, false},
+		{"above default threshold", defaultThreshold + 1, 0, true},
+		// Custom enterprise threshold (1MB) — body at 2MB should stream.
+		{"above custom threshold", 2 * 1024 * 1024, 1 * 1024 * 1024, true},
+		// Custom enterprise threshold (20MB) — body at default 10MB+1 should NOT stream.
+		{"below custom threshold", defaultThreshold + 1, 20 * 1024 * 1024, false},
+		// Chunked always streams regardless of custom threshold.
+		{"chunked with custom threshold", -1, 50 * 1024 * 1024, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &lib.Config{}
+			if tt.customThreshold > 0 {
+				cfg.StreamingDecompressThreshold = tt.customThreshold
+			}
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.Set("Content-Encoding", "gzip")
+			if tt.contentLength >= 0 {
+				ctx.Request.Header.SetContentLength(tt.contentLength)
+			} else {
+				// Simulate chunked: set body stream with unknown size
+				ctx.Request.SetBodyStream(bytes.NewReader(nil), -1)
+			}
+			if got := shouldStreamDecompress(cfg, ctx); got != tt.want {
+				t.Errorf("shouldStreamDecompress() = %v, want %v (CL=%d, threshold=%d)", got, tt.want, tt.contentLength, tt.customThreshold)
+			}
+		})
+	}
+}
+
+func TestRequestDecompressionMiddleware_StreamingPath_ChunkedGzip(t *testing.T) {
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			MaxRequestBodySizeMB: 100,
+		},
+	}
+
+	plainBody := []byte(`{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	compressedBody, err := gzipCompress(plainBody)
+	if err != nil {
+		t.Fatalf("failed to gzip: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.Header.Set("Content-Encoding", "gzip")
+	// Chunked: SetBodyStream with size -1 triggers the streaming path
+	ctx.Request.SetBodyStream(bytes.NewReader(compressedBody), -1)
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+		// Content-Encoding should be cleared
+		if ce := string(ctx.Request.Header.Peek("Content-Encoding")); ce != "" {
+			t.Errorf("expected Content-Encoding to be cleared, got %q", ce)
+		}
+		// Body should be correctly decompressed
+		body := ctx.Request.Body()
+		if string(body) != string(plainBody) {
+			t.Errorf("decompressed body mismatch: got %d bytes, want %d bytes", len(body), len(plainBody))
+		}
+	}
+
+	handler := RequestDecompressionMiddleware(config)(next)
+	handler(ctx)
+
+	if !nextCalled {
+		t.Fatal("next handler was not called")
+	}
+}
+
+func TestRequestDecompressionMiddleware_StreamingPath_AllEncodings(t *testing.T) {
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			MaxRequestBodySizeMB: 100,
+		},
+	}
+
+	plainBody := []byte(`{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	testCases := []struct {
+		name     string
+		encoding string
+		encode   func([]byte) ([]byte, error)
+	}{
+		{name: "gzip", encoding: "gzip", encode: gzipCompress},
+		{name: "deflate", encoding: "deflate", encode: deflateCompress},
+		{name: "brotli", encoding: "br", encode: brotliCompress},
+		{name: "zstd", encoding: "zstd", encode: zstdCompress},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			compressedBody, err := tc.encode(plainBody)
+			if err != nil {
+				t.Fatalf("failed to encode body: %v", err)
+			}
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.Header.SetMethod("POST")
+			ctx.Request.Header.Set("Content-Encoding", tc.encoding)
+			// Use chunked (-1) to trigger streaming path regardless of compressed size
+			ctx.Request.SetBodyStream(bytes.NewReader(compressedBody), -1)
+
+			nextCalled := false
+			next := func(ctx *fasthttp.RequestCtx) {
+				nextCalled = true
+				body := ctx.Request.Body()
+				if string(body) != string(plainBody) {
+					t.Fatalf("expected decompressed body, got %q", string(body))
+				}
+			}
+
+			handler := RequestDecompressionMiddleware(config)(next)
+			handler(ctx)
+
+			if !nextCalled {
+				t.Fatal("next handler was not called")
+			}
+			if got := string(ctx.Request.Header.Peek("Content-Encoding")); got != "" {
+				t.Fatalf("expected content-encoding to be cleared, got %q", got)
+			}
+		})
+	}
+}
+
+func TestRequestDecompressionMiddleware_StreamingPath_InvalidBody(t *testing.T) {
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			MaxRequestBodySizeMB: 100,
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.Header.Set("Content-Encoding", "gzip")
+	// Chunked with invalid gzip data → streaming path → error
+	ctx.Request.SetBodyStream(bytes.NewReader([]byte("not-a-valid-gzip-payload")), -1)
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+	}
+
+	handler := RequestDecompressionMiddleware(config)(next)
+	handler(ctx)
+
+	if nextCalled {
+		t.Fatal("next handler should not be called for invalid compressed payload")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", ctx.Response.StatusCode())
+	}
+}
+
+func TestRequestDecompressionMiddleware_StreamingPath_UnsupportedEncoding(t *testing.T) {
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			MaxRequestBodySizeMB: 100,
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.Header.Set("Content-Encoding", "snappy")
+	ctx.Request.SetBodyStream(bytes.NewReader([]byte("whatever")), -1)
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+	}
+
+	handler := RequestDecompressionMiddleware(config)(next)
+	handler(ctx)
+
+	if nextCalled {
+		t.Fatal("next handler should not be called for unsupported encoding")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", ctx.Response.StatusCode())
+	}
+}
+
+func TestRequestDecompressionMiddleware_BufferedPath_SmallGzip(t *testing.T) {
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			MaxRequestBodySizeMB: 10,
+		},
+	}
+
+	plainBody := []byte(`{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello"}]}`)
+	compressedBody, err := gzipCompress(plainBody)
+	if err != nil {
+		t.Fatalf("failed to gzip: %v", err)
+	}
+
+	// Verify compressed body is below threshold (should use buffered path)
+	if int64(len(compressedBody)) > schemas.DefaultLargePayloadRequestThresholdBytes {
+		t.Skip("compressed body unexpectedly exceeds threshold")
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.Header.Set("Content-Encoding", "gzip")
+	// SetBodyRaw with known small Content-Length → buffered path
+	ctx.Request.SetBodyRaw(compressedBody)
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+		if string(ctx.Request.Body()) != string(plainBody) {
+			t.Fatalf("expected decompressed body, got %q", string(ctx.Request.Body()))
+		}
+	}
+
+	handler := RequestDecompressionMiddleware(config)(next)
+	handler(ctx)
+
+	if !nextCalled {
+		t.Fatal("next handler was not called")
+	}
+}
+
+func TestRequestDecompressionMiddleware_StreamingPath_LargeGzip(t *testing.T) {
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			MaxRequestBodySizeMB: 100,
+		},
+	}
+
+	// Random bytes are incompressible — compressed size ≈ input size + gzip overhead.
+	bodySize := int(schemas.DefaultLargePayloadRequestThresholdBytes) + 1024*1024
+	plainBody := make([]byte, bodySize)
+	if _, err := cryptoRand.Read(plainBody); err != nil {
+		t.Fatalf("failed to generate random data: %v", err)
+	}
+	compressedBody, err := gzipCompress(plainBody)
+	if err != nil {
+		t.Fatalf("failed to gzip: %v", err)
+	}
+
+	if int64(len(compressedBody)) <= schemas.DefaultLargePayloadRequestThresholdBytes {
+		t.Skipf("compressed body %d bytes is below threshold %d",
+			len(compressedBody), schemas.DefaultLargePayloadRequestThresholdBytes)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("POST")
+	ctx.Request.Header.Set("Content-Encoding", "gzip")
+	ctx.Request.Header.SetContentLength(len(compressedBody))
+	ctx.Request.SetBodyStream(bytes.NewReader(compressedBody), len(compressedBody))
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+		if ce := string(ctx.Request.Header.Peek("Content-Encoding")); ce != "" {
+			t.Errorf("expected Content-Encoding to be cleared, got %q", ce)
+		}
+		body := ctx.Request.Body()
+		if len(body) != len(plainBody) {
+			t.Errorf("decompressed body length: got %d, want %d", len(body), len(plainBody))
+		}
+		if !bytes.Equal(body, plainBody) {
+			t.Error("decompressed body content does not match original")
+		}
+	}
+
+	handler := RequestDecompressionMiddleware(config)(next)
+	handler(ctx)
+
+	if !nextCalled {
+		t.Fatal("next handler was not called")
 	}
 }
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -309,6 +309,12 @@ type Config struct {
 	// Optional event broadcaster for real-time updates (e.g., WebSocket).
 	// Set by HTTP server at startup; may be nil in non-HTTP usage.
 	EventBroadcaster schemas.EventBroadcaster
+
+	// StreamingDecompressThreshold overrides the default threshold (10MB) for
+	// switching from buffered to streaming request decompression. Set by
+	// enterprise from LargePayloadConfig.RequestThresholdBytes. Zero means
+	// use schemas.DefaultLargePayloadRequestThresholdBytes.
+	StreamingDecompressThreshold int64
 }
 
 var DefaultClientConfig = configstore.ClientConfig{

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1315,8 +1315,6 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 		Handler:            handlers.SecurityHeadersMiddleware()(handlers.CorsMiddleware(s.Config)(handlers.RequestDecompressionMiddleware(s.Config)(s.Router.Handler))),
 		MaxRequestBodySize: s.Config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024,
 		ReadBufferSize:     1024 * 64, // 64kb
-		// Stream request bodies to reduce pre-buffering for large payload routes.
-		StreamRequestBody: true,
 	}
 	return nil
 }

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -3,12 +3,14 @@ module github.com/maximhq/bifrost/transports
 go 1.26
 
 require (
+	github.com/andybalholm/brotli v1.2.0
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4
 	github.com/bytedance/sonic v1.15.0
 	github.com/fasthttp/router v1.5.4
 	github.com/fasthttp/websocket v1.5.12
 	github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f
 	github.com/google/uuid v1.6.0
+	github.com/klauspost/compress v1.18.2
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/maximhq/bifrost/core v1.4.7
 	github.com/maximhq/bifrost/framework v1.2.26
@@ -37,7 +39,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
-	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.0 // indirect
@@ -104,7 +105,6 @@ require (
 	github.com/jaswdr/faker/v2 v2.8.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect

--- a/ui/app/_fallbacks/enterprise/components/large-payload/largePayloadView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/large-payload/largePayloadView.tsx
@@ -1,4 +1,4 @@
-import { Layers } from "lucide-react";
+import { HardDriveUpload } from "lucide-react";
 import ContactUsView from "../views/contactUsView";
 
 export default function LargePayloadView() {
@@ -6,7 +6,7 @@ export default function LargePayloadView() {
 		<div className="h-full w-full">
 			<ContactUsView
 				className="mx-auto min-h-[80vh]"
-				icon={<Layers className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
+				icon={<HardDriveUpload className="h-[5.5rem] w-[5.5rem]" strokeWidth={1} />}
 				title="Large Payload Optimization"
 				description="Large payload streaming optimization is a part of the Bifrost enterprise license. We would love to know more about your use case and how we can help you."
 				readmeLink="https://docs.getbifrost.ai/enterprise/large-payloads"

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -17,7 +17,7 @@ import {
 	Globe,
 	KeyRound,
 	Landmark,
-	Layers,
+	HardDriveUpload,
 	LayoutGrid,
 	LogOut,
 	Logs,
@@ -708,7 +708,7 @@ export default function AppSidebar() {
 								{
 									title: "Large Payload",
 									url: "/workspace/config/large-payload",
-									icon: Layers,
+									icon: HardDriveUpload,
 									description: "Large payload streaming optimization",
 									hasAccess: hasSettingsAccess,
 								},


### PR DESCRIPTION
## Summary

Add threshold-gated streaming request decompression to avoid full body
materialization for large compressed requests. Introduces pooled decompression
readers for all four supported encodings (gzip, deflate, brotli, zstd) with
panic-safe pool operations.

## Changes

- **Streaming vs buffered decompression path**: `RequestDecompressionMiddleware`
  now checks compressed Content-Length against a configurable threshold.
  Large/chunked requests use streaming decompression via `SetBodyStream`; small
  requests use the existing buffered `ReadAll + SetBodyRaw` path.
- **Configurable threshold**: Added `StreamingDecompressThreshold` field to
  `lib.Config`, allowing enterprise to override the default 10MB threshold from
  `LargePayloadConfig.RequestThresholdBytes` — matching the response-side
  pattern.
- **Unified `newDecompressReader`**: Merged the duplicate switch/case logic from
  `streamingDecompress` and `requestBodyDecoder` into a single function. Removed
  the now-unused `compress/gzip`, `brotli`, `zstd`, and `compress/flate` direct
  imports from `middlewares.go`.
- **Pooled readers for all encodings**: Extracted gzip pool from `utils.go` into
  new `decompression.go` and added deflate, brotli, and zstd pools with the same
  Acquire/Release contract. All pools have `New` funcs for consistent behavior.
- **Panic-safe pool operations**: All Acquire functions use comma-ok type
  assertions, nil checks, and a `safeReset` helper (with `recover`) to handle
  corrupt pooled instances gracefully — no panics, silent fallback to fresh
  allocation.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Pool cycle + panic-safety tests (decompression readers)
go test ./core/providers/utils/... -run "TestAcquireRelease|TestPool_|TestSafeReset|TestRelease_Nil" -v

# Decompression middleware tests (streaming + buffered paths, threshold logic)
go test ./transports/bifrost-http/handlers/... -run "TestRequestDecompression|TestShouldStreamDecompress" -v

# Full transport suite
go test ./transports/bifrost-http/...
```

## Screenshots/Recordings

N/A — backend only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Part of the large payload optimization work — mirrors the response-side
streaming pattern onto the request side.

## Security considerations

- Decompression bomb protection remains in place on the buffered path via
  `MaxRequestBodySizeMB` limit.
- Streaming path delegates size enforcement to downstream handlers (enterprise
  `LargePayloadHook` chunked-body path).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

