### PR TITLE
feat: adds search for customers

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2231,6 +2231,38 @@ func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustom
 	return customers, nil
 }
 
+// GetCustomersPaginated retrieves customers with pagination and optional search filtering.
+func (s *RDBConfigStore) GetCustomersPaginated(ctx context.Context, params CustomersQueryParams) ([]tables.TableCustomer, int64, error) {
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableCustomer{})
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
+	}
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+	limit := params.Limit
+	offset := params.Offset
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var customers []tables.TableCustomer
+	if err := baseQuery.
+		Preload("Teams").Preload("Budget").Preload("RateLimit").
+		Order("created_at ASC, id ASC").
+		Offset(offset).Limit(limit).
+		Find(&customers).Error; err != nil {
+		return nil, 0, err
+	}
+	return customers, totalCount, nil
+}
+
 // GetCustomer retrieves a specific customer from the database.
 func (s *RDBConfigStore) GetCustomer(ctx context.Context, id string) (*tables.TableCustomer, error) {
 	var customer tables.TableCustomer

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -52,6 +52,13 @@ type TeamsQueryParams struct {
 	CustomerID string
 }
 
+// CustomersQueryParams holds pagination, filtering, and search parameters for customer queries.
+type CustomersQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -140,6 +147,7 @@ type ConfigStore interface {
 
 	// Customer CRUD
 	GetCustomers(ctx context.Context) ([]tables.TableCustomer, error)
+	GetCustomersPaginated(ctx context.Context, params CustomersQueryParams) ([]tables.TableCustomer, int64, error)
 	GetCustomer(ctx context.Context, id string) (*tables.TableCustomer, error)
 	CreateCustomer(ctx context.Context, customer *tables.TableCustomer, tx ...*gorm.DB) error
 	UpdateCustomer(ctx context.Context, customer *tables.TableCustomer, tx ...*gorm.DB) error

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1608,11 +1608,42 @@ func (h *GovernanceHandler) getCustomers(ctx *fasthttp.RequestCtx) {
 			return
 		}
 		SendJSON(ctx, map[string]interface{}{
-			"customers": data.Customers,
-			"count":     len(data.Customers),
+			"customers":   data.Customers,
+			"count":       len(data.Customers),
+			"total_count": len(data.Customers),
+			"limit":       len(data.Customers),
+			"offset":      0,
 		})
 		return
 	}
+	limitStr := string(ctx.QueryArgs().Peek("limit"))
+	offsetStr := string(ctx.QueryArgs().Peek("offset"))
+	search := string(ctx.QueryArgs().Peek("search"))
+
+	if limitStr != "" || offsetStr != "" || search != "" {
+		limit, _ := strconv.Atoi(limitStr)
+		offset, _ := strconv.Atoi(offsetStr)
+		limit, offset = ClampPaginationParams(limit, offset)
+		customers, totalCount, err := h.configStore.GetCustomersPaginated(ctx, configstore.CustomersQueryParams{
+			Limit:  limit,
+			Offset: offset,
+			Search: search,
+		})
+		if err != nil {
+			logger.Error("failed to retrieve customers: %v", err)
+			SendError(ctx, 500, "failed to retrieve customers")
+			return
+		}
+		SendJSON(ctx, map[string]interface{}{
+			"customers":   customers,
+			"count":       len(customers),
+			"total_count": totalCount,
+			"limit":       limit,
+			"offset":      offset,
+		})
+		return
+	}
+
 	customers, err := h.configStore.GetCustomers(ctx)
 	if err != nil {
 		logger.Error("failed to retrieve customers: %v", err)
@@ -1620,8 +1651,11 @@ func (h *GovernanceHandler) getCustomers(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	SendJSON(ctx, map[string]interface{}{
-		"customers": customers,
-		"count":     len(customers),
+		"customers":   customers,
+		"count":       len(customers),
+		"total_count": len(customers),
+		"limit":       len(customers),
+		"offset":      0,
 	})
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -634,6 +634,10 @@ func (m *MockConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCusto
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetCustomersPaginated(ctx context.Context, params configstore.CustomersQueryParams) ([]tables.TableCustomer, int64, error) {
+	return nil, 0, nil
+}
+
 func (m *MockConfigStore) CreateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error {
 	if m.governanceConfig == nil {
 		m.governanceConfig = &configstore.GovernanceConfig{}

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -1,31 +1,76 @@
 "use client"
 
 import FullPageLoader from "@/components/fullPageLoader"
+import { useDebouncedValue } from "@/hooks/useDebounce"
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store"
-import { useEffect } from "react"
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
+import { useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import CustomersTable from "@/app/workspace/governance/views/customerTable"
 
 const POLLING_INTERVAL = 5000
+const PAGE_SIZE = 25
 
 export default function GovernanceCustomersPage() {
+  const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View)
+  const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View)
+  const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View)
+  const shownErrorsRef = useRef(new Set<string>())
+
+  const [search, setSearch] = useState("")
+  const [offset, setOffset] = useState(0)
+  const debouncedSearch = useDebouncedValue(search, 300)
+
+  useEffect(() => {
+    setOffset(0)
+  }, [debouncedSearch])
+
   const { data: virtualKeysData, error: vkError, isLoading: vkLoading } = useGetVirtualKeysQuery(undefined, {
+    skip: !hasVirtualKeysAccess,
     pollingInterval: POLLING_INTERVAL,
   })
   const { data: teamsData, error: teamsError, isLoading: teamsLoading } = useGetTeamsQuery(
     undefined,
-    { pollingInterval: POLLING_INTERVAL },
+    { skip: !hasTeamsAccess, pollingInterval: POLLING_INTERVAL },
   )
-  const { data: customersData, error: customersError, isLoading: customersLoading } = useGetCustomersQuery(undefined, {
+  const {
+    data: customersData,
+    error: customersError,
+    isLoading: customersLoading,
+  } = useGetCustomersQuery({
+    limit: PAGE_SIZE,
+    offset,
+    search: debouncedSearch || undefined,
+  }, {
+    skip: !hasCustomersAccess,
     pollingInterval: POLLING_INTERVAL,
   })
+
+  const customersTotal = customersData?.total_count ?? 0
+
+  // Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+  useEffect(() => {
+    if (!customersData || offset < customersTotal) return
+    setOffset(customersTotal === 0 ? 0 : Math.floor((customersTotal - 1) / PAGE_SIZE) * PAGE_SIZE)
+  }, [customersTotal, offset])
 
   const isLoading = vkLoading || teamsLoading || customersLoading
 
   useEffect(() => {
-    if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`)
-    if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`)
-    if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`)
+    if (!vkError && !teamsError && !customersError) {
+      shownErrorsRef.current.clear()
+      return
+    }
+    const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`
+    if (shownErrorsRef.current.has(errorKey)) return
+    shownErrorsRef.current.add(errorKey)
+    if (vkError && teamsError && customersError) {
+      toast.error("Failed to load governance data.")
+    } else {
+      if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`)
+      if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`)
+      if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`)
+    }
   }, [vkError, teamsError, customersError])
 
   if (isLoading) {
@@ -36,8 +81,15 @@ export default function GovernanceCustomersPage() {
     <div className="mx-auto w-full max-w-7xl">
       <CustomersTable
         customers={customersData?.customers || []}
+        totalCount={customersData?.total_count || 0}
         teams={teamsData?.teams || []}
         virtualKeys={virtualKeysData?.virtual_keys || []}
+        search={search}
+        debouncedSearch={debouncedSearch}
+        onSearchChange={setSearch}
+        offset={offset}
+        limit={PAGE_SIZE}
+        onOffsetChange={setOffset}
       />
     </div>
   )

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -22,7 +22,8 @@ import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { Edit, Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import CustomerDialog from "./customerDialog";
@@ -35,11 +36,18 @@ const formatResetDuration = (duration: string) => {
 
 interface CustomersTableProps {
 	customers: Customer[];
+	totalCount: number;
 	teams: Team[];
 	virtualKeys: VirtualKey[];
+	search: string;
+	debouncedSearch: string;
+	onSearchChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
 }
 
-export default function CustomersTable({ customers, teams, virtualKeys }: CustomersTableProps) {
+export default function CustomersTable({ customers, totalCount, teams, virtualKeys, search, debouncedSearch, onSearchChange, offset, limit, onOffsetChange }: CustomersTableProps) {
 	const [showCustomerDialog, setShowCustomerDialog] = useState(false);
 	const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
 
@@ -81,8 +89,10 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 		return virtualKeys.filter((vk) => vk.customer_id === customerId);
 	};
 
-	// Empty state when user has no customers (same pattern as Virtual Keys)
-	if (customers?.length === 0) {
+	const hasActiveFilters = debouncedSearch;
+
+	// True empty state: no customers at all (not just filtered to zero)
+	if (totalCount === 0 && !hasActiveFilters) {
 		return (
 			<>
 				<TooltipProvider>
@@ -114,7 +124,21 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 						</Button>
 					</div>
 
-					<div className="rounded-sm border" data-testid="customer-table-container">
+					<div className="flex items-center gap-3">
+						<div className="relative max-w-sm flex-1">
+							<Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+							<Input
+								aria-label="Search customers by name"
+								placeholder="Search by name..."
+								value={search}
+								onChange={(e) => onSearchChange(e.target.value)}
+								className="pl-9"
+								data-testid="customers-search-input"
+							/>
+						</div>
+					</div>
+
+					<div className="rounded-sm border overflow-hidden" data-testid="customer-table-container">
 						<Table>
 							<TableHeader>
 								<TableRow>
@@ -127,7 +151,14 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 								</TableRow>
 							</TableHeader>
 							<TableBody>
-								{customers?.map((customer) => {
+								{customers.length === 0 ? (
+									<TableRow>
+										<TableCell colSpan={6} className="h-24 text-center">
+											<span className="text-muted-foreground text-sm">No matching customers found.</span>
+										</TableCell>
+									</TableRow>
+								) : (
+								customers.map((customer) => {
 									const customerTeams = getTeamsForCustomer(customer.id);
 									const vks = getVirtualKeysForCustomer(customer.id);
 
@@ -374,10 +405,40 @@ export default function CustomersTable({ customers, teams, virtualKeys }: Custom
 											</TableCell>
 										</TableRow>
 									);
-								})}
+								})
+								)}
 							</TableBody>
 						</Table>
 					</div>
+
+					{/* Pagination */}
+					{totalCount > 0 && (
+						<div className="flex items-center justify-between px-2">
+							<p className="text-muted-foreground text-sm">
+								Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+							</p>
+							<div className="flex gap-2">
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={offset === 0}
+									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+									data-testid="customers-pagination-prev-btn"
+								>
+									<ChevronLeft className="mr-1 h-4 w-4" /> Previous
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={offset + limit >= totalCount}
+									onClick={() => onOffsetChange(offset + limit)}
+									data-testid="customers-pagination-next-btn"
+								>
+									Next <ChevronRight className="ml-1 h-4 w-4" />
+								</Button>
+							</div>
+						</div>
+					)}
 				</div>
 			</TooltipProvider>
 		</>

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -7,6 +7,7 @@ import {
 	Customer,
 	DebugStatsResponse,
 	GetBudgetsResponse,
+	GetCustomersParams,
 	GetCustomersResponse,
 	GetModelConfigsParams,
 	GetModelConfigsResponse,
@@ -193,8 +194,15 @@ export const governanceApi = baseApi.injectEndpoints({
 		}),
 
 		// Customers
-		getCustomers: builder.query<GetCustomersResponse, void>({
-			query: () => "/governance/customers",
+		getCustomers: builder.query<GetCustomersResponse, GetCustomersParams | void>({
+			query: (params) => ({
+				url: "/governance/customers",
+				params: {
+					...(params?.limit && { limit: params.limit }),
+					...(params?.offset !== undefined && { offset: params.offset }),
+					...(params?.search && { search: params.search }),
+				},
+			}),
 			providesTags: ["Customers"],
 		}),
 
@@ -209,16 +217,23 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: data,
 			}),
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+			async onQueryStarted(arg, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
-					dispatch(
-						governanceApi.util.updateQueryData("getCustomers", undefined, (draft) => {
-							if (!draft.customers) draft.customers = [];
-							draft.customers.unshift(data.customer);
-							draft.count = (draft.count || 0) + 1;
-						}),
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getCustomers" || entry?.status !== "fulfilled") continue;
+						const search = entry.originalArgs?.search as string | undefined;
+						if (search && !data.customer.name.toLowerCase().includes(search.toLowerCase())) continue;
+						dispatch(
+							governanceApi.util.updateQueryData("getCustomers", entry.originalArgs, (draft) => {
+								if (!draft.customers) draft.customers = [];
+								draft.customers.unshift(data.customer);
+								draft.count = (draft.count || 0) + 1;
+								draft.total_count = (draft.total_count || 0) + 1;
+							}),
+						);
+					}
 				} catch {
 					// Mutation failed
 				}
@@ -231,18 +246,22 @@ export const governanceApi = baseApi.injectEndpoints({
 				method: "PUT",
 				body: data,
 			}),
-			async onQueryStarted({ customerId }, { dispatch, queryFulfilled }) {
+			async onQueryStarted({ customerId }, { dispatch, getState, queryFulfilled }) {
 				try {
 					const { data } = await queryFulfilled;
-					dispatch(
-						governanceApi.util.updateQueryData("getCustomers", undefined, (draft) => {
-							if (!draft.customers) return;
-							const index = draft.customers.findIndex((c) => c.id === customerId);
-							if (index !== -1) {
-								draft.customers[index] = data.customer;
-							}
-						}),
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getCustomers" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							governanceApi.util.updateQueryData("getCustomers", entry.originalArgs, (draft) => {
+								if (!draft.customers) return;
+								const index = draft.customers.findIndex((c) => c.id === customerId);
+								if (index !== -1) {
+									draft.customers[index] = data.customer;
+								}
+							}),
+						);
+					}
 					dispatch(
 						governanceApi.util.updateQueryData("getCustomer", customerId, (draft) => {
 							draft.customer = data.customer;
@@ -259,16 +278,24 @@ export const governanceApi = baseApi.injectEndpoints({
 				url: `/governance/customers/${customerId}`,
 				method: "DELETE",
 			}),
-			async onQueryStarted(customerId, { dispatch, queryFulfilled }) {
+			async onQueryStarted(customerId, { dispatch, getState, queryFulfilled }) {
 				try {
 					await queryFulfilled;
-					dispatch(
-						governanceApi.util.updateQueryData("getCustomers", undefined, (draft) => {
-							if (!draft.customers) return;
-							draft.customers = draft.customers.filter((c) => c.id !== customerId);
-							draft.count = Math.max(0, (draft.count || 0) - 1);
-						}),
-					);
+					const queries = (getState() as any).api.queries;
+					for (const entry of Object.values(queries) as any[]) {
+						if (entry?.endpointName !== "getCustomers" || entry?.status !== "fulfilled") continue;
+						dispatch(
+							governanceApi.util.updateQueryData("getCustomers", entry.originalArgs, (draft) => {
+								if (!draft.customers) return;
+								const before = draft.customers.length;
+								draft.customers = draft.customers.filter((c) => c.id !== customerId);
+								if (draft.customers.length < before) {
+									draft.count = Math.max(0, (draft.count || 0) - 1);
+									draft.total_count = Math.max(0, (draft.total_count || 0) - 1);
+								}
+							}),
+						);
+					}
 				} catch {
 					// Mutation failed
 				}

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -261,9 +261,18 @@ export interface GetTeamsResponse {
 	offset: number;
 }
 
+export interface GetCustomersParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+}
+
 export interface GetCustomersResponse {
 	customers: Customer[];
 	count: number;
+	total_count: number;
+	limit: number;
+	offset: number;
 }
 
 export interface GetBudgetsResponse {


### PR DESCRIPTION
## Summary

Adds server-side search and pagination support for Customers. Previously the API
returned all customers in a single response. Now it supports `limit`, `offset`,
and `search` query parameters for efficient paginated retrieval with name-based
filtering.

## Changes

- Added `CustomersQueryParams` struct and `GetCustomersPaginated` to the
  `ConfigStore` interface and RDB implementation with `LOWER(name) LIKE ?`
  search, limit/offset clamping (default 25, max 100),
  `Preload("Teams").Preload("Budget").Preload("RateLimit")`
- Updated `getCustomers` handler: added paginated path when
  `limit`/`offset`/`search` params are present; non-paginated path now also
  returns wrapped format with `total_count`, `limit`, `offset`
- Added `GetCustomersParams` type; extended `GetCustomersResponse` with
  pagination fields
- Rewrote RTK Query `getCustomers` from `GetCustomersResponse, void` to
  `GetCustomersResponse, GetCustomersParams | void`; rewrote all three mutations
  (create/update/delete) from hardcoded `undefined` cache key to cache iteration
  pattern
- Added search input, debounced search (300ms), pagination controls, filtered
  empty state to `customerTable.tsx`
- **Notable improvements to `customers/page.tsx`**:
  - Added RBAC access checks (`hasVirtualKeysAccess`, `hasTeamsAccess`,
    `hasCustomersAccess`) with `skip` on queries — previously these queries ran
    unconditionally regardless of permissions
  - Added `shownErrorsRef` to deduplicate error toasts on repeated polling
    failures
- Added `GetCustomersPaginated` stub to `MockConfigStore` in `config_test.go`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to Customers page
2. Verify table loads with pagination (25 per page)
3. Type in the search box — results filter by customer name and reset to page 1
4. Click Previous/Next to paginate
5. Create, update, and delete a customer — table updates optimistically
6. Verify RBAC-restricted users don't trigger unnecessary API calls for
   resources they can't access
7. Simulate a polling failure — verify error toasts don't spam repeatedly

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Search uses parameterized `LIKE` queries (no SQL
injection risk). No auth, secrets, or PII changes. The added RBAC `skip` checks
are a minor improvement — they prevent unnecessary API calls for users without
permissions, but the backend already enforces authorization.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
