### PR TITLE
adds cli docs

### DIFF
--- a/docs/quickstart/cli/getting-started.mdx
+++ b/docs/quickstart/cli/getting-started.mdx
@@ -8,6 +8,14 @@ icon: "laptop-code"
 
 ## What is Bifrost CLI?
 
+<Frame>
+<iframe 
+  src="https://drive.google.com/file/d/1Sh1-xCJrVeccKscaowznopHNdyoGl2zu/preview" 
+  title="Embedded content"
+  className="w-full h-96 rounded-md"
+></iframe>
+</Frame>
+
 Bifrost CLI is an interactive terminal tool that connects your favorite coding agents — Claude Code, Codex CLI, Gemini CLI, and Opencode — to your Bifrost gateway with zero manual configuration.
 
 Instead of setting environment variables, editing config files, and looking up provider paths, you just run `bifrost` and pick your agent, model, and go.
@@ -54,8 +62,16 @@ npx -y @maximhq/bifrost
 
 In another terminal:
 
+To install 
+
 ```bash
 npx -y @maximhq/bifrost-cli
+```
+
+If you have already installed run
+
+```bash
+bifrost
 ```
 
 <Frame>


### PR DESCRIPTION
## Summary

Enhanced the CLI getting started documentation by adding an embedded video demonstration and clarifying installation instructions for both new and existing users.

## Changes

- Added an embedded Google Drive video preview using a Frame component to provide visual guidance for users
- Clarified installation instructions by separating commands for first-time installation (`npx -y @maximhq/bifrost-cli`) versus running an existing installation (`bifrost`)
- Improved user experience by providing clear context for when to use each command

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Navigate to the CLI getting started documentation page and verify:
1. The embedded video loads and displays correctly
2. Installation instructions are clear and properly formatted
3. The distinction between installation and running commands is evident

## Screenshots/Recordings

The embedded video provides a visual demonstration of the CLI functionality directly within the documentation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The embedded content uses a Google Drive preview link which should be reviewed to ensure it points to appropriate content.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable