### PR TITLE
fix: passthrough streaming responses buffered instead of streamed

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2775,6 +2775,9 @@ func (g *GenericRouter) handlePassthroughStream(
 		return
 	}
 
+	// Skip post-hook body materialization — ctx.Response.Body() would buffer the entire stream.
+	ctx.SetUserValue(schemas.BifrostContextKeyDeferTraceCompletion, true)
+
 	ctx.SetStatusCode(passthroughResp.StatusCode)
 	ctx.SetConnectionClose()
 	for k, v := range passthroughResp.Headers {


### PR DESCRIPTION
## Summary

- Passthrough stream handler (`handlePassthroughStream`) was missing the `BifrostContextKeyDeferTraceCompletion` flag
- Without it, the plugin middleware post-hook calls `ctx.Response.Body()`, which reads the entire body stream into a buffer before sending to the client
- The standard streaming handler (`handleStreaming`) already sets this flag — this aligns the passthrough path

## Root cause

In `middlewares.go:329-336`, the plugin middleware skips `HTTPTransportPostHook` for streaming responses by checking `DeferTraceCompletion`. When the flag is missing, the post-hook runs `fasthttpResponseToHTTPResponse` → `ctx.Response.Body()` (line 469), which materializes the entire stream into memory, replacing chunked transfer encoding with a fixed `Content-Length` response.

## Test plan

- [x] Verified streaming works on `/anthropic_passthrough/v1/messages` with `stream: true`
- [x] Confirmed `/anthropic/v1/messages` streaming is unaffected
- [x] Non-streaming passthrough requests unaffected (handler returns before reaching this code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)