### PR TITLE
bedrock: fallback to estimated token count when count-tokens API is unsupported

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -3564,6 +3564,23 @@ func (provider *BedrockProvider) CountTokens(ctx *schemas.BifrostContext, key sc
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
 	if bifrostErr != nil {
+		if isCountTokensUnsupported(bifrostErr) {
+			estimated := estimateTokenCount(jsonData)
+			return &schemas.BifrostCountTokensResponse{
+				Model:       deployment,
+				InputTokens: estimated,
+				TotalTokens: &estimated,
+				Object:      "response.input_tokens",
+				ExtraFields: schemas.BifrostResponseExtraFields{
+					Provider:                providerName,
+					RequestType:             schemas.CountTokensRequest,
+					ModelRequested:          request.Model,
+					ModelDeployment:         deployment,
+					Latency:                 latency.Milliseconds(),
+					ProviderResponseHeaders: providerResponseHeaders,
+				},
+			}, nil
+		}
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 

--- a/core/providers/bedrock/count_tokens.go
+++ b/core/providers/bedrock/count_tokens.go
@@ -1,8 +1,12 @@
 package bedrock
 
 import (
+	"strings"
+
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+const estimatedBytesPerToken = 4
 
 // ToBifrostCountTokensResponse converts a Bedrock count tokens response to Bifrost format
 func (resp *BedrockCountTokensResponse) ToBifrostCountTokensResponse(model string) *schemas.BifrostCountTokensResponse {
@@ -29,4 +33,25 @@ func ToBedrockCountTokensResponse(resp *schemas.BifrostCountTokensResponse) *Bed
 	return &BedrockCountTokensResponse{
 		InputTokens: resp.InputTokens,
 	}
+}
+
+// isCountTokensUnsupported checks whether a BifrostError indicates that the
+// Bedrock model does not support the count-tokens operation.
+func isCountTokensUnsupported(err *schemas.BifrostError) bool {
+	if err == nil || err.Error == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error.Message), "doesn't support counting tokens")
+}
+
+// estimateTokenCount returns a rough token count derived from the byte length
+// of the serialized request body. Claude's tokenizer averages ~4 bytes per
+// token on mixed content; this intentionally rounds up so that context-window
+// management decisions stay on the conservative side.
+func estimateTokenCount(requestBody []byte) int {
+	n := len(requestBody)
+	if n == 0 {
+		return 0
+	}
+	return (n + estimatedBytesPerToken - 1) / estimatedBytesPerToken
 }

--- a/core/providers/bedrock/count_tokens_test.go
+++ b/core/providers/bedrock/count_tokens_test.go
@@ -1,0 +1,105 @@
+package bedrock
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCountTokensUnsupported(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *schemas.BifrostError
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "nil error field",
+			err:      &schemas.BifrostError{},
+			expected: false,
+		},
+		{
+			name: "matching bedrock error message",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Message: "The provided model doesn't support counting tokens.",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "matching message with different casing",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Message: "the provided model DOESN'T SUPPORT COUNTING TOKENS.",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "unrelated error message",
+			err: &schemas.BifrostError{
+				Error: &schemas.ErrorField{
+					Message: "access denied",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isCountTokensUnsupported(tc.err))
+		})
+	}
+}
+
+func TestEstimateTokenCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected int
+	}{
+		{
+			name:     "empty input",
+			input:    []byte{},
+			expected: 0,
+		},
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: 0,
+		},
+		{
+			name:     "exact multiple of 4",
+			input:    make([]byte, 100),
+			expected: 25,
+		},
+		{
+			name:     "rounds up",
+			input:    make([]byte, 101),
+			expected: 26,
+		},
+		{
+			name:     "single byte",
+			input:    []byte("x"),
+			expected: 1,
+		},
+		{
+			name:     "realistic json body",
+			input:    []byte(`{"messages":[{"role":"user","content":"Hello, how are you today?"}],"model":"us.anthropic.claude-sonnet-4-6"}`),
+			expected: 28,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, estimateTokenCount(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Some Bedrock models (e.g. `us.anthropic.claude-sonnet-4-6`) do not support the `count-tokens` API, returning HTTP 400 with `"The provided model doesn't support counting tokens."`. This breaks clients like the Claude Agent SDK that internally call `count_tokens` for context window management — the error is fatal and cannot be caught or disabled on the client side.
- When this specific error is detected, the Bedrock provider now returns an estimated token count derived from the serialized request body size (~4 bytes per token) instead of propagating the error.
- A rough estimate is sufficient since `count_tokens` is used for context management decisions (compaction triggers, context window tracking), not billing.

## Changes

- `core/providers/bedrock/count_tokens.go` — Added `isCountTokensUnsupported()` to detect the specific Bedrock error, and `estimateTokenCount()` to compute a heuristic token count from request body size.
- `core/providers/bedrock/bedrock.go` — Modified `CountTokens` to catch the unsupported error and return an estimated `BifrostCountTokensResponse` instead of failing.
- `core/providers/bedrock/count_tokens_test.go` — Unit tests for both helper functions.

## Test plan

- [x] Unit tests for `isCountTokensUnsupported` (nil cases, matching message, case-insensitive matching, non-matching errors)
- [x] Unit tests for `estimateTokenCount` (empty, nil, exact multiple, rounding up, realistic JSON body)
- [x] Package compiles cleanly
- [ ] Integration test with a Bedrock model that doesn't support count-tokens (manual verification)


Made with [Cursor](https://cursor.com)