### PR TITLE
truncate name bigger than 64 chars

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -1103,9 +1103,9 @@ append_dynamic_columns_postgres() {
     echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels = NULL WHERE id = 1;" >> "$output_file"
     echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels = NULL WHERE id = 2;" >> "$output_file"
   fi
-  if column_exists_postgres "governance_model_pricing" "output_cost_per_image_above_512_and_512_pixels_and_premium_imag"; then
-    echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels_and_premium_imag = NULL WHERE id = 1;" >> "$output_file"
-    echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels_and_premium_imag = NULL WHERE id = 2;" >> "$output_file"
+  if column_exists_postgres "governance_model_pricing" "output_cost_per_image_above_512x512_pixels_premium"; then
+    echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512x512_pixels_premium = NULL WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512x512_pixels_premium = NULL WHERE id = 2;" >> "$output_file"
   fi
   if column_exists_postgres "governance_model_pricing" "output_cost_per_image_above_1024_and_1024_pixels"; then
     echo "UPDATE governance_model_pricing SET output_cost_per_image_above_1024_and_1024_pixels = NULL WHERE id = 1;" >> "$output_file"
@@ -1505,9 +1505,9 @@ append_dynamic_columns_sqlite() {
       echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels = NULL WHERE id = 1;" >> "$output_file"
       echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels = NULL WHERE id = 2;" >> "$output_file"
     fi
-    if column_exists_sqlite "$config_db" "governance_model_pricing" "output_cost_per_image_above_512_and_512_pixels_and_premium_image"; then
-      echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels_and_premium_image = NULL WHERE id = 1;" >> "$output_file"
-      echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512_and_512_pixels_and_premium_image = NULL WHERE id = 2;" >> "$output_file"
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "output_cost_per_image_above_512x512_pixels_premium"; then
+      echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512x512_pixels_premium = NULL WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET output_cost_per_image_above_512x512_pixels_premium = NULL WHERE id = 2;" >> "$output_file"
     fi
     if column_exists_sqlite "$config_db" "governance_model_pricing" "output_cost_per_image_above_1024_and_1024_pixels"; then
       echo "UPDATE governance_model_pricing SET output_cost_per_image_above_1024_and_1024_pixels = NULL WHERE id = 1;" >> "$output_file"

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -302,6 +302,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPricingRefactorColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationRenameTruncatedPricingColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddImageQualityPricingColumns(ctx, db); err != nil {
 		return err
 	}
@@ -4232,7 +4235,7 @@ func migrationAddPricingRefactorColumns(ctx context.Context, db *gorm.DB) error 
 				"output_cost_per_pixel",
 				"output_cost_per_image_premium_image",
 				"output_cost_per_image_above_512_and_512_pixels",
-				"output_cost_per_image_above_512_and_512_pixels_and_premium_image",
+				"output_cost_per_image_above_512x512_pixels_premium",
 				"output_cost_per_image_above_1024_and_1024_pixels",
 				"output_cost_per_image_above_1024x1024_pixels_premium",
 				"input_cost_per_audio_token",
@@ -4274,7 +4277,7 @@ func migrationAddPricingRefactorColumns(ctx context.Context, db *gorm.DB) error 
 				"output_cost_per_pixel",
 				"output_cost_per_image_premium_image",
 				"output_cost_per_image_above_512_and_512_pixels",
-				"output_cost_per_image_above_512_and_512_pixels_and_premium_image",
+				"output_cost_per_image_above_512x512_pixels_premium",
 				"output_cost_per_image_above_1024_and_1024_pixels",
 				"output_cost_per_image_above_1024x1024_pixels_premium",
 				"input_cost_per_audio_token",
@@ -4304,6 +4307,48 @@ func migrationAddPricingRefactorColumns(ctx context.Context, db *gorm.DB) error 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running pricing refactor columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationRenameTruncatedPricingColumn renames the output_cost_per_image_above_512_and_512_pixels_and_premium_image
+// column which at 64 chars exceeds PostgreSQL's 63-character identifier limit. PostgreSQL silently truncated
+// it to output_cost_per_image_above_512_and_512_pixels_and_premium_imag (63 chars), while SQLite kept the
+// full 64-char name. This migration renames whichever variant exists to the shorter canonical name.
+func migrationRenameTruncatedPricingColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "rename_truncated_pricing_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			const newName = "output_cost_per_image_above_512x512_pixels_premium"
+			if mg.HasColumn(&tables.TableModelPricing{}, newName) {
+				return nil
+			}
+
+			// PostgreSQL truncated the 64-char name to 63 chars
+			const oldNamePG = "output_cost_per_image_above_512_and_512_pixels_and_premium_imag"
+			// SQLite kept the full 64-char name
+			const oldNameSQLite = "output_cost_per_image_above_512_and_512_pixels_and_premium_image"
+
+			if mg.HasColumn(&tables.TableModelPricing{}, oldNamePG) {
+				if err := tx.Exec("ALTER TABLE governance_model_pricing RENAME COLUMN " + oldNamePG + " TO " + newName).Error; err != nil {
+					return fmt.Errorf("failed to rename column %s to %s: %w", oldNamePG, newName, err)
+				}
+			} else if mg.HasColumn(&tables.TableModelPricing{}, oldNameSQLite) {
+				if err := tx.Exec("ALTER TABLE governance_model_pricing RENAME COLUMN " + oldNameSQLite + " TO " + newName).Error; err != nil {
+					return fmt.Errorf("failed to rename column %s to %s: %w", oldNameSQLite, newName, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running rename_truncated_pricing_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -44,7 +44,7 @@ type TableModelPricing struct {
 	OutputCostPerPixel                            *float64 `gorm:"default:null;column:output_cost_per_pixel" json:"output_cost_per_pixel,omitempty"`
 	OutputCostPerImagePremiumImage                *float64 `gorm:"default:null;column:output_cost_per_image_premium_image" json:"output_cost_per_image_premium_image,omitempty"`
 	OutputCostPerImageAbove512x512Pixels          *float64 `gorm:"default:null;column:output_cost_per_image_above_512_and_512_pixels" json:"output_cost_per_image_above_512_and_512_pixels,omitempty"`
-	OutputCostPerImageAbove512x512PixelsPremium   *float64 `gorm:"default:null;column:output_cost_per_image_above_512_and_512_pixels_and_premium_image" json:"output_cost_per_image_above_512_and_512_pixels_and_premium_image,omitempty"`
+	OutputCostPerImageAbove512x512PixelsPremium   *float64 `gorm:"default:null;column:output_cost_per_image_above_512x512_pixels_premium" json:"output_cost_per_image_above_512_and_512_pixels_and_premium_image,omitempty"`
 	OutputCostPerImageAbove1024x1024Pixels        *float64 `gorm:"default:null;column:output_cost_per_image_above_1024_and_1024_pixels" json:"output_cost_per_image_above_1024_and_1024_pixels,omitempty"`
 	OutputCostPerImageAbove1024x1024PixelsPremium *float64 `gorm:"default:null;column:output_cost_per_image_above_1024x1024_pixels_premium" json:"output_cost_per_image_above_1024_and_1024_pixels_and_premium_image,omitempty"`
 	OutputCostPerImageAbove2048x2048Pixels        *float64 `gorm:"default:null;column:output_cost_per_image_above_2048_and_2048_pixels" json:"output_cost_per_image_above_2048_and_2048_pixels,omitempty"`


### PR DESCRIPTION
## Summary

Fixes database column naming inconsistency caused by PostgreSQL's 63-character identifier limit. The column `output_cost_per_image_above_512_and_512_pixels_and_premium_image` (64 chars) was silently truncated by PostgreSQL but kept in full by SQLite, creating a mismatch between database systems.

## Changes

- Renamed the problematic column to `output_cost_per_image_above_512x512_pixels_premium` (shorter, canonical name)
- Added migration `migrationRenameTruncatedPricingColumn` to handle renaming from either the truncated PostgreSQL version or full SQLite version
- Updated migration test scripts to reference the new column name for both PostgreSQL and SQLite
- Updated the struct field's gorm column tag while preserving the JSON tag for backward compatibility

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that the migration runs successfully on both PostgreSQL and SQLite databases:

```sh
# Run migration tests
./.github/workflows/scripts/run-migration-tests.sh

# Verify core functionality
go test ./framework/configstore/...

# Check that the column exists with correct name in both database types
# PostgreSQL: SELECT column_name FROM information_schema.columns WHERE table_name = 'governance_model_pricing' AND column_name = 'output_cost_per_image_above_512x512_pixels_premium';
# SQLite: PRAGMA table_info(governance_model_pricing);
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

The migration automatically handles the rename and the JSON tag remains unchanged for API compatibility.

## Related issues

N/A

## Security considerations

None - this is a database schema consistency fix with no security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable