### PR TITLE
feat: adds search for model limits

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2659,6 +2659,45 @@ func (s *RDBConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMod
 	return modelConfigs, nil
 }
 
+func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error) {
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableModelConfig{})
+
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(model_name) LIKE ?", search)
+	}
+
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := params.Limit
+	offset := params.Offset
+
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+
+	if offset < 0 {
+		offset = 0
+	}
+
+	var modelConfigs []tables.TableModelConfig
+	if err := baseQuery.
+		Preload("Budget").
+		Preload("RateLimit").
+		Order("created_at ASC, id ASC").
+		Offset(offset).
+		Limit(limit).
+		Find(&modelConfigs).Error; err != nil {
+		return nil, 0, err
+	}
+	return modelConfigs, totalCount, nil
+}
+
 // GetModelConfig retrieves a specific model config from the database by model name and optional provider.
 func (s *RDBConfigStore) GetModelConfig(ctx context.Context, modelName string, provider *string) (*tables.TableModelConfig, error) {
 	var modelConfig tables.TableModelConfig

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -23,6 +23,13 @@ type VirtualKeyQueryParams struct {
 	TeamID     string
 }
 
+// ModelConfigsQueryParams holds pagination, filtering, and search parameters for model configs queries.
+type ModelConfigsQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -143,6 +150,7 @@ type ConfigStore interface {
 
 	// Model config CRUD
 	GetModelConfigs(ctx context.Context) ([]tables.TableModelConfig, error)
+	GetModelConfigsPaginated(ctx context.Context, params ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error)
 	GetModelConfig(ctx context.Context, modelName string, provider *string) (*tables.TableModelConfig, error)
 	GetModelConfigByID(ctx context.Context, id string) (*tables.TableModelConfig, error)
 	CreateModelConfig(ctx context.Context, modelConfig *tables.TableModelConfig, tx ...*gorm.DB) error

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -321,41 +321,70 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 		SendJSON(ctx, map[string]interface{}{
 			"virtual_keys": virtualKeys,
 			"count":        len(virtualKeys),
+			"total_count":  len(virtualKeys),
+			"limit":        len(virtualKeys),
+			"offset":       0,
 		})
 		return
 	}
-	// Parse pagination and filter query params
-	params := configstore.VirtualKeyQueryParams{
-		Search:     string(ctx.QueryArgs().Peek("search")),
-		CustomerID: string(ctx.QueryArgs().Peek("customer_id")),
-		TeamID:     string(ctx.QueryArgs().Peek("team_id")),
-	}
-	if limitStr := string(ctx.QueryArgs().Peek("limit")); limitStr != "" {
-		n, err := strconv.Atoi(limitStr)
+	// Check for pagination/filter parameters
+	limitStr := string(ctx.QueryArgs().Peek("limit"))
+	offsetStr := string(ctx.QueryArgs().Peek("offset"))
+	search := string(ctx.QueryArgs().Peek("search"))
+	customerID := string(ctx.QueryArgs().Peek("customer_id"))
+	teamID := string(ctx.QueryArgs().Peek("team_id"))
+
+	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" {
+		// Paginated/filtered path
+		params := configstore.VirtualKeyQueryParams{
+			Search:     search,
+			CustomerID: customerID,
+			TeamID:     teamID,
+		}
+		if limitStr != "" {
+			n, err := strconv.Atoi(limitStr)
+			if err != nil {
+				SendError(ctx, 400, "Invalid limit parameter: must be a number")
+				return
+			}
+			if n < 0 {
+				SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
+				return
+			}
+			params.Limit = n
+		}
+		if offsetStr != "" {
+			n, err := strconv.Atoi(offsetStr)
+			if err != nil {
+				SendError(ctx, 400, "Invalid offset parameter: must be a number")
+				return
+			}
+			if n < 0 {
+				SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
+				return
+			}
+			params.Offset = n
+		}
+
+		params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+		virtualKeys, totalCount, err := h.configStore.GetVirtualKeysPaginated(ctx, params)
 		if err != nil {
-			SendError(ctx, 400, "Invalid limit parameter: must be a number")
+			logger.Error("failed to retrieve virtual keys: %v", err)
+			SendError(ctx, 500, "Failed to retrieve virtual keys")
 			return
 		}
-		if n < 0 {
-			SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
-			return
-		}
-		params.Limit = n
-	}
-	if offsetStr := string(ctx.QueryArgs().Peek("offset")); offsetStr != "" {
-		n, err := strconv.Atoi(offsetStr)
-		if err != nil {
-			SendError(ctx, 400, "Invalid offset parameter: must be a number")
-			return
-		}
-		if n < 0 {
-			SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
-			return
-		}
-		params.Offset = n
+		SendJSON(ctx, map[string]interface{}{
+			"virtual_keys": virtualKeys,
+			"count":        len(virtualKeys),
+			"total_count":  totalCount,
+			"limit":        params.Limit,
+			"offset":       params.Offset,
+		})
+		return
 	}
 
-	virtualKeys, totalCount, err := h.configStore.GetVirtualKeysPaginated(ctx, params)
+	// Non-paginated path: return all virtual keys
+	virtualKeys, err := h.configStore.GetVirtualKeys(ctx)
 	if err != nil {
 		logger.Error("failed to retrieve virtual keys: %v", err)
 		SendError(ctx, 500, "Failed to retrieve virtual keys")
@@ -364,9 +393,9 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_keys": virtualKeys,
 		"count":        len(virtualKeys),
-		"total_count":  totalCount,
-		"limit":        params.Limit,
-		"offset":       params.Offset,
+		"total_count":  len(virtualKeys),
+		"limit":        len(virtualKeys),
+		"offset":       0,
 	})
 }
 
@@ -1992,21 +2021,81 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, 500, "Governance data is not available")
 			return
 		}
-		SendJSON(ctx, map[string]interface{}{
+		SendJSON(ctx, map[string]any{
 			"model_configs": data.ModelConfigs,
 			"count":         len(data.ModelConfigs),
+			"total_count":   len(data.ModelConfigs),
+			"limit":         len(data.ModelConfigs),
+			"offset":        0,
 		})
 		return
 	}
+
+	// Check for pagination parameters
+	limitStr := string(ctx.QueryArgs().Peek("limit"))
+	offsetStr := string(ctx.QueryArgs().Peek("offset"))
+	search := string(ctx.QueryArgs().Peek("search"))
+
+	if limitStr != "" || offsetStr != "" || search != "" {
+		// Paginated path
+		params := configstore.ModelConfigsQueryParams{
+			Search: search,
+		}
+		if limitStr != "" {
+			n, err := strconv.Atoi(limitStr)
+			if err != nil {
+				SendError(ctx, 400, "Invalid limit parameter: must be a number")
+				return
+			}
+			if n < 0 {
+				SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
+				return
+			}
+			params.Limit = n
+		}
+		if offsetStr != "" {
+			n, err := strconv.Atoi(offsetStr)
+			if err != nil {
+				SendError(ctx, 400, "Invalid offset parameter: must be a number")
+				return
+			}
+			if n < 0 {
+				SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
+				return
+			}
+			params.Offset = n
+		}
+
+		params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+		modelConfigs, totalCount, err := h.configStore.GetModelConfigsPaginated(ctx, params)
+		if err != nil {
+			logger.Error("failed to retrieve model configs: %v", err)
+			SendError(ctx, 500, "Failed to retrieve model configs")
+			return
+		}
+		SendJSON(ctx, map[string]any{
+			"model_configs": modelConfigs,
+			"count":         len(modelConfigs),
+			"total_count":   totalCount,
+			"limit":         params.Limit,
+			"offset":        params.Offset,
+		})
+		return
+	}
+
+	// Non-paginated path: return all model configs
 	modelConfigs, err := h.configStore.GetModelConfigs(ctx)
 	if err != nil {
 		logger.Error("failed to retrieve model configs: %v", err)
 		SendError(ctx, 500, "Failed to retrieve model configs")
 		return
 	}
-	SendJSON(ctx, map[string]interface{}{
+	SendJSON(ctx, map[string]any{
 		"model_configs": modelConfigs,
 		"count":         len(modelConfigs),
+		"total_count":   len(modelConfigs),
+		"limit":         len(modelConfigs),
+		"offset":        0,
 	})
 }
 

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -181,6 +181,20 @@ func ParseModel(model string) (string, string, error) {
 	return provider, name, nil
 }
 
+// ClampPaginationParams applies default/max bounds to limit and offset so that
+// the handler response matches the values the store actually uses.
+func ClampPaginationParams(limit, offset int) (int, int) {
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
 // fuzzyMatch checks if all characters in query appear in text in order (case-insensitive)
 // Example: "gpt4" matches "gpt-4", "gpt-4-turbo", etc.
 func fuzzyMatch(text, query string) bool {

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -67,6 +67,14 @@ export default function GovernanceVirtualKeysPage() {
 		pollingInterval: POLLING_INTERVAL,
 	})
 
+	const vkTotal = virtualKeysData?.total_count ?? 0
+
+	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+	useEffect(() => {
+		if (!virtualKeysData || offset < vkTotal) return
+		setOffset(vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE)
+	}, [vkTotal, offset])
+
 	const isLoading = vkLoading || teamsLoading || customersLoading
 
 	useEffect(() => {
@@ -98,6 +106,7 @@ export default function GovernanceVirtualKeysPage() {
 				teams={teamsData?.teams || []}
 				customers={customersData?.customers || []}
 				search={search}
+				debouncedSearch={debouncedSearch}
 				onSearchChange={setSearch}
 				customerFilter={customerFilter}
 				onCustomerFilterChange={setCustomerFilter}

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -24,7 +25,7 @@ import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { Edit, Plus, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
@@ -40,9 +41,16 @@ const toTestIdPart = (value: string) =>
 
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
+	totalCount: number;
+	search: string;
+	debouncedSearch: string;
+	onSearchChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps) {
+export default function ModelLimitsTable({ modelConfigs, totalCount, search, debouncedSearch, onSearchChange, offset, limit, onOffsetChange }: ModelLimitsTableProps) {
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
 	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
 
@@ -83,8 +91,10 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 		setEditingModelConfigId(null);
 	};
 
-	// Empty state when user has no model limits (same pattern as Plugins / MCP Servers)
-	if (modelConfigs?.length === 0) {
+	const hasActiveFilters = debouncedSearch;
+
+	// True empty state: no model limits at all (not just filtered to zero)
+	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				{showModelLimitSheet && (
@@ -115,6 +125,21 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 					</Button>
 				</div>
 
+				{/* Toolbar: Search */}
+				<div className="flex items-center gap-3">
+					<div className="relative max-w-sm flex-1">
+						<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+						<Input
+							aria-label="Search model limits by model name"
+							placeholder="Search by model name..."
+							value={search}
+							onChange={(e) => onSearchChange(e.target.value)}
+							className="pl-9"
+							data-testid="model-limits-search-input"
+						/>
+					</div>
+				</div>
+
 				<div className="rounded-sm border" data-testid="model-limits-table">
 					<Table>
 							<TableHeader>
@@ -127,7 +152,14 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 								</TableRow>
 							</TableHeader>
 							<TableBody>
-								{modelConfigs?.map((config) => {
+								{modelConfigs.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={5} className="h-24 text-center">
+											<span className="text-muted-foreground text-sm">No matching model limits found.</span>
+										</TableCell>
+									</TableRow>
+								) : (
+								modelConfigs.map((config) => {
 									const isBudgetExhausted =
 										config.budget?.max_limit && config.budget.max_limit > 0 && config.budget.current_usage >= config.budget.max_limit;
 									const isRateLimitExhausted =
@@ -346,10 +378,42 @@ export default function ModelLimitsTable({ modelConfigs }: ModelLimitsTableProps
 											</TableCell>
 										</TableRow>
 									);
-								})}
+								})
+								)}
 							</TableBody>
 						</Table>
 				</div>
+
+				{/* Pagination */}
+				{totalCount > 0 && (
+					<div className="flex items-center justify-between px-2">
+						<p className="text-muted-foreground text-sm">
+							Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+						</p>
+						<div className="flex gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={offset === 0}
+								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+								data-testid="model-limits-pagination-prev-btn"
+							>
+								<ChevronLeft className="mr-1 h-4 w-4" />
+								Previous
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={offset + limit >= totalCount}
+								onClick={() => onOffsetChange(offset + limit)}
+								data-testid="model-limits-pagination-next-btn"
+							>
+								Next
+								<ChevronRight className="ml-1 h-4 w-4" />
+							</Button>
+						</div>
+					</div>
+				)}
 			</div>
 		</>
 	);

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -1,23 +1,47 @@
 "use client";
 
 import { getErrorMessage, useGetModelConfigsQuery } from "@/lib/store";
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitsTable from "./modelLimitsTable";
+
+const POLLING_INTERVAL = 5000;
+const PAGE_SIZE = 25;
 
 export default function ModelLimitsView() {
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 
-	// Use regular query with skip and polling
-	const {
-		data: modelConfigsData,
-		error: modelConfigsError,
-		isLoading: modelConfigsLoading,
-	} = useGetModelConfigsQuery(undefined, {
-		skip: !hasGovernanceAccess,
-		pollingInterval: 5000,
-	});
+	const [search, setSearch] = useState("");
+	const [offset, setOffset] = useState(0);
+
+	const debouncedSearch = useDebouncedValue(search, 300);
+
+	// Reset to first page when search changes
+	useEffect(() => {
+		setOffset(0);
+	}, [debouncedSearch]);
+
+	const { data: modelConfigsData, error: modelConfigsError } = useGetModelConfigsQuery(
+		{
+			limit: PAGE_SIZE,
+			offset,
+			search: debouncedSearch || undefined,
+		},
+		{
+			skip: !hasGovernanceAccess,
+			pollingInterval: POLLING_INTERVAL,
+		},
+	);
+
+	const totalCount = modelConfigsData?.total_count ?? 0;
+
+	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+	useEffect(() => {
+		if (!modelConfigsData || offset < totalCount) return;
+		setOffset(totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE);
+	}, [totalCount, offset]);
 
 	// Handle query errors
 	useEffect(() => {
@@ -28,7 +52,16 @@ export default function ModelLimitsView() {
 
 	return (
 		<div className="mx-auto w-full max-w-7xl">
-			<ModelLimitsTable modelConfigs={modelConfigsData?.model_configs || []} />
+			<ModelLimitsTable
+				modelConfigs={modelConfigsData?.model_configs || []}
+				totalCount={modelConfigsData?.total_count || 0}
+				search={search}
+				debouncedSearch={debouncedSearch}
+				onSearchChange={setSearch}
+				offset={offset}
+				limit={PAGE_SIZE}
+				onOffsetChange={setOffset}
+			/>
 		</div>
 	);
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -34,6 +34,7 @@ interface VirtualKeysTableProps {
 	teams: Team[];
 	customers: Customer[];
 	search: string;
+	debouncedSearch: string;
 	onSearchChange: (value: string) => void;
 	customerFilter: string;
 	onCustomerFilterChange: (value: string) => void;
@@ -50,6 +51,7 @@ export default function VirtualKeysTable({
 	teams,
 	customers,
 	search,
+	debouncedSearch,
 	onSearchChange,
 	customerFilter,
 	onCustomerFilterChange,
@@ -136,7 +138,7 @@ export default function VirtualKeysTable({
 		toast.success("Copied to clipboard");
 	};
 
-	const hasActiveFilters = search || customerFilter || teamFilter;
+	const hasActiveFilters = debouncedSearch || customerFilter || teamFilter;
 
 	// True empty state: no VKs at all (not just filtered to zero)
 	if (totalCount === 0 && !hasActiveFilters) {
@@ -187,6 +189,7 @@ export default function VirtualKeysTable({
 					<div className="relative max-w-sm flex-1">
 						<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
 						<Input
+							aria-label="Search virtual keys by name"
 							placeholder="Search by name..."
 							value={search}
 							onChange={(e) => onSearchChange(e.target.value)}

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -8,6 +8,7 @@ import {
 	DebugStatsResponse,
 	GetBudgetsResponse,
 	GetCustomersResponse,
+	GetModelConfigsParams,
 	GetModelConfigsResponse,
 	GetProviderGovernanceResponse,
 	GetRateLimitsResponse,
@@ -401,10 +402,14 @@ export const governanceApi = baseApi.injectEndpoints({
 		}),
 
 		// Model Configs
-		getModelConfigs: builder.query<GetModelConfigsResponse, { fromMemory?: boolean } | void>({
+		getModelConfigs: builder.query<GetModelConfigsResponse, GetModelConfigsParams | void>({
 			query: (params) => ({
 				url: "/governance/model-configs",
-				params: { from_memory: params?.fromMemory ?? false },
+				params: {
+					...(params?.limit && { limit: params.limit }),
+					...(params?.offset !== undefined && { offset: params.offset }),
+					...(params?.search && { search: params.search }),
+				},
 			}),
 			providesTags: ["ModelConfigs"],
 		}),
@@ -420,16 +425,20 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
-					const variants = [undefined, { fromMemory: true }] as const;
-					for (const variant of variants) {
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getModelConfigs" || entry?.status !== "fulfilled") continue;
+						const search = entry.originalArgs?.search as string | undefined;
+						if (search && !data.model_config.model_name.toLowerCase().includes(search.toLowerCase())) continue;
 						dispatch(
-							governanceApi.util.updateQueryData("getModelConfigs", variant, (draft) => {
+							governanceApi.util.updateQueryData("getModelConfigs", entry.originalArgs, (draft) => {
 								if (!draft.model_configs) draft.model_configs = [];
 								draft.model_configs.unshift(data.model_config);
 								draft.count = (draft.count || 0) + 1;
+								draft.total_count = (draft.total_count || 0) + 1;
 							}),
 						);
 					}
@@ -445,13 +454,14 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			async onQueryStarted({ id }, { dispatch, queryFulfilled }) {
+			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
-					const variants = [undefined, { fromMemory: true }] as const;
-					for (const variant of variants) {
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getModelConfigs" || entry?.status !== "fulfilled") continue;
 						dispatch(
-							governanceApi.util.updateQueryData("getModelConfigs", variant, (draft) => {
+							governanceApi.util.updateQueryData("getModelConfigs", entry.originalArgs, (draft) => {
 								if (!draft.model_configs) return;
 								const index = draft.model_configs.findIndex((mc) => mc.id === id);
 								if (index !== -1) {
@@ -476,16 +486,21 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/model-configs/${id}`,
 				method: "DELETE",
 			}),
-			async onQueryStarted(id, { dispatch, queryFulfilled }) {
+			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;
-					const variants = [undefined, { fromMemory: true }] as const;
-					for (const variant of variants) {
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getModelConfigs" || entry?.status !== "fulfilled") continue;
 						dispatch(
-							governanceApi.util.updateQueryData("getModelConfigs", variant, (draft) => {
+							governanceApi.util.updateQueryData("getModelConfigs", entry.originalArgs, (draft) => {
 								if (!draft.model_configs) return;
+								const before = draft.model_configs.length;
 								draft.model_configs = draft.model_configs.filter((mc) => mc.id !== id);
-								draft.count = Math.max(0, (draft.count || 0) - 1);
+								if (draft.model_configs.length < before) {
+									draft.count = Math.max(0, (draft.count || 0) - 1);
+									draft.total_count = Math.max(0, (draft.total_count || 0) - 1);
+								}
 							}),
 						);
 					}

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -327,10 +327,19 @@ export interface UpdateModelConfigRequest {
 	rate_limit?: UpdateRateLimitRequest;
 }
 
+export interface GetModelConfigsParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+}
+
 // Response types for model configs
 export interface GetModelConfigsResponse {
 	model_configs: ModelConfig[];
 	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
 }
 
 // Provider governance - for extending provider with budget/rate limit


### PR DESCRIPTION
## Summary

Adds server-side search and pagination support for Model Limits (model configs).
Previously the API returned all model configs in a single response. Now it
supports `limit`, `offset`, and `search` query parameters for efficient
paginated retrieval with name-based filtering.

## Changes

- Added `ModelConfigsQueryParams` struct and `GetModelConfigsPaginated` to the
  `ConfigStore` interface and RDB implementation with `LOWER(model_name) LIKE ?`
  search, limit/offset clamping (default 25, max 100), and
  `Preload("Budget").Preload("RateLimit")`
- Updated `getModelConfigs` handler: `from_memory` path unchanged, DB path now
  uses paginated method and returns wrapped response with `total_count`,
  `limit`, `offset`
- Added `GetModelConfigsParams` type and extended `GetModelConfigsResponse` with
  pagination fields
- Rewrote RTK Query `getModelConfigs` to accept pagination params; rewrote all
  three mutations (create/update/delete) from hardcoded
  `[undefined, { fromMemory: true }]` cache variants to cache iteration pattern
  for correct optimistic updates across dynamic pagination keys
- Added search input, debounced search (300ms), pagination controls
  (Previous/Next), and "No matching model limits found." filtered empty state to
  `modelLimitsTable.tsx` and `modelLimitsView.tsx`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to Model Limits page
2. Verify table loads with pagination (25 per page)
3. Type in the search box — results filter by model name and reset to page 1
4. Click Previous/Next to paginate
5. Create, update, and delete a model config — table updates optimistically
6. With no model configs, verify the true empty state renders
7. With model configs but a non-matching search, verify "No matching model
   limits found." shows

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A — UI changes are functional (search + pagination controls), no visual
redesign.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Search uses parameterized `LIKE` queries (no SQL
injection risk). No auth, secrets, or PII changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
