### PR TITLE
feat: adds search to routing rules

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2451,7 +2451,7 @@ func (s *RDBConfigStore) UpdateRateLimitUsage(ctx context.Context, id string, to
 }
 
 // loadRoutingRulesOrdered loads routing rules with Targets preloaded, using consistent ordering:
-// rules by priority ASC, created_at DESC; targets by weight DESC for deterministic ordering.
+// rules by priority ASC, created_at DESC, id ASC; targets by weight DESC for deterministic ordering.
 func (s *RDBConfigStore) loadRoutingRulesOrdered(ctx context.Context, dest *[]tables.TableRoutingRule, scopes ...func(*gorm.DB) *gorm.DB) error {
 	q := s.db.WithContext(ctx).
 		Preload("Targets", func(db *gorm.DB) *gorm.DB {
@@ -2460,7 +2460,7 @@ func (s *RDBConfigStore) loadRoutingRulesOrdered(ctx context.Context, dest *[]ta
 				Order("COALESCE(model, '') ASC").
 				Order("COALESCE(key_id, '') ASC")
 		}).
-		Order("priority ASC, created_at DESC")
+		Order("priority ASC, created_at DESC, id ASC")
 	for _, scope := range scopes {
 		q = scope(q)
 	}
@@ -2474,6 +2474,50 @@ func (s *RDBConfigStore) GetRoutingRules(ctx context.Context) ([]tables.TableRou
 		return nil, err
 	}
 	return rules, nil
+}
+
+// GetRoutingRulesPaginated retrieves routing rules with pagination and optional search filtering.
+func (s *RDBConfigStore) GetRoutingRulesPaginated(ctx context.Context, params RoutingRulesQueryParams) ([]tables.TableRoutingRule, int64, error) {
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableRoutingRule{})
+
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
+	}
+
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := params.Limit
+	offset := params.Offset
+
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+
+	if offset < 0 {
+		offset = 0
+	}
+
+	var rules []tables.TableRoutingRule
+	if err := baseQuery.
+		Preload("Targets", func(db *gorm.DB) *gorm.DB {
+			return db.Order("weight DESC").
+				Order("COALESCE(provider, '') ASC").
+				Order("COALESCE(model, '') ASC").
+				Order("COALESCE(key_id, '') ASC")
+		}).
+		Order("priority ASC, created_at DESC, id ASC").
+		Offset(offset).
+		Limit(limit).
+		Find(&rules).Error; err != nil {
+		return nil, 0, err
+	}
+	return rules, totalCount, nil
 }
 
 // GetRoutingRulesByScope retrieves routing rules by scope and scope ID, ordered by priority ASC.

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -30,6 +30,13 @@ type ModelConfigsQueryParams struct {
 	Search string
 }
 
+// RoutingRulesQueryParams holds pagination, filtering, and search parameters for routing rules queries.
+type RoutingRulesQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -144,6 +151,7 @@ type ConfigStore interface {
 	GetRoutingRulesByScope(ctx context.Context, scope string, scopeID string) ([]tables.TableRoutingRule, error)
 	GetRoutingRule(ctx context.Context, id string) (*tables.TableRoutingRule, error)
 	GetRedactedRoutingRules(ctx context.Context, ids []string) ([]tables.TableRoutingRule, error) // leave ids empty to get all
+	GetRoutingRulesPaginated(ctx context.Context, params RoutingRulesQueryParams) ([]tables.TableRoutingRule, int64, error)
 	CreateRoutingRule(ctx context.Context, rule *tables.TableRoutingRule, tx ...*gorm.DB) error
 	UpdateRoutingRule(ctx context.Context, rule *tables.TableRoutingRule, tx ...*gorm.DB) error
 	DeleteRoutingRule(ctx context.Context, id string, tx ...*gorm.DB) error

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -2734,9 +2734,6 @@ func (h *GovernanceHandler) getRoutingRules(ctx *fasthttp.RequestCtx) {
 	scope := string(ctx.QueryArgs().Peek("scope"))
 	scopeID := string(ctx.QueryArgs().Peek("scope_id"))
 
-	var rules []configstoreTables.TableRoutingRule
-	var err error
-
 	// Check if "from_memory" query parameter is set to true
 	fromMemory := string(ctx.QueryArgs().Peek("from_memory")) == "true"
 	if fromMemory {
@@ -2748,12 +2745,11 @@ func (h *GovernanceHandler) getRoutingRules(ctx *fasthttp.RequestCtx) {
 		inMemoryRules := gd.RoutingRules
 
 		// Filter rules by scope and scopeID
+		var rules []configstoreTables.TableRoutingRule
 		for _, rule := range inMemoryRules {
-			// If scope filter is specified, only include matching rules
 			if scope != "" && rule.Scope != scope {
 				continue
 			}
-			// If scopeID filter is specified, only include matching rules
 			if scopeID != "" {
 				ruleScope := ""
 				if rule.ScopeID != nil {
@@ -2765,28 +2761,103 @@ func (h *GovernanceHandler) getRoutingRules(ctx *fasthttp.RequestCtx) {
 			}
 			rules = append(rules, *rule)
 		}
-	} else {
-		// Get from config store (database)
-		if scope != "" || scopeID != "" {
-			rules, err = h.configStore.GetRoutingRulesByScope(ctx, scope, scopeID)
-		} else {
-			rules, err = h.configStore.GetRoutingRules(ctx)
-		}
+
+		SendJSON(ctx, map[string]interface{}{
+			"rules":       rules,
+			"count":       len(rules),
+			"total_count": len(rules),
+			"limit":       len(rules),
+			"offset":      0,
+		})
+		return
+	}
+
+	// If scope/scopeID filters are specified, use the existing non-paginated path
+	if scope != "" || scopeID != "" {
+		rules, err := h.configStore.GetRoutingRulesByScope(ctx, scope, scopeID)
 		if err != nil {
 			SendError(ctx, 500, "Failed to get routing rules")
 			return
 		}
+		response := make([]configstoreTables.TableRoutingRule, 0, len(rules))
+		for _, rule := range rules {
+			response = append(response, rule)
+		}
+		SendJSON(ctx, map[string]interface{}{
+			"rules":       response,
+			"count":       len(response),
+			"total_count": len(response),
+			"limit":       len(response),
+			"offset":      0,
+		})
+		return
 	}
 
-	// Convert to JSON-serializable format
-	response := make([]configstoreTables.TableRoutingRule, 0, len(rules))
-	for _, rule := range rules {
-		response = append(response, rule)
+	// Check for pagination parameters
+	limitStr := string(ctx.QueryArgs().Peek("limit"))
+	offsetStr := string(ctx.QueryArgs().Peek("offset"))
+	search := string(ctx.QueryArgs().Peek("search"))
+
+	if limitStr != "" || offsetStr != "" || search != "" {
+		// Paginated path
+		params := configstore.RoutingRulesQueryParams{
+			Search: search,
+		}
+		if limitStr != "" {
+			n, err := strconv.Atoi(limitStr)
+			if err != nil {
+				SendError(ctx, 400, "Invalid limit parameter: must be a number")
+				return
+			}
+			if n < 0 {
+				SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
+				return
+			}
+			params.Limit = n
+		}
+		if offsetStr != "" {
+			n, err := strconv.Atoi(offsetStr)
+			if err != nil {
+				SendError(ctx, 400, "Invalid offset parameter: must be a number")
+				return
+			}
+			if n < 0 {
+				SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
+				return
+			}
+			params.Offset = n
+		}
+
+		params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+		rules, totalCount, err := h.configStore.GetRoutingRulesPaginated(ctx, params)
+		if err != nil {
+			logger.Error("failed to retrieve routing rules: %v", err)
+			SendError(ctx, 500, "Failed to retrieve routing rules")
+			return
+		}
+		SendJSON(ctx, map[string]interface{}{
+			"rules":       rules,
+			"count":       len(rules),
+			"total_count": totalCount,
+			"limit":       params.Limit,
+			"offset":      params.Offset,
+		})
+		return
 	}
 
+	// Non-paginated path: return all routing rules
+	rules, err := h.configStore.GetRoutingRules(ctx)
+	if err != nil {
+		logger.Error("failed to retrieve routing rules: %v", err)
+		SendError(ctx, 500, "Failed to retrieve routing rules")
+		return
+	}
 	SendJSON(ctx, map[string]interface{}{
-		"rules": response,
-		"count": len(response),
+		"rules":       rules,
+		"count":       len(rules),
+		"total_count": len(rules),
+		"limit":       len(rules),
+		"offset":      0,
 	})
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -890,6 +890,10 @@ func (m *MockConfigStore) GetModelConfigs(ctx context.Context) ([]tables.TableMo
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetModelConfigsPaginated(ctx context.Context, params configstore.ModelConfigsQueryParams) ([]tables.TableModelConfig, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) GetModelConfig(ctx context.Context, modelName string, provider *string) (*tables.TableModelConfig, error) {
 	return nil, nil
 }
@@ -1021,6 +1025,10 @@ func (m *MockConfigStore) GetRoutingRule(ctx context.Context, id string) (*table
 
 func (m *MockConfigStore) GetRedactedRoutingRules(ctx context.Context, ids []string) ([]tables.TableRoutingRule, error) {
 	return nil, nil
+}
+
+func (m *MockConfigStore) GetRoutingRulesPaginated(ctx context.Context, params configstore.RoutingRulesQueryParams) ([]tables.TableRoutingRule, int64, error) {
+	return nil, 0, nil
 }
 
 func (m *MockConfigStore) CreateRoutingRule(ctx context.Context, rule *tables.TableRoutingRule, tx ...*gorm.DB) error {

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -82,7 +82,8 @@ export function RoutingRuleSheet({
 	editingRule,
 	onSuccess,
 }: RoutingRuleDialogProps) {
-	const { data: rules = [] } = useGetRoutingRulesQuery();
+	const { data: rulesData } = useGetRoutingRulesQuery();
+	const rules = rulesData?.rules || [];
 	const { data: providersData = [] } = useGetProvidersQuery();
 	const { data: vksData = { virtual_keys: [] } } = useGetVirtualKeysQuery();
 	const { data: teamsData = { teams: [] } } = useGetTeamsQuery({});

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -8,6 +8,7 @@
 import { RoutingRule } from "@/lib/types/routingRules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
 	Table,
 	TableBody,
@@ -26,7 +27,7 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
-import { Edit, Trash2, AlertCircle } from "lucide-react";
+import { ChevronLeft, ChevronRight, Edit, Search, Trash2 } from "lucide-react";
 import { truncateCELExpression, getScopeLabel, getPriorityBadgeClass } from "@/lib/utils/routingRules";
 import { useState } from "react";
 import { useDeleteRoutingRuleMutation } from "@/lib/store/apis/routingRulesApi";
@@ -38,13 +39,19 @@ import { RoutingTarget } from "@/lib/types/routingRules";
 
 interface RoutingRulesTableProps {
 	rules: RoutingRule[] | undefined;
+	totalCount: number;
 	isLoading: boolean;
 	onEdit: (rule: RoutingRule) => void;
 	/** When false, delete button is hidden and deletion is disabled (e.g. for read-only users). */
 	canDelete?: boolean;
+	search: string;
+	onSearchChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false }: RoutingRulesTableProps) {
+export function RoutingRulesTable({ rules, totalCount, isLoading, onEdit, canDelete = false, search, onSearchChange, offset, limit, onOffsetChange }: RoutingRulesTableProps) {
 	const [deleteRuleId, setDeleteRuleId] = useState<string | null>(null);
 	const [deleteRoutingRule, { isLoading: isDeleting }] = useDeleteRoutingRuleMutation();
 
@@ -89,21 +96,26 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 		);
 	}
 
-	if (!rules || rules.length === 0) {
-		return (
-			<div className="rounded-sm border border-dashed p-8 text-center">
-				<AlertCircle className="h-8 w-8 text-muted-foreground mx-auto mb-3" />
-				<p className="font-medium">No routing rules yet</p>
-				<p className="text-sm text-muted-foreground">Create your first rule to get started</p>
-			</div>
-		);
-	}
-
-	const sortedRules = [...rules].sort((a, b) => a.priority - b.priority);
+	const sortedRules = rules ? [...rules].sort((a, b) => a.priority - b.priority) : [];
 	const ruleToDelete = sortedRules.find((r) => r.id === deleteRuleId);
 
 	return (
 		<>
+			{/* Toolbar: Search */}
+			<div className="flex items-center gap-3">
+				<div className="relative max-w-sm flex-1">
+					<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+					<Input
+						aria-label="Search routing rules by name"
+						placeholder="Search by name..."
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						className="pl-9"
+						data-testid="routing-rules-search-input"
+					/>
+				</div>
+			</div>
+
 			<div className="rounded-sm border overflow-hidden">
 				<Table>
 					<TableHeader>
@@ -118,7 +130,14 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 						</TableRow>
 					</TableHeader>
 					<TableBody>
-						{sortedRules.map((rule) => (
+						{sortedRules.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={7} className="h-24 text-center">
+									<span className="text-muted-foreground text-sm">No matching routing rules found.</span>
+								</TableCell>
+							</TableRow>
+						) : (
+						sortedRules.map((rule) => (
 							<TableRow key={rule.id} className="hover:bg-muted/50 cursor-pointer transition-colors">
 								<TableCell className="font-medium">
 									<div className="flex flex-col gap-1">
@@ -167,10 +186,42 @@ export function RoutingRulesTable({ rules, isLoading, onEdit, canDelete = false 
 									</div>
 								</TableCell>
 							</TableRow>
-						))}
+						))
+						)}
 					</TableBody>
 				</Table>
 			</div>
+
+			{/* Pagination */}
+			{totalCount > 0 && (
+				<div className="flex items-center justify-between px-2">
+					<p className="text-muted-foreground text-sm">
+						Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+					</p>
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={offset === 0}
+							onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+							data-testid="routing-rules-pagination-prev-btn"
+						>
+							<ChevronLeft className="mr-1 h-4 w-4" />
+							Previous
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={offset + limit >= totalCount}
+							onClick={() => onOffsetChange(offset + limit)}
+							data-testid="routing-rules-pagination-next-btn"
+						>
+							Next
+							<ChevronRight className="ml-1 h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			)}
 
 			<AlertDialog open={!!deleteRuleId} onOpenChange={(open) => !open && setDeleteRuleId(null)}>
 				<AlertDialogContent>

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -7,24 +7,56 @@
 
 import { RbacOperation, RbacResource, useRbac } from "@/app/_fallbacks/enterprise/lib/contexts/rbacContext";
 import { Button } from "@/components/ui/button";
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { useGetRoutingRulesQuery } from "@/lib/store/apis/routingRulesApi";
 import { RoutingRule } from "@/lib/types/routingRules";
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { RoutingRuleSheet } from "./routingRuleSheet";
 import { RoutingRulesEmptyState } from "./routingRulesEmptyState";
 import { RoutingRulesTable } from "./routingRulesTable";
 
+const POLLING_INTERVAL = 5000;
+const PAGE_SIZE = 25;
+
 export function RoutingRulesView() {
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [editingRule, setEditingRule] = useState<RoutingRule | null>(null);
+
+	const [search, setSearch] = useState("");
+	const [offset, setOffset] = useState(0);
+
+	const debouncedSearch = useDebouncedValue(search, 300);
+
+	// Reset to first page when search changes
+	useEffect(() => {
+		setOffset(0);
+	}, [debouncedSearch]);
 
 	// Permissions
 	const canCreate = useRbac(RbacResource.RoutingRules, RbacOperation.Create);
 	const canDelete = useRbac(RbacResource.RoutingRules, RbacOperation.Delete);
 
 	// API
-	const { data: rules = [], isLoading } = useGetRoutingRulesQuery();
+	const { data: rulesData, isLoading } = useGetRoutingRulesQuery(
+		{
+			limit: PAGE_SIZE,
+			offset,
+			search: debouncedSearch || undefined,
+		},
+		{
+			pollingInterval: POLLING_INTERVAL,
+		},
+	);
+
+	const rules = rulesData?.rules || [];
+	const totalCount = rulesData?.total_count || 0;
+
+	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+	useEffect(() => {
+		if (!rulesData || offset < totalCount) return;
+		setOffset(totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE);
+	}, [totalCount, offset]);
 
 	const handleCreateNew = () => {
 		setEditingRule(null);
@@ -43,8 +75,10 @@ export function RoutingRulesView() {
 		}
 	};
 
-	// Empty state (same pattern as Plugins / MCP Servers): no header, just empty state + sheet
-	if (!isLoading && rules.length === 0) {
+	const hasActiveFilters = debouncedSearch;
+
+	// True empty state: no rules at all (not just filtered to zero)
+	if (!isLoading && totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				<RoutingRulesEmptyState onAddClick={handleCreateNew} canCreate={canCreate} />
@@ -74,7 +108,18 @@ export function RoutingRulesView() {
 				)}
 			</div>
 
-			<RoutingRulesTable rules={rules} isLoading={isLoading} onEdit={handleEdit} canDelete={canDelete} />
+			<RoutingRulesTable
+				rules={rules}
+				totalCount={totalCount}
+				isLoading={isLoading}
+				onEdit={handleEdit}
+				canDelete={canDelete}
+				search={search}
+				onSearchChange={setSearch}
+				offset={offset}
+				limit={PAGE_SIZE}
+				onOffsetChange={setOffset}
+			/>
 
 			<RoutingRuleSheet open={dialogOpen} onOpenChange={handleDialogOpenChange} editingRule={editingRule} />
 		</div>

--- a/ui/lib/store/apis/routingRulesApi.ts
+++ b/ui/lib/store/apis/routingRulesApi.ts
@@ -3,24 +3,21 @@
  * Handles all API communication for routing rules CRUD operations
  */
 
-import { RoutingRule, GetRoutingRulesResponse, CreateRoutingRuleRequest, UpdateRoutingRuleRequest } from "@/lib/types/routingRules";
+import { RoutingRule, GetRoutingRulesResponse, GetRoutingRulesParams, CreateRoutingRuleRequest, UpdateRoutingRuleRequest } from "@/lib/types/routingRules";
 import { baseApi } from "./baseApi";
 
 export const routingRulesApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
-		// Get all routing rules
-		getRoutingRules: builder.query<RoutingRule[], { fromMemory?: boolean } | void>({
-			query: (params) => {
-				const searchParams = new URLSearchParams();
-				if (params?.fromMemory) {
-					searchParams.append("from_memory", "true");
-				}
-				return {
-					url: `/governance/routing-rules${searchParams.toString() ? `?${searchParams.toString()}` : ""}`,
-					method: "GET",
-				};
-			},
-			transformResponse: (response: GetRoutingRulesResponse) => response.rules || [],
+		// Get routing rules with pagination
+		getRoutingRules: builder.query<GetRoutingRulesResponse, GetRoutingRulesParams | void>({
+			query: (params) => ({
+				url: "/governance/routing-rules",
+				params: {
+					...(params?.limit && { limit: params.limit }),
+					...(params?.offset !== undefined && { offset: params.offset }),
+					...(params?.search && { search: params.search }),
+				},
+			}),
 			providesTags: ["RoutingRules"],
 		}),
 
@@ -42,22 +39,23 @@ export const routingRulesApi = baseApi.injectEndpoints({
 				body,
 			}),
 			transformResponse: (response: { rule: RoutingRule }) => response.rule,
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data: newRule } = await queryFulfilled;
-					// Update the default cache variant
-					dispatch(
-						routingRulesApi.util.updateQueryData("getRoutingRules", undefined, (draft) => {
-							draft.push(newRule);
-						})
-					);
-					// Update the fromMemory cache variant
-					dispatch(
-						routingRulesApi.util.updateQueryData("getRoutingRules", { fromMemory: true }, (draft) => {
-							draft.push(newRule);
-						})
-					);
-					// Also update the individual routing rule cache
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getRoutingRules" || entry?.status !== "fulfilled") continue;
+						const search = entry.originalArgs?.search as string | undefined;
+						if (search && !newRule.name.toLowerCase().includes(search.toLowerCase())) continue;
+						dispatch(
+							routingRulesApi.util.updateQueryData("getRoutingRules", entry.originalArgs, (draft) => {
+								if (!draft.rules) draft.rules = [];
+								draft.rules.unshift(newRule);
+								draft.count = (draft.count || 0) + 1;
+								draft.total_count = (draft.total_count || 0) + 1;
+							}),
+						);
+					}
 					dispatch(
 						routingRulesApi.util.updateQueryData("getRoutingRule", newRule.id, () => newRule)
 					);
@@ -73,28 +71,22 @@ export const routingRulesApi = baseApi.injectEndpoints({
 				body: data,
 			}),
 			transformResponse: (response: { rule: RoutingRule }) => response.rule,
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+			async onQueryStarted({ id }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data: updatedRule } = await queryFulfilled;
-					// Update the default cache variant
-					dispatch(
-						routingRulesApi.util.updateQueryData("getRoutingRules", undefined, (draft) => {
-							const index = draft.findIndex((r) => r.id === updatedRule.id);
-							if (index !== -1) {
-								draft[index] = updatedRule;
-							}
-						})
-					);
-					// Update the fromMemory cache variant
-					dispatch(
-						routingRulesApi.util.updateQueryData("getRoutingRules", { fromMemory: true }, (draft) => {
-							const index = draft.findIndex((r) => r.id === updatedRule.id);
-							if (index !== -1) {
-								draft[index] = updatedRule;
-							}
-						})
-					);
-					// Also update the individual routing rule cache
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getRoutingRules" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							routingRulesApi.util.updateQueryData("getRoutingRules", entry.originalArgs, (draft) => {
+								if (!draft.rules) return;
+								const index = draft.rules.findIndex((r) => r.id === id);
+								if (index !== -1) {
+									draft.rules[index] = updatedRule;
+								}
+							}),
+						);
+					}
 					dispatch(
 						routingRulesApi.util.updateQueryData("getRoutingRule", updatedRule.id, () => updatedRule)
 					);
@@ -108,27 +100,24 @@ export const routingRulesApi = baseApi.injectEndpoints({
 				url: `/governance/routing-rules/${id}`,
 				method: "DELETE",
 			}),
-			async onQueryStarted(ruleId, { dispatch, queryFulfilled }) {
+			async onQueryStarted(ruleId, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;
-					// Update the default cache variant
-					dispatch(
-						routingRulesApi.util.updateQueryData("getRoutingRules", undefined, (draft) => {
-							const index = draft.findIndex((r) => r.id === ruleId);
-							if (index !== -1) {
-								draft.splice(index, 1);
-							}
-						})
-					);
-					// Update the fromMemory cache variant
-					dispatch(
-						routingRulesApi.util.updateQueryData("getRoutingRules", { fromMemory: true }, (draft) => {
-							const index = draft.findIndex((r) => r.id === ruleId);
-							if (index !== -1) {
-								draft.splice(index, 1);
-							}
-						})
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getRoutingRules" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							routingRulesApi.util.updateQueryData("getRoutingRules", entry.originalArgs, (draft) => {
+								if (!draft.rules) return;
+								const before = draft.rules.length;
+								draft.rules = draft.rules.filter((r) => r.id !== ruleId);
+								if (draft.rules.length < before) {
+									draft.count = Math.max(0, (draft.count || 0) - 1);
+									draft.total_count = Math.max(0, (draft.total_count || 0) - 1);
+								}
+							}),
+						);
+					}
 				} catch {}
 			},
 		}),

--- a/ui/lib/types/routingRules.ts
+++ b/ui/lib/types/routingRules.ts
@@ -44,9 +44,18 @@ export interface CreateRoutingRuleRequest {
 /** Partial update: only sent fields are applied; allows clearing fields by sending "" or []. */
 export type UpdateRoutingRuleRequest = Partial<CreateRoutingRuleRequest>;
 
+export interface GetRoutingRulesParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+}
+
 export interface GetRoutingRulesResponse {
 	rules: RoutingRule[];
 	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
 }
 
 export interface GetRoutingRuleResponse {


### PR DESCRIPTION
## Summary

Adds server-side search and pagination support for Routing Rules. Previously the
API returned all routing rules in a single response. Now it supports `limit`,
`offset`, and `search` query parameters for efficient paginated retrieval with
name-based filtering.

## Changes

- Added `RoutingRulesQueryParams` struct and `GetRoutingRulesPaginated` to the
  `ConfigStore` interface and RDB implementation with `LOWER(name) LIKE ?`
  search, limit/offset clamping (default 25, max 100), `Preload("Targets")` with
  the same target ordering as the non-paginated version, and
  `Order("priority ASC, created_at DESC")`
- Refactored `getRoutingRules` handler into three distinct paths: (1)
  `from_memory=true` returns in-memory rules unchanged, (2) `scope`/`scope_id`
  filters use existing `GetRoutingRulesByScope` non-paginated, (3) default uses
  new `GetRoutingRulesPaginated` — all paths now return wrapped
  `{ rules, count, total_count, limit, offset }` format
- Added `GetRoutingRulesParams` type and extended `GetRoutingRulesResponse` with
  pagination fields; removed `transformResponse` since the response is now a
  wrapped object
- Rewrote RTK Query `getRoutingRules` to accept pagination params; rewrote all
  three mutations (create/update/delete) from dual hardcoded cache variants
  (`undefined` + `{ fromMemory: true }`) to cache iteration pattern
- Added search input, debounced search (300ms), pagination controls, and
  filtered empty state to `routingRulesTable.tsx` and `routingRulesView.tsx`;
  removed the old inline "No routing rules yet" empty state with `AlertCircle`
  icon (now handled by parent view's true empty state)
- **Notable**: Updated `routingRuleSheet.tsx` from `const { data: rules = [] }`
  to `rulesData?.rules || []` since the query response shape changed from a bare
  array to a wrapped object — this is a consumer that populates the priority
  dropdown
- Added `GetModelConfigsPaginated` and `GetRoutingRulesPaginated` stubs to
  `MockConfigStore` in `config_test.go`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to Routing Rules page
2. Verify table loads with pagination (25 per page)
3. Type in the search box — results filter by rule name and reset to page 1
4. Click Previous/Next to paginate
5. Create, update, and delete a routing rule — table updates optimistically
6. Open the routing rule sheet and verify the priority dropdown still populates
   from existing rules
7. Verify `from_memory` and `scope`/`scope_id` query paths still work (used by
   internal consumers)

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A — UI changes are functional (search + pagination controls), no visual
redesign.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Search uses parameterized `LIKE` queries (no SQL
injection risk). No auth, secrets, or PII changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
