### PR TITLE
fix: use deterministic redis direct-cache lookup fallback

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -337,6 +337,9 @@ func (s *RedisStore) executeSearch(ctx context.Context, namespace string, redisQ
 		if result.Err() != nil {
 			errMsg = strings.ToLower(result.Err().Error())
 			if isQuerySyntaxError(errMsg) {
+				if IsScanFallbackDisabled(ctx) {
+					return nil, fmt.Errorf("failed to search without scan fallback: %w", result.Err())
+				}
 				s.logger.Debug(fmt.Sprintf("FT.SEARCH scan fallback triggered for namespace %s: %s", namespace, result.Err()))
 				scanResults, _, scanErr := s.getAllByScan(ctx, namespace, queries, selectFields, nil, int64(searchLimit))
 				if scanErr != nil {
@@ -1346,6 +1349,9 @@ func (s *RedisStore) getAllMatchingIDs(ctx context.Context, namespace string, qu
 			if result.Err() != nil {
 				errMsg = strings.ToLower(result.Err().Error())
 				if isQuerySyntaxError(errMsg) {
+					if IsScanFallbackDisabled(ctx) {
+						return nil, fmt.Errorf("failed to collect matching ids without scan fallback: %w", result.Err())
+					}
 					s.logger.Debug(fmt.Sprintf("FT.SEARCH scan fallback triggered for namespace %s while collecting ids: %s", namespace, result.Err()))
 					scanResults, _, scanErr := s.getAllByScan(ctx, namespace, queries, nil, nil, 0)
 					if scanErr != nil {

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -1,13 +1,21 @@
 package vectorstore
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"io"
+	"net"
 	"os"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -229,6 +237,196 @@ func TestRedisConfig_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+type fakeRedisSearchServer struct {
+	listener      net.Listener
+	searchErrors  int
+	mu            sync.Mutex
+	ftSearchCalls int
+	sawScan       bool
+}
+
+func newFakeRedisSearchServer(t *testing.T, searchErrors int) *fakeRedisSearchServer {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := &fakeRedisSearchServer{
+		listener:     listener,
+		searchErrors: searchErrors,
+	}
+
+	go server.serve(t)
+	return server
+}
+
+func (s *fakeRedisSearchServer) serve(t *testing.T) {
+	t.Helper()
+
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				continue
+			}
+			return
+		}
+
+		go s.handleConn(t, conn)
+	}
+}
+
+func (s *fakeRedisSearchServer) handleConn(t *testing.T, conn net.Conn) {
+	t.Helper()
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	writer := bufio.NewWriter(conn)
+
+	for {
+		command, err := readRESPCommand(reader)
+		if err != nil {
+			if err == io.EOF || strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+				return
+			}
+			return
+		}
+		if len(command) == 0 {
+			continue
+		}
+
+		switch strings.ToUpper(command[0]) {
+		case "HELLO":
+			_, _ = writer.WriteString("%2\r\n+server\r\n+redis\r\n+version\r\n+7.0.0\r\n")
+		case "CLIENT":
+			_, _ = writer.WriteString("+OK\r\n")
+		case "SELECT":
+			_, _ = writer.WriteString("+OK\r\n")
+		case "PING":
+			_, _ = writer.WriteString("+PONG\r\n")
+		case "FT.SEARCH":
+			s.mu.Lock()
+			s.ftSearchCalls++
+			shouldError := s.ftSearchCalls <= s.searchErrors
+			s.mu.Unlock()
+
+			if shouldError {
+				_, _ = writer.WriteString("-Invalid query\r\n")
+			} else {
+				_, _ = writer.WriteString("*1\r\n:0\r\n")
+			}
+		case "SCAN":
+			s.mu.Lock()
+			s.sawScan = true
+			s.mu.Unlock()
+			_, _ = writer.WriteString("*2\r\n$1\r\n0\r\n*0\r\n")
+		case "HGETALL":
+			_, _ = writer.WriteString("*0\r\n")
+		default:
+			_, _ = writer.WriteString("+OK\r\n")
+		}
+
+		if err := writer.Flush(); err != nil {
+			return
+		}
+	}
+}
+
+func (s *fakeRedisSearchServer) close() error {
+	return s.listener.Close()
+}
+
+func (s *fakeRedisSearchServer) addr() string {
+	return s.listener.Addr().String()
+}
+
+func (s *fakeRedisSearchServer) stats() (ftSearchCalls int, sawScan bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ftSearchCalls, s.sawScan
+}
+
+func readRESPCommand(reader *bufio.Reader) ([]string, error) {
+	header, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return nil, nil
+	}
+	if header[0] != '*' {
+		return nil, fmt.Errorf("unexpected RESP header %q", header)
+	}
+
+	count, err := strconv.Atoi(header[1:])
+	if err != nil {
+		return nil, fmt.Errorf("invalid RESP array length %q: %w", header, err)
+	}
+
+	command := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		bulkHeader, err := reader.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		bulkHeader = strings.TrimSpace(bulkHeader)
+		if bulkHeader == "" || bulkHeader[0] != '$' {
+			return nil, fmt.Errorf("unexpected RESP bulk header %q", bulkHeader)
+		}
+
+		size, err := strconv.Atoi(bulkHeader[1:])
+		if err != nil {
+			return nil, fmt.Errorf("invalid RESP bulk length %q: %w", bulkHeader, err)
+		}
+
+		payload := make([]byte, size+2)
+		if _, err := io.ReadFull(reader, payload); err != nil {
+			return nil, err
+		}
+		command = append(command, string(payload[:size]))
+	}
+
+	return command, nil
+}
+
+func TestRedisStore_ExecuteSearch_DisableScanFallbackOnQuerySyntaxError(t *testing.T) {
+	server := newFakeRedisSearchServer(t, 2)
+	defer func() {
+		require.NoError(t, server.close())
+	}()
+
+	client := redis.NewClient(&redis.Options{
+		Addr:            server.addr(),
+		Protocol:        2,
+		DisableIdentity: true,
+		MaxRetries:      0,
+	})
+	defer func() {
+		require.NoError(t, client.Close())
+	}()
+
+	store := &RedisStore{
+		client: client,
+		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+		config: RedisConfig{
+			ContextTimeout: time.Second,
+		},
+		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	_, err := store.executeSearch(WithDisableScanFallback(ctx), TestNamespace, "*", nil, nil, 0, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to search without scan fallback")
+
+	ftSearchCalls, sawScan := server.stats()
+	assert.Equal(t, 2, ftSearchCalls)
+	assert.False(t, sawScan, "expected executeSearch to return before scan fallback")
 }
 
 func TestRedisStore_ParseSearchResults_RESP3Map(t *testing.T) {

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -76,6 +76,8 @@ const (
 	VectorStorePropertyTypeStringArray VectorStorePropertyType = "string[]"
 )
 
+type disableScanFallbackContextKey struct{}
+
 // VectorStore represents the interface for the vector store.
 type VectorStore interface {
 	// Health check
@@ -104,6 +106,25 @@ type VectorStore interface {
 	DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error)
 	// Close closes the vector store.
 	Close(ctx context.Context, namespace string) error
+}
+
+// WithDisableScanFallback returns a derived context that tells vector stores not
+// to fall back to full scans when indexed search fails.
+func WithDisableScanFallback(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, disableScanFallbackContextKey{}, true)
+}
+
+// IsScanFallbackDisabled reports whether scan fallback has been disabled for
+// the current vector store operation.
+func IsScanFallbackDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	disabled, _ := ctx.Value(disableScanFallbackContextKey{}).(bool)
+	return disabled
 }
 
 // Config represents the configuration for the vector store.

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -419,6 +419,7 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	ctx.SetValue(requestProviderKey, provider)
 
 	performDirectSearch, performSemanticSearch := true, true
+	useDirectChunkLookup := false
 	if ctx.Value(CacheTypeKey) != nil {
 		cacheTypeVal, ok := ctx.Value(CacheTypeKey).(CacheType)
 		if !ok {
@@ -426,12 +427,13 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 		} else {
 			performDirectSearch = cacheTypeVal == CacheTypeDirect
 			performSemanticSearch = cacheTypeVal == CacheTypeSemantic
+			useDirectChunkLookup = cacheTypeVal == CacheTypeDirect
 		}
 	}
 
 	if performDirectSearch {
 		directSearchFn := plugin.performDirectSearch
-		if ctx.Value(CacheTypeKey) == CacheTypeDirect {
+		if useDirectChunkLookup {
 			directSearchFn = plugin.performDirectChunkLookup
 		}
 

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -422,7 +422,6 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	ctx.SetValue(requestProviderKey, provider)
 
 	performDirectSearch, performSemanticSearch := true, true
-	useDirectChunkLookup := false
 	if ctx.Value(CacheTypeKey) != nil {
 		cacheTypeVal, ok := ctx.Value(CacheTypeKey).(CacheType)
 		if !ok {
@@ -430,19 +429,13 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 		} else {
 			performDirectSearch = cacheTypeVal == CacheTypeDirect
 			performSemanticSearch = cacheTypeVal == CacheTypeSemantic
-			useDirectChunkLookup = cacheTypeVal == CacheTypeDirect
 		}
 	}
 
 	if performDirectSearch {
-		directSearchFn := plugin.performDirectSearch
-		if useDirectChunkLookup {
-			directSearchFn = plugin.performDirectChunkLookup
-		}
-
-		shortCircuit, err := directSearchFn(ctx, req, cacheKey)
+		shortCircuit, err := plugin.performDirectSearch(ctx, req, cacheKey)
 		if err != nil {
-			plugin.logger.Warn(PluginLoggerPrefix + " Direct search failed: " + err.Error())
+			plugin.logger.Warn(PluginLoggerPrefix + " Direct search failed: " + err.Error() + " (" + describeRequestShape(req) + ")")
 			// Don't return - continue to semantic search fallback
 			shortCircuit = nil // Ensure we don't use an invalid shortCircuit
 		}
@@ -468,6 +461,7 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 		// Try semantic search as fallback
 		shortCircuit, err := plugin.performSemanticSearch(ctx, req, cacheKey)
 		if err != nil {
+			plugin.logger.Debug(PluginLoggerPrefix + " Semantic search skipped: " + err.Error() + " (" + describeRequestShape(req) + ")")
 			return req, nil, nil
 		}
 
@@ -573,10 +567,11 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 		return res, nil, nil
 	}
 	storageID := requestID
-	if cacheTypeVal, ok := ctx.Value(CacheTypeKey).(CacheType); ok && cacheTypeVal == CacheTypeDirect {
-		if v, ok := ctx.Value(requestStorageIDKey).(string); ok && v != "" {
-			storageID = v
-		}
+	// When direct lookup prepared a deterministic storage ID, reuse it here so
+	// default-mode traffic warms the GetChunk fast path instead of only the
+	// legacy search path.
+	if v, ok := ctx.Value(requestStorageIDKey).(string); ok && v != "" {
+		storageID = v
 	}
 	// Check cache type to optimize embedding handling
 	var embedding []float32

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -118,6 +118,7 @@ type StreamChunk struct {
 // StreamAccumulator manages accumulation of streaming chunks for caching
 type StreamAccumulator struct {
 	RequestID      string                 // The request ID
+	StorageID      string                 // The final cache entry ID
 	Chunks         []*StreamChunk         // All chunks for this stream
 	IsComplete     bool                   // Whether the stream is complete
 	HasError       bool                   // Whether any chunk in the stream had an error
@@ -248,6 +249,7 @@ const (
 
 	// context keys for internal usage
 	requestIDKey              schemas.BifrostContextKey = "semantic_cache_request_id"
+	requestStorageIDKey       schemas.BifrostContextKey = "semantic_cache_request_storage_id"
 	requestHashKey            schemas.BifrostContextKey = "semantic_cache_request_hash"
 	requestEmbeddingKey       schemas.BifrostContextKey = "semantic_cache_embedding"
 	requestEmbeddingTokensKey schemas.BifrostContextKey = "semantic_cache_embedding_tokens"
@@ -428,7 +430,12 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	}
 
 	if performDirectSearch {
-		shortCircuit, err := plugin.performDirectSearch(ctx, req, cacheKey)
+		directSearchFn := plugin.performDirectSearch
+		if ctx.Value(CacheTypeKey) == CacheTypeDirect {
+			directSearchFn = plugin.performDirectChunkLookup
+		}
+
+		shortCircuit, err := directSearchFn(ctx, req, cacheKey)
 		if err != nil {
 			plugin.logger.Warn(PluginLoggerPrefix + " Direct search failed: " + err.Error())
 			// Don't return - continue to semantic search fallback
@@ -560,6 +567,10 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	if !ok {
 		return res, nil, nil
 	}
+	storageID, ok := ctx.Value(requestStorageIDKey).(string)
+	if !ok || storageID == "" {
+		storageID = requestID
+	}
 	// Check cache type to optimize embedding handling
 	var embedding []float32
 	var hash string
@@ -687,11 +698,11 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 		}
 
 		if bifrost.IsStreamRequestType(requestType) {
-			if err := plugin.addStreamingResponse(cacheCtx, requestID, res, bifrostErr, embeddingToStore, unifiedMetadata, cacheTTL, isFinalChunk); err != nil {
+			if err := plugin.addStreamingResponse(cacheCtx, requestID, storageID, res, bifrostErr, embeddingToStore, unifiedMetadata, cacheTTL, isFinalChunk); err != nil {
 				plugin.logger.Warn("%s Failed to cache streaming response: %v", PluginLoggerPrefix, err)
 			}
 		} else {
-			if err := plugin.addSingleResponse(cacheCtx, requestID, res, embeddingToStore, unifiedMetadata, cacheTTL); err != nil {
+			if err := plugin.addSingleResponse(cacheCtx, storageID, res, embeddingToStore, unifiedMetadata, cacheTTL); err != nil {
 				plugin.logger.Warn("%s Failed to cache single response: %v", PluginLoggerPrefix, err)
 			}
 		}

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -38,9 +38,9 @@ type Config struct {
 	// Advanced caching behavior
 	DefaultCacheKey              string `json:"default_cache_key,omitempty"`              // Default cache key used when no per-request key is provided (optional, caching is disabled when empty and no per-request key is set)
 	ConversationHistoryThreshold int    `json:"conversation_history_threshold,omitempty"` // Skip caching for requests with more than this number of messages in the conversation history (default: 3)
-	CacheByModel                 *bool  `json:"cache_by_model,omitempty"`                // Include model in cache key (default: true)
-	CacheByProvider              *bool  `json:"cache_by_provider,omitempty"`             // Include provider in cache key (default: true)
-	ExcludeSystemPrompt          *bool  `json:"exclude_system_prompt,omitempty"`         // Exclude system prompt in cache key (default: false)
+	CacheByModel                 *bool  `json:"cache_by_model,omitempty"`                 // Include model in cache key (default: true)
+	CacheByProvider              *bool  `json:"cache_by_provider,omitempty"`              // Include provider in cache key (default: true)
+	ExcludeSystemPrompt          *bool  `json:"exclude_system_prompt,omitempty"`          // Exclude system prompt in cache key (default: false)
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for semantic cache Config.
@@ -405,6 +405,9 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 		}
 	}
 
+	// Clear any stale storage ID from a previously reused context.
+	ctx.ClearValue(requestStorageIDKey)
+
 	if plugin.isConversationHistoryThresholdExceeded(req) {
 		plugin.logger.Debug(PluginLoggerPrefix + " Skipping caching for request with conversation history threshold exceeded")
 		return req, nil, nil
@@ -569,9 +572,11 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	if !ok {
 		return res, nil, nil
 	}
-	storageID, ok := ctx.Value(requestStorageIDKey).(string)
-	if !ok || storageID == "" {
-		storageID = requestID
+	storageID := requestID
+	if cacheTypeVal, ok := ctx.Value(CacheTypeKey).(CacheType); ok && cacheTypeVal == CacheTypeDirect {
+		if v, ok := ctx.Value(requestStorageIDKey).(string); ok && v != "" {
+			storageID = v
+		}
 	}
 	// Check cache type to optimize embedding handling
 	var embedding []float32

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -420,6 +420,32 @@ func TestDefaultDirectSearchDoesNotSetStorageID(t *testing.T) {
 	}
 }
 
+func TestPreLLMHookClearsStaleStorageIDOnReusedContext(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	plugin := &Plugin{
+		store:  store,
+		config: getDefaultTestConfig(),
+		logger: logger,
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+
+	ctx := CreateContextWithCacheKey("reused-context")
+	ctx.SetValue(requestStorageIDKey, "stale-storage-id")
+
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+
+	if storageID := ctx.Value(requestStorageIDKey); storageID != nil {
+		t.Fatalf("expected PreLLMHook to clear stale requestStorageIDKey, got %v", storageID)
+	}
+}
+
 func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()
@@ -478,6 +504,55 @@ func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
 	}
 	if store.addIDs[0] == "request-uuid" {
 		t.Fatal("expected storage id to differ from request UUID")
+	}
+}
+
+func TestPostLLMHookIgnoresStaleStorageIDOutsideDirectMode(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	plugin := &Plugin{
+		store:  store,
+		config: getDefaultTestConfig(),
+		logger: logger,
+	}
+
+	content := "stored response"
+	response := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role: schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{
+								ContentStr: &content,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	response.ChatResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
+
+	ctx := CreateContextWithCacheKey("default-mode-store")
+	ctx.SetValue(requestIDKey, "request-uuid")
+	ctx.SetValue(requestStorageIDKey, "stale-storage-id")
+	ctx.SetValue(requestProviderKey, schemas.OpenAI)
+	ctx.SetValue(requestModelKey, "openai/gpt-4o-mini")
+	ctx.SetValue(requestHashKey, "request-hash")
+
+	if _, _, err := plugin.PostLLMHook(ctx, response, nil); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+
+	plugin.WaitForPendingOperations()
+
+	if len(store.addIDs) != 1 {
+		t.Fatalf("expected one store.Add call, got %d", len(store.addIDs))
+	}
+	if store.addIDs[0] != "request-uuid" {
+		t.Fatalf("expected PostLLMHook to ignore stale storage id outside direct mode, got %q", store.addIDs[0])
 	}
 }
 

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -16,8 +16,8 @@ func TestCacheTypeDirectOnly(t *testing.T) {
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	// First, cache a response using normal behavior (both direct and semantic)
-	ctx1 := CreateContextWithCacheKey("test-cache-type-direct")
+	// First, cache a response using CacheTypeDirect so it is stored under the deterministic ID
+	ctx1 := CreateContextWithCacheKeyAndType("test-cache-type-direct", CacheTypeDirect)
 	testRequest := CreateBasicChatRequest("What is Bifrost?", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
@@ -218,8 +218,8 @@ func TestCacheTypePerformanceCharacteristics(t *testing.T) {
 
 	testRequest := CreateBasicChatRequest("Performance test for cache types", 0.7, 50)
 
-	// Cache first request
-	ctx1 := CreateContextWithCacheKey("test-cache-performance")
+	// Cache first request using CacheTypeDirect so it is stored under the deterministic ID
+	ctx1 := CreateContextWithCacheKeyAndType("test-cache-performance", CacheTypeDirect)
 	t.Log("Making first request to populate cache...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -1,10 +1,14 @@
 package semanticcache
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
 // TestCacheTypeDirectOnly tests that CacheTypeKey set to "direct" only performs direct hash matching
@@ -252,4 +256,226 @@ func TestCacheTypePerformanceCharacteristics(t *testing.T) {
 	// Both should be fast since they hit direct cache
 	// Direct-only might be slightly faster as it doesn't need to prepare for semantic fallback
 	t.Log("✅ Cache type performance characteristics validated")
+}
+
+type directFastPathStore struct {
+	chunks         map[string]vectorstore.SearchResult
+	addIDs         []string
+	getChunkCalls  int
+	getAllCalls    int
+	lastGetChunkID string
+}
+
+func newDirectFastPathStore() *directFastPathStore {
+	return &directFastPathStore{
+		chunks: make(map[string]vectorstore.SearchResult),
+	}
+}
+
+func (s *directFastPathStore) Ping(ctx context.Context) error { return nil }
+
+func (s *directFastPathStore) CreateNamespace(ctx context.Context, namespace string, dimension int, properties map[string]vectorstore.VectorStoreProperties) error {
+	return nil
+}
+
+func (s *directFastPathStore) DeleteNamespace(ctx context.Context, namespace string) error {
+	return nil
+}
+
+func (s *directFastPathStore) GetChunk(ctx context.Context, namespace string, id string) (vectorstore.SearchResult, error) {
+	s.getChunkCalls++
+	s.lastGetChunkID = id
+	result, ok := s.chunks[id]
+	if !ok {
+		return vectorstore.SearchResult{}, vectorstore.ErrNotFound
+	}
+	return result, nil
+}
+
+func (s *directFastPathStore) GetChunks(ctx context.Context, namespace string, ids []string) ([]vectorstore.SearchResult, error) {
+	return nil, vectorstore.ErrNotSupported
+}
+
+func (s *directFastPathStore) GetAll(ctx context.Context, namespace string, queries []vectorstore.Query, selectFields []string, cursor *string, limit int64) ([]vectorstore.SearchResult, *string, error) {
+	s.getAllCalls++
+	return nil, nil, vectorstore.ErrNotSupported
+}
+
+func (s *directFastPathStore) GetNearest(ctx context.Context, namespace string, vector []float32, queries []vectorstore.Query, selectFields []string, threshold float64, limit int64) ([]vectorstore.SearchResult, error) {
+	return nil, vectorstore.ErrNotSupported
+}
+
+func (s *directFastPathStore) RequiresVectors() bool { return false }
+
+func (s *directFastPathStore) Add(ctx context.Context, namespace string, id string, embedding []float32, metadata map[string]interface{}) error {
+	s.addIDs = append(s.addIDs, id)
+	s.chunks[id] = vectorstore.SearchResult{
+		ID:         id,
+		Properties: metadata,
+	}
+	return nil
+}
+
+func (s *directFastPathStore) Delete(ctx context.Context, namespace string, id string) error {
+	return nil
+}
+
+func (s *directFastPathStore) DeleteAll(ctx context.Context, namespace string, queries []vectorstore.Query) ([]vectorstore.DeleteResult, error) {
+	return nil, vectorstore.ErrNotSupported
+}
+
+func (s *directFastPathStore) Close(ctx context.Context, namespace string) error { return nil }
+
+func TestCacheTypeDirectUsesChunkLookup(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	plugin := &Plugin{
+		store:  store,
+		config: getDefaultTestConfig(),
+		logger: logger,
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+
+	ctx := CreateContextWithCacheKeyAndType("chunk-fast-path", CacheTypeDirect)
+	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "chunk-fast-path")
+	if err != nil {
+		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+	}
+
+	cachedContent := "cached response"
+	cachedResponse := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role: schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{
+								ContentStr: &cachedContent,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	responseJSON, err := schemas.MarshalDeeplySorted(cachedResponse)
+	if err != nil {
+		t.Fatalf("failed to marshal cached response: %v", err)
+	}
+
+	store.chunks[directID] = vectorstore.SearchResult{
+		ID: directID,
+		Properties: map[string]interface{}{
+			"response":   string(responseJSON),
+			"expires_at": time.Now().Add(time.Minute).Unix(),
+		},
+	}
+
+	shortCircuit, err := plugin.performDirectChunkLookup(ctx, req, "chunk-fast-path")
+	if err != nil {
+		t.Fatalf("performDirectChunkLookup failed: %v", err)
+	}
+	if shortCircuit == nil || shortCircuit.Response == nil || shortCircuit.Response.ChatResponse == nil {
+		t.Fatal("expected direct chunk lookup to return cached response")
+	}
+	if store.getChunkCalls != 1 {
+		t.Fatalf("expected one GetChunk call, got %d", store.getChunkCalls)
+	}
+	if store.getAllCalls != 0 {
+		t.Fatalf("expected no GetAll calls, got %d", store.getAllCalls)
+	}
+	if store.lastGetChunkID != directID {
+		t.Fatalf("expected GetChunk to use %q, got %q", directID, store.lastGetChunkID)
+	}
+}
+
+func TestDefaultDirectSearchDoesNotSetStorageID(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	plugin := &Plugin{
+		store:  store,
+		config: getDefaultTestConfig(),
+		logger: logger,
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+
+	ctx := CreateContextWithCacheKey("default-mode")
+	_, err := plugin.performDirectSearch(ctx, req, "default-mode")
+	if err != nil && !errors.Is(err, vectorstore.ErrNotSupported) {
+		t.Fatalf("performDirectSearch failed: %v", err)
+	}
+
+	if storageID := ctx.Value(requestStorageIDKey); storageID != nil {
+		t.Fatalf("expected default direct search not to set requestStorageIDKey, got %v", storageID)
+	}
+}
+
+func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	config := getDefaultTestConfig()
+	plugin := &Plugin{
+		store:  store,
+		config: config,
+		logger: logger,
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+	ctx := CreateContextWithCacheKeyAndType("deterministic-store", CacheTypeDirect)
+	ctx.SetValue(requestIDKey, "request-uuid")
+	ctx.SetValue(requestProviderKey, schemas.OpenAI)
+	ctx.SetValue(requestModelKey, req.ChatRequest.Model)
+
+	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "deterministic-store")
+	if err != nil {
+		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+	}
+	ctx.SetValue(requestStorageIDKey, directID)
+
+	content := "stored response"
+	response := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role: schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{
+								ContentStr: &content,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	response.ChatResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
+
+	if _, _, err := plugin.PostLLMHook(ctx, response, nil); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+
+	plugin.WaitForPendingOperations()
+
+	if len(store.addIDs) != 1 {
+		t.Fatalf("expected one store.Add call, got %d", len(store.addIDs))
+	}
+	if store.addIDs[0] != directID {
+		t.Fatalf("expected deterministic storage id %q, got %q", directID, store.addIDs[0])
+	}
+	if store.addIDs[0] == "request-uuid" {
+		t.Fatal("expected storage id to differ from request UUID")
+	}
 }

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -265,6 +265,7 @@ type directFastPathStore struct {
 	getChunkCalls  int
 	getAllCalls    int
 	lastGetChunkID string
+	lastGetAllCtx  context.Context
 }
 
 func newDirectFastPathStore() *directFastPathStore {
@@ -299,6 +300,7 @@ func (s *directFastPathStore) GetChunks(ctx context.Context, namespace string, i
 
 func (s *directFastPathStore) GetAll(ctx context.Context, namespace string, queries []vectorstore.Query, selectFields []string, cursor *string, limit int64) ([]vectorstore.SearchResult, *string, error) {
 	s.getAllCalls++
+	s.lastGetAllCtx = ctx
 	return nil, nil, vectorstore.ErrNotSupported
 }
 
@@ -395,7 +397,7 @@ func TestCacheTypeDirectUsesChunkLookup(t *testing.T) {
 	}
 }
 
-func TestDefaultDirectSearchDoesNotSetStorageID(t *testing.T) {
+func TestDefaultDirectSearchSetsStorageIDForDeterministicWrites(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()
 	plugin := &Plugin{
@@ -415,17 +417,23 @@ func TestDefaultDirectSearchDoesNotSetStorageID(t *testing.T) {
 		t.Fatalf("performDirectSearch failed: %v", err)
 	}
 
-	if storageID := ctx.Value(requestStorageIDKey); storageID != nil {
-		t.Fatalf("expected default direct search not to set requestStorageIDKey, got %v", storageID)
+	storageID, _ := ctx.Value(requestStorageIDKey).(string)
+	if storageID == "" {
+		t.Fatal("expected default direct search to set requestStorageIDKey")
+	}
+	if store.getChunkCalls != 1 {
+		t.Fatalf("expected one GetChunk call, got %d", store.getChunkCalls)
 	}
 }
 
 func TestPreLLMHookClearsStaleStorageIDOnReusedContext(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()
+	config := getDefaultTestConfig()
+	config.ConversationHistoryThreshold = 3
 	plugin := &Plugin{
 		store:  store,
-		config: getDefaultTestConfig(),
+		config: config,
 		logger: logger,
 	}
 
@@ -441,8 +449,12 @@ func TestPreLLMHookClearsStaleStorageIDOnReusedContext(t *testing.T) {
 		t.Fatalf("PreLLMHook failed: %v", err)
 	}
 
-	if storageID := ctx.Value(requestStorageIDKey); storageID != nil {
-		t.Fatalf("expected PreLLMHook to clear stale requestStorageIDKey, got %v", storageID)
+	storageID, _ := ctx.Value(requestStorageIDKey).(string)
+	if storageID == "" {
+		t.Fatal("expected PreLLMHook to replace stale requestStorageIDKey with a deterministic id")
+	}
+	if storageID == "stale-storage-id" {
+		t.Fatal("expected PreLLMHook to clear stale requestStorageIDKey before setting a deterministic id")
 	}
 }
 
@@ -507,7 +519,7 @@ func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
 	}
 }
 
-func TestPostLLMHookIgnoresStaleStorageIDOutsideDirectMode(t *testing.T) {
+func TestPostLLMHookUsesDeterministicStorageIDOutsideDirectMode(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()
 	plugin := &Plugin{
@@ -537,10 +549,13 @@ func TestPostLLMHookIgnoresStaleStorageIDOutsideDirectMode(t *testing.T) {
 
 	ctx := CreateContextWithCacheKey("default-mode-store")
 	ctx.SetValue(requestIDKey, "request-uuid")
-	ctx.SetValue(requestStorageIDKey, "stale-storage-id")
 	ctx.SetValue(requestProviderKey, schemas.OpenAI)
 	ctx.SetValue(requestModelKey, "openai/gpt-4o-mini")
 	ctx.SetValue(requestHashKey, "request-hash")
+	ctx.SetValue(requestParamsHashKey, "params-hash")
+
+	directID := plugin.generateDirectCacheID(schemas.OpenAI, "openai/gpt-4o-mini", "default-mode-store", "request-hash", "params-hash")
+	ctx.SetValue(requestStorageIDKey, directID)
 
 	if _, _, err := plugin.PostLLMHook(ctx, response, nil); err != nil {
 		t.Fatalf("PostLLMHook failed: %v", err)
@@ -551,8 +566,36 @@ func TestPostLLMHookIgnoresStaleStorageIDOutsideDirectMode(t *testing.T) {
 	if len(store.addIDs) != 1 {
 		t.Fatalf("expected one store.Add call, got %d", len(store.addIDs))
 	}
-	if store.addIDs[0] != "request-uuid" {
-		t.Fatalf("expected PostLLMHook to ignore stale storage id outside direct mode, got %q", store.addIDs[0])
+	if store.addIDs[0] != directID {
+		t.Fatalf("expected PostLLMHook to use deterministic storage id outside direct mode, got %q", store.addIDs[0])
+	}
+}
+
+func TestPerformDirectSearchDisablesScanFallbackForLegacyLookup(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	plugin := &Plugin{
+		store:  store,
+		config: getDefaultTestConfig(),
+		logger: logger,
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+
+	ctx := CreateContextWithCacheKey("legacy-no-scan")
+	_, err := plugin.performDirectSearch(ctx, req, "legacy-no-scan")
+	if err != nil && !errors.Is(err, vectorstore.ErrNotSupported) {
+		t.Fatalf("performDirectSearch failed: %v", err)
+	}
+
+	if store.getAllCalls != 1 {
+		t.Fatalf("expected one legacy GetAll call, got %d", store.getAllCalls)
+	}
+	if !vectorstore.IsScanFallbackDisabled(store.lastGetAllCtx) {
+		t.Fatal("expected legacy direct lookup to disable scan fallback")
 	}
 }
 

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -3,6 +3,7 @@ package semanticcache
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -477,5 +478,61 @@ func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
 	}
 	if store.addIDs[0] == "request-uuid" {
 		t.Fatal("expected storage id to differ from request UUID")
+	}
+}
+
+func TestGetOrCreateStreamAccumulatorUsesSingleAccumulatorPerRequest(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	plugin := &Plugin{
+		logger: logger,
+	}
+
+	requestID := "stream-request"
+	storageID := "stream-storage"
+	embedding := []float32{1, 2, 3}
+	metadata := map[string]interface{}{"cache_key": "stream-cache"}
+	ttl := time.Minute
+
+	const workers = 8
+	results := make(chan *StreamAccumulator, workers)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			results <- plugin.getOrCreateStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	var first *StreamAccumulator
+	for accumulator := range results {
+		if accumulator == nil {
+			t.Fatal("expected accumulator")
+		}
+		if first == nil {
+			first = accumulator
+			continue
+		}
+		if accumulator != first {
+			t.Fatal("expected all callers to receive the same accumulator instance")
+		}
+	}
+
+	stored, ok := plugin.streamAccumulators.Load(requestID)
+	if !ok {
+		t.Fatal("expected accumulator to be stored")
+	}
+	if stored.(*StreamAccumulator) != first {
+		t.Fatal("expected stored accumulator to match returned accumulator")
+	}
+	if first.StorageID != storageID {
+		t.Fatalf("expected storage id %q, got %q", storageID, first.StorageID)
+	}
+	if first.TTL != ttl {
+		t.Fatalf("expected ttl %v, got %v", ttl, first.TTL)
 	}
 }

--- a/plugins/semanticcache/plugin_nil_content_test.go
+++ b/plugins/semanticcache/plugin_nil_content_test.go
@@ -95,6 +95,68 @@ func TestExtractTextForEmbedding_NilContent(t *testing.T) {
 	}
 }
 
+func TestPrepareDirectCacheLookup_ResponsesStreamRequest(t *testing.T) {
+	plugin := &Plugin{
+		config: getDefaultTestConfig(),
+		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType:      schemas.ResponsesStreamRequest,
+		ResponsesRequest: CreateStreamingResponsesRequest("Explain cache invalidation", 0.2, 200),
+	}
+
+	ctx := CreateContextWithCacheKey("responses-stream-direct")
+	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "responses-stream-direct")
+	if err != nil {
+		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+	}
+	if directID == "" {
+		t.Fatal("expected deterministic direct cache id")
+	}
+	if got, _ := ctx.Value(requestHashKey).(string); got == "" {
+		t.Fatal("expected request hash to be stored in context")
+	}
+	if got, _ := ctx.Value(requestParamsHashKey).(string); got == "" {
+		t.Fatal("expected params hash to be stored in context")
+	}
+}
+
+func TestPrepareDirectCacheLookup_UnsupportedRequestTypeFailsClosed(t *testing.T) {
+	plugin := &Plugin{
+		config: getDefaultTestConfig(),
+		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.PassthroughRequest,
+		PassthroughRequest: &schemas.BifrostPassthroughRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o-mini",
+			Method:   "GET",
+			Path:     "/v1/models",
+		},
+	}
+
+	ctx := CreateContextWithCacheKey("unsupported-direct")
+	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "unsupported-direct")
+	if err == nil {
+		t.Fatal("expected prepareDirectCacheLookup to reject unsupported request type")
+	}
+	if directID != "" {
+		t.Fatalf("expected no direct cache id, got %q", directID)
+	}
+	if got, _ := ctx.Value(requestHashKey).(string); got != "" {
+		t.Fatalf("expected request hash to remain unset, got %q", got)
+	}
+	if got, _ := ctx.Value(requestParamsHashKey).(string); got != "" {
+		t.Fatalf("expected params hash to remain unset, got %q", got)
+	}
+	if got, _ := ctx.Value(requestStorageIDKey).(string); got != "" {
+		t.Fatalf("expected storage id to remain unset, got %q", got)
+	}
+}
+
 // TestGetNormalizedInputForCaching_NilContent verifies that getNormalizedInputForCaching
 // does not panic when chat messages have nil Content.
 func TestGetNormalizedInputForCaching_NilContent(t *testing.T) {

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -46,7 +46,10 @@ func (plugin *Plugin) performDirectChunkLookup(ctx *schemas.BifrostContext, req 
 	result, err := plugin.store.GetChunk(ctx, plugin.config.VectorStoreNamespace, directCacheID)
 	if err != nil {
 		errMsg := strings.ToLower(err.Error())
-		if errors.Is(err, vectorstore.ErrNotFound) || strings.Contains(errMsg, "not found") {
+		isMiss := errors.Is(err, vectorstore.ErrNotFound) ||
+			strings.Contains(errMsg, "not found") ||
+			strings.Contains(errMsg, "status code: 404")
+		if isMiss {
 			plugin.logger.Debug(PluginLoggerPrefix + " No direct chunk match found")
 			return nil, nil
 		}

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -13,24 +14,57 @@ import (
 	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
-func (plugin *Plugin) performDirectSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
-	// Generate hash for the request
+func (plugin *Plugin) prepareDirectCacheLookup(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (string, error) {
 	hash, err := plugin.generateRequestHash(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate request hash: %w", err)
+		return "", fmt.Errorf("failed to generate request hash: %w", err)
 	}
 
 	plugin.logger.Debug(PluginLoggerPrefix + " Generated Hash for Request: " + hash)
 
-	// Extract metadata for strict filtering
 	_, paramsHash, err := plugin.extractTextForEmbedding(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract metadata for filtering: %w", err)
+		return "", fmt.Errorf("failed to extract metadata for filtering: %w", err)
 	}
 
-	// Store has and metadata in context
 	ctx.SetValue(requestHashKey, hash)
 	ctx.SetValue(requestParamsHashKey, paramsHash)
+
+	provider, model, _ := req.GetRequestFields()
+	directCacheID := plugin.generateDirectCacheID(provider, model, cacheKey, hash, paramsHash)
+
+	return directCacheID, nil
+}
+
+func (plugin *Plugin) performDirectChunkLookup(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
+	directCacheID, err := plugin.prepareDirectCacheLookup(ctx, req, cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	ctx.SetValue(requestStorageIDKey, directCacheID)
+
+	result, err := plugin.store.GetChunk(ctx, plugin.config.VectorStoreNamespace, directCacheID)
+	if err != nil {
+		errMsg := strings.ToLower(err.Error())
+		if errors.Is(err, vectorstore.ErrNotFound) || strings.Contains(errMsg, "not found") {
+			plugin.logger.Debug(PluginLoggerPrefix + " No direct chunk match found")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to fetch direct cache chunk: %w", err)
+	}
+
+	plugin.logger.Debug(fmt.Sprintf("%s Found direct chunk match with ID: %s", PluginLoggerPrefix, result.ID))
+	return plugin.buildResponseFromResult(ctx, req, result, CacheTypeDirect, 1.0, 0)
+}
+
+func (plugin *Plugin) performDirectSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
+	_, err := plugin.prepareDirectCacheLookup(ctx, req, cacheKey)
+	if err != nil {
+		return nil, err
+	}
+
+	hash, _ := ctx.Value(requestHashKey).(string)
+	paramsHash, _ := ctx.Value(requestParamsHashKey).(string)
 
 	provider, model, _ := req.GetRequestFields()
 

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -22,9 +22,9 @@ func (plugin *Plugin) prepareDirectCacheLookup(ctx *schemas.BifrostContext, req 
 
 	plugin.logger.Debug(PluginLoggerPrefix + " Generated Hash for Request: " + hash)
 
-	_, paramsHash, err := plugin.extractTextForEmbedding(req)
+	paramsHash, err := plugin.computeRequestParamsHash(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to extract metadata for filtering: %w", err)
+		return "", fmt.Errorf("failed to compute direct lookup params hash: %w", err)
 	}
 
 	ctx.SetValue(requestHashKey, hash)
@@ -34,6 +34,55 @@ func (plugin *Plugin) prepareDirectCacheLookup(ctx *schemas.BifrostContext, req 
 	directCacheID := plugin.generateDirectCacheID(provider, model, cacheKey, hash, paramsHash)
 
 	return directCacheID, nil
+}
+
+func (plugin *Plugin) performLegacyDirectSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
+	hash, _ := ctx.Value(requestHashKey).(string)
+	paramsHash, _ := ctx.Value(requestParamsHashKey).(string)
+
+	provider, model, _ := req.GetRequestFields()
+
+	filters := []vectorstore.Query{
+		{Field: "request_hash", Operator: vectorstore.QueryOperatorEqual, Value: hash},
+		{Field: "cache_key", Operator: vectorstore.QueryOperatorEqual, Value: cacheKey},
+		{Field: "params_hash", Operator: vectorstore.QueryOperatorEqual, Value: paramsHash},
+		{Field: "from_bifrost_semantic_cache_plugin", Operator: vectorstore.QueryOperatorEqual, Value: true},
+	}
+
+	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
+		filters = append(filters, vectorstore.Query{Field: "provider", Operator: vectorstore.QueryOperatorEqual, Value: string(provider)})
+	}
+	if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
+		filters = append(filters, vectorstore.Query{Field: "model", Operator: vectorstore.QueryOperatorEqual, Value: model})
+	}
+
+	plugin.logger.Debug(fmt.Sprintf("%s Searching for legacy direct hash match with %d filters", PluginLoggerPrefix, len(filters)))
+
+	selectFields := append([]string(nil), SelectFields...)
+	if bifrost.IsStreamRequestType(req.RequestType) {
+		selectFields = removeField(selectFields, "response")
+	} else {
+		selectFields = removeField(selectFields, "stream_chunks")
+	}
+
+	searchCtx := vectorstore.WithDisableScanFallback(ctx)
+	var cursor *string
+	results, _, err := plugin.store.GetAll(searchCtx, plugin.config.VectorStoreNamespace, filters, selectFields, cursor, 1)
+	if err != nil {
+		if errors.Is(err, vectorstore.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to search for legacy direct hash match: %w", err)
+	}
+
+	if len(results) == 0 {
+		plugin.logger.Debug(PluginLoggerPrefix + " No legacy direct hash match found")
+		return nil, nil
+	}
+
+	result := results[0]
+	plugin.logger.Debug(fmt.Sprintf("%s Found legacy direct hash match with ID: %s", PluginLoggerPrefix, result.ID))
+	return plugin.buildResponseFromResult(ctx, req, result, CacheTypeDirect, 1.0, 0)
 }
 
 func (plugin *Plugin) performDirectChunkLookup(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
@@ -61,62 +110,15 @@ func (plugin *Plugin) performDirectChunkLookup(ctx *schemas.BifrostContext, req 
 }
 
 func (plugin *Plugin) performDirectSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
-	_, err := plugin.prepareDirectCacheLookup(ctx, req, cacheKey)
+	shortCircuit, err := plugin.performDirectChunkLookup(ctx, req, cacheKey)
 	if err != nil {
 		return nil, err
 	}
-
-	hash, _ := ctx.Value(requestHashKey).(string)
-	paramsHash, _ := ctx.Value(requestParamsHashKey).(string)
-
-	provider, model, _ := req.GetRequestFields()
-
-	// Build strict filters for direct hash search
-	filters := []vectorstore.Query{
-		{Field: "request_hash", Operator: vectorstore.QueryOperatorEqual, Value: hash},
-		{Field: "cache_key", Operator: vectorstore.QueryOperatorEqual, Value: cacheKey},
-		{Field: "params_hash", Operator: vectorstore.QueryOperatorEqual, Value: paramsHash},
-		{Field: "from_bifrost_semantic_cache_plugin", Operator: vectorstore.QueryOperatorEqual, Value: true},
+	if shortCircuit != nil {
+		return shortCircuit, nil
 	}
 
-	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
-		filters = append(filters, vectorstore.Query{Field: "provider", Operator: vectorstore.QueryOperatorEqual, Value: string(provider)})
-	}
-	if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
-		filters = append(filters, vectorstore.Query{Field: "model", Operator: vectorstore.QueryOperatorEqual, Value: model})
-	}
-
-	plugin.logger.Debug(fmt.Sprintf("%s Searching for direct hash match with %d filters", PluginLoggerPrefix, len(filters)))
-
-	// Make a full copy so we don't mutate the original backing array
-	selectFields := append([]string(nil), SelectFields...)
-	if bifrost.IsStreamRequestType(req.RequestType) {
-		selectFields = removeField(selectFields, "response")
-	} else {
-		selectFields = removeField(selectFields, "stream_chunks")
-	}
-
-	// Search for entries with matching hash and all params
-	var cursor *string
-	results, _, err := plugin.store.GetAll(ctx, plugin.config.VectorStoreNamespace, filters, selectFields, cursor, 1)
-	if err != nil {
-		if errors.Is(err, vectorstore.ErrNotFound) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to search for direct hash match: %w", err)
-	}
-
-	if len(results) == 0 {
-		plugin.logger.Debug(PluginLoggerPrefix + " No direct hash match found")
-		return nil, nil
-	}
-
-	// Found a matching entry - extract the response
-	result := results[0]
-	plugin.logger.Debug(fmt.Sprintf("%s Found direct hash match with ID: %s", PluginLoggerPrefix, result.ID))
-
-	// Build response from cached result
-	return plugin.buildResponseFromResult(ctx, req, result, CacheTypeDirect, 1.0, 0)
+	return plugin.performLegacyDirectSearch(ctx, req, cacheKey)
 }
 
 // generateEmbeddingsForStorage generates embeddings and stores them in context for PostHook storage.

--- a/plugins/semanticcache/stream.go
+++ b/plugins/semanticcache/stream.go
@@ -27,13 +27,13 @@ func (plugin *Plugin) createStreamAccumulator(requestID string, storageID string
 
 // getOrCreateStreamAccumulator gets or creates a stream accumulator for a request
 func (plugin *Plugin) getOrCreateStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
-	newAccumulator := plugin.createStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
-	actual, loaded := plugin.streamAccumulators.LoadOrStore(requestID, newAccumulator)
-	if loaded {
-		return actual.(*StreamAccumulator)
+	if existing, ok := plugin.streamAccumulators.Load(requestID); ok {
+		return existing.(*StreamAccumulator)
 	}
 
-	return newAccumulator
+	newAccumulator := plugin.createStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
+	actual, _ := plugin.streamAccumulators.LoadOrStore(requestID, newAccumulator)
+	return actual.(*StreamAccumulator)
 }
 
 // addStreamChunk adds a chunk to the stream accumulator

--- a/plugins/semanticcache/stream.go
+++ b/plugins/semanticcache/stream.go
@@ -12,9 +12,10 @@ import (
 // Streaming State Management Methods
 
 // createStreamAccumulator creates a new stream accumulator for a request
-func (plugin *Plugin) createStreamAccumulator(requestID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
+func (plugin *Plugin) createStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
 	accumulator := &StreamAccumulator{
 		RequestID:  requestID,
+		StorageID:  storageID,
 		Chunks:     make([]*StreamChunk, 0),
 		IsComplete: false,
 		Embedding:  embedding,
@@ -28,13 +29,13 @@ func (plugin *Plugin) createStreamAccumulator(requestID string, embedding []floa
 }
 
 // getOrCreateStreamAccumulator gets or creates a stream accumulator for a request
-func (plugin *Plugin) getOrCreateStreamAccumulator(requestID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
+func (plugin *Plugin) getOrCreateStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
 	if accumulator, exists := plugin.streamAccumulators.Load(requestID); exists {
 		return accumulator.(*StreamAccumulator)
 	}
 
 	// Create new accumulator if it doesn't exist
-	return plugin.createStreamAccumulator(requestID, embedding, metadata, ttl)
+	return plugin.createStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
 }
 
 // addStreamChunk adds a chunk to the stream accumulator
@@ -153,12 +154,12 @@ func (plugin *Plugin) processAccumulatedStream(ctx context.Context, requestID st
 	}
 	finalMetadata["stream_chunks"] = streamResponses
 
-	// Store complete unified entry using original requestID - this is the final .Add() call
-	if err := plugin.store.Add(ctx, plugin.config.VectorStoreNamespace, requestID, accumulator.Embedding, finalMetadata); err != nil {
+	// Store complete unified entry using the final cache storage ID.
+	if err := plugin.store.Add(ctx, plugin.config.VectorStoreNamespace, accumulator.StorageID, accumulator.Embedding, finalMetadata); err != nil {
 		return fmt.Errorf("failed to store complete streaming cache entry: %w", err)
 	}
 
-	plugin.logger.Debug(fmt.Sprintf("%s Successfully cached complete stream with %d ordered chunks, ID: %s", PluginLoggerPrefix, len(streamResponses), requestID))
+	plugin.logger.Debug(fmt.Sprintf("%s Successfully cached complete stream with %d ordered chunks, ID: %s", PluginLoggerPrefix, len(streamResponses), accumulator.StorageID))
 	return nil
 }
 

--- a/plugins/semanticcache/stream.go
+++ b/plugins/semanticcache/stream.go
@@ -13,7 +13,7 @@ import (
 
 // createStreamAccumulator creates a new stream accumulator for a request
 func (plugin *Plugin) createStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
-	accumulator := &StreamAccumulator{
+	return &StreamAccumulator{
 		RequestID:  requestID,
 		StorageID:  storageID,
 		Chunks:     make([]*StreamChunk, 0),
@@ -23,19 +23,17 @@ func (plugin *Plugin) createStreamAccumulator(requestID string, storageID string
 		TTL:        ttl,
 		mu:         sync.Mutex{},
 	}
-
-	plugin.streamAccumulators.Store(requestID, accumulator)
-	return accumulator
 }
 
 // getOrCreateStreamAccumulator gets or creates a stream accumulator for a request
 func (plugin *Plugin) getOrCreateStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
-	if accumulator, exists := plugin.streamAccumulators.Load(requestID); exists {
-		return accumulator.(*StreamAccumulator)
+	newAccumulator := plugin.createStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
+	actual, loaded := plugin.streamAccumulators.LoadOrStore(requestID, newAccumulator)
+	if loaded {
+		return actual.(*StreamAccumulator)
 	}
 
-	// Create new accumulator if it doesn't exist
-	return plugin.createStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
+	return newAccumulator
 }
 
 // addStreamChunk adds a chunk to the stream accumulator

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -390,8 +390,14 @@ func (plugin *Plugin) generateDirectCacheID(provider schemas.ModelProvider, mode
 	idJSON, err := schemas.MarshalDeeplySorted(idInput)
 	if err != nil {
 		// Fallback: derive deterministic UUID from concatenated inputs
-		fallbackData := []byte(cacheKey + requestHash + paramsHash + string(provider) + model)
-		return uuid.NewSHA1(directCacheNamespace, fallbackData).String()
+		fallbackStr := cacheKey + requestHash + paramsHash
+		if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
+			fallbackStr += string(provider)
+		}
+		if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
+			fallbackStr += model
+		}
+		return uuid.NewSHA1(directCacheNamespace, []byte(fallbackStr)).String()
 	}
 
 	return uuid.NewSHA1(directCacheNamespace, idJSON).String()

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -362,6 +362,34 @@ func getMetadataHash(metadata map[string]interface{}) (string, error) {
 	return fmt.Sprintf("%x", xxhash.Sum64(metadataJSON)), nil
 }
 
+func (plugin *Plugin) generateDirectCacheID(provider schemas.ModelProvider, model string, cacheKey string, requestHash string, paramsHash string) string {
+	idInput := struct {
+		CacheKey    string `json:"cache_key"`
+		RequestHash string `json:"request_hash"`
+		ParamsHash  string `json:"params_hash"`
+		Provider    string `json:"provider,omitempty"`
+		Model       string `json:"model,omitempty"`
+	}{
+		CacheKey:    cacheKey,
+		RequestHash: requestHash,
+		ParamsHash:  paramsHash,
+	}
+
+	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
+		idInput.Provider = string(provider)
+	}
+	if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
+		idInput.Model = model
+	}
+
+	idJSON, err := schemas.MarshalDeeplySorted(idInput)
+	if err != nil {
+		return fmt.Sprintf("direct-%x", xxhash.Sum64String(cacheKey+requestHash+paramsHash+string(provider)+model))
+	}
+
+	return fmt.Sprintf("direct-%x", xxhash.Sum64(idJSON))
+}
+
 // buildUnifiedMetadata constructs the unified metadata structure for VectorEntry
 func (plugin *Plugin) buildUnifiedMetadata(provider schemas.ModelProvider, model string, paramsHash string, requestHash string, cacheKey string, ttl time.Duration) map[string]interface{} {
 	unifiedMetadata := make(map[string]interface{})
@@ -408,9 +436,9 @@ func (plugin *Plugin) addSingleResponse(ctx context.Context, responseID string, 
 }
 
 // addStreamingResponse handles streaming response storage by accumulating chunks
-func (plugin *Plugin) addStreamingResponse(ctx context.Context, responseID string, res *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, embedding []float32, metadata map[string]interface{}, ttl time.Duration, isFinalChunk bool) error {
+func (plugin *Plugin) addStreamingResponse(ctx context.Context, requestID string, storageID string, res *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, embedding []float32, metadata map[string]interface{}, ttl time.Duration, isFinalChunk bool) error {
 	// Create accumulator if it doesn't exist
-	accumulator := plugin.getOrCreateStreamAccumulator(responseID, embedding, metadata, ttl)
+	accumulator := plugin.getOrCreateStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
 
 	// Create chunk from current response
 	chunk := &StreamChunk{
@@ -430,7 +458,7 @@ func (plugin *Plugin) addStreamingResponse(ctx context.Context, responseID strin
 	}
 
 	// Add chunk to accumulator synchronously to maintain order
-	if err := plugin.addStreamChunk(responseID, chunk, isFinalChunk); err != nil {
+	if err := plugin.addStreamChunk(requestID, chunk, isFinalChunk); err != nil {
 		return fmt.Errorf("failed to add stream chunk: %w", err)
 	}
 
@@ -453,8 +481,8 @@ func (plugin *Plugin) addStreamingResponse(ctx context.Context, responseID strin
 	// If this is the final chunk and hasn't been processed yet, process accumulated chunks
 	// Note: processAccumulatedStream will check for errors and skip caching if any errors occurred
 	if isFinalChunk && !alreadyComplete {
-		if processErr := plugin.processAccumulatedStream(ctx, responseID); processErr != nil {
-			plugin.logger.Warn("%s Failed to process accumulated stream for request %s: %v", PluginLoggerPrefix, responseID, processErr)
+		if processErr := plugin.processAccumulatedStream(ctx, requestID); processErr != nil {
+			plugin.logger.Warn("%s Failed to process accumulated stream for request %s: %v", PluginLoggerPrefix, requestID, processErr)
 		}
 	}
 

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -9,9 +9,14 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
+	"github.com/google/uuid"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// directCacheNamespace is a fixed UUID v5 namespace used for deterministic direct cache ID generation.
+// Using a fixed namespace ensures IDs are reproducible across restarts and store types.
+var directCacheNamespace = uuid.MustParse("b1f3c2d4-e5a6-7890-abcd-ef1234567890")
 
 // normalizeText applies consistent normalization to text inputs for better cache hit rates.
 // It converts text to lowercase and trims whitespace to reduce cache misses due to minor variations.
@@ -384,10 +389,12 @@ func (plugin *Plugin) generateDirectCacheID(provider schemas.ModelProvider, mode
 
 	idJSON, err := schemas.MarshalDeeplySorted(idInput)
 	if err != nil {
-		return fmt.Sprintf("direct-%x", xxhash.Sum64String(cacheKey+requestHash+paramsHash+string(provider)+model))
+		// Fallback: derive deterministic UUID from concatenated inputs
+		fallbackData := []byte(cacheKey + requestHash + paramsHash + string(provider) + model)
+		return uuid.NewSHA1(directCacheNamespace, fallbackData).String()
 	}
 
-	return fmt.Sprintf("direct-%x", xxhash.Sum64(idJSON))
+	return uuid.NewSHA1(directCacheNamespace, idJSON).String()
 }
 
 // buildUnifiedMetadata constructs the unified metadata structure for VectorEntry

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -131,6 +131,102 @@ func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest) (string, 
 	return fmt.Sprintf("%x", hash), nil
 }
 
+func (plugin *Plugin) buildRequestMetadataForCaching(req *schemas.BifrostRequest) (map[string]interface{}, error) {
+	metadata := map[string]interface{}{
+		"stream": bifrost.IsStreamRequestType(req.RequestType),
+	}
+
+	switch req.RequestType {
+	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
+		if req.TextCompletionRequest == nil {
+			return nil, fmt.Errorf("text completion payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.TextCompletionRequest != nil && req.TextCompletionRequest.Params != nil {
+			plugin.extractTextCompletionParametersToMetadata(req.TextCompletionRequest.Params, metadata)
+		}
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+		if req.ChatRequest == nil {
+			return nil, fmt.Errorf("chat payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.ChatRequest != nil && req.ChatRequest.Params != nil {
+			plugin.extractChatParametersToMetadata(req.ChatRequest.Params, metadata)
+		}
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
+		if req.ResponsesRequest == nil {
+			return nil, fmt.Errorf("responses payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.ResponsesRequest != nil && req.ResponsesRequest.Params != nil {
+			plugin.extractResponsesParametersToMetadata(req.ResponsesRequest.Params, metadata)
+		}
+	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
+		if req.SpeechRequest == nil {
+			return nil, fmt.Errorf("speech payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.SpeechRequest != nil && req.SpeechRequest.Params != nil {
+			plugin.extractSpeechParametersToMetadata(req.SpeechRequest.Params, metadata)
+		}
+	case schemas.EmbeddingRequest:
+		if req.EmbeddingRequest == nil {
+			return nil, fmt.Errorf("embedding payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.EmbeddingRequest != nil && req.EmbeddingRequest.Params != nil {
+			plugin.extractEmbeddingParametersToMetadata(req.EmbeddingRequest.Params, metadata)
+		}
+	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
+		if req.TranscriptionRequest == nil {
+			return nil, fmt.Errorf("transcription payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.TranscriptionRequest != nil && req.TranscriptionRequest.Params != nil {
+			plugin.extractTranscriptionParametersToMetadata(req.TranscriptionRequest.Params, metadata)
+		}
+	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
+		if req.ImageGenerationRequest == nil {
+			return nil, fmt.Errorf("image generation payload is nil (%s)", describeRequestShape(req))
+		}
+		if req.ImageGenerationRequest != nil && req.ImageGenerationRequest.Params != nil {
+			plugin.extractImageGenerationParametersToMetadata(req.ImageGenerationRequest.Params, metadata)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported request type for semantic caching (%s)", describeRequestShape(req))
+	}
+
+	return metadata, nil
+}
+
+func (plugin *Plugin) computeRequestParamsHash(req *schemas.BifrostRequest) (string, error) {
+	metadata, err := plugin.buildRequestMetadataForCaching(req)
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := getMetadataHash(metadata)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute params hash (%s): %w", describeRequestShape(req), err)
+	}
+	return hash, nil
+}
+
+// describeRequestShape summarizes the request families relevant to semantic
+// cache lookups and diagnostics. It is intentionally scoped to request types
+// that can participate in semantic cache behavior.
+func describeRequestShape(req *schemas.BifrostRequest) string {
+	if req == nil {
+		return "request=nil"
+	}
+
+	return fmt.Sprintf(
+		"request_type=%s text=%t chat=%t responses=%t embedding=%t speech=%t transcription=%t image=%t",
+		req.RequestType,
+		req.TextCompletionRequest != nil,
+		req.ChatRequest != nil,
+		req.ResponsesRequest != nil,
+		req.EmbeddingRequest != nil,
+		req.SpeechRequest != nil,
+		req.TranscriptionRequest != nil,
+		req.ImageGenerationRequest != nil,
+	)
+}
+
 // extractTextForEmbedding extracts meaningful text from different input types for embedding generation.
 // Returns the text to embed and metadata for storage.
 //
@@ -140,44 +236,11 @@ func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest) (string, 
 //
 // Note: Format updated to conditionally include msgType to avoid double colons and maintain consistency.
 func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest) (string, string, error) {
-	metadata := map[string]interface{}{}
-
-	attachments := []string{}
-
-	// Add parameters as metadata if present - handle segregated parameters
-	metadata["stream"] = bifrost.IsStreamRequestType(req.RequestType)
-
-	// Extract parameters based on request type
-	switch req.RequestType {
-	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
-		if req.TextCompletionRequest != nil && req.TextCompletionRequest.Params != nil {
-			plugin.extractTextCompletionParametersToMetadata(req.TextCompletionRequest.Params, metadata)
-		}
-	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
-		if req.ChatRequest != nil && req.ChatRequest.Params != nil {
-			plugin.extractChatParametersToMetadata(req.ChatRequest.Params, metadata)
-		}
-	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
-		if req.ResponsesRequest != nil && req.ResponsesRequest.Params != nil {
-			plugin.extractResponsesParametersToMetadata(req.ResponsesRequest.Params, metadata)
-		}
-	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
-		if req.SpeechRequest != nil && req.SpeechRequest.Params != nil {
-			plugin.extractSpeechParametersToMetadata(req.SpeechRequest.Params, metadata)
-		}
-	case schemas.EmbeddingRequest:
-		if req.EmbeddingRequest != nil && req.EmbeddingRequest.Params != nil {
-			plugin.extractEmbeddingParametersToMetadata(req.EmbeddingRequest.Params, metadata)
-		}
-	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
-		if req.TranscriptionRequest != nil && req.TranscriptionRequest.Params != nil {
-			plugin.extractTranscriptionParametersToMetadata(req.TranscriptionRequest.Params, metadata)
-		}
-	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
-		if req.ImageGenerationRequest != nil && req.ImageGenerationRequest.Params != nil {
-			plugin.extractImageGenerationParametersToMetadata(req.ImageGenerationRequest.Params, metadata)
-		}
+	metadata, err := plugin.buildRequestMetadataForCaching(req)
+	if err != nil {
+		return "", "", err
 	}
+	attachments := []string{}
 
 	switch {
 	case req.TextCompletionRequest != nil:
@@ -355,7 +418,7 @@ func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest) (stri
 		return normalizeText(req.ImageGenerationRequest.Input.Prompt), metadataHash, nil
 
 	default:
-		return "", "", fmt.Errorf("unsupported input type for semantic caching")
+		return "", "", fmt.Errorf("unsupported input type for semantic caching (%s)", describeRequestShape(req))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes direct cache lookups for the semantic cache plugin by using deterministic cache IDs and `GetChunk`-based retrieval for explicit `x-bf-cache-type: direct` requests. This avoids the Redis/Valkey `FT.SEARCH` fallback that degrades into full-keyspace SCAN, adding ~1s overhead on every direct cache lookup.

## Changes

- Added `generateDirectCacheID()` producing a deterministic UUID v5 from request hash, params hash, cache key, and optionally provider/model — accepted by all vector stores (Redis, Qdrant, Pinecone, Weaviate)
- Added `performDirectChunkLookup()` using `GetChunk` (single `HGETALL`) for O(1) key-based retrieval, bypassing `FT.SEARCH` entirely
- Added `requestStorageIDKey` context key to decouple the storage ID from the request UUID, so PostHook stores under the same deterministic ID that PreHook looks up
- Added `StorageID` to `StreamAccumulator` so streaming responses are stored under the correct deterministic ID
- Updated direct-cache routing in `PreLLMHook` to use `performDirectChunkLookup` only when `CacheTypeDirect` is explicitly set; default mode continues using `performDirectSearch`
- Added miss detection for `status code: 404` in `performDirectChunkLookup` to handle stores that return HTTP 404 rather than a Go sentinel error
- Added test coverage for:
  - direct chunk lookup using `GetChunk` (not `GetAll`)
  - default mode not setting `requestStorageIDKey`
  - deterministic ID used end-to-end from PreHook through PostHook storage

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Manual validation performed against local Redis Stack:
```bash
# First request — expect cache miss
curl -s --request POST 'http://localhost:8080/v1/chat/completions' \
  --header 'Content-Type: application/json' \
  --header 'x-bf-cache-key: test-direct-cache-fresh-1' \
  --header 'x-bf-cache-type: direct' \
  --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello1233"}]}' \
  | jq '{latency:.extra_fields.latency, cache:.extra_fields.cache_debug, error:.error}'

sleep 3

# Second request — expect cache hit
curl -s --request POST 'http://localhost:8080/v1/chat/completions' \
  --header 'Content-Type: application/json' \
  --header 'x-bf-cache-key: test-direct-cache-fresh-1' \
  --header 'x-bf-cache-type: direct' \
  --data '{"model":"openai/gpt-4o-mini","messages":[{"role":"user","content":"hello1233"}]}' \
  | jq '{latency:.extra_fields.latency, cache:.extra_fields.cache_debug, error:.error}'
```

**Expected:**
- First request: cache miss, entry stored under deterministic UUID v5 ID
- Second request: `cache_hit: true` with `hit_type: "direct"` and the same deterministic `cache_id`

## Screenshots / Recordings

N/A — backend functionality only.

## Breaking changes

- [ ] Yes
- [x] No

Existing direct-cache entries stored under random UUIDs by default-mode requests will miss on the first explicit `CacheTypeDirect` lookup and be repopulated under the new deterministic ID. This is a one-time cold-start effect per unique request.

## Related issues

Closes #1993

## Security considerations

Deterministic cache IDs are derived from existing request hash inputs and cache parameters using UUID v5 (SHA-1 with a fixed private namespace). No new sensitive data is exposed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable