### PR TITLE
fixed windows build issue

### DIFF
--- a/cli/internal/runtime/tabmgr_windows.go
+++ b/cli/internal/runtime/tabmgr_windows.go
@@ -12,6 +12,10 @@ import (
 // without creating any tabs.
 var ErrQuit = errors.New("user quit")
 
+// ErrBackToTabs is returned by the newTabFn when the user presses Ctrl+B
+// to dismiss the chooser and return to tab command mode.
+var ErrBackToTabs = errors.New("back to tabs")
+
 // NewTabFunc is called when the user requests a new tab.
 // stdinReader provides keyboard input; when nil the callback should read os.Stdin.
 type NewTabFunc func(ctx context.Context, notify func(level TabNoticeLevel, message string), stdinReader io.Reader) (*LaunchSpec, error)


### PR DESCRIPTION
## Summary

Adds a new error type `ErrBackToTabs` to handle the Ctrl+B keyboard shortcut that allows users to dismiss the chooser interface and return to tab command mode in the Windows tab manager.

## Changes

- Added `ErrBackToTabs` error variable with documentation explaining its purpose for Ctrl+B functionality
- Provides a standardized way for the `newTabFn` to signal when users want to return to tab mode

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new error handling by verifying the Ctrl+B functionality works correctly in the Windows tab manager:

```sh
# Core/Transports
go version
go test ./...
```

Verify that pressing Ctrl+B in the chooser interface properly returns the `ErrBackToTabs` error and transitions back to tab command mode.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a simple error type addition for keyboard navigation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable