### PR TITLE
feat: adds search for teams

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2096,6 +2096,46 @@ func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tab
 	return teams, nil
 }
 
+// GetTeamsPaginated retrieves teams with pagination, filtering, and search support.
+func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQueryParams) ([]tables.TableTeam, int64, error) {
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableTeam{})
+
+	if params.CustomerID != "" {
+		baseQuery = baseQuery.Where("customer_id = ?", params.CustomerID)
+	}
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
+	}
+
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := params.Limit
+	offset := params.Offset
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var teams []tables.TableTeam
+	if err := baseQuery.
+		Preload("Customer").Preload("Budget").Preload("RateLimit").
+		Order("created_at ASC, id ASC").
+		Offset(offset).Limit(limit).
+		Find(&teams).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return teams, totalCount, nil
+}
+
 // GetTeam retrieves a specific team from the database.
 func (s *RDBConfigStore) GetTeam(ctx context.Context, id string) (*tables.TableTeam, error) {
 	var team tables.TableTeam

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -44,6 +44,14 @@ type MCPClientsQueryParams struct {
 	Search string
 }
 
+// TeamsQueryParams holds pagination, filtering, and search parameters for team queries.
+type TeamsQueryParams struct {
+	Limit      int
+	Offset     int
+	Search     string
+	CustomerID string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -124,6 +132,7 @@ type ConfigStore interface {
 
 	// Team CRUD
 	GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error)
+	GetTeamsPaginated(ctx context.Context, params TeamsQueryParams) ([]tables.TableTeam, int64, error)
 	GetTeam(ctx context.Context, id string) (*tables.TableTeam, error)
 	CreateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error
 	UpdateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1197,18 +1197,55 @@ func (h *GovernanceHandler) getTeams(ctx *fasthttp.RequestCtx) {
 				}
 			}
 			SendJSON(ctx, map[string]interface{}{
-				"teams": teams,
-				"count": len(teams),
+				"teams":       teams,
+				"count":       len(teams),
+				"total_count": len(teams),
+				"limit":       len(teams),
+				"offset":      0,
 			})
 		} else {
 			SendJSON(ctx, map[string]interface{}{
-				"teams": data.Teams,
-				"count": len(data.Teams),
+				"teams":       data.Teams,
+				"count":       len(data.Teams),
+				"total_count": len(data.Teams),
+				"limit":       len(data.Teams),
+				"offset":      0,
 			})
 		}
 		return
 	}
-	// Preload relationships for complete information
+
+	// Check for pagination parameters
+	limitStr := string(ctx.QueryArgs().Peek("limit"))
+	offsetStr := string(ctx.QueryArgs().Peek("offset"))
+	search := string(ctx.QueryArgs().Peek("search"))
+
+	if limitStr != "" || offsetStr != "" || search != "" {
+		limit, _ := strconv.Atoi(limitStr)
+		offset, _ := strconv.Atoi(offsetStr)
+		limit, offset = ClampPaginationParams(limit, offset)
+		teams, totalCount, err := h.configStore.GetTeamsPaginated(ctx, configstore.TeamsQueryParams{
+			Limit:      limit,
+			Offset:     offset,
+			Search:     search,
+			CustomerID: customerID,
+		})
+		if err != nil {
+			logger.Error("failed to retrieve teams: %v", err)
+			SendError(ctx, 500, fmt.Sprintf("Failed to retrieve teams: %v", err))
+			return
+		}
+		SendJSON(ctx, map[string]interface{}{
+			"teams":       teams,
+			"count":       len(teams),
+			"total_count": totalCount,
+			"limit":       limit,
+			"offset":      offset,
+		})
+		return
+	}
+
+	// Non-paginated path: return all teams
 	teams, err := h.configStore.GetTeams(ctx, customerID)
 	if err != nil {
 		logger.Error("failed to retrieve teams: %v", err)
@@ -1216,8 +1253,11 @@ func (h *GovernanceHandler) getTeams(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	SendJSON(ctx, map[string]interface{}{
-		"teams": teams,
-		"count": len(teams),
+		"teams":       teams,
+		"count":       len(teams),
+		"total_count": len(teams),
+		"limit":       len(teams),
+		"offset":      0,
 	})
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -659,6 +659,10 @@ func (m *MockConfigStore) GetTeams(ctx context.Context, customerID string) ([]ta
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetTeamsPaginated(ctx context.Context, params configstore.TeamsQueryParams) ([]tables.TableTeam, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) CreateVirtualKey(ctx context.Context, virtualKey *tables.TableVirtualKey, tx ...*gorm.DB) error {
 	if m.governanceConfig == nil {
 		m.governanceConfig = &configstore.GovernanceConfig{}

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -13,7 +13,7 @@ export default function GovernanceCustomersPage() {
     pollingInterval: POLLING_INTERVAL,
   })
   const { data: teamsData, error: teamsError, isLoading: teamsLoading } = useGetTeamsQuery(
-    {},
+    undefined,
     { pollingInterval: POLLING_INTERVAL },
   )
   const { data: customersData, error: customersError, isLoading: customersLoading } = useGetCustomersQuery(undefined, {

--- a/ui/app/workspace/governance/teams/page.tsx
+++ b/ui/app/workspace/governance/teams/page.tsx
@@ -1,31 +1,53 @@
 "use client"
 
 import FullPageLoader from "@/components/fullPageLoader"
+import { useDebouncedValue } from "@/hooks/useDebounce"
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store"
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import TeamsTable from "@/app/workspace/governance/views/teamsTable"
 
 const POLLING_INTERVAL = 5000
+const PAGE_SIZE = 25
 
 export default function GovernanceTeamsPage() {
   const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View)
   const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View)
   const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View)
 
+  const [search, setSearch] = useState("")
+  const [offset, setOffset] = useState(0)
+  const debouncedSearch = useDebouncedValue(search, 300)
+
+  useEffect(() => {
+    setOffset(0)
+  }, [debouncedSearch])
+
   const { data: virtualKeysData, error: vkError, isLoading: vkLoading } = useGetVirtualKeysQuery(undefined, {
     skip: !hasVirtualKeysAccess,
     pollingInterval: POLLING_INTERVAL,
   })
   const { data: teamsData, error: teamsError, isLoading: teamsLoading } = useGetTeamsQuery(
-    {},
+    {
+      limit: PAGE_SIZE,
+      offset,
+      search: debouncedSearch || undefined,
+    },
     { skip: !hasTeamsAccess, pollingInterval: POLLING_INTERVAL },
   )
   const { data: customersData, error: customersError, isLoading: customersLoading } = useGetCustomersQuery(undefined, {
     skip: !hasCustomersAccess,
     pollingInterval: POLLING_INTERVAL,
   })
+
+  const teamsTotal = teamsData?.total_count ?? 0
+
+  // Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+  useEffect(() => {
+    if (!teamsData || offset < teamsTotal) return
+    setOffset(teamsTotal === 0 ? 0 : Math.floor((teamsTotal - 1) / PAGE_SIZE) * PAGE_SIZE)
+  }, [teamsTotal, offset])
 
   const isLoading = vkLoading || teamsLoading || customersLoading
 
@@ -39,12 +61,22 @@ export default function GovernanceTeamsPage() {
     return <FullPageLoader />
   }
 
+  const teams = teamsData?.teams || []
+  const totalCount = teamsData?.total_count || 0
+
   return (
     <div className="mx-auto w-full max-w-7xl">
       <TeamsTable
-        teams={teamsData?.teams || []}
+        teams={teams}
+        totalCount={totalCount}
         customers={customersData?.customers || []}
         virtualKeys={virtualKeysData?.virtual_keys || []}
+        search={search}
+        debouncedSearch={debouncedSearch}
+        onSearchChange={setSearch}
+        offset={offset}
+        limit={PAGE_SIZE}
+        onOffsetChange={setOffset}
       />
     </div>
   )

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -22,7 +22,8 @@ import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { Edit, Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import TeamDialog from "./teamDialog";
@@ -35,11 +36,18 @@ const formatResetDuration = (duration: string) => {
 
 interface TeamsTableProps {
 	teams: Team[];
+	totalCount: number;
 	customers: Customer[];
 	virtualKeys: VirtualKey[];
+	search: string;
+	debouncedSearch: string;
+	onSearchChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTableProps) {
+export default function TeamsTable({ teams, totalCount, customers, virtualKeys, search, debouncedSearch, onSearchChange, offset, limit, onOffsetChange }: TeamsTableProps) {
 	const [showTeamDialog, setShowTeamDialog] = useState(false);
 	const [editingTeam, setEditingTeam] = useState<Team | null>(null);
 
@@ -83,8 +91,10 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 		return customer ? customer.name : "Unknown Customer";
 	};
 
-	// Empty state when user has no teams (same pattern as Virtual Keys)
-	if (teams?.length === 0) {
+	const hasActiveFilters = debouncedSearch;
+
+	// True empty state: no teams at all (not just filtered to zero)
+	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				<TooltipProvider>
@@ -116,7 +126,21 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 						</Button>
 					</div>
 
-					<div className="rounded-sm border" data-testid="teams-table">
+					<div className="flex items-center gap-3">
+						<div className="relative max-w-sm flex-1">
+							<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+							<Input
+								aria-label="Search teams by name"
+								placeholder="Search by name..."
+								value={search}
+								onChange={(e) => onSearchChange(e.target.value)}
+								className="pl-9"
+								data-testid="teams-search-input"
+							/>
+						</div>
+					</div>
+
+					<div className="rounded-sm border overflow-hidden" data-testid="teams-table">
 						<Table>
 							<TableHeader>
 								<TableRow>
@@ -129,7 +153,14 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 								</TableRow>
 							</TableHeader>
 							<TableBody>
-								{teams?.map((team) => {
+								{teams.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={6} className="h-24 text-center">
+											<span className="text-muted-foreground text-sm">No matching teams found.</span>
+										</TableCell>
+									</TableRow>
+								) : (
+								teams.map((team) => {
 									const vks = getVirtualKeysForTeam(team.id);
 									const customerName = getCustomerName(team.customer_id);
 
@@ -354,10 +385,40 @@ export default function TeamsTable({ teams, customers, virtualKeys }: TeamsTable
 											</TableCell>
 										</TableRow>
 									);
-								})}
+								})
+								)}
 							</TableBody>
 						</Table>
 					</div>
+
+					{/* Pagination */}
+					{totalCount > 0 && (
+						<div className="flex items-center justify-between px-2">
+							<p className="text-muted-foreground text-sm">
+								Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+							</p>
+							<div className="flex gap-2">
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={offset === 0}
+									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+									data-testid="teams-pagination-prev-btn"
+								>
+									<ChevronLeft className="mr-1 h-4 w-4" /> Previous
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={offset + limit >= totalCount}
+									onClick={() => onOffsetChange(offset + limit)}
+									data-testid="teams-pagination-next-btn"
+								>
+									Next <ChevronRight className="ml-1 h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					)}
 				</div>
 			</TooltipProvider>
 		</>

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -53,7 +53,7 @@ export default function GovernanceVirtualKeysPage() {
 		data: teamsData,
 		error: teamsError,
 		isLoading: teamsLoading,
-	} = useGetTeamsQuery({}, {
+	} = useGetTeamsQuery(undefined, {
 		skip: !hasTeamsAccess,
 		pollingInterval: POLLING_INTERVAL,
 	})

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -86,7 +86,7 @@ export function RoutingRuleSheet({
 	const rules = rulesData?.rules || [];
 	const { data: providersData = [] } = useGetProvidersQuery();
 	const { data: vksData = { virtual_keys: [] } } = useGetVirtualKeysQuery();
-	const { data: teamsData = { teams: [] } } = useGetTeamsQuery({});
+	const { data: teamsData = { teams: [], count: 0, total_count: 0, limit: 0, offset: 0 } } = useGetTeamsQuery();
 	const { data: customersData = { customers: [] } } = useGetCustomersQuery();
 	const [createRoutingRule, { isLoading: isCreating }] = useCreateRoutingRuleMutation();
 	const [updateRoutingRule, { isLoading: isUpdating }] = useUpdateRoutingRuleMutation();

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -12,6 +12,7 @@ import {
 	GetModelConfigsResponse,
 	GetProviderGovernanceResponse,
 	GetRateLimitsResponse,
+	GetTeamsParams,
 	GetTeamsResponse,
 	GetUsageStatsResponse,
 	GetVirtualKeysParams,
@@ -82,10 +83,15 @@ export const governanceApi = baseApi.injectEndpoints({
 		}),
 
 		// Teams
-		getTeams: builder.query<GetTeamsResponse, { customerId?: string }>({
-			query: ({ customerId } = {}) => ({
+		getTeams: builder.query<GetTeamsResponse, GetTeamsParams | void>({
+			query: (params) => ({
 				url: "/governance/teams",
-				params: customerId ? { customer_id: customerId } : {},
+				params: {
+					...(params?.limit && { limit: params.limit }),
+					...(params?.offset !== undefined && { offset: params.offset }),
+					...(params?.search && { search: params.search }),
+					...(params?.customer_id && { customer_id: params.customer_id }),
+				},
 			}),
 			providesTags: ["Teams"],
 		}),
@@ -101,16 +107,23 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
-					dispatch(
-						governanceApi.util.updateQueryData("getTeams", {}, (draft) => {
-							if (!draft.teams) draft.teams = [];
-							draft.teams.unshift(data.team);
-							draft.count = (draft.count || 0) + 1;
-						}),
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getTeams" || entry?.status !== "fulfilled") continue;
+						const search = entry.originalArgs?.search as string | undefined;
+						if (search && !data.team.name.toLowerCase().includes(search.toLowerCase())) continue;
+						dispatch(
+							governanceApi.util.updateQueryData("getTeams", entry.originalArgs, (draft) => {
+								if (!draft.teams) draft.teams = [];
+								draft.teams.unshift(data.team);
+								draft.count = (draft.count || 0) + 1;
+								draft.total_count = (draft.total_count || 0) + 1;
+							}),
+						);
+					}
 				} catch {
 					// Mutation failed
 				}
@@ -123,18 +136,22 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			async onQueryStarted({ teamId }, { dispatch, queryFulfilled }) {
+			async onQueryStarted({ teamId }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
-					dispatch(
-						governanceApi.util.updateQueryData("getTeams", {}, (draft) => {
-							if (!draft.teams) return;
-							const index = draft.teams.findIndex((t) => t.id === teamId);
-							if (index !== -1) {
-								draft.teams[index] = data.team;
-							}
-						}),
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getTeams" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							governanceApi.util.updateQueryData("getTeams", entry.originalArgs, (draft) => {
+								if (!draft.teams) return;
+								const index = draft.teams.findIndex((t) => t.id === teamId);
+								if (index !== -1) {
+									draft.teams[index] = data.team;
+								}
+							}),
+						);
+					}
 					dispatch(
 						governanceApi.util.updateQueryData("getTeam", teamId, (draft) => {
 							draft.team = data.team;
@@ -151,16 +168,24 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/teams/${teamId}`,
 				method: "DELETE",
 			}),
-			async onQueryStarted(teamId, { dispatch, queryFulfilled }) {
+			async onQueryStarted(teamId, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;
-					dispatch(
-						governanceApi.util.updateQueryData("getTeams", {}, (draft) => {
-							if (!draft.teams) return;
-							draft.teams = draft.teams.filter((t) => t.id !== teamId);
-							draft.count = Math.max(0, (draft.count || 0) - 1);
-						}),
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getTeams" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							governanceApi.util.updateQueryData("getTeams", entry.originalArgs, (draft) => {
+								if (!draft.teams) return;
+								const before = draft.teams.length;
+								draft.teams = draft.teams.filter((t) => t.id !== teamId);
+								if (draft.teams.length < before) {
+									draft.count = Math.max(0, (draft.count || 0) - 1);
+									draft.total_count = Math.max(0, (draft.total_count || 0) - 1);
+								}
+							}),
+						);
+					}
 				} catch {
 					// Mutation failed
 				}

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -246,9 +246,19 @@ export interface GetVirtualKeysResponse {
 	offset: number;
 }
 
+export interface GetTeamsParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+	customer_id?: string;
+}
+
 export interface GetTeamsResponse {
 	teams: Team[];
 	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
 }
 
 export interface GetCustomersResponse {


### PR DESCRIPTION
## Summary

Adds server-side search and pagination support for Teams. Previously the API
returned all teams in a single response. Now it supports `limit`, `offset`, and
`search` query parameters for efficient paginated retrieval with name-based
filtering, while preserving the existing `customer_id` filter.

## Changes

- Added `TeamsQueryParams` struct (includes `CustomerID` field for existing
  filter) and `GetTeamsPaginated` to the `ConfigStore` interface and RDB
  implementation with `customer_id` filter, `LOWER(name) LIKE ?` search,
  limit/offset clamping (default 25, max 100),
  `Preload("Customer").Preload("Budget").Preload("RateLimit")`
- Updated `getTeams` handler: added paginated path when
  `limit`/`offset`/`search` params are present; non-paginated path now also
  returns wrapped format with `total_count`, `limit`, `offset`
- Added `GetTeamsParams` type (with optional `customerId`); extended
  `GetTeamsResponse` with pagination fields
- Rewrote RTK Query `getTeams` from `GetTeamsResponse, { customerId?: string }`
  to `GetTeamsResponse, GetTeamsParams | void`; rewrote all three mutations
  (create/update/delete) from hardcoded `{}` cache key to cache iteration
  pattern
- Added search input, debounced search (300ms), pagination controls, filtered
  empty state to `teamsTable.tsx` and `teams/page.tsx`
- **Notable cross-cutting fixes** — three other consumers of `useGetTeamsQuery`
  needed updating because the query signature changed from
  `{ customerId?: string }` to `GetTeamsParams | void`:
  - `customers/page.tsx`: `useGetTeamsQuery({})` → `useGetTeamsQuery(undefined)`
    (fetches all teams for customer-team associations)
  - `virtual-keys/page.tsx`: `useGetTeamsQuery({})` →
    `useGetTeamsQuery(undefined)`
  - `routingRuleSheet.tsx`: `useGetTeamsQuery({})` → `useGetTeamsQuery()` with
    full default value
    `{ teams: [], count: 0, total_count: 0, limit: 0, offset: 0 }`
- Added `GetTeamsPaginated` stub to `MockConfigStore` in `config_test.go`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to Teams page
2. Verify table loads with pagination (25 per page)
3. Type in the search box — results filter by team name and reset to page 1
4. Click Previous/Next to paginate
5. Create, update, and delete a team — table updates optimistically
6. Navigate to Customers page — verify teams still load correctly (non-paginated
   fetch for associations)
7. Navigate to Virtual Keys page — verify teams still load correctly
8. Open the Routing Rule sheet — verify team dropdown still populates

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Search uses parameterized `LIKE` queries (no SQL
injection risk). No auth, secrets, or PII changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
