### PR TITLE
adds compaction support for anthropic

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -85,6 +85,7 @@ type TestScenarios struct {
 	PassthroughAPI         bool // Raw HTTP passthrough API (Passthrough + PassthroughStream)
 	WebSocketResponses     bool // WebSocket Responses API mode
 	Realtime               bool // Realtime API (bidirectional audio/text)
+	Compaction             bool // Server-side compaction (context management)
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios
@@ -122,6 +123,7 @@ type ComprehensiveTestConfig struct {
 	DisableParallelFor       []string               // Test scenarios to disable parallel execution for (e.g., "Transcription" for rate-limited APIs)
 	ExpectRawRequestResponse bool                   // When true, validate rawRequest/rawResponse in ExtraFields
 	PassthroughModel         string                 // Model for passthrough API tests; defaults to ChatModel when empty
+	CompactionModel          string                 // Model for compaction tests; defaults to claude-sonnet-4-6
 	RealtimeModel            string                 // Model for Realtime API (e.g., "gpt-4o-realtime-preview")
 }
 

--- a/core/internal/llmtests/compaction.go
+++ b/core/internal/llmtests/compaction.go
@@ -1,0 +1,174 @@
+package llmtests
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunCompactionTest tests that context_management with compaction is correctly
+// forwarded through Bifrost via the Responses API.
+//
+// Because compaction requires a minimum trigger of 50,000 input tokens, this
+// test does NOT trigger actual compaction. Instead it verifies:
+//  1. The context_management field survives the Bifrost request round-trip
+//  2. The compact-2026-01-12 beta header is properly sent
+//  3. The API accepts the request without error (non-streaming + streaming)
+func RunCompactionTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.Compaction {
+		t.Logf("Compaction not supported for provider %s", testConfig.Provider)
+		return
+	}
+
+	// Compaction is currently Anthropic-only
+	if testConfig.Provider != schemas.Anthropic {
+		t.Logf("Compaction test skipped: only supported for Anthropic provider")
+		return
+	}
+
+	t.Run("Compaction", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		// Build context_management with compaction config
+		contextManagement := &anthropic.ContextManagement{
+			Edits: []anthropic.ContextManagementEdit{
+				{
+					Type: anthropic.ContextManagementEditTypeCompact,
+					CompactManagementEditConfig: &anthropic.CompactManagementEditConfig{
+						// Use minimum trigger to avoid actual compaction on short input
+						Trigger: &anthropic.CompactManagementEditTypeAndValue{
+							TypeAndValueObject: &anthropic.CompactManagementEditTypeAndValueObject{
+								Type:  "input_tokens",
+								Value: schemas.Ptr(50000),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		messages := []schemas.ResponsesMessage{
+			CreateBasicResponsesMessage("Hello! What is the capital of France? Answer in one word."),
+		}
+
+		// Compaction requires Claude Opus 4.6 or Claude Sonnet 4.6
+		compactionModel := testConfig.CompactionModel
+		if compactionModel == "" {
+			compactionModel = "claude-sonnet-4-6"
+		}
+
+		// --- Non-streaming test ---
+		t.Run("NonStreaming", func(t *testing.T) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			request := &schemas.BifrostResponsesRequest{
+				Provider: testConfig.Provider,
+				Model:    compactionModel,
+				Input:    messages,
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: bifrost.Ptr(100),
+					ExtraParams: map[string]interface{}{
+						"context_management": contextManagement,
+					},
+				},
+				Fallbacks: testConfig.Fallbacks,
+			}
+
+			response, err := client.ResponsesRequest(bfCtx, request)
+			if err != nil {
+				t.Fatalf("Compaction non-streaming request failed: %s", GetErrorMessage(err))
+			}
+			if response == nil {
+				t.Fatal("Expected non-nil response")
+			}
+
+			content := GetResponsesContent(response)
+			if content == "" {
+				t.Error("Expected non-empty response content")
+			}
+
+			// Verify stop_reason is NOT "compaction" (input is too short to trigger)
+			if response.StopReason != nil && *response.StopReason == "compaction" {
+				t.Log("Compaction triggered unexpectedly on short input")
+			}
+
+			t.Logf("Compaction non-streaming passed: stop_reason=%v, content=%s",
+				response.StopReason, content)
+		})
+
+		// --- Streaming test ---
+		t.Run("Streaming", func(t *testing.T) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			request := &schemas.BifrostResponsesRequest{
+				Provider: testConfig.Provider,
+				Model:    compactionModel,
+				Input:    messages,
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: bifrost.Ptr(100),
+					ExtraParams: map[string]interface{}{
+						"context_management": contextManagement,
+					},
+				},
+				Fallbacks: testConfig.Fallbacks,
+			}
+
+			responseChan, err := client.ResponsesStreamRequest(bfCtx, request)
+			if err != nil {
+				t.Fatalf("Compaction streaming request failed: %s", GetErrorMessage(err))
+			}
+
+			var fullContent strings.Builder
+			var chunkCount int
+			var hasCreated, hasCompleted bool
+
+			streamCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			defer cancel()
+
+			for {
+				select {
+				case chunk, ok := <-responseChan:
+					if !ok {
+						goto done
+					}
+					chunkCount++
+					if chunk.BifrostResponsesStreamResponse != nil {
+						if chunk.BifrostResponsesStreamResponse.Type == schemas.ResponsesStreamResponseTypeCreated {
+							hasCreated = true
+						}
+						if chunk.BifrostResponsesStreamResponse.Type == schemas.ResponsesStreamResponseTypeCompleted {
+							hasCompleted = true
+						}
+						if chunk.BifrostResponsesStreamResponse.Delta != nil {
+							fullContent.WriteString(*chunk.BifrostResponsesStreamResponse.Delta)
+						}
+					}
+				case <-streamCtx.Done():
+					t.Fatal("Streaming timed out")
+				}
+			}
+		done:
+
+			if chunkCount == 0 {
+				t.Fatal("Expected at least one streaming chunk")
+			}
+			if !hasCreated {
+				t.Error("Missing response.created event")
+			}
+			if !hasCompleted {
+				t.Error("Missing response.completed event")
+			}
+
+			content := fullContent.String()
+			t.Logf("Compaction streaming passed: %d chunks, content=%s", chunkCount, content)
+		})
+	})
+}

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -117,6 +117,7 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunPassthroughAPITest,
 		RunWebSocketResponsesTest,
 		RunRealtimeTest,
+		RunCompactionTest,
 	}
 
 	// Execute all test scenarios without raw request/response (default behavior)
@@ -233,6 +234,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"PassthroughAPI", testConfig.Scenarios.PassthroughAPI},
 		{"WebSocketResponses", testConfig.Scenarios.WebSocketResponses && testConfig.ChatModel != ""},
 		{"Realtime", testConfig.Scenarios.Realtime && testConfig.RealtimeModel != ""},
+		{"Compaction", testConfig.Scenarios.Compaction},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1270,6 +1270,29 @@ func HandleAnthropicResponsesStream(
 				providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, bifrostErr, responseChan, logger)
 				break
 			}
+			// Passthrough: when conversion returns no responses but we need to forward raw events,
+			// create a minimal pass-through response to carry the raw event data.
+			// This ensures events like compaction content_block_start/stop are not silently dropped.
+			if len(responses) == 0 && sendBackRawResponse {
+				passthroughResp := &schemas.BifrostResponsesStreamResponse{
+					Type:           schemas.ResponsesStreamResponseType(eventType),
+					SequenceNumber: chunkIndex,
+					ExtraFields: schemas.BifrostResponseExtraFields{
+						RequestType:    schemas.ResponsesStreamRequest,
+						Provider:       providerName,
+						ModelRequested: modelName,
+						ChunkIndex:     chunkIndex,
+						Latency:        time.Since(lastChunkTime).Milliseconds(),
+						RawResponse:    eventData,
+					},
+				}
+				lastChunkTime = time.Now()
+				chunkIndex++
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner,
+					providerUtils.GetBifrostResponseForStreamResponse(nil, nil, passthroughResp, nil, nil, nil),
+					responseChan)
+				continue
+			}
 			// Handle each response in the slice
 			for i, response := range responses {
 				if response != nil {

--- a/core/providers/anthropic/anthropic_test.go
+++ b/core/providers/anthropic/anthropic_test.go
@@ -69,6 +69,7 @@ func TestAnthropic(t *testing.T) {
 			CountTokens:           true,
 			StructuredOutputs:     true, // Structured outputs with nullable enum support
 			PassthroughAPI:        true,
+			Compaction:            true,
 		},
 	}
 

--- a/core/providers/anthropic/compaction_test.go
+++ b/core/providers/anthropic/compaction_test.go
@@ -1,0 +1,703 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// --- isCompactionItem tests ---
+
+func TestIsCompactionItem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		item     *schemas.ResponsesMessage
+		expected bool
+	}{
+		{
+			name:     "nil item",
+			item:     nil,
+			expected: false,
+		},
+		{
+			name: "nil type",
+			item: &schemas.ResponsesMessage{
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{Type: schemas.ResponsesOutputMessageContentTypeCompaction},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "message type with compaction content block",
+			item: &schemas.ResponsesMessage{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeCompaction,
+							ResponsesOutputMessageContentCompaction: &schemas.ResponsesOutputMessageContentCompaction{
+								Summary: "Summary of conversation",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "message type with text content block",
+			item: &schemas.ResponsesMessage{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{
+						{
+							Type: schemas.ResponsesOutputMessageContentTypeText,
+							Text: schemas.Ptr("Hello"),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "function call type",
+			item: &schemas.ResponsesMessage{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+			},
+			expected: false,
+		},
+		{
+			name: "message type with nil content",
+			item: &schemas.ResponsesMessage{
+				Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Content: nil,
+			},
+			expected: false,
+		},
+		{
+			name: "message type with empty content blocks",
+			item: &schemas.ResponsesMessage{
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Content: &schemas.ResponsesMessageContent{
+					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCompactionItem(tt.item)
+			if result != tt.expected {
+				t.Errorf("isCompactionItem() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+// --- Streaming: Anthropic → Bifrost (inbound) ---
+
+func TestToBifrostResponsesStream_CompactionContentBlockStart(t *testing.T) {
+	t.Parallel()
+
+	state := &AnthropicResponsesStreamState{
+		ContentIndexToOutputIndex: make(map[int]int),
+		ContentIndexToBlockType:   make(map[int]AnthropicContentBlockType),
+		ToolArgumentBuffers:       make(map[int]string),
+		MCPCallOutputIndices:      make(map[int]bool),
+		ItemIDs:                   make(map[int]string),
+		OutputItems:               make(map[int]*schemas.ResponsesMessage),
+		ReasoningSignatures:       make(map[int]string),
+		TextContentIndices:        make(map[int]bool),
+		ReasoningContentIndices:   make(map[int]bool),
+		CompactionContentIndices:  make(map[int]*schemas.CacheControl),
+		CurrentOutputIndex:        0,
+		CreatedAt:                 1234567890,
+		HasEmittedCreated:         true,
+		HasEmittedInProgress:      true,
+	}
+
+	// content_block_start with compaction type should return nil (defers to delta)
+	chunk := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: schemas.Ptr(0),
+		ContentBlock: &AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeCompaction,
+			CacheControl: &schemas.CacheControl{
+				Type: "ephemeral",
+			},
+		},
+	}
+
+	responses, err, isLast := chunk.ToBifrostResponsesStream(context.Background(), 0, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isLast {
+		t.Error("should not be last chunk")
+	}
+	if len(responses) != 0 {
+		t.Errorf("expected 0 responses for compaction content_block_start, got %d", len(responses))
+	}
+
+	// Verify state was tracked
+	if _, exists := state.CompactionContentIndices[0]; !exists {
+		t.Error("expected compaction to be tracked in CompactionContentIndices")
+	}
+	if blockType, exists := state.ContentIndexToBlockType[0]; !exists || blockType != AnthropicContentBlockTypeCompaction {
+		t.Error("expected compaction block type tracked in ContentIndexToBlockType")
+	}
+}
+
+func TestToBifrostResponsesStream_CompactionDelta(t *testing.T) {
+	t.Parallel()
+
+	state := &AnthropicResponsesStreamState{
+		ContentIndexToOutputIndex: map[int]int{0: 0},
+		ContentIndexToBlockType:   map[int]AnthropicContentBlockType{0: AnthropicContentBlockTypeCompaction},
+		ToolArgumentBuffers:       make(map[int]string),
+		MCPCallOutputIndices:      make(map[int]bool),
+		ItemIDs:                   map[int]string{0: "cmp_0"},
+		OutputItems:               make(map[int]*schemas.ResponsesMessage),
+		ReasoningSignatures:       make(map[int]string),
+		TextContentIndices:        make(map[int]bool),
+		ReasoningContentIndices:   make(map[int]bool),
+		CompactionContentIndices:  map[int]*schemas.CacheControl{0: {Type: "ephemeral"}},
+		CurrentOutputIndex:        1,
+		CreatedAt:                 1234567890,
+		HasEmittedCreated:         true,
+		HasEmittedInProgress:      true,
+	}
+
+	summary := "The user asked about building a website. We discussed HTML, CSS, and JavaScript."
+	chunk := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockDelta,
+		Index: schemas.Ptr(0),
+		Delta: &AnthropicStreamDelta{
+			Type:    AnthropicStreamDeltaTypeCompaction,
+			Content: &summary,
+		},
+	}
+
+	responses, err, isLast := chunk.ToBifrostResponsesStream(context.Background(), 0, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isLast {
+		t.Error("should not be last chunk")
+	}
+
+	// Should emit output_item.added and output_item.done
+	if len(responses) != 2 {
+		t.Fatalf("expected 2 responses for compaction delta, got %d", len(responses))
+	}
+
+	// First: output_item.added
+	added := responses[0]
+	if added.Type != schemas.ResponsesStreamResponseTypeOutputItemAdded {
+		t.Errorf("first response type = %v, want %v", added.Type, schemas.ResponsesStreamResponseTypeOutputItemAdded)
+	}
+	if added.Item == nil || added.Item.Content == nil || len(added.Item.Content.ContentBlocks) == 0 {
+		t.Fatal("output_item.added should have content blocks")
+	}
+	block := added.Item.Content.ContentBlocks[0]
+	if block.Type != schemas.ResponsesOutputMessageContentTypeCompaction {
+		t.Errorf("content block type = %v, want compaction", block.Type)
+	}
+	if block.ResponsesOutputMessageContentCompaction == nil {
+		t.Fatal("expected compaction content to be non-nil")
+	}
+	if block.ResponsesOutputMessageContentCompaction.Summary != summary {
+		t.Errorf("summary = %q, want %q", block.ResponsesOutputMessageContentCompaction.Summary, summary)
+	}
+	// Cache control should be preserved from content_block_start
+	if block.CacheControl == nil || block.CacheControl.Type != "ephemeral" {
+		t.Error("expected cache control to be preserved")
+	}
+
+	// Second: output_item.done
+	done := responses[1]
+	if done.Type != schemas.ResponsesStreamResponseTypeOutputItemDone {
+		t.Errorf("second response type = %v, want %v", done.Type, schemas.ResponsesStreamResponseTypeOutputItemDone)
+	}
+}
+
+func TestToBifrostResponsesStream_CompactionContentBlockStop(t *testing.T) {
+	t.Parallel()
+
+	state := &AnthropicResponsesStreamState{
+		ContentIndexToOutputIndex: map[int]int{0: 0},
+		ContentIndexToBlockType:   map[int]AnthropicContentBlockType{0: AnthropicContentBlockTypeCompaction},
+		ToolArgumentBuffers:       make(map[int]string),
+		MCPCallOutputIndices:      make(map[int]bool),
+		ItemIDs:                   map[int]string{0: "cmp_0"},
+		OutputItems:               make(map[int]*schemas.ResponsesMessage),
+		ReasoningSignatures:       make(map[int]string),
+		TextContentIndices:        make(map[int]bool),
+		ReasoningContentIndices:   make(map[int]bool),
+		CompactionContentIndices:  make(map[int]*schemas.CacheControl),
+		CurrentOutputIndex:        1,
+		CreatedAt:                 1234567890,
+		HasEmittedCreated:         true,
+		HasEmittedInProgress:      true,
+	}
+
+	chunk := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: schemas.Ptr(0),
+	}
+
+	responses, err, isLast := chunk.ToBifrostResponsesStream(context.Background(), 0, state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if isLast {
+		t.Error("should not be last chunk")
+	}
+	// content_block_stop for compaction should return nil (done was already emitted with delta)
+	if len(responses) != 0 {
+		t.Errorf("expected 0 responses for compaction content_block_stop, got %d", len(responses))
+	}
+}
+
+// --- Streaming: Bifrost → Anthropic (outbound, non-passthrough) ---
+
+func TestToAnthropicResponsesStreamResponse_CompactionOutputItemAdded(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	summary := "Summary of the conversation about building a website"
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+		OutputIndex: schemas.Ptr(0),
+		Item: &schemas.ResponsesMessage{
+			ID:     schemas.Ptr("cmp_test123"),
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Status: schemas.Ptr("completed"),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
+						Type: schemas.ResponsesOutputMessageContentTypeCompaction,
+						ResponsesOutputMessageContentCompaction: &schemas.ResponsesOutputMessageContentCompaction{
+							Summary: summary,
+						},
+						CacheControl: &schemas.CacheControl{Type: "ephemeral"},
+					},
+				},
+			},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+
+	// Should emit: content_block_start (compaction) + content_block_delta (compaction_delta)
+	if len(events) < 2 {
+		t.Fatalf("expected at least 2 events, got %d", len(events))
+	}
+
+	// Event 1: content_block_start
+	start := events[0]
+	if start.Type != AnthropicStreamEventTypeContentBlockStart {
+		t.Errorf("event[0] type = %v, want content_block_start", start.Type)
+	}
+	if start.ContentBlock == nil {
+		t.Fatal("content_block_start should have ContentBlock")
+	}
+	if start.ContentBlock.Type != AnthropicContentBlockTypeCompaction {
+		t.Errorf("ContentBlock.Type = %v, want compaction", start.ContentBlock.Type)
+	}
+	if start.ContentBlock.CacheControl == nil || start.ContentBlock.CacheControl.Type != "ephemeral" {
+		t.Error("expected cache control to be preserved on content_block_start")
+	}
+
+	// Event 2: content_block_delta with compaction_delta
+	delta := events[1]
+	if delta.Type != AnthropicStreamEventTypeContentBlockDelta {
+		t.Errorf("event[1] type = %v, want content_block_delta", delta.Type)
+	}
+	if delta.Delta == nil {
+		t.Fatal("content_block_delta should have Delta")
+	}
+	if delta.Delta.Type != AnthropicStreamDeltaTypeCompaction {
+		t.Errorf("Delta.Type = %v, want compaction_delta", delta.Delta.Type)
+	}
+	if delta.Delta.Content == nil || *delta.Delta.Content != summary {
+		t.Errorf("Delta.Content = %v, want %q", delta.Delta.Content, summary)
+	}
+}
+
+func TestToAnthropicResponsesStreamResponse_CompactionOutputItemDone(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+		OutputIndex: schemas.Ptr(0),
+		ItemID:      schemas.Ptr("cmp_test123"),
+		Item: &schemas.ResponsesMessage{
+			ID:     schemas.Ptr("cmp_test123"),
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Status: schemas.Ptr("completed"),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
+						Type: schemas.ResponsesOutputMessageContentTypeCompaction,
+						ResponsesOutputMessageContentCompaction: &schemas.ResponsesOutputMessageContentCompaction{
+							Summary: "Summary text",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+
+	// Should emit content_block_stop
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event for output_item.done, got %d", len(events))
+	}
+
+	stop := events[0]
+	if stop.Type != AnthropicStreamEventTypeContentBlockStop {
+		t.Errorf("event type = %v, want content_block_stop", stop.Type)
+	}
+}
+
+func TestToAnthropicResponsesStreamResponse_TextOutputItemAdded_NotAffectedByCompactionCheck(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	// Regular text message should still emit content_block_start with type=text
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+		OutputIndex: schemas.Ptr(0),
+		Item: &schemas.ResponsesMessage{
+			ID:     schemas.Ptr("msg_test123"),
+			Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Status: schemas.Ptr("in_progress"),
+			Role:   schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
+						Type: schemas.ResponsesOutputMessageContentTypeText,
+						Text: schemas.Ptr(""),
+					},
+				},
+			},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+	if len(events) == 0 {
+		t.Fatal("expected at least 1 event")
+	}
+
+	start := events[0]
+	if start.Type != AnthropicStreamEventTypeContentBlockStart {
+		t.Errorf("event type = %v, want content_block_start", start.Type)
+	}
+	if start.ContentBlock == nil {
+		t.Fatal("expected ContentBlock to be non-nil")
+	}
+	if start.ContentBlock.Type != AnthropicContentBlockTypeText {
+		t.Errorf("ContentBlock.Type = %v, want text", start.ContentBlock.Type)
+	}
+}
+
+// --- Non-Streaming: stop_reason mapping ---
+
+func TestToBifrostResponsesResponse_PreservesStopReason(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		stopReason         AnthropicStopReason
+		expectedStopReason string
+	}{
+		{
+			name:               "compaction stop reason",
+			stopReason:         AnthropicStopReasonCompaction,
+			expectedStopReason: "compaction",
+		},
+		{
+			name:               "end_turn stop reason",
+			stopReason:         AnthropicStopReasonEndTurn,
+			expectedStopReason: "end_turn",
+		},
+		{
+			name:               "tool_use stop reason",
+			stopReason:         AnthropicStopReasonToolUse,
+			expectedStopReason: "tool_use",
+		},
+		{
+			name:               "max_tokens stop reason",
+			stopReason:         AnthropicStopReasonMaxTokens,
+			expectedStopReason: "max_tokens",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+			defer cancel()
+
+			resp := &AnthropicMessageResponse{
+				ID:         "msg_test",
+				Type:       "message",
+				Role:       "assistant",
+				Model:      "claude-sonnet-4-6",
+				StopReason: tt.stopReason,
+				Content: []AnthropicContentBlock{
+					{Type: AnthropicContentBlockTypeText, Text: schemas.Ptr("Hello")},
+				},
+			}
+
+			bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+
+			if bifrostResp.StopReason == nil {
+				t.Fatal("expected StopReason to be non-nil")
+			}
+			if *bifrostResp.StopReason != tt.expectedStopReason {
+				t.Errorf("StopReason = %q, want %q", *bifrostResp.StopReason, tt.expectedStopReason)
+			}
+		})
+	}
+}
+
+func TestToBifrostResponsesResponse_EmptyStopReason(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	resp := &AnthropicMessageResponse{
+		ID:      "msg_test",
+		Type:    "message",
+		Role:    "assistant",
+		Model:   "claude-sonnet-4-6",
+		Content: []AnthropicContentBlock{},
+	}
+
+	bifrostResp := resp.ToBifrostResponsesResponse(ctx)
+
+	if bifrostResp.StopReason != nil {
+		t.Errorf("expected nil StopReason for empty stop_reason, got %q", *bifrostResp.StopReason)
+	}
+}
+
+func TestToAnthropicResponsesResponse_StopReasonFromBifrost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		stopReason     *string
+		contentBlocks  []schemas.ResponsesMessage
+		expectedReason AnthropicStopReason
+	}{
+		{
+			name:           "compaction stop reason from bifrost",
+			stopReason:     schemas.Ptr("compaction"),
+			expectedReason: AnthropicStopReasonCompaction,
+		},
+		{
+			name:           "end_turn mapped from stop",
+			stopReason:     schemas.Ptr("stop"),
+			expectedReason: AnthropicStopReasonEndTurn,
+		},
+		{
+			name:           "tool_use mapped from tool_calls",
+			stopReason:     schemas.Ptr("tool_calls"),
+			expectedReason: AnthropicStopReasonToolUse,
+		},
+		{
+			name:       "nil stop_reason defaults to end_turn",
+			stopReason: nil,
+			expectedReason: AnthropicStopReasonEndTurn,
+		},
+		{
+			name:       "nil stop_reason with tool_use content defaults to tool_use",
+			stopReason: nil,
+			contentBlocks: []schemas.ResponsesMessage{
+				{
+					Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: schemas.Ptr("call_123"),
+						Name:   schemas.Ptr("my_tool"),
+					},
+				},
+			},
+			expectedReason: AnthropicStopReasonToolUse,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+			defer cancel()
+
+			bifrostResp := &schemas.BifrostResponsesResponse{
+				ID:         schemas.Ptr("resp_test"),
+				Model:      "claude-sonnet-4-6",
+				StopReason: tt.stopReason,
+				Output:     tt.contentBlocks,
+			}
+
+			result := ToAnthropicResponsesResponse(ctx, bifrostResp)
+
+			if result.StopReason != tt.expectedReason {
+				t.Errorf("StopReason = %v, want %v", result.StopReason, tt.expectedReason)
+			}
+		})
+	}
+}
+
+// --- Non-Streaming: compaction content block round-trip ---
+
+func TestCompactionContentBlock_NonStreamingRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	summary := "The user requested help building a web scraper using Python with BeautifulSoup."
+
+	// Simulate Anthropic response with compaction block
+	anthropicResp := &AnthropicMessageResponse{
+		ID:         "msg_compaction_test",
+		Type:       "message",
+		Role:       "assistant",
+		Model:      "claude-opus-4-6",
+		StopReason: AnthropicStopReasonCompaction,
+		Content: []AnthropicContentBlock{
+			{
+				Type: AnthropicContentBlockTypeCompaction,
+				Content: &AnthropicContent{
+					ContentStr: &summary,
+				},
+				CacheControl: &schemas.CacheControl{Type: "ephemeral"},
+			},
+		},
+	}
+
+	// Step 1: Anthropic → Bifrost
+	bifrostResp := anthropicResp.ToBifrostResponsesResponse(ctx)
+
+	if bifrostResp.StopReason == nil || *bifrostResp.StopReason != "compaction" {
+		t.Fatalf("expected stop_reason='compaction', got %v", bifrostResp.StopReason)
+	}
+	if len(bifrostResp.Output) == 0 {
+		t.Fatal("expected at least one output message")
+	}
+
+	// Find the compaction block
+	var foundCompaction bool
+	for _, msg := range bifrostResp.Output {
+		if msg.Content != nil {
+			for _, block := range msg.Content.ContentBlocks {
+				if block.Type == schemas.ResponsesOutputMessageContentTypeCompaction {
+					foundCompaction = true
+					if block.ResponsesOutputMessageContentCompaction == nil {
+						t.Fatal("expected compaction content to be non-nil")
+					}
+					if block.ResponsesOutputMessageContentCompaction.Summary != summary {
+						t.Errorf("summary = %q, want %q", block.ResponsesOutputMessageContentCompaction.Summary, summary)
+					}
+				}
+			}
+		}
+	}
+	if !foundCompaction {
+		t.Error("compaction block not found in Bifrost output")
+	}
+
+	// Step 2: Bifrost → Anthropic
+	result := ToAnthropicResponsesResponse(ctx, bifrostResp)
+
+	if result.StopReason != AnthropicStopReasonCompaction {
+		t.Errorf("result StopReason = %v, want compaction", result.StopReason)
+	}
+
+	// Find compaction content block in result
+	var foundResultCompaction bool
+	for _, block := range result.Content {
+		if block.Type == AnthropicContentBlockTypeCompaction {
+			foundResultCompaction = true
+			if block.Content == nil || block.Content.ContentStr == nil {
+				t.Fatal("expected compaction content string")
+			}
+			if *block.Content.ContentStr != summary {
+				t.Errorf("result summary = %q, want %q", *block.Content.ContentStr, summary)
+			}
+			if block.CacheControl == nil || block.CacheControl.Type != "ephemeral" {
+				t.Error("expected cache control to be preserved")
+			}
+		}
+	}
+	if !foundResultCompaction {
+		t.Error("compaction block not found in Anthropic result")
+	}
+}
+
+// --- Streaming: compaction stop_reason in response.completed ---
+
+func TestToAnthropicResponsesStreamResponse_CompletedWithCompactionStopReason(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	bifrostResp := &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeCompleted,
+		Response: &schemas.BifrostResponsesResponse{
+			ID:         schemas.Ptr("resp_test"),
+			Model:      "claude-opus-4-6",
+			StopReason: schemas.Ptr("compaction"),
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  1000,
+				OutputTokens: 500,
+				TotalTokens:  1500,
+			},
+		},
+	}
+
+	events := ToAnthropicResponsesStreamResponse(ctx, bifrostResp)
+
+	// Should emit message_delta + message_stop
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events for response.completed, got %d", len(events))
+	}
+
+	// message_delta should have stop_reason=compaction
+	messageDelta := events[0]
+	if messageDelta.Type != AnthropicStreamEventTypeMessageDelta {
+		t.Errorf("event[0] type = %v, want message_delta", messageDelta.Type)
+	}
+	if messageDelta.Delta == nil || messageDelta.Delta.StopReason == nil {
+		t.Fatal("expected Delta.StopReason in message_delta")
+	}
+	if *messageDelta.Delta.StopReason != AnthropicStopReasonCompaction {
+		t.Errorf("StopReason = %v, want compaction", *messageDelta.Delta.StopReason)
+	}
+
+	// message_stop
+	messageStop := events[1]
+	if messageStop.Type != AnthropicStreamEventTypeMessageStop {
+		t.Errorf("event[1] type = %v, want message_stop", messageStop.Type)
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -196,6 +196,15 @@ func (state *AnthropicResponsesStreamState) flush() {
 	state.StructuredOutputIndex = nil
 }
 
+// isCompactionItem checks if a ResponsesMessage represents a compaction item
+// (a message with a compaction content block as its first content block)
+func isCompactionItem(item *schemas.ResponsesMessage) bool {
+	return item != nil && item.Type != nil &&
+		*item.Type == schemas.ResponsesMessageTypeMessage &&
+		item.Content != nil && len(item.Content.ContentBlocks) > 0 &&
+		item.Content.ContentBlocks[0].Type == schemas.ResponsesOutputMessageContentTypeCompaction
+}
+
 // getOrCreateOutputIndex returns the output index for a given content index, creating a new one if needed
 func (state *AnthropicResponsesStreamState) getOrCreateOutputIndex(contentIndex *int) int {
 	if contentIndex == nil {
@@ -1468,7 +1477,15 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			// Build content_block based on item type
 			if bifrostResp.Item != nil {
 				contentBlock := &AnthropicContentBlock{}
-				if bifrostResp.Item.Type != nil {
+
+				// Check if this is a compaction item (message with compaction content block)
+				if isCompactionItem(bifrostResp.Item) {
+					contentBlock.Type = AnthropicContentBlockTypeCompaction
+					contentBlock.Content = &AnthropicContent{ContentStr: schemas.Ptr("")}
+					if bifrostResp.Item.Content.ContentBlocks[0].CacheControl != nil {
+						contentBlock.CacheControl = bifrostResp.Item.Content.ContentBlocks[0].CacheControl
+					}
+				} else if bifrostResp.Item.Type != nil {
 					switch *bifrostResp.Item.Type {
 					case schemas.ResponsesMessageTypeMessage:
 						contentBlock.Type = AnthropicContentBlockTypeText
@@ -1562,6 +1579,27 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		// Generate synthetic input_json_delta events for tool calls with arguments
 		var events []*AnthropicStreamEvent
 		events = append(events, streamResp)
+
+		// Generate compaction_delta event for compaction items
+		if isCompactionItem(bifrostResp.Item) {
+			block := bifrostResp.Item.Content.ContentBlocks[0]
+			if block.ResponsesOutputMessageContentCompaction != nil {
+				var indexToUse *int
+				if bifrostResp.OutputIndex != nil {
+					indexToUse = bifrostResp.OutputIndex
+				} else if bifrostResp.ContentIndex != nil {
+					indexToUse = bifrostResp.ContentIndex
+				}
+				events = append(events, &AnthropicStreamEvent{
+					Type:  AnthropicStreamEventTypeContentBlockDelta,
+					Index: indexToUse,
+					Delta: &AnthropicStreamDelta{
+						Type:    AnthropicStreamDeltaTypeCompaction,
+						Content: &block.ResponsesOutputMessageContentCompaction.Summary,
+					},
+				})
+			}
+		}
 
 		// Check if this is a tool call with arguments that need to be streamed
 		if bifrostResp.Item != nil && bifrostResp.Item.ResponsesToolMessage != nil {
@@ -2566,6 +2604,11 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 
 	bifrostResp.Model = response.Model
 
+	// Preserve stop reason from Anthropic response
+	if response.StopReason != "" {
+		bifrostResp.StopReason = schemas.Ptr(string(response.StopReason))
+	}
+
 	return bifrostResp
 }
 
@@ -2605,14 +2648,16 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 		anthropicResp.Content = []AnthropicContentBlock{}
 	}
 
-	// Set default stop reason - could be enhanced based on additional context
-	anthropicResp.StopReason = AnthropicStopReasonEndTurn
-
-	// Check if there are tool calls to set appropriate stop reason
-	for _, block := range contentBlocks {
-		if block.Type == AnthropicContentBlockTypeToolUse {
-			anthropicResp.StopReason = AnthropicStopReasonToolUse
-			break
+	// Map stop reason from Bifrost response if available, otherwise infer from content
+	if bifrostResp.StopReason != nil {
+		anthropicResp.StopReason = ConvertBifrostFinishReasonToAnthropic(*bifrostResp.StopReason)
+	} else {
+		anthropicResp.StopReason = AnthropicStopReasonEndTurn
+		for _, block := range contentBlocks {
+			if block.Type == AnthropicContentBlockTypeToolUse {
+				anthropicResp.StopReason = AnthropicStopReasonToolUse
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds support for compaction content blocks in Anthropic streaming responses by implementing passthrough handling for raw events and proper conversion logic for compaction items.

## Changes

- Added passthrough response creation when conversion returns no responses but raw events need forwarding, preventing silent dropping of compaction events
- Implemented `isCompactionItem` helper function to identify messages containing compaction content blocks
- Enhanced `ToAnthropicResponsesStreamResponse` to handle compaction items by creating appropriate content blocks and generating compaction_delta events
- Added stop reason preservation from Anthropic responses to Bifrost responses and improved stop reason mapping logic

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with compaction content blocks to ensure events are properly forwarded and converted:

```sh
# Core/Transports
go version
go test ./...

# Test specifically with Anthropic provider streaming responses containing compaction blocks
# Verify that compaction_delta events are generated and raw events are not dropped
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects response processing and event forwarding logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable