### PR TITLE
fixes mintlify changelog flow for OSS

### DIFF
--- a/.github/workflows/scripts/push-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-mintlify-changelog.sh
@@ -179,9 +179,16 @@ if ! grep -q "\"$route\"" docs/docs.json; then
       process.exit(1);
     }
     
+    // Find the Open Source menu item
+    const openSourceItem = changelogsTab.menu?.find(item => item.item === 'Open Source');
+    if (!openSourceItem) {
+      console.error('Open Source menu item not found in Changelogs tab');
+      process.exit(1);
+    }
+    
     // Get all top-level entries and existing groups
-    const topLevelEntries = changelogsTab.pages.filter(p => typeof p === 'string');
-    const existingGroups = changelogsTab.pages.filter(p => typeof p === 'object');
+    const topLevelEntries = openSourceItem.pages.filter(p => typeof p === 'string');
+    const existingGroups = openSourceItem.pages.filter(p => typeof p === 'object');
     
     // Check if we need to group existing top-level entries
     if (topLevelEntries.length > 0) {
@@ -217,27 +224,27 @@ if ! grep -q "\"$route\"" docs/docs.json; then
         console.log(\`✅ Created \${topLevelMonth} group with \${topLevelEntries.length} entries (sorted)\`);
         
         // Clear top-level entries (they're now in the group)
-        changelogsTab.pages = existingGroups;
+        openSourceItem.pages = existingGroups;
       } else {
         console.log(\`📋 Same month (\${releaseMonthYear}), keeping existing top-level entries\`);
         // Keep existing structure (top-level entries + groups)
-        changelogsTab.pages = [...topLevelEntries, ...existingGroups];
+        openSourceItem.pages = [...topLevelEntries, ...existingGroups];
       }
     }
     
     const newRoute = '$route';
     
     // Add the new changelog at the top level
-    changelogsTab.pages.unshift(newRoute);
+    openSourceItem.pages.unshift(newRoute);
     console.log(\`✅ Added \${newRoute} to top level\`);
     
     // Sort the top-level pages array by semver
-    const topLevelPages = changelogsTab.pages.filter(p => typeof p === 'string');
-    const groupPages = changelogsTab.pages.filter(p => typeof p === 'object');
+    const topLevelPages = openSourceItem.pages.filter(p => typeof p === 'string');
+    const groupPages = openSourceItem.pages.filter(p => typeof p === 'object');
     
     if (topLevelPages.length > 0) {
       const sortedTopLevel = sortPagesBySemver(topLevelPages);
-      changelogsTab.pages = [...sortedTopLevel, ...groupPages];
+      openSourceItem.pages = [...sortedTopLevel, ...groupPages];
       console.log(\`✅ Sorted \${topLevelPages.length} top-level pages by semver\`);
     }
     

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -429,6 +429,7 @@
             "item": "Open Source",
             "icon": "rocket",
             "pages": [
+              "changelogs/v1.4.12",
               "changelogs/v1.4.11",
               "changelogs/v1.4.10",
               {


### PR DESCRIPTION
## Summary

Updates the changelog management script to organize changelog entries under the "Open Source" submenu instead of directly under the main "Changelogs" tab, and adds the new v1.4.12 changelog entry.

## Changes

- Modified the push-mintlify-changelog.sh script to target the "Open Source" menu item within the Changelogs tab for adding new changelog entries
- Added error handling to ensure the "Open Source" menu item exists before attempting to modify it
- Updated all references from `changelogsTab.pages` to `openSourceItem.pages` to reflect the new nested structure
- Added v1.4.12 changelog entry to the Open Source section in docs.json

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the changelog script correctly adds new entries to the Open Source submenu:

```sh
# Test the changelog script
.github/workflows/scripts/push-mintlify-changelog.sh

# Verify docs.json structure is valid
cat docs/docs.json | jq '.tabs[] | select(.tab == "Changelogs") | .menu[] | select(.item == "Open Source")'
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a documentation structure change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable