### PR TITLE
fix: skip all body building in case of large payload flow in `getRequestBodyFor...` functions

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -78,6 +78,12 @@ func setEffortOnOutputConfig(req *AnthropicMessageRequest, effort string) {
 }
 
 func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, providerName schemas.ModelProvider, isStreaming bool, excludeFields []string) ([]byte, *schemas.BifrostError) {
+	// Large payload mode: body streams directly from the LP reader in completeRequest/
+	// setAnthropicRequestBody — skip all body building here (matches CheckContextAndGetRequestBody).
+	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
+		return nil, nil
+	}
+
 	var jsonBody []byte
 	var err error
 

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -11,6 +11,12 @@ import (
 )
 
 func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, providerName schemas.ModelProvider, isStreaming bool) ([]byte, *schemas.BifrostError) {
+	// Large payload mode: body streams directly from the LP reader — skip all body building
+	// (matches CheckContextAndGetRequestBody guard).
+	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
+		return nil, nil
+	}
+
 	var jsonBody []byte
 	var err error
 

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -11,6 +11,12 @@ import (
 )
 
 func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, providerName schemas.ModelProvider, isStreaming bool, isCountTokens bool) ([]byte, *schemas.BifrostError) {
+	// Large payload mode: body streams directly from the LP reader — skip all body building
+	// (matches CheckContextAndGetRequestBody guard).
+	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
+		return nil, nil
+	}
+
 	var jsonBody []byte
 	var err error
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13617,24 +13617,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/watchpack": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",


### PR DESCRIPTION
## Summary

Add large payload passthrough mode support to provider request body builders.
When large payload mode is enabled, request body building is skipped and the
body streams directly from the LP reader instead.

## Changes

- Added `IsLargePayloadPassthroughEnabled` checks to
  `getRequestBodyForResponses` functions in Anthropic, Azure, and Vertex
  providers
- When large payload mode is detected, these functions now return `nil, nil` to
  skip body building
- Removed unused YAML dependency from UI package-lock.json

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that large payload requests are handled correctly across all supported
providers:

Test with large payload requests to ensure body streaming works properly and
request body building is bypassed when the feature is enabled.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

