### PR TITLE
feat: adds search to mcp server catalog

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -935,6 +935,44 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 	}, nil
 }
 
+// GetMCPClientsPaginated retrieves MCP clients with pagination and optional search.
+func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error) {
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableMCPClient{})
+
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
+	}
+
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := params.Limit
+	offset := params.Offset
+
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+
+	if offset < 0 {
+		offset = 0
+	}
+
+	var clients []tables.TableMCPClient
+	if err := baseQuery.
+		Order("created_at ASC, client_id ASC").
+		Offset(offset).
+		Limit(limit).
+		Find(&clients).Error; err != nil {
+		return nil, 0, err
+	}
+	return clients, totalCount, nil
+}
+
 // GetMCPClientByID retrieves an MCP client by ID from the database.
 func (s *RDBConfigStore) GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error) {
 	var mcpClient tables.TableMCPClient

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -37,6 +37,13 @@ type RoutingRulesQueryParams struct {
 	Search string
 }
 
+// MCPClientsQueryParams holds pagination, filtering, and search parameters for MCP client queries.
+type MCPClientsQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -68,6 +75,7 @@ type ConfigStore interface {
 	GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, error)
 	GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error)
 	GetMCPClientByName(ctx context.Context, name string) (*tables.TableMCPClient, error)
+	GetMCPClientsPaginated(ctx context.Context, params MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error)
 	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error
 	DeleteMCPClientConfig(ctx context.Context, id string) error

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -65,14 +67,32 @@ type MCPClientResponse struct {
 
 // getMCPClients handles GET /api/mcp/clients - Get all MCP clients
 func (h *MCPHandler) getMCPClients(ctx *fasthttp.RequestCtx) {
+	emptyResponse := map[string]interface{}{
+		"clients":     []MCPClientResponse{},
+		"count":       0,
+		"total_count": 0,
+		"limit":       0,
+		"offset":      0,
+	}
 	if h.store.ConfigStore == nil {
-		SendJSON(ctx, []MCPClientResponse{})
+		SendJSON(ctx, emptyResponse)
 		return
 	}
-	// Get clients from store config
+
+	// Check if pagination params are present — if so, use paginated DB path
+	limitStr := string(ctx.QueryArgs().Peek("limit"))
+	offsetStr := string(ctx.QueryArgs().Peek("offset"))
+	searchStr := string(ctx.QueryArgs().Peek("search"))
+
+	if limitStr != "" || offsetStr != "" || searchStr != "" {
+		h.getMCPClientsPaginated(ctx, limitStr, offsetStr, searchStr)
+		return
+	}
+
+	// Non-paginated path: read from in-memory config
 	configsInStore := h.store.MCPConfig
 	if configsInStore == nil {
-		SendJSON(ctx, []MCPClientResponse{})
+		SendJSON(ctx, emptyResponse)
 		return
 	}
 	// Get actual connected clients from Bifrost
@@ -114,7 +134,114 @@ func (h *MCPHandler) getMCPClients(ctx *fasthttp.RequestCtx) {
 			})
 		}
 	}
-	SendJSON(ctx, clients)
+	SendJSON(ctx, map[string]interface{}{
+		"clients":     clients,
+		"count":       len(clients),
+		"total_count": len(clients),
+		"limit":       len(clients),
+		"offset":      0,
+	})
+}
+
+// getMCPClientsPaginated handles the paginated path for GET /api/mcp/clients
+func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, offsetStr, searchStr string) {
+	params := configstore.MCPClientsQueryParams{
+		Search: searchStr,
+	}
+	if limitStr != "" {
+		n, err := strconv.Atoi(limitStr)
+		if err != nil {
+			SendError(ctx, 400, "Invalid limit parameter: must be a number")
+			return
+		}
+		if n < 0 {
+			SendError(ctx, 400, "Invalid limit parameter: must be non-negative")
+			return
+		}
+		params.Limit = n
+	}
+	if offsetStr != "" {
+		n, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			SendError(ctx, 400, "Invalid offset parameter: must be a number")
+			return
+		}
+		if n < 0 {
+			SendError(ctx, 400, "Invalid offset parameter: must be non-negative")
+			return
+		}
+		params.Offset = n
+	}
+
+	dbClients, totalCount, err := h.store.ConfigStore.GetMCPClientsPaginated(ctx, params)
+	if err != nil {
+		logger.Error("failed to retrieve MCP clients: %v", err)
+		SendError(ctx, 500, "Failed to retrieve MCP clients")
+		return
+	}
+
+	// Get connected clients from Bifrost engine for state/tools merge
+	clientsInBifrost, err := h.client.GetMCPClients()
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get MCP clients from Bifrost: %v", err))
+		return
+	}
+	connectedClientsMap := make(map[string]schemas.MCPClient)
+	for _, client := range clientsInBifrost {
+		connectedClientsMap[client.Config.ID] = client
+	}
+
+	// Convert DB rows to MCPClientConfig and merge with engine state
+	clients := make([]MCPClientResponse, 0, len(dbClients))
+	for _, dbClient := range dbClients {
+		isPingAvailable := true
+		if dbClient.IsPingAvailable != nil {
+			isPingAvailable = *dbClient.IsPingAvailable
+		}
+		clientConfig := &schemas.MCPClientConfig{
+			ID:                 dbClient.ClientID,
+			Name:               dbClient.Name,
+			IsCodeModeClient:   dbClient.IsCodeModeClient,
+			ConnectionType:     schemas.MCPConnectionType(dbClient.ConnectionType),
+			ConnectionString:   dbClient.ConnectionString,
+			StdioConfig:        dbClient.StdioConfig,
+			AuthType:           schemas.MCPAuthType(dbClient.AuthType),
+			OauthConfigID:      dbClient.OauthConfigID,
+			ToolsToExecute:     dbClient.ToolsToExecute,
+			ToolsToAutoExecute: dbClient.ToolsToAutoExecute,
+			Headers:            dbClient.Headers,
+			IsPingAvailable:    isPingAvailable,
+			ToolSyncInterval:   time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+			ToolPricing:        dbClient.ToolPricing,
+		}
+		redactedConfig := h.store.RedactMCPClientConfig(clientConfig)
+		if connectedClient, exists := connectedClientsMap[clientConfig.ID]; exists {
+			sortedTools := make([]schemas.ChatToolFunction, len(connectedClient.Tools))
+			copy(sortedTools, connectedClient.Tools)
+			sort.Slice(sortedTools, func(i, j int) bool {
+				return sortedTools[i].Name < sortedTools[j].Name
+			})
+			clients = append(clients, MCPClientResponse{
+				Config: redactedConfig,
+				Tools:  sortedTools,
+				State:  connectedClient.State,
+			})
+		} else {
+			clients = append(clients, MCPClientResponse{
+				Config: redactedConfig,
+				Tools:  []schemas.ChatToolFunction{},
+				State:  schemas.MCPConnectionStateError,
+			})
+		}
+	}
+
+	SendJSON(ctx, map[string]interface{}{
+		"clients":     clients,
+		"count":       len(clients),
+		"total_count": totalCount,
+		"limit":       params.Limit,
+		"offset":      params.Offset,
+	})
 }
 
 // reconnectMCPClient handles POST /api/mcp/client/{id}/reconnect - Reconnect an MCP client

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -518,6 +518,10 @@ func (m *MockConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, 
 	return nil
 }
 
+func (m *MockConfigStore) GetMCPClientsPaginated(ctx context.Context, params configstore.MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
 	return nil
 }

--- a/ui/app/workspace/mcp-registry/page.tsx
+++ b/ui/app/workspace/mcp-registry/page.tsx
@@ -2,15 +2,45 @@
 
 import FullPageLoader from "@/components/fullPageLoader";
 import { useToast } from "@/hooks/use-toast";
+import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetMCPClientsQuery } from "@/lib/store";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import MCPClientsTable from "./views/mcpClientsTable";
 
+const POLLING_INTERVAL = 5000;
+const PAGE_SIZE = 25;
+
 export default function MCPServersPage() {
-	const { data: mcpClients, error, isLoading, refetch } = useGetMCPClientsQuery();
+	const [search, setSearch] = useState("");
+	const [offset, setOffset] = useState(0);
+	const debouncedSearch = useDebouncedValue(search, 300);
+
+	// Reset to first page when search changes
+	useEffect(() => {
+		setOffset(0);
+	}, [debouncedSearch]);
+
+	const { data: mcpClientsData, error, isLoading, refetch } = useGetMCPClientsQuery(
+		{
+			limit: PAGE_SIZE,
+			offset,
+			search: debouncedSearch || undefined,
+		},
+		{
+			pollingInterval: POLLING_INTERVAL,
+		},
+	);
+
+	const mcpClients = mcpClientsData?.clients || [];
+	const totalCount = mcpClientsData?.total_count || 0;
+
+	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+	useEffect(() => {
+		if (!mcpClientsData || offset < totalCount) return;
+		setOffset(totalCount === 0 ? 0 : Math.floor((totalCount - 1) / PAGE_SIZE) * PAGE_SIZE);
+	}, [totalCount, offset]);
 
 	const { toast } = useToast();
-
 
 	useEffect(() => {
 		if (error) {
@@ -28,7 +58,17 @@ export default function MCPServersPage() {
 
 	return (
 		<div className="mx-auto w-full max-w-7xl">
-			<MCPClientsTable mcpClients={mcpClients || []} refetch={refetch} />
+			<MCPClientsTable
+				mcpClients={mcpClients}
+				totalCount={totalCount}
+				refetch={refetch}
+				search={search}
+				debouncedSearch={debouncedSearch}
+				onSearchChange={setSearch}
+				offset={offset}
+				limit={PAGE_SIZE}
+				onOffsetChange={setOffset}
+			/>
 		</div>
 	);
 }

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -15,23 +15,31 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
 import { MCP_STATUS_COLORS } from "@/lib/constants/config";
 import { getErrorMessage, useDeleteMCPClientMutation, useReconnectMCPClientMutation } from "@/lib/store";
 import { MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { Loader2, Plus, RefreshCcw, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, Plus, RefreshCcw, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import MCPClientSheet from "./mcpClientSheet";
 
 interface MCPClientsTableProps {
 	mcpClients: MCPClient[];
+	totalCount: number;
 	refetch?: () => void;
+	search: string;
+	debouncedSearch: string;
+	onSearchChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export default function MCPClientsTable({ mcpClients, refetch }: MCPClientsTableProps) {
+export default function MCPClientsTable({ mcpClients, totalCount, refetch, search, debouncedSearch, onSearchChange, offset, limit, onOffsetChange }: MCPClientsTableProps) {
 	const [formOpen, setFormOpen] = useState(false);
 	const hasCreateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Create);
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
@@ -127,8 +135,10 @@ export default function MCPClientsTable({ mcpClients, refetch }: MCPClientsTable
 		}
 	};
 
-	// Empty state when user has no MCP servers (same pattern as Virtual Keys, Plugins)
-	if (mcpClients.length === 0) {
+	const hasActiveFilters = debouncedSearch;
+
+	// True empty state: no servers at all (not just filtered to zero)
+	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				{formOpen && <ClientForm open={formOpen} onClose={() => setFormOpen(false)} onSaved={handleSaved} />}
@@ -152,22 +162,45 @@ export default function MCPClientsTable({ mcpClients, refetch }: MCPClientsTable
 				</CardTitle>
 				<CardDescription>Manage servers that can connect to the MCP Tools endpoint.</CardDescription>
 			</CardHeader>
-			<div className="rounded-sm border">
+
+			{/* Toolbar: Search */}
+			<div className="flex items-center gap-3">
+				<div className="relative max-w-sm flex-1">
+					<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+					<Input
+						aria-label="Search MCP servers by name"
+						placeholder="Search by name..."
+						value={search}
+						onChange={(e) => onSearchChange(e.target.value)}
+						className="pl-9"
+						data-testid="mcp-clients-search-input"
+					/>
+				</div>
+			</div>
+
+			<div className="rounded-sm border overflow-hidden">
 				<Table data-testid="mcp-clients-table">
 					<TableHeader>
-						<TableRow>
-							<TableHead>Name</TableHead>
-							<TableHead>Connection Type</TableHead>
-							<TableHead>Code Mode</TableHead>
-							<TableHead>Connection Info</TableHead>
-							<TableHead>Enabled Tools</TableHead>
-							<TableHead>Auto-execute Tools</TableHead>
-							<TableHead>State</TableHead>
+						<TableRow className="bg-muted/50">
+							<TableHead className="font-semibold">Name</TableHead>
+							<TableHead className="font-semibold">Connection Type</TableHead>
+							<TableHead className="font-semibold">Code Mode</TableHead>
+							<TableHead className="font-semibold">Connection Info</TableHead>
+							<TableHead className="font-semibold">Enabled Tools</TableHead>
+							<TableHead className="font-semibold">Auto-execute Tools</TableHead>
+							<TableHead className="font-semibold">State</TableHead>
 							<TableHead className="w-20 text-right"></TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
-						{mcpClients.map((c: MCPClient) => {
+						{mcpClients.length === 0 ? (
+							<TableRow>
+								<TableCell colSpan={8} className="h-24 text-center">
+									<span className="text-muted-foreground text-sm">No matching MCP servers found.</span>
+								</TableCell>
+							</TableRow>
+						) : (
+						mcpClients.map((c: MCPClient) => {
 							const enabledToolsCount =
 								c.state == "connected"
 									? c.config.tools_to_execute?.includes("*")
@@ -257,10 +290,43 @@ export default function MCPClientsTable({ mcpClients, refetch }: MCPClientsTable
 									</TableCell>
 								</TableRow>
 							);
-						})}
+						})
+						)}
 					</TableBody>
 				</Table>
 			</div>
+
+			{/* Pagination */}
+			{totalCount > 0 && (
+				<div className="flex items-center justify-between px-2">
+					<p className="text-muted-foreground text-sm">
+						Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+					</p>
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={offset === 0}
+							onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+							data-testid="mcp-clients-pagination-prev-btn"
+						>
+							<ChevronLeft className="mr-1 h-4 w-4" />
+							Previous
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={offset + limit >= totalCount}
+							onClick={() => onOffsetChange(offset + limit)}
+							data-testid="mcp-clients-pagination-next-btn"
+						>
+							Next
+							<ChevronRight className="ml-1 h-4 w-4" />
+						</Button>
+					</div>
+				</div>
+			)}
+
 			{formOpen && <ClientForm open={formOpen} onClose={() => setFormOpen(false)} onSaved={handleSaved} />}
 		</div>
 	);

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -148,7 +148,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 	const { data: keysData, error: keysError, isLoading: keysLoading } = useGetAllKeysQuery();
 	const [createVirtualKey, { isLoading: isCreating }] = useCreateVirtualKeyMutation();
 	const [updateVirtualKey, { isLoading: isUpdating }] = useUpdateVirtualKeyMutation();
-	const { data: mcpClientsData, error: mcpClientsError, isLoading: mcpClientsLoading } = useGetMCPClientsQuery();
+	const { data: mcpClientsResponse, error: mcpClientsError, isLoading: mcpClientsLoading } = useGetMCPClientsQuery();
+	const mcpClientsData = mcpClientsResponse?.clients || [];
 	const isLoading = isCreating || isUpdating;
 
 	const availableKeys = keysData || [];

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -1,13 +1,20 @@
-import { CreateMCPClientRequest, MCPClient, OAuthFlowResponse, OAuthStatusResponse, UpdateMCPClientRequest } from "@/lib/types/mcp";
+import { CreateMCPClientRequest, GetMCPClientsParams, GetMCPClientsResponse, MCPClient, OAuthFlowResponse, OAuthStatusResponse, UpdateMCPClientRequest } from "@/lib/types/mcp";
 import { baseApi } from "./baseApi";
 
 type CreateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
 
 export const mcpApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
-		// Get all MCP clients
-		getMCPClients: builder.query<MCPClient[], void>({
-			query: () => "/mcp/clients",
+		// Get MCP clients with pagination
+		getMCPClients: builder.query<GetMCPClientsResponse, GetMCPClientsParams | void>({
+			query: (params) => ({
+				url: "/mcp/clients",
+				params: {
+					...(params?.limit && { limit: params.limit }),
+					...(params?.offset !== undefined && { offset: params.offset }),
+					...(params?.search && { search: params.search }),
+				},
+			}),
 			providesTags: ["MCPClients"],
 		}),
 
@@ -18,7 +25,19 @@ export const mcpApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			invalidatesTags: ["MCPClients"],
+			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
+				try {
+					await queryFulfilled;
+					// MCP create may return an OAuth flow response, so we can't optimistically
+					// add the client — just invalidate to refetch
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getMCPClients" || entry?.status !== "fulfilled") continue;
+						dispatch(mcpApi.util.invalidateTags(["MCPClients"]));
+						break;
+					}
+				} catch {}
+			},
 		}),
 
 		// Update existing MCP client
@@ -28,7 +47,32 @@ export const mcpApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			invalidatesTags: ["MCPClients"],
+			async onQueryStarted({ id, data }, { dispatch, getState, queryFulfilled }) {
+				try {
+					await queryFulfilled;
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getMCPClients" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							mcpApi.util.updateQueryData("getMCPClients", entry.originalArgs, (draft) => {
+								if (!draft.clients) return;
+								const index = draft.clients.findIndex((c) => c.config.client_id === id);
+								if (index !== -1) {
+									// Merge the updated fields into the existing client
+									if (data.name !== undefined) draft.clients[index].config.name = data.name;
+									if (data.is_code_mode_client !== undefined) draft.clients[index].config.is_code_mode_client = data.is_code_mode_client;
+									if (data.headers !== undefined) draft.clients[index].config.headers = data.headers;
+									if (data.tools_to_execute !== undefined) draft.clients[index].config.tools_to_execute = data.tools_to_execute;
+									if (data.tools_to_auto_execute !== undefined) draft.clients[index].config.tools_to_auto_execute = data.tools_to_auto_execute;
+									if (data.is_ping_available !== undefined) draft.clients[index].config.is_ping_available = data.is_ping_available;
+									if (data.tool_pricing !== undefined) draft.clients[index].config.tool_pricing = data.tool_pricing;
+									if (data.tool_sync_interval !== undefined) draft.clients[index].config.tool_sync_interval = data.tool_sync_interval;
+								}
+							}),
+						);
+					}
+				} catch {}
+			},
 		}),
 
 		// Delete MCP client
@@ -37,7 +81,26 @@ export const mcpApi = baseApi.injectEndpoints({
 				url: `/mcp/client/${id}`,
 				method: "DELETE",
 			}),
-			invalidatesTags: ["MCPClients"],
+			async onQueryStarted(id, { dispatch, getState, queryFulfilled }) {
+				try {
+					await queryFulfilled;
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getMCPClients" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							mcpApi.util.updateQueryData("getMCPClients", entry.originalArgs, (draft) => {
+								if (!draft.clients) return;
+								const before = draft.clients.length;
+								draft.clients = draft.clients.filter((c) => c.config.client_id !== id);
+								if (draft.clients.length < before) {
+									draft.count = Math.max(0, (draft.count || 0) - 1);
+									draft.total_count = Math.max(0, (draft.total_count || 0) - 1);
+								}
+							}),
+						);
+					}
+				} catch {}
+			},
 		}),
 
 		// Reconnect MCP client

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -92,6 +92,22 @@ export interface UpdateMCPClientRequest {
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
 }
 
+// Pagination params for MCP clients list
+export interface GetMCPClientsParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+}
+
+// Paginated response for MCP clients list
+export interface GetMCPClientsResponse {
+	clients: MCPClient[];
+	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
+}
+
 // Types for MCP Tool Selector component
 export interface SelectedTool {
 	mcpClientId: string;


### PR DESCRIPTION
## Summary

Adds server-side search and pagination support for the MCP Server Catalog (MCP
clients). Previously the API returned all MCP clients as a bare array. Now it
supports `limit`, `offset`, and `search` query parameters for efficient
paginated retrieval with name-based filtering.

## Changes

- Added `MCPClientsQueryParams` struct and `GetMCPClientsPaginated` to the
  `ConfigStore` interface and RDB implementation with `LOWER(name) LIKE ?`
  search, limit/offset clamping (default 25, max 100)
- Refactored `getMCPClients` handler into two paths: (1) non-paginated (no
  `limit`/`offset`/`search` params) reads from in-memory config, (2) paginated
  path queries DB then merges with Bifrost engine state (connected clients,
  tools, connection state) for each result — both paths now return wrapped
  `{ clients, count, total_count, limit, offset }` instead of a bare array
- Added `GetMCPClientsParams` and `GetMCPClientsResponse` types
- Rewrote RTK Query `getMCPClients` from `MCPClient[], void` to
  `GetMCPClientsResponse, GetMCPClientsParams | void`; create mutation uses
  `invalidatesTags` fallback (since MCP create may return an OAuth flow
  response, not the created client); update mutation does field-level merge via
  cache iteration; delete mutation uses cache iteration with count decrement
- Added search input, debounced search (300ms), pagination controls, filtered
  empty state to `mcpClientsTable.tsx` and `page.tsx`; also added `bg-muted/50`
  and `font-semibold` styling to table headers
- **Notable**: Updated `virtualKeySheet.tsx` (outside the MCP pages) from
  `const { data: mcpClientsData }` to `mcpClientsResponse?.clients || []` since
  the response shape changed from a bare array to a wrapped object — this is a
  consumer that populates the MCP client dropdown in the virtual key form
- Added `GetMCPClientsPaginated` stub to `MockConfigStore` in `config_test.go`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to MCP Server Catalog page
2. Verify table loads with pagination (25 per page)
3. Type in the search box — results filter by server name and reset to page 1
4. Click Previous/Next to paginate
5. Create an MCP client (including OAuth flow if applicable) — table refreshes
6. Update and delete an MCP client — table updates optimistically
7. Verify connection state and tools still display correctly for
   connected/disconnected servers
8. Navigate to Virtual Keys → create/edit a virtual key and verify MCP client
   dropdown still populates

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Search uses parameterized `LIKE` queries (no SQL
injection risk). No auth, secrets, or PII changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
