### PR TITLE
feat: add Enabled field to ChatReasoning struct

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -249,6 +249,7 @@ type ChatAudioParameters struct {
 
 // Not in OpenAI's spec, but needed to support extra parameters for reasoning.
 type ChatReasoning struct {
+	Enabled   *bool   `json:"enabled,omitempty"`    // Explicitly enable or disable reasoning (required by OpenRouter to disable reasoning for some models)
 	Effort    *string `json:"effort,omitempty"`     // "none" |  "minimal" | "low" | "medium" | "high" (any value other than "none" will enable reasoning)
 	MaxTokens *int    `json:"max_tokens,omitempty"` // Maximum number of tokens to generate for the reasoning output (required for anthropic)
 }

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -975,7 +975,7 @@ func (cr *BifrostChatRequest) ToResponsesRequest() *BifrostResponsesRequest {
 		}
 
 		// Handle Reasoning from reasoning_effort
-		if cr.Params.Reasoning != nil && (cr.Params.Reasoning.Effort != nil || cr.Params.Reasoning.MaxTokens != nil) {
+		if cr.Params.Reasoning != nil && (cr.Params.Reasoning.Enabled != nil || cr.Params.Reasoning.Effort != nil || cr.Params.Reasoning.MaxTokens != nil) {
 			brr.Params.Reasoning = &ResponsesParametersReasoning{
 				Effort:    cr.Params.Reasoning.Effort,
 				MaxTokens: cr.Params.Reasoning.MaxTokens,

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -701,6 +701,9 @@ func (plugin *Plugin) extractChatParametersToMetadata(params *schemas.ChatParame
 	if params.PromptCacheKey != nil {
 		metadata["prompt_cache_key"] = *params.PromptCacheKey
 	}
+	if params.Reasoning != nil && params.Reasoning.Enabled != nil {
+		metadata["reasoning_enabled"] = *params.Reasoning.Enabled
+	}
 	if params.Reasoning != nil && params.Reasoning.Effort != nil {
 		metadata["reasoning_effort"] = *params.Reasoning.Effort
 	}


### PR DESCRIPTION
## Summary

- Add optional `Enabled` (`*bool`) field to `ChatReasoning` struct
- Allows callers to explicitly disable reasoning via `{reasoning: {enabled: false}}`
- Required by OpenRouter to disable reasoning for models like `x-ai/grok-4-fast`

## Problem

OpenRouter requires `reasoning.enabled: false` to disable reasoning. Currently, `ChatReasoning` only has `Effort` and `MaxTokens` fields. Sending `{reasoning: {effort: "none"}}` does **not** disable reasoning on OpenRouter.

## Changes

| File | Change |
|------|--------|
| `core/schemas/chatcompletions.go` | Add `Enabled *bool` field to `ChatReasoning` |
| `core/schemas/mux.go` | Include `Enabled` in nil-check condition for Chat→Responses conversion |
| `plugins/semanticcache/utils.go` | Include `reasoning_enabled` in cache metadata |

## Usage

```json
{
  "reasoning": {
    "enabled": false
  }
}
```

## Test Plan

- [ ] Verify JSON serialization includes `enabled` when set, omits when nil
- [ ] Verify existing `effort`/`max_tokens` behavior is unchanged
- [ ] Verify OpenRouter reasoning disable works with the new field
- [ ] Run `make test` to confirm no regression

Closes #1395