### PR TITLE
gcc-config-support

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1443,6 +1443,10 @@
                       "clientSecret": {
                         "type": "string"
                       },
+                      "cloud": {
+                        "type": "string",
+                        "enum": ["commercial", "gcc-high", "dod"]
+                      },
                       "audience": {
                         "type": "string"
                       },

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -549,6 +549,7 @@ bifrost:
       # tenantId: ""
       # clientId: ""
       # clientSecret: ""
+      # cloud: "commercial"  # or "gcc-high" or "dod"
       # audience: ""
       # appIdUri: ""
       # userIdField: "oid"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3135,6 +3135,12 @@
           "type": "string",
           "description": "Client secret (optional, required for token revocation)"
         },
+        "cloud": {
+          "type": "string",
+          "enum": ["commercial", "gcc-high", "dod"],
+          "default": "commercial",
+          "description": "Cloud environment: 'commercial' (default), 'gcc-high' for US Government GCC High, or 'dod' for Department of Defense"
+        },
         "audience": {
           "type": "string",
           "description": "JWT audience for validation (default: clientId)"


### PR DESCRIPTION
## Summary

Adds support for Azure cloud environment configuration to enable authentication against different Azure cloud instances including US Government GCC High and Department of Defense environments.

## Changes

- Added `cloud` configuration field to Azure authentication with three supported values: "commercial" (default), "gcc-high", and "dod"
- Updated Helm chart schema and values to include the new cloud environment option
- Added comprehensive documentation describing each cloud environment option

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the configuration schema accepts the new cloud field:

```sh
# Test with different cloud values
# Set cloud: "commercial" (default)
# Set cloud: "gcc-high" for US Government
# Set cloud: "dod" for Department of Defense

# Verify schema validation
go test ./transports/...
```

New configuration options:
- `cloud`: Azure cloud environment ("commercial", "gcc-high", "dod")

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change enables authentication against different Azure sovereign cloud environments, which is important for organizations with specific compliance requirements (government, DoD). The default remains "commercial" to maintain backward compatibility.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable