### PR TITLE
fix: handle request body passthrough for count tokens endpoint for Anthropic and Vertex providers

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -4,3 +4,4 @@
 - fix: add AudioFilenameFromBytes utility to detect audio format from file headers with mp3 fallback
 - fix: record ttft in nanoseconds instead of milliseconds to avoid truncation to 0
 - fix: streaming tool call indices for multiple parallel tool calls in chat completions stream
+- fix: handle request body passthrough for count tokens endpoint for Anthropic and Vertex providers

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -913,7 +913,7 @@ func (provider *AnthropicProvider) Responses(ctx *schemas.BifrostContext, key sc
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
 		return nil, err
 	}
-	jsonBody, err := getRequestBodyForResponses(ctx, request, provider.GetProviderKey(), false)
+	jsonBody, err := getRequestBodyForResponses(ctx, request, provider.GetProviderKey(), false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -988,7 +988,7 @@ func (provider *AnthropicProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	jsonBody, err := getRequestBodyForResponses(ctx, request, provider.GetProviderKey(), true)
+	jsonBody, err := getRequestBodyForResponses(ctx, request, provider.GetProviderKey(), true, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2349,37 +2349,12 @@ func (provider *AnthropicProvider) CountTokens(ctx *schemas.BifrostContext, key 
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.CountTokensRequest); err != nil {
 		return nil, err
 	}
-
-	// Convert to Anthropic format and get required beta headers
-	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
-		ctx,
-		request,
-		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			anthropicReq, convErr := ToAnthropicResponsesRequest(ctx, request)
-			if convErr != nil {
-				return nil, convErr
-			}
-			addMissingBetaHeadersToContext(ctx, anthropicReq)
-			return anthropicReq, nil
-		},
-		provider.GetProviderKey())
-	if bifrostErr != nil {
-		return nil, bifrostErr
+	jsonBody, err := getRequestBodyForResponses(ctx, request, provider.GetProviderKey(), false, []string{"max_tokens", "temperature"})
+	if err != nil {
+		return nil, err
 	}
 
-	// Remove max_tokens and temperature for count_tokens endpoint
-	var payload map[string]any
-	if err := sonic.Unmarshal(jsonData, &payload); err == nil {
-		delete(payload, "max_tokens")
-		delete(payload, "temperature")
-		newData, err := sonic.Marshal(payload)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, provider.GetProviderKey())
-		}
-		jsonData = newData
-	}
-
-	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, provider.buildRequestURL(ctx, "/v1/messages/count_tokens", schemas.CountTokensRequest), key.Value.GetValue(), &providerUtils.RequestMetadata{
+	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonBody, provider.buildRequestURL(ctx, "/v1/messages/count_tokens", schemas.CountTokensRequest), key.Value.GetValue(), &providerUtils.RequestMetadata{
 		Provider:    provider.GetProviderKey(),
 		Model:       request.Model,
 		RequestType: schemas.CountTokensRequest,
@@ -2388,20 +2363,20 @@ func (provider *AnthropicProvider) CountTokens(ctx *schemas.BifrostContext, key 
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
 	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	anthropicResponse := &AnthropicCountTokensResponse{}
 	rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(
 		responseBody,
 		anthropicResponse,
-		jsonData,
+		jsonBody,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 	)
 
 	if bifrostErr != nil {
-		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonBody, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	response := anthropicResponse.ToBifrostCountTokensResponse(request.Model)

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -77,7 +77,7 @@ func setEffortOnOutputConfig(req *AnthropicMessageRequest, effort string) {
 	req.OutputConfig.Effort = &effort
 }
 
-func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, providerName schemas.ModelProvider, isStreaming bool) ([]byte, *schemas.BifrostError) {
+func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, providerName schemas.ModelProvider, isStreaming bool, excludeFields []string) ([]byte, *schemas.BifrostError) {
 	var jsonBody []byte
 	var err error
 
@@ -103,6 +103,12 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		// Add stream if not present
 		if isStreaming {
 			requestBody["stream"] = true
+		}
+		// Remove excluded fields
+		if len(excludeFields) > 0 {
+			for _, field := range excludeFields {
+				delete(requestBody, field)
+			}
 		}
 		jsonBody, err = sonic.Marshal(requestBody)
 		if err != nil {
@@ -134,10 +140,32 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 				if err := sonic.Unmarshal(jsonBody, &jsonMap); err != nil {
 					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 				}
+				// Remove excluded fields
+				if len(excludeFields) > 0 {
+					for _, field := range excludeFields {
+						delete(jsonMap, field)
+					}
+				}
 				// Merge ExtraParams recursively (handles nested maps)
 				providerUtils.MergeExtraParams(jsonMap, extraParams)
 				// Re-marshal the merged map
 				jsonBody, err = providerUtils.MarshalSorted(jsonMap)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+				}
+			}
+		} else {
+			// Remove excluded fields
+			if len(excludeFields) > 0 {
+				var jsonMap map[string]interface{}
+				if err := sonic.Unmarshal(jsonBody, &jsonMap); err != nil {
+					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+				}
+				for _, field := range excludeFields {
+					delete(jsonMap, field)
+				}
+				// Re-marshal the map
+				jsonBody, err = sonic.Marshal(jsonMap)
 				if err != nil {
 					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 				}

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, providerName schemas.ModelProvider, isStreaming bool) ([]byte, *schemas.BifrostError) {
+func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, providerName schemas.ModelProvider, isStreaming bool, isCountTokens bool) ([]byte, *schemas.BifrostError) {
 	var jsonBody []byte
 	var err error
 
@@ -22,20 +22,26 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		if err := sonic.Unmarshal(jsonBody, &requestBody); err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, fmt.Errorf("failed to unmarshal request body: %w", err), providerName)
 		}
-		// Add max_tokens if not present
-		if _, exists := requestBody["max_tokens"]; !exists {
-			requestBody["max_tokens"] = anthropic.AnthropicDefaultMaxTokens
+		if isCountTokens {
+			delete(requestBody, "max_tokens")
+			delete(requestBody, "temperature")
+			requestBody["model"] = deployment
+		} else {
+			// Add max_tokens if not present
+			if _, exists := requestBody["max_tokens"]; !exists {
+				requestBody["max_tokens"] = anthropic.AnthropicDefaultMaxTokens
+			}
+			delete(requestBody, "model")
+			// Add stream if not present
+			if isStreaming {
+				requestBody["stream"] = true
+			}
 		}
-		delete(requestBody, "model")
 		delete(requestBody, "region")
 		delete(requestBody, "fallbacks")
 		// Add anthropic_version if not present
 		if _, exists := requestBody["anthropic_version"]; !exists {
 			requestBody["anthropic_version"] = DefaultVertexAnthropicVersion
-		}
-		// Add stream if not present
-		if isStreaming {
-			requestBody["stream"] = true
 		}
 		jsonBody, err = sonic.Marshal(requestBody)
 		if err != nil {
@@ -43,7 +49,6 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		}
 	} else {
 		// Convert request to Anthropic format
-		request.Model = deployment
 		reqBody, err := anthropic.ToAnthropicResponsesRequest(ctx, request)
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, err, providerName)
@@ -51,6 +56,7 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		if reqBody == nil {
 			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil, providerName)
 		}
+		reqBody.Model = deployment
 
 		if isStreaming {
 			reqBody.Stream = schemas.Ptr(true)
@@ -74,8 +80,13 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 			requestBody["anthropic_version"] = DefaultVertexAnthropicVersion
 		}
 
-		// Remove fields not needed by Vertex API
-		delete(requestBody, "model")
+		if isCountTokens {
+			delete(requestBody, "max_tokens")
+			delete(requestBody, "temperature")
+		} else {
+			// Remove fields not needed by Vertex API
+			delete(requestBody, "model")
+		}
 		delete(requestBody, "region")
 
 		jsonBody, err = sonic.Marshal(requestBody)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -963,7 +963,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 	}
 
 	if schemas.IsAnthropicModel(deployment) {
-		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false)
+		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false, false)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -1286,7 +1286,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			return nil, providerUtils.NewConfigurationError("project ID is not set", providerName)
 		}
 
-		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, true)
+		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, true, false)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -2810,37 +2810,10 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	)
 
 	if schemas.IsAnthropicModel(deployment) {
-		jsonBody, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
-			ctx,
-			request,
-			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				return anthropic.ToAnthropicResponsesRequest(ctx, request)
-			},
-			providerName,
-		)
+		jsonBody, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false, true)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
-
-		var payload map[string]any
-		if err := sonic.Unmarshal(jsonBody, &payload); err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, err, providerName)
-		}
-
-		payload["model"] = deployment
-		if _, exists := payload["anthropic_version"]; !exists {
-			payload["anthropic_version"] = DefaultVertexAnthropicVersion
-		}
-
-		delete(payload, "region")
-		delete(payload, "max_tokens")
-		delete(payload, "temperature")
-
-		newBody, err := sonic.Marshal(payload)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
-		}
-		jsonBody = newBody
 	} else {
 		jsonBody, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
 			ctx,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -6,6 +6,7 @@
 - feat: adds attachment support in Maxim plugin
 - feat: add x-bf-api-key-id header support for explicit key selection by ID, with priority over x-bf-api-key name selection
 - fix: streaming tool call indices for multiple parallel tool calls in chat completions stream
+- fix: handle request body passthrough for count tokens endpoint for Anthropic and Vertex providers
 
 ## Migration Guide
 


### PR DESCRIPTION
## Summary

Fixes request body passthrough handling for the count tokens endpoint in Anthropic and Vertex providers by consolidating the request body preparation logic and properly excluding required fields.

## Changes

- Refactored `getRequestBodyForResponses` in Anthropic provider to accept an `excludeFields` parameter for removing specific fields like `max_tokens` and `temperature`
- Updated `CountTokens` method in Anthropic provider to use the centralized request body preparation function instead of duplicated logic
- Modified `getRequestBodyForAnthropicResponses` in Vertex provider to handle count tokens requests with proper field exclusion
- Updated Vertex provider's `CountTokens` method to use the consolidated request preparation logic
- Added proper field exclusion logic that works with both raw request bodies and those with extra parameters

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test count tokens endpoint with Anthropic and Vertex providers to ensure request body is properly formatted:

```sh
# Core/Transports
go version
go test ./...

# Test count tokens endpoint specifically
curl -X POST /v1/count_tokens \
  -H "Content-Type: application/json" \
  -d '{"model": "claude-3-sonnet", "messages": [{"role": "user", "content": "Hello"}]}'
```

Verify that `max_tokens` and `temperature` fields are properly excluded from the request sent to provider APIs.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a bug fix for request body formatting.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable