### PR TITLE
fix: format cost display with 6 decimal precision in log details

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -338,7 +338,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 									<LogEntryDetailsView className="w-full" label="Input Tokens" value={log.token_usage?.prompt_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Output Tokens" value={log.token_usage?.completion_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Total Tokens" value={log.token_usage?.total_tokens || "-"} />
-									<LogEntryDetailsView className="w-full" label="Cost" value={log.cost != null ? `$${log.cost}` : "-"} />
+									<LogEntryDetailsView className="w-full" label="Cost" value={log.cost != null ? `$${parseFloat(log.cost.toFixed(6))}` : "-"} />
 									{log.token_usage?.prompt_tokens_details && (
 										<>
 											{(log.token_usage.prompt_tokens_details.cached_read_tokens ||


### PR DESCRIPTION
## Summary

Fixed cost display formatting in the log details sheet to show costs with proper decimal precision and remove trailing zeros.

## Changes

- Modified the cost display logic to format costs using `parseFloat(log.cost.toFixed(6))` instead of directly displaying the raw cost value
- This ensures costs are displayed with up to 6 decimal places while removing unnecessary trailing zeros

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the workspace logs section
2. Open a log entry that has cost information
3. Verify that the cost is displayed with proper decimal formatting (no unnecessary trailing zeros)
4. Test with various cost values to ensure formatting works correctly

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Cost might display with excessive decimal places or formatting issues
After: Cost displays cleanly with appropriate precision

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None - this is a display formatting change only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable