### PR TITLE
feat: restore sidebar state from cookie after hydration

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -122,7 +122,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent className="dark:bg-card flex w-full flex-col gap-4 overflow-x-hidden bg-white p-8 sm:max-w-[60%]">
+			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
 				<SheetHeader className="flex flex-row items-center px-0">
 					<div className="flex w-full items-center justify-between">
 						<SheetTitle className="flex w-fit items-center gap-2 font-medium">

--- a/ui/app/workspace/logs/sheets/observabilityConfigSheet.tsx
+++ b/ui/app/workspace/logs/sheets/observabilityConfigSheet.tsx
@@ -13,7 +13,7 @@ export function ObservabilityConfigSheet({ open, onOpenChange }: ObservabilityCo
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
-        className="dark:bg-card flex w-full flex-col gap-4 overflow-x-hidden bg-white p-8 sm:max-w-[60%]"
+        className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]"
       >
         <SheetHeader className="flex flex-row items-center px-0">
           <SheetTitle>Observability settings</SheetTitle>

--- a/ui/app/workspace/logs/sheets/observabilitySettingsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/observabilitySettingsSheet.tsx
@@ -11,7 +11,7 @@ interface ObservabilitySettingsSheetProps {
 export function ObservabilitySettingsSheet({ open, onOpenChange }: ObservabilitySettingsSheetProps) {
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent side="right" className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-8 pt-6 sm:max-w-3xl">
+			<SheetContent side="right" className="flex w-full flex-col overflow-x-hidden px-8 pt-6 sm:max-w-3xl">
 				<SheetHeader className="">
 					<SheetTitle className="text-lg font-semibold">Logging settings</SheetTitle>
 				</SheetHeader>

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -64,7 +64,7 @@ export function MCPLogDetailSheet({ log, open, onOpenChange, handleDelete }: MCP
 
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent className="dark:bg-card flex w-full flex-col gap-4 overflow-x-hidden bg-white p-8 sm:max-w-[60%]">
+			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
 				<SheetHeader className="flex flex-row items-center px-0">
 					<div className="flex w-full items-center justify-between">
 						<SheetTitle className="flex w-fit items-center gap-2 font-medium">

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -274,7 +274,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 	return (
 		<Sheet open={open} onOpenChange={(open) => !open && onClose()}>
-			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-4 pb-8">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden px-4 pb-8">
 				<SheetHeader className="flex flex-col items-start px-4 pt-8">
 					<SheetTitle>New MCP Server</SheetTitle>
 					<SheetDescription>Configure and connect to a new Model Context Protocol server.</SheetDescription>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -220,7 +220,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 
 	return (
 		<Sheet open onOpenChange={onClose}>
-			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8 sm:max-w-[60%]">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8 sm:max-w-[60%]">
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col">
 						<SheetHeader className="w-full p-0" showCloseButton={false}>

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -211,7 +211,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 	return (
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
 			<SheetContent
-				className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8"
+				className="flex w-full flex-col overflow-x-hidden p-8"
 				onInteractOutside={(e) => { if (isEditing ? form.formState.isDirty : (!!form.watch("modelName") || hasAnyLimit)) e.preventDefault(); }}
 				onEscapeKeyDown={(e) => { if (isEditing ? form.formState.isDirty : (!!form.watch("modelName") || hasAnyLimit)) e.preventDefault(); }}
 				data-testid="model-limit-sheet"

--- a/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
@@ -151,7 +151,7 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 
 	return (
 		<Sheet open={open} onOpenChange={handleClose}>
-			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8">
 				<SheetHeader className="p-0 flex flex-col items-start">
 					<SheetTitle>{isEditMode ? "Update Plugin" : "Install New Plugin"}</SheetTitle>
 					<SheetDescription>

--- a/ui/app/workspace/plugins/sheets/pluginSequenceSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/pluginSequenceSheet.tsx
@@ -136,7 +136,7 @@ export default function PluginSequenceSheet({ open, onClose, plugins }: PluginSe
 
 	return (
 		<Sheet open={open} onOpenChange={onClose}>
-			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8">
 				<SheetHeader className="flex flex-col items-start p-0">
 					<SheetTitle>Edit Plugin Sequence</SheetTitle>
 					<SheetDescription>Drag plugins above or below the built-in plugins block to control execution order.</SheetDescription>

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -229,7 +229,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 export default function AddCustomProviderSheet(props: Props) {
 	return (
 		<Sheet open={props.show} onOpenChange={(open) => !open && props.onClose()}>
-			<SheetContent className="custom-scrollbar dark:bg-card flex flex-col bg-white p-8 sm:max-w-3xl" data-testid="custom-provider-sheet">
+			<SheetContent className="custom-scrollbar flex flex-col p-8 sm:max-w-3xl" data-testid="custom-provider-sheet">
 				<AddCustomProviderSheetContent {...props} />
 			</SheetContent>
 		</Sheet>

--- a/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
@@ -28,7 +28,7 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyIndex, pro
 				if (!open) onCancel();
 			}}
 		>
-			<SheetContent className="custom-scrollbar dark:bg-card bg-white p-8" data-testid="key-form">
+			<SheetContent className="custom-scrollbar p-8" data-testid="key-form">
 				<SheetHeader className="flex flex-col items-start">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -74,7 +74,7 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 				if (!open) onCancel();
 			}}
 		>
-			<SheetContent className="custom-scrollbar dark:bg-card bg-white p-8 sm:max-w-[50%]">
+			<SheetContent className="custom-scrollbar p-8 sm:max-w-[50%]">
 				<SheetHeader className="flex flex-col items-start">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -284,7 +284,7 @@ export function RoutingRuleSheet({
 
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent className="dark:bg-card flex w-full flex-col min-w-1/2 gap-4 overflow-x-hidden bg-white p-8">
+			<SheetContent className="flex w-full flex-col min-w-1/2 gap-4 overflow-x-hidden p-8">
 				<SheetHeader className="flex flex-col items-start">
 					<SheetTitle>
 						{isEditing ? "Edit Routing Rule" : "Create New Routing Rule"}

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -41,7 +41,7 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 
 	return (
 		<Sheet open onOpenChange={onClose}>
-			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-8 sm:max-w-2xl">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8 sm:max-w-2xl">
 				<SheetHeader className="p-0 flex flex-col items-start">
 					<SheetTitle>{virtualKey.name}</SheetTitle>
 					<SheetDescription>{virtualKey.description || "Virtual key details and usage information"}</SheetDescription>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -486,7 +486,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 	return (
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-			<SheetContent className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-4 pb-8" data-testid="vk-sheet">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden px-4 pb-8" data-testid="vk-sheet">
 				<SheetHeader className="flex flex-col items-start px-3 pt-8">
 					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Create Virtual Key"}</SheetTitle>
 					<SheetDescription>

--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -105,7 +105,7 @@ function SheetContent({
 					onPointerDownOutside={handlePointerDownOutside}
 					onInteractOutside={handleInteractOutside}
 					className={cn(
-						"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out custom-scrollbar fixed z-50 flex flex-col shadow-lg transition-all ease-in-out overscroll-none data-[state=closed]:duration-100 data-[state=open]:duration-100",
+						"bg-card data-[state=open]:animate-in data-[state=closed]:animate-out custom-scrollbar fixed z-50 flex flex-col shadow-lg transition-all ease-in-out overscroll-none data-[state=closed]:duration-100 data-[state=open]:duration-100",
 						side === "right" &&
 							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 right-0 bottom-2 h-auto w-3/4 rounded-l-lg border-l",
 						side === "right" && (!expandable || !expanded) && "sm:max-w-2xl",

--- a/ui/components/ui/sidebar.tsx
+++ b/ui/components/ui/sidebar.tsx
@@ -61,6 +61,16 @@ function SidebarProvider({
 	// This is the internal state of the sidebar.
 	// We use openProp and setOpenProp for control from outside the component.
 	const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
+
+	// Restore persisted sidebar state from cookie after hydration.
+	React.useEffect(() => {
+		if (openProp !== undefined) return;
+		const match = document.cookie.match(new RegExp(`(?:^|; )${SIDEBAR_COOKIE_NAME}=([^;]*)`));
+		if (match && (match[1] === "true" || match[1] === "false")) {
+			setInternalOpen(match[1] === "true");
+		}
+	}, [openProp]);
+
 	const open = openProp ?? internalOpen;
 	const setOpen = React.useCallback(
 		(value: boolean | ((value: boolean) => boolean)) => {
@@ -71,7 +81,6 @@ function SidebarProvider({
 				setInternalOpen(openState);
 			}
 
-			// This sets the cookie to keep the sidebar state.
 			document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
 		},
 		[setOpenProp, open],


### PR DESCRIPTION
## Summary

Adds cookie-based persistence for sidebar state by restoring the saved state from cookies after component hydration.

## Changes

- Added a `useEffect` hook to read the sidebar state from cookies on component mount
- The effect only runs when `openProp` is undefined, allowing external control to take precedence
- Removed an outdated comment about cookie setting behavior

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Open the application and toggle the sidebar state
2. Refresh the page and verify the sidebar maintains its previous state
3. Test that external control via `openProp` still takes precedence over cookie state

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Uses document.cookie for client-side state persistence with path and max-age restrictions already in place.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable