### PR TITLE
fix: update Bifrost Anthropic endpoint URL and improve MCP client JSON parsing

### DIFF
--- a/docs/cli-agents/opencode.mdx
+++ b/docs/cli-agents/opencode.mdx
@@ -50,7 +50,7 @@ Route Anthropic models through Bifrost's Anthropic endpoint:
     "anthropic": {
       "name": "Bifrost",
       "options": {
-        "baseURL": "http://localhost:8080/anthropic",
+        "baseURL": "http://localhost:8080/anthropic/v1",
         "apiKey": "your-bifrost-key"
       },
       "models": {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -145,7 +145,7 @@ async function ensureTestClient001AndSendResponses(baseUrl: string): Promise<voi
   }
   let clients: MCPClientItem[]
   try {
-    const parsed = JSON.parse(clientsRes.body)
+    const parsed = JSON.parse(clientsRes.body) as { clients?: MCPClientItem[] } | MCPClientItem[]
     clients = Array.isArray(parsed) ? parsed : (parsed.clients ?? [])
   } catch {
     throw new Error('Invalid JSON from GET /api/mcp/clients')
@@ -175,7 +175,8 @@ async function ensureTestClient001AndSendResponses(baseUrl: string): Promise<voi
   if (listResAfter.statusCode !== 200) {
     throw new Error(`GET /api/mcp/clients failed after create: ${listResAfter.statusCode} ${listResAfter.body}`)
   }
-  const listAfter = JSON.parse(listResAfter.body) as MCPClientItem[]
+  const parsedAfter = JSON.parse(listResAfter.body) as { clients?: MCPClientItem[] } | MCPClientItem[]
+  const listAfter = Array.isArray(parsedAfter) ? parsedAfter : (parsedAfter.clients ?? [])
   const clientAfter = listAfter.find((c) => c.config?.name === TEST_MCP_CLIENT_NAME)
   if (!clientAfter) {
     throw new Error(`MCP client "${TEST_MCP_CLIENT_NAME}" not found after create.`)
@@ -195,7 +196,8 @@ async function ensureTestClient001AndSendResponses(baseUrl: string): Promise<voi
   if (listRes2.statusCode !== 200) {
     throw new Error(`GET /api/mcp/clients failed after reconnect: ${listRes2.statusCode} ${listRes2.body}`)
   }
-  const list2 = (JSON.parse(listRes2.body) as MCPClientItem[]).filter((c) => c.config?.name === TEST_MCP_CLIENT_NAME)
+  const parsed2 = JSON.parse(listRes2.body) as { clients?: MCPClientItem[] } | MCPClientItem[]
+  const list2 = (Array.isArray(parsed2) ? parsed2 : (parsed2.clients ?? [])).filter((c) => c.config?.name === TEST_MCP_CLIENT_NAME)
   const client = list2[0]
   if (!client || client.state !== 'connected') {
     throw new Error(


### PR DESCRIPTION
## Summary

Updates the Bifrost Anthropic endpoint URL in documentation and fixes JSON response parsing in e2e tests to handle both array and object response formats.

## Changes

- Updated Bifrost Anthropic baseURL from `http://localhost:8080/anthropic` to `http://localhost:8080/anthropic/v1` in the OpenCode CLI agent documentation
- Enhanced JSON parsing in e2e tests to handle API responses that can be either an array of `MCPClientItem[]` or an object containing a `clients` property with the array

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation shows the correct Bifrost endpoint URL and that e2e tests handle both response formats correctly:

```sh
# Run e2e tests to verify JSON parsing works with both response formats
npm test -- tests/e2e/

# Verify documentation builds correctly
cd docs
npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a documentation update and test robustness improvement.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable