### PR TITLE
build fixes for 1.4.12

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1110,6 +1110,35 @@
                   "cel_expression": {
                     "type": "string"
                   },
+                  "targets": {
+                    "type": "array",
+                    "minItems": 1,
+                    "description": "Weighted routing targets. Weights must sum to 1.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "provider": {
+                          "type": "string",
+                          "description": "Target provider name"
+                        },
+                        "model": {
+                          "type": "string",
+                          "description": "Target model name"
+                        },
+                        "key_id": {
+                          "type": "string",
+                          "description": "Optional API key UUID to pin for this target"
+                        },
+                        "weight": {
+                          "type": "number",
+                          "description": "Probability weight for this target (must be > 0, all weights must sum to 1)",
+                          "exclusiveMinimum": 0,
+                          "maximum": 1
+                        }
+                      },
+                      "required": ["weight"]
+                    }
+                  },
                   "provider": {
                     "type": "string"
                   },
@@ -1139,7 +1168,7 @@
                     "additionalProperties": true
                   }
                 },
-                "required": ["id", "name"]
+                "required": ["id", "name", "targets"]
               }
             },
             "authConfig": {

--- a/ui/components/prompts/components/promptsViewHeader.tsx
+++ b/ui/components/prompts/components/promptsViewHeader.tsx
@@ -155,21 +155,13 @@ export default function PromptsViewHeader() {
 
 	return (
 		<div className="flex items-center justify-between border-b px-4 py-3">
-			<div className="flex items-center gap-2 min-w-0">
+			<div className="flex min-w-0 items-center gap-2">
 				<h3 className="truncate font-semibold">
 					{selectedPrompt?.name || "Playground"}
 					{hasChanges && <span className="text-destructive ml-1">*</span>}
 				</h3>
-				{displayVersion && (
-					<Badge variant={"secondary"}>
-						v{displayVersion.version_number}
-					</Badge>
-				)}
-				{hasVersionChanges && versions.length > 0 && (
-					<Badge variant="outline">
-						Unpublished Changes
-					</Badge>
-				)}
+				{displayVersion && <Badge variant={"secondary"}>v{displayVersion.version_number}</Badge>}
+				{hasVersionChanges && versions.length > 0 && <Badge variant="outline">Unpublished Changes</Badge>}
 			</div>
 			<div className="flex shrink-0 items-center gap-4">
 				{messages.length > 1 && (
@@ -214,7 +206,7 @@ export default function PromptsViewHeader() {
 						className: cn("bg-transparent"),
 					}}
 					button={{
-						"data-testid": "header-save-session",
+						dataTestId: "header-save-session",
 						className: "bg-transparent disabled:opacity-100 disabled:text-muted-foreground",
 						disabled: !hasChanges || !canUpdate,
 					}}
@@ -260,7 +252,7 @@ export default function PromptsViewHeader() {
 						className: cn("bg-transparent"),
 					}}
 					button={{
-						"data-testid": "header-commit-version",
+						dataTestId: "header-commit-version",
 						className: "bg-transparent disabled:opacity-100 disabled:text-muted-foreground",
 						disabled: !hasVersionChanges || !canUpdate,
 					}}

--- a/ui/components/ui/button.tsx
+++ b/ui/components/ui/button.tsx
@@ -39,14 +39,16 @@ function Button({
 	asChild = false,
 	children,
 	isLoading = false,
+	dataTestId,
 	...props
 }: React.ComponentProps<"button"> &
 	VariantProps<typeof buttonVariants> & {
 		asChild?: boolean;
 		isLoading?: boolean;
+		dataTestId?: string;
 	}) {
 	return (
-		<BaseButton className={className} variant={variant} size={size} asChild={asChild} {...props}>
+		<BaseButton className={className} variant={variant} size={size} asChild={asChild} dataTestId={dataTestId} {...props}>
 			{isLoading ? <Loader2 className="size-4 animate-spin" /> : children}
 		</BaseButton>
 	);
@@ -57,14 +59,23 @@ function BaseButton({
 	variant,
 	size,
 	asChild = false,
+	dataTestId,
 	...props
 }: React.ComponentProps<"button"> &
 	VariantProps<typeof buttonVariants> & {
 		asChild?: boolean;
+		dataTestId?: string;
 	}) {
 	const Comp = asChild ? Slot : "button";
 
-	return <Comp data-slot="button" className={cn(buttonVariants({ variant, size, className }), "cursor-pointer")} {...props} />;
+	return (
+		<Comp
+			data-slot="button"
+			data-testid={dataTestId}
+			className={cn(buttonVariants({ variant, size, className }), "cursor-pointer")}
+			{...props}
+		/>
+	);
 }
 
 export { Button, buttonVariants };

--- a/ui/components/ui/splitButton.tsx
+++ b/ui/components/ui/splitButton.tsx
@@ -1,16 +1,12 @@
 'use client'
 
-import { Content } from '@radix-ui/react-dropdown-menu'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { Check, ChevronDown, Loader2 } from 'lucide-react'
-import React, { MouseEventHandler, useCallback, useRef, useState } from 'react'
-import { cn } from '@/lib/utils'
-import { Button, buttonVariants } from './button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from './dropdownMenu'
+import { cn } from "@/lib/utils";
+import { Content } from "@radix-ui/react-dropdown-menu";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Check, ChevronDown, Loader2 } from "lucide-react";
+import React, { MouseEventHandler, useCallback, useRef, useState } from "react";
+import { Button, buttonVariants } from "./button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "./dropdownMenu";
 
 export const splitButtonVariants = cva(
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium',
@@ -33,159 +29,127 @@ export const splitButtonVariants = cva(
   }
 )
 
-export interface SplitButtonProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>,
-    VariantProps<typeof splitButtonVariants> {
-  button?: Omit<
-    React.ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>,
-    'children' | 'onClick'
-  >
-  dropdownTrigger?: Omit<
-    React.ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>,
-    'onClick'
-  >
-  dropdownContent: React.ComponentPropsWithoutRef<typeof Content> & {
-    open?: boolean
-    onOpenChange?: (open: boolean) => void
-  }
-  disabled?: boolean
-  isLoading?: boolean
-  onClick?: MouseEventHandler<HTMLButtonElement>
-  disabledCheck?: boolean
+export interface SplitButtonProps extends Omit<React.HTMLAttributes<HTMLDivElement>, "onClick">, VariantProps<typeof splitButtonVariants> {
+	button?: Omit<React.ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>, "children" | "onClick"> & {
+		dataTestId?: string;
+	};
+	dropdownTrigger?: Omit<React.ButtonHTMLAttributes<HTMLButtonElement> & VariantProps<typeof buttonVariants>, "onClick"> & {
+		dataTestId?: string;
+	};
+	dropdownContent: React.ComponentPropsWithoutRef<typeof Content> & {
+		open?: boolean;
+		onOpenChange?: (open: boolean) => void;
+	};
+	disabled?: boolean;
+	isLoading?: boolean;
+	onClick?: MouseEventHandler<HTMLButtonElement>;
+	disabledCheck?: boolean;
 }
 
 const a11yClasses =
-  'ring-offset-background focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50'
+	"ring-offset-background focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:pointer-events-none disabled:opacity-50";
 
 export const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
-  (
-    {
-      className,
-      variant,
-      size,
-      children,
-      button,
-      dropdownContent,
-      dropdownTrigger,
-      disabled,
-      isLoading,
-      onClick,
-      disabledCheck,
-      ...props
-    },
-    ref
-  ) => {
-    const [clicked, setClicked] = useState(false)
-    const [contentWidth, setContentWidth] = useState(0)
-    const [open, setOpen] = useState(false)
-    const buttonRef = useRef<HTMLButtonElement | null>(null)
+	(
+		{ className, variant, size, children, button, dropdownContent, dropdownTrigger, disabled, isLoading, onClick, disabledCheck, ...props },
+		ref,
+	) => {
+		const [clicked, setClicked] = useState(false);
+		const [contentWidth, setContentWidth] = useState(0);
+		const [open, setOpen] = useState(false);
+		const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-    const memoizedRefCallback = useCallback(
-      (el: HTMLButtonElement | null) => {
-        if (!clicked && el) {
-          setContentWidth(el.clientWidth)
-        }
-        buttonRef.current = el
-      },
-      [clicked]
-    )
+		const memoizedRefCallback = useCallback(
+			(el: HTMLButtonElement | null) => {
+				if (!clicked && el) {
+					setContentWidth(el.clientWidth);
+				}
+				buttonRef.current = el;
+			},
+			[clicked],
+		);
 
-    const {
-      className: buttonClassName,
-      variant: buttonVariant,
-      disabled: buttonDisabled,
-      ...buttonProps
-    } = button ?? {}
-    const {
-      className: dropdownTriggerClassName,
-      variant: dropdownTriggerVariant,
-      children: dropdownTriggerChildren,
-      disabled: dropdownTriggerDisabled,
-      ...dropdownTriggerProps
-    } = dropdownTrigger ?? {}
-    const {
-      className: dropdownContentClassName,
-      open: dropdownContentOpen,
-      onOpenChange: dropdownContentOnOpenChange,
-      align: dropdownContentAlign,
-      ...dropdownContentProps
-    } = dropdownContent ?? {}
+		const { className: buttonClassName, variant: buttonVariant, disabled: buttonDisabled, ...buttonProps } = button ?? {};
+		const {
+			className: dropdownTriggerClassName,
+			variant: dropdownTriggerVariant,
+			children: dropdownTriggerChildren,
+			disabled: dropdownTriggerDisabled,
+			dataTestId: dropdownTriggerDataTestId,
+			...dropdownTriggerProps
+		} = dropdownTrigger ?? {};
+		const {
+			className: dropdownContentClassName,
+			open: dropdownContentOpen,
+			onOpenChange: dropdownContentOnOpenChange,
+			align: dropdownContentAlign,
+			...dropdownContentProps
+		} = dropdownContent ?? {};
 
-    return (
-      <div
-        className={cn(splitButtonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      >
-        <Button
-          ref={memoizedRefCallback}
-          className={cn(
-            'h-full rounded-r-none border active:scale-100',
-            a11yClasses,
-            clicked ? 'disabled:opacity-100' : '',
-            buttonClassName ?? ''
-          )}
-          variant={buttonVariant ?? 'outline'}
-          disabled={buttonDisabled || disabled || clicked || isLoading}
-          onClick={async (e) => {
-            if (onClick) {
-              try {
-                await onClick(e)
-                if (!disabledCheck) {
-                  setClicked(true)
-                  setTimeout(() => setClicked(false), 1000)
-                }
-              } catch (err) {
-                throw err
-              }
-            }
-          }}
-          {...buttonProps}
-        >
-          {clicked ? (
-            <div
-              style={{ width: contentWidth - 24 }}
-              className="flex items-center justify-center"
-            >
-              <Check className="h-4 w-4" />
-            </div>
-          ) : isLoading ? (
-            <div
-              style={{ width: contentWidth - 24 }}
-              className="flex items-center justify-center"
-            >
-              <Loader2 className="h-4 w-4 animate-spin" />
-            </div>
-          ) : (
-            children
-          )}
-        </Button>
-        <DropdownMenu
-          open={dropdownContentOpen ?? open}
-          onOpenChange={dropdownContentOnOpenChange ?? setOpen}
-        >
-          <DropdownMenuTrigger asChild>
-            <Button
-              className={cn(
-                'h-full w-[32px] shrink-0 rounded-l-none border border-l-0 p-0 active:scale-100',
-                a11yClasses,
-                dropdownTriggerClassName ?? ''
-              )}
-              variant={dropdownTriggerVariant ?? 'outline'}
-              disabled={dropdownTriggerDisabled || disabled || isLoading}
-              {...dropdownTriggerProps}
-            >
-              {dropdownTriggerChildren ?? <ChevronDown className="h-4 w-4" />}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className={cn(dropdownContentClassName ?? '')}
-            align={dropdownContentAlign ?? 'end'}
-            {...dropdownContentProps}
-          />
-        </DropdownMenu>
-      </div>
-    )
-  }
-)
+		return (
+			<div className={cn(splitButtonVariants({ variant, size, className }))} ref={ref} {...props}>
+				<Button
+					ref={memoizedRefCallback}
+					className={cn(
+						"h-full rounded-r-none border active:scale-100",
+						a11yClasses,
+						clicked ? "disabled:opacity-100" : "",
+						buttonClassName ?? "",
+					)}
+					dataTestId={buttonProps.dataTestId}
+					variant={buttonVariant ?? "outline"}
+					disabled={buttonDisabled || disabled || clicked || isLoading}
+					onClick={async (e) => {
+						if (onClick) {
+							try {
+								await onClick(e);
+								if (!disabledCheck) {
+									setClicked(true);
+									setTimeout(() => setClicked(false), 1000);
+								}
+							} catch (err) {
+								throw err;
+							}
+						}
+					}}
+					{...buttonProps}
+				>
+					{clicked ? (
+						<div style={{ width: contentWidth - 24 }} className="flex items-center justify-center">
+							<Check className="h-4 w-4" />
+						</div>
+					) : isLoading ? (
+						<div style={{ width: contentWidth - 24 }} className="flex items-center justify-center">
+							<Loader2 className="h-4 w-4 animate-spin" />
+						</div>
+					) : (
+						children
+					)}
+				</Button>
+				<DropdownMenu open={dropdownContentOpen ?? open} onOpenChange={dropdownContentOnOpenChange ?? setOpen}>
+					<DropdownMenuTrigger asChild>
+						<Button
+							className={cn(
+								"h-full w-[32px] shrink-0 rounded-l-none border border-l-0 p-0 active:scale-100",
+								a11yClasses,
+								dropdownTriggerClassName ?? "",
+							)}
+							variant={dropdownTriggerVariant ?? "outline"}
+							disabled={dropdownTriggerDisabled || disabled || isLoading}
+							{...dropdownTriggerProps}
+							dataTestId={dropdownTriggerDataTestId}
+						>
+							{dropdownTriggerChildren ?? <ChevronDown className="h-4 w-4" />}
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent
+						className={cn(dropdownContentClassName ?? "")}
+						align={dropdownContentAlign ?? "end"}
+						{...dropdownContentProps}
+					/>
+				</DropdownMenu>
+			</div>
+		);
+	},
+);
 SplitButton.displayName = 'SplitButton'


### PR DESCRIPTION
## Summary

Adds weighted routing targets configuration to the Bifrost Helm chart schema and improves UI component test attributes for better testability.

## Changes

- Added `targets` array schema to Bifrost values with weighted routing configuration including provider, model, key_id, and weight properties
- Made `targets` a required field alongside existing `id` and `name` requirements
- Added `dataTestId` prop support to Button and SplitButton components for improved test targeting
- Replaced hardcoded `data-testid` attributes with the new `dataTestId` prop in prompts header
- Applied code formatting improvements to UI components (import organization, spacing)

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] UI (Next.js)

## How to test

Validate the Helm chart schema changes:
```sh
# Validate schema with targets configuration
helm template bifrost ./helm-charts/bifrost --values test-values.yaml
```

Test UI component changes:
```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify test attributes are properly applied to buttons in the prompts interface.

## Breaking changes

- [x] Yes

The `targets` field is now required in Bifrost configuration. Existing configurations must be updated to include at least one target with appropriate weight values that sum to 1.

## Security considerations

The weighted routing targets include optional `key_id` fields for API key pinning, which should be handled securely and validated against authorized key UUIDs.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable