### PR TITLE
Replace database cascade deletion with manual cascade for SQLite compatibility

### DIFF
--- a/framework/configstore/prompts.go
+++ b/framework/configstore/prompts.go
@@ -78,16 +78,57 @@ func (s *RDBConfigStore) UpdateFolder(ctx context.Context, folder *tables.TableF
 	return nil
 }
 
-// DeleteFolder deletes a folder (child prompts, versions, sessions and messages are cascade-deleted by the DB)
+// DeleteFolder deletes a folder and all its child prompts (with their versions, sessions, and messages).
+// PostgreSQL uses native ON DELETE CASCADE; SQLite requires manual cascade because it cannot
+// alter foreign key constraints after table creation.
 func (s *RDBConfigStore) DeleteFolder(ctx context.Context, id string) error {
-	result := s.db.WithContext(ctx).Delete(&tables.TableFolder{}, "id = ?", id)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Check folder exists
+		var folder tables.TableFolder
+		if err := tx.First(&folder, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		// PostgreSQL: ON DELETE CASCADE handles all child deletions
+		if s.db.Dialector.Name() == "postgres" {
+			return tx.Delete(&folder).Error
+		}
+
+		// SQLite: manual cascade deletion
+		var promptIDs []string
+		if err := tx.Model(&tables.TablePrompt{}).Where("folder_id = ?", id).Pluck("id", &promptIDs).Error; err != nil {
+			return err
+		}
+
+		if len(promptIDs) > 0 {
+			// Delete version messages
+			if err := tx.Where("prompt_id IN ?", promptIDs).Delete(&tables.TablePromptVersionMessage{}).Error; err != nil {
+				return err
+			}
+			// Delete versions
+			if err := tx.Where("prompt_id IN ?", promptIDs).Delete(&tables.TablePromptVersion{}).Error; err != nil {
+				return err
+			}
+			// Delete session messages
+			if err := tx.Where("prompt_id IN ?", promptIDs).Delete(&tables.TablePromptSessionMessage{}).Error; err != nil {
+				return err
+			}
+			// Delete sessions
+			if err := tx.Where("prompt_id IN ?", promptIDs).Delete(&tables.TablePromptSession{}).Error; err != nil {
+				return err
+			}
+			// Delete prompts
+			if err := tx.Where("folder_id = ?", id).Delete(&tables.TablePrompt{}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Delete the folder
+		return tx.Delete(&folder).Error
+	})
 }
 
 // ============================================================================
@@ -180,16 +221,40 @@ func (s *RDBConfigStore) UpdatePrompt(ctx context.Context, prompt *tables.TableP
 	return nil
 }
 
-// DeletePrompt deletes a prompt (child versions, sessions and messages are cascade-deleted by the DB)
+// DeletePrompt deletes a prompt and all its child versions, sessions, and messages.
+// PostgreSQL uses native ON DELETE CASCADE; SQLite requires manual cascade because it cannot
+// alter foreign key constraints after table creation.
 func (s *RDBConfigStore) DeletePrompt(ctx context.Context, id string) error {
-	result := s.db.WithContext(ctx).Delete(&tables.TablePrompt{}, "id = ?", id)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Check prompt exists
+		var prompt tables.TablePrompt
+		if err := tx.First(&prompt, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		// PostgreSQL: ON DELETE CASCADE handles all child deletions
+		if s.db.Dialector.Name() == "postgres" {
+			return tx.Delete(&prompt).Error
+		}
+
+		// SQLite: manual cascade deletion
+		if err := tx.Where("prompt_id = ?", id).Delete(&tables.TablePromptVersionMessage{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("prompt_id = ?", id).Delete(&tables.TablePromptVersion{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("prompt_id = ?", id).Delete(&tables.TablePromptSessionMessage{}).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("prompt_id = ?", id).Delete(&tables.TablePromptSession{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&prompt).Error
+	})
 }
 
 // ============================================================================
@@ -293,7 +358,8 @@ func (s *RDBConfigStore) CreatePromptVersion(ctx context.Context, version *table
 	return fmt.Errorf("failed to create prompt version after %d retries due to concurrent version_number conflict", maxRetries)
 }
 
-// DeletePromptVersion deletes a version
+// DeletePromptVersion deletes a version and promotes the previous version to latest if needed.
+// PostgreSQL uses native ON DELETE CASCADE for messages; SQLite requires manual cascade.
 func (s *RDBConfigStore) DeletePromptVersion(ctx context.Context, id uint) error {
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Get the version to check if it's latest
@@ -305,7 +371,14 @@ func (s *RDBConfigStore) DeletePromptVersion(ctx context.Context, id uint) error
 			return err
 		}
 
-		// Delete version (messages are cascade-deleted by the DB)
+		// SQLite: manually delete version messages (PostgreSQL CASCADE handles this)
+		if s.db.Dialector.Name() != "postgres" {
+			if err := tx.Where("version_id = ?", id).Delete(&tables.TablePromptVersionMessage{}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Delete the version
 		if err := tx.Delete(&tables.TablePromptVersion{}, "id = ?", id).Error; err != nil {
 			return err
 		}
@@ -467,14 +540,28 @@ func (s *RDBConfigStore) RenamePromptSession(ctx context.Context, id uint, name 
 	return nil
 }
 
-// DeletePromptSession deletes a session (messages are cascade-deleted by the DB)
+// DeletePromptSession deletes a session and its messages.
+// PostgreSQL uses native ON DELETE CASCADE for messages; SQLite requires manual cascade.
 func (s *RDBConfigStore) DeletePromptSession(ctx context.Context, id uint) error {
-	result := s.db.WithContext(ctx).Delete(&tables.TablePromptSession{}, "id = ?", id)
-	if result.Error != nil {
-		return result.Error
-	}
-	if result.RowsAffected == 0 {
-		return ErrNotFound
-	}
-	return nil
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var session tables.TablePromptSession
+		if err := tx.First(&session, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+
+		// PostgreSQL: ON DELETE CASCADE handles message deletion
+		if s.db.Dialector.Name() == "postgres" {
+			return tx.Delete(&session).Error
+		}
+
+		// SQLite: manually delete messages first
+		if err := tx.Where("session_id = ?", id).Delete(&tables.TablePromptSessionMessage{}).Error; err != nil {
+			return err
+		}
+
+		return tx.Delete(&session).Error
+	})
 }

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -2,6 +2,7 @@ package configstore
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -35,6 +36,12 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 		&tables.TablePlugin{},
 		&tables.TableMCPClient{},
 		&tables.TableVirtualKeyMCPConfig{},
+		&tables.TableFolder{},
+		&tables.TablePrompt{},
+		&tables.TablePromptVersion{},
+		&tables.TablePromptVersionMessage{},
+		&tables.TablePromptSession{},
+		&tables.TablePromptSessionMessage{},
 	)
 	require.NoError(t, err, "Failed to migrate test database")
 
@@ -1041,4 +1048,273 @@ func TestRateLimitDurationFormats(t *testing.T) {
 		err := store.CreateRateLimit(ctx, rateLimit)
 		assert.NoError(t, err, "Duration %s should be valid", duration)
 	}
+}
+
+// =============================================================================
+// Prompt Deletion Tests
+// =============================================================================
+
+// testPromptTree holds IDs of entities created by createTestPromptTree for verification
+type testPromptTree struct {
+	FolderID   string
+	PromptIDs  []string
+	VersionIDs []uint
+	SessionIDs []uint
+}
+
+// createTestPromptTree creates a folder with 2 prompts, each having 2 versions (with messages) and 1 session (with messages).
+func createTestPromptTree(t *testing.T, store *RDBConfigStore, ctx context.Context) testPromptTree {
+	t.Helper()
+
+	tree := testPromptTree{}
+
+	// Create folder
+	folder := &tables.TableFolder{ID: "folder-1", Name: "Test Folder"}
+	require.NoError(t, store.CreateFolder(ctx, folder))
+	tree.FolderID = folder.ID
+
+	for i, promptID := range []string{"prompt-1", "prompt-2"} {
+		_ = i
+		prompt := &tables.TablePrompt{ID: promptID, Name: "Prompt " + promptID, FolderID: &tree.FolderID}
+		require.NoError(t, store.CreatePrompt(ctx, prompt))
+		tree.PromptIDs = append(tree.PromptIDs, promptID)
+
+		// Create 2 versions with messages
+		for v := 0; v < 2; v++ {
+			version := &tables.TablePromptVersion{
+				PromptID:      promptID,
+				CommitMessage: "version commit",
+				Messages: []tables.TablePromptVersionMessage{
+					{PromptID: promptID, Message: json.RawMessage(`{"role":"user","content":"hello"}`)},
+				},
+			}
+			require.NoError(t, store.CreatePromptVersion(ctx, version))
+			tree.VersionIDs = append(tree.VersionIDs, version.ID)
+		}
+
+		// Create 1 session with messages
+		session := &tables.TablePromptSession{
+			PromptID: promptID,
+			Name:     "Session " + promptID,
+			Messages: []tables.TablePromptSessionMessage{
+				{PromptID: promptID, Message: json.RawMessage(`{"role":"user","content":"hi"}`)},
+			},
+		}
+		require.NoError(t, store.CreatePromptSession(ctx, session))
+		tree.SessionIDs = append(tree.SessionIDs, session.ID)
+	}
+
+	return tree
+}
+
+// countRows returns the number of rows in a table
+func countRows(t *testing.T, store *RDBConfigStore, model interface{}) int64 {
+	t.Helper()
+	var count int64
+	require.NoError(t, store.db.Model(model).Count(&count).Error)
+	return count
+}
+
+func TestDeleteFolder(t *testing.T) {
+	t.Run("NotFound", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		err := store.DeleteFolder(ctx, "nonexistent")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("Empty", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		folder := &tables.TableFolder{ID: "folder-empty", Name: "Empty"}
+		require.NoError(t, store.CreateFolder(ctx, folder))
+
+		require.NoError(t, store.DeleteFolder(ctx, "folder-empty"))
+
+		_, err := store.GetFolderByID(ctx, "folder-empty")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("CascadesAll", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		// Verify entities exist before deletion
+		assert.Greater(t, countRows(t, store, &tables.TablePrompt{}), int64(0))
+		assert.Greater(t, countRows(t, store, &tables.TablePromptVersion{}), int64(0))
+		assert.Greater(t, countRows(t, store, &tables.TablePromptVersionMessage{}), int64(0))
+		assert.Greater(t, countRows(t, store, &tables.TablePromptSession{}), int64(0))
+		assert.Greater(t, countRows(t, store, &tables.TablePromptSessionMessage{}), int64(0))
+
+		require.NoError(t, store.DeleteFolder(ctx, tree.FolderID))
+
+		// All child entities should be deleted
+		assert.Equal(t, int64(0), countRows(t, store, &tables.TableFolder{}))
+		assert.Equal(t, int64(0), countRows(t, store, &tables.TablePrompt{}))
+		assert.Equal(t, int64(0), countRows(t, store, &tables.TablePromptVersion{}))
+		assert.Equal(t, int64(0), countRows(t, store, &tables.TablePromptVersionMessage{}))
+		assert.Equal(t, int64(0), countRows(t, store, &tables.TablePromptSession{}))
+		assert.Equal(t, int64(0), countRows(t, store, &tables.TablePromptSessionMessage{}))
+	})
+}
+
+func TestDeletePrompt(t *testing.T) {
+	t.Run("NotFound", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		err := store.DeletePrompt(ctx, "nonexistent")
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("CascadesAll", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		require.NoError(t, store.DeletePrompt(ctx, tree.PromptIDs[0]))
+
+		// First prompt and its children should be gone
+		_, err := store.GetPromptByID(ctx, tree.PromptIDs[0])
+		assert.ErrorIs(t, err, ErrNotFound)
+
+		// Second prompt should still exist
+		p2, err := store.GetPromptByID(ctx, tree.PromptIDs[1])
+		require.NoError(t, err)
+		assert.Equal(t, tree.PromptIDs[1], p2.ID)
+	})
+
+	t.Run("LeavesFolder", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		require.NoError(t, store.DeletePrompt(ctx, tree.PromptIDs[0]))
+
+		// Folder should still exist
+		folder, err := store.GetFolderByID(ctx, tree.FolderID)
+		require.NoError(t, err)
+		assert.Equal(t, tree.FolderID, folder.ID)
+	})
+
+	t.Run("LeavesSiblings", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		require.NoError(t, store.DeletePrompt(ctx, tree.PromptIDs[0]))
+
+		// Sibling prompt's versions and sessions should be unaffected
+		versions, err := store.GetPromptVersions(ctx, tree.PromptIDs[1])
+		require.NoError(t, err)
+		assert.Len(t, versions, 2)
+
+		sessions, err := store.GetPromptSessions(ctx, tree.PromptIDs[1])
+		require.NoError(t, err)
+		assert.Len(t, sessions, 1)
+	})
+}
+
+func TestDeletePromptVersion(t *testing.T) {
+	t.Run("NotFound", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		err := store.DeletePromptVersion(ctx, 99999)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("NonLatest", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		// Version at index 0 is v1 (non-latest), index 1 is v2 (latest) for prompt-1
+		nonLatestID := tree.VersionIDs[0]
+		latestID := tree.VersionIDs[1]
+
+		require.NoError(t, store.DeletePromptVersion(ctx, nonLatestID))
+
+		// Non-latest version should be gone
+		_, err := store.GetPromptVersionByID(ctx, nonLatestID)
+		assert.ErrorIs(t, err, ErrNotFound)
+
+		// Latest version should still be latest
+		latest, err := store.GetPromptVersionByID(ctx, latestID)
+		require.NoError(t, err)
+		assert.True(t, latest.IsLatest)
+	})
+
+	t.Run("LatestPromotesPrevious", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		// Delete the latest version (index 1 = v2 for prompt-1)
+		latestID := tree.VersionIDs[1]
+		prevID := tree.VersionIDs[0]
+
+		require.NoError(t, store.DeletePromptVersion(ctx, latestID))
+
+		// Previous version should now be latest
+		prev, err := store.GetPromptVersionByID(ctx, prevID)
+		require.NoError(t, err)
+		assert.True(t, prev.IsLatest)
+	})
+
+	t.Run("LeavesPrompt", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		require.NoError(t, store.DeletePromptVersion(ctx, tree.VersionIDs[0]))
+
+		// Prompt should still exist
+		prompt, err := store.GetPromptByID(ctx, tree.PromptIDs[0])
+		require.NoError(t, err)
+		assert.Equal(t, tree.PromptIDs[0], prompt.ID)
+	})
+}
+
+func TestDeletePromptSession(t *testing.T) {
+	t.Run("NotFound", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		err := store.DeletePromptSession(ctx, 99999)
+		assert.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("CascadesMessages", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		sessionID := tree.SessionIDs[0]
+		require.NoError(t, store.DeletePromptSession(ctx, sessionID))
+
+		// Session should be gone
+		_, err := store.GetPromptSessionByID(ctx, sessionID)
+		assert.ErrorIs(t, err, ErrNotFound)
+
+		// Session messages for that session should be gone
+		var msgCount int64
+		require.NoError(t, store.db.Model(&tables.TablePromptSessionMessage{}).Where("session_id = ?", sessionID).Count(&msgCount).Error)
+		assert.Equal(t, int64(0), msgCount)
+	})
+
+	t.Run("LeavesPrompt", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		ctx := context.Background()
+		tree := createTestPromptTree(t, store, ctx)
+
+		require.NoError(t, store.DeletePromptSession(ctx, tree.SessionIDs[0]))
+
+		// Prompt and versions should still exist
+		prompt, err := store.GetPromptByID(ctx, tree.PromptIDs[0])
+		require.NoError(t, err)
+		assert.Equal(t, tree.PromptIDs[0], prompt.ID)
+
+		versions, err := store.GetPromptVersions(ctx, tree.PromptIDs[0])
+		require.NoError(t, err)
+		assert.Len(t, versions, 2)
+	})
 }


### PR DESCRIPTION
## Summary

Implements manual cascade deletion for folder, prompt, version, and session operations to ensure proper cleanup of related records in SQLite databases where foreign key constraints cannot be altered after table creation.

## Changes

- Replaced simple delete operations with transactional manual cascade deletion in `DeleteFolder`, `DeletePrompt`, `DeletePromptVersion`, and `DeletePromptSession` methods
- Added explicit deletion of child records (messages, versions, sessions) before deleting parent records
- Wrapped all deletion operations in database transactions to ensure atomicity
- Added proper existence checks before deletion to maintain consistent error handling

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test deletion operations to ensure child records are properly cleaned up:

```sh
# Core/Transports
go version
go test ./...

# Test specific deletion scenarios:
# 1. Create a folder with prompts, versions, sessions, and messages
# 2. Delete the folder and verify all child records are removed
# 3. Repeat for individual prompt, version, and session deletions
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects data cleanup operations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable