### PR TITLE
fix: openrouter health check icon

### DIFF
--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -64,11 +64,6 @@ func (provider *OpenRouterProvider) GetProviderKey() schemas.ModelProvider {
 	return schemas.OpenRouter
 }
 
-// validationModel is a free model used to validate API keys.
-// OpenRouter's /v1/models endpoint doesn't require authentication,
-// so we make a minimal chat completion call to verify the key is valid.
-const validationModel = "meta-llama/llama-3.2-1b-instruct:free"
-
 // validateKey makes a minimal chat completion request to verify the API key is valid.
 // OpenRouter's /v1/models endpoint doesn't require authentication, so list models
 // will succeed even with an invalid key. This method catches invalid keys.
@@ -89,8 +84,8 @@ func (provider *OpenRouterProvider) validateKey(ctx *schemas.BifrostContext, key
 	req.Header.SetContentType("application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", keyValue))
 
-	// Minimal request body: single "hi" message with max_tokens=1
-	requestBody := []byte(`{"model":"` + validationModel + `","messages":[{"role":"user","content":"hi"}],"max_tokens":1}`)
+	// Minimal request body: single "hi" message with max_tokens=1 and empty model ID
+	requestBody := []byte(`{"model":"","messages":[{"role":"user","content":"hi"}],"max_tokens":1}`)
 	req.SetBody(requestBody)
 
 	// Set any extra headers from network config
@@ -105,12 +100,12 @@ func (provider *OpenRouterProvider) validateKey(ctx *schemas.BifrostContext, key
 	// Check for auth errors (401, 403)
 	statusCode := resp.StatusCode()
 	if statusCode == fasthttp.StatusUnauthorized || statusCode == fasthttp.StatusForbidden {
-		return openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), validationModel)
+		return openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), "")
 	}
 
 	// Any 4xx/5xx error indicates the key might be invalid
-	if statusCode >= 400 {
-		return openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), validationModel)
+	if statusCode > 400 {
+		return openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), "")
 	}
 
 	return nil

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -97,13 +97,8 @@ func (provider *OpenRouterProvider) validateKey(ctx *schemas.BifrostContext, key
 		return bifrostErr
 	}
 
-	// Check for auth errors (401, 403)
-	statusCode := resp.StatusCode()
-	if statusCode == fasthttp.StatusUnauthorized || statusCode == fasthttp.StatusForbidden {
-		return openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), "")
-	}
-
 	// Any 4xx/5xx error indicates the key might be invalid
+	statusCode := resp.StatusCode()
 	if statusCode > 400 {
 		return openai.ParseOpenAIError(resp, schemas.ChatCompletionRequest, provider.GetProviderKey(), "")
 	}


### PR DESCRIPTION
## Summary

Switched the HTTP error check from `>= 400` to `> 400` because 400 means the authorization key was valid. We also don't need to specify a model. It can be empty.

Update: There was also unnecessary double check. Removed one.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


