### PR TITLE
adds prompt caching improvements by removing unordered marshalling

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -22,6 +22,8 @@ require (
 	github.com/mark3labs/mcp-go v0.43.2
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tidwall/gjson v1.18.0
+	github.com/tidwall/sjson v1.2.5
 	github.com/valyala/fasthttp v1.68.0
 	go.starlark.net v0.0.0-20260102030733-3fee463870c9
 	golang.org/x/oauth2 v0.35.0
@@ -63,6 +65,8 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/savsgio/gotils v0.0.0-20250408102913-196191ec6287 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -135,6 +135,15 @@ github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXl
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bytedance/sonic"
 	"github.com/valyala/fasthttp"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -90,41 +89,43 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 	// Check if raw request body should be used
 	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
 		jsonBody = request.GetRawRequestBody()
-		// Unmarshal and check if model and region are present
-		var requestBody map[string]interface{}
-		if err := sonic.Unmarshal(jsonBody, &requestBody); err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, fmt.Errorf("failed to unmarshal request body: %w", err), providerName)
-		}
-		// update model with provider model
-		if modelVal, exists := requestBody["model"]; exists {
-			if modelStr, ok := modelVal.(string); ok {
+
+		// Update model with provider model (using gjson/sjson to preserve key order for prompt caching)
+		if modelResult := providerUtils.GetJSONField(jsonBody, "model"); modelResult.Exists() {
+			if modelStr := modelResult.String(); modelStr != "" {
 				_, model := schemas.ParseModelString(modelStr, schemas.Anthropic)
-				requestBody["model"] = model
+				jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", model)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+				}
 			}
 		}
 		// Add max_tokens if not present
-		if _, exists := requestBody["max_tokens"]; !exists {
-			requestBody["max_tokens"] = AnthropicDefaultMaxTokens
-		}
-		// Add stream if not present
-		if isStreaming {
-			requestBody["stream"] = true
-		}
-		// Remove excluded fields
-		if len(excludeFields) > 0 {
-			for _, field := range excludeFields {
-				delete(requestBody, field)
+		if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", AnthropicDefaultMaxTokens)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 			}
 		}
-		jsonBody, err = providerUtils.MarshalSorted(requestBody)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		// Add stream if streaming
+		if isStreaming {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
+		}
+		// Remove excluded fields
+		for _, field := range excludeFields {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		}
 	} else {
 		// Convert request to Anthropic format
-		reqBody, err := ToAnthropicResponsesRequest(ctx, request)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, err, providerName)
+		reqBody, convErr := ToAnthropicResponsesRequest(ctx, request)
+		if convErr != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, convErr, providerName)
 		}
 		if reqBody == nil {
 			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil, providerName)
@@ -133,8 +134,8 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		if isStreaming {
 			reqBody.Stream = schemas.Ptr(true)
 		}
-		// Convert struct to map
-		jsonBody, err = sonic.Marshal(reqBody)
+		// Marshal struct to JSON bytes
+		jsonBody, err = providerUtils.MarshalSorted(reqBody)
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), providerName)
 		}
@@ -142,31 +143,26 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		if ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) != nil && ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
 			extraParams := reqBody.GetExtraParams()
 			if len(extraParams) > 0 {
-				var jsonMap map[string]interface{}
-				if err := sonic.Unmarshal(jsonBody, &jsonMap); err != nil {
+				// Use MergeExtraParamsIntoJSON which preserves key order
+				jsonBody, err = providerUtils.MergeExtraParamsIntoJSON(jsonBody, extraParams)
+				if err != nil {
 					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 				}
-				// Remove excluded fields
-				if len(excludeFields) > 0 {
-					for _, field := range excludeFields {
-						delete(jsonMap, field)
-					}
-				}
-				// Merge ExtraParams recursively (handles nested maps)
-				providerUtils.MergeExtraParams(jsonMap, extraParams)
-				// Re-marshal the merged map
-				jsonBody, err = providerUtils.MarshalSorted(jsonMap)
+			}
+			// Remove excluded fields after merging (using sjson to preserve order)
+			for _, field := range excludeFields {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
 				if err != nil {
 					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 				}
 			}
 		} else if len(excludeFields) > 0 {
-			// Remove top-level keys while preserving nested JSON byte ordering
-			// (avoids roundtrip through map[string]interface{} which loses key order
-			// in nested objects like tool input_schema).
-			jsonBody, err = excludeTopLevelJSONKeys(jsonBody, excludeFields)
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			// Remove excluded fields using sjson to preserve key order
+			for _, field := range excludeFields {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+				}
 			}
 		}
 	}
@@ -1639,17 +1635,3 @@ func IsClaudeCodeRequest(ctx *schemas.BifrostContext) bool {
 	return false
 }
 
-// excludeTopLevelJSONKeys removes the specified top-level keys from a JSON
-// object without parsing nested values. Nested bytes are preserved as-is,
-// which keeps the original key ordering within tool schemas and other
-// deeply nested structures.
-func excludeTopLevelJSONKeys(data []byte, keys []string) ([]byte, error) {
-	var raw map[string]json.RawMessage
-	if err := sonic.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("anthropic: unmarshalling for field exclusion: %w", err)
-	}
-	for _, k := range keys {
-		delete(raw, k)
-	}
-	return sonic.Marshal(raw)
-}

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -23,32 +22,37 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 	// Check if raw request body should be used
 	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
 		jsonBody = request.GetRawRequestBody()
-		// Unmarshal and check if model and region are present
-		var requestBody map[string]interface{}
-		if err := sonic.Unmarshal(jsonBody, &requestBody); err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, fmt.Errorf("failed to unmarshal request body: %w", err), providerName)
-		}
-		// Add max_tokens if not present
-		if _, exists := requestBody["max_tokens"]; !exists {
-			requestBody["max_tokens"] = anthropic.AnthropicDefaultMaxTokens
+
+		// Add max_tokens if not present (using sjson to preserve key order for prompt caching)
+		if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", anthropic.AnthropicDefaultMaxTokens)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		}
 		// Replace model with deployment
-		requestBody["model"] = deployment
-		delete(requestBody, "fallbacks")
-		// Add stream if not present
-		if isStreaming {
-			requestBody["stream"] = true
-		}
-		jsonBody, err = sonic.Marshal(requestBody)
+		jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", deployment)
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
+		// Delete fallbacks field
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
+		// Add stream if streaming
+		if isStreaming {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		}
 	} else {
 		// Convert request to Anthropic format
 		request.Model = deployment
-		reqBody, err := anthropic.ToAnthropicResponsesRequest(ctx, request)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, err, providerName)
+		reqBody, convErr := anthropic.ToAnthropicResponsesRequest(ctx, request)
+		if convErr != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, convErr, providerName)
 		}
 		if reqBody == nil {
 			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil, providerName)
@@ -58,8 +62,8 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 			reqBody.Stream = schemas.Ptr(true)
 		}
 
-		// Convert struct to map
-		jsonBody, err = sonic.Marshal(reqBody)
+		// Marshal struct to JSON bytes, preserving field order
+		jsonBody, err = providerUtils.MarshalSorted(reqBody)
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), providerName)
 		}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -28,6 +28,8 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/network"
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpproxy"
 )
@@ -45,6 +47,28 @@ func MarshalSorted(v interface{}) ([]byte, error) {
 // MarshalSortedIndent marshals v to indented JSON with map keys sorted alphabetically.
 func MarshalSortedIndent(v interface{}, prefix, indent string) ([]byte, error) {
 	return sortedAPI.MarshalIndent(v, prefix, indent)
+}
+
+// SetJSONField sets a field in JSON bytes without disturbing other fields' ordering.
+// Uses in-place byte manipulation for minimal allocations and preserves nested structure.
+func SetJSONField(data []byte, path string, value interface{}) ([]byte, error) {
+	return sjson.SetBytes(data, path, value)
+}
+
+// DeleteJSONField deletes a field from JSON bytes without disturbing other fields' ordering.
+// Uses in-place byte manipulation for minimal allocations and preserves nested structure.
+func DeleteJSONField(data []byte, path string) ([]byte, error) {
+	return sjson.DeleteBytes(data, path)
+}
+
+// JSONFieldExists checks if a field exists in JSON bytes.
+func JSONFieldExists(data []byte, path string) bool {
+	return gjson.GetBytes(data, path).Exists()
+}
+
+// GetJSONField retrieves a field value from JSON bytes without parsing the entire document.
+func GetJSONField(data []byte, path string) gjson.Result {
+	return gjson.GetBytes(data, path)
 }
 
 // logger is the global logger for the provider utils (thread-safe via atomic.Pointer).

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -88,6 +88,23 @@ func (r *VertexRequestBody) MarshalJSON() ([]byte, error) {
 	return sonic.Marshal(r.RequestBody)
 }
 
+// VertexRawRequestBody holds pre-serialized JSON bytes to preserve key ordering
+// for LLM prompt caching. This avoids the map[string]interface{} round-trip that
+// destroys key order.
+type VertexRawRequestBody struct {
+	RawBody     []byte                 `json:"-"`
+	ExtraParams map[string]interface{} `json:"-"`
+}
+
+func (r *VertexRawRequestBody) GetExtraParams() map[string]interface{} {
+	return r.ExtraParams
+}
+
+// MarshalJSON returns the pre-serialized JSON bytes directly, preserving key order.
+func (r *VertexRawRequestBody) MarshalJSON() ([]byte, error) {
+	return r.RawBody, nil
+}
+
 // VertexAdvancedVoiceOptions represents advanced voice options for TTS synthesis.
 type VertexAdvancedVoiceOptions struct {
 	LowLatencyJourneySynthesis bool `json:"lowLatencyJourneySynthesis,omitempty"`

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -23,41 +22,62 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 	// Check if raw request body should be used
 	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
 		jsonBody = request.GetRawRequestBody()
-		// Unmarshal and check if model and region are present
-		var requestBody map[string]interface{}
-		if err := sonic.Unmarshal(jsonBody, &requestBody); err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, fmt.Errorf("failed to unmarshal request body: %w", err), providerName)
-		}
+
 		if isCountTokens {
-			delete(requestBody, "max_tokens")
-			delete(requestBody, "temperature")
-			requestBody["model"] = deployment
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", deployment)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		} else {
 			// Add max_tokens if not present
-			if _, exists := requestBody["max_tokens"]; !exists {
-				requestBody["max_tokens"] = anthropic.AnthropicDefaultMaxTokens
+			if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
+				jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", anthropic.AnthropicDefaultMaxTokens)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+				}
 			}
-			delete(requestBody, "model")
-			// Add stream if not present
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
+			// Add stream if streaming
 			if isStreaming {
-				requestBody["stream"] = true
+				jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
+				if err != nil {
+					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+				}
 			}
 		}
-		delete(requestBody, "region")
-		delete(requestBody, "fallbacks")
-		// Add anthropic_version if not present
-		if _, exists := requestBody["anthropic_version"]; !exists {
-			requestBody["anthropic_version"] = DefaultVertexAnthropicVersion
-		}
-		jsonBody, err = sonic.Marshal(requestBody)
+
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 		}
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
+
+		// Add anthropic_version if not present
+		if !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", DefaultVertexAnthropicVersion)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
+		}
 	} else {
 		// Convert request to Anthropic format
-		reqBody, err := anthropic.ToAnthropicResponsesRequest(ctx, request)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, err, providerName)
+		reqBody, convErr := anthropic.ToAnthropicResponsesRequest(ctx, request)
+		if convErr != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, convErr, providerName)
 		}
 		if reqBody == nil {
 			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil, providerName)
@@ -70,32 +90,38 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 
 		reqBody.SetStripCacheControlScope(true)
 
-		// Convert struct to map for Vertex API
-		reqBytes, err := sonic.Marshal(reqBody)
+		// Marshal struct to JSON bytes
+		jsonBody, err = providerUtils.MarshalSorted(reqBody)
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), providerName)
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 		}
 
-		var requestBody map[string]interface{}
-		if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, fmt.Errorf("failed to unmarshal request body: %w", err), providerName)
-		}
-
-		// Add anthropic_version if not present
-		if _, exists := requestBody["anthropic_version"]; !exists {
-			requestBody["anthropic_version"] = DefaultVertexAnthropicVersion
+		// Add anthropic_version if not present (using sjson to preserve order)
+		if !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", DefaultVertexAnthropicVersion)
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		}
 
 		if isCountTokens {
-			delete(requestBody, "max_tokens")
-			delete(requestBody, "temperature")
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		} else {
-			// Remove fields not needed by Vertex API
-			delete(requestBody, "model")
+			// Remove model field for Vertex API (it's in URL)
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
+			if err != nil {
+				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			}
 		}
-		delete(requestBody, "region")
 
-		jsonBody, err = sonic.Marshal(requestBody)
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 		}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -376,28 +376,38 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			//TODO: optimize this double Marshal
-			// Format messages for Vertex API
-			var requestBody map[string]interface{}
+			// Format messages for Vertex API, preserving key order for prompt caching
+			var rawBody []byte
 			var extraParams map[string]interface{}
+			var err error
+
 			if schemas.IsAnthropicModel(deployment) {
 				// Use centralized Anthropic converter
-				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
-				if err != nil {
-					return nil, err
+				reqBody, convErr := anthropic.ToAnthropicChatRequest(ctx, request)
+				if convErr != nil {
+					return nil, convErr
 				}
 				if reqBody == nil {
 					return nil, fmt.Errorf("chat completion input is not provided")
 				}
 				extraParams = reqBody.GetExtraParams()
 				reqBody.Model = deployment
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes, preserving struct field order
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
+				// Add anthropic_version if not present (using sjson to preserve order)
+				if !providerUtils.JSONFieldExists(rawBody, "anthropic_version") {
+					rawBody, err = providerUtils.SetJSONField(rawBody, "anthropic_version", DefaultVertexAnthropicVersion)
+					if err != nil {
+						return nil, fmt.Errorf("failed to set anthropic_version: %w", err)
+					}
+				}
+				// Remove model field (it's in URL for Vertex)
+				rawBody, err = providerUtils.DeleteJSONField(rawBody, "model")
+				if err != nil {
+					return nil, fmt.Errorf("failed to delete model field: %w", err)
 				}
 			} else if schemas.IsGeminiModel(deployment) || schemas.IsAllDigitsASCII(deployment) {
 				reqBody := gemini.ToGeminiChatCompletionRequest(request)
@@ -408,13 +418,10 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 				reqBody.Model = deployment
 				// Strip unsupported fields for Vertex Gemini
 				stripVertexGeminiUnsupportedFields(reqBody)
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
-				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
 				}
 			} else {
 				// Use centralized OpenAI converter for non-Claude models
@@ -424,24 +431,19 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 				}
 				extraParams = reqBody.GetExtraParams()
 				reqBody.Model = deployment
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
-				}
 			}
 
-			if schemas.IsAnthropicModel(deployment) {
-				if _, exists := requestBody["anthropic_version"]; !exists {
-					requestBody["anthropic_version"] = DefaultVertexAnthropicVersion
-				}
-				delete(requestBody, "model")
+			// Remove region field if present
+			rawBody, err = providerUtils.DeleteJSONField(rawBody, "region")
+			if err != nil {
+				return nil, fmt.Errorf("failed to delete region field: %w", err)
 			}
-			delete(requestBody, "region")
-			return &VertexRequestBody{RequestBody: requestBody, ExtraParams: extraParams}, nil
+			return &VertexRawRequestBody{RawBody: rawBody, ExtraParams: extraParams}, nil
 		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
@@ -724,33 +726,41 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
 				var extraParams map[string]interface{}
-				reqBody, err := anthropic.ToAnthropicChatRequest(ctx, request)
-				if err != nil {
-					return nil, err
+				reqBody, convErr := anthropic.ToAnthropicChatRequest(ctx, request)
+				if convErr != nil {
+					return nil, convErr
+				}
+				if reqBody == nil {
+					return nil, fmt.Errorf("chat completion input is not provided")
 				}
 				extraParams = reqBody.GetExtraParams()
-				if reqBody != nil {
-					reqBody.Model = deployment
-					reqBody.Stream = schemas.Ptr(true)
-				}
+				reqBody.Model = deployment
+				reqBody.Stream = schemas.Ptr(true)
 
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes, preserving struct field order for prompt caching
+				rawBody, err := providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-				var requestBody map[string]interface{}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
+
+				// Add anthropic_version if not present (using sjson to preserve order)
+				if !providerUtils.JSONFieldExists(rawBody, "anthropic_version") {
+					rawBody, err = providerUtils.SetJSONField(rawBody, "anthropic_version", DefaultVertexAnthropicVersion)
+					if err != nil {
+						return nil, fmt.Errorf("failed to set anthropic_version: %w", err)
+					}
 				}
 
-				if _, exists := requestBody["anthropic_version"]; !exists {
-					requestBody["anthropic_version"] = DefaultVertexAnthropicVersion
+				// Remove model and region fields (using sjson to preserve order)
+				rawBody, err = providerUtils.DeleteJSONField(rawBody, "model")
+				if err != nil {
+					return nil, fmt.Errorf("failed to delete model field: %w", err)
 				}
-
-				delete(requestBody, "model")
-				delete(requestBody, "region")
-				return &VertexRequestBody{RequestBody: requestBody, ExtraParams: extraParams}, nil
+				rawBody, err = providerUtils.DeleteJSONField(rawBody, "region")
+				if err != nil {
+					return nil, fmt.Errorf("failed to delete region field: %w", err)
+				}
+				return &VertexRawRequestBody{RawBody: rawBody, ExtraParams: extraParams}, nil
 			},
 			provider.GetProviderKey())
 		if bifrostErr != nil {
@@ -1814,8 +1824,10 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			var requestBody map[string]interface{}
+			var rawBody []byte
 			var extraParams map[string]interface{}
+			var err error
+
 			if schemas.IsGeminiModel(deployment) || schemas.IsAllDigitsASCII(deployment) {
 				reqBody := gemini.ToGeminiImageGenerationRequest(request)
 				if reqBody == nil {
@@ -1825,13 +1837,10 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 				reqBody.Model = deployment
 				// Strip unsupported fields for Vertex Gemini
 				stripVertexGeminiUnsupportedFields(reqBody)
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes, preserving key order
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
-				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
 				}
 			} else if schemas.IsImagenModel(deployment) {
 				reqBody := gemini.ToImagenImageGenerationRequest(request)
@@ -1839,18 +1848,19 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 					return nil, fmt.Errorf("image generation input is not provided")
 				}
 				extraParams = reqBody.GetExtraParams()
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes, preserving key order
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
-				}
 			}
 
-			delete(requestBody, "region")
-			return &VertexRequestBody{RequestBody: requestBody, ExtraParams: extraParams}, nil
+			// Remove region field if present
+			rawBody, err = providerUtils.DeleteJSONField(rawBody, "region")
+			if err != nil {
+				return nil, fmt.Errorf("failed to delete region field: %w", err)
+			}
+			return &VertexRawRequestBody{RawBody: rawBody, ExtraParams: extraParams}, nil
 		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {
@@ -2076,43 +2086,43 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			var requestBody map[string]interface{}
+			var rawBody []byte
 			var extraParams map[string]interface{}
+			var err error
+
 			if schemas.IsGeminiModel(deployment) || schemas.IsAllDigitsASCII(deployment) {
 				reqBody := gemini.ToGeminiImageEditRequest(request)
-				extraParams = reqBody.GetExtraParams()
 				if reqBody == nil {
 					return nil, fmt.Errorf("image edit input is not provided")
 				}
+				extraParams = reqBody.GetExtraParams()
 				reqBody.Model = deployment
 				// Strip unsupported fields for Vertex Gemini
 				stripVertexGeminiUnsupportedFields(reqBody)
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				// Marshal to JSON bytes, preserving key order
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
-				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
 				}
 			} else if schemas.IsImagenModel(deployment) {
 				reqBody := gemini.ToImagenImageEditRequest(request)
-				extraParams = reqBody.GetExtraParams()
 				if reqBody == nil {
 					return nil, fmt.Errorf("image edit input is not provided")
 				}
-				// Convert struct to map for Vertex API
-				reqBytes, err := sonic.Marshal(reqBody)
+				extraParams = reqBody.GetExtraParams()
+				// Marshal to JSON bytes, preserving key order
+				rawBody, err = providerUtils.MarshalSorted(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("failed to marshal request body: %w", err)
 				}
-				if err := sonic.Unmarshal(reqBytes, &requestBody); err != nil {
-					return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
-				}
 			}
 
-			delete(requestBody, "region")
-			return &VertexRequestBody{RequestBody: requestBody, ExtraParams: extraParams}, nil
+			// Remove region field if present
+			rawBody, err = providerUtils.DeleteJSONField(rawBody, "region")
+			if err != nil {
+				return nil, fmt.Errorf("failed to delete region field: %w", err)
+			}
+			return &VertexRawRequestBody{RawBody: rawBody, ExtraParams: extraParams}, nil
 		},
 		provider.GetProviderKey())
 	if bifrostErr != nil {


### PR DESCRIPTION
## Summary

Preserve JSON key ordering for LLM prompt caching by replacing map-based JSON manipulation with direct byte-level operations using gjson/sjson libraries.

## Changes

- Added `github.com/tidwall/gjson` and `github.com/tidwall/sjson` dependencies for efficient JSON manipulation
- Introduced new utility functions in `providers/utils/utils.go`:
  - `SetJSONField()` - sets fields without disturbing key order
  - `DeleteJSONField()` - removes fields while preserving structure
  - `JSONFieldExists()` - checks field existence without parsing
  - `GetJSONField()` - retrieves values without full document parsing
- Replaced `sonic.Unmarshal` → map manipulation → `sonic.Marshal` patterns with direct byte operations in:
  - Anthropic provider request body handling
  - Azure Anthropic responses processing
  - Vertex AI request formatting for all model types
- Added `VertexRawRequestBody` type to handle pre-serialized JSON bytes
- Eliminated double marshaling in Vertex provider by using `MarshalSorted()` directly

The key insight is that LLM prompt caching is sensitive to JSON key ordering, and Go's `map[string]interface{}` destroys this ordering. By operating directly on JSON bytes, we preserve the original structure while still allowing field modifications.

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [ ] Transports (HTTP)
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that JSON key ordering is preserved and prompt caching works correctly:

```sh
# Core/Transports
go version
go test ./...

# Test specific provider functionality
go test ./core/providers/anthropic/...
go test ./core/providers/vertex/...
go test ./core/providers/azure/...
```

Test with requests that include cache control headers to ensure key ordering preservation doesn't break prompt caching functionality.

## Screenshots/Recordings

N/A - Internal refactoring with no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

This is an internal refactoring that maintains the same external API while improving JSON handling efficiency.

## Related issues

Addresses prompt caching reliability issues caused by JSON key reordering during request processing.

## Security considerations

No security implications - this is an internal JSON processing optimization that doesn't affect authentication, secrets, or data handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable