### PR TITLE
fix: suppress MCP configuration error toast in registry page

### DIFF
--- a/ui/app/workspace/mcp-registry/page.tsx
+++ b/ui/app/workspace/mcp-registry/page.tsx
@@ -44,9 +44,11 @@ export default function MCPServersPage() {
 
 	useEffect(() => {
 		if (error) {
+			const message = getErrorMessage(error);
+			if (message.toLowerCase().includes("mcp is not configured in this bifrost instance")) return;
 			toast({
 				title: "Error",
-				description: getErrorMessage(error),
+				description: message,
 				variant: "destructive",
 			});
 		}


### PR DESCRIPTION
## Summary

Prevents error toast notifications from appearing when MCP is not configured in the Bifrost instance, improving user experience by suppressing expected configuration messages.

## Changes

- Added conditional check to suppress toast notifications when the error message indicates MCP is not configured
- Extracted error message to a variable to avoid duplicate `getErrorMessage()` calls
- Used case-insensitive string matching to detect the specific "mcp is not configured" error condition

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test with a Bifrost instance that doesn't have MCP configured to verify no error toast appears on the MCP registry page.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects UI error message display logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable