### PR TITLE
modelcatalog data race fix

### DIFF
--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -254,9 +254,6 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 	// Start background sync worker
 	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)
 	mc.startSyncWorker(mc.syncCtx)
-	mc.configStore = configStore
-	mc.logger = logger
-
 	return mc, nil
 }
 


### PR DESCRIPTION
## Summary

Removes duplicate assignment of `configStore` and `logger` fields in the modelcatalog initialization function that were already set earlier in the function.

## Changes

- Removed redundant assignment of `mc.configStore = configStore` and `mc.logger = logger` from the `Init` function
- These fields are already properly assigned earlier in the initialization process, making the duplicate assignments unnecessary

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that the modelcatalog initialization still works correctly and that the configStore and logger are properly accessible.

```sh
# Core/Transports
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a simple code cleanup that removes duplicate assignments.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable