### PR TITLE
adds edit sesion, fixes cursor missing in main tab for cli

### DIFF
--- a/cli/internal/app/app.go
+++ b/cli/internal/app/app.go
@@ -112,20 +112,33 @@ func (a *App) Run(ctx context.Context) error {
 	// chooseAndPrepare runs the chooser TUI, handles installation flows,
 	// persists state, and returns a launch spec. Loops internally until
 	// the user picks a valid harness or quits.
-	chooseAndPrepare := func(_ context.Context, notify func(runtime.TabNoticeLevel, string), stdinReader io.Reader, msg string, isAfterSession bool) (*runtime.LaunchSpec, error) {
+	chooseAndPrepare := func(_ context.Context, notify func(runtime.TabNoticeLevel, string), stdinReader io.Reader, msg string, isAfterSession bool, seed *runtime.LaunchSpec) (*runtime.LaunchSpec, error) {
+		seedApplied := false
 		for {
 			harnesses := a.harnessOptions()
+			baseURL := activeProfile.BaseURL
+			currentVK := vk
+			currentSelection := selection
+			currentWorktree := worktree
+			if seed != nil && !seedApplied {
+				baseURL = seed.BaseURL
+				currentVK = seed.VirtualKey
+				currentSelection.Harness = seed.Harness.ID
+				currentSelection.Model = seed.Model
+				currentWorktree = seed.Worktree
+				seedApplied = true
+			}
 
 			choice, err := tui.RunChooser(tui.ChooserConfig{
 				Version:      a.opts.Version,
 				Commit:       a.opts.Commit,
 				ConfigSrc:    a.configSource,
 				Message:      msg,
-				BaseURL:      activeProfile.BaseURL,
-				VirtualKey:   vk,
-				Harness:      selection.Harness,
-				Model:        selection.Model,
-				Worktree:     worktree,
+				BaseURL:      baseURL,
+				VirtualKey:   currentVK,
+				Harness:      currentSelection.Harness,
+				Model:        currentSelection.Model,
+				Worktree:     currentWorktree,
 				AfterSession: isAfterSession,
 				ReservedRows: 1, // bottom tab bar
 				Harnesses:    harnesses,
@@ -248,8 +261,8 @@ func (a *App) Run(ctx context.Context) error {
 	}
 
 	// Enter tabbed mode — draws chrome, opens chooser, runs tabs.
-	err = runtime.RunTabbed(ctx, a.out, a.errOut, a.opts.Version, func(tabCtx context.Context, notify func(runtime.TabNoticeLevel, string), stdinReader io.Reader) (*runtime.LaunchSpec, error) {
-		return chooseAndPrepare(tabCtx, notify, stdinReader, message, afterSession)
+	err = runtime.RunTabbed(ctx, a.out, a.errOut, a.opts.Version, func(tabCtx context.Context, notify func(runtime.TabNoticeLevel, string), stdinReader io.Reader, seed *runtime.LaunchSpec) (*runtime.LaunchSpec, error) {
+		return chooseAndPrepare(tabCtx, notify, stdinReader, message, afterSession, seed)
 	})
 
 	if errors.Is(err, runtime.ErrQuit) {

--- a/cli/internal/harness/harness.go
+++ b/cli/internal/harness/harness.go
@@ -54,7 +54,6 @@ var all = map[string]Harness{
 		BasePath:         "/anthropic",
 		BaseURLEnv:       "ANTHROPIC_BASE_URL",
 		APIKeyEnv:        "ANTHROPIC_API_KEY",
-		ModelEnv:         "ANTHROPIC_MODEL",
 		SupportsMCP:      true,
 		SupportsWorktree: true,
 		RunArgsForMod: func(model string) []string {

--- a/cli/internal/harness/harness_test.go
+++ b/cli/internal/harness/harness_test.go
@@ -5,7 +5,90 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/bytedance/sonic"
 )
+
+func TestClaudePreLaunchPinsSelectedModelAcrossClaudeTiers(t *testing.T) {
+	t.Parallel()
+
+	env, cleanup, err := claudePreLaunch("https://example.com/anthropic", "test-key", "openai/gpt-5")
+	if err != nil {
+		t.Fatalf("claudePreLaunch() error = %v", err)
+	}
+	defer cleanup()
+
+	for _, want := range []string{
+		"CLAUDE_CODE_SIMPLE=1",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL=openai/gpt-5",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL=openai/gpt-5",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL=openai/gpt-5",
+	} {
+		parts := strings.SplitN(want, "=", 2)
+		if got := envValue(env, parts[0]); got != parts[1] {
+			t.Fatalf("env[%q] = %q, want %q", parts[0], got, parts[1])
+		}
+	}
+
+	if got := envValue(env, "ANTHROPIC_MODEL"); got != "" {
+		t.Fatalf("did not expect ANTHROPIC_MODEL in env, got %#v", env)
+	}
+}
+
+func TestClaudeWriteNativeConfigPinsTierDefaults(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	settingsDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	settingsPath := filepath.Join(settingsDir, "settings.json")
+	initial := `{"env":{"EXISTING":"keep","ANTHROPIC_MODEL":"stale-model"}}`
+	if err := os.WriteFile(settingsPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("write initial settings: %v", err)
+	}
+
+	if err := claudeWriteNativeConfig("https://example.com/anthropic", "test-key", "openai/gpt-5"); err != nil {
+		t.Fatalf("claudeWriteNativeConfig() error = %v", err)
+	}
+
+	b, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+
+	var settings map[string]any
+	if err := sonic.Unmarshal(b, &settings); err != nil {
+		t.Fatalf("unmarshal settings: %v", err)
+	}
+
+	envRaw, ok := settings["env"]
+	if !ok {
+		t.Fatalf("expected env map in settings, got %#v", settings)
+	}
+	envMap, ok := envRaw.(map[string]any)
+	if !ok {
+		t.Fatalf("env map type = %T, want map[string]any", envRaw)
+	}
+
+	for key, want := range map[string]string{
+		"EXISTING":                       "keep",
+		"ANTHROPIC_BASE_URL":             "https://example.com/anthropic",
+		"ANTHROPIC_API_KEY":              "test-key",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": "openai/gpt-5",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   "openai/gpt-5",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  "openai/gpt-5",
+	} {
+		if got, _ := envMap[key].(string); got != want {
+			t.Fatalf("env[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	if _, ok := envMap["ANTHROPIC_MODEL"]; ok {
+		t.Fatalf("did not expect legacy ANTHROPIC_MODEL in settings env: %#v", envMap)
+	}
+}
 
 func TestOpencodeModelRef(t *testing.T) {
 	t.Parallel()

--- a/cli/internal/harness/native_config.go
+++ b/cli/internal/harness/native_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/cli/internal/config"
@@ -14,7 +15,11 @@ import (
 // launched inside Bifrost's tab multiplexer. This avoids Claude-specific
 // full-screen terminal behavior that doesn't restore reliably across tab swaps.
 func claudePreLaunch(baseURL, apiKey, model string) ([]string, func(), error) {
-	return []string{"CLAUDE_CODE_SIMPLE=1"}, func() {}, nil
+	env := []string{"CLAUDE_CODE_SIMPLE=1"}
+	if model = strings.TrimSpace(model); model != "" {
+		env = append(env, claudeTierModelEnv(model)...)
+	}
+	return env, func() {}, nil
 }
 
 // claudeWriteNativeConfig writes the bifrost endpoint, API key, and model
@@ -55,8 +60,11 @@ func claudeWriteNativeConfig(baseURL, apiKey, model string) error {
 
 	envMap["ANTHROPIC_BASE_URL"] = baseURL
 	envMap["ANTHROPIC_API_KEY"] = apiKey
-	if model != "" {
-		envMap["ANTHROPIC_MODEL"] = model
+	if model = strings.TrimSpace(model); model != "" {
+		for key, value := range claudeTierModelEnvMap(model) {
+			envMap[key] = value
+		}
+		delete(envMap, "ANTHROPIC_MODEL")
 	}
 
 	settings["env"] = envMap
@@ -70,4 +78,21 @@ func claudeWriteNativeConfig(baseURL, apiKey, model string) error {
 		return fmt.Errorf("create claude config dir: %w", err)
 	}
 	return config.WriteAtomic(settingsPath, b, 0o600)
+}
+
+func claudeTierModelEnv(model string) []string {
+	envMap := claudeTierModelEnvMap(model)
+	return []string{
+		"ANTHROPIC_DEFAULT_SONNET_MODEL=" + envMap["ANTHROPIC_DEFAULT_SONNET_MODEL"],
+		"ANTHROPIC_DEFAULT_OPUS_MODEL=" + envMap["ANTHROPIC_DEFAULT_OPUS_MODEL"],
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL=" + envMap["ANTHROPIC_DEFAULT_HAIKU_MODEL"],
+	}
+}
+
+func claudeTierModelEnvMap(model string) map[string]string {
+	return map[string]string{
+		"ANTHROPIC_DEFAULT_SONNET_MODEL": model,
+		"ANTHROPIC_DEFAULT_OPUS_MODEL":   model,
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  model,
+	}
 }

--- a/cli/internal/runtime/pty.go
+++ b/cli/internal/runtime/pty.go
@@ -62,7 +62,10 @@ func runWithPTY(ctx context.Context, stdout io.Writer, cmd *exec.Cmd) error {
 		oldState = nil
 	}
 	if oldState != nil {
-		defer term.Restore(int(os.Stdin.Fd()), oldState)
+		defer func() {
+			_ = term.Restore(int(os.Stdin.Fd()), oldState)
+			_, _ = io.WriteString(stdout, hostCursorResetSequence())
+		}()
 	}
 
 	// Relay stdout: PTY master → caller's stdout

--- a/cli/internal/runtime/runtime.go
+++ b/cli/internal/runtime/runtime.go
@@ -34,10 +34,7 @@ func BuildEnv(spec LaunchSpec) ([]string, error) {
 	vk := strings.TrimSpace(spec.VirtualKey)
 	if vk != "" {
 		env = append(env, spec.Harness.APIKeyEnv+"="+vk)
-	} else {
-		env = append(env, spec.Harness.APIKeyEnv+"=dummy-key")
-	}
-
+	} 	
 	model := strings.TrimSpace(spec.Model)
 	if model != "" {
 		env = append(env, "BIFROST_MODEL="+model)

--- a/cli/internal/runtime/tabmgr.go
+++ b/cli/internal/runtime/tabmgr.go
@@ -39,6 +39,7 @@ const pendingTabLabel = "Bifrost"
 type Tab struct {
 	id               int
 	label            string
+	spec             LaunchSpec
 	ptmx             *os.File
 	cmd              *PreparedCmd
 	done             chan struct{} // closed when the process exits
@@ -75,11 +76,12 @@ type belParserState struct {
 	escPending bool
 }
 
-// NewTabFunc is called when the user requests a new tab.
-// It should present any UI needed (e.g. the harness chooser) and return
-// the launch spec. Return a nil spec to cancel.
+// NewTabFunc is called when the user requests a new tab or reopens the
+// chooser for the active tab. It should present any UI needed (e.g. the
+// harness chooser) and return the launch spec. Return a nil spec to cancel.
+// When seed is non-nil, the chooser should use it to prefill the current tab.
 // stdinReader provides keyboard input; when nil the callback should read os.Stdin.
-type NewTabFunc func(ctx context.Context, notify func(level TabNoticeLevel, message string), stdinReader io.Reader) (*LaunchSpec, error)
+type NewTabFunc func(ctx context.Context, notify func(level TabNoticeLevel, message string), stdinReader io.Reader, seed *LaunchSpec) (*LaunchSpec, error)
 
 // TabManager multiplexes multiple CLI sessions. Each session runs in its own PTY,
 // with a virtual terminal emulator capturing output. A 30fps render loop composites
@@ -148,7 +150,7 @@ func RunTabbed(ctx context.Context, stdout, stderr io.Writer, version string, ne
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		// Can't go raw — fall back: open chooser directly, then single-session
-		spec, err := newTabFn(ctx, tm.emitNotice, nil)
+		spec, err := newTabFn(ctx, tm.emitNotice, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -250,9 +252,25 @@ func RunTabbed(ctx context.Context, stdout, stderr io.Writer, version string, ne
 // addTab creates a new PTY session for the given spec, initializes a virtual
 // terminal emulator, and starts reading PTY output into it.
 func (tm *TabManager) addTab(ctx context.Context, spec LaunchSpec) error {
-	p, err := PrepareCommand(ctx, spec)
+	tab, err := tm.createTab(ctx, spec)
 	if err != nil {
 		return err
+	}
+
+	tm.mu.Lock()
+	tm.tabs = append(tm.tabs, tab)
+	tm.activeIdx = len(tm.tabs) - 1
+	tm.needsRender = true
+	tm.mu.Unlock()
+
+	tm.startTab(tab)
+	return nil
+}
+
+func (tm *TabManager) createTab(ctx context.Context, spec LaunchSpec) (*Tab, error) {
+	p, err := PrepareCommand(ctx, spec)
+	if err != nil {
+		return nil, err
 	}
 
 	contentRows := tm.contentRows()
@@ -267,7 +285,7 @@ func (tm *TabManager) addTab(ctx context.Context, spec LaunchSpec) error {
 		if p.Cleanup != nil {
 			p.Cleanup()
 		}
-		return fmt.Errorf("start pty: %w", err)
+		return nil, fmt.Errorf("start pty: %w", err)
 	}
 
 	// Build label: "harness" or "harness:worktree"
@@ -279,6 +297,7 @@ func (tm *TabManager) addTab(ctx context.Context, spec LaunchSpec) error {
 	tab := &Tab{
 		id:        tm.nextID,
 		label:     label,
+		spec:      spec,
 		ptmx:      ptmx,
 		cmd:       p,
 		done:      make(chan struct{}),
@@ -291,28 +310,24 @@ func (tm *TabManager) addTab(ctx context.Context, spec LaunchSpec) error {
 	tab.cursorVisible.Store(true)
 	tm.nextID++
 
-	tm.mu.Lock()
-	tm.tabs = append(tm.tabs, tab)
-	tm.activeIdx = len(tm.tabs) - 1
-	tm.needsRender = true
-	tm.mu.Unlock()
+	return tab, nil
+}
 
+func (tm *TabManager) startTab(tab *Tab) {
 	// Read PTY output into the VT emulator
 	go tm.readPTY(tab)
 
 	// Wait for process exit
 	go func() {
-		tab.exitErr = p.Cmd.Wait()
+		tab.exitErr = tab.cmd.Cmd.Wait()
 		tab.ptmx.Close()
 		tab.exited.Store(true)
 		close(tab.done)
-		if p.Cleanup != nil {
-			p.Cleanup()
+		if tab.cmd.Cleanup != nil {
+			tab.cmd.Cleanup()
 		}
 		tm.removeTab(tab)
 	}()
-
-	return nil
 }
 
 func (tm *TabManager) addPendingTab() (*Tab, int) {
@@ -480,6 +495,7 @@ const prefix = 0x02
 // Keybindings while in tab command mode (^B prefix):
 //
 //	N               — open new tab (shows chooser)
+//	E               — edit the current session
 //	X               — close current tab
 //	H/L or J/K      — move left/right
 //	1…9             — jump to tab N
@@ -1073,6 +1089,23 @@ func (tm *TabManager) clearNotice() bool {
 	return true
 }
 
+func (tm *TabManager) hasStickyErrorNotice() bool {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	return tm.noticeText != "" && tm.noticeSticky && tm.noticeLevel == TabNoticeError
+}
+
+func (tm *TabManager) clearNoticeAndStayInCommandMode() {
+	hadNotice := tm.clearNotice()
+	if tm.hasTabs() {
+		tm.enterCommandMode()
+		return
+	}
+	if hadNotice {
+		tm.drawTabBar()
+	}
+}
+
 func (tm *TabManager) clearNoticeAndResume() {
 	hadNotice := tm.clearNotice()
 	if tm.hasTabs() {
@@ -1112,8 +1145,18 @@ func (tm *TabManager) exitCommandMode() {
 func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc, termState *term.State, b byte) {
 	switch {
 	case b == ' ':
+		if tm.hasStickyErrorNotice() {
+			tm.clearNoticeAndStayInCommandMode()
+			return
+		}
 		tm.clearNoticeAndResume()
 	case b == prefix || b == 0x1b || b == '\r' || b == '\n':
+		if tm.hasStickyErrorNotice() {
+			if b == 0x1b {
+				tm.clearNoticeAndStayInCommandMode()
+			}
+			return
+		}
 		if !tm.hasTabs() {
 			tm.drawTabBar()
 			return
@@ -1123,6 +1166,8 @@ func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc,
 		tm.switchTabAndResume(int(b - '1'))
 	case b == 'n' || b == 'N':
 		tm.openNewTab(ctx, newTabFn, termState)
+	case isEditSessionKey(b):
+		tm.openCurrentTabChooser(ctx, newTabFn, termState)
 	case b == 'x' || b == 'X' || b == 'w' || b == 'W':
 		tm.closeCurrentTab()
 	case b == 'l' || b == 'L' || b == 'j' || b == 'J' || b == '\t':
@@ -1130,6 +1175,10 @@ func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc,
 	case b == 'h' || b == 'H' || b == 'k' || b == 'K' || b == 'p' || b == 'P':
 		tm.moveTabSelection(-1)
 	}
+}
+
+func isEditSessionKey(b byte) bool {
+	return b == 'e' || b == 'E'
 }
 
 // switchTabAndResume exits command mode and activates the selected tab.
@@ -1384,47 +1433,7 @@ func (tm *TabManager) openNewTab(ctx context.Context, newTabFn NewTabFunc, termS
 	}
 
 	pendingTab, prevActive := tm.addPendingTab()
-	fullscreenChooser := prefersFullscreenChooser()
-
-	// Clear screen for the chooser. On most terminals, show the tab bar
-	// above the chooser; Apple Terminal gets a full-screen render.
-	tm.resetHostInputModes()
-	tm.writeString("\x1b[2J\x1b[H")
-	if !fullscreenChooser {
-		tm.drawTabBar()
-	}
-	term.Restore(int(os.Stdin.Fd()), termState)
-
-	// Pause the stdinCh goroutine so Bubble Tea can own os.Stdin exclusively.
-	// SetReadDeadline on the dup'd non-blocking fd forces the blocked Read
-	// to return immediately, so the goroutine enters its sleep loop without
-	// eating the user's next keystroke.
-	tm.stdinPaused.Store(true)
-	if tm.stdinPollFd != nil {
-		tm.stdinPollFd.SetReadDeadline(time.Now())
-	}
-	time.Sleep(20 * time.Millisecond) // let goroutine wake and enter sleep loop
-	// Drain any buffered data from the channel.
-	for {
-		select {
-		case <-tm.stdinCh:
-		default:
-			goto drained
-		}
-	}
-drained:
-
-	spec, err := newTabFn(ctx, tm.emitNotice, nil)
-
-	// Resume the stdinCh goroutine — clear deadline so it can Read again.
-	if tm.stdinPollFd != nil {
-		tm.stdinPollFd.SetReadDeadline(time.Time{})
-	}
-	tm.stdinPaused.Store(false)
-
-	// Re-enter raw mode and clear any scroll region left by the chooser (bubbletea)
-	term.MakeRaw(int(os.Stdin.Fd()))
-	tm.writeString("\x1b[r")
+	spec, err := tm.runChooser(ctx, newTabFn, termState, nil)
 
 	if err != nil || spec == nil {
 		// Cancelled — remove the placeholder tab and resume the previous session.
@@ -1471,6 +1480,148 @@ drained:
 	tm.commandMode = false
 	tm.needsRender = true
 	tm.mu.Unlock()
+}
+
+func (tm *TabManager) openCurrentTabChooser(ctx context.Context, newTabFn NewTabFunc, termState *term.State) {
+	if newTabFn == nil {
+		return
+	}
+
+	currentTab, current, ok := tm.activeTabSeed()
+	if !ok {
+		return
+	}
+
+	tm.mu.Lock()
+	tm.paused = true
+	tm.commandMode = false
+	tm.needsRender = true
+	tm.mu.Unlock()
+
+	spec, err := tm.runChooser(ctx, newTabFn, termState, &current)
+	if err != nil || spec == nil {
+		tm.mu.Lock()
+		tm.paused = false
+		tm.needsRender = true
+		tm.mu.Unlock()
+
+		if errors.Is(err, ErrBackToTabs) {
+			tm.enterCommandMode()
+			return
+		}
+		if err != nil {
+			tm.emitNotice(TabNoticeError, err.Error())
+		}
+		return
+	}
+
+	if err := tm.replaceTab(ctx, currentTab, *spec); err != nil {
+		tm.mu.Lock()
+		tm.paused = false
+		tm.needsRender = true
+		tm.mu.Unlock()
+		tm.emitNotice(TabNoticeError, fmt.Sprintf("tab relaunch failed: %v", err))
+		return
+	}
+
+	tm.mu.Lock()
+	tm.paused = false
+	tm.commandMode = false
+	tm.needsRender = true
+	tm.mu.Unlock()
+}
+
+func (tm *TabManager) activeTabSeed() (*Tab, LaunchSpec, bool) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+
+	if tm.activeIdx < 0 || tm.activeIdx >= len(tm.tabs) {
+		return nil, LaunchSpec{}, false
+	}
+	tab := tm.tabs[tm.activeIdx]
+	return tab, tab.spec, true
+}
+
+func (tm *TabManager) replaceTab(ctx context.Context, target *Tab, spec LaunchSpec) error {
+	newTab, err := tm.createTab(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	var oldTab *Tab
+	tm.mu.Lock()
+	replaceIdx := -1
+	for i, tab := range tm.tabs {
+		if tab == target {
+			replaceIdx = i
+			break
+		}
+	}
+	if replaceIdx >= 0 {
+		oldTab = tm.tabs[replaceIdx]
+		tm.tabs[replaceIdx] = newTab
+		tm.activeIdx = replaceIdx
+	} else {
+		tm.tabs = append(tm.tabs, newTab)
+		tm.activeIdx = len(tm.tabs) - 1
+	}
+	tm.needsRender = true
+	tm.mu.Unlock()
+
+	tm.startTab(newTab)
+
+	if oldTab != nil && oldTab.cmd != nil && oldTab.cmd.Cmd.Process != nil && !oldTab.exited.Load() {
+		_ = oldTab.cmd.Cmd.Process.Signal(syscall.SIGHUP)
+	}
+
+	return nil
+}
+
+func (tm *TabManager) runChooser(ctx context.Context, newTabFn NewTabFunc, termState *term.State, seed *LaunchSpec) (*LaunchSpec, error) {
+	fullscreenChooser := prefersFullscreenChooser()
+
+	// Clear screen for the chooser. On most terminals, show the tab bar
+	// above the chooser; Apple Terminal gets a full-screen render.
+	tm.resetHostInputModes()
+	tm.writeString("\x1b[2J\x1b[H")
+	if !fullscreenChooser {
+		tm.drawTabBar()
+	}
+	if termState != nil {
+		_ = term.Restore(int(os.Stdin.Fd()), termState)
+	}
+
+	// Pause the stdinCh goroutine so Bubble Tea can own os.Stdin exclusively.
+	// SetReadDeadline on the dup'd non-blocking fd forces the blocked Read
+	// to return immediately, so the goroutine enters its sleep loop without
+	// eating the user's next keystroke.
+	tm.stdinPaused.Store(true)
+	if tm.stdinPollFd != nil {
+		_ = tm.stdinPollFd.SetReadDeadline(time.Now())
+	}
+	time.Sleep(20 * time.Millisecond) // let goroutine wake and enter sleep loop
+	for {
+		select {
+		case <-tm.stdinCh:
+		default:
+			goto drained
+		}
+	}
+drained:
+
+	spec, err := newTabFn(ctx, tm.emitNotice, nil, seed)
+
+	if tm.stdinPollFd != nil {
+		_ = tm.stdinPollFd.SetReadDeadline(time.Time{})
+	}
+	tm.stdinPaused.Store(false)
+
+	if termState != nil {
+		_, _ = term.MakeRaw(int(os.Stdin.Fd()))
+	}
+	tm.writeString("\x1b[r")
+
+	return spec, err
 }
 
 func prefersFullscreenChooser() bool {
@@ -1961,12 +2112,12 @@ func (tm *TabManager) buildTabBarString() string {
 	hint := " ^B tab mode "
 	if noticeText != "" {
 		if noticeLevel == TabNoticeError {
-			hint = " error: " + noticeText + "  space: resume "
+			hint = " error: " + noticeText + "  Esc: clear "
 		} else {
 			hint = " " + noticeText + " "
 		}
 	} else if cmdMode {
-		hint = " n:new x:close h/l:move 1-9:jump Esc:resume "
+		hint = " n:new e:edit session x:close h/l:move 1-9:jump Esc:resume "
 	}
 	used := tm.tabBarContentWidth(tabs) + len(hint) + len(versionLabel)
 	if cols > used {
@@ -2217,7 +2368,7 @@ func (tm *TabManager) writeString(s string) {
 }
 
 func (tm *TabManager) resetHostInputModes() {
-	seq := tm.syncHostInputModes(0) + hostKeyboardResetSequence()
+	seq := tm.syncHostInputModes(0) + hostKeyboardResetSequence() + hostCursorResetSequence()
 	if seq == "" {
 		return
 	}
@@ -2272,4 +2423,10 @@ func hostKeyboardResetSequence() string {
 	// Bubble Tea or the host shell. This fixes chooser key handling without
 	// spraying broader terminal-keyboard mode resets into every terminal.
 	return "\x1b[<u"
+}
+
+func hostCursorResetSequence() string {
+	// Restore a visible default cursor in case the child CLI hid it or left a
+	// custom DECSCUSR shape behind.
+	return "\x1b[0 q\x1b[?25h"
 }

--- a/cli/internal/runtime/tabmgr_test.go
+++ b/cli/internal/runtime/tabmgr_test.go
@@ -132,6 +132,20 @@ func TestEnterCommandModeDrawsHomeTabBarWithoutTabs(t *testing.T) {
 	}
 }
 
+func TestEditSessionKey(t *testing.T) {
+	t.Parallel()
+
+	if !isEditSessionKey('e') {
+		t.Fatal("expected lowercase e to edit the current session")
+	}
+	if !isEditSessionKey('E') {
+		t.Fatal("expected uppercase E to edit the current session")
+	}
+	if isEditSessionKey('n') {
+		t.Fatal("did not expect n to be treated as edit session")
+	}
+}
+
 func TestBuildTabBarStringUsesCLIBrandAndRightSideVersion(t *testing.T) {
 	t.Parallel()
 
@@ -179,8 +193,30 @@ func TestBuildTabBarStringShowsErrorNoticeInRed(t *testing.T) {
 	if !strings.Contains(got, "error: new tab failed") {
 		t.Fatalf("expected error message in tab bar, got %q", got)
 	}
-	if !strings.Contains(got, "space: resume") {
-		t.Fatalf("expected space-to-resume hint, got %q", got)
+	if !strings.Contains(got, "Esc: clear") {
+		t.Fatalf("expected escape-to-clear hint, got %q", got)
+	}
+	if strings.Contains(got, "space: resume") {
+		t.Fatalf("did not expect space-to-resume hint during sticky error, got %q", got)
+	}
+}
+
+func TestBuildTabBarStringShowsEditSessionHintInCommandMode(t *testing.T) {
+	t.Parallel()
+
+	tm := &TabManager{
+		rows:        24,
+		cols:        120,
+		commandMode: true,
+		tabs: []*Tab{
+			{id: 1, label: "Codex"},
+		},
+	}
+
+	got := tm.buildTabBarString()
+
+	if !strings.Contains(got, "e:edit session") {
+		t.Fatalf("expected command mode hint to include edit session, got %q", got)
 	}
 }
 
@@ -223,6 +259,16 @@ func TestHostKeyboardResetSequenceDisablesEnhancedKeyboardModes(t *testing.T) {
 	}
 }
 
+func TestHostCursorResetSequenceShowsVisibleDefaultCursor(t *testing.T) {
+	t.Parallel()
+
+	got := hostCursorResetSequence()
+
+	if got != "\x1b[0 q\x1b[?25h" {
+		t.Fatalf("hostCursorResetSequence() = %q, want %q", got, "\x1b[0 q\x1b[?25h")
+	}
+}
+
 func TestSyncHostInputModesReturnsSequenceOnlyOnChange(t *testing.T) {
 	t.Parallel()
 
@@ -240,6 +286,19 @@ func TestSyncHostInputModesReturnsSequenceOnlyOnChange(t *testing.T) {
 	reset := tm.syncHostInputModes(0)
 	if !strings.Contains(reset, "\x1b[?1000l") {
 		t.Fatalf("expected reset sequence to disable mouse tracking, got %q", reset)
+	}
+}
+
+func TestResetHostInputModesRestoresCursorVisibility(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	tm := &TabManager{stdout: &out}
+
+	tm.resetHostInputModes()
+
+	if got := out.String(); !strings.Contains(got, "\x1b[?25h") {
+		t.Fatalf("expected resetHostInputModes() to restore visible cursor, got %q", got)
 	}
 }
 
@@ -263,6 +322,54 @@ func TestHandleCommandKeySpaceClearsNoticeAndResumes(t *testing.T) {
 	}
 	if tm.noticeText != "" {
 		t.Fatalf("expected notice to clear after space resume, got %q", tm.noticeText)
+	}
+}
+
+func TestHandleCommandKeyEscapeClearsStickyErrorAndStaysInCommandMode(t *testing.T) {
+	t.Parallel()
+
+	tm := &TabManager{
+		stdout:       io.Discard,
+		rows:         24,
+		cols:         80,
+		commandMode:  true,
+		noticeText:   "oops",
+		noticeLevel:  TabNoticeError,
+		noticeSticky: true,
+		tabs:         []*Tab{{id: 1, label: "Codex"}},
+	}
+
+	tm.handleCommandKey(nil, nil, nil, 0x1b)
+
+	if !tm.commandMode {
+		t.Fatal("expected command mode to stay enabled after clearing sticky error")
+	}
+	if tm.noticeText != "" {
+		t.Fatalf("expected sticky error notice to clear on escape, got %q", tm.noticeText)
+	}
+}
+
+func TestHandleCommandKeyEnterDoesNotResumeWhileStickyErrorIsShown(t *testing.T) {
+	t.Parallel()
+
+	tm := &TabManager{
+		stdout:       io.Discard,
+		rows:         24,
+		cols:         80,
+		commandMode:  true,
+		noticeText:   "oops",
+		noticeLevel:  TabNoticeError,
+		noticeSticky: true,
+		tabs:         []*Tab{{id: 1, label: "Codex"}},
+	}
+
+	tm.handleCommandKey(nil, nil, nil, '\r')
+
+	if !tm.commandMode {
+		t.Fatal("expected sticky error to keep tab manager in command mode")
+	}
+	if tm.noticeText != "oops" {
+		t.Fatalf("expected enter to leave sticky error untouched, got %q", tm.noticeText)
 	}
 }
 

--- a/cli/internal/runtime/tabmgr_windows.go
+++ b/cli/internal/runtime/tabmgr_windows.go
@@ -16,13 +16,14 @@ var ErrQuit = errors.New("user quit")
 // to dismiss the chooser and return to tab command mode.
 var ErrBackToTabs = errors.New("back to tabs")
 
-// NewTabFunc is called when the user requests a new tab.
+// NewTabFunc is called when the user requests a new tab or reopens the
+// chooser for the active tab.
 // stdinReader provides keyboard input; when nil the callback should read os.Stdin.
-type NewTabFunc func(ctx context.Context, notify func(level TabNoticeLevel, message string), stdinReader io.Reader) (*LaunchSpec, error)
+type NewTabFunc func(ctx context.Context, notify func(level TabNoticeLevel, message string), stdinReader io.Reader, seed *LaunchSpec) (*LaunchSpec, error)
 
 // RunTabbed is not supported on Windows — falls back to single-session mode.
 func RunTabbed(ctx context.Context, stdout, stderr io.Writer, version string, newTabFn NewTabFunc) error {
-	spec, err := newTabFn(ctx, func(TabNoticeLevel, string) {}, nil)
+	spec, err := newTabFn(ctx, func(TabNoticeLevel, string) {}, nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Adds session editing functionality to the tab manager, allowing users to modify existing tabs without creating new ones. Also improves Claude model configuration by pinning selected models across all Claude tiers and enhances terminal state management.

## Changes

- Added "edit session" functionality accessible via `^B e` that reopens the chooser for the current tab with prefilled values
- Modified `NewTabFunc` signature to accept a `seed` parameter for prefilling chooser state
- Updated Claude harness to pin selected models across Sonnet, Opus, and Haiku tiers instead of using legacy `ANTHROPIC_MODEL`
- Removed `ModelEnv` field from Claude harness configuration
- Enhanced error notice handling in command mode with sticky error states
- Improved terminal cursor restoration on PTY exit
- Removed automatic dummy API key injection when virtual key is empty
- Updated vt10x dependency to newer version

## Type of change

- [x] Feature
- [x] Bug fix
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test session editing:
```sh
# Start bifrost and create a tab
./bifrost
# Press ^B to enter command mode, then 'e' to edit current session
# Verify chooser opens with current session values prefilled
```

Test Claude model pinning:
```sh
# Set a model and verify it's pinned across all Claude tiers
export BIFROST_MODEL="claude-3-5-sonnet-20241022"
./bifrost --harness claude
# Check that ANTHROPIC_DEFAULT_*_MODEL vars are set correctly
```

Core functionality:
```sh
go version
go test ./...
```

## Breaking changes

- [x] Yes

The `NewTabFunc` signature now includes a `seed *LaunchSpec` parameter. Existing implementations need to be updated to handle this parameter.

## Security considerations

Removes automatic dummy API key injection, which improves security by not setting placeholder credentials when no virtual key is provided.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable