### PR TITLE
feat: improve message UI with JSON editor, smaller icons, and better scroll behavior

### DIFF
--- a/ui/components/prompts/components/messagesView/assistantMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/assistantMessageView.tsx
@@ -83,12 +83,12 @@ export function AssistantMessageView({
 					)}
 					{!disabled && !isStreaming && (
 						<button type="button" aria-label="Edit message" data-testid="assistant-msg-edit" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 					{!disabled && onRemove && (
 						<button type="button" aria-label="Delete message" data-testid="assistant-msg-delete" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+							<XIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 				</div>
@@ -136,6 +136,10 @@ export function AssistantMessageView({
 							jsonBufferRef.current = value ?? "";
 						}}
 						onBlur={flushJsonBuffer}
+						options={{
+							showIndentLines: false,
+							disableHover: true,
+						}}
 					/>
 				) : (
 					<div

--- a/ui/components/prompts/components/messagesView/errorMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/errorMessageView.tsx
@@ -12,7 +12,7 @@ export default function ErrorMessageView({ message, disabled, onRemove }: { mess
 				<div className="ml-auto">
 					{!disabled && onRemove && (
 						<button type="button" aria-label="Delete message" data-testid="error-msg-delete" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+							<XIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 				</div>

--- a/ui/components/prompts/components/messagesView/rootMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/rootMessageView.tsx
@@ -16,7 +16,9 @@ export function MessagesView() {
 
 	useEffect(() => {
 		const lastId = messages[messages.length - 1]?.id;
-		const shouldScroll = messages.length !== prevLengthRef.current || lastId !== prevLastIdRef.current;
+		const grew = messages.length > prevLengthRef.current;
+		const lastChanged = lastId !== prevLastIdRef.current;
+		const shouldScroll = grew || (lastChanged && messages.length >= prevLengthRef.current);
 		prevLengthRef.current = messages.length;
 		prevLastIdRef.current = lastId;
 		if (shouldScroll) {

--- a/ui/components/prompts/components/messagesView/systemMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/systemMessageView.tsx
@@ -2,7 +2,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { Message, SerializedMessage } from "@/lib/message";
 import { PencilIcon, XIcon } from "lucide-react";
 import { Markdown } from "@/components/ui/markdown";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { isJson } from "@/lib/utils/validation";
+import { CodeEditor } from "@/components/ui/codeEditor";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 import { RichTextarea } from "@/components/ui/custom/richTextarea";
 import { JINJA_VAR_HIGHLIGHT_PATTERNS, JINJA_VAR_REGEX } from "@/lib/message/constant";
@@ -20,11 +22,40 @@ export function SystemMessageView({
 }) {
 	const [editMode, setEditMode] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const messageRef = useRef(message);
+	messageRef.current = message;
 	const pendingCursorRef = useRef<number | null>(null);
 	const content = message.content;
 	const isEmpty = !content;
 	const hasVariables = JINJA_VAR_REGEX.test(content);
 	JINJA_VAR_REGEX.lastIndex = 0;
+	const jsonBufferRef = useRef<string | null>(null);
+	const contentIsJson = useMemo(() => !isEmpty && isJson(content), [content, isEmpty]);
+	const formattedJson = useMemo(() => {
+		if (!contentIsJson) return "";
+		try {
+			return JSON.stringify(JSON.parse(content), null, 2);
+		} catch {
+			return content;
+		}
+	}, [content, contentIsJson]);
+
+	const applyPendingJsonBuffer = (msg: Message): Message => {
+		if (jsonBufferRef.current !== null) {
+			const clone = msg.clone();
+			clone.content = jsonBufferRef.current;
+			jsonBufferRef.current = null;
+			return clone;
+		}
+		return msg;
+	};
+
+	const flushJsonBuffer = () => {
+		const updated = applyPendingJsonBuffer(messageRef.current);
+		if (updated !== messageRef.current) {
+			onChange(updated.serialized);
+		}
+	};
 
 	useEffect(() => {
 		const handleClick = (e: MouseEvent) => {
@@ -37,7 +68,8 @@ export function SystemMessageView({
 	}, []);
 
 	const handleRoleChange = (role: string) => {
-		const clone = message.clone();
+		const latest = applyPendingJsonBuffer(messageRef.current);
+		const clone = latest.clone();
 		clone.role = role as any;
 		onChange(clone.serialized);
 	};
@@ -67,12 +99,12 @@ export function SystemMessageView({
 				<div className="ml-auto flex items-center gap-0.5 h-5">
 					{!disabled && (
 						<button type="button" aria-label="Edit message" data-testid="system-msg-edit" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 					{!disabled && onRemove && (
 						<button type="button" aria-label="Delete message" data-testid="system-msg-delete" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+							<XIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 				</div>
@@ -99,6 +131,22 @@ export function SystemMessageView({
 					/>
 				) : isEmpty ? (
 					<div className="text-muted-foreground min-h-[20px] text-sm italic">Enter system message...</div>
+				) : contentIsJson ? (
+					<CodeEditor
+						wrap
+						code={formattedJson}
+						lang="json"
+						readonly={disabled}
+						autoResize
+						onChange={(value) => {
+							jsonBufferRef.current = value ?? "";
+						}}
+						options={{
+							showIndentLines: false,
+							disableHover: true,
+						}}
+						onBlur={flushJsonBuffer}
+					/>
 				) : hasVariables ? (
 					<RichTextarea
 						readOnly

--- a/ui/components/prompts/components/messagesView/toolCallResultView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallResultView.tsx
@@ -1,7 +1,9 @@
 import { Textarea } from "@/components/ui/textarea";
 import { Message, MessageRole, SerializedMessage } from "@/lib/message";
+import { isJson } from "@/lib/utils/validation";
+import { CodeEditor } from "@/components/ui/codeEditor";
 import { PencilIcon, XIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 
 export default function ToolResultMessageView({
@@ -17,7 +19,37 @@ export default function ToolResultMessageView({
 }) {
 	const [editMode, setEditMode] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const messageRef = useRef(message);
+	messageRef.current = message;
 	const content = message.content;
+	const isEmpty = !content;
+	const jsonBufferRef = useRef<string | null>(null);
+	const contentIsJson = useMemo(() => !isEmpty && isJson(content), [content, isEmpty]);
+	const formattedJson = useMemo(() => {
+		if (!contentIsJson) return "";
+		try {
+			return JSON.stringify(JSON.parse(content), null, 2);
+		} catch {
+			return content;
+		}
+	}, [content, contentIsJson]);
+
+	const applyPendingJsonBuffer = (msg: Message): Message => {
+		if (jsonBufferRef.current !== null) {
+			const clone = msg.clone();
+			clone.content = jsonBufferRef.current;
+			jsonBufferRef.current = null;
+			return clone;
+		}
+		return msg;
+	};
+
+	const flushJsonBuffer = () => {
+		const updated = applyPendingJsonBuffer(messageRef.current);
+		if (updated !== messageRef.current) {
+			onChange(updated.serialized);
+		}
+	};
 
 	useEffect(() => {
 		const handleClick = (e: MouseEvent) => {
@@ -30,7 +62,8 @@ export default function ToolResultMessageView({
 	}, []);
 
 	const handleRoleChange = (role: string) => {
-		const clone = message.clone();
+		const latest = applyPendingJsonBuffer(messageRef.current);
+		const clone = latest.clone();
 		clone.role = role as any;
 		onChange(clone.serialized);
 	};
@@ -39,18 +72,18 @@ export default function ToolResultMessageView({
 		<div className="group hover:border-border focus-within:border-border rounded-sm border border-transparent px-3 py-2 transition-colors" ref={containerRef}>
 			<div className="mb-1 flex items-center">
 				<MessageRoleSwitcher role={message.role ?? MessageRole.ASSISTANT} disabled={disabled} onRoleChange={handleRoleChange} />
-				<div className="ml-auto flex items-center gap-0.5 overflow-x-auto max-w-1/2 h-5">
+				<div className="ml-auto flex items-center gap-0.5 h-5">
 					{message.toolCallId && (
-						<span className="text-muted-foreground ml-4 truncate font-mono text-xs">{message.toolCallId}</span>
+						<span className="text-muted-foreground ml-4 truncate max-w-[200px] font-mono text-xs">{message.toolCallId}</span>
 					)}
 					{!disabled && (
 						<button type="button" aria-label="Edit message" data-testid="tool-result-msg-edit" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 					{!disabled && onRemove && (
 						<button type="button" aria-label="Delete message" data-testid="tool-result-msg-delete" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+							<XIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 				</div>
@@ -69,9 +102,34 @@ export default function ToolResultMessageView({
 						}}
 						onBlur={() => setEditMode(false)}
 					/>
+				) : isEmpty ? (
+					<div className="text-muted-foreground min-h-[20px] font-mono text-sm italic">Enter tool result...</div>
+				) : contentIsJson ? (
+					<CodeEditor
+						wrap
+						code={formattedJson}
+						lang="json"
+						readonly={disabled}
+						autoResize
+						onChange={(value) => {
+							jsonBufferRef.current = value ?? "";
+						}}
+						options={{
+							showIndentLines: false,
+							disableHover: true,
+						}}
+						onBlur={flushJsonBuffer}
+					/>
 				) : (
-					<div className="text-muted-foreground min-h-[20px] font-mono text-sm whitespace-pre-wrap">
-						{content || <span className="text-muted-foreground italic">Enter tool result...</span>}
+					<div
+						className={!disabled ? "cursor-text" : undefined}
+						onClick={() => {
+							if (!disabled) setEditMode(true);
+						}}
+					>
+						<div className="text-muted-foreground min-h-[20px] font-mono text-sm whitespace-pre-wrap">
+							{content}
+						</div>
 					</div>
 				)}
 			</div>

--- a/ui/components/prompts/components/messagesView/toolCallView.tsx
+++ b/ui/components/prompts/components/messagesView/toolCallView.tsx
@@ -1,8 +1,10 @@
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Message, SerializedMessage } from "@/lib/message";
+import { isJson } from "@/lib/utils/validation";
+import { CodeEditor } from "@/components/ui/codeEditor";
 import { Wrench, XIcon } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 
 export default function ToolCallMessageView({
@@ -22,9 +24,39 @@ export default function ToolCallMessageView({
 }) {
 	const toolCalls = message.toolCalls ?? [];
 	const [responses, setResponses] = useState<Record<string, string>>({});
+	const messageRef = useRef(message);
+	messageRef.current = message;
+	const jsonBufferRef = useRef<Record<string, string>>({});
+
+	const applyPendingJsonBuffers = (msg: Message): Message => {
+		const keys = Object.keys(jsonBufferRef.current);
+		if (keys.length === 0) return msg;
+		const clone = msg.clone();
+		for (const toolCallId of keys) {
+			const tc = clone.toolCalls?.find((t) => t.id === toolCallId);
+			if (tc) {
+				tc.function.arguments = jsonBufferRef.current[toolCallId];
+			}
+		}
+		jsonBufferRef.current = {};
+		return clone;
+	};
+
+	const flushJsonBuffer = (toolCallId: string) => {
+		if (jsonBufferRef.current[toolCallId] !== undefined) {
+			const clone = messageRef.current.clone();
+			const tc = clone.toolCalls?.find((t) => t.id === toolCallId);
+			if (tc) {
+				tc.function.arguments = jsonBufferRef.current[toolCallId];
+				onChange(clone.serialized);
+			}
+			delete jsonBufferRef.current[toolCallId];
+		}
+	};
 
 	const handleRoleChange = (role: string) => {
-		const clone = message.clone();
+		const latest = applyPendingJsonBuffers(messageRef.current);
+		const clone = latest.clone();
 		clone.role = role as any;
 		onChange(clone.serialized);
 	};
@@ -51,28 +83,51 @@ export default function ToolCallMessageView({
 				<div className="ml-auto h-5">
 					{!disabled && onRemove && (
 							<button type="button" aria-label="Delete message" data-testid="tool-call-msg-delete" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+							<XIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 				</div>
 			</div>
 			<div className="space-y-2">
 				{toolCalls.map((tc) => {
+					const argsIsJson = isJson(tc.function.arguments);
 					let formattedArgs = tc.function.arguments;
-					try {
-						formattedArgs = JSON.stringify(JSON.parse(tc.function.arguments), null, 2);
-					} catch {
-						// keep raw string if not valid JSON
+					if (argsIsJson) {
+						try {
+							formattedArgs = JSON.stringify(JSON.parse(tc.function.arguments), null, 2);
+						} catch {
+							// keep raw string
+						}
 					}
 					return (
-						<div key={tc.id} className="bg-muted/50 rounded-sm border px-3 py-2">
+						<div key={tc.id} className="bg-muted/50 rounded-sm border px-3 py-2 mt-2">
 							<div className="flex items-center gap-2">
 								<Wrench className="text-muted-foreground h-3 w-3 shrink-0" />
 								<span className="font-mono text-xs font-medium shrink-0 mr-4">{tc.function.name}</span>
 								<span className="text-muted-foreground ml-auto font-mono text-[10px] truncate">{tc.id}</span>
 							</div>
 							{formattedArgs && (
-								<pre className="text-muted-foreground mt-2 overflow-x-auto rounded bg-black/5 p-2 text-xs leading-relaxed dark:bg-white/5">{formattedArgs}</pre>
+								argsIsJson ? (
+									<div className="mt-2">
+										<CodeEditor
+											wrap
+											code={formattedArgs}
+											lang="json"
+											readonly={disabled}
+											autoResize
+											onChange={(value) => {
+												jsonBufferRef.current[tc.id] = value ?? "";
+											}}
+											options={{
+												showIndentLines: false,
+												disableHover: true,
+											}}
+											onBlur={() => flushJsonBuffer(tc.id)}
+										/>
+									</div>
+								) : (
+									<pre className="text-muted-foreground mt-2 overflow-x-auto rounded bg-card p-2 text-xs leading-relaxed">{formattedArgs}</pre>
+								)
 							)}
 							{!disabled && onSubmitToolResult && !respondedToolCallIds?.has(tc.id) && (
 								<div className="mt-2 border-t pt-2">

--- a/ui/components/prompts/components/messagesView/userMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/userMessageView.tsx
@@ -2,12 +2,14 @@ import { Textarea } from "@/components/ui/textarea";
 import { Message, SerializedMessage, type MessageContent } from "@/lib/message";
 import { FileIcon, Mic, Paperclip, PencilIcon, XIcon } from "lucide-react";
 import { Markdown } from "@/components/ui/markdown";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
 import { fileToAttachment } from "../../utils/attachment";
 import { RichTextarea } from "@/components/ui/custom/richTextarea";
 import { JINJA_VAR_HIGHLIGHT_PATTERNS, JINJA_VAR_REGEX } from "@/lib/message/constant";
 import { AttachmentDisplay } from "./attachmentViews";
+import { isJson } from "@/lib/utils/validation";
+import { CodeEditor } from "@/components/ui/codeEditor";
 
 export function UserMessageView({
 	message,
@@ -34,6 +36,33 @@ export function UserMessageView({
 	const canAttach = supportsVision && !disabled;
 	const hasVariables = JINJA_VAR_REGEX.test(content);
 	JINJA_VAR_REGEX.lastIndex = 0;
+	const jsonBufferRef = useRef<string | null>(null);
+	const contentIsJson = useMemo(() => !isEmpty && isJson(content), [content, isEmpty]);
+	const formattedJson = useMemo(() => {
+		if (!contentIsJson) return "";
+		try {
+			return JSON.stringify(JSON.parse(content), null, 2);
+		} catch {
+			return content;
+		}
+	}, [content, contentIsJson]);
+
+	const applyPendingJsonBuffer = (msg: Message): Message => {
+		if (jsonBufferRef.current !== null) {
+			const clone = msg.clone();
+			clone.content = jsonBufferRef.current;
+			jsonBufferRef.current = null;
+			return clone;
+		}
+		return msg;
+	};
+
+	const flushJsonBuffer = () => {
+		const updated = applyPendingJsonBuffer(messageRef.current);
+		if (updated !== messageRef.current) {
+			onChange(updated.serialized);
+		}
+	};
 
 	useEffect(() => {
 		const handleClick = (e: MouseEvent) => {
@@ -46,14 +75,15 @@ export function UserMessageView({
 	}, []);
 
 	const handleRoleChange = (role: string) => {
-		const clone = message.clone();
+		const latest = applyPendingJsonBuffer(messageRef.current);
+		const clone = latest.clone();
 		clone.role = role as any;
 		onChange(clone.serialized);
 	};
 
 	const addAttachments = useCallback(
 		(newAttachments: MessageContent[]) => {
-			const latest = messageRef.current;
+			const latest = applyPendingJsonBuffer(messageRef.current);
 			const clone = latest.clone();
 			clone.attachments = [...latest.attachments, ...newAttachments];
 			onChange(clone.serialized);
@@ -63,8 +93,9 @@ export function UserMessageView({
 
 	const handleRemoveAttachment = useCallback(
 		(index: number) => {
-			const clone = message.clone();
-			clone.attachments = message.attachments.filter((_, i) => i !== index);
+			const latest = applyPendingJsonBuffer(messageRef.current);
+			const clone = latest.clone();
+			clone.attachments = latest.attachments.filter((_, i) => i !== index);
 			onChange(clone.serialized);
 		},
 		[message, onChange],
@@ -185,12 +216,12 @@ export function UserMessageView({
 					)}
 					{!disabled && (
 						<button type="button" aria-label="Edit message" data-testid="user-msg-edit" onClick={() => setEditMode(true)} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<PencilIcon className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-pointer" />
+							<PencilIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 					{!disabled && onRemove && (
 						<button type="button" aria-label="Delete message" data-testid="user-msg-delete" onClick={onRemove} className="rounded-sm p-1 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-muted focus:bg-muted focus:opacity-100">
-							<XIcon className="text-muted-foreground hover:text-foreground h-4 w-4 shrink-0 cursor-pointer" />
+							<XIcon className="text-muted-foreground hover:text-foreground h-3 w-3 shrink-0 cursor-pointer" />
 						</button>
 					)}
 				</div>
@@ -217,6 +248,22 @@ export function UserMessageView({
 					/>
 				) : isEmpty && messageAttachments.length === 0 ? (
 					<div className="text-muted-foreground min-h-[20px] text-sm italic">Enter user message...</div>
+				) : contentIsJson ? (
+					<CodeEditor
+						wrap
+						code={formattedJson}
+						lang="json"
+						readonly={disabled}
+						autoResize
+						onChange={(value) => {
+							jsonBufferRef.current = value ?? "";
+						}}
+						options={{
+							showIndentLines: false,
+							disableHover: true,
+						}}
+						onBlur={flushJsonBuffer}
+					/>
 				) : hasVariables ? (
 					<RichTextarea
 						readOnly

--- a/ui/components/prompts/components/promptsViewHeader.tsx
+++ b/ui/components/prompts/components/promptsViewHeader.tsx
@@ -304,12 +304,12 @@ function SessionItem({
 
 	if (isEditing) {
 		return (
-			<div className="px-2 py-1.5" onKeyDown={(e) => e.stopPropagation()}>
+			<div className="flex items-center gap-2 rounded-sm px-2 py-1.5" onKeyDown={(e) => e.stopPropagation()}>
 				<Input
 					ref={inputRef}
 					defaultValue={session.name}
 					placeholder="Session name"
-					className="h-7 text-sm"
+					className="h-auto border-none bg-transparent p-0 text-sm shadow-none focus-visible:border-none focus-visible:ring-0"
 					data-testid="session-rename-input"
 					autoFocus
 					onKeyDown={(e) => {
@@ -326,7 +326,7 @@ function SessionItem({
 		<CommandItem
 			value={`${session.id}-${dateLabel}-${session.name}`}
 			onSelect={onSelect}
-			className="group/item flex items-center justify-between gap-2"
+			className="group/item flex items-center justify-between gap-2 py-1"
 		>
 			<div className="flex min-w-0 flex-col">
 				<span className="truncate text-sm">

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -155,7 +155,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	}, []);
 	const [provider, setProvider] = useState("");
 	const [model, setModel] = useState("");
-	const [modelParams, setModelParams] = useState<ModelParams>({});
+	const [modelParams, setModelParams] = useState<ModelParams>({ stream: true });
 	const [apiKeyId, setApiKeyId] = useState("__auto__");
 	const [isStreaming, setIsStreaming] = useState(false);
 	const activeRunRef = useRef<symbol | null>(null);
@@ -205,7 +205,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 
 		const loadFromParams = (params: ModelParams, prov: string, mod: string) => {
 			const { api_key_id, ...rest } = params || ({} as ModelParams);
-			setModelParams(rest);
+			setModelParams({ stream: true, ...rest });
 			setApiKeyId(api_key_id || "__auto__");
 			setProvider(prov || "");
 			setModel(mod || "");
@@ -246,7 +246,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			setMessages([Message.system("")]);
 			setProvider("");
 			setModel("");
-			setModelParams({});
+			setModelParams({ stream: true });
 			setApiKeyId("__auto__");
 		}
 	}, [selectedSession, selectedVersion, selectedPrompt, selectedSessionId, selectedVersionId, setUrlState, isSessionsLoading, sessions.length]);
@@ -275,7 +275,14 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const currentApiKeyId = apiKeyId !== "__auto__" ? apiKeyId : undefined;
 			if (currentApiKeyId !== (refApiKeyId || undefined)) return true;
 
-			if (JSON.stringify(modelParams, Object.keys(modelParams).sort()) !== JSON.stringify(refParamsRest, Object.keys(refParamsRest).sort()))
+			// Normalize: treat missing stream as stream: true so legacy params without stream don't appear changed
+			const normalizeParams = (p: ModelParams): ModelParams => {
+				const { stream = true, ...rest } = p;
+				return { stream, ...rest };
+			};
+			const normalizedCurrent = normalizeParams(modelParams);
+			const normalizedRef = normalizeParams(refParamsRest);
+			if (JSON.stringify(normalizedCurrent, Object.keys(normalizedCurrent).sort()) !== JSON.stringify(normalizedRef, Object.keys(normalizedRef).sort()))
 				return true;
 
 			const currentSerialized = Message.serializeAll(messages);
@@ -342,7 +349,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			setMessages([Message.system("")]);
 			setProvider("");
 			setModel("");
-			setModelParams({});
+			setModelParams({ stream: true });
 			setApiKeyId("__auto__");
 			setUrlState({ promptId: id, sessionId: null, versionId: null });
 		},

--- a/ui/components/prompts/fragments/playgroundPanel.tsx
+++ b/ui/components/prompts/fragments/playgroundPanel.tsx
@@ -1,14 +1,11 @@
 import { ScrollArea } from "@/components/ui/scrollArea";
-import { useRef } from "react";
 import { MessagesView } from "../components/messagesView/rootMessageView";
 import { NewMessageInputView } from "../components/newMessageInputView";
 
 export function PlaygroundPanel() {
-	const scrollAreaRef = useRef<HTMLDivElement>(null);
-
 	return (
 		<div className="custom-scrollbar relative flex h-full flex-col overscroll-none">
-			<ScrollArea className="flex-1 overflow-y-auto" ref={scrollAreaRef} viewportClassName="no-table">
+			<ScrollArea className="flex-1 scroll-mb-12 overflow-y-auto" viewportClassName="no-table">
 				<MessagesView />
 			</ScrollArea>
 			<NewMessageInputView />

--- a/ui/components/prompts/utils/executor.ts
+++ b/ui/components/prompts/utils/executor.ts
@@ -67,7 +67,7 @@ export async function executePrompt(
 				model: `${config.provider}/${config.model}`,
 				messages: Message.toAPIMessages(resolvedMessages),
 				...requestParams,
-				stream: requestParams.stream ?? true,
+				stream: requestParams.stream,
 			}),
 		});
 

--- a/ui/components/ui/codeEditor.tsx
+++ b/ui/components/ui/codeEditor.tsx
@@ -101,41 +101,30 @@ export function CodeEditor(props: CodeEditorProps) {
 	};
 
 	// Handle editor mount
-	const handleEditorDidMount = (editor: any, monaco: any) => {
+	const handleEditorDidMount = (editor: editor.IStandaloneCodeEditor, monaco: any) => {
 		if (props.autoFocus) {
 			editor.focus();
 		}
 
 		// Auto-resize logic
 		if (props.shouldAdjustInitialHeight || props.autoResize) {
-			const updateHeight = () => {
-				try {
-					let contentHeight = editor.getContentHeight();
-					if (props.minHeight && contentHeight < props.minHeight) {
-						contentHeight = props.minHeight;
-					}
-					if (props.maxHeight && contentHeight > props.maxHeight) {
-						contentHeight = props.maxHeight;
-					}
-					setEditorHeight(contentHeight + 15);
-					editor.layout();
-				} catch (error) {
-					console.warn("Error updating editor height:", error);
-				}
+			const clampHeight = (h: number) => {
+				if (props.minHeight && h < props.minHeight) h = props.minHeight;
+				if (props.maxHeight && h > props.maxHeight) h = props.maxHeight;
+				return h;
 			};
 
-			// Initial height adjustment
-			setTimeout(updateHeight, 100);
+			editor.onDidContentSizeChange((e: editor.IContentSizeChangedEvent) => {
+				if (!e.contentHeightChanged) return;
+				const height = clampHeight(e.contentHeight);
+				setEditorHeight(height);
+				editor.layout();
+			});
 
-			// Auto-resize on content change
-			if (props.autoResize) {
-				const model = editor.getModel();
-				if (model) {
-					model.onDidChangeContent(() => {
-						requestAnimationFrame(updateHeight);
-					});
-				}
-			}
+			// Initial height adjustment
+			const height = clampHeight(editor.getContentHeight());
+			setEditorHeight(height);
+			editor.layout();
 		}
 
 		// Auto-format

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -74,7 +74,6 @@ const DEFAULT_MODEL_PARAMETERS: ModelDatasheetResponse = {
 			helpText:
 				"What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.",
 			type: "number",
-			default: 1,
 			range: { min: 0, max: 2, step: 0.01 },
 		},
 		{
@@ -82,8 +81,14 @@ const DEFAULT_MODEL_PARAMETERS: ModelDatasheetResponse = {
 			label: "Max Tokens",
 			helpText: "The maximum number of tokens that can be generated in the Result.",
 			type: "number",
-			default: 4096,
 			range: { min: 1, max: 8192, step: 1 },
+		},
+		{
+			id: "stream",
+			label: "Stream",
+			helpText:
+				"The stream parameter in the API controls whether the response is sent in incremental updates, like tokenized data as it's generated, or as a complete result in one go.",
+			type: "boolean",
 		},
 	],
 };


### PR DESCRIPTION
## Summary

Enhances the message view components with JSON syntax highlighting and improved UI consistency. JSON content in messages is now automatically detected and displayed with proper formatting and syntax highlighting using the CodeEditor component.

## Changes

- Added JSON detection and syntax highlighting to system, user, assistant, tool call, and tool result message views
- Standardized icon sizes across all message components (edit and delete buttons now use consistent h-3 w-3 sizing)
- Improved auto-scrolling logic in MessagesView to handle message updates more intelligently
- Enhanced tool call result view with better layout and clickable content areas
- Added stream parameter as a default model parameter with proper UI controls
- Configured CodeEditor with disabled hover and indent lines for cleaner message display
- Implemented JSON buffer management for real-time editing with proper change detection

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] UI (Next.js)

## How to test

Test JSON message rendering and editing:
1. Create messages with JSON content in system, user, assistant, or tool result roles
2. Verify JSON is automatically formatted and syntax highlighted
3. Test editing JSON content maintains proper formatting
4. Verify non-JSON content displays normally
5. Check that edit/delete button sizes are consistent across all message types

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A - Internal UI improvements for JSON handling and icon consistency

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - purely UI enhancements for better JSON content display.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable