### PR TITLE
feat: add variables support to prompt sessions and versions with persistence

### DIFF
--- a/ui/components/prompts/components/promptsViewHeader.tsx
+++ b/ui/components/prompts/components/promptsViewHeader.tsx
@@ -26,6 +26,7 @@ export default function PromptsViewHeader() {
 		modelParams,
 		provider,
 		model,
+		variables,
 		hasChanges,
 		hasVersionChanges,
 		hasSessionChanges,
@@ -87,6 +88,7 @@ export default function PromptsViewHeader() {
 					model_params: buildSaveParams(),
 					provider,
 					model,
+					variables: Object.keys(variables).length > 0 ? variables : undefined,
 				},
 			}).unwrap();
 			setUrlState({ sessionId: result.session.id, versionId: null });
@@ -94,7 +96,7 @@ export default function PromptsViewHeader() {
 		} catch (err) {
 			toast.error("Failed to save session", { description: getErrorMessage(err) });
 		}
-	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, createSession, setUrlState, hasChanges, isStreaming]);
+	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, variables, createSession, setUrlState, hasChanges, isStreaming]);
 
 	// Cmd+S / Ctrl+S to save session
 	useHotkeys(
@@ -126,6 +128,7 @@ export default function PromptsViewHeader() {
 					model_params: buildSaveParams(),
 					provider,
 					model,
+					variables: Object.keys(variables).length > 0 ? variables : undefined,
 				},
 			}).unwrap();
 			setUrlState({ sessionId: result.session.id, versionId: null });
@@ -133,7 +136,7 @@ export default function PromptsViewHeader() {
 		} catch (err) {
 			toast.error("Failed to save session", { description: getErrorMessage(err) });
 		}
-	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, createSession, setUrlState, onSessionSaved, hasChanges]);
+	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, variables, createSession, setUrlState, onSessionSaved, hasChanges]);
 
 	const handleRenameSession = useCallback(
 		async (sessionId: number, name: string) => {

--- a/ui/components/prompts/components/variablesTableView.tsx
+++ b/ui/components/prompts/components/variablesTableView.tsx
@@ -10,7 +10,7 @@ export function VariablesTableView({
 	variables: VariableMap;
 	onChange: React.Dispatch<React.SetStateAction<VariableMap>>;
 }) {
-	const entries = useMemo(() => Object.entries(variables), [variables]);
+	const entries = useMemo(() => Object.entries(variables).sort(([a], [b]) => a.localeCompare(b)), [variables]);
 
 	const handleValueChange = useCallback(
 		(name: string, value: string) => {
@@ -25,7 +25,7 @@ export function VariablesTableView({
 			<p className="text-muted-foreground text-xs">
 				Detected from <code className="bg-muted rounded px-1">{"{{ }}"}</code> syntax in messages. Values are substituted at runtime.
 			</p>
-			<div className="border-border overflow-hidden rounded-md border">
+			<div className="border-border overflow-hidden rounded-sm border">
 				<table className="w-full table-fixed text-sm">
 					<thead>
 						<tr className="bg-muted/50 border-border border-b">

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -220,6 +220,10 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(selectedSession.model_params, selectedSession.provider, selectedSession.model);
+			// Restore variables (key:value) from session
+			if (selectedSession.variables && Object.keys(selectedSession.variables).length > 0) {
+				setVariables(selectedSession.variables);
+			}
 		} else if (selectedVersion) {
 			// If sessions are still loading and no session is explicitly selected,
 			// wait — a session may auto-select and take priority
@@ -228,6 +232,10 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(selectedVersion.model_params, selectedVersion.provider, selectedVersion.model);
+			// Initialize variables from version (keys with empty values)
+			if (selectedVersion.variables && Object.keys(selectedVersion.variables).length > 0) {
+				setVariables((prev) => mergeVariables(prev, Object.keys(selectedVersion.variables!)));
+			}
 		} else if (selectedPrompt?.latest_version) {
 			// Only fall back to latest_version after sessions have settled
 			// to avoid racing with the session auto-select effect
@@ -237,6 +245,10 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(version.model_params, version.provider, version.model);
+			// Initialize variables from version (keys with empty values)
+			if (version.variables && Object.keys(version.variables).length > 0) {
+				setVariables((prev) => mergeVariables(prev, Object.keys(version.variables!)));
+			}
 			if (sessions.length === 0) {
 				setUrlState({ versionId: version.id });
 			}

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -168,12 +168,12 @@ export function SettingsPanel() {
 						/>
 					)}
 
-					{/* {Object.keys(variables).length > 0 && (
+					{Object.keys(variables).length > 0 && (
 						<>
 							<Separator />
 							<VariablesTableView variables={variables} onChange={setVariables} />
 						</>
-					)} */}
+					)}
 
 					{model && (
 						<>

--- a/ui/lib/message/constant.ts
+++ b/ui/lib/message/constant.ts
@@ -19,7 +19,7 @@ export const JINJA_VAR_REGEX = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*\}\}/g;
  */
 export const JINJA_VAR_HIGHLIGHT_PATTERNS = [
 	{
-		pattern: /{{.*?}}/g,
+		pattern: /\{\{\s*[a-zA-Z_][a-zA-Z0-9_.]*\s*\}\}/g,
 		className: "outline-content-brand-light text-sm cursor-pointer bg-green-500/20",
 		validate: (part: string) => {
 			return (

--- a/ui/lib/types/prompts.ts
+++ b/ui/lib/types/prompts.ts
@@ -43,18 +43,19 @@ export interface ModelParams {
 }
 
 export interface PromptVersion {
-	id: number;
-	prompt_id: string;
-	version_number: number;
-	commit_message: string;
-	messages: PromptVersionMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
-	is_latest: boolean;
-	created_by_id?: number;
-	created_by?: PromptUser;
-	created_at: string; // No updated_at - versions are immutable
+  id: number
+  prompt_id: string
+  version_number: number
+  commit_message: string
+  messages: PromptVersionMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
+  is_latest: boolean
+  created_by_id?: number
+  created_by?: PromptUser
+  created_at: string // No updated_at - versions are immutable
 }
 
 export interface PromptVersionMessage {
@@ -66,20 +67,21 @@ export interface PromptVersionMessage {
 }
 
 export interface PromptSession {
-	id: number;
-	prompt_id: string;
-	prompt?: Prompt;
-	version_id?: number;
-	version?: PromptVersion;
-	name: string;
-	messages: PromptSessionMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
-	created_by_id?: number;
-	created_by?: PromptUser;
-	created_at: string;
-	updated_at: string;
+  id: number
+  prompt_id: string
+  prompt?: Prompt
+  version_id?: number
+  version?: PromptVersion
+  name: string
+  messages: PromptSessionMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
+  created_by_id?: number
+  created_by?: PromptUser
+  created_at: string
+  updated_at: string
 }
 
 export interface PromptSessionMessage {
@@ -205,12 +207,13 @@ export interface GetSessionResponse {
 }
 
 export interface CreateSessionRequest {
-	name?: string;
-	version_id?: number;
-	messages?: PromptMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
+  name?: string
+  version_id?: number
+  messages?: PromptMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
 }
 
 export interface CreateSessionResponse {
@@ -218,11 +221,12 @@ export interface CreateSessionResponse {
 }
 
 export interface UpdateSessionRequest {
-	name?: string;
-	messages: PromptMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
+  name?: string
+  messages: PromptMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
 }
 
 export interface UpdateSessionResponse {


### PR DESCRIPTION
## Summary

Adds support for variables in prompt sessions and versions, allowing users to define and persist template variables that can be used in Jinja-style templating within prompts.

## Changes

- Added `variables` field to `PromptVersion`, `PromptSession`, and related request/response types
- Updated session creation and saving logic to include variables when they exist
- Modified prompt context to restore variables from sessions and initialize variables from versions
- Enabled the variables table view in the settings panel (previously commented out)
- Improved Jinja variable regex pattern to be more restrictive and accurate
- Variables are conditionally included in API requests only when they contain data

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Create or open a prompt with Jinja-style variables (e.g., `{{ variable_name }}`)
2. Verify that variables are automatically detected and displayed in the settings panel
3. Set values for the variables in the variables table
4. Save the session and verify variables persist when reloading
5. Test that variables are properly initialized from versions vs restored from sessions

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Variables are stored as key-value pairs and should be validated on the backend to prevent injection attacks when used in template rendering.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable