### PR TITLE
feat: add variables support to prompt sessions and versions with database migration

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -359,6 +359,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddRoutingChainMaxDepthColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddPromptVariablesColumns(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddModelCapabilityColumns(ctx, db); err != nil {
 		return err
 	}
@@ -5462,6 +5465,50 @@ func migrationAddOpenAIConfigJSONColumn(ctx context.Context, db *gorm.DB) error 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add_open_ai_config_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddPromptVariablesColumns adds variables_json column to prompt_sessions and prompt_versions
+func migrationAddPromptVariablesColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_prompt_variables_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+
+			if !migrator.HasColumn(&tables.TablePromptSession{}, "variables_json") {
+				if err := migrator.AddColumn(&tables.TablePromptSession{}, "VariablesJSON"); err != nil {
+					return fmt.Errorf("failed to add variables_json column to prompt_sessions: %w", err)
+				}
+			}
+
+			if !migrator.HasColumn(&tables.TablePromptVersion{}, "variables_json") {
+				if err := migrator.AddColumn(&tables.TablePromptVersion{}, "VariablesJSON"); err != nil {
+					return fmt.Errorf("failed to add variables_json column to prompt_versions: %w", err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&tables.TablePromptSession{}, "variables_json") {
+				if err := migrator.DropColumn(&tables.TablePromptSession{}, "variables_json"); err != nil {
+					return err
+				}
+			}
+			if migrator.HasColumn(&tables.TablePromptVersion{}, "variables_json") {
+				if err := migrator.DropColumn(&tables.TablePromptVersion{}, "variables_json"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add_prompt_variables_columns migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/promptSessions.go
+++ b/framework/configstore/tables/promptSessions.go
@@ -22,6 +22,8 @@ type TablePromptSession struct {
 	ModelParams     ModelParams         `gorm:"-" json:"model_params"`
 	Provider        string              `gorm:"type:varchar(100)" json:"provider"`
 	Model           string              `gorm:"type:varchar(100)" json:"model"`
+	VariablesJSON   *string             `gorm:"type:text;column:variables_json" json:"-"`
+	Variables       PromptVariables     `gorm:"-" json:"variables,omitempty"` // {key: value} map for Jinja2 variables
 	CreatedAt       time.Time           `gorm:"not null" json:"created_at"`
 	UpdatedAt       time.Time           `gorm:"not null" json:"updated_at"`
 
@@ -40,6 +42,17 @@ func (s *TablePromptSession) BeforeSave(tx *gorm.DB) error {
 	}
 	paramsStr := string(data)
 	s.ModelParamsJSON = &paramsStr
+
+	if s.Variables != nil {
+		varsData, err := json.Marshal(s.Variables)
+		if err != nil {
+			return err
+		}
+		varsStr := string(varsData)
+		s.VariablesJSON = &varsStr
+	} else {
+		s.VariablesJSON = nil
+	}
 	return nil
 }
 
@@ -51,6 +64,15 @@ func (s *TablePromptSession) AfterFind(tx *gorm.DB) error {
 		if err := dec.Decode(&s.ModelParams); err != nil {
 			return err
 		}
+	}
+	if s.VariablesJSON != nil && *s.VariablesJSON != "" {
+		var vars PromptVariables
+		if err := json.Unmarshal([]byte(*s.VariablesJSON), &vars); err != nil {
+			return err
+		}
+		s.Variables = vars
+	} else {
+		s.Variables = nil
 	}
 	return nil
 }

--- a/framework/configstore/tables/promptVersions.go
+++ b/framework/configstore/tables/promptVersions.go
@@ -12,17 +12,19 @@ import (
 // TablePromptVersion represents an immutable version of a prompt
 // Once created, a version cannot be modified - to make changes, create a new version
 type TablePromptVersion struct {
-	ID              uint         `gorm:"primaryKey;autoIncrement" json:"id"`
-	PromptID        string       `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_prompt_version" json:"prompt_id"`
-	Prompt          *TablePrompt `gorm:"foreignKey:PromptID" json:"prompt,omitempty"`
-	VersionNumber   int          `gorm:"not null;uniqueIndex:idx_prompt_version" json:"version_number"`
-	CommitMessage   string       `gorm:"type:text" json:"commit_message"`
-	ModelParamsJSON *string      `gorm:"type:text;column:model_params_json" json:"-"`
-	ModelParams     ModelParams  `gorm:"-" json:"model_params"`
-	Provider        string       `gorm:"type:varchar(100)" json:"provider"`
-	Model           string       `gorm:"type:varchar(100)" json:"model"`
-	IsLatest        bool         `gorm:"not null;default:false" json:"is_latest"`
-	CreatedAt       time.Time    `gorm:"not null" json:"created_at"`
+	ID               uint         `gorm:"primaryKey;autoIncrement" json:"id"`
+	PromptID         string       `gorm:"type:varchar(36);not null;index;uniqueIndex:idx_prompt_version" json:"prompt_id"`
+	Prompt           *TablePrompt `gorm:"foreignKey:PromptID" json:"prompt,omitempty"`
+	VersionNumber    int          `gorm:"not null;uniqueIndex:idx_prompt_version" json:"version_number"`
+	CommitMessage    string       `gorm:"type:text" json:"commit_message"`
+	ModelParamsJSON  *string      `gorm:"type:text;column:model_params_json" json:"-"`
+	ModelParams      ModelParams  `gorm:"-" json:"model_params"`
+	Provider         string       `gorm:"type:varchar(100)" json:"provider"`
+	Model            string       `gorm:"type:varchar(100)" json:"model"`
+	VariablesJSON    *string         `gorm:"type:text;column:variables_json" json:"-"`
+	Variables        PromptVariables `gorm:"-" json:"variables,omitempty"` // {key: value} map for Jinja2 variables
+	IsLatest         bool            `gorm:"not null;default:false" json:"is_latest"`
+	CreatedAt        time.Time    `gorm:"not null" json:"created_at"`
 	// No UpdatedAt - versions are immutable
 
 	// Relationships
@@ -36,6 +38,10 @@ func (TablePromptVersion) TableName() string { return "prompt_versions" }
 // so that any provider-specific params (response_format, seed, logprobs, etc.) are preserved.
 type ModelParams map[string]interface{}
 
+// PromptVariables represents a map of Jinja2 variable names to their values.
+// Sessions store full {key: value} pairs; versions store {key: ""} (keys only).
+type PromptVariables map[string]string
+
 // BeforeSave GORM hook to serialize JSON fields
 func (v *TablePromptVersion) BeforeSave(tx *gorm.DB) error {
 	if v.ModelParams != nil {
@@ -46,6 +52,14 @@ func (v *TablePromptVersion) BeforeSave(tx *gorm.DB) error {
 		paramsStr := string(data)
 		v.ModelParamsJSON = &paramsStr
 	}
+	if v.Variables != nil {
+		varsData, err := json.Marshal(v.Variables)
+		if err != nil {
+			return err
+		}
+		varsStr := string(varsData)
+		v.VariablesJSON = &varsStr
+	}
 	return nil
 }
 
@@ -55,6 +69,11 @@ func (v *TablePromptVersion) AfterFind(tx *gorm.DB) error {
 		dec := json.NewDecoder(strings.NewReader(*v.ModelParamsJSON))
 		dec.UseNumber()
 		if err := dec.Decode(&v.ModelParams); err != nil {
+			return err
+		}
+	}
+	if v.VariablesJSON != nil && *v.VariablesJSON != "" {
+		if err := json.Unmarshal([]byte(*v.VariablesJSON), &v.Variables); err != nil {
 			return err
 		}
 	}

--- a/transports/bifrost-http/handlers/prompts.go
+++ b/transports/bifrost-http/handlers/prompts.go
@@ -137,25 +137,28 @@ type CreateVersionRequest struct {
 	ModelParams   tables.ModelParams     `json:"model_params"`
 	Provider      string                 `json:"provider"`
 	Model         string                 `json:"model"`
+	Variables     tables.PromptVariables  `json:"variables,omitempty"`
 }
 
 // CreateSessionRequest represents the request body for creating a session
 type CreateSessionRequest struct {
-	Name        string                 `json:"name"`
-	VersionID   *uint                  `json:"version_id,omitempty"`
-	Messages    []tables.PromptMessage `json:"messages,omitempty"`
-	ModelParams tables.ModelParams     `json:"model_params"`
-	Provider    string                 `json:"provider"`
-	Model       string                 `json:"model"`
+	Name        string                  `json:"name"`
+	VersionID   *uint                   `json:"version_id,omitempty"`
+	Messages    []tables.PromptMessage  `json:"messages,omitempty"`
+	ModelParams tables.ModelParams      `json:"model_params"`
+	Provider    string                  `json:"provider"`
+	Model       string                  `json:"model"`
+	Variables   tables.PromptVariables  `json:"variables,omitempty"`
 }
 
 // UpdateSessionRequest represents the request body for updating a session
 type UpdateSessionRequest struct {
-	Name        string                 `json:"name"`
-	Messages    []tables.PromptMessage `json:"messages"`
-	ModelParams tables.ModelParams     `json:"model_params"`
-	Provider    string                 `json:"provider"`
-	Model       string                 `json:"model"`
+	Name        string                  `json:"name"`
+	Messages    []tables.PromptMessage  `json:"messages"`
+	ModelParams tables.ModelParams      `json:"model_params"`
+	Provider    string                  `json:"provider"`
+	Model       string                  `json:"model"`
+	Variables   tables.PromptVariables  `json:"variables,omitempty"`
 }
 
 // RenameSessionRequest represents the request body for renaming a session
@@ -631,12 +634,22 @@ func (h *PromptsHandler) createVersion(ctx *fasthttp.RequestCtx) {
 		})
 	}
 
+	// Strip variable values — versions store keys only; values live in sessions
+	var versionVars tables.PromptVariables
+	if len(req.Variables) > 0 {
+		versionVars = make(tables.PromptVariables, len(req.Variables))
+		for key := range req.Variables {
+			versionVars[key] = ""
+		}
+	}
+
 	version := &tables.TablePromptVersion{
 		PromptID:      promptID,
 		CommitMessage: req.CommitMessage,
 		ModelParams:   req.ModelParams,
 		Provider:      req.Provider,
 		Model:         req.Model,
+		Variables:     versionVars,
 		Messages:      messages,
 	}
 
@@ -835,6 +848,7 @@ func (h *PromptsHandler) createSession(ctx *fasthttp.RequestCtx) {
 		ModelParams: req.ModelParams,
 		Provider:    req.Provider,
 		Model:       req.Model,
+		Variables:   req.Variables,
 		Messages:    messages,
 	}
 
@@ -890,6 +904,7 @@ func (h *PromptsHandler) updateSession(ctx *fasthttp.RequestCtx) {
 	session.ModelParams = req.ModelParams
 	session.Provider = req.Provider
 	session.Model = req.Model
+	session.Variables = req.Variables
 
 	// Update messages
 	var messages []tables.TablePromptSessionMessage
@@ -1066,12 +1081,22 @@ func (h *PromptsHandler) commitSession(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// Copy variable keys from session with empty values for the version
+	var versionVars tables.PromptVariables
+	if len(session.Variables) > 0 {
+		versionVars = make(tables.PromptVariables, len(session.Variables))
+		for key := range session.Variables {
+			versionVars[key] = ""
+		}
+	}
+
 	version := &tables.TablePromptVersion{
 		PromptID:      session.PromptID,
 		CommitMessage: req.CommitMessage,
 		ModelParams:   session.ModelParams,
 		Provider:      session.Provider,
 		Model:         session.Model,
+		Variables:     versionVars,
 		Messages:      messages,
 	}
 

--- a/ui/components/prompts/components/promptsViewHeader.tsx
+++ b/ui/components/prompts/components/promptsViewHeader.tsx
@@ -26,6 +26,7 @@ export default function PromptsViewHeader() {
 		modelParams,
 		provider,
 		model,
+		variables,
 		hasChanges,
 		hasVersionChanges,
 		hasSessionChanges,
@@ -87,6 +88,7 @@ export default function PromptsViewHeader() {
 					model_params: buildSaveParams(),
 					provider,
 					model,
+					variables: Object.keys(variables).length > 0 ? variables : undefined,
 				},
 			}).unwrap();
 			setUrlState({ sessionId: result.session.id, versionId: null });
@@ -94,7 +96,7 @@ export default function PromptsViewHeader() {
 		} catch (err) {
 			toast.error("Failed to save session", { description: getErrorMessage(err) });
 		}
-	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, createSession, setUrlState, hasChanges, isStreaming]);
+	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, variables, createSession, setUrlState, hasChanges, isStreaming]);
 
 	// Cmd+S / Ctrl+S to save session
 	useHotkeys(
@@ -126,6 +128,7 @@ export default function PromptsViewHeader() {
 					model_params: buildSaveParams(),
 					provider,
 					model,
+					variables: Object.keys(variables).length > 0 ? variables : undefined,
 				},
 			}).unwrap();
 			setUrlState({ sessionId: result.session.id, versionId: null });
@@ -133,7 +136,7 @@ export default function PromptsViewHeader() {
 		} catch (err) {
 			toast.error("Failed to save session", { description: getErrorMessage(err) });
 		}
-	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, createSession, setUrlState, onSessionSaved, hasChanges]);
+	}, [selectedPrompt?.id, messages, buildSaveParams, provider, model, variables, createSession, setUrlState, onSessionSaved, hasChanges]);
 
 	const handleRenameSession = useCallback(
 		async (sessionId: number, name: string) => {

--- a/ui/components/prompts/components/variablesTableView.tsx
+++ b/ui/components/prompts/components/variablesTableView.tsx
@@ -10,7 +10,7 @@ export function VariablesTableView({
 	variables: VariableMap;
 	onChange: React.Dispatch<React.SetStateAction<VariableMap>>;
 }) {
-	const entries = useMemo(() => Object.entries(variables), [variables]);
+	const entries = useMemo(() => Object.entries(variables).sort(([a], [b]) => a.localeCompare(b)), [variables]);
 
 	const handleValueChange = useCallback(
 		(name: string, value: string) => {
@@ -25,7 +25,7 @@ export function VariablesTableView({
 			<p className="text-muted-foreground text-xs">
 				Detected from <code className="bg-muted rounded px-1">{"{{ }}"}</code> syntax in messages. Values are substituted at runtime.
 			</p>
-			<div className="border-border overflow-hidden rounded-md border">
+			<div className="border-border overflow-hidden rounded-sm border">
 				<table className="w-full table-fixed text-sm">
 					<thead>
 						<tr className="bg-muted/50 border-border border-b">

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -220,6 +220,10 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(selectedSession.model_params, selectedSession.provider, selectedSession.model);
+			// Restore variables (key:value) from session
+			if (selectedSession.variables && Object.keys(selectedSession.variables).length > 0) {
+				setVariables(selectedSession.variables);
+			}
 		} else if (selectedVersion) {
 			// If sessions are still loading and no session is explicitly selected,
 			// wait — a session may auto-select and take priority
@@ -228,6 +232,10 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(selectedVersion.model_params, selectedVersion.provider, selectedVersion.model);
+			// Initialize variables from version (keys with empty values)
+			if (selectedVersion.variables && Object.keys(selectedVersion.variables).length > 0) {
+				setVariables((prev) => mergeVariables(prev, Object.keys(selectedVersion.variables!)));
+			}
 		} else if (selectedPrompt?.latest_version) {
 			// Only fall back to latest_version after sessions have settled
 			// to avoid racing with the session auto-select effect
@@ -237,6 +245,10 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			const loaded = Message.fromLegacyAll(raw);
 			loadMessages(loaded.length > 0 ? loaded : [Message.system("")]);
 			loadFromParams(version.model_params, version.provider, version.model);
+			// Initialize variables from version (keys with empty values)
+			if (version.variables && Object.keys(version.variables).length > 0) {
+				setVariables((prev) => mergeVariables(prev, Object.keys(version.variables!)));
+			}
 			if (sessions.length === 0) {
 				setUrlState({ versionId: version.id });
 			}

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -168,12 +168,12 @@ export function SettingsPanel() {
 						/>
 					)}
 
-					{/* {Object.keys(variables).length > 0 && (
+					{Object.keys(variables).length > 0 && (
 						<>
 							<Separator />
 							<VariablesTableView variables={variables} onChange={setVariables} />
 						</>
-					)} */}
+					)}
 
 					{model && (
 						<>

--- a/ui/lib/message/constant.ts
+++ b/ui/lib/message/constant.ts
@@ -19,7 +19,7 @@ export const JINJA_VAR_REGEX = /\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*\}\}/g;
  */
 export const JINJA_VAR_HIGHLIGHT_PATTERNS = [
 	{
-		pattern: /{{.*?}}/g,
+		pattern: /\{\{\s*[a-zA-Z_][a-zA-Z0-9_.]*\s*\}\}/g,
 		className: "outline-content-brand-light text-sm cursor-pointer bg-green-500/20",
 		validate: (part: string) => {
 			return (

--- a/ui/lib/message/variables.test.ts
+++ b/ui/lib/message/variables.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { Message } from "./message";
 import {
-	extractVariablesFromText,
 	extractVariablesFromMessages,
-	replaceVariablesInText,
-	replaceVariablesInMessages,
+	extractVariablesFromText,
 	mergeVariables,
+	replaceVariablesInMessages,
+	replaceVariablesInText,
 } from "./variables";
 
 // =============================================================================
@@ -122,7 +122,7 @@ describe("extractVariablesFromMessages", () => {
 
 	it("extracts variables from an assistant message", () => {
 		const messages = [Message.response("Hello {{ name }}")];
-		expect(extractVariablesFromMessages(messages)).toEqual(["name"]);
+		expect(extractVariablesFromMessages(messages)).toEqual([]);
 	});
 
 	it("extracts variables across multiple messages", () => {
@@ -178,6 +178,14 @@ describe("replaceVariablesInText", () => {
 
 	it("replaces all occurrences of the same variable", () => {
 		expect(replaceVariablesInText("{{ x }} and {{ x }}", { x: "yes" })).toBe("yes and yes");
+	});
+
+	it("preserves leading curly braces that are not part of variables", () => {
+		expect(replaceVariablesInText("{{{ x }} and {{ x }}", { x: "yes" })).toBe("{yes and yes");
+	});
+
+	it("preserves trailing curly braces that are not part of variables", () => {
+		expect(replaceVariablesInText("{{ x }} and {{ x }}}}", { x: "yes" })).toBe("yes and yes}}");
 	});
 
 	it("leaves variable untouched when not in map", () => {

--- a/ui/lib/types/prompts.ts
+++ b/ui/lib/types/prompts.ts
@@ -43,18 +43,19 @@ export interface ModelParams {
 }
 
 export interface PromptVersion {
-	id: number;
-	prompt_id: string;
-	version_number: number;
-	commit_message: string;
-	messages: PromptVersionMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
-	is_latest: boolean;
-	created_by_id?: number;
-	created_by?: PromptUser;
-	created_at: string; // No updated_at - versions are immutable
+  id: number
+  prompt_id: string
+  version_number: number
+  commit_message: string
+  messages: PromptVersionMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
+  is_latest: boolean
+  created_by_id?: number
+  created_by?: PromptUser
+  created_at: string // No updated_at - versions are immutable
 }
 
 export interface PromptVersionMessage {
@@ -66,20 +67,21 @@ export interface PromptVersionMessage {
 }
 
 export interface PromptSession {
-	id: number;
-	prompt_id: string;
-	prompt?: Prompt;
-	version_id?: number;
-	version?: PromptVersion;
-	name: string;
-	messages: PromptSessionMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
-	created_by_id?: number;
-	created_by?: PromptUser;
-	created_at: string;
-	updated_at: string;
+  id: number
+  prompt_id: string
+  prompt?: Prompt
+  version_id?: number
+  version?: PromptVersion
+  name: string
+  messages: PromptSessionMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
+  created_by_id?: number
+  created_by?: PromptUser
+  created_at: string
+  updated_at: string
 }
 
 export interface PromptSessionMessage {
@@ -205,12 +207,13 @@ export interface GetSessionResponse {
 }
 
 export interface CreateSessionRequest {
-	name?: string;
-	version_id?: number;
-	messages?: PromptMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
+  name?: string
+  version_id?: number
+  messages?: PromptMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
 }
 
 export interface CreateSessionResponse {
@@ -218,11 +221,12 @@ export interface CreateSessionResponse {
 }
 
 export interface UpdateSessionRequest {
-	name?: string;
-	messages: PromptMessage[];
-	model_params: ModelParams;
-	provider: string;
-	model: string;
+  name?: string
+  messages: PromptMessage[]
+  model_params: ModelParams
+  provider: string
+  model: string
+  variables?: Record<string, string>
 }
 
 export interface UpdateSessionResponse {


### PR DESCRIPTION
## Summary

Adds support for Jinja2 template variables in prompt sessions and versions. This enables users to define reusable prompts with placeholders like `{{ name }}` and `{{ topic }}` that can be dynamically replaced with values.

## Changes

- Added `variables_json` database columns to `prompt_sessions` and `prompt_versions` tables with migration
- Created `PromptVariables` type as a map of variable names to values
- Added JSON serialization/deserialization hooks for the new variables fields
- Updated HTTP handlers to accept and process variables in create/update requests
- Modified session commit logic to store variable keys (with empty values) in versions while preserving full key-value pairs in sessions
- Enhanced frontend variable extraction to skip assistant/response messages (variables only processed for system and user messages)
- Improved variable replacement logic to handle edge cases with extra curly braces

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)

## How to test

Test the database migration and variable functionality:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Create a prompt session with variables like `{{ name }}` in message content, verify they can be set and replaced correctly. Test that committing a session preserves variable structure in the created version.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Variables are stored as JSON text in the database and processed server-side. No direct template execution occurs - only simple string replacement, reducing security risks from template injection.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable