### PR TITLE
adds async flow for syncModelParameters

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3468,7 +3468,6 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 					}
 				}
 			} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebSearch) {
-				// Handle web_search tool
 				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebSearchCall)
 				bifrostMsg.ResponsesToolMessage.Name = nil
 				if inputMap, ok := toolBlock.Input.(map[string]interface{}); ok {
@@ -3477,7 +3476,19 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 							ResponsesWebSearchToolCallAction: &schemas.ResponsesWebSearchToolCallAction{
 								Type:    "search",
 								Query:   schemas.Ptr(query),
-								Queries: []string{query}, // Anthropic uses single query
+								Queries: []string{query},
+							},
+						}
+					}
+				}
+			} else if toolBlock.Name != nil && *toolBlock.Name == string(AnthropicToolNameWebFetch) {
+				bifrostMsg.Type = schemas.Ptr(schemas.ResponsesMessageTypeWebFetchCall)
+				bifrostMsg.ResponsesToolMessage.Name = nil
+				if inputMap, ok := toolBlock.Input.(map[string]interface{}); ok {
+					if url, ok := inputMap["url"].(string); ok {
+						bifrostMsg.ResponsesToolMessage.Action = &schemas.ResponsesToolMessageActionStruct{
+							ResponsesWebFetchToolCallAction: &schemas.ResponsesWebFetchToolCallAction{
+								URL: url,
 							},
 						}
 					}

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -212,10 +212,12 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			if err := mc.syncPricing(ctx); err != nil {
 				return nil, fmt.Errorf("failed to sync pricing data: %w", err)
 			}
-			// Sync model parameters into memory
-			if err := mc.syncModelParameters(ctx); err != nil {
-				mc.logger.Warn("failed to sync model parameters data: %v", err)
-			}
+			// Sync model parameters asynchronously - not needed for startup
+			go func() {
+				if err := mc.syncModelParameters(ctx); err != nil {
+					mc.logger.Warn("failed to sync model parameters data: %v", err)
+				}
+			}()
 		} else {
 			lock, err := mc.distributedLockManager.NewLock("model_catalog_pricing_sync")
 			if err != nil {
@@ -232,10 +234,12 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			if err := mc.syncPricing(ctx); err != nil {
 				return nil, fmt.Errorf("failed to sync pricing data: %w", err)
 			}
-			// Sync model parameters into memory
-			if err := mc.syncModelParameters(ctx); err != nil {
-				mc.logger.Warn("failed to sync model parameters data: %v", err)
-			}
+			// Sync model parameters asynchronously - not needed for startup
+			go func() {
+				if err := mc.syncModelParameters(ctx); err != nil {
+					mc.logger.Warn("failed to sync model parameters data: %v", err)
+				}
+			}()
 		}
 	} else {
 		// Load pricing data from config memory


### PR DESCRIPTION
## Summary

This PR adds support for the `web_fetch` tool in Anthropic responses and optimizes model catalog initialization by making model parameter syncing asynchronous.

## Changes

- Added handling for `AnthropicToolNameWebFetch` tool calls in the Anthropic response converter, mapping them to `ResponsesMessageTypeWebFetchCall` with URL extraction
- Moved model parameter syncing to run asynchronously during model catalog initialization to improve startup performance
- Removed an unnecessary comment in the web search tool handling code

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Verify that Anthropic web fetch tool calls are properly converted and that model catalog initialization completes faster:

```sh
# Core/Transports
go version
go test ./...
```

Test with Anthropic models that use web_fetch tools to ensure proper message type conversion and URL extraction.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The web fetch functionality handles URLs from external tool responses - ensure proper validation is in place downstream.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable