### PR TITLE
feat: add custom JSON unmarshaling for MCP duration fields and update config schema

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -5,7 +5,9 @@ package schemas
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -57,6 +59,83 @@ const (
 	DefaultMaxAgentDepth        = 10
 	DefaultToolExecutionTimeout = 30 * time.Second
 )
+
+// parseMCPDurationJSON parses a JSON duration value that is either a Go duration
+// string (e.g. "10m", "1h30m") or, as a fallback, an integer number of nanoseconds.
+func parseMCPDurationJSON(raw json.RawMessage) (time.Duration, error) {
+	var s string
+	if sonic.Unmarshal(raw, &s) == nil {
+		return time.ParseDuration(s)
+	}
+	var n int64
+	if err := sonic.Unmarshal(raw, &n); err != nil {
+		return 0, fmt.Errorf("expected Go duration string (e.g. \"10m\") or integer nanoseconds, got %s", string(raw))
+	}
+	return time.Duration(n), nil
+}
+
+// UnmarshalJSON implements custom JSON decoding for MCPConfig, handling
+// tool_sync_interval as a Go duration string (e.g. "10m", "1h").
+func (c *MCPConfig) UnmarshalJSON(data []byte) error {
+	type Alias MCPConfig
+	aux := &struct {
+		ToolSyncInterval json.RawMessage `json:"tool_sync_interval,omitempty"`
+		*Alias
+	}{Alias: (*Alias)(c)}
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.ToolSyncInterval) > 0 {
+		d, err := parseMCPDurationJSON(aux.ToolSyncInterval)
+		if err != nil {
+			return fmt.Errorf("invalid tool_sync_interval: %w", err)
+		}
+		c.ToolSyncInterval = d
+	}
+	return nil
+}
+
+// UnmarshalJSON implements custom JSON decoding for MCPClientConfig, handling
+// tool_sync_interval as a Go duration string (e.g. "10m", "1h").
+func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
+	type Alias MCPClientConfig
+	aux := &struct {
+		ToolSyncInterval json.RawMessage `json:"tool_sync_interval,omitempty"`
+		*Alias
+	}{Alias: (*Alias)(c)}
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.ToolSyncInterval) > 0 {
+		d, err := parseMCPDurationJSON(aux.ToolSyncInterval)
+		if err != nil {
+			return fmt.Errorf("invalid tool_sync_interval: %w", err)
+		}
+		c.ToolSyncInterval = d
+	}
+	return nil
+}
+
+// UnmarshalJSON implements custom JSON decoding for MCPToolManagerConfig, handling
+// tool_execution_timeout as an integer number of seconds (as documented in the schema).
+func (c *MCPToolManagerConfig) UnmarshalJSON(data []byte) error {
+	type Alias MCPToolManagerConfig
+	aux := &struct {
+		ToolExecutionTimeout json.RawMessage `json:"tool_execution_timeout,omitempty"`
+		*Alias
+	}{Alias: (*Alias)(c)}
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.ToolExecutionTimeout) > 0 {
+		var seconds int64
+		if err := sonic.Unmarshal(aux.ToolExecutionTimeout, &seconds); err != nil {
+			return fmt.Errorf("invalid tool_execution_timeout: expected integer (seconds): %w", err)
+		}
+		c.ToolExecutionTimeout = time.Duration(seconds) * time.Second
+	}
+	return nil
+}
 
 // CodeModeBindingLevel defines how tools are exposed in the VFS for code execution
 type CodeModeBindingLevel string

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -75,7 +75,7 @@
         },
         "enforce_governance_header": {
           "type": "boolean",
-          "description": "Enforce governance header. This will require every incoming request to include x-bf-vk header."
+          "description": "Deprecated: use enforce_auth_on_inference instead. Enforce governance header. This will require every incoming request to include x-bf-vk header."
         },
         "enforce_auth_on_inference": {
           "type": "boolean",
@@ -1551,7 +1551,7 @@
     },
     "virtual_key_mcp_config": {
       "type": "object",
-      "description": "MCP configuration for a virtual key",
+      "description": "MCP configuration for a virtual key. Exactly one of mcp_client_id or mcp_client_name must be provided.",
       "properties": {
         "id": {
           "type": "integer",
@@ -1563,7 +1563,11 @@
         },
         "mcp_client_id": {
           "type": "integer",
-          "description": "Associated MCP client ID"
+          "description": "Associated MCP client ID (use this or mcp_client_name)"
+        },
+        "mcp_client_name": {
+          "type": "string",
+          "description": "MCP client name (config file alternative to mcp_client_id; resolved to mcp_client_id at load time)"
         },
         "tools_to_execute": {
           "type": "array",
@@ -1573,9 +1577,6 @@
           }
         }
       },
-      "required": [
-        "mcp_client_id"
-      ],
       "additionalProperties": false
     },
     "auth_config": {


### PR DESCRIPTION
## Summary

Enhances MCP (Model Context Protocol) configuration handling by adding custom JSON unmarshaling for duration fields and improves the configuration schema with better validation and documentation.

## Changes

- Added custom JSON unmarshaling for `MCPConfig`, `MCPClientConfig`, and `MCPToolManagerConfig` to handle duration fields properly
- `tool_sync_interval` now accepts Go duration strings (e.g. "10m", "1h30m") with fallback to nanosecond integers
- `tool_execution_timeout` accepts integer seconds as documented in the schema
- Enhanced virtual key MCP configuration to support both `mcp_client_id` and `mcp_client_name` options
- Deprecated `enforce_governance_header` in favor of `enforce_auth_on_inference`
- Removed provider-level pricing overrides from multiple provider configurations
- Consolidated pricing override definitions and added enum validation for request types
- Improved schema descriptions and validation rules

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

## How to test

Validate MCP configuration parsing with duration strings:

```sh
# Test Go duration parsing
go test ./core/schemas -v -run TestMCP

# Test schema validation
go test ./transports -v -run TestConfig
```

Test configuration files with the new duration format:
```json
{
  "mcp": {
    "tool_sync_interval": "10m",
    "tool_execution_timeout": 30
  }
}
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes

The `virtual_key_mcp_config` no longer requires `mcp_client_id` as a mandatory field since `mcp_client_name` can be used as an alternative. Provider-level pricing overrides have been removed from provider configurations.

## Related issues

N/A

## Security considerations

No security implications - this change only affects configuration parsing and validation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable