### PR TITLE
fix: include function_call items in streaming response.completed Output

### DIFF
--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1914,6 +1914,8 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 		if state.Model != nil {
 			response.Model = *state.Model
 		}
+		var allOutput []ResponsesMessage
+
 		if state.TextItemAdded {
 			statusFinal := terminalStatus
 			messageType := ResponsesMessageTypeMessage
@@ -1942,7 +1944,39 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			if itemID != "" {
 				msg.ID = &itemID
 			}
-			response.Output = []ResponsesMessage{msg}
+			allOutput = append(allOutput, msg)
+		}
+
+		for toolCallID, args := range state.ToolArgumentBuffers {
+			if args == "" {
+				continue
+			}
+			statusFinal := terminalStatus
+			messageType := ResponsesMessageTypeFunctionCall
+			callName, hasName := state.ToolCallNames[toolCallID]
+			var callNamePtr *string
+			if hasName && callName != "" {
+				callNamePtr = &callName
+			}
+			argsValue := args
+			fcMsg := ResponsesMessage{
+				Type:   &messageType,
+				Status: &statusFinal,
+				ResponsesToolMessage: &ResponsesToolMessage{
+					CallID:    &toolCallID,
+					Name:      callNamePtr,
+					Arguments: &argsValue,
+				},
+			}
+			itemID := state.ItemIDs[toolCallID]
+			if itemID != "" {
+				fcMsg.ID = &itemID
+			}
+			allOutput = append(allOutput, fcMsg)
+		}
+
+		if len(allOutput) > 0 {
+			response.Output = allOutput
 		}
 
 		responses = append(responses, &BifrostResponsesStreamResponse{

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -1947,10 +1948,21 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			allOutput = append(allOutput, msg)
 		}
 
-		for toolCallID, args := range state.ToolArgumentBuffers {
-			if args == "" {
-				continue
-			}
+		// Collect tool call IDs sorted by outputIndex for deterministic order
+		type toolCallEntry struct {
+			toolCallID  string
+			outputIndex int
+		}
+		var toolCallEntries []toolCallEntry
+		for toolCallID, outputIndex := range state.ToolCallOutputIndices {
+			toolCallEntries = append(toolCallEntries, toolCallEntry{toolCallID: toolCallID, outputIndex: outputIndex})
+		}
+		sort.Slice(toolCallEntries, func(i, j int) bool {
+			return toolCallEntries[i].outputIndex < toolCallEntries[j].outputIndex
+		})
+
+		for _, entry := range toolCallEntries {
+			toolCallID := entry.toolCallID
 			statusFinal := terminalStatus
 			messageType := ResponsesMessageTypeFunctionCall
 			callName, hasName := state.ToolCallNames[toolCallID]
@@ -1958,14 +1970,14 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			if hasName && callName != "" {
 				callNamePtr = &callName
 			}
-			argsValue := args
+			args := state.ToolArgumentBuffers[toolCallID]
 			fcMsg := ResponsesMessage{
 				Type:   &messageType,
 				Status: &statusFinal,
 				ResponsesToolMessage: &ResponsesToolMessage{
 					CallID:    &toolCallID,
 					Name:      callNamePtr,
-					Arguments: &argsValue,
+					Arguments: &args,
 				},
 			}
 			itemID := state.ItemIDs[toolCallID]

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -401,6 +401,247 @@ func TestToBifrostResponsesResponse_UnknownFinishReasonLeavesStatusUnset(t *test
 	}
 }
 
+func TestToBifrostResponsesStreamResponse_IncludesFunctionCallsInCompletedOutput(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	role := string(ChatMessageRoleAssistant)
+	part1 := "Let me help"
+	toolCallsFinish := string(BifrostFinishReasonToolCalls)
+	funcName := "get_weather"
+	toolCallID := "call_abc123"
+
+	var all []*BifrostResponsesStreamResponse
+
+	// Role chunk
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						Role: &role,
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Text content chunk
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						Content: &part1,
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Tool call chunk with function name
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						ToolCalls: []ChatAssistantMessageToolCall{
+							{
+								Index:    0,
+								ID:       &toolCallID,
+								Function: ChatAssistantMessageToolCallFunction{Name: &funcName, Arguments: `{"city":`},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Tool call argument continuation
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						ToolCalls: []ChatAssistantMessageToolCall{
+							{
+								Index:    0,
+								Function: ChatAssistantMessageToolCallFunction{Arguments: `"Paris"}`},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Finish with tool_calls
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				FinishReason: &toolCallsFinish,
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	var completed *BifrostResponsesStreamResponse
+	for _, evt := range all {
+		if evt != nil && evt.Type == ResponsesStreamResponseTypeCompleted {
+			completed = evt
+		}
+	}
+
+	if completed == nil || completed.Response == nil {
+		t.Fatal("expected response.completed event")
+	}
+
+	output := completed.Response.Output
+	if len(output) < 2 {
+		t.Fatalf("expected at least 2 output items (text + function_call), got %d", len(output))
+	}
+
+	var hasText, hasFunctionCall bool
+	for _, item := range output {
+		if item.Type != nil && *item.Type == ResponsesMessageTypeMessage {
+			hasText = true
+			if item.Content == nil || len(item.Content.ContentBlocks) == 0 || item.Content.ContentBlocks[0].Text == nil {
+				t.Fatal("text message missing content")
+			}
+			if *item.Content.ContentBlocks[0].Text != "Let me help" {
+				t.Fatalf("expected text %q, got %q", "Let me help", *item.Content.ContentBlocks[0].Text)
+			}
+		}
+		if item.Type != nil && *item.Type == ResponsesMessageTypeFunctionCall {
+			hasFunctionCall = true
+			if item.ResponsesToolMessage == nil {
+				t.Fatal("function_call item missing ResponsesToolMessage")
+			}
+			if item.Name == nil || *item.Name != "get_weather" {
+				t.Fatalf("expected function name %q, got %v", "get_weather", item.Name)
+			}
+			if item.Arguments == nil || *item.Arguments != `{"city":"Paris"}` {
+				t.Fatalf("expected arguments %q, got %v", `{"city":"Paris"}`, item.Arguments)
+			}
+			if item.CallID == nil || *item.CallID != toolCallID {
+				t.Fatalf("expected call_id %q, got %v", toolCallID, item.CallID)
+			}
+		}
+	}
+
+	if !hasText {
+		t.Fatal("expected text message in completed output")
+	}
+	if !hasFunctionCall {
+		t.Fatal("expected function_call item in completed output")
+	}
+}
+
+func TestToBifrostResponsesStreamResponse_ToolCallsOnlyInCompletedOutput(t *testing.T) {
+	state := AcquireChatToResponsesStreamState()
+	defer ReleaseChatToResponsesStreamState(state)
+
+	role := string(ChatMessageRoleAssistant)
+	toolCallsFinish := string(BifrostFinishReasonToolCalls)
+	funcName := "get_weather"
+	toolCallID := "call_xyz789"
+
+	var all []*BifrostResponsesStreamResponse
+
+	// Role chunk
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						Role: &role,
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Tool call chunk (no text content at all)
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{
+						ToolCalls: []ChatAssistantMessageToolCall{
+							{
+								Index:    0,
+								ID:       &toolCallID,
+								Function: ChatAssistantMessageToolCallFunction{Name: &funcName, Arguments: `{"q":"test"}`},
+							},
+						},
+					},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	// Finish with tool_calls
+	all = append(all, (&BifrostChatResponse{
+		ID:    "chatcmpl-test",
+		Model: "test-model",
+		Choices: []BifrostResponseChoice{
+			{
+				FinishReason: &toolCallsFinish,
+				ChatStreamResponseChoice: &ChatStreamResponseChoice{
+					Delta: &ChatStreamResponseChoiceDelta{},
+				},
+			},
+		},
+	}).ToBifrostResponsesStreamResponse(state)...)
+
+	var completed *BifrostResponsesStreamResponse
+	for _, evt := range all {
+		if evt != nil && evt.Type == ResponsesStreamResponseTypeCompleted {
+			completed = evt
+		}
+	}
+
+	if completed == nil || completed.Response == nil {
+		t.Fatal("expected response.completed event")
+	}
+
+	output := completed.Response.Output
+	if len(output) != 1 {
+		t.Fatalf("expected 1 output item (function_call only), got %d", len(output))
+	}
+
+	item := output[0]
+	if item.Type == nil || *item.Type != ResponsesMessageTypeFunctionCall {
+		t.Fatal("expected function_call type")
+	}
+	if item.ResponsesToolMessage == nil {
+		t.Fatal("function_call item missing ResponsesToolMessage")
+	}
+	if item.Name == nil || *item.Name != "get_weather" {
+		t.Fatalf("expected function name %q, got %v", "get_weather", item.Name)
+	}
+	if item.Arguments == nil || *item.Arguments != `{"q":"test"}` {
+		t.Fatalf("expected arguments %q, got %v", `{"q":"test"}`, item.Arguments)
+	}
+}
+
 func TestToBifrostResponsesStreamResponse_MapsLengthToIncompleteEvent(t *testing.T) {
 	state := AcquireChatToResponsesStreamState()
 	defer ReleaseChatToResponsesStreamState(state)


### PR DESCRIPTION
Fixes #1978

## Changes

`ToBifrostResponsesStreamResponse()` in `core/schemas/mux.go` was only assigning text messages to `response.Output` in the completed event, ignoring accumulated `ToolArgumentBuffers`/`ToolCallNames`.

The fix refactors the output assembly to:
1. Initialize an `allOutput` slice
2. Append the text message if `TextItemAdded` is true
3. Iterate `ToolArgumentBuffers` to build `function_call` `ResponsesMessage` entries (using `ToolCallNames` for name, `ItemIDs` for ID, `terminalStatus` for status)
4. Assign `allOutput` to `response.Output`

This ensures `response.completed` contains both text and function_call items per the OpenAI Responses API spec.

## Test Plan

- `TestToBifrostResponsesStreamResponse_IncludesFunctionCallsInCompletedOutput`: verifies completed output contains both a text message and a function_call item with correct name, call_id, and arguments
- `TestToBifrostResponsesStreamResponse_ToolCallsOnlyInCompletedOutput`: verifies function_call items appear even when there is no text content