### PR TITLE
fix: remove resolution parameter from image generation and add MCP client config fields

### DIFF
--- a/core/providers/replicate/images.go
+++ b/core/providers/replicate/images.go
@@ -72,10 +72,6 @@ func ToReplicateImageGenerationInput(bifrostReq *schemas.BifrostImageGenerationR
 			input.AspectRatio = params.AspectRatio
 		}
 
-		if params.Resolution != nil {
-			input.Resolution = params.Resolution
-		}
-
 		// Map OutputFormat
 		if params.OutputFormat != nil {
 			input.OutputFormat = params.OutputFormat

--- a/core/providers/replicate/types.go
+++ b/core/providers/replicate/types.go
@@ -62,7 +62,6 @@ type ReplicatePredictionRequestInput struct {
 	// Image generation parameters
 	AspectRatio  *string  `json:"aspect_ratio,omitempty"`
 	OutputFormat *string  `json:"output_format,omitempty"`
-	Resolution   *string  `json:"resolution,omitempty"`   // e.g., "1 MP"
 	InputImages  []string `json:"input_images,omitempty"` // Image input for image-to-image models
 	ImagePrompt  *string  `json:"image_prompt,omitempty"` // Image prompt for image models (flux family)
 	ImageInput   []string `json:"image_input,omitempty"`  // Image input for chat models (openai family)
@@ -155,7 +154,6 @@ func (r *ReplicatePredictionRequestInput) UnmarshalJSON(data []byte) error {
 		"frequency_penalty":     true,
 		"aspect_ratio":          true,
 		"output_format":         true,
-		"resolution":            true,
 		"input_images":          true,
 		"image_prompt":          true,
 		"input_image":           true,

--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -47,7 +47,6 @@ type ImageGenerationParameters struct {
 	User              *string                `json:"user,omitempty"`
 	InputImages       []string               `json:"input_images,omitempty"` // input images for image generation, base64 encoded or URL
 	AspectRatio       *string                `json:"aspect_ratio,omitempty"` // aspect ratio of the image
-	Resolution        *string                `json:"resolution,omitempty"`   // resolution of the image
 	ExtraParams       map[string]interface{} `json:"-"`
 }
 

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fasthttp/router"
 	"github.com/google/uuid"
 	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -234,12 +235,33 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 
+		toolSyncInterval := mcp.DefaultToolSyncInterval
+		if req.ToolSyncInterval != 0 {
+			toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
+		} else {
+			config, err := h.store.ConfigStore.GetClientConfig(ctx)
+			if err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get client config: %v", err))
+				return
+			}
+			if config != nil {
+				toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
+			}
+		}
+
+		isPingAvailable := true
+		if req.IsPingAvailable != nil {
+			isPingAvailable = *req.IsPingAvailable
+		}
+
 		// Store MCP client config in OAuth provider memory (not in database)
 		// It will be stored in database only after OAuth completion
 		pendingConfig := schemas.MCPClientConfig{
 			ID:                 req.ClientID,
 			Name:               req.Name,
 			IsCodeModeClient:   req.IsCodeModeClient,
+			IsPingAvailable:    isPingAvailable,
+			ToolSyncInterval:   toolSyncInterval,
 			ConnectionType:     schemas.MCPConnectionType(req.ConnectionType),
 			ConnectionString:   req.ConnectionString,
 			StdioConfig:        req.StdioConfig,
@@ -269,7 +291,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	toolSyncInterval := 10 * time.Minute
+	toolSyncInterval := mcp.DefaultToolSyncInterval
 	if req.ToolSyncInterval != 0 {
 		toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
 	} else {
@@ -281,8 +303,8 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		if config != nil {
 			toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
 		}
-
 	}
+
 	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
 	// Dereference IsPingAvailable pointer, defaulting to true if nil (new clients default to ping available)
 	isPingAvailable := true
@@ -404,7 +426,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
-	toolSyncInterval := 10 * time.Minute
+	toolSyncInterval := mcp.DefaultToolSyncInterval
 	if req.ToolSyncInterval != 0 {
 		toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
 	} else {
@@ -416,7 +438,6 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		if config != nil {
 			toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
 		}
-
 	}
 	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
 	isPingAvailable := true


### PR DESCRIPTION
## Summary

Removes the `Resolution` parameter from image generation functionality across the Replicate provider and core schemas, while adding support for ping availability and tool sync interval configuration in MCP client setup.

## Changes

- Removed `Resolution` field from `ImageGenerationParameters` in core schemas
- Removed `Resolution` field from `ReplicatePredictionRequestInput` struct and its JSON unmarshaling logic
- Eliminated resolution parameter mapping in `ToReplicateImageGenerationInput` function
- Added `IsPingAvailable` and `ToolSyncInterval` configuration support in MCP client handler with proper defaults

## Type of change

- [x] Refactor
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Validate image generation still works without resolution parameter and MCP client configuration accepts new parameters:

```sh
# Core/Transports
go version
go test ./...
```

Test image generation requests to ensure they work without the resolution parameter. Test MCP client creation with and without the new `IsPingAvailable` and `ToolSyncInterval` parameters to verify proper defaults are applied.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes

The removal of the `Resolution` parameter from image generation requests is a breaking change. Any clients currently sending this parameter will need to remove it from their requests. The parameter will be ignored if sent.

## Related issues

N/A

## Security considerations

No security implications identified. The changes involve parameter removal and configuration additions without affecting authentication or sensitive data handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable