### PR TITLE
Update documentation link in NotAvailableBanner to new quickstart URL

### DIFF
--- a/ui/components/notAvailableBanner.tsx
+++ b/ui/components/notAvailableBanner.tsx
@@ -16,7 +16,7 @@ const NotAvailableBanner = () => {
 						<div className="text-muted-foreground">
 							To enable the UI, please add the database settings to your config.json (see{" "}
 							<Link
-								href="https://www.getmaxim.ai/bifrost/docs/#two-configuration-modes"
+								href="https://www.getmaxim.ai/bifrost/docs/quickstart/gateway/setting-up#two-configuration-modes"
 								target="_blank"
 								rel="noopener noreferrer"
 								className="font-medium underline underline-offset-2"


### PR DESCRIPTION
## Summary

Updates the documentation link in the NotAvailableBanner component to point to the correct Bifrost quickstart guide for gateway setup configuration.

## Changes

- Updated the href attribute from the old documentation URL to point to the specific quickstart gateway setup section
- The link now directs users to `https://www.getmaxim.ai/bifrost/docs/quickstart/gateway/setting-up#two-configuration-modes`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the UI when database settings are not configured to see the NotAvailableBanner, then click the documentation link to verify it leads to the correct Bifrost documentation page.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable