### PR TITLE
chore: update docs for CRUD search support

### DIFF
--- a/docs/features/governance/budget-and-limits.mdx
+++ b/docs/features/governance/budget-and-limits.mdx
@@ -199,6 +199,10 @@ The info sheet for the virtual key provides real-time monitoring of:
 - Provider availability status
 - Usage trends and forecasting
 
+### Managing Model Limits
+
+Use the **Model Limits** page to manage model-level budgets and rate limits outside individual virtual keys. The OSS table supports server-side search by model name and paginated browsing.
+
 </Tab>
 <Tab title="API">
 
@@ -332,6 +336,28 @@ curl -X PUT "https://your-bifrost-instance.com/api/governance/virtual-keys/{vk_i
 | `budget.calendar_aligned` | boolean | When true, resets at calendar boundaries in UTC (requires `d`/`w`/`M`/`Y` durations) |
 | `rate_limit.token_max_limit` | integer | Maximum tokens per period |
 | `rate_limit.request_max_limit` | integer | Maximum requests per period |
+
+### List Model Limits
+
+```bash
+curl "https://your-bifrost-instance.com/api/governance/model-configs?search=gpt-4&limit=25&offset=0"
+```
+
+```json
+{
+  "model_configs": [
+    {
+      "id": "mc_123",
+      "model_name": "gpt-4o",
+      "provider": "openai"
+    }
+  ],
+  "count": 1,
+  "total_count": 6,
+  "limit": 25,
+  "offset": 0
+}
+```
 
 </Tab>
 <Tab title="config.json">

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -264,6 +264,8 @@ Teams provide organizational grouping for virtual keys with department-level bud
 
 1. Go to **Users & Groups** → **Teams**
 
+The Teams table supports server-side search by team name and paginated browsing in the OSS dashboard.
+
 2. Click on **Add Team** button
 
 ![Team Creation](../../media/ui-create-teams.png)
@@ -310,8 +312,30 @@ curl -X PUT http://localhost:8080/api/governance/teams/{team_id} \
 # List all teams
 curl http://localhost:8080/api/governance/teams
 
+# Search teams by name with pagination
+curl "http://localhost:8080/api/governance/teams?search=engineering&limit=25&offset=0"
+
+# Filter teams by customer and search within that customer
+curl "http://localhost:8080/api/governance/teams?customer_id=customer-acme-corp&search=platform&limit=25&offset=0"
+
 # Get specific team
 curl http://localhost:8080/api/governance/teams/{team_id}
+```
+
+**List Response:**
+```json
+{
+  "teams": [
+    {
+      "id": "team-eng-001",
+      "name": "Engineering Team"
+    }
+  ],
+  "count": 1,
+  "total_count": 4,
+  "limit": 25,
+  "offset": 0
+}
 ```
 
 **Delete Team:**
@@ -379,6 +403,8 @@ Customers represent the highest level in the governance hierarchy, typically cor
 
 1. Go to **Users & Groups** → **Customers**
 
+The Customers table supports server-side search by customer name and paginated browsing in the OSS dashboard.
+
 2. Click on **Add Customer** button
 
 ![Customer Creation](../../media/ui-create-customer.png)
@@ -429,8 +455,27 @@ curl -X PUT http://localhost:8080/api/governance/customers/{customer_id} \
 # List all customers
 curl http://localhost:8080/api/governance/customers
 
+# Search customers by name with pagination
+curl "http://localhost:8080/api/governance/customers?search=acme&limit=25&offset=0"
+
 # Get specific customer
 curl http://localhost:8080/api/governance/customers/{customer_id}
+```
+
+**List Response:**
+```json
+{
+  "customers": [
+    {
+      "id": "customer-acme-corp",
+      "name": "Acme Corporation"
+    }
+  ],
+  "count": 1,
+  "total_count": 8,
+  "limit": 25,
+  "offset": 0
+}
 ```
 
 **Delete Customer:**

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -178,6 +178,8 @@ Server-Sent Events (SSE) connections provide real-time, persistent connections t
   <img src="/media/ui-mcp-servers-table.png" alt="MCP Servers Table" />
 </Frame>
 
+The MCP Server Catalog supports server-side search by client name and paginated browsing in OSS.
+
 2. Click **New MCP Server** button to open the creation form
 
 3. Fill in the connection details:
@@ -259,29 +261,38 @@ curl -X POST http://localhost:8080/api/mcp/client \
 
 ```bash
 curl http://localhost:8080/api/mcp/clients
+
+# Search by client name with pagination
+curl "http://localhost:8080/api/mcp/clients?search=filesystem&limit=25&offset=0"
 ```
 
 Response:
 ```json
-[
-  {
-    "config": {
-      "id": "abc123",
-      "name": "filesystem",
-      "connection_type": "stdio",
-      "stdio_config": {
-        "command": "npx",
-        "args": ["-y", "@anthropic/mcp-filesystem"]
-      }
-    },
-    "tools": [
-      {"name": "read_file", "description": "Read contents of a file"},
-      {"name": "write_file", "description": "Write contents to a file"},
-      {"name": "list_directory", "description": "List directory contents"}
-    ],
-    "state": "connected"
-  }
-]
+{
+  "clients": [
+    {
+      "config": {
+        "id": "abc123",
+        "name": "filesystem",
+        "connection_type": "stdio",
+        "stdio_config": {
+          "command": "npx",
+          "args": ["-y", "@anthropic/mcp-filesystem"]
+        }
+      },
+      "tools": [
+        {"name": "read_file", "description": "Read contents of a file"},
+        {"name": "write_file", "description": "Write contents to a file"},
+        {"name": "list_directory", "description": "List directory contents"}
+      ],
+      "state": "connected"
+    }
+  ],
+  "count": 1,
+  "total_count": 3,
+  "limit": 25,
+  "offset": 0
+}
 ```
 
 </Tab>

--- a/docs/mcp/filtering.mdx
+++ b/docs/mcp/filtering.mdx
@@ -461,20 +461,29 @@ Client Config Tools ∩ Request Filters ∩ VK Filters = Available Tools
 **Gateway API:**
 ```bash
 curl http://localhost:8080/api/mcp/clients
+
+# Search by client name with pagination
+curl "http://localhost:8080/api/mcp/clients?search=file&limit=25&offset=0"
 ```
 
 **Response shows tools per client:**
 ```json
-[
-  {
-    "config": { "name": "filesystem", "tools_to_execute": ["read_file", "write_file"] },
-    "tools": [
-      { "name": "read_file", "description": "Read file contents" },
-      { "name": "write_file", "description": "Write to file" }
-    ],
-    "state": "connected"
-  }
-]
+{
+  "clients": [
+    {
+      "config": { "name": "filesystem", "tools_to_execute": ["read_file", "write_file"] },
+      "tools": [
+        { "name": "read_file", "description": "Read file contents" },
+        { "name": "write_file", "description": "Write to file" }
+      ],
+      "state": "connected"
+    }
+  ],
+  "count": 1,
+  "total_count": 2,
+  "limit": 25,
+  "offset": 0
+}
 ```
 
 ### Check What LLM Receives

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -159,7 +159,12 @@ teams:
   get:
     operationId: listTeams
     summary: List teams
-    description: Returns a list of all teams.
+    description: |
+      Returns teams in a wrapped list response.
+
+      Supports server-side search and pagination on the default database-backed path via
+      `search`, `limit`, and `offset`. When `from_memory=true`, Bifrost returns the
+      in-memory config snapshot instead. The existing `customer_id` filter is preserved.
     tags:
       - Governance
     parameters:
@@ -168,6 +173,25 @@ teams:
         description: Filter teams by customer ID
         schema:
           type: string
+      - name: search
+        in: query
+        description: Case-insensitive name search on the database-backed list path
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Number of teams to return. Defaults to 25 and is capped at 100.
+        schema:
+          type: integer
+          minimum: 0
+          default: 25
+      - name: offset
+        in: query
+        description: Number of teams to skip before returning results
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
       - name: from_memory
         in: query
         description: If true, returns teams from in-memory cache instead of database
@@ -319,10 +343,34 @@ customers:
   get:
     operationId: listCustomers
     summary: List customers
-    description: Returns a list of all customers.
+    description: |
+      Returns customers in a wrapped list response.
+
+      Supports server-side search and pagination on the default database-backed path via
+      `search`, `limit`, and `offset`. When `from_memory=true`, Bifrost returns the
+      in-memory config snapshot instead.
     tags:
       - Governance
     parameters:
+      - name: search
+        in: query
+        description: Case-insensitive name search on the database-backed list path
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Number of customers to return. Defaults to 25 and is capped at 100.
+        schema:
+          type: integer
+          minimum: 0
+          default: 25
+      - name: offset
+        in: query
+        description: Number of customers to skip before returning results
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
       - name: from_memory
         in: query
         description: If true, returns customers from in-memory cache instead of database
@@ -524,7 +572,12 @@ routing-rules:
   get:
     operationId: listRoutingRules
     summary: List routing rules
-    description: Returns a list of all routing rules configured for intelligent request routing across providers.
+    description: |
+      Returns routing rules in a wrapped list response.
+
+      Supports server-side search and pagination on the default database-backed list path via
+      `search`, `limit`, and `offset`. `scope` and `scope_id` continue to filter rules by scope,
+      and `from_memory=true` returns the in-memory rule set.
     tags:
       - Governance
     parameters:
@@ -538,6 +591,31 @@ routing-rules:
         description: Filter routing rules by scope ID
         schema:
           type: string
+      - name: search
+        in: query
+        description: Case-insensitive name search on the database-backed list path
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Number of routing rules to return. Defaults to 25 and is capped at 100.
+        schema:
+          type: integer
+          minimum: 0
+          default: 25
+      - name: offset
+        in: query
+        description: Number of routing rules to skip before returning results
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+      - name: from_memory
+        in: query
+        description: If true, returns routing rules from in-memory cache instead of database
+        schema:
+          type: boolean
+          default: false
     responses:
       '200':
         description: Successful response
@@ -677,9 +755,40 @@ model-configs:
   get:
     operationId: listModelConfigs
     summary: List model configs
-    description: Returns a list of all model configurations with their budget and rate limit settings.
+    description: |
+      Returns model configs in a wrapped list response.
+
+      Supports server-side search and pagination on the default database-backed path via
+      `search`, `limit`, and `offset`. When `from_memory=true`, Bifrost returns the
+      in-memory config snapshot instead.
     tags:
       - Governance
+    parameters:
+      - name: search
+        in: query
+        description: Case-insensitive search on `model_name` for the database-backed list path
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Number of model configs to return. Defaults to 25 and is capped at 100.
+        schema:
+          type: integer
+          minimum: 0
+          default: 25
+      - name: offset
+        in: query
+        description: Number of model configs to skip before returning results
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+      - name: from_memory
+        in: query
+        description: If true, returns model configs from in-memory cache instead of database
+        schema:
+          type: boolean
+          default: false
     responses:
       '200':
         description: Successful response

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -71,18 +71,39 @@ clients:
   get:
     operationId: getMCPClients
     summary: List MCP clients
-    description: Returns a list of all configured MCP clients with their tools and connection state.
+    description: |
+      Returns MCP clients in a wrapped list response with their tools and connection state.
+
+      Supports server-side search and pagination via `search`, `limit`, and `offset`.
     tags:
       - MCP
+    parameters:
+      - name: search
+        in: query
+        description: Case-insensitive name search for MCP clients
+        schema:
+          type: string
+      - name: limit
+        in: query
+        description: Number of MCP clients to return. Defaults to 25 and is capped at 100.
+        schema:
+          type: integer
+          minimum: 0
+          default: 25
+      - name: offset
+        in: query
+        description: Number of MCP clients to skip before returning results
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
     responses:
       '200':
         description: Successful response
         content:
           application/json:
             schema:
-              type: array
-              items:
-                $ref: '../../schemas/management/mcp.yaml#/MCPClient'
+              $ref: '../../schemas/management/mcp.yaml#/ListMCPClientsResponse'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -413,6 +413,16 @@ ListTeamsResponse:
         $ref: '#/Team'
     count:
       type: integer
+      description: Number of teams returned in this response
+    total_count:
+      type: integer
+      description: Total number of teams matching the active filters
+    limit:
+      type: integer
+      description: Applied page size
+    offset:
+      type: integer
+      description: Applied page offset
 
 TeamResponse:
   type: object
@@ -482,6 +492,16 @@ ListCustomersResponse:
         $ref: '#/Customer'
     count:
       type: integer
+      description: Number of customers returned in this response
+    total_count:
+      type: integer
+      description: Total number of customers matching the active filters
+    limit:
+      type: integer
+      description: Applied page size
+    offset:
+      type: integer
+      description: Applied page offset
 
 ListBudgetsResponse:
   type: object
@@ -817,7 +837,16 @@ ListRoutingRulesResponse:
         $ref: '#/RoutingRule'
     count:
       type: integer
-      description: Number of routing rules returned
+      description: Number of routing rules returned in this response
+    total_count:
+      type: integer
+      description: Total number of routing rules matching the active filters
+    limit:
+      type: integer
+      description: Applied page size
+    offset:
+      type: integer
+      description: Applied page offset
 
 # Model Configs
 
@@ -868,7 +897,16 @@ ListModelConfigsResponse:
         $ref: '#/ModelConfig'
     count:
       type: integer
-      description: Number of model configs returned
+      description: Number of model configs returned in this response
+    total_count:
+      type: integer
+      description: Total number of model configs matching the active filters
+    limit:
+      type: integer
+      description: Applied page size
+    offset:
+      type: integer
+      description: Applied page offset
 
 CreateModelConfigRequest:
   type: object

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -394,6 +394,27 @@ MCPClient:
         $ref: '#/MCPVKConfigResponse'
       description: Virtual key assignments for this MCP client
 
+ListMCPClientsResponse:
+  type: object
+  description: Response containing MCP clients with pagination metadata
+  properties:
+    clients:
+      type: array
+      items:
+        $ref: '#/MCPClient'
+    count:
+      type: integer
+      description: Number of MCP clients returned in this response
+    total_count:
+      type: integer
+      description: Total number of MCP clients matching the active filters
+    limit:
+      type: integer
+      description: Applied page size
+    offset:
+      type: integer
+      description: Applied page offset
+
 ExecuteToolRequest:
   oneOf:
     - title: Chat (Default)

--- a/docs/providers/routing-rules.mdx
+++ b/docs/providers/routing-rules.mdx
@@ -224,6 +224,7 @@ Access routing rules from the dashboard:
 
 **Features:**
 - List all rules with scope, priority, and enabled status
+- Search rules by name with server-side pagination
 - Filter by scope or scope_id
 - Create/Edit/Delete rules
 - View rule expressions and targets
@@ -266,8 +267,12 @@ The dashboard includes a visual query builder for CEL expressions:
 GET /api/governance/routing-rules
 
 # Optional query parameters:
-?scope=global&scope_id=<id>&from_memory=true
+?search=premium&limit=25&offset=0
+?scope=team&scope_id=<id>
+?from_memory=true
 ```
+
+`search`, `limit`, and `offset` apply to the default database-backed list path. `scope`/`scope_id` and `from_memory=true` continue to return wrapped list responses, but they bypass the paginated search path.
 
 **Response:**
 ```json
@@ -292,7 +297,10 @@ GET /api/governance/routing-rules
       "updated_at": "2024-01-15T10:30:00Z"
     }
   ],
-  "count": 1
+  "count": 1,
+  "total_count": 4,
+  "limit": 25,
+  "offset": 0
 }
 ```
 
@@ -1004,6 +1012,16 @@ curl http://localhost:8080/api/governance/routing-rules \
   -G \
   --data-urlencode "scope=team" \
   --data-urlencode "scope_id=team-uuid-123"
+```
+
+#### Search Rules by Name
+```bash
+curl http://localhost:8080/api/governance/routing-rules \
+  -H "Authorization: Bearer your-token" \
+  -G \
+  --data-urlencode "search=premium" \
+  --data-urlencode "limit=25" \
+  --data-urlencode "offset=0"
 ```
 
 #### Get In-Memory Rules (Debug)

--- a/docs/quickstart/gateway/tool-calling.mdx
+++ b/docs/quickstart/gateway/tool-calling.mdx
@@ -98,7 +98,12 @@ curl --location 'http://localhost:8080/api/mcp/client' \
 **List configured MCP clients:**
 ```bash
 curl --location 'http://localhost:8080/api/mcp/clients'
+
+# Search configured clients by name
+curl --location 'http://localhost:8080/api/mcp/clients?search=filesystem&limit=25&offset=0'
 ```
+
+The list endpoint returns a wrapped response with `clients`, `count`, `total_count`, `limit`, and `offset`.
 </Tab>
 
 <Tab title="Using config.json">


### PR DESCRIPTION
## Summary

Updates the OSS documentation to reflect the search and pagination support added across the new CRUD list APIs. This keeps the narrative docs
and management API reference aligned with the shipped behavior for teams,
customers, routing rules, model configs, and MCP clients.

## Changes

- Updated governance docs to show server-side search and paginated list examples
  for Teams and Customers
- Updated Routing Rules docs to document `search`, `limit`, and `offset`
  behavior and the wrapped list response shape
- Updated MCP docs and quickstart examples to reflect MCP client catalog search
  support and the `{ clients, count, total_count, limit, offset }` response
  format
- Updated Model Limits documentation to mention OSS search support and include
  API examples
- Updated OpenAPI path and schema sources to document the new query parameters
  and pagination metadata

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

1. Review the updated docs pages and confirm they mention search + pagination
   for:
   - Teams
   - Customers
   - Routing Rules
   - Model Limits / model configs
   - MCP clients
2. Confirm the management API docs now show `search`, `limit`, and `offset` for:
   - `/api/governance/teams`
   - `/api/governance/customers`
   - `/api/governance/routing-rules`
   - `/api/governance/model-configs`
   - `/api/mcp/clients`
3. Verify the bundled OpenAPI JSON is valid:

```sh
ruby -rjson -e 'JSON.parse(File.read("docs/openapi/openapi.json")); puts "openapi.json ok"'
```

Expected outcome:

- The relevant docs pages describe search and pagination accurately
- `docs/openapi/openapi.json` parses successfully

Notes:

- Full Go/UI test suites were not run for this docs-only change
- No new configs or environment variables were added

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security impact. This change updates documentation and API reference content
only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable

