### PR TITLE
feat: improve prompt UI with version badges, change indicators, and refined diff detection

### DIFF
--- a/ui/components/prompts/components/promptsViewHeader.tsx
+++ b/ui/components/prompts/components/promptsViewHeader.tsx
@@ -2,8 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { SplitButton } from "@/components/ui/splitButton";
 import { DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdownMenu";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Check, ChevronDown, GitCommit, PencilIcon, Save, Trash2 } from "lucide-react";
+import { Check, GitCommit, PencilIcon, Save, Trash2 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { parseAsInteger, useQueryStates } from "nuqs";
@@ -15,6 +14,7 @@ import { usePromptContext } from "../context";
 import { ModelParams, PromptSession } from "@/lib/types/prompts";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 
 export default function PromptsViewHeader() {
 	const {
@@ -27,6 +27,8 @@ export default function PromptsViewHeader() {
 		provider,
 		model,
 		hasChanges,
+		hasVersionChanges,
+		hasSessionChanges,
 		isStreaming,
 	} = usePromptContext();
 
@@ -146,9 +148,28 @@ export default function PromptsViewHeader() {
 		}
 	}, [messages]);
 
+	const selectedVersion = versions.find((v) => v.id === selectedVersionId);
+	const latestVersion = versions.find((v) => v.is_latest);
+	const displayVersion = selectedVersion ?? latestVersion;
+
 	return (
 		<div className="flex items-center justify-between border-b px-4 py-3">
-			<h3 className="truncate font-semibold">{selectedPrompt?.name || "Playground"}</h3>
+			<div className="flex items-center gap-2 min-w-0">
+				<h3 className="truncate font-semibold">
+					{selectedPrompt?.name || "Playground"}
+					{hasChanges && <span className="text-destructive ml-1">*</span>}
+				</h3>
+				{displayVersion && (
+					<Badge variant={"secondary"}>
+						v{displayVersion.version_number}
+					</Badge>
+				)}
+				{hasVersionChanges && versions.length > 0 && (
+					<Badge variant="outline">
+						Unpublished Changes
+					</Badge>
+				)}
+			</div>
 			<div className="flex shrink-0 items-center gap-4">
 				{messages.length > 1 && (
 					<Button variant="ghost" size="sm" data-testid="header-clear" onClick={handleClearConversation} disabled={isStreaming}>
@@ -156,31 +177,16 @@ export default function PromptsViewHeader() {
 						Clear
 					</Button>
 				)}
-				<div className="inline-flex items-center">
-					<Button
-						variant="outline"
-						className="h-8 rounded-r-none border bg-transparent"
-						data-testid="header-save-session"
-						onClick={handleSaveSession}
-						disabled={isCreatingSession || !hasChanges || isStreaming}
-					>
-						<Save className="h-4 w-4" />
-						Save Session
-					</Button>
-					<Popover open={sessionsOpen} onOpenChange={setSessionsOpen}>
-						<PopoverTrigger asChild>
-							<Button
-								variant="outline"
-								data-testid="header-sessions-dropdown"
-								className={cn(
-									"h-8 w-8 rounded-l-none border border-l-0 bg-transparent p-0",
-									isCreatingSession || !hasChanges || isStreaming ? "border-border/50" : "",
-								)}
-							>
-								<ChevronDown className="h-4 w-4" />
-							</Button>
-						</PopoverTrigger>
-						<PopoverContent className="w-72 p-0" align="end">
+				<SplitButton
+					onClick={handleSaveSession}
+					disabled={isCreatingSession || isStreaming}
+					isLoading={isCreatingSession}
+					data-testid="header-save-session"
+					dropdownContent={{
+						className: "w-72 p-0",
+						open: sessionsOpen,
+						onOpenChange: setSessionsOpen,
+						children: (
 							<Command>
 								<CommandInput placeholder="Search sessions..." data-testid="header-sessions-search" />
 								<CommandList>
@@ -201,9 +207,20 @@ export default function PromptsViewHeader() {
 									</CommandGroup>
 								</CommandList>
 							</Command>
-						</PopoverContent>
-					</Popover>
-				</div>
+						),
+					}}
+					variant={"outline"}
+					dropdownTrigger={{
+						className: cn("bg-transparent"),
+					}}
+					button={{
+						className: "bg-transparent disabled:opacity-100 disabled:text-muted-foreground",
+						disabled: !hasChanges,
+					}}
+				>
+					<Save className="h-4 w-4" />
+					Save Session
+				</SplitButton>
 				<SplitButton
 					onClick={handleCommitVersion}
 					disabled={isCreatingSession || isStreaming}
@@ -229,7 +246,7 @@ export default function PromptsViewHeader() {
 													{version.is_latest && <span className="text-primary ml-1.5 text-xs">(latest)</span>}
 												</span>
 												<span className="text-muted-foreground truncate text-xs">{version.commit_message || "No commit message"}</span>
-												<span className="text-muted-foreground text-xs">{new Date(version.created_at).toLocaleString()}</span>
+												<span className="text-muted-foreground text-xs">{formatSessionDate(version.created_at)}</span>
 											</div>
 											{selectedVersionId === version.id && <Check className="text-primary h-4 w-4 shrink-0" />}
 										</DropdownMenuItem>
@@ -240,10 +257,11 @@ export default function PromptsViewHeader() {
 					}}
 					variant={"outline"}
 					dropdownTrigger={{
-						className: "bg-transparent",
+						className: cn("bg-transparent"),
 					}}
 					button={{
-						className: "bg-transparent",
+						className: "bg-transparent disabled:opacity-100 disabled:text-muted-foreground",
+						disabled: !hasVersionChanges,
 					}}
 				>
 					<GitCommit className="h-4 w-4" />

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -82,6 +82,8 @@ interface PromptContextValue {
 
 	// Diff detection
 	hasChanges: boolean;
+	hasVersionChanges: boolean;
+	hasSessionChanges: boolean;
 
 	// Handlers
 	handleSelectPrompt: (id: string) => void;
@@ -170,7 +172,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	const selectedSession = useMemo(() => sessions.find((s) => s.id === selectedSessionId), [sessions, selectedSessionId]);
 
 	// Fetch full version data (with messages) when a version is selected
-	const { currentData: selectedVersionData, isLoading: isVersionLoading } = useGetPromptVersionQuery(selectedVersionId ?? 0, {
+	const { currentData: selectedVersionData, isLoading: isVersionLoading, isFetching: isVersionFetching } = useGetPromptVersionQuery(selectedVersionId ?? 0, {
 		skip: !selectedVersionId,
 	});
 	const selectedVersion = selectedVersionData?.version;
@@ -210,6 +212,9 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(selectedSession.model_params, selectedSession.provider, selectedSession.model);
 		} else if (selectedVersion) {
+			// If sessions are still loading and no session is explicitly selected,
+			// wait — a session may auto-select and take priority
+			if (isSessionsLoading && !selectedSessionId) return;
 			const raw = (selectedVersion.messages ?? []).map((m) => m.message);
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
@@ -236,53 +241,89 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	}, [selectedSession, selectedVersion, selectedPrompt, selectedSessionId, selectedVersionId, setUrlState, isSessionsLoading, sessions.length]);
 
 	// Auto-select the most recent session when sessions load and none is selected
+	// Sessions take priority over versions for initial loading
 	useEffect(() => {
 		if (sessions.length > 0 && !selectedSessionId && !selectedVersionId) {
 			setUrlState({ sessionId: sessions[0].id });
 		}
 	}, [selectedPromptId, sessions, selectedSessionId, selectedVersionId, setUrlState]);
 
+	// Diff detection helper — compares current playground state against a reference config
+	const diffAgainst = useCallback(
+		(ref: { messages?: any[]; model_params?: ModelParams; provider?: string; model?: string } | undefined) => {
+			if (!ref) return true; // No reference — treat as changed
+			const refMessages = ref.messages ?? [];
+			const refProvider = ref.provider;
+			const refModel = ref.model;
+			const refParams = ref.model_params;
+
+			if (provider !== refProvider) return true;
+			if (model !== refModel) return true;
+
+			const { api_key_id: refApiKeyId, ...refParamsRest } = refParams || ({} as ModelParams);
+			const currentApiKeyId = apiKeyId !== "__auto__" ? apiKeyId : undefined;
+			if (currentApiKeyId !== (refApiKeyId || undefined)) return true;
+
+			if (JSON.stringify(modelParams, Object.keys(modelParams).sort()) !== JSON.stringify(refParamsRest, Object.keys(refParamsRest).sort()))
+				return true;
+
+			const currentSerialized = Message.serializeAll(messages);
+			if (JSON.stringify(currentSerialized) !== JSON.stringify(refMessages)) return true;
+
+			return false;
+		},
+		[provider, model, modelParams, apiKeyId, messages],
+	);
+
 	// Diff detection — compare current playground state against the loaded session/version
 	const hasChanges = useMemo(() => {
-		let refMessages: any[] | undefined;
-		let refParams: ModelParams | undefined;
-		let refProvider: string | undefined;
-		let refModel: string | undefined;
-
+		// Suppress diff while version data is in flight to avoid flicker
+		if (selectedVersionId && (isVersionFetching || selectedVersion?.id !== selectedVersionId)) return false;
 		if (selectedSession) {
-			refMessages = selectedSession.messages?.map((m) => m.message) ?? [];
-			refParams = selectedSession.model_params;
-			refProvider = selectedSession.provider;
-			refModel = selectedSession.model;
-		} else if (selectedVersion) {
-			refMessages = selectedVersion.messages?.map((m) => m.message) ?? [];
-			refParams = selectedVersion.model_params;
-			refProvider = selectedVersion.provider;
-			refModel = selectedVersion.model;
-		} else {
-			// No reference to compare against — always allow save
-			return true;
+			return diffAgainst({
+				messages: selectedSession.messages?.map((m) => m.message) ?? [],
+				model_params: selectedSession.model_params,
+				provider: selectedSession.provider,
+				model: selectedSession.model,
+			});
 		}
+		if (selectedVersion) {
+			return diffAgainst({
+				messages: selectedVersion.messages?.map((m) => m.message) ?? [],
+				model_params: selectedVersion.model_params,
+				provider: selectedVersion.provider,
+				model: selectedVersion.model,
+			});
+		}
+		return true;
+	}, [selectedSession, selectedVersion, diffAgainst, selectedVersionId, isVersionFetching]);
 
-		// Quick string checks first
-		if (provider !== refProvider) return true;
-		if (model !== refModel) return true;
+	// Diff against the active version — drives "unpublished changes" badge & commit button
+	// Uses the explicitly selected version if available, otherwise falls back to latest_version
+	const activeVersionRef = selectedVersion ?? selectedPrompt?.latest_version;
 
-		// Compare api_key_id
-		const { api_key_id: refApiKeyId, ...refParamsRest } = refParams || ({} as ModelParams);
-		const currentApiKeyId = apiKeyId !== "__auto__" ? apiKeyId : undefined;
-		if (currentApiKeyId !== (refApiKeyId || undefined)) return true;
+	const hasVersionChanges = useMemo(() => {
+		// Suppress diff while version data is in flight or mismatched to avoid flash
+		if (selectedVersionId && (isVersionFetching || selectedVersion?.id !== selectedVersionId)) return false;
+		if (!activeVersionRef) return true; // No versions yet — always allow commit
+		return diffAgainst({
+			messages: activeVersionRef.messages?.map((m) => m.message) ?? [],
+			model_params: activeVersionRef.model_params,
+			provider: activeVersionRef.provider,
+			model: activeVersionRef.model,
+		});
+	}, [activeVersionRef, diffAgainst, selectedVersionId, isVersionFetching, selectedVersion?.id]);
 
-		// Compare model params (excluding api_key_id)
-		if (JSON.stringify(modelParams, Object.keys(modelParams).sort()) !== JSON.stringify(refParamsRest, Object.keys(refParamsRest).sort()))
-			return true;
-
-		// Compare messages (most expensive — do last)
-		const currentSerialized = Message.serializeAll(messages);
-		if (JSON.stringify(currentSerialized) !== JSON.stringify(refMessages)) return true;
-
-		return false;
-	}, [selectedSession, selectedVersion, provider, model, modelParams, apiKeyId, messages]);
+	// Diff against the selected session — drives red asterisk indicator
+	const hasSessionChanges = useMemo(() => {
+		if (!selectedSession) return false;
+		return diffAgainst({
+			messages: selectedSession.messages?.map((m) => m.message) ?? [],
+			model_params: selectedSession.model_params,
+			provider: selectedSession.provider,
+			model: selectedSession.model,
+		});
+	}, [selectedSession, diffAgainst]);
 
 	// Handlers
 	const handleSelectPrompt = useCallback(
@@ -520,6 +561,8 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 		isDeletingPrompt,
 		supportsVision,
 		hasChanges,
+		hasVersionChanges,
+		hasSessionChanges,
 		handleSelectPrompt,
 		handleMovePrompt,
 		handleDeleteFolder,

--- a/ui/components/prompts/promptsView.tsx
+++ b/ui/components/prompts/promptsView.tsx
@@ -39,19 +39,19 @@ export default function PromptsView() {
 	}
 
 	return (
-		<div className="no-padding-parent no-border-parent bg-background h-[calc(100dvh_-_18px)] w-full">
+		<div className="no-padding-parent no-border-parent bg-background h-[calc(100dvh_-_16px)] w-full">
 			<DeleteFolderDialog />
 			<DeletePromptDialog />
 			<PromptSheets />
 
 			<ResizablePanelGroup direction="horizontal" className="h-full">
-				<ResizablePanel defaultSize={20} className="bg-card mr-1 overflow-hidden rounded-r-md rounded-br-none">
+				<ResizablePanel defaultSize={20} className="bg-card mr-1 overflow-hidden rounded-r-md">
 					<PromptSidebar />
 				</ResizablePanel>
 
 				<ResizableHandle className="mr-1 bg-transparent" />
 
-				<ResizablePanel defaultSize={80} minSize={50} className="bg-card overflow-hidden rounded-md rounded-bl-none">
+				<ResizablePanel defaultSize={80} minSize={50} className="bg-card overflow-hidden rounded-md">
 					{selectedPromptId ? (
 						<div className="flex h-full flex-col">
 							<PromptsViewHeader />

--- a/ui/components/ui/resizable.tsx
+++ b/ui/components/ui/resizable.tsx
@@ -38,23 +38,23 @@ function ResizablePanel({
 }
 
 function ResizableHandle({
-  withHandle,
+  hideHandle,
   className,
   ...props
 }: SeparatorProps & {
-  withHandle?: boolean
+  hideHandle?: boolean
 }) {
   return (
     <Separator
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring group/resizable-handle relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
         className
       )}
       {...props}
     >
-      {withHandle && (
-        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+      {!hideHandle && (
+        <div className="bg-border z-10 flex h-5 w-3 items-center justify-center rounded-sm border opacity-0 transition-opacity group-hover/resizable-handle:opacity-100 group-active/resizable-handle:opacity-100">
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}


### PR DESCRIPTION
## Summary

Improves the prompts interface by adding visual indicators for unsaved changes and unpublished versions, along with enhanced diff detection and UI refinements.

## Changes

- Added version badge and "Unpublished Changes" indicator to the header
- Implemented separate change tracking for sessions vs versions with distinct visual cues (red asterisk for unsaved session changes)
- Enhanced diff detection logic with separate `hasVersionChanges` and `hasSessionChanges` flags
- Converted save session controls from manual Popover to SplitButton component for consistency
- Improved button states - save/commit buttons are now properly disabled when no changes exist
- Added hover effects to resizable panel handles with improved visual feedback
- Fixed panel border radius styling inconsistencies

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] UI (Next.js)

## How to test

Test the prompts interface to verify:
1. Version badges display correctly in the header
2. Red asterisk appears when session has unsaved changes
3. "Unpublished Changes" badge shows when version differs from published
4. Save/commit buttons are disabled when no changes exist
5. Resizable panel handles show grip icon on hover
6. SplitButton components work correctly for both save session and commit version actions

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable