### PR TITLE
fix(mcp): Return 202 instead of 202 for mcp notifications

### DIFF
--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -94,7 +94,7 @@ func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
 
 	// Check if response is nil (notification - no response needed)
 	if response == nil {
-		ctx.SetStatusCode(fasthttp.StatusOK)
+		ctx.SetStatusCode(fasthttp.StatusAccepted)
 		return
 	}
 


### PR DESCRIPTION
## Summary
Per the MCP spec [1], the server should returns a 202 Accepted status code when the server receives a notification message.

[1] https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server

## Changes

Return 202 instead of 200 for mcp notifications.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test
Test locally.

## Screenshots/Recordings
Before:
<img width="2261" height="288" alt="截屏2026-03-21 20 13 43" src="https://github.com/user-attachments/assets/d6600adb-76f9-4ab3-a86a-f03b84768ee2" />

After:
<img width="2524" height="604" alt="截屏2026-03-21 20 14 47" src="https://github.com/user-attachments/assets/8e30d84f-b90d-4230-a9bd-33ed4f856f26" />

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues
NA

## Security considerations
NA

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


