### PR TITLE
fix(modelcatalog): refine replicate model slugs

### DIFF
--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -646,38 +646,53 @@ func (mc *ModelCatalog) UpsertUnfilteredModelDataForProvider(provider schemas.Mo
 // - When the provider is not handled or no refinement is needed, returns the original model unchanged
 func (mc *ModelCatalog) RefineModelForProvider(provider schemas.ModelProvider, model string) (string, error) {
 	switch provider {
-	// These providers have {provider}/{model} format for models
 	case schemas.Groq:
 		if strings.Contains(model, "gpt-") {
 			return "openai/" + model, nil
 		}
-		// Check if the model without provider prefix is present in the provider's catalog
-		// Guard concurrent access to mc.modelPool with read lock
-		mc.mu.RLock()
-		models, ok := mc.modelPool[provider]
-		mc.mu.RUnlock()
-
-		if ok {
-			var candidateModels []string
-			for _, poolModel := range models {
-				providerPart, modelPart := schemas.ParseModelString(poolModel, "")
-				if model == modelPart {
-					candidateModels = append(candidateModels, string(providerPart)+"/"+modelPart)
-				}
-			}
-			// Handle candidateModels based on count
-			if len(candidateModels) == 1 {
-				return candidateModels[0], nil
-			} else if len(candidateModels) == 0 {
-				// No matches found, return original model to allow fallback
-				return model, nil
-			} else {
-				// Multiple matches found, return error
-				return "", fmt.Errorf("multiple compatible models found for model %s: %v", model, candidateModels)
-			}
-		}
+		return mc.refineNestedProviderModel(provider, model)
+	case schemas.Replicate:
+		return mc.refineNestedProviderModel(provider, model)
 	}
 	return model, nil
+}
+
+// refineNestedProviderModel resolves provider-native model slugs such as
+// "openai/gpt-5-nano" from a base model request like "gpt-5-nano".
+// It only considers catalog entries whose leading segment is a known Bifrost provider,
+// so Replicate owner/model identifiers like "meta/llama-3-8b" are left untouched.
+func (mc *ModelCatalog) refineNestedProviderModel(provider schemas.ModelProvider, model string) (string, error) {
+	mc.mu.RLock()
+	models, ok := mc.modelPool[provider]
+	mc.mu.RUnlock()
+	if !ok {
+		return model, nil
+	}
+
+	candidateModels := make([]string, 0)
+	seenCandidates := make(map[string]struct{})
+	for _, poolModel := range models {
+		providerPart, modelPart := schemas.ParseModelString(poolModel, "")
+		if providerPart == "" || model != modelPart {
+			continue
+		}
+
+		candidate := string(providerPart) + "/" + modelPart
+		if _, seen := seenCandidates[candidate]; seen {
+			continue
+		}
+		seenCandidates[candidate] = struct{}{}
+		candidateModels = append(candidateModels, candidate)
+	}
+
+	switch len(candidateModels) {
+	case 0:
+		return model, nil
+	case 1:
+		return candidateModels[0], nil
+	default:
+		return "", fmt.Errorf("multiple compatible models found for model %s: %v", model, candidateModels)
+	}
 }
 
 // IsTextCompletionSupported checks if a model supports text completion for the given provider.

--- a/framework/modelcatalog/refine_test.go
+++ b/framework/modelcatalog/refine_test.go
@@ -1,0 +1,45 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefineModelForProvider_ReplicateRefinesOpenAIModel(t *testing.T) {
+	mc := newTestCatalog(map[schemas.ModelProvider][]string{
+		schemas.Replicate: {"openai/gpt-5-nano"},
+	}, map[string]string{
+		"openai/gpt-5-nano": "gpt-5-nano",
+	})
+
+	refined, err := mc.RefineModelForProvider(schemas.Replicate, "gpt-5-nano")
+	require.NoError(t, err)
+	assert.Equal(t, "openai/gpt-5-nano", refined)
+}
+
+func TestRefineModelForProvider_ReplicatePreservesOwnerSlashModel(t *testing.T) {
+	mc := newTestCatalog(map[schemas.ModelProvider][]string{
+		schemas.Replicate: {"meta/meta-llama-3-8b"},
+	}, nil)
+
+	refined, err := mc.RefineModelForProvider(schemas.Replicate, "meta/meta-llama-3-8b")
+	require.NoError(t, err)
+	assert.Equal(t, "meta/meta-llama-3-8b", refined)
+}
+
+func TestRefineModelForProvider_ReplicateReturnsAmbiguousMatchError(t *testing.T) {
+	mc := newTestCatalog(map[schemas.ModelProvider][]string{
+		schemas.Replicate: {
+			"openai/gpt-5-nano",
+			"xai/gpt-5-nano",
+		},
+	}, nil)
+
+	refined, err := mc.RefineModelForProvider(schemas.Replicate, "gpt-5-nano")
+	require.Error(t, err)
+	assert.Empty(t, refined)
+	assert.Contains(t, err.Error(), "multiple compatible models found")
+}

--- a/framework/modelcatalog/refine_test.go
+++ b/framework/modelcatalog/refine_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRefineModelForProvider_ReplicateRefinesOpenAIModel verifies that
+// Replicate can recover nested provider slugs for provider-pinned OpenAI-family models.
 func TestRefineModelForProvider_ReplicateRefinesOpenAIModel(t *testing.T) {
 	mc := newTestCatalog(map[schemas.ModelProvider][]string{
 		schemas.Replicate: {"openai/gpt-5-nano"},
@@ -20,6 +22,8 @@ func TestRefineModelForProvider_ReplicateRefinesOpenAIModel(t *testing.T) {
 	assert.Equal(t, "openai/gpt-5-nano", refined)
 }
 
+// TestRefineModelForProvider_ReplicatePreservesOwnerSlashModel verifies that
+// standard Replicate owner/model slugs are not mistaken for nested provider slugs.
 func TestRefineModelForProvider_ReplicatePreservesOwnerSlashModel(t *testing.T) {
 	mc := newTestCatalog(map[schemas.ModelProvider][]string{
 		schemas.Replicate: {"meta/meta-llama-3-8b"},
@@ -30,6 +34,8 @@ func TestRefineModelForProvider_ReplicatePreservesOwnerSlashModel(t *testing.T) 
 	assert.Equal(t, "meta/meta-llama-3-8b", refined)
 }
 
+// TestRefineModelForProvider_ReplicateReturnsAmbiguousMatchError verifies that
+// refinement fails fast when multiple nested provider slugs match the same base model.
 func TestRefineModelForProvider_ReplicateReturnsAmbiguousMatchError(t *testing.T) {
 	mc := newTestCatalog(map[schemas.ModelProvider][]string{
 		schemas.Replicate: {

--- a/plugins/governance/http_transport_prehook_test.go
+++ b/plugins/governance/http_transport_prehook_test.go
@@ -1,0 +1,63 @@
+package governance
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel(t *testing.T) {
+	logger := NewMockLogger()
+	mc := modelcatalog.NewTestCatalog(map[string]string{
+		"openai/gpt-5-nano": "gpt-5-nano",
+	})
+	mc.UpsertModelDataForProvider(schemas.Replicate, &schemas.BifrostListModelsResponse{
+		Data: []schemas.Model{
+			{ID: "replicate/openai/gpt-5-nano"},
+		},
+	}, nil)
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk1",
+		"sk-bf-test",
+		"replicate-only",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("replicate", nil),
+		},
+	)
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+	}, mc)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, mc, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/v1/chat/completions"
+	req.Headers["Authorization"] = "Bearer sk-bf-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"model":"gpt-5-nano","messages":[{"role":"user","content":"Hello!"}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	var payload struct {
+		Model string `json:"model"`
+	}
+	require.NoError(t, json.Unmarshal(req.Body, &payload))
+	require.Equal(t, "replicate/openai/gpt-5-nano", payload.Model)
+}

--- a/plugins/governance/http_transport_prehook_test.go
+++ b/plugins/governance/http_transport_prehook_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel verifies that
+// virtual-key provider pinning rewrites the request model to Replicate's nested provider slug.
 func TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel(t *testing.T) {
 	logger := NewMockLogger()
 	mc := modelcatalog.NewTestCatalog(map[string]string{


### PR DESCRIPTION
## Summary

This PR fixes provider-pinned Replicate requests that use a bare model name like `gpt-5-nano`. When governance selected the `replicate` provider, the request model was rewritten to `replicate/gpt-5-nano`, but Replicate needs the nested provider-native slug `replicate/openai/gpt-5-nano` for OpenAI-family models.

## Changes

- update `framework/modelcatalog.RefineModelForProvider` to refine Replicate models through the provider catalog, the same way nested provider slugs are recovered for other provider-specific formats
- preserve standard Replicate owner/model slugs such as `meta/meta-llama-3-8b` instead of treating them as nested provider slugs
- return an explicit error when a base model maps to multiple nested provider slugs for Replicate
- add model catalog regression tests for the refinement behavior
- add a governance HTTP pre-hook regression test that verifies virtual-key provider pinning rewrites `gpt-5-nano` to `replicate/openai/gpt-5-nano`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Create a temporary Go workspace so the governance module resolves the local patched `framework` module instead of the released dependency version, then run the focused Go tests.

```sh
REPO_ROOT=$(pwd)
WORKDIR=$(mktemp -d)
GOCACHE_DIR=$(mktemp -d)
GOMODCACHE_DIR=$(mktemp -d)
GOPATH_DIR=$(mktemp -d)
GO_BIN=go1.26.1

cd "$WORKDIR"
"$GO_BIN" work init \
  "$REPO_ROOT/core" \
  "$REPO_ROOT/framework" \
  "$REPO_ROOT/plugins/governance"

(
  cd "$REPO_ROOT/framework"
  env GOWORK="$WORKDIR/go.work" \
    GOCACHE="$GOCACHE_DIR" \
    GOMODCACHE="$GOMODCACHE_DIR" \
    GOPATH="$GOPATH_DIR" \
    "$GO_BIN" test ./modelcatalog
)

(
  cd "$REPO_ROOT/plugins/governance"
  env GOWORK="$WORKDIR/go.work" \
    GOCACHE="$GOCACHE_DIR" \
    GOMODCACHE="$GOMODCACHE_DIR" \
    GOPATH="$GOPATH_DIR" \
    "$GO_BIN" test ./...
)
```

Expected outcome:
- `framework/modelcatalog` passes
- `plugins/governance` passes
- the governance regression verifies the rewritten request model is `replicate/openai/gpt-5-nano`

No new configs or environment variables are required for the product change itself.

## Screenshots/Recordings

N/A. No UI changes.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

No auth, secret handling, or PII behavior changed. This fix only refines the provider-native model slug used before dispatching a request to Replicate.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
