### PR TITLE
feat: groq stt / tts

### DIFF
--- a/core/internal/llmtests/speech_synthesis.go
+++ b/core/internal/llmtests/speech_synthesis.go
@@ -111,7 +111,6 @@ func RunSpeechSynthesisTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 					OnFinalFail: retryConfig.OnFinalFail,
 				}
 
-				
 				speechResponse, bifrostErr := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "SpeechSynthesis_"+tc.name, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
 					requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 					return client.SpeechRequest(requestCtx, request)
@@ -189,6 +188,11 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 				Fallbacks: testConfig.SpeechSynthesisFallbacks,
 			}
 
+			// Groq doesn't support instructions
+			if testConfig.Provider == schemas.Groq {
+				request.Params.Instructions = ""
+			}
+
 			retryConfig := GetTestRetryConfigForScenario("SpeechSynthesisHD", testConfig)
 			retryContext := TestRetryContext{
 				ScenarioName: "SpeechSynthesis_HD_LongText",
@@ -217,8 +221,6 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 				OnRetry:     retryConfig.OnRetry,
 				OnFinalFail: retryConfig.OnFinalFail,
 			}
-
-			
 
 			speechResponse, bifrostErr := WithSpeechTestRetry(t, speechRetryConfig, retryContext, expectations, "SpeechSynthesis_HD", func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
 				requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
@@ -302,7 +304,6 @@ func RunSpeechSynthesisAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx c
 						OnFinalFail: voiceRetryConfig.OnFinalFail,
 					}
 
-					
 					speechResponse, bifrostErr := WithSpeechTestRetry(t, voiceSpeechRetryConfig, voiceRetryContext, expectations, "SpeechSynthesis_VoiceType_"+voiceType, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
 						requestCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 						return client.SpeechRequest(requestCtx, request)

--- a/core/internal/llmtests/transcription.go
+++ b/core/internal/llmtests/transcription.go
@@ -35,21 +35,21 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 				name:           "RoundTrip_Basic_MP3",
 				text:           TTSTestTextBasic,
 				voiceType:      "primary",
-				format:         "mp3",
+				format:         GetProviderDefaultFormat(testConfig.Provider),
 				responseFormat: bifrost.Ptr("json"),
 			},
 			{
 				name:           "RoundTrip_Medium_MP3",
 				text:           TTSTestTextMedium,
 				voiceType:      "secondary",
-				format:         "mp3",
+				format:         GetProviderDefaultFormat(testConfig.Provider),
 				responseFormat: bifrost.Ptr("json"),
 			},
 			{
 				name:           "RoundTrip_Technical_MP3",
 				text:           TTSTestTextTechnical,
 				voiceType:      "tertiary",
-				format:         "mp3",
+				format:         GetProviderDefaultFormat(testConfig.Provider),
 				responseFormat: bifrost.Ptr("json"),
 			},
 		}
@@ -138,7 +138,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 					}
 
 					ttsResponse, err := WithSpeechTestRetry(t, speechRetryConfig, ttsRetryContext, ttsExpectations, "Transcription_RoundTrip_TTS_"+tc.name, func() (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)	
+						bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 						return client.SpeechRequest(bfCtx, ttsRequest)
 					})
 					if err != nil {
@@ -258,6 +258,8 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 						speechSynthesisModel = testConfig.ExternalTTSModel
 					}
 
+					audioFormat := GetProviderDefaultFormat(testConfig.Provider)
+
 					var audioData []byte
 					var readErr error
 					if testConfig.Provider == schemas.HuggingFace && strings.HasPrefix(testConfig.TranscriptionModel, "fal-ai/") {
@@ -271,10 +273,10 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 						if readErr != nil {
 							t.Fatalf("failed to read audio fixture %s: %v", filePath, readErr)
 						}
+						audioFormat = "mp3"
 					} else {
-
 						// Use the utility function to generate audio
-						audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, tc.text, "primary", "mp3")
+						audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, tc.text, "primary", audioFormat)
 					}
 					// Test transcription
 					request := &schemas.BifrostTranscriptionRequest{
@@ -285,7 +287,7 @@ func RunTranscriptionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Con
 						},
 						Params: &schemas.TranscriptionParameters{
 							Language:       tc.language,
-							Format:         bifrost.Ptr("mp3"),
+							Format:         &audioFormat,
 							ResponseFormat: tc.responseFormat,
 						},
 						Fallbacks: testConfig.TranscriptionFallbacks,
@@ -365,6 +367,8 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 						speechSynthesisModel = testConfig.ExternalTTSModel
 					}
 
+					audioFormat := GetProviderDefaultFormat(testConfig.Provider)
+
 					var audioData []byte
 					var readErr error
 					if testConfig.Provider == schemas.HuggingFace && strings.HasPrefix(testConfig.TranscriptionModel, "fal-ai/") {
@@ -378,10 +382,10 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 						if readErr != nil {
 							t.Fatalf("failed to read audio fixture %s: %v", filePath, readErr)
 						}
+						audioFormat = "mp3"
 					} else {
-
 						// Use the utility function to generate audio
-						audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, TTSTestTextBasic, "primary", "mp3")
+						audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, TTSTestTextBasic, "primary", audioFormat)
 					}
 
 					formatCopy := format
@@ -392,7 +396,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 							File: audioData,
 						},
 						Params: &schemas.TranscriptionParameters{
-							Format:         bifrost.Ptr("mp3"),
+							Format:         &audioFormat,
 							ResponseFormat: &formatCopy,
 						},
 						Fallbacks: testConfig.TranscriptionFallbacks,
@@ -458,6 +462,8 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				speechSynthesisModel = testConfig.ExternalTTSModel
 			}
 
+			audioFormat := GetProviderDefaultFormat(testConfig.Provider)
+
 			var audioData []byte
 			var readErr error
 			if testConfig.Provider == schemas.HuggingFace && strings.HasPrefix(testConfig.TranscriptionModel, "fal-ai/") {
@@ -471,10 +477,10 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				if readErr != nil {
 					t.Fatalf("failed to read audio fixture %s: %v", filePath, readErr)
 				}
+				audioFormat = "mp3"
 			} else {
-
 				// Generate audio for custom parameters test
-				audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, TTSTestTextMedium, "secondary", "mp3")
+				audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, TTSTestTextMedium, "secondary", audioFormat)
 			}
 
 			// Test with custom parameters and temperature
@@ -486,7 +492,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 				},
 				Params: &schemas.TranscriptionParameters{
 					Language:       bifrost.Ptr("en"),
-					Format:         bifrost.Ptr("mp3"),
+					Format:         &audioFormat,
 					Prompt:         bifrost.Ptr("This audio contains technical terminology and proper nouns."),
 					ResponseFormat: bifrost.Ptr("json"), // Use json instead of verbose_json for whisper-1
 				},
@@ -555,6 +561,8 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 						speechSynthesisModel = testConfig.ExternalTTSModel
 					}
 
+					audioFormat := GetProviderDefaultFormat(testConfig.Provider)
+
 					var audioData []byte
 					var readErr error
 					if testConfig.Provider == schemas.HuggingFace && strings.HasPrefix(testConfig.TranscriptionModel, "fal-ai/") {
@@ -568,10 +576,10 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 						if readErr != nil {
 							t.Fatalf("failed to read audio fixture %s: %v", filePath, readErr)
 						}
+						audioFormat = "mp3"
 					} else {
-
 						// Use the utility function to generate audio
-						audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, TTSTestTextBasic, "primary", "mp3")
+						audioData, _ = GenerateTTSAudioForTest(ctx, t, client, speechSynthesisProvider, speechSynthesisModel, TTSTestTextBasic, "primary", audioFormat)
 					}
 
 					langCopy := lang
@@ -582,7 +590,7 @@ func RunTranscriptionAdvancedTest(t *testing.T, client *bifrost.Bifrost, ctx con
 							File: audioData,
 						},
 						Params: &schemas.TranscriptionParameters{
-							Format:   bifrost.Ptr("mp3"),
+							Format:   &audioFormat,
 							Language: &langCopy,
 						},
 						Fallbacks: testConfig.TranscriptionFallbacks,

--- a/core/internal/llmtests/utils.go
+++ b/core/internal/llmtests/utils.go
@@ -28,7 +28,7 @@ const (
 
 func GetProviderDefaultFormat(provider schemas.ModelProvider) string {
 	switch provider {
-	case schemas.Gemini:
+	case schemas.Gemini, schemas.Groq:
 		return "wav"
 	default:
 		return "mp3"
@@ -59,6 +59,17 @@ func GetProviderVoice(provider schemas.ModelProvider, voiceType string) string {
 			return "erinome"
 		default:
 			return "achernar"
+		}
+	case schemas.Groq:
+		switch voiceType {
+		case "primary":
+			return "troy"
+		case "secondary":
+			return "autumn"
+		case "tertiary":
+			return "diana"
+		default:
+			return "troy"
 		}
 	case schemas.Elevenlabs:
 		switch voiceType {
@@ -336,7 +347,8 @@ func CreateImageResponsesMessage(text, imageURL string) schemas.ResponsesMessage
 		Content: &schemas.ResponsesMessageContent{
 			ContentBlocks: []schemas.ResponsesMessageContentBlock{
 				{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: bifrost.Ptr(text)},
-				{Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+				{
+					Type: schemas.ResponsesInputMessageContentBlockTypeImage,
 					ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
 						ImageURL: bifrost.Ptr(imageURL),
 					},
@@ -577,7 +589,6 @@ func ExtractToolCalls(response *schemas.BifrostResponse) []ToolCallInfo {
 
 // getEmbeddingVector extracts the float32 vector from a BifrostEmbeddingResponse
 func getEmbeddingVector(embedding schemas.EmbeddingData) ([]float32, error) {
-
 	if embedding.Embedding.EmbeddingArray != nil {
 		return embedding.Embedding.EmbeddingArray, nil
 	}

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -169,9 +169,23 @@ func (provider *GroqProvider) Embedding(ctx *schemas.BifrostContext, key schemas
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
 }
 
-// Speech is not supported by the Groq provider.
+// Speech handles non-streaming speech synthesis requests.
+// It formats the request body, makes the API call, and returns the response.
+// Returns the response and any error that occurred.
 func (provider *GroqProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
+	return openai.HandleOpenAISpeechRequest(
+		ctx,
+		provider.client,
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		schemas.Groq,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		nil,
+		provider.logger,
+	)
 }
 
 // Rerank is not supported by the Groq provider.
@@ -184,9 +198,22 @@ func (provider *GroqProvider) SpeechStream(ctx *schemas.BifrostContext, postHook
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
 }
 
-// Transcription is not supported by the Groq provider.
+// Transcription handles non-streaming transcription requests.
+// It creates a multipart form, adds fields, makes the API call, and returns the response.
+// Returns the response and any error that occurred.
 func (provider *GroqProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.TranscriptionRequest, provider.GetProviderKey())
+	return openai.HandleOpenAITranscriptionRequest(
+		ctx,
+		provider.client,
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		schemas.Groq,
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		nil,
+		provider.logger,
+	)
 }
 
 // TranscriptionStream is not supported by the Groq provider.

--- a/core/providers/groq/groq_test.go
+++ b/core/providers/groq/groq_test.go
@@ -32,8 +32,10 @@ func TestGroq(t *testing.T) {
 		TextCompletionFallbacks: []schemas.Fallback{
 			{Provider: schemas.Groq, Model: "openai/gpt-oss-20b"},
 		},
-		EmbeddingModel: "", // Groq doesn't support embedding
-		ReasoningModel: "openai/gpt-oss-120b",
+		EmbeddingModel:       "", // Groq doesn't support embedding
+		ReasoningModel:       "openai/gpt-oss-120b",
+		TranscriptionModel:   "whisper-large-v3",
+		SpeechSynthesisModel: "canopylabs/orpheus-v1-english",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        false,
 			TextCompletionStream:  false,
@@ -54,6 +56,8 @@ func TestGroq(t *testing.T) {
 			Embedding:             false,
 			ListModels:            true,
 			Reasoning:             true,
+			Transcription:         true,
+			SpeechSynthesis:       true,
 		},
 	}
 	t.Run("GroqTests", func(t *testing.T) {

--- a/core/schemas/speech.go
+++ b/core/schemas/speech.go
@@ -56,7 +56,7 @@ type SpeechParameters struct {
 	Speed          *float64          `json:"speed,omitempty"`
 
 	LanguageCode                    *string                                `json:"language_code,omitempty"`
-	PronunciationDictionaryLocators []SpeechPronunciationDictionaryLocator `json:"pronunciation_dictionary_locators"`
+	PronunciationDictionaryLocators []SpeechPronunciationDictionaryLocator `json:"pronunciation_dictionary_locators,omitempty"`
 	EnableLogging                   *bool                                  `json:"enable_logging,omitempty"`
 	OptimizeStreamingLatency        *bool                                  `json:"optimize_streaming_latency,omitempty"`
 	WithTimestamps                  *bool                                  `json:"with_timestamps,omitempty"` // Returns character-level timing information


### PR DESCRIPTION
## Summary

Adds speech synthesis and transcription support to the Groq provider.

## Changes

- Implemented `Speech()` method in Groq provider using OpenAI speech request handler
- Implemented `Transcription()` method in Groq provider using OpenAI transcription request handler
- Added Groq-specific voice mappings (troy, autumn, diana) in test utilities
- Updated `GetProviderDefaultFormat()` to return "wav" format for Groq provider
- Added provider-specific handling for Groq in speech synthesis tests to clear unsupported instructions parameter
- Updated transcription tests to use provider-specific default formats instead of hardcoded "mp3"
- Enabled transcription and speech synthesis test scenarios for Groq provider
- Added test configuration for Groq transcription and speech synthesis models
- Removed extraneous whitespace and formatting inconsistencies

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
# Core/Transports
go version
go test ./...

# Test Groq speech synthesis and transcription specifically
go test ./core/providers/groq -v
```

Set up Groq API credentials and run the provider tests to validate speech synthesis and transcription functionality.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2062

## Security considerations

Uses existing OpenAI request handlers which maintain the same security patterns for API key handling and request validation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable