### PR TITLE
adds missing plugin order and placement to helm

### DIFF
--- a/.github/workflows/scripts/validate-go-config-fields.sh
+++ b/.github/workflows/scripts/validate-go-config-fields.sh
@@ -175,6 +175,13 @@ compare_struct_to_schema \
   "state" \
   "config_hash"
 
+# PluginConfig — core/schemas/plugin.go → .properties.plugins.items.properties
+compare_struct_to_schema \
+  "Plugin Config" \
+  "$REPO_ROOT/core/schemas/plugin.go" \
+  "PluginConfig" \
+  '.properties.plugins.items.properties'
+
 # Summary
 echo ""
 echo "========================================================"

--- a/.github/workflows/scripts/validate-helm-schema.sh
+++ b/.github/workflows/scripts/validate-helm-schema.sh
@@ -558,6 +558,36 @@ else
   echo "✅ Plugin items required fields match: [$CONFIG_PLUGIN_ITEMS_REQUIRED]"
 fi
 
+# Check plugin item properties completeness (all config properties must exist in helm custom items)
+echo ""
+echo "🔍 Checking plugin item property completeness..."
+
+CONFIG_PLUGIN_PROPS=$(jq -r '.properties.plugins.items.properties | keys | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_CUSTOM_PLUGIN_PROPS=$(jq -r '.properties.bifrost.properties.plugins.properties.custom.items.properties | keys | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+# Check each config property exists in helm custom items
+for prop in $(echo "$CONFIG_PLUGIN_PROPS" | tr ',' '\n'); do
+  if ! echo "$HELM_CUSTOM_PLUGIN_PROPS" | tr ',' '\n' | grep -qx "$prop"; then
+    echo "❌ Plugin property '$prop' exists in config.schema.json but missing from helm custom plugin items"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "✅ Plugin property '$prop' present in both schemas"
+  fi
+done
+
+# Verify placement enum values match
+CONFIG_PLACEMENT_ENUM=$(jq -r '.properties.plugins.items.properties.placement.enum // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+HELM_PLACEMENT_ENUM=$(jq -r '.properties.bifrost.properties.plugins.properties.custom.items.properties.placement.enum // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+
+if [ "$CONFIG_PLACEMENT_ENUM" != "$HELM_PLACEMENT_ENUM" ]; then
+  echo "❌ Plugin placement enum mismatch:"
+  echo "   Config: [$CONFIG_PLACEMENT_ENUM]"
+  echo "   Helm:   [$HELM_PLACEMENT_ENUM]"
+  ERRORS=$((ERRORS + 1))
+else
+  echo "✅ Plugin placement enum values match: [$CONFIG_PLACEMENT_ENUM]"
+fi
+
 # Check maxim plugin config required fields (api_key)
 # Note: Helm allows either config.api_key OR secretRef.name via anyOf
 CONFIG_MAXIM_REQUIRED=$(jq -r '.properties.plugins.items.allOf[] | select(.if.properties.name.const == "maxim") | .then.properties.config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")

--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -54,7 +54,7 @@ test_template() {
 
 # 1. Storage Combinations (9 tests)
 echo ""
-echo -e "${CYAN}📦 1/5 - Testing Storage Combinations (9 tests)...${NC}"
+echo -e "${CYAN}📦 1/6 - Testing Storage Combinations (9 tests)...${NC}"
 echo "---------------------------------------------------"
 
 # config=no, logs=no
@@ -126,7 +126,7 @@ test_template "config=postgres, logs=postgres" \
 
 # 2. Vector Store Combinations (6 tests)
 echo ""
-echo -e "${CYAN}🗄️  2/5 - Testing Vector Store Combinations (6 tests)...${NC}"
+echo -e "${CYAN}🗄️  2/6 - Testing Vector Store Combinations (6 tests)...${NC}"
 echo "--------------------------------------------------------"
 
 # Weaviate
@@ -175,7 +175,7 @@ test_template "sqlite + qdrant" \
 
 # 3. Special Configurations (7 tests)
 echo ""
-echo -e "${CYAN}⚙️  3/5 - Testing Special Configurations (7 tests)...${NC}"
+echo -e "${CYAN}⚙️  3/6 - Testing Special Configurations (7 tests)...${NC}"
 echo "-----------------------------------------------------"
 
 # semantic cache: direct mode (dimension: 1, no provider/keys)
@@ -251,7 +251,7 @@ test_template "production-like config" \
 
 # 4. New Property Rendering (Gap 1-8 tests)
 echo ""
-echo -e "${CYAN}🆕 4/5 - Testing New Property Rendering (Gap 1-8)...${NC}"
+echo -e "${CYAN}🆕 4/6 - Testing New Property Rendering (Gap 1-8)...${NC}"
 echo "-----------------------------------------------------"
 
 # Gap 1+2: Client new properties
@@ -332,7 +332,7 @@ test_template "combined: all new Gap 1-8 fields" \
 
 # 5. Plugin Name Validation
 echo ""
-echo -e "${CYAN}🔌 5/5 - Validating Plugin Names Match Go Registry...${NC}"
+echo -e "${CYAN}🔌 5/6 - Validating Plugin Names Match Go Registry...${NC}"
 echo "------------------------------------------------------"
 
 # Verify semantic cache plugin renders with correct name ("semantic_cache", not "semantic_cache")
@@ -352,6 +352,63 @@ if helm template bifrost ./helm-charts/bifrost \
     report_result "$test_name" 0
   else
     report_result "$test_name" 1
+  fi
+else
+  report_result "$test_name" 1
+  echo -e "${YELLOW}  Error output:${NC}"
+  head -10 /tmp/helm-template-output.yaml | sed 's/^/    /'
+fi
+
+# 6. Custom Plugin Placement and Order Rendering
+echo ""
+echo -e "${CYAN}🔧 6/6 - Validating Custom Plugin placement and order Rendering...${NC}"
+echo "-------------------------------------------------------------------"
+
+# Test custom plugin renders successfully with placement and order
+test_template "custom plugin with placement and order" \
+  --set 'bifrost.plugins.custom[0].name=my-plugin' \
+  --set 'bifrost.plugins.custom[0].enabled=true' \
+  --set 'bifrost.plugins.custom[0].path=/plugins/my-plugin.so' \
+  --set 'bifrost.plugins.custom[0].placement=pre_builtin' \
+  --set 'bifrost.plugins.custom[0].order=2'
+
+# Verify placement appears in rendered output
+test_name="custom plugin rendered JSON contains placement field"
+if helm template bifrost ./helm-charts/bifrost \
+  --set image.tag=v1.0.0 \
+  --set 'bifrost.plugins.custom[0].name=my-plugin' \
+  --set 'bifrost.plugins.custom[0].enabled=true' \
+  --set 'bifrost.plugins.custom[0].path=/plugins/my-plugin.so' \
+  --set 'bifrost.plugins.custom[0].placement=pre_builtin' \
+  --set 'bifrost.plugins.custom[0].order=2' \
+  > /tmp/helm-template-output.yaml 2>&1; then
+  if grep -Eq '"placement"[[:space:]]*:[[:space:]]*"pre_builtin"' /tmp/helm-template-output.yaml; then
+    report_result "$test_name" 0
+  else
+    report_result "$test_name" 1
+    echo -e "${YELLOW}  placement field not found in rendered output${NC}"
+  fi
+else
+  report_result "$test_name" 1
+  echo -e "${YELLOW}  Error output:${NC}"
+  head -10 /tmp/helm-template-output.yaml | sed 's/^/    /'
+fi
+
+# Verify order appears in rendered output
+test_name="custom plugin rendered JSON contains order field"
+if helm template bifrost ./helm-charts/bifrost \
+  --set image.tag=v1.0.0 \
+  --set 'bifrost.plugins.custom[0].name=my-plugin' \
+  --set 'bifrost.plugins.custom[0].enabled=true' \
+  --set 'bifrost.plugins.custom[0].path=/plugins/my-plugin.so' \
+  --set 'bifrost.plugins.custom[0].placement=pre_builtin' \
+  --set 'bifrost.plugins.custom[0].order=2' \
+  > /tmp/helm-template-output.yaml 2>&1; then
+  if grep -Eq '"order"[[:space:]]*:[[:space:]]*2' /tmp/helm-template-output.yaml; then
+    report_result "$test_name" 0
+  else
+    report_result "$test_name" 1
+    echo -e "${YELLOW}  order field not found in rendered output${NC}"
   fi
 else
   report_result "$test_name" 1

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.13
+version: 2.0.14
 appVersion: "1.4.11"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,16 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.13
+**Latest Version:** 2.0.14
 
 ## Changelog
+
+### v2.0.14
+
+- Added `placement` and `order` fields to custom plugin schema and template rendering
+- Added plugin property completeness check to `validate-helm-schema.sh`
+- Added custom plugin placement/order rendering tests to `validate-helm-templates.sh`
+- Added `PluginConfig` struct validation to `validate-go-config-fields.sh`
 
 ### v2.0.13
 
@@ -374,6 +381,8 @@ bifrost:
         enabled: true
         path: "/plugins/my-plugin.so"
         version: 1
+        placement: "pre_builtin"  # or "post_builtin" (default)
+        order: 0                  # execution order within placement group
         config:
           key: value
 ```

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -878,6 +878,8 @@ false
 {{- if .path }}{{- $_ := set $customPlugin "path" .path }}{{- end }}
 {{- if .version }}{{- $_ := set $customPlugin "version" .version }}{{- end }}
 {{- if .config }}{{- $_ := set $customPlugin "config" .config }}{{- end }}
+{{- if .placement }}{{- $_ := set $customPlugin "placement" .placement }}{{- end }}
+{{- if .order }}{{- $_ := set $customPlugin "order" (.order | int) }}{{- end }}
 {{- $plugins = append $plugins $customPlugin }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -868,6 +868,17 @@
                   },
                   "config": {
                     "type": "object"
+                  },
+                  "placement": {
+                    "type": "string",
+                    "enum": ["pre_builtin", "post_builtin"],
+                    "default": "post_builtin",
+                    "description": "Plugin execution placement relative to built-in plugins"
+                  },
+                  "order": {
+                    "type": "integer",
+                    "default": 0,
+                    "description": "Position within placement group. Lower = earlier execution"
                   }
                 },
                 "required": [

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.11
+    created: "2026-03-20T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.14.tgz
+    version: 2.0.14
+  - apiVersion: v2
+    appVersion: 1.4.11
     created: "2026-03-11T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
     digest: ""


### PR DESCRIPTION
## Summary

Added `placement` and `order` fields to custom plugin configuration in Helm charts, enabling control over plugin execution order relative to built-in plugins.

## Changes

- Added `placement` field with enum values `pre_builtin` and `post_builtin` (default) to control when custom plugins execute relative to built-in plugins
- Added `order` field as integer to control execution order within placement groups (lower values execute earlier)
- Enhanced validation scripts to verify plugin configuration consistency between Go structs and JSON schemas
- Added comprehensive test coverage for custom plugin rendering with placement and order fields
- Updated Helm chart version from 2.0.13 to 2.0.14

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Plugins
- [x] Docs

## How to test

Validate the Helm chart renders custom plugins with placement and order fields:

```sh
# Test custom plugin with placement and order
helm template bifrost ./helm-charts/bifrost \
  --set image.tag=v1.0.0 \
  --set 'bifrost.plugins.custom[0].name=my-plugin' \
  --set 'bifrost.plugins.custom[0].enabled=true' \
  --set 'bifrost.plugins.custom[0].path=/plugins/my-plugin.so' \
  --set 'bifrost.plugins.custom[0].placement=pre_builtin' \
  --set 'bifrost.plugins.custom[0].order=2'

# Run validation scripts
.github/workflows/scripts/validate-helm-schema.sh
.github/workflows/scripts/validate-helm-templates.sh
.github/workflows/scripts/validate-go-config-fields.sh
```

Example custom plugin configuration:
```yaml
bifrost:
  plugins:
    custom:
      - name: "my-plugin"
        enabled: true
        path: "/plugins/my-plugin.so"
        placement: "pre_builtin"  # Execute before built-in plugins
        order: 0                  # Execute first within pre_builtin group
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications - this change only affects plugin execution ordering configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable