### PR TITLE
cli test fixes

### DIFF
--- a/cli/internal/runtime/tabmgr.go
+++ b/cli/internal/runtime/tabmgr.go
@@ -1114,10 +1114,11 @@ func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc,
 	case b == ' ':
 		tm.clearNoticeAndResume()
 	case b == prefix || b == 0x1b || b == '\r' || b == '\n':
-		tm.exitCommandMode()
 		if !tm.hasTabs() {
 			tm.drawTabBar()
+			return
 		}
+		tm.exitCommandMode()
 	case b >= '1' && b <= '9':
 		tm.switchTabAndResume(int(b - '1'))
 	case b == 'n' || b == 'N':

--- a/npx/bifrost-cli/package.json
+++ b/npx/bifrost-cli/package.json
@@ -14,7 +14,7 @@
     "homepage": "https://github.com/maximhq/bifrost",
     "repository": {
         "type": "git",
-        "url": "https://github.com/maximhq/bifrost.git"
+        "url": "git+https://github.com/maximhq/bifrost.git"
     },
     "license": "Apache-2.0",
     "author": "Maxim HQ",

--- a/npx/bifrost/package.json
+++ b/npx/bifrost/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/maximhq/bifrost",
   "repository": {
     "type": "git",
-    "url": "https://github.com/maximhq/bifrost.git"
+    "url": "git+https://github.com/maximhq/bifrost.git"
   },
   "license": "Apache-2.0",
   "author": "Maxim HQ",


### PR DESCRIPTION
## Summary

Fix command mode exit behavior when no tabs are present and update npm package repository URLs to include the git+ prefix for proper package manager compatibility.

## Changes

- Fixed tab manager command key handling to prevent exiting command mode when no tabs are present, ensuring the tab bar is drawn and execution returns early
- Updated repository URLs in package.json files to use the standard `git+https://` format instead of plain `https://`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the tab manager command mode behavior:

```sh
# Core/Transports
go version
go test ./...

# Test tab manager functionality specifically
go test ./cli/internal/runtime/...
```

Verify npm package metadata:

```sh
# Check package.json validity
cd npx/bifrost-cli && npm pack --dry-run
cd ../bifrost && npm pack --dry-run
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable