### PR TITLE
feat: add virtual key limit resets

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -185,6 +185,20 @@ func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
 		req.TokenResetDuration == nil && req.RequestResetDuration == nil
 }
 
+func collectProviderConfigDeleteIDs(
+	config configstoreTables.TableVirtualKeyProviderConfig,
+	budgetIDs []string,
+	rateLimitIDs []string,
+) ([]string, []string) {
+	if config.BudgetID != nil {
+		budgetIDs = append(budgetIDs, *config.BudgetID)
+	}
+	if config.RateLimitID != nil {
+		rateLimitIDs = append(rateLimitIDs, *config.RateLimitID)
+	}
+	return budgetIDs, rateLimitIDs
+}
+
 // CreateTeamRequest represents the request body for creating a team
 type CreateTeamRequest struct {
 	Name       string                  `json:"name" validate:"required"`
@@ -983,6 +997,11 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 			// Delete provider configs that are not in the request
 			for id := range existingConfigsMap {
 				if !requestConfigsMap[id] {
+					providerBudgetIDsToDelete, providerRateLimitIDsToDelete = collectProviderConfigDeleteIDs(
+						existingConfigsMap[id],
+						providerBudgetIDsToDelete,
+						providerRateLimitIDsToDelete,
+					)
 					if err := h.configStore.DeleteVirtualKeyProviderConfig(ctx, id, tx); err != nil {
 						return err
 					}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -176,6 +176,15 @@ type UpdateRateLimitRequest struct {
 	RequestResetDuration *string `json:"request_reset_duration,omitempty"` // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 }
 
+func isBudgetRemovalRequest(req *UpdateBudgetRequest) bool {
+	return req != nil && req.MaxLimit == nil && req.ResetDuration == nil
+}
+
+func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
+	return req != nil && req.TokenMaxLimit == nil && req.RequestMaxLimit == nil &&
+		req.TokenResetDuration == nil && req.RequestResetDuration == nil
+}
+
 // CreateTeamRequest represents the request body for creating a team
 type CreateTeamRequest struct {
 	Name       string                  `json:"name" validate:"required"`
@@ -611,6 +620,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		var budgetIDToDelete, rateLimitIDToDelete string
+		var providerBudgetIDsToDelete, providerRateLimitIDsToDelete []string
+
 		// Update fields if provided
 		if req.Name != nil {
 			vk.Name = *req.Name
@@ -636,7 +648,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		}
 		// Handle budget updates
 		if req.Budget != nil {
-			if vk.BudgetID != nil {
+			if isBudgetRemovalRequest(req.Budget) {
+				if vk.BudgetID != nil {
+					budgetIDToDelete = *vk.BudgetID
+					vk.BudgetID = nil
+					vk.Budget = nil
+				}
+			} else if vk.BudgetID != nil {
 				// Update existing budget
 				budget := configstoreTables.TableBudget{}
 				if err := tx.First(&budget, "id = ?", *vk.BudgetID).Error; err != nil {
@@ -687,7 +705,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		}
 		// Handle rate limit updates
 		if req.RateLimit != nil {
-			if vk.RateLimitID != nil {
+			if isRateLimitRemovalRequest(req.RateLimit) {
+				if vk.RateLimitID != nil {
+					rateLimitIDToDelete = *vk.RateLimitID
+					vk.RateLimitID = nil
+					vk.RateLimit = nil
+				}
+			} else if vk.RateLimitID != nil {
 				// Update existing rate limit
 				rateLimit := configstoreTables.TableRateLimit{}
 				if err := tx.First(&rateLimit, "id = ?", *vk.RateLimitID).Error; err != nil {
@@ -851,7 +875,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 
 					// Handle budget updates for provider config
 					if pc.Budget != nil {
-						if existing.BudgetID != nil {
+						if isBudgetRemovalRequest(pc.Budget) {
+							if existing.BudgetID != nil {
+								providerBudgetIDsToDelete = append(providerBudgetIDsToDelete, *existing.BudgetID)
+								existing.BudgetID = nil
+								existing.Budget = nil
+							}
+						} else if existing.BudgetID != nil {
 							// Update existing budget
 							budget := configstoreTables.TableBudget{}
 							if err := tx.First(&budget, "id = ?", *existing.BudgetID).Error; err != nil {
@@ -898,7 +928,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					}
 					// Handle rate limit updates for provider config
 					if pc.RateLimit != nil {
-						if existing.RateLimitID != nil {
+						if isRateLimitRemovalRequest(pc.RateLimit) {
+							if existing.RateLimitID != nil {
+								providerRateLimitIDsToDelete = append(providerRateLimitIDsToDelete, *existing.RateLimitID)
+								existing.RateLimitID = nil
+								existing.RateLimit = nil
+							}
+						} else if existing.RateLimitID != nil {
 							// Update existing rate limit
 							rateLimit := configstoreTables.TableRateLimit{}
 							if err := tx.First(&rateLimit, "id = ?", *existing.RateLimitID).Error; err != nil {
@@ -1010,6 +1046,28 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 				}
 			}
 		}
+
+		if budgetIDToDelete != "" {
+			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
+				return err
+			}
+		}
+		if rateLimitIDToDelete != "" {
+			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
+				return err
+			}
+		}
+		for _, id := range providerBudgetIDsToDelete {
+			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", id).Error; err != nil {
+				return err
+			}
+		}
+		for _, id := range providerRateLimitIDsToDelete {
+			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", id).Error; err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}); err != nil {
 		errMsg := err.Error()

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -248,6 +248,69 @@ func TestRateLimitRemovalRequestDetection(t *testing.T) {
 	}
 }
 
+func TestCollectProviderConfigDeleteIDs(t *testing.T) {
+	budgetID := "budget-1"
+	rateLimitID := "rate-limit-1"
+
+	tests := []struct {
+		name             string
+		config           configstoreTables.TableVirtualKeyProviderConfig
+		initialBudgetIDs []string
+		initialRateIDs   []string
+		wantBudgetIDs    []string
+		wantRateIDs      []string
+	}{
+		{
+			name: "collects both IDs",
+			config: configstoreTables.TableVirtualKeyProviderConfig{
+				BudgetID:    &budgetID,
+				RateLimitID: &rateLimitID,
+			},
+			wantBudgetIDs: []string{budgetID},
+			wantRateIDs:   []string{rateLimitID},
+		},
+		{
+			name: "appends to existing slices",
+			config: configstoreTables.TableVirtualKeyProviderConfig{
+				BudgetID:    &budgetID,
+				RateLimitID: &rateLimitID,
+			},
+			initialBudgetIDs: []string{"budget-0"},
+			initialRateIDs:   []string{"rate-limit-0"},
+			wantBudgetIDs:    []string{"budget-0", budgetID},
+			wantRateIDs:      []string{"rate-limit-0", rateLimitID},
+		},
+		{
+			name:   "ignores missing IDs",
+			config: configstoreTables.TableVirtualKeyProviderConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBudgetIDs, gotRateIDs := collectProviderConfigDeleteIDs(tt.config, tt.initialBudgetIDs, tt.initialRateIDs)
+
+			if len(gotBudgetIDs) != len(tt.wantBudgetIDs) {
+				t.Fatalf("budget IDs length = %d, want %d", len(gotBudgetIDs), len(tt.wantBudgetIDs))
+			}
+			for i := range gotBudgetIDs {
+				if gotBudgetIDs[i] != tt.wantBudgetIDs[i] {
+					t.Fatalf("budget IDs[%d] = %q, want %q", i, gotBudgetIDs[i], tt.wantBudgetIDs[i])
+				}
+			}
+
+			if len(gotRateIDs) != len(tt.wantRateIDs) {
+				t.Fatalf("rate limit IDs length = %d, want %d", len(gotRateIDs), len(tt.wantRateIDs))
+			}
+			for i := range gotRateIDs {
+				if gotRateIDs[i] != tt.wantRateIDs[i] {
+					t.Fatalf("rate limit IDs[%d] = %q, want %q", i, gotRateIDs[i], tt.wantRateIDs[i])
+				}
+			}
+		})
+	}
+}
+
 func bifrostFloat(v float64) *float64 {
 	return &v
 }

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -165,3 +165,97 @@ func TestGetVirtualKeys_PaginatedEndpoint_QueryParams(t *testing.T) {
 // Ensure mockLogger satisfies schemas.Logger (already defined in middlewares_test.go
 // but we reference it here — same package, so no redeclaration needed).
 var _ schemas.Logger = (*mockLogger)(nil)
+
+func TestBudgetRemovalRequestDetection(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *UpdateBudgetRequest
+		want bool
+	}{
+		{
+			name: "nil request is not removal",
+			req:  nil,
+			want: false,
+		},
+		{
+			name: "empty object is removal",
+			req:  &UpdateBudgetRequest{},
+			want: true,
+		},
+		{
+			name: "max limit present is not removal",
+			req:  &UpdateBudgetRequest{MaxLimit: bifrostFloat(10)},
+			want: false,
+		},
+		{
+			name: "reset duration only is not removal",
+			req:  &UpdateBudgetRequest{ResetDuration: bifrostString("1h")},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBudgetRemovalRequest(tt.req); got != tt.want {
+				t.Fatalf("isBudgetRemovalRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitRemovalRequestDetection(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *UpdateRateLimitRequest
+		want bool
+	}{
+		{
+			name: "nil request is not removal",
+			req:  nil,
+			want: false,
+		},
+		{
+			name: "empty object is removal",
+			req:  &UpdateRateLimitRequest{},
+			want: true,
+		},
+		{
+			name: "token limit present is not removal",
+			req:  &UpdateRateLimitRequest{TokenMaxLimit: bifrostInt64(100)},
+			want: false,
+		},
+		{
+			name: "request limit present is not removal",
+			req:  &UpdateRateLimitRequest{RequestMaxLimit: bifrostInt64(10)},
+			want: false,
+		},
+		{
+			name: "durations only is not removal",
+			req: &UpdateRateLimitRequest{
+				TokenResetDuration:   bifrostString("1h"),
+				RequestResetDuration: bifrostString("1h"),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRateLimitRemovalRequest(tt.req); got != tt.want {
+				t.Fatalf("isRateLimitRemovalRequest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func bifrostFloat(v float64) *float64 {
+	return &v
+}
+
+func bifrostInt64(v int64) *int64 {
+	return &v
+}
+
+func bifrostString(v string) *string {
+	return &v
+}

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -34,7 +34,7 @@ import { KnownProvider } from "@/lib/types/config";
 import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Building, Info, Trash2, Users, X } from "lucide-react";
+import { Building, Info, RotateCcw, Trash2, Users, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { components, MultiValueProps, OptionProps } from "react-select";
@@ -244,6 +244,11 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 	// Get current MCP configs from form
 	const mcpConfigs = form.watch("mcpConfigs") || [];
 
+	// Watch budget/rate-limit fields for conditional rendering of reset buttons
+	const watchedBudgetMaxLimit = form.watch("budgetMaxLimit");
+	const watchedTokenMaxLimit = form.watch("tokenMaxLimit");
+	const watchedRequestMaxLimit = form.watch("requestMaxLimit");
+
 	// Handle adding a new provider configuration
 	const handleAddProvider = (provider: string) => {
 		const existingConfig = providerConfigs.find((config) => config.provider === provider);
@@ -304,28 +309,67 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 		form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
 	};
 
+	const clearVirtualKeyBudget = () => {
+		form.setValue("budgetMaxLimit", "", { shouldDirty: true });
+		form.setValue("budgetResetDuration", "1M", { shouldDirty: true });
+	};
+
+	const clearVirtualKeyRateLimits = () => {
+		form.setValue("tokenMaxLimit", "", { shouldDirty: true });
+		form.setValue("tokenResetDuration", "1h", { shouldDirty: true });
+		form.setValue("requestMaxLimit", "", { shouldDirty: true });
+		form.setValue("requestResetDuration", "1h", { shouldDirty: true });
+	};
+
+	const normalizeIntegerField = (value: string | undefined): number | undefined => {
+		if (value === undefined || value === "") return undefined;
+		const num = parseInt(value, 10);
+		return isNaN(num) ? undefined : num;
+	};
+
 	// Helper function to convert string weights to numbers and normalize budget/rate limit fields
-	const normalizeProviderConfigs = (configs: any[]): any[] => {
+	const normalizeProviderConfigs = (
+		configs: NonNullable<FormData["providerConfigs"]>,
+		existingConfigs?: VirtualKey["provider_configs"],
+	): any[] => {
 		return configs.map((config) => ({
 			...config,
 			weight: typeof config.weight === "string" ? parseFloat(config.weight) || 0 : config.weight,
-			budget: config.budget?.max_limit
-				? {
-						max_limit: parseFloat(config.budget.max_limit) || 0,
-						reset_duration: config.budget.reset_duration || "1M",
-					}
-				: undefined,
-			rate_limit:
-				config.rate_limit?.token_max_limit || config.rate_limit?.request_max_limit
-					? {
-							token_max_limit: config.rate_limit.token_max_limit ? parseInt(config.rate_limit.token_max_limit) || undefined : undefined,
-							token_reset_duration: config.rate_limit.token_reset_duration || "1h",
-							request_max_limit: config.rate_limit.request_max_limit
-								? parseInt(config.rate_limit.request_max_limit) || undefined
-								: undefined,
-							request_reset_duration: config.rate_limit.request_reset_duration || "1h",
-						}
-					: undefined,
+			budget: (() => {
+				const budgetMaxLimit = normalizeNumericField(config.budget?.max_limit);
+				if (budgetMaxLimit) {
+					return {
+						max_limit: budgetMaxLimit,
+						reset_duration: config.budget?.reset_duration || "1M",
+					};
+				}
+
+				const existingConfig = existingConfigs?.find((item) => (config.id ? item.id === config.id : item.provider === config.provider));
+				if (existingConfig?.budget) {
+					return {};
+				}
+
+				return undefined;
+			})(),
+			rate_limit: (() => {
+				const tokenMaxLimit = normalizeIntegerField(config.rate_limit?.token_max_limit);
+				const requestMaxLimit = normalizeIntegerField(config.rate_limit?.request_max_limit);
+				if (tokenMaxLimit || requestMaxLimit) {
+					return {
+						token_max_limit: tokenMaxLimit ?? null,
+						token_reset_duration: tokenMaxLimit ? config.rate_limit?.token_reset_duration || "1h" : null,
+						request_max_limit: requestMaxLimit ?? null,
+						request_reset_duration: requestMaxLimit ? config.rate_limit?.request_reset_duration || "1h" : null,
+					};
+				}
+
+				const existingConfig = existingConfigs?.find((item) => (config.id ? item.id === config.id : item.provider === config.provider));
+				if (existingConfig?.rate_limit) {
+					return {};
+				}
+
+				return undefined;
+			})(),
 		}));
 	};
 
@@ -344,7 +388,9 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 		}
 		try {
 			// Normalize provider configs to ensure weights are numbers and handle budget/rate limits
-			const normalizedProviderConfigs = data.providerConfigs ? normalizeProviderConfigs(data.providerConfigs) : [];
+			const normalizedProviderConfigs = data.providerConfigs
+				? normalizeProviderConfigs(data.providerConfigs, virtualKey?.provider_configs)
+				: [];
 			if (isEditing && virtualKey) {
 				// Update existing virtual key
 				const updateData: UpdateVirtualKeyRequest = {
@@ -359,23 +405,31 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 				// Add budget if enabled
 				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
-				if (budgetMaxLimit) {
+				const hadBudget = !!virtualKey.budget;
+				const hasBudget = !!budgetMaxLimit;
+				if (hasBudget) {
 					updateData.budget = {
 						max_limit: budgetMaxLimit,
 						reset_duration: data.budgetResetDuration || "1M",
 					};
+				} else if (hadBudget) {
+					updateData.budget = {};
 				}
 
 				// Add rate limit if enabled
-				const tokenMaxLimit = normalizeNumericField(data.tokenMaxLimit);
-				const requestMaxLimit = normalizeNumericField(data.requestMaxLimit);
-				if (tokenMaxLimit || requestMaxLimit) {
+				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
+				const requestMaxLimit = normalizeIntegerField(data.requestMaxLimit);
+				const hadRateLimit = !!virtualKey.rate_limit;
+				const hasRateLimit = !!tokenMaxLimit || !!requestMaxLimit;
+				if (hasRateLimit) {
 					updateData.rate_limit = {
-						token_max_limit: tokenMaxLimit,
-						token_reset_duration: data.tokenResetDuration || "1h",
-						request_max_limit: requestMaxLimit,
-						request_reset_duration: data.requestResetDuration || "1h",
+						token_max_limit: tokenMaxLimit ?? null,
+						token_reset_duration: tokenMaxLimit ? data.tokenResetDuration || "1h" : null,
+						request_max_limit: requestMaxLimit ?? null,
+						request_reset_duration: requestMaxLimit ? data.requestResetDuration || "1h" : null,
 					};
+				} else if (hadRateLimit) {
+					updateData.rate_limit = {};
 				}
 
 				await updateVirtualKey({ vkId: virtualKey.id, data: updateData }).unwrap();
@@ -402,8 +456,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 				}
 
 				// Add rate limit if enabled
-				const tokenMaxLimit = normalizeNumericField(data.tokenMaxLimit);
-				const requestMaxLimit = normalizeNumericField(data.requestMaxLimit);
+				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
+				const requestMaxLimit = normalizeIntegerField(data.requestMaxLimit);
 				if (tokenMaxLimit || requestMaxLimit) {
 					createData.rate_limit = {
 						token_max_limit: tokenMaxLimit,
@@ -425,10 +479,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 	return (
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-			<SheetContent
-				className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-4 pb-8"
-				data-testid="vk-sheet"
-			>
+			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-4 pb-8" data-testid="vk-sheet">
 				<SheetHeader className="flex flex-col items-start px-3 pt-8">
 					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Create Virtual Key"}</SheetTitle>
 					<SheetDescription>
@@ -533,24 +584,28 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 												return (
 													<>
 														{/* Base providers first */}
-														{baseProviders.filter((p) => p.name).map((provider, index) => (
-															<SelectItem key={`base-${index}`} value={provider.name}>
-																<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
-																{ProviderLabels[provider.name as ProviderName]}
-															</SelectItem>
-														))}
+														{baseProviders
+															.filter((p) => p.name)
+															.map((provider, index) => (
+																<SelectItem key={`base-${index}`} value={provider.name}>
+																	<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
+																	{ProviderLabels[provider.name as ProviderName]}
+																</SelectItem>
+															))}
 
 														{/* Custom providers second */}
-														{customProviders.filter((p) => p.name).map((provider, index) => (
-															<SelectItem key={`custom-${index}`} value={provider.name}>
-																<RenderProviderIcon
-																	provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
-																	size="sm"
-																	className="h-4 w-4"
-																/>
-																{provider.name}
-															</SelectItem>
-														))}
+														{customProviders
+															.filter((p) => p.name)
+															.map((provider, index) => (
+																<SelectItem key={`custom-${index}`} value={provider.name}>
+																	<RenderProviderIcon
+																		provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
+																		size="sm"
+																		className="h-4 w-4"
+																	/>
+																	{provider.name}
+																</SelectItem>
+															))}
 													</>
 												);
 											})()}
@@ -857,7 +912,10 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 													{mcpClientsData.filter((client) => !mcpConfigs.some((config) => config.mcp_client_name === client.config.name))
 														.length > 0 ? (
 														mcpClientsData
-															.filter((client) => client.config.name && !mcpConfigs.some((config) => config.mcp_client_name === client.config.name))
+															.filter(
+																(client) =>
+																	client.config.name && !mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
+															)
 															.map((client, index) => {
 																const client_tools = client.tools || [];
 																const totalTools = client.config.tools_to_execute?.includes("*")
@@ -963,7 +1021,21 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 							{/* Budget Configuration */}
 							<div className="space-y-4">
-								<Label className="text-sm font-medium">Budget Configuration</Label>
+								<div className="flex items-center justify-between gap-2">
+									<Label className="text-sm font-medium">Budget Configuration</Label>
+									{isEditing && (virtualKey?.budget || watchedBudgetMaxLimit) && (
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											onClick={clearVirtualKeyBudget}
+											data-testid="vk-budget-reset-button"
+										>
+											<RotateCcw className="h-4 w-4" />
+											Reset
+										</Button>
+									)}
+								</div>
 								<FormField
 									control={form.control}
 									name="budgetMaxLimit"
@@ -989,7 +1061,21 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 							{/* Rate Limiting Configuration */}
 							<div className="space-y-4">
-								<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
+								<div className="flex items-center justify-between gap-2">
+									<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
+									{isEditing && (virtualKey?.rate_limit || watchedTokenMaxLimit || watchedRequestMaxLimit) && (
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											onClick={clearVirtualKeyRateLimits}
+											data-testid="vk-rate-limit-reset-button"
+										>
+											<RotateCcw className="h-4 w-4" />
+											Reset
+										</Button>
+									)}
+								</div>
 
 								<FormField
 									control={form.control}
@@ -1170,7 +1256,11 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 									<Tooltip>
 										<TooltipTrigger asChild>
 											<span className="inline-block">
-												<Button type="submit" disabled={isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit} data-testid="vk-save-btn">
+												<Button
+													type="submit"
+													disabled={isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit}
+													data-testid="vk-save-btn"
+												>
 													{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
 												</Button>
 											</span>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -337,7 +337,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 			weight: typeof config.weight === "string" ? parseFloat(config.weight) || 0 : config.weight,
 			budget: (() => {
 				const budgetMaxLimit = normalizeNumericField(config.budget?.max_limit);
-				if (budgetMaxLimit) {
+				if (budgetMaxLimit !== undefined) {
 					return {
 						max_limit: budgetMaxLimit,
 						reset_duration: config.budget?.reset_duration || "1M",
@@ -354,12 +354,14 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 			rate_limit: (() => {
 				const tokenMaxLimit = normalizeIntegerField(config.rate_limit?.token_max_limit);
 				const requestMaxLimit = normalizeIntegerField(config.rate_limit?.request_max_limit);
-				if (tokenMaxLimit || requestMaxLimit) {
+				const hasTokenMaxLimit = tokenMaxLimit !== undefined;
+				const hasRequestMaxLimit = requestMaxLimit !== undefined;
+				if (hasTokenMaxLimit || hasRequestMaxLimit) {
 					return {
 						token_max_limit: tokenMaxLimit ?? null,
-						token_reset_duration: tokenMaxLimit ? config.rate_limit?.token_reset_duration || "1h" : null,
+						token_reset_duration: hasTokenMaxLimit ? config.rate_limit?.token_reset_duration || "1h" : null,
 						request_max_limit: requestMaxLimit ?? null,
-						request_reset_duration: requestMaxLimit ? config.rate_limit?.request_reset_duration || "1h" : null,
+						request_reset_duration: hasRequestMaxLimit ? config.rate_limit?.request_reset_duration || "1h" : null,
 					};
 				}
 
@@ -406,7 +408,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 				// Add budget if enabled
 				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
 				const hadBudget = !!virtualKey.budget;
-				const hasBudget = !!budgetMaxLimit;
+				const hasBudget = budgetMaxLimit !== undefined;
 				if (hasBudget) {
 					updateData.budget = {
 						max_limit: budgetMaxLimit,
@@ -420,13 +422,15 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
 				const requestMaxLimit = normalizeIntegerField(data.requestMaxLimit);
 				const hadRateLimit = !!virtualKey.rate_limit;
-				const hasRateLimit = !!tokenMaxLimit || !!requestMaxLimit;
+				const hasTokenMaxLimit = tokenMaxLimit !== undefined;
+				const hasRequestMaxLimit = requestMaxLimit !== undefined;
+				const hasRateLimit = hasTokenMaxLimit || hasRequestMaxLimit;
 				if (hasRateLimit) {
 					updateData.rate_limit = {
 						token_max_limit: tokenMaxLimit ?? null,
-						token_reset_duration: tokenMaxLimit ? data.tokenResetDuration || "1h" : null,
+						token_reset_duration: hasTokenMaxLimit ? data.tokenResetDuration || "1h" : null,
 						request_max_limit: requestMaxLimit ?? null,
-						request_reset_duration: requestMaxLimit ? data.requestResetDuration || "1h" : null,
+						request_reset_duration: hasRequestMaxLimit ? data.requestResetDuration || "1h" : null,
 					};
 				} else if (hadRateLimit) {
 					updateData.rate_limit = {};
@@ -448,7 +452,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 				// Add budget if enabled
 				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
-				if (budgetMaxLimit) {
+				if (budgetMaxLimit !== undefined) {
 					createData.budget = {
 						max_limit: budgetMaxLimit,
 						reset_duration: data.budgetResetDuration || "1M",
@@ -458,12 +462,14 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 				// Add rate limit if enabled
 				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
 				const requestMaxLimit = normalizeIntegerField(data.requestMaxLimit);
-				if (tokenMaxLimit || requestMaxLimit) {
+				const hasTokenMaxLimit = tokenMaxLimit !== undefined;
+				const hasRequestMaxLimit = requestMaxLimit !== undefined;
+				if (hasTokenMaxLimit || hasRequestMaxLimit) {
 					createData.rate_limit = {
 						token_max_limit: tokenMaxLimit,
-						token_reset_duration: data.tokenResetDuration || "1h",
+						token_reset_duration: hasTokenMaxLimit ? data.tokenResetDuration || "1h" : undefined,
 						request_max_limit: requestMaxLimit,
-						request_reset_duration: data.requestResetDuration || "1h",
+						request_reset_duration: hasRequestMaxLimit ? data.requestResetDuration || "1h" : undefined,
 					};
 				}
 


### PR DESCRIPTION
## Summary

Adds support for removing budget and rate limit configurations from virtual keys during update flows. Previously, virtual key and provider-level budget/rate limit configs could be updated, but not explicitly removed from the edit UI.

 ## Changes

  - Added `isBudgetRemovalRequest()` and `isRateLimitRemovalRequest()` to detect explicit removal requests from empty update objects
  - Updated the virtual key update handler to detach and delete budget/rate limit records inside the existing transaction
  - Added support for removing provider-level budget and rate limit configs during virtual key updates
  - Updated the virtual key sheet UI with `Reset` actions for budget and rate limit sections when editing
  - Updated form normalization so edits distinguish between keeping, updating, creating, and removing limit configs
  - Added tests covering removal-request detection logic, including protection for duration-only partial updates

 ## Type of change

  - [x] Feature
  - [ ] Bug fix
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Chore/CI

 ## Affected areas

  - [ ] Core (Go)
  - [x] Transports (HTTP)
  - [ ] Providers/Integrations
  - [ ] Plugins
  - [x] UI (Next.js)
  - [ ] Docs

 ## How to test

  1. Create a virtual key with budget and rate limit configurations.
  2. Edit the virtual key and click the `Reset` actions for budget and rate limits.
  3. Save and verify the limits are removed from the virtual key.
  4. Repeat with provider-specific budget/rate limit configs.
  5. Verify duration-only edits still update existing limits instead of removing them.

 ```sh
  go test ./transports/bifrost-http/handlers

  cd ui
  pnpm build
```

 ## Screenshots/Recordings

The virtual key edit sheet now shows Reset actions beside Budget Configuration and Rate Limiting Configuration when an existing limit is present.

 ## Breaking changes

  - [ ] Yes
  - [x] No

## Related issues
Closes #2046

## Security considerations

 Removal is handled within the existing transactional update path for virtual keys and provider configs.

 ## Checklist

  - [x] I read docs/contributing/README.md and followed the guidelines
  - [x] I added/updated tests where appropriate
  - [ ] I updated documentation where needed
  - [x] I verified builds succeed (Go and UI)
  - [ ] I verified the CI pipeline passes locally if applicable