### PR TITLE
fix: chooser update shortcut test phase

### DIFF
--- a/cli/internal/ui/tui/chooser_test.go
+++ b/cli/internal/ui/tui/chooser_test.go
@@ -60,6 +60,8 @@ func TestChooserUpdateShortcutRequestsUpdate(t *testing.T) {
 	m := newChooserModel(ChooserConfig{
 		UpdateVersion: "v1.2.3",
 	})
+	// Move to a non-text-entry phase so 'y' isn't consumed by the input field.
+	m.phase = phaseSummary
 
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	got := next.(chooserModel)


### PR DESCRIPTION
## Summary
- The phase guard added in #2075 for the `y` update shortcut correctly blocks it during text-entry phases (baseURL, virtualKey, model, worktree)
- However, `TestChooserUpdateShortcutRequestsUpdate` used the default `phaseBaseURL`, causing the `y` key to be consumed by the text input instead of triggering the update
- Sets the test model to `phaseSummary` before sending the key event

## Test plan
- [x] `go test ./cli/internal/ui/tui/` passes
- [x] Full `go test ./cli/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)