### PR TITLE
feat: migrate frontend to dedicated provider keys API

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -7,7 +7,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { PricingFieldSelector } from "./pricingFieldSelector";
 import {
@@ -17,6 +16,7 @@ import {
 	useGetVirtualKeysQuery,
 	useUpdatePricingOverrideMutation,
 } from "@/lib/store";
+import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel, RequestTypeLabels } from "@/lib/constants/logs";
 import { ModelProvider, RequestType } from "@/lib/types/config";
@@ -67,22 +67,62 @@ export function getRequestTypeGroup(rt: string): string | undefined {
 
 export const PRICING_FIELDS = [
 	// Chat / Text / Responses fields
-	{ key: "input_cost_per_token", label: "Input / token", group: "chat", requestTypeGroups: ["chat", "embedding", "rerank", "audio", "image", "video"] },
-	{ key: "output_cost_per_token", label: "Output / token", group: "chat", requestTypeGroups: ["chat", "rerank", "audio", "image", "video"] },
+	{
+		key: "input_cost_per_token",
+		label: "Input / token",
+		group: "chat",
+		requestTypeGroups: ["chat", "embedding", "rerank", "audio", "image", "video"],
+	},
+	{
+		key: "output_cost_per_token",
+		label: "Output / token",
+		group: "chat",
+		requestTypeGroups: ["chat", "rerank", "audio", "image", "video"],
+	},
 	{ key: "input_cost_per_token_batches", label: "Input / token (batch)", group: "chat", requestTypeGroups: ["chat"] },
 	{ key: "output_cost_per_token_batches", label: "Output / token (batch)", group: "chat", requestTypeGroups: ["chat"] },
 	{ key: "input_cost_per_token_priority", label: "Input / token (priority)", group: "chat", requestTypeGroups: ["chat"] },
 	{ key: "output_cost_per_token_priority", label: "Output / token (priority)", group: "chat", requestTypeGroups: ["chat"] },
-	{ key: "input_cost_per_token_above_128k_tokens", label: "Input / token (>128k)", group: "chat", requestTypeGroups: ["chat", "embedding", "rerank"] },
-	{ key: "output_cost_per_token_above_128k_tokens", label: "Output / token (>128k)", group: "chat", requestTypeGroups: ["chat", "rerank", "audio"] },
-	{ key: "input_cost_per_token_above_200k_tokens", label: "Input / token (>200k)", group: "chat", requestTypeGroups: ["chat", "embedding", "rerank"] },
-	{ key: "output_cost_per_token_above_200k_tokens", label: "Output / token (>200k)", group: "chat", requestTypeGroups: ["chat", "rerank", "audio"] },
+	{
+		key: "input_cost_per_token_above_128k_tokens",
+		label: "Input / token (>128k)",
+		group: "chat",
+		requestTypeGroups: ["chat", "embedding", "rerank"],
+	},
+	{
+		key: "output_cost_per_token_above_128k_tokens",
+		label: "Output / token (>128k)",
+		group: "chat",
+		requestTypeGroups: ["chat", "rerank", "audio"],
+	},
+	{
+		key: "input_cost_per_token_above_200k_tokens",
+		label: "Input / token (>200k)",
+		group: "chat",
+		requestTypeGroups: ["chat", "embedding", "rerank"],
+	},
+	{
+		key: "output_cost_per_token_above_200k_tokens",
+		label: "Output / token (>200k)",
+		group: "chat",
+		requestTypeGroups: ["chat", "rerank", "audio"],
+	},
 	{ key: "cache_creation_input_token_cost", label: "Cache creation / token", group: "chat", requestTypeGroups: ["chat"] },
 	{ key: "cache_read_input_token_cost", label: "Cache read / token", group: "chat", requestTypeGroups: ["chat"] },
-	{ key: "cache_creation_input_token_cost_above_200k_tokens", label: "Cache creation / token (>200k)", group: "chat", requestTypeGroups: ["chat"] },
+	{
+		key: "cache_creation_input_token_cost_above_200k_tokens",
+		label: "Cache creation / token (>200k)",
+		group: "chat",
+		requestTypeGroups: ["chat"],
+	},
 	{ key: "cache_read_input_token_cost_above_200k_tokens", label: "Cache read / token (>200k)", group: "chat", requestTypeGroups: ["chat"] },
 	{ key: "cache_creation_input_token_cost_above_1hr", label: "Cache creation / token (>1hr)", group: "chat", requestTypeGroups: ["chat"] },
-	{ key: "cache_creation_input_token_cost_above_1hr_above_200k_tokens", label: "Cache creation / token (>1hr, >200k)", group: "chat", requestTypeGroups: ["chat"] },
+	{
+		key: "cache_creation_input_token_cost_above_1hr_above_200k_tokens",
+		label: "Cache creation / token (>1hr, >200k)",
+		group: "chat",
+		requestTypeGroups: ["chat"],
+	},
 	{ key: "cache_read_input_token_cost_priority", label: "Cache read / token (priority)", group: "chat", requestTypeGroups: ["chat"] },
 	{ key: "search_context_cost_per_query", label: "Search context / query", group: "chat", requestTypeGroups: ["chat", "rerank"] },
 	{ key: "code_interpreter_cost_per_session", label: "Code interpreter / session", group: "chat", requestTypeGroups: ["chat"] },
@@ -90,7 +130,12 @@ export const PRICING_FIELDS = [
 	{ key: "input_cost_per_character", label: "Input / character", group: "audio", requestTypeGroups: ["audio"] },
 	{ key: "input_cost_per_audio_token", label: "Input / audio token", group: "audio", requestTypeGroups: ["audio"] },
 	{ key: "input_cost_per_audio_per_second", label: "Input / audio second", group: "audio", requestTypeGroups: ["audio"] },
-	{ key: "input_cost_per_audio_per_second_above_128k_tokens", label: "Input / audio second (>128k)", group: "audio", requestTypeGroups: ["audio"] },
+	{
+		key: "input_cost_per_audio_per_second_above_128k_tokens",
+		label: "Input / audio second (>128k)",
+		group: "audio",
+		requestTypeGroups: ["audio"],
+	},
 	{ key: "input_cost_per_second", label: "Input / second", group: "audio", requestTypeGroups: ["audio", "video"] },
 	{ key: "output_cost_per_audio_token", label: "Output / audio token", group: "audio", requestTypeGroups: ["audio"] },
 	{ key: "output_cost_per_second", label: "Output / second", group: "audio", requestTypeGroups: ["audio", "video"] },
@@ -105,9 +150,24 @@ export const PRICING_FIELDS = [
 	{ key: "output_cost_per_pixel", label: "Output / pixel", group: "image", requestTypeGroups: ["image"] },
 	{ key: "output_cost_per_image_premium_image", label: "Output / image (premium)", group: "image", requestTypeGroups: ["image"] },
 	{ key: "output_cost_per_image_above_512_and_512_pixels", label: "Output / image (>512px)", group: "image", requestTypeGroups: ["image"] },
-	{ key: "output_cost_per_image_above_512_and_512_pixels_and_premium_image", label: "Output / image (>512px, premium)", group: "image", requestTypeGroups: ["image"] },
-	{ key: "output_cost_per_image_above_1024_and_1024_pixels", label: "Output / image (>1024px)", group: "image", requestTypeGroups: ["image"] },
-	{ key: "output_cost_per_image_above_1024_and_1024_pixels_and_premium_image", label: "Output / image (>1024px, premium)", group: "image", requestTypeGroups: ["image"] },
+	{
+		key: "output_cost_per_image_above_512_and_512_pixels_and_premium_image",
+		label: "Output / image (>512px, premium)",
+		group: "image",
+		requestTypeGroups: ["image"],
+	},
+	{
+		key: "output_cost_per_image_above_1024_and_1024_pixels",
+		label: "Output / image (>1024px)",
+		group: "image",
+		requestTypeGroups: ["image"],
+	},
+	{
+		key: "output_cost_per_image_above_1024_and_1024_pixels_and_premium_image",
+		label: "Output / image (>1024px, premium)",
+		group: "image",
+		requestTypeGroups: ["image"],
+	},
 	{ key: "output_cost_per_image_low_quality", label: "Output / image (low quality)", group: "image", requestTypeGroups: ["image"] },
 	{ key: "output_cost_per_image_medium_quality", label: "Output / image (medium quality)", group: "image", requestTypeGroups: ["image"] },
 	{ key: "output_cost_per_image_high_quality", label: "Output / image (high quality)", group: "image", requestTypeGroups: ["image"] },
@@ -115,7 +175,12 @@ export const PRICING_FIELDS = [
 	{ key: "cache_read_input_image_token_cost", label: "Cache read / image token", group: "image", requestTypeGroups: ["image"] },
 	// Video fields
 	{ key: "input_cost_per_video_per_second", label: "Input / video second", group: "video", requestTypeGroups: ["video"] },
-	{ key: "input_cost_per_video_per_second_above_128k_tokens", label: "Input / video second (>128k)", group: "video", requestTypeGroups: ["video"] },
+	{
+		key: "input_cost_per_video_per_second_above_128k_tokens",
+		label: "Input / video second (>128k)",
+		group: "video",
+		requestTypeGroups: ["video"],
+	},
 	{ key: "output_cost_per_video_per_second", label: "Output / video second", group: "video", requestTypeGroups: ["video"] },
 ] as const;
 
@@ -301,7 +366,6 @@ export function renderFields(
 	);
 }
 
-
 interface PricingOverrideDrawerProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -339,6 +403,7 @@ function isCompleteScopeLock(scopeLock?: PricingOverrideDrawerProps["scopeLock"]
 export default function PricingOverrideSheet({ open, onOpenChange, editingOverride, scopeLock, onSaved }: PricingOverrideDrawerProps) {
 	const { data: providersData, isLoading: isProvidersLoading, error: providersError } = useGetProvidersQuery();
 	const { data: virtualKeysData, isLoading: isVirtualKeysLoading, error: virtualKeysError } = useGetVirtualKeysQuery();
+	const { data: allKeysData = [] } = useGetAllKeysQuery();
 	const [createOverride, { isLoading: isCreating }] = useCreatePricingOverrideMutation();
 	const [updateOverride, { isLoading: isPatching }] = useUpdatePricingOverrideMutation();
 
@@ -356,14 +421,12 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 
 	const providerKeyOptions = useMemo(
 		() =>
-			providers.flatMap((provider) =>
-				(provider.keys || []).map((key) => ({
-					id: key.id,
-					providerName: provider.name,
-					label: key.name || key.id,
-				})),
-			),
-		[providers],
+			allKeysData.map((key) => ({
+				id: key.key_id,
+				providerName: key.provider,
+				label: key.name || key.key_id,
+			})),
+		[allKeysData],
 	);
 	const providerScopedKeyOptions = useMemo(
 		() => providerKeyOptions.filter((key) => key.providerName === form.providerID),
@@ -399,8 +462,8 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 				providerKeyID: scopeLock.providerKeyID ?? "",
 				scopeRoot:
 					scopeLock.scopeKind === "virtual_key" ||
-						scopeLock.scopeKind === "virtual_key_provider" ||
-						scopeLock.scopeKind === "virtual_key_provider_key"
+					scopeLock.scopeKind === "virtual_key_provider" ||
+					scopeLock.scopeKind === "virtual_key_provider_key"
 						? "virtual_key"
 						: "global",
 			};
@@ -501,13 +564,12 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		jsonEditingRef.current = false;
 	}, []);
 
-
 	const handleCloseDrawer = () => {
 		onOpenChange(false);
 		setRequestTypePopoverOpen(false);
 	};
 
-	const toggleRequestType = (requestType: string) => {
+	const toggleRequestType = (requestType: RequestType) => {
 		setForm((prev) => ({
 			...prev,
 			requestTypes: prev.requestTypes.includes(requestType)
@@ -625,7 +687,6 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		}
 	};
 
-
 	return (
 		<Sheet open={open} onOpenChange={(o) => (o ? onOpenChange(true) : handleCloseDrawer())}>
 			<SheetContent side="right" className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-4 pb-6 sm:max-w-2xl">
@@ -636,14 +697,27 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 				<div className="custom-scrollbar flex-1 space-y-6 overflow-y-auto px-3 pb-4">
 					<div className="space-y-4">
 						<div className="space-y-2">
-							<Label htmlFor="pricing-override-name-input">Name <span className="text-red-500">*</span></Label>
-							<Input id="pricing-override-name-input" data-testid="pricing-override-name-input" placeholder="e.g., GPT-4 Negotiated Rate" value={form.name} onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))} />
+							<Label htmlFor="pricing-override-name-input">
+								Name <span className="text-red-500">*</span>
+							</Label>
+							<Input
+								id="pricing-override-name-input"
+								data-testid="pricing-override-name-input"
+								placeholder="e.g., GPT-4 Negotiated Rate"
+								value={form.name}
+								onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+							/>
 						</div>
 
 						{shouldLockScope && scopeLock ? (
 							<div className="space-y-2">
 								<Label htmlFor="pricing-override-scope-lock-input">Scope</Label>
-								<Input id="pricing-override-scope-lock-input" data-testid="pricing-override-scope-lock-input" value={scopeLock.label ?? scopeLock.scopeKind} readOnly />
+								<Input
+									id="pricing-override-scope-lock-input"
+									data-testid="pricing-override-scope-lock-input"
+									value={scopeLock.label ?? scopeLock.scopeKind}
+									readOnly
+								/>
 							</div>
 						) : (
 							<>
@@ -651,11 +725,13 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 									<Label htmlFor="pricing-override-scope-root-select">Scope root</Label>
 									<Select
 										value={form.scopeRoot}
-										onValueChange={(value: ScopeRoot) =>
-											setForm((prev) => ({ ...prev, scopeRoot: value, virtualKeyID: "" }))
-										}
+										onValueChange={(value: ScopeRoot) => setForm((prev) => ({ ...prev, scopeRoot: value, virtualKeyID: "" }))}
 									>
-										<SelectTrigger id="pricing-override-scope-root-select" data-testid="pricing-override-scope-root-select" className="w-full">
+										<SelectTrigger
+											id="pricing-override-scope-root-select"
+											data-testid="pricing-override-scope-root-select"
+											className="w-full"
+										>
 											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
@@ -667,14 +743,21 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 
 								{form.scopeRoot === "virtual_key" && (
 									<div className="space-y-2">
-										<Label htmlFor="pricing-override-virtual-key-select">Virtual key <span className="text-red-500">*</span></Label>
+										<Label htmlFor="pricing-override-virtual-key-select">
+											Virtual key <span className="text-red-500">*</span>
+										</Label>
 										<Select
 											value={form.virtualKeyID || "__none__"}
 											onValueChange={(value) =>
 												setForm((prev) => ({ ...prev, virtualKeyID: value === "__none__" ? "" : value, providerID: "", providerKeyID: "" }))
 											}
 										>
-											<SelectTrigger id="pricing-override-virtual-key-select" data-testid="pricing-override-virtual-key-select" className="w-full" disabled={isVirtualKeysLoading || !!virtualKeysError}>
+											<SelectTrigger
+												id="pricing-override-virtual-key-select"
+												data-testid="pricing-override-virtual-key-select"
+												className="w-full"
+												disabled={isVirtualKeysLoading || !!virtualKeysError}
+											>
 												<SelectValue placeholder={isVirtualKeysLoading ? "Loading..." : "Select virtual key"} />
 											</SelectTrigger>
 											<SelectContent>
@@ -686,7 +769,9 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 												))}
 											</SelectContent>
 										</Select>
-										{virtualKeysError && <p className="text-destructive text-xs mt-1">Failed to load virtual keys: {getErrorMessage(virtualKeysError)}</p>}
+										{virtualKeysError ? (
+											<p className="text-destructive mt-1 text-xs">Failed to load virtual keys: {getErrorMessage(virtualKeysError)}</p>
+										) : null}
 									</div>
 								)}
 
@@ -699,7 +784,12 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 												setForm((prev) => ({ ...prev, providerID: value === "__none__" ? "" : value, providerKeyID: "" }))
 											}
 										>
-											<SelectTrigger id="pricing-override-provider-select" data-testid="pricing-override-provider-select" className="w-full" disabled={isProvidersLoading || !!providersError}>
+											<SelectTrigger
+												id="pricing-override-provider-select"
+												data-testid="pricing-override-provider-select"
+												className="w-full"
+												disabled={isProvidersLoading || !!providersError}
+											>
 												{isProvidersLoading ? (
 													<span className="text-muted-foreground">Loading...</span>
 												) : form.providerID ? (
@@ -723,7 +813,9 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 												))}
 											</SelectContent>
 										</Select>
-										{providersError && <p className="text-destructive text-xs mt-1">Failed to load providers: {getErrorMessage(providersError)}</p>}
+										{providersError ? (
+											<p className="text-destructive mt-1 text-xs">Failed to load providers: {getErrorMessage(providersError)}</p>
+										) : null}
 									</div>
 
 									{form.providerID ? (
@@ -733,7 +825,11 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 												value={form.providerKeyID || "__none__"}
 												onValueChange={(value) => setForm((prev) => ({ ...prev, providerKeyID: value === "__none__" ? "" : value }))}
 											>
-												<SelectTrigger id="pricing-override-provider-key-select" data-testid="pricing-override-provider-key-select" className="w-full">
+												<SelectTrigger
+													id="pricing-override-provider-key-select"
+													data-testid="pricing-override-provider-key-select"
+													className="w-full"
+												>
 													<SelectValue placeholder="All provider keys" />
 												</SelectTrigger>
 												<SelectContent>
@@ -750,7 +846,6 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 										<div />
 									)}
 								</div>
-
 							</>
 						)}
 					</div>
@@ -763,7 +858,11 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 									value={form.matchType}
 									onValueChange={(value: PricingOverrideMatchType) => setForm((prev) => ({ ...prev, matchType: value }))}
 								>
-									<SelectTrigger id="pricing-override-match-type-select" data-testid="pricing-override-match-type-select" className="w-full">
+									<SelectTrigger
+										id="pricing-override-match-type-select"
+										data-testid="pricing-override-match-type-select"
+										className="w-full"
+									>
 										<SelectValue placeholder="Select match type" />
 									</SelectTrigger>
 									<SelectContent>
@@ -773,8 +872,12 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 								</Select>
 							</div>
 							<div className="space-y-2">
-								<Label htmlFor="pricing-override-pattern-input">Pattern <span className="text-red-500">*</span></Label>
-								<Input id="pricing-override-pattern-input" data-testid="pricing-override-pattern-input"
+								<Label htmlFor="pricing-override-pattern-input">
+									Pattern <span className="text-red-500">*</span>
+								</Label>
+								<Input
+									id="pricing-override-pattern-input"
+									data-testid="pricing-override-pattern-input"
 									value={form.pattern}
 									onChange={(e) => setForm((prev) => ({ ...prev, pattern: e.target.value }))}
 									placeholder={form.matchType === "exact" ? "e.g., gpt-4o" : "e.g., gpt-4*"}
@@ -784,14 +887,24 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 					</div>
 
 					<div className="space-y-2">
-						<Label htmlFor="pricing-override-request-types-btn">Request types <span className="text-red-500">*</span></Label>
+						<Label htmlFor="pricing-override-request-types-btn">
+							Request types <span className="text-red-500">*</span>
+						</Label>
 						<Popover open={requestTypePopoverOpen} onOpenChange={setRequestTypePopoverOpen} modal={false}>
 							<PopoverTrigger asChild>
-								<Button id="pricing-override-request-types-btn" data-testid="pricing-override-request-types-btn" type="button" variant="outline" className="h-10 w-full justify-between">
+								<Button
+									id="pricing-override-request-types-btn"
+									data-testid="pricing-override-request-types-btn"
+									type="button"
+									variant="outline"
+									className="h-10 w-full justify-between"
+								>
 									<span className="truncate text-left">
-										{form.requestTypes.length > 0
-											? form.requestTypes.map((rt) => RequestTypeLabels[rt as keyof typeof RequestTypeLabels] ?? rt).join(", ")
-											: <span className="text-muted-foreground">Select request types...</span>}
+										{form.requestTypes.length > 0 ? (
+											form.requestTypes.map((rt) => RequestTypeLabels[rt as keyof typeof RequestTypeLabels] ?? rt).join(", ")
+										) : (
+											<span className="text-muted-foreground">Select request types...</span>
+										)}
 									</span>
 									<ChevronDown className="h-4 w-4 shrink-0" />
 								</Button>
@@ -836,7 +949,10 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 					</div>
 
 					<div className="space-y-2">
-						<Label>Pricing fields <span className="text-red-500">*</span> <span className="text-muted-foreground font-normal text-xs">(USD per unit)</span></Label>
+						<Label>
+							Pricing fields <span className="text-red-500">*</span>{" "}
+							<span className="text-muted-foreground text-xs font-normal">(USD per unit)</span>
+						</Label>
 						<PricingFieldSelector
 							key={open ? (editingOverride?.id ?? "new") : "closed"}
 							values={form.pricingValues}

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -20,6 +20,7 @@ import {
 	useGetProvidersQuery,
 	useGetVirtualKeysQuery,
 } from "@/lib/store";
+import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { PricingOverride, PricingOverrideScopeKind } from "@/lib/types/governance";
@@ -150,6 +151,7 @@ export default function ScopedPricingOverridesView() {
 	}, [totalCount, offset]);
 	const { data: providersData } = useGetProvidersQuery();
 	const { data: virtualKeysData } = useGetVirtualKeysQuery();
+	const { data: allKeysData = [] } = useGetAllKeysQuery();
 	const [deleteOverride, { isLoading: isDeleting }] = useDeletePricingOverrideMutation();
 
 	useEffect(() => {
@@ -169,14 +171,12 @@ export default function ScopedPricingOverridesView() {
 	const providerMap = useMemo(() => new Map<string, string>(providers.map((provider) => [provider.name, provider.name])), [providers]);
 	const providerKeyOptions = useMemo(
 		() =>
-			providers.flatMap((provider) =>
-				(provider.keys || []).map((key) => ({
-					id: key.id,
-					label: key.name || key.id,
-					providerName: provider.name,
-				})),
-			),
-		[providers],
+			allKeysData.map((key) => ({
+				id: key.key_id,
+				label: key.name || key.key_id,
+				providerName: key.provider,
+			})),
+		[allKeysData],
 	);
 	const providerKeyProviderMap = useMemo(
 		() => new Map<string, string>(providerKeyOptions.map((key) => [key.id, key.providerName])),

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -100,7 +100,6 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 				retry_backoff_initial: 500,
 				retry_backoff_max: 5000,
 			},
-			keys: [],
 		};
 
 		addProvider(payload)

--- a/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
@@ -8,12 +8,12 @@ interface Props {
 	show: boolean;
 	onCancel: () => void;
 	provider: ModelProvider;
-	keyIndex: number;
+	keyId: string | null;
 	providerName?: string;
 }
 
-export default function AddNewKeySheet({ show, onCancel, provider, keyIndex, providerName }: Props) {
-	const isEditing = keyIndex < provider.keys.length;
+export default function AddNewKeySheet({ show, onCancel, provider, keyId, providerName }: Props) {
+	const isEditing = keyId !== null;
 	const resolvedProviderName = (providerName ?? provider.name).toLowerCase();
 	const isVLLM = resolvedProviderName === "vllm";
 	const entityLabel = isVLLM ? "model" : "key";
@@ -47,7 +47,7 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyIndex, pro
 				<div>
 					<ProviderKeyForm
 						provider={provider}
-						keyIndex={keyIndex}
+						keyId={keyId}
 						onCancel={onCancel}
 						onSave={() => {
 							toast.success(successMessage);

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import { buildProviderUpdatePayload } from "../views/utils";
 import { AllowedRequestsFields } from "./allowedRequestsFields";
 
 // Type for form data
@@ -66,15 +67,14 @@ export function ApiStructureFormFragment({ provider }: Props) {
 
 	const onSubmit = (data: FormCustomProviderConfig) => {
 		// Create updated provider configuration
-		updateProvider({
-			...provider,
+		updateProvider(buildProviderUpdatePayload(provider, {
 			custom_provider_config: {
 				base_provider_type: data.base_provider_type as unknown as BaseProvider,
 				is_key_less: data.is_key_less ?? false,
 				allowed_requests: data.allowed_requests,
 				request_path_overrides: cleanPathOverrides(data.request_path_overrides),
 			},
-		})
+		}))
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");

--- a/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
@@ -12,6 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
+import { buildProviderUpdatePayload } from "../views/utils";
 
 interface DebuggingFormFragmentProps {
 	provider: ModelProvider;
@@ -45,12 +46,11 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 	}, [form, provider.name, provider.send_back_raw_request, provider.send_back_raw_response, provider.store_raw_request_response]);
 
 	const onSubmit = (data: DebuggingFormSchema) => {
-		const updatedProvider: ModelProvider = {
-			...provider,
+		const updatedProvider = buildProviderUpdatePayload(provider, {
 			send_back_raw_request: data.send_back_raw_request,
 			send_back_raw_response: data.send_back_raw_response,
 			store_raw_request_response: data.store_raw_request_response,
-		};
+		});
 		updateProvider(updatedProvider)
 			.unwrap()
 			.then(() => {

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -17,6 +17,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
+import { buildProviderUpdatePayload } from "../views/utils";
 
 interface NetworkFormFragmentProps {
 	provider: ModelProvider;
@@ -98,8 +99,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 			return;
 		}
 		// Create updated provider configuration
-		const updatedProvider: ModelProvider = {
-			...provider,
+		const updatedProvider = buildProviderUpdatePayload(provider, {
 			network_config: {
 				...provider.network_config,
 				base_url: data.network_config?.base_url || undefined,
@@ -116,7 +116,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 					data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 				enforce_http2: data.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 			},
-		};
+		});
 		updateProvider(updatedProvider)
 			.unwrap()
 			.then(() => {

--- a/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
@@ -14,6 +14,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
+import { buildProviderUpdatePayload } from "../views/utils";
 
 interface PerformanceFormFragmentProps {
 	provider: ModelProvider;
@@ -51,13 +52,12 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 
 	const onSubmit = (data: PerformanceFormSchema) => {
 		// Create updated provider configuration (raw request/response are in Debugging tab)
-		const updatedProvider: ModelProvider = {
-			...provider,
+		const updatedProvider = buildProviderUpdatePayload(provider, {
 			concurrency_and_buffer_size: {
 				concurrency: data.concurrency_and_buffer_size.concurrency,
 				buffer_size: data.concurrency_and_buffer_size.buffer_size,
 			},
-		};
+		});
 		updateProvider(updatedProvider)
 			.unwrap()
 			.then(() => {

--- a/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
@@ -15,6 +15,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
+import { buildProviderUpdatePayload } from "../views/utils";
 
 interface ProxyFormFragmentProps {
 	provider: ModelProvider;
@@ -58,8 +59,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 	const watchedProxyType = form.watch("proxy_config.type");
 
 	const onSubmit = (data: ProxyOnlyFormSchema) => {
-		updateProvider({
-			...provider,
+		updateProvider(buildProviderUpdatePayload(provider, {
 			proxy_config: {
 				type: data.proxy_config?.type ?? "none",
 				url: data.proxy_config?.url || undefined,
@@ -67,7 +67,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 				password: data.proxy_config?.password || undefined,
 				ca_cert_pem: data.proxy_config?.ca_cert_pem || undefined,
 			},
-		})
+		}))
 			.unwrap()
 			.then(() => {
 				toast.success("Provider configuration updated successfully");

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -80,7 +80,7 @@ export default function Providers() {
 					dispatch(
 						setSelectedProvider({
 							name: provider as ModelProviderName,
-							keys: [],
+
 							concurrency_and_buffer_size: DefaultPerformanceConfig,
 							network_config: DefaultNetworkConfig,
 							custom_provider_config: undefined,
@@ -123,7 +123,7 @@ export default function Providers() {
 
 	const handleSelectKnownProvider = async (name: string) => {
 		try {
-			await createProvider({ provider: name as ModelProviderName, keys: [] }).unwrap();
+			await createProvider({ provider: name as ModelProviderName }).unwrap();
 			setProvider(name);
 		} catch (err: any) {
 			if (err?.status === 409) {
@@ -320,33 +320,20 @@ function KeyDiscoveryFailedBadge({
 	provider,
 }: {
 	provider: {
-		keys: Array<{ status?: string }>;
 		status?: string;
 		description?: string;
 	};
 }) {
-	const hasFailedKeys = provider.keys?.some((key) => key.status === "list_models_failed");
 	const providerFailed = provider.status === "list_models_failed";
-	const hasFailed = hasFailedKeys || providerFailed;
 
-	if (!hasFailed) return null;
-
-	// Determine the tooltip message
-	let tooltipMessage = "";
-	if (providerFailed && hasFailedKeys) {
-		tooltipMessage = "Provider and one or more keys have failed model discovery.";
-	} else if (providerFailed) {
-		tooltipMessage = provider.description || "Provider model discovery failed.";
-	} else if (hasFailedKeys) {
-		tooltipMessage = "One or more keys have failed list models. Check keys for details.";
-	}
+	if (!providerFailed) return null;
 
 	return (
 		<Tooltip>
 			<TooltipTrigger>
 				<AlertCircle className="h-3 w-3" />
 			</TooltipTrigger>
-			<TooltipContent>{tooltipMessage}</TooltipContent>
+			<TooltipContent>{provider.description || "Provider model discovery failed."}</TooltipContent>
 		</Tooltip>
 	);
 }

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -16,7 +16,8 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { getErrorMessage, useUpdateProviderMutation } from "@/lib/store";
+import { getErrorMessage } from "@/lib/store";
+import { useDeleteProviderKeyMutation, useGetProviderKeysQuery, useUpdateProviderKeyMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -40,12 +41,16 @@ export default function ModelProviderKeysTableView({ provider, className, header
 	const EntityLabel = entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1);
 	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
 	const hasDeleteProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
-	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
-	const [showAddNewKeyDialog, setShowAddNewKeyDialog] = useState<{ show: boolean; keyIndex: number } | undefined>(undefined);
-	const [showDeleteKeyDialog, setShowDeleteKeyDialog] = useState<{ show: boolean; keyIndex: number } | undefined>(undefined);
+	const [updateProviderKey, { isLoading: isUpdatingProviderKey }] = useUpdateProviderKeyMutation();
+	const [deleteProviderKey, { isLoading: isDeletingProviderKey }] = useDeleteProviderKeyMutation();
+	const { data: keys = [] } = useGetProviderKeysQuery(provider.name);
+	const isMutatingProviderKey = isUpdatingProviderKey || isDeletingProviderKey;
+	const [togglingKeyIds, setTogglingKeyIds] = useState<Set<string>>(new Set());
+	const [showAddNewKeyDialog, setShowAddNewKeyDialog] = useState<{ show: boolean; keyId: string | null } | undefined>(undefined);
+	const [showDeleteKeyDialog, setShowDeleteKeyDialog] = useState<{ show: boolean; keyId: string } | undefined>(undefined);
 
-	function handleAddKey(keyIndex: number) {
-		setShowAddNewKeyDialog({ show: true, keyIndex: keyIndex });
+	function handleAddKey() {
+		setShowAddNewKeyDialog({ show: true, keyId: null });
 	}
 
 	return (
@@ -55,18 +60,20 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					<AlertDialogContent onClick={(e) => e.stopPropagation()}>
 						<AlertDialogHeader>
 							<AlertDialogTitle>Delete {EntityLabel}</AlertDialogTitle>
-							<AlertDialogDescription>Are you sure you want to delete this {entityLabel}. This action cannot be undone.</AlertDialogDescription>
+							<AlertDialogDescription>
+								Are you sure you want to delete this {entityLabel}. This action cannot be undone.
+							</AlertDialogDescription>
 						</AlertDialogHeader>
 						<AlertDialogFooter className="pt-4">
-							<AlertDialogCancel onClick={() => setShowDeleteKeyDialog(undefined)} disabled={isUpdatingProvider}>
+							<AlertDialogCancel onClick={() => setShowDeleteKeyDialog(undefined)} disabled={isMutatingProviderKey}>
 								Cancel
 							</AlertDialogCancel>
 							<AlertDialogAction
-								disabled={isUpdatingProvider || !hasDeleteProviderAccess}
+								disabled={isMutatingProviderKey || !hasDeleteProviderAccess}
 								onClick={() => {
-									updateProvider({
-										...provider,
-										keys: provider.keys.filter((_, index) => index !== showDeleteKeyDialog.keyIndex),
+									deleteProviderKey({
+										provider: provider.name,
+										keyId: showDeleteKeyDialog.keyId,
 									})
 										.unwrap()
 										.then(() => {
@@ -91,7 +98,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					show={showAddNewKeyDialog.show}
 					onCancel={() => setShowAddNewKeyDialog(undefined)}
 					provider={provider}
-					keyIndex={showAddNewKeyDialog.keyIndex}
+					keyId={showAddNewKeyDialog.keyId}
 					providerName={providerName}
 				/>
 			)}
@@ -105,7 +112,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 								disabled={!hasUpdateProviderAccess}
 								data-testid="add-key-btn"
 								onClick={() => {
-									handleAddKey(provider.keys.length);
+									handleAddKey();
 								}}
 							>
 								<PlusIcon className="h-4 w-4" />
@@ -121,7 +128,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					<p>You can edit the provider configuration using the button above.</p>
 				</div>
 			) : (
-				<div className="w-full rounded-sm border flex flex-col gap-2">
+				<div className="flex w-full flex-col gap-2 rounded-sm border">
 					<Table className="w-full" data-testid="keys-table">
 						<TableHeader className="w-full">
 							<TableRow>
@@ -132,24 +139,34 @@ export default function ModelProviderKeysTableView({ provider, className, header
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							{provider.keys.length === 0 && (
+							{keys.length === 0 && (
 								<TableRow data-testid="keys-table-empty-state">
 									<TableCell colSpan={4} className="py-6 text-center">
 										No {entityLabelPlural} found.
 									</TableCell>
 								</TableRow>
 							)}
-							{provider.keys.map((key, index) => {
+							{keys.map((key) => {
 								const isKeyEnabled = key.enabled ?? true;
 								return (
-									<TableRow key={index} data-testid={`key-row-${key.name}`} className="text-sm transition-colors hover:bg-white" onClick={() => {}}>
+									<TableRow
+										key={key.id}
+										data-testid={`key-row-${key.name}`}
+										className="text-sm transition-colors hover:bg-white"
+										onClick={() => {}}
+									>
 										<TableCell>
 											<div className="flex items-center space-x-2">
 												{key.status === "success" && (
 													<Tooltip>
 														<TooltipTrigger asChild>
-															<button type="button" aria-label="Key status: list models working" data-testid={`key-status-success-${key.name}`} className="inline-flex">
-																<CheckCircle2 aria-hidden className="text-green-600 h-4 w-4 flex-shrink-0" />
+															<button
+																type="button"
+																aria-label="Key status: list models working"
+																data-testid={`key-status-success-${key.name}`}
+																className="inline-flex"
+															>
+																<CheckCircle2 aria-hidden className="h-4 w-4 flex-shrink-0 text-green-600" />
 															</button>
 														</TooltipTrigger>
 														<TooltipContent>List models working</TooltipContent>
@@ -158,7 +175,12 @@ export default function ModelProviderKeysTableView({ provider, className, header
 												{key.status === "list_models_failed" && (
 													<Tooltip>
 														<TooltipTrigger asChild>
-															<button type="button" aria-label="Key status: list models failed" data-testid={`key-status-error-${key.name}`} className="inline-flex">
+															<button
+																type="button"
+																aria-label="Key status: list models failed"
+																data-testid={`key-status-error-${key.name}`}
+																className="inline-flex"
+															>
 																<AlertCircle aria-hidden className="text-destructive h-4 w-4 flex-shrink-0" />
 															</button>
 														</TooltipTrigger>
@@ -180,11 +202,13 @@ export default function ModelProviderKeysTableView({ provider, className, header
 												data-testid="key-enabled-switch"
 												checked={isKeyEnabled}
 												size="md"
-												disabled={!hasUpdateProviderAccess}
+												disabled={!hasUpdateProviderAccess || togglingKeyIds.has(key.id)}
 												onCheckedChange={(checked) => {
-													updateProvider({
-														...provider,
-														keys: provider.keys.map((k, i) => (i === index ? { ...k, enabled: checked } : k)),
+													setTogglingKeyIds((prev) => new Set(prev).add(key.id));
+													updateProviderKey({
+														provider: provider.name,
+														keyId: key.id,
+														key: { ...key, enabled: checked },
 													})
 														.unwrap()
 														.then(() => {
@@ -192,6 +216,13 @@ export default function ModelProviderKeysTableView({ provider, className, header
 														})
 														.catch((err) => {
 															toast.error(`Failed to update ${entityLabel}`, { description: getErrorMessage(err) });
+														})
+														.finally(() => {
+															setTogglingKeyIds((prev) => {
+																const next = new Set(prev);
+																next.delete(key.id);
+																return next;
+															});
 														});
 												}}
 											/>
@@ -207,16 +238,16 @@ export default function ModelProviderKeysTableView({ provider, className, header
 													<DropdownMenuContent align="end">
 														<DropdownMenuItem
 															onClick={() => {
-																setShowAddNewKeyDialog({ show: true, keyIndex: index });
+																setShowAddNewKeyDialog({ show: true, keyId: key.id });
 															}}
-															disabled={!hasUpdateProviderAccess || !isKeyEnabled}
+															disabled={!hasUpdateProviderAccess}
 														>
 															<PencilIcon className="mr-1 h-4 w-4" />
 															Edit
 														</DropdownMenuItem>
 														<DropdownMenuItem
 															onClick={() => {
-																setShowDeleteKeyDialog({ show: true, keyIndex: index });
+																setShowDeleteKeyDialog({ show: true, keyId: key.id });
 															}}
 															disabled={!hasDeleteProviderAccess}
 														>

--- a/ui/app/workspace/providers/views/providerKeyForm.tsx
+++ b/ui/app/workspace/providers/views/providerKeyForm.tsx
@@ -2,7 +2,8 @@ import { Button } from "@/components/ui/button";
 import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
 import { Form } from "@/components/ui/form";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { getErrorMessage, useUpdateProviderMutation } from "@/lib/store";
+import { getErrorMessage } from "@/lib/store";
+import { useCreateProviderKeyMutation, useGetProviderKeysQuery, useUpdateProviderKeyMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider } from "@/lib/types/config";
 import { modelProviderKeySchema } from "@/lib/types/schemas";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -15,7 +16,7 @@ import { z } from "zod";
 import { ApiKeyFormFragment } from "../fragments";
 interface Props {
 	provider: ModelProvider;
-	keyIndex: number;
+	keyId: string | null;
 	onCancel: () => void;
 	onSave: () => void;
 }
@@ -27,17 +28,19 @@ const providerKeyFormSchema = z.object({
 
 type ProviderKeyFormValues = z.infer<typeof modelProviderKeySchema>;
 
-export default function ProviderKeyForm({ provider, keyIndex, onCancel, onSave }: Props) {
-	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
-	const isEditing = provider?.keys?.[keyIndex] !== undefined;
-	const currentKey = provider?.keys?.[keyIndex];
+export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: Props) {
+	const [createProviderKey, { isLoading: isCreatingProviderKey }] = useCreateProviderKeyMutation();
+	const [updateProviderKey, { isLoading: isUpdatingProviderKey }] = useUpdateProviderKeyMutation();
+	const { data: keys = [] } = useGetProviderKeysQuery(provider.name);
+	const isEditing = keyId !== null;
+	const currentKey = keyId ? keys.find((k) => k.id === keyId) : undefined;
 
 	const form = useForm({
 		resolver: zodResolver(providerKeyFormSchema),
 		mode: "onChange",
 		reValidateMode: "onChange",
 		defaultValues: {
-			key: (provider?.keys?.[keyIndex] as ProviderKeyFormValues) ?? {
+			key: (currentKey as ProviderKeyFormValues) ?? {
 				id: uuid(),
 				name: "",
 				models: ["*"],
@@ -46,6 +49,13 @@ export default function ProviderKeyForm({ provider, keyIndex, onCancel, onSave }
 			},
 		},
 	});
+
+	// Reset form when currentKey arrives (handles late async resolution)
+	// Skip reset if user has unsaved edits to avoid discarding changes during background refetches
+	useEffect(() => {
+		if (!isEditing || !currentKey || form.formState.isDirty) return;
+		form.reset({ key: currentKey as ProviderKeyFormValues });
+	}, [isEditing, currentKey, form]);
 
 	// Trigger validation on mount when editing existing data
 	useEffect(() => {
@@ -65,18 +75,25 @@ export default function ProviderKeyForm({ provider, keyIndex, onCancel, onSave }
 	}, [form?.formState.errors, form?.formState.isValid, form?.formState.isDirty]);
 
 	const onSubmit = (value: any) => {
-		const keys = provider.keys ?? [];
-		const updatedKeys = [...keys.slice(0, keyIndex), value.key, ...keys.slice(keyIndex + 1)];
-		updateProvider({
-			...provider,
-			keys: updatedKeys,
-		})
+		if (isEditing && !currentKey) return;
+		const mutation = isEditing
+			? updateProviderKey({
+					provider: provider.name,
+					keyId: currentKey!.id,
+					key: value.key,
+				})
+			: createProviderKey({
+					provider: provider.name,
+					key: value.key,
+				});
+
+		mutation
 			.unwrap()
 			.then(() => {
 				onSave();
 			})
 			.catch((err) => {
-				toast.error("Error while updating key", {
+				toast.error(isEditing ? "Error updating key" : "Error creating key", {
 					description: getErrorMessage(err),
 				});
 			});
@@ -99,7 +116,7 @@ export default function ProviderKeyForm({ provider, keyIndex, onCancel, onSave }
 										<Button
 											type="submit"
 											disabled={!form.formState.isDirty || !form.formState.isValid}
-											isLoading={form.formState.isSubmitting || isUpdatingProvider}
+											isLoading={form.formState.isSubmitting || isCreatingProviderKey || isUpdatingProviderKey}
 											data-testid="key-save-btn"
 										>
 											<Save className="h-4 w-4" />

--- a/ui/app/workspace/providers/views/utils.ts
+++ b/ui/app/workspace/providers/views/utils.ts
@@ -1,1 +1,19 @@
+import { DefaultNetworkConfig, DefaultPerformanceConfig } from "@/lib/constants/config";
+import { ModelProvider, UpdateProviderRequest } from "@/lib/types/config";
+
 export const keysRequired = (selectedProvider: string) => selectedProvider.toLowerCase() === "custom" || !["ollama", "sgl"].includes(selectedProvider.toLowerCase());
+
+export const buildProviderUpdatePayload = (provider: ModelProvider, updates: Partial<UpdateProviderRequest>) => {
+	const { name } = provider;
+
+	return {
+		name,
+		network_config: updates.network_config ?? provider.network_config ?? DefaultNetworkConfig,
+		concurrency_and_buffer_size: updates.concurrency_and_buffer_size ?? provider.concurrency_and_buffer_size ?? DefaultPerformanceConfig,
+		proxy_config: updates.proxy_config ?? provider.proxy_config,
+		send_back_raw_request: updates.send_back_raw_request ?? provider.send_back_raw_request,
+		send_back_raw_response: updates.send_back_raw_response ?? provider.send_back_raw_response,
+		store_raw_request_response: updates.store_raw_request_response ?? provider.store_raw_request_response,
+		custom_provider_config: updates.custom_provider_config ?? provider.custom_provider_config,
+	};
+};

--- a/ui/app/workspace/routing-rules/views/routingRuleInfoSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleInfoSheet.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Separator } from "@/components/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { RoutingRule } from "@/lib/types/routingRules";
+import { getScopeLabel } from "@/lib/utils/routingRules";
+import { getOperatorLabel } from "@/lib/config/celOperatorsRouting";
+import { baseRoutingFields } from "@/lib/config/celFieldsRouting";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { getProviderLabel } from "@/lib/constants/logs";
+import { useGetTeamsQuery, useGetCustomersQuery, useGetVirtualKeysQuery } from "@/lib/store/apis/governanceApi";
+import { useMemo } from "react";
+import { RuleGroupType, RuleType } from "react-querybuilder";
+
+interface Props {
+	rule: RoutingRule | null;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+function getFieldLabel(fieldName: string): string {
+	const field = baseRoutingFields.find((f) => f.name === fieldName);
+	return field?.label ?? fieldName;
+}
+
+function formatRuleValue(value: any): string {
+	if (Array.isArray(value)) return value.join(", ");
+	if (typeof value === "string") return value;
+	return String(value ?? "");
+}
+
+function ConditionRow({ rule }: { rule: RuleType }) {
+	const fieldLabel = getFieldLabel(rule.field);
+	const opLabel = getOperatorLabel(rule.operator);
+	const value = formatRuleValue(rule.value);
+	const isExistence = rule.operator === "null" || rule.operator === "notNull";
+
+	return (
+		<div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs">
+			<Badge variant="outline" className="shrink-0 font-medium">
+				{fieldLabel}
+			</Badge>
+			<span className="text-muted-foreground shrink-0">{opLabel}</span>
+			{!isExistence && <code className="bg-muted text-foreground truncate rounded px-1.5 py-0.5 font-mono">{value}</code>}
+		</div>
+	);
+}
+
+function CombinatorPill({ combinator }: { combinator: string }) {
+	return (
+		<div className="flex items-center gap-1.5 px-2.5">
+			<div className="bg-border h-px flex-1" />
+			<span className="text-muted-foreground text-[10px] font-semibold uppercase">{combinator}</span>
+			<div className="bg-border h-px flex-1" />
+		</div>
+	);
+}
+
+function ConditionGroup({ group, depth = 0 }: { group: RuleGroupType; depth?: number }) {
+	const rules = group.rules ?? [];
+	if (rules.length === 0) return null;
+
+	const content = rules.map((rule, i) => (
+		<div key={i}>
+			{i > 0 && <CombinatorPill combinator={group.combinator} />}
+			{"combinator" in rule ? <ConditionGroup group={rule as RuleGroupType} depth={depth + 1} /> : <ConditionRow rule={rule as RuleType} />}
+		</div>
+	));
+
+	if (depth === 0) {
+		return <div className="rounded-md border py-1">{content}</div>;
+	}
+
+	return (
+		<div className="border-foreground/25 relative mx-2.5 my-1 rounded border border-dashed py-1">
+			<span className="bg-background text-muted-foreground absolute -top-2 right-2 rounded px-1 text-[10px] font-medium">Group</span>
+			{content}
+		</div>
+	);
+}
+
+function useScopeName(scope: string, scopeId?: string): string | undefined {
+	const { data: teamsData } = useGetTeamsQuery(undefined, { skip: scope !== "team" || !scopeId });
+	const { data: customersData } = useGetCustomersQuery(undefined, { skip: scope !== "customer" || !scopeId });
+	const { data: vksData } = useGetVirtualKeysQuery(undefined, { skip: scope !== "virtual_key" || !scopeId });
+
+	return useMemo(() => {
+		if (!scopeId) return undefined;
+		if (scope === "team") {
+			return teamsData?.teams?.find((t) => t.id === scopeId)?.name;
+		}
+		if (scope === "customer") {
+			return customersData?.customers?.find((c) => c.id === scopeId)?.name;
+		}
+		if (scope === "virtual_key") {
+			return vksData?.virtual_keys?.find((v) => v.id === scopeId)?.name;
+		}
+		return undefined;
+	}, [scope, scopeId, teamsData, customersData, vksData]);
+}
+
+function TargetCard({ target }: { target: RoutingRule["targets"][0] }) {
+	const providerLabel = target.provider ? getProviderLabel(target.provider) : "Any provider";
+	const weightPercent = Math.round(target.weight * 100);
+
+	return (
+		<div className="flex items-center gap-3 rounded-md border px-3 py-2.5">
+			<div className="flex min-w-0 flex-1 items-center gap-2.5">
+				{target.provider && <RenderProviderIcon provider={target.provider as ProviderIconType} size="sm" className="h-5 w-5 shrink-0" />}
+				<div className="flex min-w-0 flex-col">
+					<span className="truncate text-sm font-medium">{providerLabel}</span>
+					{target.model ? (
+						<span className="text-muted-foreground truncate font-mono text-xs">{target.model}</span>
+					) : (
+						<span className="text-muted-foreground text-xs">All models</span>
+					)}
+				</div>
+			</div>
+			<div className="shrink-0">
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<div className="flex items-center gap-1.5">
+							<div className="bg-muted h-1.5 w-16 overflow-hidden rounded-full">
+								<div className="bg-primary h-full rounded-full transition-all" style={{ width: `${weightPercent}%` }} />
+							</div>
+							<span className="text-muted-foreground w-8 text-right font-mono text-xs">{weightPercent}%</span>
+						</div>
+					</TooltipTrigger>
+					<TooltipContent>Weight: {target.weight}</TooltipContent>
+				</Tooltip>
+			</div>
+		</div>
+	);
+}
+
+function FallbackChain({ fallbacks }: { fallbacks: string[] }) {
+	return (
+		<div className="flex flex-wrap items-center gap-y-1.5">
+			{fallbacks.map((fb, i) => {
+				const parts = fb.split("/");
+				const provider = parts[0];
+				const model = parts.length > 1 ? parts.slice(1).join("/") : undefined;
+
+				return (
+					<div key={i} className="flex items-center">
+						{i > 0 && <span className="text-muted-foreground mx-1.5 text-xs">&rarr;</span>}
+						<Badge variant="outline" className="gap-1.5 font-normal">
+							{provider && <RenderProviderIcon provider={provider as ProviderIconType} size="sm" className="h-3.5 w-3.5 shrink-0" />}
+							<span className="font-mono text-xs">{model ? `${provider}/${model}` : fb}</span>
+						</Badge>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+export function RoutingRuleInfoSheet({ rule, open, onOpenChange }: Props) {
+	const targets = rule?.targets ?? [];
+	const fallbacks = rule?.fallbacks ?? [];
+	const hasQuery = rule?.query && (rule.query.rules?.length ?? 0) > 0;
+	const scopeName = useScopeName(rule?.scope ?? "global", rule?.scope_id);
+
+	return (
+		<Sheet open={open} onOpenChange={onOpenChange}>
+			{rule && (
+				<SheetContent className="custom-scrollbar p-8" data-testid="routing-rule-info">
+					<SheetHeader className="flex flex-col items-start">
+						<SheetTitle>Rule details</SheetTitle>
+					</SheetHeader>
+
+					<div className="space-y-6">
+						{/* Identity */}
+						<div>
+							<div className="flex items-center gap-2">
+								<h3 className="text-base font-medium">{rule.name}</h3>
+								<Badge variant={rule.enabled ? "success" : "secondary"} className="px-1.5 py-0 text-[10px]">
+									{rule.enabled ? "Enabled" : "Disabled"}
+								</Badge>
+							</div>
+							{rule.description && <p className="text-muted-foreground mt-1 text-sm">{rule.description}</p>}
+						</div>
+
+						<Separator />
+
+						{/* Metadata grid */}
+						<div className="grid grid-cols-2 gap-4">
+							<div>
+								<p className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">Scope</p>
+								<div className="flex items-center gap-1.5">
+									<Badge variant="secondary">{getScopeLabel(rule.scope)}</Badge>
+									{scopeName && <span className="text-sm font-medium">{scopeName}</span>}
+								</div>
+							</div>
+							<div>
+								<p className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">Priority</p>
+								<span className="bg-primary text-primary-foreground inline-block rounded px-2.5 py-0.5 text-xs font-medium">
+									{rule.priority}
+								</span>
+							</div>
+						</div>
+
+						{/* Rule Conditions */}
+						{hasQuery && (
+							<>
+								<Separator />
+								<div>
+									<p className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">Conditions</p>
+									<ConditionGroup group={rule.query!} />
+								</div>
+							</>
+						)}
+
+						{/* Targets */}
+						{targets.length > 0 && (
+							<>
+								<Separator />
+								<div>
+									<p className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">Targets ({targets.length})</p>
+									<div className="space-y-2">
+										{targets.map((target, i) => (
+											<TargetCard key={i} target={target} />
+										))}
+									</div>
+								</div>
+							</>
+						)}
+
+						{/* Fallbacks */}
+						{fallbacks.length > 0 && (
+							<>
+								<Separator />
+								<div>
+									<p className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">Fallback Chain</p>
+									<FallbackChain fallbacks={fallbacks} />
+								</div>
+							</>
+						)}
+
+						{/* Timestamps */}
+						<Separator />
+						<div className="grid grid-cols-2 gap-4">
+							<div>
+								<p className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">Created</p>
+								<span className="text-sm">
+									{new Date(rule.created_at).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+								</span>
+							</div>
+							<div>
+								<p className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">Updated</p>
+								<span className="text-sm">
+									{new Date(rule.updated_at).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+								</span>
+							</div>
+						</div>
+					</div>
+				</SheetContent>
+			)}
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -41,7 +41,7 @@ import {
 	useGetTeamsQuery,
 	useGetCustomersQuery,
 } from "@/lib/store/apis/governanceApi";
-import { useGetProvidersQuery } from "@/lib/store/apis/providersApi";
+import { useGetProvidersQuery, useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { toast } from "sonner";
 import dynamic from "next/dynamic";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
@@ -85,6 +85,7 @@ export function RoutingRuleSheet({
 	const { data: rulesData } = useGetRoutingRulesQuery();
 	const rules = rulesData?.rules || [];
 	const { data: providersData = [] } = useGetProvidersQuery();
+	const { data: allKeysData = [] } = useGetAllKeysQuery();
 	const { data: vksData = { virtual_keys: [] } } = useGetVirtualKeysQuery();
 	const { data: teamsData = { teams: [], count: 0, total_count: 0, limit: 0, offset: 0 } } = useGetTeamsQuery();
 	const { data: customersData = { customers: [] } } = useGetCustomersQuery();
@@ -487,7 +488,7 @@ export function RoutingRuleSheet({
 									target={target}
 									index={index}
 									availableProviders={availableProviders}
-									providersData={providersData}
+									allKeys={allKeysData}
 									showRemove={targets.length > 1}
 									onUpdate={updateTarget}
 									onRemove={removeTarget}
@@ -623,15 +624,15 @@ interface TargetRowProps {
 	target: RoutingTargetFormData;
 	index: number;
 	availableProviders: string[];
-	providersData: Array<{ name: string; keys: Array<{ id: string; name: string }> }>;
+	allKeys: Array<{ key_id: string; name: string; provider: string }>;
 	showRemove: boolean;
 	onUpdate: (index: number, field: keyof RoutingTargetFormData, value: string | number) => void;
 	onRemove: (index: number) => void;
 }
 
-function TargetRow({ target, index, availableProviders, providersData, showRemove, onUpdate, onRemove }: TargetRowProps) {
+function TargetRow({ target, index, availableProviders, allKeys, showRemove, onUpdate, onRemove }: TargetRowProps) {
 	const availableKeys = target.provider
-		? (providersData.find((p) => p.name === target.provider)?.keys ?? [])
+		? allKeys.filter((k) => k.provider === target.provider).map((k) => ({ id: k.key_id, name: k.name }))
 		: [];
 
 	return (

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -9,6 +9,7 @@ import { useGetAllKeysQuery, useGetProvidersQuery, useLazyGetModelsQuery } from 
 import { useGetVirtualKeysQuery } from "@/lib/store";
 import { useCallback, useEffect, useMemo } from "react";
 import { ModelProviderName } from "@/lib/types/config";
+import { Skeleton } from "@/components/ui/skeleton";
 import { usePromptContext } from "../context";
 import { VariablesTableView } from "../components/variablesTableView";
 import { ApiKeySelectorView } from "../components/apiKeySelectorView";
@@ -44,18 +45,27 @@ export function SettingsPanel() {
 		[setApiKeyId],
 	);
 	// Dynamic providers
-	const { data: providers } = useGetProvidersQuery();
+	const { data: providers, isLoading: isLoadingProviders } = useGetProvidersQuery();
 	const { data: virtualKeysData } = useGetVirtualKeysQuery();
+	// Keys for the API Key selector (from /api/keys endpoint, provider-filtered)
+	const { data: allKeys, isSuccess: hasLoadedAllKeys } = useGetAllKeysQuery();
+
+	const isInitialLoading = isLoadingProviders;
+
 	const configuredProviders = useMemo(() => {
 		const activeVirtualKeys = virtualKeysData?.virtual_keys?.filter((vk) => vk.is_active) ?? [];
+		if (!hasLoadedAllKeys) {
+			return providers ?? [];
+		}
+		const keyedProviders = new Set((allKeys ?? []).map((k) => k.provider));
 		return (providers ?? []).filter((p) => {
-			if (p.keys && p.keys.length > 0) return true;
+			if (keyedProviders.has(p.name)) return true;
 			// Include providers that have active virtual keys (wildcard or explicitly targeting this provider)
 			return activeVirtualKeys.some(
 				(vk) => !vk.provider_configs || vk.provider_configs.length === 0 || vk.provider_configs.some((pc) => pc.provider === p.name),
 			);
 		});
-	}, [providers, virtualKeysData]);
+	}, [providers, virtualKeysData, allKeys, hasLoadedAllKeys]);
 
 	// Ensure current provider always has a label-resolved option (even before providers query loads)
 	const providerOptions = useMemo(() => {
@@ -66,13 +76,8 @@ export function SettingsPanel() {
 		return opts;
 	}, [configuredProviders, provider]);
 
-	// Get keys from the provider config (has models[] per key)
-	const selectedProvider = useMemo(() => configuredProviders.find((p) => p.name === provider), [configuredProviders, provider]);
-	const providerKeyConfigs = useMemo(() => selectedProvider?.keys ?? [], [selectedProvider]);
-
-	// Keys for the API Key selector (from /api/keys endpoint, provider-filtered)
-	const { data: allKeys } = useGetAllKeysQuery();
 	const providerKeys = useMemo(() => (allKeys ?? []).filter((k) => k.provider === provider), [allKeys, provider]);
+	const providerKeyConfigs = useMemo(() => providerKeys.map((k) => ({ id: k.key_id, models: k.models })), [providerKeys]);
 
 	// Virtual keys filtered by selected provider
 	const providerVirtualKeys = useMemo(() => {
@@ -130,6 +135,23 @@ export function SettingsPanel() {
 		},
 		[onModelParamsChange],
 	);
+
+	if (isInitialLoading) {
+		return (
+			<div className="flex h-full flex-col">
+				<div className="space-y-6 p-4">
+					<div className="flex flex-col gap-2">
+						<Skeleton className="h-4 w-16" />
+						<Skeleton className="h-9 w-full rounded-sm" />
+					</div>
+					<div className="flex flex-col gap-2">
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-9 w-full rounded-sm" />
+					</div>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="flex h-full flex-col">

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -134,6 +134,7 @@ export const baseApi = createApi({
 		"DebugStats",
 		"HealthCheck",
 		"DBKeys",
+		"ProviderKeys",
 		"Models",
 		"BaseModels",
 		"ModelConfigs",

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -1,4 +1,14 @@
-import { AddProviderRequest, ListProvidersResponse, ModelProvider, ModelProviderName } from "@/lib/types/config";
+import {
+	AddProviderRequest,
+	CreateProviderKeyRequest,
+	ListProviderKeysResponse,
+	ListProvidersResponse,
+	ModelProvider,
+	ModelProviderKey,
+	ModelProviderName,
+	UpdateProviderRequest,
+	UpdateProviderKeyRequest,
+} from "@/lib/types/config";
 import { DBKey } from "@/lib/types/governance";
 import { baseApi } from "./baseApi";
 
@@ -64,6 +74,8 @@ export interface ListBaseModelsResponse {
 	total: number;
 }
 
+type UpdateProviderMutationArg = UpdateProviderRequest & { name: ModelProviderName };
+
 const DEFAULT_MODEL_PARAMETERS: ModelDatasheetResponse = {
 	mode: "chat",
 	base_model: "default",
@@ -108,6 +120,17 @@ export const providersApi = baseApi.injectEndpoints({
 			providesTags: (result, error, provider) => [{ type: "Providers", id: provider }],
 		}),
 
+		getProviderKeys: builder.query<ModelProviderKey[], string>({
+			query: (provider) => `/providers/${encodeURIComponent(provider)}/keys`,
+			transformResponse: (response: ListProviderKeysResponse) => response.keys ?? [],
+			providesTags: (result, error, provider) => [{ type: "ProviderKeys", id: provider }],
+		}),
+
+		getProviderKey: builder.query<ModelProviderKey, { provider: string; keyId: string }>({
+			query: ({ provider, keyId }) => `/providers/${encodeURIComponent(provider)}/keys/${encodeURIComponent(keyId)}`,
+			providesTags: (result, error, { provider }) => [{ type: "ProviderKeys", id: provider }],
+		}),
+
 		// Create new provider
 		createProvider: builder.mutation<ModelProvider, AddProviderRequest>({
 			query: (data) => ({
@@ -129,12 +152,13 @@ export const providersApi = baseApi.injectEndpoints({
 		}),
 
 		// Update existing provider
-		updateProvider: builder.mutation<ModelProvider, ModelProvider>({
-			query: (provider) => ({
-				url: `/providers/${encodeURIComponent(provider.name)}`,
+		updateProvider: builder.mutation<ModelProvider, UpdateProviderMutationArg>({
+			query: ({ name, ...body }) => ({
+				url: `/providers/${encodeURIComponent(name)}`,
 				method: "PUT",
-				body: provider,
+				body,
 			}),
+			invalidatesTags: (result, error, arg) => [{ type: "ProviderKeys", id: arg.name }, "DBKeys"],
 			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
 				try {
 					const { data: updatedProvider } = await queryFulfilled;
@@ -147,6 +171,101 @@ export const providersApi = baseApi.injectEndpoints({
 						}),
 					);
 					dispatch(providersApi.util.updateQueryData("getProvider", arg.name, () => updatedProvider));
+				} catch {}
+			},
+		}),
+
+		createProviderKey: builder.mutation<ModelProviderKey, { provider: string; key: CreateProviderKeyRequest }>({
+			query: ({ provider, key }) => ({
+				url: `/providers/${encodeURIComponent(provider)}/keys`,
+				method: "POST",
+				body: key,
+			}),
+			async onQueryStarted({ provider }, { dispatch, queryFulfilled }) {
+				try {
+					const { data: newKey } = await queryFulfilled;
+					dispatch(
+						providersApi.util.updateQueryData("getProviderKeys", provider, (draft) => {
+							const exists = draft.some((k) => k.id === newKey.id);
+							if (!exists) {
+								draft.push(newKey);
+							}
+						}),
+					);
+					dispatch(
+						providersApi.util.updateQueryData("getAllKeys", undefined, (draft) => {
+							const exists = draft.some((k) => k.key_id === newKey.id);
+							if (!exists) {
+								draft.push({
+									key_id: newKey.id,
+									name: newKey.name,
+									provider_id: "",
+									models: newKey.models ?? [],
+									provider: provider as ModelProviderName,
+								});
+							}
+						}),
+					);
+				} catch {}
+			},
+		}),
+
+		updateProviderKey: builder.mutation<ModelProviderKey, { provider: string; keyId: string; key: UpdateProviderKeyRequest }>({
+			query: ({ provider, keyId, key }) => ({
+				url: `/providers/${encodeURIComponent(provider)}/keys/${encodeURIComponent(keyId)}`,
+				method: "PUT",
+				body: key,
+			}),
+			async onQueryStarted({ provider, keyId }, { dispatch, queryFulfilled }) {
+				try {
+					const { data: updatedKey } = await queryFulfilled;
+					dispatch(
+						providersApi.util.updateQueryData("getProviderKeys", provider, (draft) => {
+							const index = draft.findIndex((key) => key.id === keyId);
+							if (index !== -1) {
+								draft[index] = updatedKey;
+							}
+						}),
+					);
+					dispatch(
+						providersApi.util.updateQueryData("getProviderKey", { provider, keyId }, () => updatedKey),
+					);
+					dispatch(
+						providersApi.util.updateQueryData("getAllKeys", undefined, (draft) => {
+							const index = draft.findIndex((k) => k.key_id === keyId);
+							if (index !== -1) {
+								draft[index] = { ...draft[index], name: updatedKey.name, models: updatedKey.models ?? [] };
+							}
+						}),
+					);
+				} catch {}
+			},
+		}),
+
+		deleteProviderKey: builder.mutation<ModelProviderKey, { provider: string; keyId: string }>({
+			query: ({ provider, keyId }) => ({
+				url: `/providers/${encodeURIComponent(provider)}/keys/${encodeURIComponent(keyId)}`,
+				method: "DELETE",
+			}),
+			async onQueryStarted({ provider, keyId }, { dispatch, queryFulfilled }) {
+				try {
+					await queryFulfilled;
+					dispatch(
+						providersApi.util.updateQueryData("getProviderKeys", provider, (draft) => {
+							const index = draft.findIndex((key) => key.id === keyId);
+							if (index !== -1) {
+								draft.splice(index, 1);
+							}
+						}),
+					);
+					dispatch(
+						providersApi.util.updateQueryData("getAllKeys", undefined, (draft) => {
+							const index = draft.findIndex((k) => k.key_id === keyId);
+							if (index !== -1) {
+								draft.splice(index, 1);
+							}
+						}),
+					);
 				} catch {}
 			},
 		}),
@@ -167,6 +286,16 @@ export const providersApi = baseApi.injectEndpoints({
 								draft.splice(index, 1);
 							}
 						}),
+					);
+					dispatch(
+						providersApi.util.updateQueryData("getProviderKeys", providerName, (draft) => {
+							draft.splice(0, draft.length);
+						}),
+					);
+					dispatch(
+						providersApi.util.updateQueryData("getAllKeys", undefined, (draft) =>
+							draft.filter((key) => key.provider !== providerName),
+						),
 					);
 				} catch {}
 			},
@@ -224,14 +353,21 @@ export const providersApi = baseApi.injectEndpoints({
 export const {
 	useGetProvidersQuery,
 	useGetProviderQuery,
+	useGetProviderKeysQuery,
+	useGetProviderKeyQuery,
 	useCreateProviderMutation,
 	useUpdateProviderMutation,
+	useCreateProviderKeyMutation,
+	useUpdateProviderKeyMutation,
+	useDeleteProviderKeyMutation,
 	useDeleteProviderMutation,
 	useGetAllKeysQuery,
 	useGetModelsQuery,
 	useGetBaseModelsQuery,
 	useLazyGetProvidersQuery,
 	useLazyGetProviderQuery,
+	useLazyGetProviderKeysQuery,
+	useLazyGetProviderKeyQuery,
 	useLazyGetAllKeysQuery,
 	useLazyGetModelsQuery,
 	useLazyGetBaseModelsQuery,

--- a/ui/lib/store/slices/providerSlice.ts
+++ b/ui/lib/store/slices/providerSlice.ts
@@ -57,16 +57,14 @@ const providerSlice = createSlice({
 			}
 		});
 
-	// Listen to updateProvider fulfilled to update selected provider if it's the same one
-	builder.addMatcher(providersApi.endpoints.updateProvider.matchFulfilled, (state, action) => {
-		const updatedProvider = action.payload;
-		// If the updated provider is the currently selected one, update it
-		if (state.selectedProvider && updatedProvider.name === state.selectedProvider.name) {
-			state.selectedProvider = updatedProvider;
-		}
-	});
-
-		
+		// Listen to updateProvider fulfilled to update selected provider if it's the same one
+		builder.addMatcher(providersApi.endpoints.updateProvider.matchFulfilled, (state, action) => {
+			const updatedProvider = action.payload;
+			// If the updated provider is the currently selected one, update it
+			if (state.selectedProvider && updatedProvider.name === state.selectedProvider.name) {
+				state.selectedProvider = updatedProvider;
+			}
+		});
 	},
 });
 

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -270,7 +270,6 @@ export interface CustomProviderConfig {
 
 // ProviderConfig matching Go's lib.ProviderConfig
 export interface ModelProviderConfig {
-	keys: ModelProviderKey[];
 	network_config?: NetworkConfig;
 	concurrency_and_buffer_size?: ConcurrencyAndBufferSize;
 	proxy_config?: ProxyConfig;
@@ -298,7 +297,6 @@ export interface ListProvidersResponse {
 // AddProviderRequest matching Go's AddProviderRequest
 export interface AddProviderRequest {
 	provider: ModelProviderName;
-	keys: ModelProviderKey[];
 	network_config?: NetworkConfig;
 	concurrency_and_buffer_size?: ConcurrencyAndBufferSize;
 	proxy_config?: ProxyConfig;
@@ -310,14 +308,22 @@ export interface AddProviderRequest {
 
 // UpdateProviderRequest matching Go's UpdateProviderRequest
 export interface UpdateProviderRequest {
-	keys: ModelProviderKey[];
 	network_config: NetworkConfig;
 	concurrency_and_buffer_size: ConcurrencyAndBufferSize;
-	proxy_config: ProxyConfig;
+	proxy_config?: ProxyConfig;
 	send_back_raw_request?: boolean;
 	send_back_raw_response?: boolean;
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+}
+
+export interface CreateProviderKeyRequest extends ModelProviderKey {}
+
+export interface UpdateProviderKeyRequest extends ModelProviderKey {}
+
+export interface ListProviderKeysResponse {
+	keys: ModelProviderKey[];
+	total: number;
 }
 
 // BifrostErrorResponse matching Go's schemas.BifrostError

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -437,7 +437,7 @@ export interface PricingOverride {
 	provider_key_id?: string;
 	match_type: PricingOverrideMatchType;
 	pattern: string;
-	request_types?: string[];
+	request_types?: RequestType[];
 	pricing_patch: string;
 	config_hash?: string;
 	created_at: string;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -197,6 +197,7 @@ export const modelProviderKeySchema = z
 		replicate_key_config: replicateKeyConfigSchema.optional(),
 		vllm_key_config: vllmKeyConfigSchema.optional(),
 		use_for_batch_api: z.boolean().optional(),
+		enabled: z.boolean().optional(),
 	})
 	.refine(
 		(data) => {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13617,24 +13617,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/watchpack": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",


### PR DESCRIPTION
## Summary

Migrates the frontend from reading provider keys via `provider.keys` (removed
from provider API response in PR #2160) to the dedicated `getProviderKeys`
query and `/api/keys` endpoint. Removes `keys` from all provider TypeScript
types. Key mutations patch caches from authoritative server responses; provider
updates invalidate the `ProviderKeys` tag to refresh key statuses after model
discovery. Also adds a read-only routing rule info sheet.

## Changes

### Types (`config.ts`, `schemas.ts`)
- Removed `keys` field from `ModelProviderConfig`, `AddProviderRequest`, and
  `UpdateProviderRequest`
- Added `CreateProviderKeyRequest`, `UpdateProviderKeyRequest`,
  `ListProviderKeysResponse` types

### Store (`providersApi.ts`, `baseApi.ts`)
- Added `ProviderKeys` tag type to `baseApi`
- Changed `getProviderKeys`/`getProviderKey` from `Providers` tag to
  `ProviderKeys` tag (avoids invalidating provider cache on key changes)
- Added `invalidatesTags: [ProviderKeys, DBKeys]` on `updateProvider` mutation
  (refreshes key statuses after model discovery)
- Removed `getProvider`/`getProviders` cache patches from `createProviderKey`,
  `updateProviderKey`, `deleteProviderKey` (providers no longer carry keys)
- Added duplicate-check guards on `createProviderKey` cache patches to prevent
  ghost keys
- Each key mutation patches `getProviderKeys` and `getAllKeys` caches from
  authoritative server response

### Components
- **`modelProviderKeysTableView.tsx`**: Already uses `useGetProviderKeysQuery`;
  formatting/indentation fixes
- **`page.tsx`**: Removed `keys: []` from fallback provider object and
  `createProvider` call; simplified `KeyDiscoveryFailedBadge` to only check
  provider-level status (removed per-key status check since keys are no longer
  on provider)
- **`routingRuleSheet.tsx`**: `TargetRow` now receives `allKeys` prop (from
  `useGetAllKeysQuery`) instead of `providersData` with `.keys`; filters keys
  by target provider
- **`routingRuleInfoSheet.tsx`**: New read-only sheet component that displays
  routing rule details (conditions, targets with provider icons and weight bars,
  fallback chain, scope, priority, timestamps)
- **`settingsPanel.tsx`**: Uses `useGetAllKeysQuery` to determine configured
  providers (replaces `p.keys.length > 0` check) and derive
  `providerKeyConfigs` per provider

### Other frontend changes (from prior commit, unchanged)
- Added `getProviderKeys`, `getProviderKey` RTK Query endpoints
- Added `createProviderKey`, `updateProviderKey`, `deleteProviderKey` mutations
- Added `buildProviderUpdatePayload` utility for key-free provider updates
- Migrated `providerKeyForm.tsx` to separate create/update mutations
- Updated `addNewKeySheet.tsx` props from `keyIndex` to `keyId`
- Updated all 6 provider form fragments to use `buildProviderUpdatePayload`
- Removed dead `selectedProvider.keys` sync matchers from `providerSlice.ts`

## Type of change

- [x] Feature
- [x] Refactor
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
cd ui
npm run build
npm run lint
```

Manual testing:

1. Navigate to Providers page, select a provider with keys
2. Verify keys table loads correctly from dedicated API
3. Create a new key — verify it appears immediately (no ghost/duplicate)
4. Toggle enable/disable — verify switch updates immediately
5. Edit a key — verify form pre-populates, save works
6. Delete a key — verify it disappears immediately
7. Update provider settings — verify key statuses refresh after save
8. Check sidebar badge shows provider-level discovery failures
9. Open Playground settings — verify provider/key dropdowns work
10. Open Routing Rules — verify target key selector works
11. Click a routing rule row — verify info sheet opens with correct details
    (conditions, targets, fallbacks, scope, priority)

## Screenshots/Recordings

N/A — no visual changes to existing features; routing rule info sheet is new.

## Breaking changes

- [ ] Yes
- [x] No

Frontend-only changes consuming the new API shape from PR #2160.

## Related issues

N/A

## Security considerations

No new security considerations. Key values continue to be handled through
existing redaction on the backend.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
