### PR TITLE
logstore: guard metadata jsonb casts for empty values

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -1753,7 +1753,7 @@ func migrationAddMetadataGINIndex(ctx context.Context, db *gorm.DB) error {
 				}
 
 				// Create the GIN index now that all metadata values are valid JSON or NULL.
-				if err := tx.Exec("CREATE INDEX IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb))").Error; err != nil {
+				if err := tx.Exec("CREATE INDEX IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((NULLIF(metadata,'')::jsonb))").Error; err != nil {
 					return fmt.Errorf("failed to create metadata GIN index: %w", err)
 				}
 			}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -164,7 +164,7 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 				} else {
 					jsonFragment = fmt.Sprintf(`{%q: %q}`, key, value)
 				}
-				baseQuery = baseQuery.Where("metadata::jsonb @> ?::jsonb", jsonFragment)
+				baseQuery = baseQuery.Where("NULLIF(metadata,'')::jsonb @> ?::jsonb", jsonFragment)
 			default:
 				// SQLite: quote the member name so dots/hyphens stay part of the key
 				path := `$."` + key + `"`


### PR DESCRIPTION
## Summary
- prevent Postgres log inserts from failing when metadata is an empty string
- use NULLIF in the metadata GIN index expression and metadata filters to keep queries safe

## Testing
- not run (Go toolchain not available in this environment)

Fixes #2148