### PR TITLE
feat(genai): add support for Gemini metadata endpoint (/v1beta/models/{model})

### DIFF
--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -215,6 +215,12 @@ func (provider *GeminiProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
+	if len(geminiResponse.Models) == 0 {
+		var singleModel GeminiModel
+		if err := sonic.Unmarshal(resp.Body(), &singleModel); err == nil && singleModel.Name != "" {
+			geminiResponse.Models = []GeminiModel{singleModel}
+		}
+	}
 
 	response := geminiResponse.ToBifrostListModelsResponse(providerName, key.Models, request.Unfiltered)
 

--- a/core/providers/gemini/list_models_single_payload_test.go
+++ b/core/providers/gemini/list_models_single_payload_test.go
@@ -1,0 +1,58 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testNoopLogger struct{}
+
+func (testNoopLogger) Debug(string, ...any)                   {}
+func (testNoopLogger) Info(string, ...any)                    {}
+func (testNoopLogger) Warn(string, ...any)                    {}
+func (testNoopLogger) Error(string, ...any)                   {}
+func (testNoopLogger) Fatal(string, ...any)                   {}
+func (testNoopLogger) SetLevel(schemas.LogLevel)              {}
+func (testNoopLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testNoopLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func TestListModelsByKey_ParsesSingleModelPayload(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/models/gemini-2.5-pro" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"models/gemini-2.5-pro","displayName":"Gemini 2.5 Pro","description":"test","inputTokenLimit":1048576,"outputTokenLimit":8192,"supportedGenerationMethods":["generateContent"]}`))
+	}))
+	defer ts.Close()
+
+	provider := NewGeminiProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: ts.URL},
+	}, testNoopLogger{})
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyURLPath, "/models/gemini-2.5-pro")
+
+	key := schemas.Key{Value: *schemas.NewEnvVar("dummy-key")}
+	resp, err := provider.listModelsByKey(ctx, key, &schemas.BifrostListModelsRequest{Provider: schemas.Gemini})
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Data, 1)
+	assert.Equal(t, "gemini/gemini-2.5-pro", resp.Data[0].ID)
+	require.NotNil(t, resp.Data[0].Name)
+	assert.Equal(t, "Gemini 2.5 Pro", *resp.Data[0].Name)
+}

--- a/core/providers/gemini/models.go
+++ b/core/providers/gemini/models.go
@@ -7,6 +7,16 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+func toGeminiModelResourceName(modelID string) string {
+	if strings.HasPrefix(modelID, "models/") {
+		return modelID
+	}
+	if idx := strings.Index(modelID, "/"); idx >= 0 && idx+1 < len(modelID) {
+		return "models/" + modelID[idx+1:]
+	}
+	return "models/" + modelID
+}
+
 func (response *GeminiListModelsResponse) ToBifrostListModelsResponse(providerKey schemas.ModelProvider, allowedModels []string, unfiltered bool) *schemas.BifrostListModelsResponse {
 	if response == nil {
 		return nil
@@ -64,7 +74,7 @@ func ToGeminiListModelsResponse(resp *schemas.BifrostListModelsResponse) *Gemini
 
 	for _, model := range resp.Data {
 		geminiModel := GeminiModel{
-			Name:                       model.ID,
+			Name:                       toGeminiModelResourceName(model.ID),
 			SupportedGenerationMethods: model.SupportedMethods,
 		}
 		if model.Name != nil {

--- a/core/providers/gemini/models_test.go
+++ b/core/providers/gemini/models_test.go
@@ -1,0 +1,41 @@
+package gemini
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToGeminiModelResourceName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "already native", input: "models/gemini-2.5-pro", want: "models/gemini-2.5-pro"},
+		{name: "provider prefixed", input: "gemini/gemini-2.5-pro", want: "models/gemini-2.5-pro"},
+		{name: "bare model", input: "gemini-2.5-pro", want: "models/gemini-2.5-pro"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, toGeminiModelResourceName(tc.input))
+		})
+	}
+}
+
+func TestToGeminiListModelsResponse_UsesNativeModelResourceName(t *testing.T) {
+	resp := &schemas.BifrostListModelsResponse{
+		Data: []schemas.Model{
+			{ID: "gemini/gemini-2.5-pro"},
+			{ID: "models/gemini-2.5-flash"},
+		},
+	}
+
+	converted := ToGeminiListModelsResponse(resp)
+	if assert.Len(t, converted.Models, 2) {
+		assert.Equal(t, "models/gemini-2.5-pro", converted.Models[0].Name)
+		assert.Equal(t, "models/gemini-2.5-flash", converted.Models[1].Name)
+	}
+}

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -28,6 +28,8 @@ const isGeminiVideoGenerationRequestContextKey schemas.BifrostContextKey = "bifr
 
 const isGeminiBatchCreateRequestContextKey schemas.BifrostContextKey = "bifrost-is-gemini-batch-create-request"
 
+const requestedGeminiModelMetadataContextKey schemas.BifrostContextKey = "bifrost-requested-gemini-model-metadata"
+
 // GenAIRouter holds route registrations for genai endpoints.
 type GenAIRouter struct {
 	*GenericRouter
@@ -247,6 +249,31 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			},
 		},
 		PreCallback: extractAndSetModelAndRequestType,
+	})
+
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeGenAI,
+		Path:   pathPrefix + "/v1beta/models/{model}",
+		Method: "GET",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ListModelsRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) interface{} {
+			return &schemas.BifrostListModelsRequest{}
+		},
+		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
+			if listModelsReq, ok := req.(*schemas.BifrostListModelsRequest); ok {
+				return &schemas.BifrostRequest{
+					ListModelsRequest: listModelsReq,
+				}, nil
+			}
+			return nil, errors.New("invalid request type")
+		},
+		ListModelsResponseConverter: convertGeminiModelMetadataResponse,
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
+			return gemini.ToGeminiError(err)
+		},
+		PreCallback: extractGeminiModelMetadataParams,
 	})
 
 	routes = append(routes, RouteConfig{
@@ -1166,8 +1193,8 @@ func isImageEditRequest(req *gemini.GeminiGenerationRequest) bool {
 // extractGeminiListModelsParams extracts query parameters for list models request
 func extractGeminiListModelsParams(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
 	if listModelsReq, ok := req.(*schemas.BifrostListModelsRequest); ok {
-		// Set provider to Gemini
-		listModelsReq.Provider = schemas.Gemini
+		// Set provider to Gemini unless explicitly overridden.
+		listModelsReq.Provider = getProviderFromHeader(ctx, schemas.Gemini)
 
 		// Extract pageSize from query parameters (Gemini uses pageSize instead of limit)
 		if pageSizeStr := string(ctx.QueryArgs().Peek("pageSize")); pageSizeStr != "" {
@@ -1184,6 +1211,55 @@ func extractGeminiListModelsParams(ctx *fasthttp.RequestCtx, bifrostCtx *schemas
 		return nil
 	}
 	return errors.New("invalid request type for Gemini list models")
+}
+
+func extractGeminiModelMetadataParams(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
+	listModelsReq, ok := req.(*schemas.BifrostListModelsRequest)
+	if !ok {
+		return errors.New("invalid request type for Gemini model metadata")
+	}
+
+	model := ctx.UserValue("model")
+	if model == nil {
+		return errors.New("model parameter is required")
+	}
+
+	provider := getProviderFromHeader(ctx, schemas.Gemini)
+	listModelsReq.Provider = provider
+
+	modelStr, ok := model.(string)
+	if !ok || modelStr == "" {
+		return errors.New("model parameter must be a non-empty string")
+	}
+
+	modelStr = strings.TrimPrefix(modelStr, "models/")
+	bifrostCtx.SetValue(requestedGeminiModelMetadataContextKey, modelStr)
+
+	if provider == schemas.Gemini {
+		// Use Gemini native metadata endpoint for direct model lookup.
+		bifrostCtx.SetValue(schemas.BifrostContextKeyURLPath, "/models/"+modelStr)
+	}
+
+	return nil
+}
+
+func convertGeminiModelMetadataResponse(ctx *schemas.BifrostContext, resp *schemas.BifrostListModelsResponse) (interface{}, error) {
+	geminiResp := gemini.ToGeminiListModelsResponse(resp)
+	if geminiResp == nil {
+		return nil, errors.New("gemini model metadata response is nil")
+	}
+
+	if len(geminiResp.Models) > 0 {
+		return geminiResp.Models[0], nil
+	}
+
+	if requestedModel, ok := ctx.Value(requestedGeminiModelMetadataContextKey).(string); ok && requestedModel != "" {
+		// Gracefully return a minimal metadata object so SDK metadata discovery
+		// does not fail when no models are configured yet.
+		return gemini.GeminiModel{Name: "models/" + requestedModel}, nil
+	}
+
+	return nil, errors.New("no model metadata returned")
 }
 
 // extractGeminiVideoOperationFromPath extracts model and operation_id from path

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -1249,11 +1249,14 @@ func convertGeminiModelMetadataResponse(ctx *schemas.BifrostContext, resp *schem
 		return nil, errors.New("gemini model metadata response is nil")
 	}
 
-	if len(geminiResp.Models) > 0 {
-		return geminiResp.Models[0], nil
+	requestedModel, _ := ctx.Value(requestedGeminiModelMetadataContextKey).(string)
+	for _, m := range geminiResp.Models {
+		if strings.TrimPrefix(m.Name, "models/") == requestedModel {
+			return m, nil
+		}
 	}
 
-	if requestedModel, ok := ctx.Value(requestedGeminiModelMetadataContextKey).(string); ok && requestedModel != "" {
+	if requestedModel != "" {
 		// Gracefully return a minimal metadata object so SDK metadata discovery
 		// does not fail when no models are configured yet.
 		return gemini.GeminiModel{Name: "models/" + requestedModel}, nil

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -161,6 +161,7 @@ func TestExtractGeminiModelMetadataParams(t *testing.T) {
 
 func TestConvertGeminiModelMetadataResponse(t *testing.T) {
 	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostCtx.SetValue(requestedGeminiModelMetadataContextKey, "gemini-2.5-pro")
 
 	resp := &schemas.BifrostListModelsResponse{
 		Data: []schemas.Model{{ID: "gemini/gemini-2.5-pro", Name: schemas.Ptr("Gemini 2.5 Pro")}},
@@ -173,6 +174,26 @@ func TestConvertGeminiModelMetadataResponse(t *testing.T) {
 	require.True(t, ok, "expected gemini.GeminiModel")
 	assert.Equal(t, "models/gemini-2.5-pro", model.Name)
 	assert.Equal(t, "Gemini 2.5 Pro", model.DisplayName)
+}
+
+func TestConvertGeminiModelMetadataResponse_MatchesRequestedModelNotFirst(t *testing.T) {
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostCtx.SetValue(requestedGeminiModelMetadataContextKey, "gemini-3-pro-preview")
+
+	resp := &schemas.BifrostListModelsResponse{
+		Data: []schemas.Model{
+			{ID: "gemini/gemini-1.5-pro", Name: schemas.Ptr("Gemini 1.5 Pro")},
+			{ID: "gemini/gemini-3-pro-preview", Name: schemas.Ptr("Gemini 3 Pro Preview")},
+		},
+	}
+
+	converted, err := convertGeminiModelMetadataResponse(bifrostCtx, resp)
+	require.NoError(t, err)
+
+	model, ok := converted.(gemini.GeminiModel)
+	require.True(t, ok, "expected gemini.GeminiModel")
+	assert.Equal(t, "models/gemini-3-pro-preview", model.Name)
+	assert.Equal(t, "Gemini 3 Pro Preview", model.DisplayName)
 }
 
 func TestConvertGeminiModelMetadataResponse_EmptyReturnsMinimalModel(t *testing.T) {

--- a/transports/bifrost-http/integrations/genai_test.go
+++ b/transports/bifrost-http/integrations/genai_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/providers/vertex"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 func TestCreateGenAIRerankRouteConfig(t *testing.T) {
@@ -124,4 +126,62 @@ func TestGenAIRerankResponseConverterFallsBackWhenNotVertex(t *testing.T) {
 	converted, err := route.RerankResponseConverter(nil, resp)
 	require.NoError(t, err)
 	assert.Equal(t, resp, converted)
+}
+
+func TestCreateGenAIRouteConfigsIncludesModelMetadataRoute(t *testing.T) {
+	routes := CreateGenAIRouteConfigs("/genai")
+
+	found := false
+	for _, route := range routes {
+		if route.Path == "/genai/v1beta/models/{model}" && route.Method == "GET" {
+			found = true
+			assert.Equal(t, schemas.ListModelsRequest, route.GetHTTPRequestType(nil))
+			require.NotNil(t, route.PreCallback)
+			require.NotNil(t, route.ListModelsResponseConverter)
+			break
+		}
+	}
+
+	assert.True(t, found, "expected model metadata route in genai route configs")
+}
+
+func TestExtractGeminiModelMetadataParams(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("model", "models/gemini-3-pro-preview")
+
+	listReq := &schemas.BifrostListModelsRequest{}
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	err := extractGeminiModelMetadataParams(ctx, bifrostCtx, listReq)
+	require.NoError(t, err)
+	assert.Equal(t, schemas.Gemini, listReq.Provider)
+	assert.Equal(t, "/models/gemini-3-pro-preview", bifrostCtx.Value(schemas.BifrostContextKeyURLPath))
+	assert.Equal(t, "gemini-3-pro-preview", bifrostCtx.Value(requestedGeminiModelMetadataContextKey))
+}
+
+func TestConvertGeminiModelMetadataResponse(t *testing.T) {
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	resp := &schemas.BifrostListModelsResponse{
+		Data: []schemas.Model{{ID: "gemini/gemini-2.5-pro", Name: schemas.Ptr("Gemini 2.5 Pro")}},
+	}
+
+	converted, err := convertGeminiModelMetadataResponse(bifrostCtx, resp)
+	require.NoError(t, err)
+
+	model, ok := converted.(gemini.GeminiModel)
+	require.True(t, ok, "expected gemini.GeminiModel")
+	assert.Equal(t, "models/gemini-2.5-pro", model.Name)
+	assert.Equal(t, "Gemini 2.5 Pro", model.DisplayName)
+}
+
+func TestConvertGeminiModelMetadataResponse_EmptyReturnsMinimalModel(t *testing.T) {
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostCtx.SetValue(requestedGeminiModelMetadataContextKey, "gemini-3-pro-preview")
+
+	converted, err := convertGeminiModelMetadataResponse(bifrostCtx, &schemas.BifrostListModelsResponse{Data: []schemas.Model{}})
+	require.NoError(t, err)
+	model, ok := converted.(gemini.GeminiModel)
+	require.True(t, ok, "expected gemini.GeminiModel")
+	assert.Equal(t, "models/gemini-3-pro-preview", model.Name)
 }


### PR DESCRIPTION
## Summary

Adds support for the Gemini model metadata endpoint required by frameworks such as `llama_index.llms.google_genai`.

Previously, requests to:

/genai/v1beta/models/{model}

returned a 404 because the route was not registered in the GenAI integration. This PR introduces the missing route and ensures the response format matches the expected Gemini metadata structure.

## Changes

- Added support for `GET /genai/v1beta/models/{model}` in the GenAI router
- Extracted the requested model from the path and forwarded it to the Gemini provider
- Added support for Gemini APIs that return a single model object instead of a list
- Normalized Gemini model resource names to the `models/{id}` format
- Added unit tests for:
  - single-model metadata payload handling
  - metadata conversion logic
  - route integration

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the core tests:

```sh
go test ./...
````

Start the server and query the metadata endpoint:

```sh
curl http://127.0.0.1:8080/genai/v1beta/models/gemini-3-pro-preview
```

Expected response:

```json
{
  "name": "models/gemini-3-pro-preview"
}
```

The endpoint should return JSON metadata instead of a 404.

## Screenshots/Recordings

<img width="1315" height="690" alt="Screenshot 2026-03-13 222545" src="https://github.com/user-attachments/assets/6678fdfc-edcb-4ae7-b470-73edba1e54f8" />


## Breaking changes

* [x] No

## Related issues

Closes #1308

## Security considerations

No new security implications. The change only introduces an additional read-only metadata endpoint and improves response handling for the Gemini provider.

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [x] I verified builds succeed
* [x] I verified the tests pass locally

