### PR TITLE
feat: anthropic passthrough

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -82,6 +82,7 @@ type TestScenarios struct {
 	ContainerFileDelete    bool // Container File API delete functionality
 	PassThroughExtraParams bool // Pass through extra params functionality
 	Rerank                 bool // Rerank functionality
+	PassthroughAPI         bool // Raw HTTP passthrough API (Passthrough + PassthroughStream)
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios
@@ -118,6 +119,7 @@ type ComprehensiveTestConfig struct {
 	FileExtraParams          map[string]interface{} // Extra params for file operations (e.g., s3_bucket for Bedrock)
 	DisableParallelFor       []string               // Test scenarios to disable parallel execution for (e.g., "Transcription" for rate-limited APIs)
 	ExpectRawRequestResponse bool                   // When true, validate rawRequest/rawResponse in ExtraFields
+	PassthroughModel         string                 // Model for passthrough API tests; defaults to ChatModel when empty
 }
 
 // ComprehensiveTestAccount provides a test implementation of the Account interface for comprehensive testing.

--- a/core/internal/llmtests/passthrough_api.go
+++ b/core/internal/llmtests/passthrough_api.go
@@ -1,0 +1,235 @@
+package llmtests
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/providers/gemini"
+	"github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// passthroughChatReq holds the provider-native path and JSON body for a
+// minimal one-turn chat request used by the passthrough API tests.
+type passthroughChatReq struct {
+	path  string
+	body  []byte
+	query string
+}
+
+// basePassthroughChatRequest returns a minimal BifrostChatRequest suitable for
+// conversion into a provider-native passthrough body.
+func basePassthroughChatRequest(model string) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Model: model,
+		Input: []schemas.ChatMessage{
+			CreateBasicChatMessage("Say hello in one word"),
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: bifrost.Ptr(300),
+		},
+	}
+}
+
+// buildPassthroughChatReq converts a minimal BifrostChatRequest into the
+// provider-native HTTP path and JSON body using each provider's own converter.
+//
+// Streaming is requested when stream is true.
+// Returns (req, true) for supported providers, (zero, false) to signal skip.
+func buildPassthroughChatReq(provider schemas.ModelProvider, model string, stream bool) (passthroughChatReq, bool) {
+	bfReq := basePassthroughChatRequest(model)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	switch provider {
+	case schemas.OpenAI:
+		nativeReq := openai.ToOpenAIChatRequest(ctx, bfReq)
+		if stream {
+			nativeReq.Stream = bifrost.Ptr(true)
+		}
+		body, err := sonic.Marshal(nativeReq)
+		if err != nil {
+			return passthroughChatReq{}, false
+		}
+		return passthroughChatReq{path: "/v1/chat/completions", body: body}, true
+
+	case schemas.Anthropic:
+		nativeReq, err := anthropic.ToAnthropicChatRequest(ctx, bfReq)
+		if err != nil {
+			return passthroughChatReq{}, false
+		}
+		if stream {
+			nativeReq.Stream = bifrost.Ptr(true)
+		}
+		body, err := sonic.Marshal(nativeReq)
+		if err != nil {
+			return passthroughChatReq{}, false
+		}
+		return passthroughChatReq{path: "/v1/messages", body: body}, true
+
+	case schemas.Gemini:
+		nativeReq := gemini.ToGeminiChatCompletionRequest(bfReq)
+		body, err := sonic.Marshal(nativeReq)
+		if err != nil {
+			return passthroughChatReq{}, false
+		}
+		endpoint := ":generateContent"
+		query := ""
+		if stream {
+			endpoint = ":streamGenerateContent"
+			query = "alt=sse"
+		}
+		req := passthroughChatReq{
+			path: fmt.Sprintf("/models/%s%s", model, endpoint),
+			body: body,
+		}
+		if query != "" {
+			req.query = query
+		}
+		return req, true
+
+	default:
+		return passthroughChatReq{}, false
+	}
+}
+
+// resolvePassthroughModel returns the model to use for passthrough tests:
+// PassthroughModel if set, otherwise ChatModel.
+func resolvePassthroughModel(cfg ComprehensiveTestConfig) string {
+	if cfg.PassthroughModel != "" {
+		return cfg.PassthroughModel
+	}
+	return cfg.ChatModel
+}
+
+// RunPassthroughAPITest exercises Bifrost's raw HTTP passthrough API for the
+// configured provider using two sub-tests:
+//
+//   - PassthroughAPI/NonStream – calls client.Passthrough and verifies a 2xx
+//     response with a non-empty body and correct ExtraFields.
+//   - PassthroughAPI/Stream   – calls client.PassthroughStream and verifies
+//     that at least one chunk with body data is received.
+//
+// The test is skipped when Scenarios.PassthroughAPI is false or the provider's
+// native request format is not yet covered by buildPassthroughChatReq.
+func RunPassthroughAPITest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.PassthroughAPI {
+		t.Logf("PassthroughAPI not enabled for provider %s, skipping", testConfig.Provider)
+		return
+	}
+
+	model := resolvePassthroughModel(testConfig)
+	if model == "" {
+		t.Logf("No model configured for PassthroughAPI test on provider %s, skipping", testConfig.Provider)
+		return
+	}
+
+	t.Run("PassthroughAPI", func(t *testing.T) {
+		t.Run("NonStream", func(t *testing.T) {
+			if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+				t.Parallel()
+			}
+
+			req, ok := buildPassthroughChatReq(testConfig.Provider, model, false)
+			if !ok {
+				t.Skipf("PassthroughAPI/NonStream: no native request format defined for provider %s", testConfig.Provider)
+			}
+
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			resp, bifrostErr := client.Passthrough(bfCtx, testConfig.Provider, &schemas.BifrostPassthroughRequest{
+				Method: "POST",
+				Path:   req.path,
+				Body:   req.body,
+				SafeHeaders: map[string]string{
+					"content-type": "application/json",
+				},
+				Model: model,
+			})
+
+			if bifrostErr != nil {
+				t.Fatalf("❌ Passthrough request failed: %s", GetErrorMessage(bifrostErr))
+			}
+			if resp == nil {
+				t.Fatal("❌ Passthrough response is nil")
+			}
+
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				t.Fatalf("❌ Passthrough returned non-2xx status %d; body: %s", resp.StatusCode, string(resp.Body))
+			}
+			if len(resp.Body) == 0 {
+				t.Fatal("❌ Passthrough response body is empty")
+			}
+			if resp.ExtraFields.Provider == "" {
+				t.Error("❌ ExtraFields.Provider is empty")
+			}
+			if resp.ExtraFields.Latency <= 0 {
+				t.Error("❌ ExtraFields.Latency is not positive")
+			}
+			if resp.ExtraFields.RequestType != schemas.PassthroughRequest {
+				t.Errorf("❌ ExtraFields.RequestType = %q, want %q", resp.ExtraFields.RequestType, schemas.PassthroughRequest)
+			}
+
+			t.Logf("✅ Passthrough non-streaming OK: status=%d body_len=%d latency=%dms",
+				resp.StatusCode, len(resp.Body), resp.ExtraFields.Latency)
+		})
+
+		t.Run("Stream", func(t *testing.T) {
+			if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+				t.Parallel()
+			}
+
+			req, ok := buildPassthroughChatReq(testConfig.Provider, model, true)
+			if !ok {
+				t.Skipf("PassthroughAPI/Stream: no native request format defined for provider %s", testConfig.Provider)
+			}
+
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			ch, bifrostErr := client.PassthroughStream(bfCtx, testConfig.Provider, &schemas.BifrostPassthroughRequest{
+				Method:   "POST",
+				Path:     req.path,
+				Body:     req.body,
+				RawQuery: req.query,
+				SafeHeaders: map[string]string{
+					"content-type": "application/json",
+				},
+				Model: model,
+			})
+
+			if bifrostErr != nil {
+				t.Fatalf("❌ PassthroughStream failed: %s", GetErrorMessage(bifrostErr))
+			}
+			if ch == nil {
+				t.Fatal("❌ PassthroughStream returned nil channel")
+			}
+
+			var totalBytes int
+			var chunkCount int
+			for chunk := range ch {
+				if chunk == nil {
+					continue
+				}
+				if chunk.BifrostError != nil {
+					t.Fatalf("❌ Stream chunk contained error: %s", GetErrorMessage(chunk.BifrostError))
+				}
+				if chunk.BifrostPassthroughResponse != nil {
+					totalBytes += len(chunk.BifrostPassthroughResponse.Body)
+					if len(chunk.BifrostPassthroughResponse.Body) > 0 {
+						chunkCount++
+					}
+				}
+			}
+
+			if chunkCount == 0 {
+				t.Fatal("❌ PassthroughStream received no chunks with body data")
+			}
+
+			t.Logf("✅ Passthrough streaming OK: %d chunks, %d total bytes", chunkCount, totalBytes)
+		})
+	})
+}

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -112,6 +112,7 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunContainerFileUnsupportedTest,
 		RunPassthroughExtraParamsTest,
 		RunStreamErrorStatusCodeTest,
+		RunPassthroughAPITest,
 	}
 
 	// Execute all test scenarios without raw request/response (default behavior)
@@ -223,6 +224,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"ContainerFileUnsupported", !testConfig.Scenarios.ContainerFileCreate && !testConfig.Scenarios.ContainerFileList && !testConfig.Scenarios.ContainerFileRetrieve && !testConfig.Scenarios.ContainerFileContent && !testConfig.Scenarios.ContainerFileDelete},
 		{"PassThroughExtraParams", testConfig.Scenarios.PassThroughExtraParams},
 		{"StreamErrorStatusCode", testConfig.Scenarios.CompletionStream},
+		{"PassthroughAPI", testConfig.Scenarios.PassthroughAPI},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -2474,11 +2474,219 @@ func (provider *AnthropicProvider) ContainerFileDelete(_ *schemas.BifrostContext
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
 }
 
-// Passthrough is not supported by the Anthropic provider.
-func (provider *AnthropicProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+func (provider *AnthropicProvider) Passthrough(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.PassthroughRequest); err != nil {
+		return nil, err
+	}
+
+	url := provider.networkConfig.BaseURL + req.Path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	if key.Value.GetValue() != "" {
+		fasthttpReq.Header.Set("x-api-key", key.Value.GetValue())
+	}
+	fasthttpReq.Header.Set("anthropic-version", provider.apiVersion)
+
+	fasthttpReq.SetBody(req.Body)
+
+	latency, bifrostErr := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err, provider.GetProviderKey())
+	}
+
+	for k := range headers {
+		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
+			delete(headers, k)
+		}
+	}
+
+	bifrostResponse := &schemas.BifrostPassthroughResponse{
+		StatusCode: resp.StatusCode(),
+		Headers:    headers,
+		Body:       body,
+	}
+
+	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
+	bifrostResponse.ExtraFields.ModelRequested = req.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.PassthroughRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+	}
+
+	return bifrostResponse, nil
 }
 
-func (provider *AnthropicProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
+func (provider *AnthropicProvider) PassthroughStream(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.PassthroughStreamRequest); err != nil {
+		return nil, err
+	}
+
+	url := provider.networkConfig.BaseURL + req.Path
+	if req.RawQuery != "" {
+		url += "?" + req.RawQuery
+	}
+
+	startTime := time.Now()
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	fasthttpReq.Header.Set("Connection", "close")
+
+	if key.Value.GetValue() != "" {
+		fasthttpReq.Header.Set("x-api-key", key.Value.GetValue())
+	}
+	fasthttpReq.Header.Set("anthropic-version", provider.apiVersion)
+
+	fasthttpReq.SetBody(req.Body)
+
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
+	if err := activeClient.Do(fasthttpReq, resp); err != nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestTimedOut, err, provider.GetProviderKey())
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey())
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+
+	bodyStream := resp.BodyStream()
+	if bodyStream == nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		return nil, providerUtils.NewBifrostOperationError(
+			"provider returned an empty stream body",
+			fmt.Errorf("provider returned an empty stream body"),
+			provider.GetProviderKey(),
+		)
+	}
+
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, bodyStream, provider.logger)
+
+	extraFields := schemas.BifrostResponseExtraFields{
+		Provider:       provider.GetProviderKey(),
+		ModelRequested: req.Model,
+		RequestType:    schemas.PassthroughStreamRequest,
+	}
+	statusCode := resp.StatusCode()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
+	}
+
+	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			}
+			close(ch)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		defer stopCancellation()
+
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := bodyStream.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				select {
+				case ch <- &schemas.BifrostStreamChunk{
+					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						Body:        chunk,
+						ExtraFields: extraFields,
+					},
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if readErr == io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				finalResp := &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						ExtraFields: extraFields,
+					},
+				}
+				postHookRunner(ctx, finalResp, nil)
+				if finalizer, ok := ctx.Value(schemas.BifrostContextKeyPostHookSpanFinalizer).(func(context.Context)); ok && finalizer != nil {
+					finalizer(ctx)
+				}
+				return
+			}
+			if readErr != nil {
+				if ctx.Err() != nil {
+					return // let defer handle cancel/timeout
+				}
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, ch, schemas.PassthroughStreamRequest, provider.GetProviderKey(), req.Model, provider.logger)
+				return
+			}
+		}
+	}()
+	return ch, nil
 }

--- a/core/providers/anthropic/anthropic_test.go
+++ b/core/providers/anthropic/anthropic_test.go
@@ -32,6 +32,7 @@ func TestAnthropic(t *testing.T) {
 		VisionModel:        "claude-sonnet-4-5", // Same model supports vision
 		ReasoningModel:     "claude-opus-4-5",
 		PromptCachingModel: "claude-sonnet-4-20250514",
+		PassthroughModel:   "claude-sonnet-4-5",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        false, // Not supported
 			SimpleChat:            true,
@@ -66,6 +67,7 @@ func TestAnthropic(t *testing.T) {
 			FileBatchInput:        false, // Anthropic batch API only supports inline requests, not file-based input
 			CountTokens:           true,
 			StructuredOutputs:     true, // Structured outputs with nullable enum support
+			PassthroughAPI:        true,
 		},
 	}
 

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -42,6 +42,7 @@ func TestGemini(t *testing.T) {
 		},
 		ReasoningModel:       "gemini-3-pro-preview",
 		VideoGenerationModel: "veo-3.1-generate-preview",
+		PassthroughModel:     "gemini-2.5-flash",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        false, // Not supported
 			SimpleChat:            true,
@@ -85,6 +86,7 @@ func TestGemini(t *testing.T) {
 			FileBatchInput:        true,
 			CountTokens:           true,
 			StructuredOutputs:     true, // Structured outputs with nullable enum support
+			PassthroughAPI:        true,
 		},
 	}
 
@@ -1978,23 +1980,23 @@ func TestConvertGeminiUsageMetadataToChatUsage(t *testing.T) {
 				},
 				ThoughtsTokenCount: 41,
 			},
-		expected: &schemas.BifrostLLMUsage{
-			PromptTokens:     6,
-			CompletionTokens: 83,
-			TotalTokens:      48,
-			PromptTokensDetails: &schemas.ChatPromptTokensDetails{
-				TextTokens:  6,
-				AudioTokens: 0,
-				ImageTokens: 0,
-			},
-			CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
-				TextTokens:      1,
-				ReasoningTokens: 41,
+			expected: &schemas.BifrostLLMUsage{
+				PromptTokens:     6,
+				CompletionTokens: 83,
+				TotalTokens:      48,
+				PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+					TextTokens:  6,
+					AudioTokens: 0,
+					ImageTokens: 0,
+				},
+				CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{
+					TextTokens:      1,
+					ReasoningTokens: 41,
+				},
 			},
 		},
-	},
-	{
-		name: "MultimodalInputWithCache",
+		{
+			name: "MultimodalInputWithCache",
 			metadata: &gemini.GenerateContentResponseUsageMetadata{
 				PromptTokenCount:        150,
 				CandidatesTokenCount:    50,
@@ -2160,24 +2162,24 @@ func TestConvertGeminiUsageMetadataToResponsesUsage(t *testing.T) {
 				},
 				ThoughtsTokenCount: 5,
 			},
-		expected: &schemas.ResponsesResponseUsage{
-			TotalTokens:  150,
-			InputTokens:  100,
-			OutputTokens: 55,
-			InputTokensDetails: &schemas.ResponsesResponseInputTokens{
-				TextTokens:  60,
-				AudioTokens: 20,
-				ImageTokens: 20,
-			},
-			OutputTokensDetails: &schemas.ResponsesResponseOutputTokens{
-				TextTokens:      40,
-				AudioTokens:     10,
-				ReasoningTokens: 5,
+			expected: &schemas.ResponsesResponseUsage{
+				TotalTokens:  150,
+				InputTokens:  100,
+				OutputTokens: 55,
+				InputTokensDetails: &schemas.ResponsesResponseInputTokens{
+					TextTokens:  60,
+					AudioTokens: 20,
+					ImageTokens: 20,
+				},
+				OutputTokensDetails: &schemas.ResponsesResponseOutputTokens{
+					TextTokens:      40,
+					AudioTokens:     10,
+					ReasoningTokens: 5,
+				},
 			},
 		},
-	},
-	{
-		name: "WithCachedTokens",
+		{
+			name: "WithCachedTokens",
 			metadata: &gemini.GenerateContentResponseUsageMetadata{
 				PromptTokenCount:        200,
 				CandidatesTokenCount:    100,

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -43,6 +43,7 @@ func TestOpenAI(t *testing.T) {
 		ImageVariationModel:  "", // dall-e-2 is deprecated and no other OpenAI model supports image variations
 		VideoGenerationModel: "sora-2",
 		ChatAudioModel:       "gpt-4o-mini-audio-preview",
+		PassthroughModel:     "gpt-4o",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        true,
 			TextCompletionStream:  true,
@@ -102,6 +103,7 @@ func TestOpenAI(t *testing.T) {
 			ContainerFileRetrieve: true,
 			ContainerFileContent:  true,
 			ContainerFileDelete:   true,
+			PassthroughAPI:        true,
 		},
 	}
 

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -735,6 +735,10 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {
 				params.StatusCode = result.PassthroughResponse.StatusCode
 			}
+			// Flip status for passthrough error responses (4xx/5xx from provider)
+			if isPassthroughErrorResponse(result) {
+				entry.Status = "error"
+			}
 		}
 		applyLargePayloadPreviewsToEntry(ctx, entry)
 
@@ -760,6 +764,10 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	} else if result != nil {
 		entry.Status = "success"
 		p.applyNonStreamingOutputToEntry(entry, result)
+		// Flip status for passthrough error responses (4xx/5xx from provider)
+		if isPassthroughErrorResponse(result) {
+			entry.Status = "error"
+		}
 	}
 	applyLargePayloadPreviewsToEntry(ctx, entry)
 

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -596,6 +596,14 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 	}
 }
 
+// isPassthroughErrorResponse returns true when the result is a passthrough
+// response with a provider-reported HTTP error status (4xx or 5xx).
+func isPassthroughErrorResponse(result *schemas.BifrostResponse) bool {
+	return result != nil &&
+		result.PassthroughResponse != nil &&
+		result.PassthroughResponse.StatusCode >= 400
+}
+
 // applyNonStreamingOutputToEntry applies non-streaming response data to a log entry.
 func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse) {
 	if result == nil {

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -13,6 +13,7 @@ bifrost:
     cohere: "cohere"
     google: "genai"
     "gemini_passthrough": "genai_passthrough"
+    "anthropic_passthrough": "anthropic_passthrough"
     litellm: "litellm"
     langchain: "langchain"
     pydanticai: "pydanticai"

--- a/tests/integrations/python/tests/test_anthropic.py
+++ b/tests/integrations/python/tests/test_anthropic.py
@@ -40,6 +40,8 @@ Tests all core scenarios using Anthropic SDK directly:
 29. Prompt caching - messages checkpoint
 30. Prompt caching - tools checkpoint
 31. Count tokens (Cross-Provider)
+32. Passthrough messages (non-streaming)
+33. Passthrough messages (streaming)
 """
 
 import logging
@@ -133,12 +135,13 @@ def test_config():
     return Config()
 
 
-def get_provider_anthropic_client(provider):
+def get_provider_anthropic_client(provider, passthrough: bool = False):
     """Create Anthropic client with x-model-provider header for given provider"""
     from .utils.config_loader import get_config, get_integration_url
 
     api_key = get_api_key("anthropic")
-    base_url = get_integration_url("anthropic")
+    integration = "anthropic_passthrough" if passthrough else "anthropic"
+    base_url = get_integration_url(integration)
     config = get_config()
     api_config = config.get_api_config()
     integration_settings = config.get_integration_settings("anthropic")
@@ -2833,6 +2836,70 @@ This document is used to verify that the AI can read and understand text documen
                 return
 
         pytest.fail(f"Async job did not complete after {max_polls} polls")
+
+    # =========================================================================
+    # Passthrough Tests
+    # =========================================================================
+
+    @pytest.mark.parametrize(
+        "provider,model",
+        get_cross_provider_params_for_scenario("simple_chat", include_providers=["anthropic"]),
+    )
+    def test_51_passthrough_messages(self, test_config, provider, model):
+        """Test Case 51: Passthrough messages (non-streaming) - sends request directly to Anthropic API"""
+        _ = test_config
+        if provider == "_no_providers_" or model == "_no_model_":
+            pytest.skip("No providers configured for passthrough scenario")
+
+        print(f"\n=== Testing Passthrough Messages (non-streaming) for provider {provider} ===")
+
+        client = get_provider_anthropic_client(provider, passthrough=True)
+        messages = convert_to_anthropic_messages(SIMPLE_CHAT_MESSAGES)
+
+        response = client.messages.create(
+            model=format_provider_model(provider, model),
+            messages=messages,
+            max_tokens=100,
+        )
+
+        assert_valid_chat_response(response)
+        assert len(response.content) > 0
+        assert response.content[0].type == "text"
+        assert len(response.content[0].text) > 0
+        print(f"  Response: {response.content[0].text[:80]}...")
+        print("✓ Passthrough messages test passed!")
+
+    @pytest.mark.parametrize(
+        "provider,model",
+        get_cross_provider_params_for_scenario("simple_chat", include_providers=["anthropic"]),
+    )
+    def test_52_passthrough_messages_streaming(self, test_config, provider, model):
+        """Test Case 52: Passthrough messages (streaming) - streams response directly from Anthropic API"""
+        _ = test_config
+        if provider == "_no_providers_" or model == "_no_model_":
+            pytest.skip("No providers configured for passthrough scenario")
+
+        print(f"\n=== Testing Passthrough Messages (streaming) for provider {provider} ===")
+
+        client = get_provider_anthropic_client(provider, passthrough=True)
+        messages = convert_to_anthropic_messages(STREAMING_CHAT_MESSAGES)
+
+        stream = client.messages.create(
+            model=format_provider_model(provider, model),
+            messages=messages,
+            max_tokens=200,
+            stream=True,
+        )
+
+        content, chunk_count, tool_calls_detected = collect_streaming_content(
+            stream, "anthropic", timeout=300
+        )
+
+        assert chunk_count > 0, "Should receive at least one chunk"
+        assert len(content) > 0, "Should receive non-empty streamed content"
+        assert not tool_calls_detected, "Basic passthrough streaming should not have tool calls"
+        print(f"  Received {chunk_count} chunks, total content length: {len(content)}")
+        print("✓ Passthrough streaming test passed!")
 
 
 # Additional helper functions specific to Anthropic

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -30,6 +30,7 @@ func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStor
 		// passthrough routers
 		integrations.NewGenAIPassthroughRouter(client, handlerStore, logger),
 		integrations.NewOpenAIPassthroughRouter(client, handlerStore, logger),
+		integrations.NewAnthropicPassthroughRouter(client, handlerStore, logger),
 		integrations.NewCursorRouter(client, handlerStore, logger),
 	}
 

--- a/transports/bifrost-http/integrations/passthrough.go
+++ b/transports/bifrost-http/integrations/passthrough.go
@@ -27,6 +27,16 @@ func NewPassthroughRouter(
 	}
 }
 
+// NewAnthropicPassthroughRouter creates a passthrough router for /anthropic_passthrough.
+func NewAnthropicPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+		Provider: schemas.Anthropic,
+		StripPrefix: []string{
+			"/anthropic_passthrough",
+		},
+	})
+}
+
 // NewOpenAIPassthroughRouter creates a passthrough router for /openai_passthrough.
 func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
 	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2643,7 +2643,7 @@ func (g *GenericRouter) handlePassthrough(ctx *fasthttp.RequestCtx) {
 		keyStr := strings.ToLower(string(key))
 		switch keyStr {
 		case "authorization", "api-key", "x-api-key", "x-goog-api-key",
-			"host", "connection", "transfer-encoding", "cookie", "set-cookie", "proxy-authorization":
+			"host", "connection", "transfer-encoding", "cookie", "set-cookie", "proxy-authorization", "accept-encoding":
 		default:
 			if strings.HasPrefix(keyStr, "x-bf-") {
 				return true // drop internal gateway headers


### PR DESCRIPTION
## Summary

Adds raw HTTP passthrough API support for Anthropic and Gemini providers, enabling direct provider-native requests while maintaining Bifrost's authentication, logging, and monitoring capabilities.

## Changes

- Added `PassthroughAPI` test scenario and `PassthroughModel` configuration to the testing framework
- Implemented `Passthrough` and `PassthroughStream` methods for Anthropic provider (previously returned unsupported operation errors)
- Created comprehensive test suite `RunPassthroughAPITest` that validates both streaming and non-streaming passthrough requests
- Added `/anthropic_passthrough` HTTP endpoint alongside existing `/genai_passthrough` and `/openai_passthrough`
- Enhanced logging plugin to properly mark 4xx/5xx passthrough responses as errors
- Updated provider test configurations to enable passthrough testing for OpenAI, Anthropic, and Gemini
- Added Python integration tests for Anthropic passthrough functionality
- Fixed header filtering to exclude `accept-encoding` from passthrough requests

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins

## How to test

Test the passthrough functionality with provider-specific endpoints:

```sh
# Run comprehensive tests including passthrough
go test ./core/providers/anthropic -v
go test ./core/providers/gemini -v
go test ./core/providers/openai -v

# Test HTTP transport integration
go test ./transports/bifrost-http/integrations -v

# Run Python integration tests
cd tests/integrations/python
python -m pytest tests/test_anthropic.py::TestAnthropicCrossProvider::test_51_passthrough_messages -v
python -m pytest tests/test_anthropic.py::TestAnthropicCrossProvider::test_52_passthrough_messages_streaming -v
```

The passthrough API allows sending raw provider requests through endpoints like:
- `/anthropic_passthrough/v1/messages` 
- `/genai_passthrough/models/gemini-2.5-flash:generateContent`
- `/openai_passthrough/v1/chat/completions`

## Breaking changes

- [ ] No

## Security considerations

The passthrough API maintains existing authentication mechanisms while allowing raw HTTP requests. Header filtering prevents sensitive headers from being passed through, and the `SafeHeaders` mechanism ensures only approved headers are forwarded to providers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable