### PR TITLE
fixes gemin flow for openai integration

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -5,8 +5,21 @@ import (
 	"fmt"
 	"strings"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// contentBlockMeta stores type and length of a content block for multi-turn reconstruction.
+type contentBlockMeta struct {
+	T string `json:"t"` // "thinking" or "text"
+	L int    `json:"l"` // length in UTF-8 bytes
+}
+
+// orderedTextPart tracks original Gemini part ordering for correct flattening.
+type orderedTextPart struct {
+	kind string // "thinking" or "text"
+	text string
+}
 
 // ToGeminiChatCompletionRequest converts a BifrostChatRequest to Gemini's generation request format for chat completion
 func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *GeminiGenerationRequest {
@@ -98,6 +111,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	var toolCalls []schemas.ChatAssistantMessageToolCall
 	var contentBlocks []schemas.ChatContentBlock
 	var reasoningDetails []schemas.ChatReasoningDetails
+	var orderedTextParts []orderedTextPart
 	var contentStr *string
 
 	// Process candidate content to extract text, tool calls, and reasoning
@@ -110,6 +124,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 					Type:  schemas.BifrostReasoningDetailsTypeText,
 					Text:  &part.Text,
 				})
+				orderedTextParts = append(orderedTextParts, orderedTextPart{kind: "thinking", text: part.Text})
 				continue
 			}
 			// Handle regular text
@@ -118,6 +133,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 					Type: schemas.ChatContentBlockTypeText,
 					Text: &part.Text,
 				})
+				orderedTextParts = append(orderedTextParts, orderedTextPart{kind: "text", text: part.Text})
 				// Add thought signature to reasoning details if present with text
 				if len(part.ThoughtSignature) > 0 {
 					thoughtSig := base64.StdEncoding.EncodeToString(part.ThoughtSignature)
@@ -187,6 +203,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 						Type: schemas.ChatContentBlockTypeText,
 						Text: &output,
 					})
+					orderedTextParts = append(orderedTextParts, orderedTextPart{kind: "text", text: output})
 				}
 			}
 
@@ -201,6 +218,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 						Type: schemas.ChatContentBlockTypeText,
 						Text: &output,
 					})
+					orderedTextParts = append(orderedTextParts, orderedTextPart{kind: "text", text: output})
 				}
 			}
 
@@ -211,6 +229,7 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 					Type: schemas.ChatContentBlockTypeText,
 					Text: &codeContent,
 				})
+				orderedTextParts = append(orderedTextParts, orderedTextPart{kind: "text", text: codeContent})
 			}
 
 			// Handle standalone thought signature (not associated with function call or text)
@@ -229,9 +248,56 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 			Role: schemas.ChatMessageRoleAssistant,
 		}
 
-		if len(contentBlocks) == 1 && contentBlocks[0].Type == schemas.ChatContentBlockTypeText {
-			contentStr = contentBlocks[0].Text
-			contentBlocks = nil
+		if len(contentBlocks) > 0 {
+			allText := true
+			for _, block := range contentBlocks {
+				if block.Type != schemas.ChatContentBlockTypeText {
+					allText = false
+					break
+				}
+			}
+			if allText {
+				needsCombine := len(contentBlocks) > 1 || len(reasoningDetails) > 0
+				if !needsCombine {
+					// Single text block, no thinking — simple collapse
+					contentStr = contentBlocks[0].Text
+				} else {
+					// Combine thinking + text blocks into a single string, preserving original Gemini part order
+					var parts []string
+					var blockMeta []contentBlockMeta
+
+					for _, op := range orderedTextParts {
+						parts = append(parts, op.text)
+						blockMeta = append(blockMeta, contentBlockMeta{T: op.kind, L: len(op.text)})
+					}
+
+					joined := strings.Join(parts, "\n\n")
+					contentStr = &joined
+
+					// Record boundaries for multi-turn reconstruction
+					if len(blockMeta) > 1 {
+						if metaJSON, err := providerUtils.MarshalSorted(blockMeta); err == nil {
+							metaStr := string(metaJSON)
+							reasoningDetails = append(reasoningDetails, schemas.ChatReasoningDetails{
+								Index: len(reasoningDetails),
+								Type:  schemas.BifrostReasoningDetailsTypeContentBlocks,
+								Text:  &metaStr,
+							})
+						}
+					}
+
+					// Remove thinking text entries from reasoning_details (text moved into contentStr)
+					filtered := reasoningDetails[:0]
+					for _, rd := range reasoningDetails {
+						if rd.Type != schemas.BifrostReasoningDetailsTypeText {
+							rd.Index = len(filtered)
+							filtered = append(filtered, rd)
+						}
+					}
+					reasoningDetails = filtered
+				}
+				contentBlocks = nil
+			}
 		}
 
 		message.Content = &schemas.ChatMessageContent{

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -157,7 +157,7 @@ providers:
     vision: "claude-sonnet-4-5"
     tools: "gemini-2.5-flash"
     file: "claude-sonnet-4-5"
-    thinking: "gemini-3-pro-preview"
+    thinking: "gemini-2.5-pro"
     embeddings: "gemini-embedding-001"
     image_generation: "imagen-4.0-generate-001"
     image_edit: "imagen-3.0-capability-001"

--- a/tests/integrations/python/tests/test_openai.py
+++ b/tests/integrations/python/tests/test_openai.py
@@ -2120,6 +2120,7 @@ class TestOpenAIIntegration:
     def test_37a_chat_reasoning_content_is_string(self, test_config, provider, model, vk_enabled):
         """Test Case 37a: Chat completion with reasoning returns content as string, not array"""
         client = get_provider_openai_client(provider, vk_enabled=vk_enabled)
+        client = client.with_options(timeout=300)
         model_to_use = format_provider_model(provider, model)
 
         try:

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -67,13 +67,12 @@ export function LogsDataTable({
 		[columns],
 	);
 
-	const fixedColumnIds = useMemo(() => new Set(["status", "actions"]), []);
+	const fixedColumnIds = useMemo(() => new Set<string>([]), []);
 
 	// Column config: order, visibility, pinning — persisted in URL
 	const { entries, columnOrder, columnVisibility, columnPinning, toggleVisibility, togglePin, reorder, reset } = useColumnConfig({
 		columnIds,
 		paramName: "cols",
-		fixedColumns: { left: ["status"], right: ["actions"] },
 	});
 
 	// Measure actual header cell widths for pixel-perfect pin offsets


### PR DESCRIPTION
## Summary

Enhances the Gemini provider's chat response handling to combine thinking blocks with text content blocks into a single string while preserving metadata for multi-turn conversation reconstruction.

## Changes

- Added `contentBlockMeta` struct to track content block types and lengths for reconstruction purposes
- Modified `ToBifrostChatResponse()` to combine thinking blocks and multiple text blocks into a single content string
- Implemented metadata serialization using `providerUtils.MarshalSorted()` to store block boundaries in reasoning details
- Added logic to clear thinking text from reasoning details after combination, keeping only signatures
- Enhanced content block processing to handle cases with mixed thinking and text content more efficiently

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the Gemini provider's chat completion functionality with responses containing both thinking blocks and multiple text content blocks:

```sh
# Core/Transports
go version
go test ./...

# Test specifically the Gemini provider
go test ./core/providers/gemini/...
```

Verify that responses with thinking content and multiple text blocks are properly combined into single content strings while preserving reconstruction metadata.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects internal content processing and metadata handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable