### PR TITLE
custom sse stream reader to nuke burstiness of fasthttp stream reader

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -3,7 +3,6 @@
 package handlers
 
 import (
-	"bufio"
 	"context"
 
 	"encoding/json"
@@ -1540,12 +1539,17 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 	if interceptor != nil {
 		httpReq = lib.BuildHTTPRequestFromFastHTTP(ctx)
 	}
-	var includeEventType bool
-	// Use streaming response writer
-	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+	// Use SSEStreamReader to bypass fasthttp's internal pipe (fasthttputil.PipeConns)
+	// which batches multiple SSE events into single TCP segments.
+	// Each event is delivered individually via a channel, ensuring one HTTP chunk per event.
+	reader := lib.NewSSEStreamReader()
+	ctx.Response.SetBodyStream(reader, -1)
+
+	// Producer goroutine: processes the stream channel, formats SSE events, sends to reader
+	go func() {
 		defer func() {
 			schemas.ReleaseHTTPRequest(httpReq)
-			w.Flush()
+			reader.Done()
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL
 			if traceCompleter != nil {
@@ -1553,6 +1557,7 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 			}
 		}()
 
+		var includeEventType bool
 		var skipDoneMarker bool
 
 		// Process streaming responses
@@ -1581,15 +1586,11 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 					if chunk == nil {
 						errorJSON, marshalErr := sonic.Marshal(map[string]string{"error": err.Error()})
 						if marshalErr != nil {
-							cancel() // Client disconnected or payload invalid
+							cancel() // Payload invalid
 							return
 						}
-						// Return error event and stopping the streaming
-						if _, err := fmt.Fprintf(w, "event: error\ndata: %s\n\n", errorJSON); err != nil {
-							cancel() // Client disconnected (write error), cancel upstream stream
-							return
-						}
-						_ = w.Flush()
+						// Return error event and stop streaming
+						reader.SendError(errorJSON)
 						cancel()
 						return
 					}
@@ -1609,10 +1610,10 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 				continue
 			}
 
-			// Send as SSE data
+			// Format and send as SSE data
+			var eventType string
 			if includeEventType {
 				// For responses and image gen API, use OpenAI-compatible format with event line
-				eventType := ""
 				if chunk.BifrostResponsesStreamResponse != nil {
 					eventType = string(chunk.BifrostResponsesStreamResponse.Type)
 				} else if chunk.BifrostImageGenerationStreamResponse != nil {
@@ -1620,43 +1621,25 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 				} else if chunk.BifrostError != nil {
 					eventType = string(schemas.ResponsesStreamResponseTypeError)
 				}
-				if eventType != "" {
-					if _, err := fmt.Fprintf(w, "event: %s\n", eventType); err != nil {
-						cancel() // Client disconnected (write error), cancel upstream stream
-						return
-					}
-				}
-				if _, err := fmt.Fprintf(w, "data: %s\n\n", chunkJSON); err != nil {
-					cancel() // Client disconnected (write error), cancel upstream stream
-					return
-				}
-			} else {
-				// For other APIs, use standard format
-				if _, err := fmt.Fprintf(w, "data: %s\n\n", chunkJSON); err != nil {
-					cancel() // Client disconnected (write error), cancel upstream stream
-					return
-				}
 			}
 
-			// Flush immediately to send the chunk
-			if err := w.Flush(); err != nil {
-				cancel() // Client disconnected (write error), cancel upstream stream
+			if !reader.SendEvent(eventType, chunkJSON) {
+				cancel() // Client disconnected, cancel upstream stream
 				return
 			}
 		}
 
 		if !includeEventType && !skipDoneMarker {
 			// Send the [DONE] marker to indicate the end of the stream (only for non-responses/image-gen APIs)
-			if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
-				logger.Warn("Failed to write SSE [DONE] marker: %v", err)
-				cancel() // Client disconnected (write error), cancel upstream stream
+			if !reader.SendDone() {
+				cancel()
 				return
 			}
 		}
 		// Note: OpenAI responses API doesn't use [DONE] marker, it ends when the stream closes
 		// Stream completed normally, Bifrost handles cleanup internally
 		cancel()
-	})
+	}()
 }
 
 // validateAudioFile checks if the file size and format are valid

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -3,7 +3,6 @@
 package handlers
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"slices"
@@ -126,11 +125,14 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 	// Convert context
 	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, false, h.config.GetHeaderMatcher())
 
-	// Use streaming response writer
-	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+	// Use SSEStreamReader to bypass fasthttp's internal pipe batching
+	reader := lib.NewSSEStreamReader()
+	ctx.Response.SetBodyStream(reader, -1)
+
+	go func() {
 		defer func() {
 			cancel()
-			_ = w.Flush()
+			reader.Done()
 		}()
 
 		// Send initial connection message
@@ -139,13 +141,16 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 			"method":  "connection/opened",
 		}
 		if initJSON, err := sonic.Marshal(initMessage); err == nil {
-			fmt.Fprintf(w, "data: %s\n\n", initJSON)
-			w.Flush()
+			buf := make([]byte, 0, len(initJSON)+8)
+			buf = append(buf, "data: "...)
+			buf = append(buf, initJSON...)
+			buf = append(buf, '\n', '\n')
+			reader.Send(buf)
 		}
 
 		// Wait for context cancellation (client disconnect or server-side cancel)
 		<-(*bifrostCtx).Done()
-	})
+	}()
 }
 
 // Sync methods for MCP servers

--- a/transports/bifrost-http/handlers/ssestreaming_test.go
+++ b/transports/bifrost-http/handlers/ssestreaming_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// TestSSEStreamReaderNoEventBatching verifies that SSE events are delivered
+// individually through fasthttp's chunked transfer encoding, not batched
+// into larger TCP segments. This is the core regression test for the
+// fasthttputil.PipeConns batching fix.
+func TestSSEStreamReaderNoEventBatching(t *testing.T) {
+	const numEvents = 20
+
+	// Build expected events
+	events := make([]string, numEvents)
+	for i := range events {
+		events[i] = fmt.Sprintf("data: {\"index\":%d,\"content\":\"chunk-%d\"}\n\n", i, i)
+	}
+
+	handler := func(ctx *fasthttp.RequestCtx) {
+		ctx.SetContentType("text/event-stream")
+		ctx.Response.Header.Set("Cache-Control", "no-cache")
+
+		reader := lib.NewSSEStreamReader()
+
+		go func() {
+			defer reader.Done()
+			for _, event := range events {
+				if !reader.Send([]byte(event)) {
+					return
+				}
+			}
+		}()
+
+		ctx.Response.SetBodyStream(reader, -1)
+	}
+
+	// Use net.Pipe for deterministic in-process testing
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	// Run fasthttp server on one end of the pipe
+	go func() {
+		_ = fasthttp.ServeConn(serverConn, handler)
+	}()
+
+	// Send HTTP request through the pipe
+	_, err := clientConn.Write([]byte("GET /stream HTTP/1.1\r\nHost: test\r\n\r\n"))
+	if err != nil {
+		t.Fatalf("failed to write request: %v", err)
+	}
+
+	// Read response using bufio to parse chunked encoding
+	br := bufio.NewReader(clientConn)
+
+	// Read and skip HTTP response headers
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("failed to read response header: %v", err)
+		}
+		if strings.TrimSpace(line) == "" {
+			break // End of headers
+		}
+	}
+
+	// Read chunked transfer-encoded body.
+	// Each HTTP chunk should contain exactly one SSE event.
+	var receivedEvents []string
+	for {
+		// Read chunk size line (hex size + CRLF)
+		sizeLine, err := br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("failed to read chunk size: %v", err)
+		}
+		sizeLine = strings.TrimSpace(sizeLine)
+
+		var chunkSize int
+		_, err = fmt.Sscanf(sizeLine, "%x", &chunkSize)
+		if err != nil {
+			t.Fatalf("failed to parse chunk size %q: %v", sizeLine, err)
+		}
+
+		if chunkSize == 0 {
+			break // Terminal chunk
+		}
+
+		// Read exactly chunkSize bytes + trailing CRLF
+		chunkData := make([]byte, chunkSize+2) // +2 for CRLF
+		n := 0
+		for n < len(chunkData) {
+			nn, err := br.Read(chunkData[n:])
+			if err != nil {
+				t.Fatalf("failed to read chunk data: %v", err)
+			}
+			n += nn
+		}
+
+		chunk := string(chunkData[:chunkSize])
+		receivedEvents = append(receivedEvents, chunk)
+	}
+
+	// Verify each chunk contains exactly one SSE event
+	if len(receivedEvents) != numEvents {
+		t.Errorf("expected %d individual chunks, got %d (events were batched)", numEvents, len(receivedEvents))
+		for i, chunk := range receivedEvents {
+			eventCount := strings.Count(chunk, "\n\n")
+			t.Logf("  chunk %d: %d SSE events, %d bytes", i, eventCount, len(chunk))
+		}
+	}
+
+	for i, chunk := range receivedEvents {
+		if i >= len(events) {
+			break
+		}
+		if chunk != events[i] {
+			t.Errorf("chunk %d: got %q, want %q", i, chunk, events[i])
+		}
+	}
+}

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -48,7 +48,6 @@
 package integrations
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -2280,11 +2279,16 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 		httpReq = lib.BuildHTTPRequestFromFastHTTP(ctx)
 	}
 
-	// Use streaming response writer
-	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+	// Use SSEStreamReader to bypass fasthttp's internal pipe (fasthttputil.PipeConns)
+	// which batches multiple SSE events into single TCP segments.
+	reader := lib.NewSSEStreamReader()
+	ctx.Response.SetBodyStream(reader, -1)
+
+	// Producer goroutine: processes the stream channel, formats events, sends to reader
+	go func() {
 		defer func() {
 			schemas.ReleaseHTTPRequest(httpReq)
-			w.Flush()
+			reader.Done()
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL
 			if traceCompleter != nil {
@@ -2311,13 +2315,11 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 
 			// Note: We no longer check ctx.Done() here because fasthttp.RequestCtx.Done()
 			// only closes when the whole server shuts down, not when an individual client disconnects.
-			// Client disconnects are detected via write errors, which trigger the defer cancel() above.
+			// Client disconnects are detected via write errors on reader.Send(), which returns false.
 
 			// Handle errors
 			if chunk.BifrostError != nil {
 				var errorResponse interface{}
-				var errorJSON []byte
-				var err error
 
 				// Use stream error converter if available, otherwise fallback to regular error converter
 				if config.StreamConfig != nil && config.StreamConfig.ErrorConverter != nil {
@@ -2338,16 +2340,10 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 				if sseErrorString, ok := errorResponse.(string); ok {
 					// CUSTOM SSE FORMAT: The converter returned a complete SSE string
 					// This is used by providers like Anthropic that need custom event types
-					// Example: "event: error\ndata: {...}\n\n"
-					if _, err := fmt.Fprint(w, sseErrorString); err != nil {
-						cancel() // Client disconnected (write error), cancel upstream stream
-						return
-					}
+					reader.Send([]byte(sseErrorString))
 				} else {
 					// STANDARD SSE FORMAT: The converter returned an object
-					// This will be JSON marshaled and wrapped as "data: {json}\n\n"
-					// Used by most providers (OpenAI, Google, etc.)
-					errorJSON, err = sonic.Marshal(errorResponse)
+					errorJSON, err := sonic.Marshal(errorResponse)
 					if err != nil {
 						// Fallback to basic error if marshaling fails
 						basicError := map[string]interface{}{
@@ -2357,23 +2353,15 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 							},
 						}
 						if errorJSON, err = sonic.Marshal(basicError); err != nil {
-							cancel() // Can't send error (client likely disconnected), cancel upstream stream
+							cancel()
 							return
 						}
 					}
 
 					// Send error as SSE data
-					if _, err := fmt.Fprintf(w, "data: %s\n\n", errorJSON); err != nil {
-						cancel() // Client disconnected (write error), cancel upstream stream
-						return
-					}
+					reader.SendEvent("", errorJSON)
 				}
 
-				// Flush and return on error
-				if err := w.Flush(); err != nil {
-					cancel() // Client disconnected (write error), cancel upstream stream
-					return
-				}
 				return // End stream on error, Bifrost handles cleanup internally
 			} else {
 				// Allow plugins to modify/filter the chunk via StreamChunkInterceptor
@@ -2387,12 +2375,8 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 								cancel()
 								return
 							}
-							// Return error event and stopping the streaming
-							if _, err := fmt.Fprintf(w, "event: error\ndata: %s\n\n", errorJSON); err != nil {
-								cancel()
-								return
-							}
-							_ = w.Flush()
+							// Return error event and stop streaming
+							reader.SendError(errorJSON)
 							cancel()
 							return
 						}
@@ -2439,18 +2423,10 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 					continue
 				}
 
-				if eventType != "" {
-					// OPENAI RESPONSES FORMAT: Use event: and data: lines for OpenAI responses API compatibility
-					if _, err := fmt.Fprintf(w, "event: %s\n", eventType); err != nil {
-						cancel() // Client disconnected (write error), cancel upstream stream
-						return
-					}
-				}
 				// Handle Bedrock Event Stream format
 				if config.Type == RouteConfigTypeBedrock && eventStreamEncoder != nil {
 					// We need to cast to BedrockStreamEvent to determine event type and structure
 					if bedrockEvent, ok := convertedResponse.(*bedrock.BedrockStreamEvent); ok {
-						// Passing it to interceptor to modify the event
 						// Convert to sequence of specific Bedrock events
 						events := bedrockEvent.ToEncodedEvents()
 
@@ -2482,54 +2458,55 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 								Payload: jsonData,
 							}
 
-							if err := eventStreamEncoder.Encode(w, message); err != nil {
+							var msgBuf bytes.Buffer
+							if err := eventStreamEncoder.Encode(&msgBuf, message); err != nil {
 								g.logger.Warn("[Bedrock Stream] Failed to encode message: %v", err)
 								cancel()
 								return
 							}
 
-							// Flush each message to ensure proper delivery
-							if err := w.Flush(); err != nil {
-								g.logger.Warn("[Bedrock Stream] Failed to flush writer: %v", err)
+							if !reader.Send(msgBuf.Bytes()) {
+								g.logger.Warn("[Bedrock Stream] Client disconnected")
 								cancel()
 								return
 							}
 						}
 					}
-					// Continue to next chunk (we handled flushing internally)
+					// Continue to next chunk (we handled sending internally)
 					continue
-				} else if sseString, ok := convertedResponse.(string); ok {
-					// CUSTOM SSE FORMAT: The converter returned a complete SSE string
-					// This is used by providers like Anthropic that need custom event types
-					// Example: "event: content_block_delta\ndata: {...}\n\n"
-					if !strings.HasPrefix(sseString, "data: ") && !strings.HasPrefix(sseString, "event: ") {
-						sseString = fmt.Sprintf("data: %s\n\n", sseString)
-					}
-					if _, err := fmt.Fprint(w, sseString); err != nil {
-						cancel() // Client disconnected (write error), cancel upstream stream
-						return
+				}
+
+				// Build and send SSE event
+				var buf []byte
+				var sent bool
+				if sseString, ok := convertedResponse.(string); ok {
+					if strings.HasPrefix(sseString, "data: ") || strings.HasPrefix(sseString, "event: ") {
+						// Pre-formatted SSE string (e.g. Anthropic custom event types)
+						if eventType != "" {
+							// Prepend event type line to pre-formatted data
+							buf = make([]byte, 0, 7+len(eventType)+1+len(sseString))
+							buf = append(buf, "event: "...)
+							buf = append(buf, eventType...)
+							buf = append(buf, '\n')
+							buf = append(buf, sseString...)
+							sent = reader.Send(buf)
+						} else {
+							sent = reader.Send([]byte(sseString))
+						}
+					} else {
+						sent = reader.SendEvent(eventType, []byte(sseString))
 					}
 				} else {
-					// STANDARD SSE FORMAT: The converter returned an object
-					// This will be JSON marshaled and wrapped as "data: {json}\n\n"
-					// Used by most providers (OpenAI chat/completions, Google, etc.)
 					responseJSON, err := sonic.Marshal(convertedResponse)
 					if err != nil {
-						// Log JSON marshaling error but continue processing
 						g.logger.Warn("Failed to marshal streaming response: %v", err)
 						continue
 					}
-
-					// Send as SSE data
-					if _, err := fmt.Fprintf(w, "data: %s\n\n", responseJSON); err != nil {
-						cancel() // Client disconnected (write error), cancel upstream stream
-						return
-					}
+					sent = reader.SendEvent(eventType, responseJSON)
 				}
 
-				// Flush immediately to send the chunk
-				if err := w.Flush(); err != nil {
-					cancel() // Client disconnected (write error), cancel upstream stream
+				if !sent {
+					cancel() // Client disconnected, cancel upstream stream
 					return
 				}
 			}
@@ -2541,13 +2518,13 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 		//   - Bedrock: uses AWS Event Stream format rather than SSE with [DONE].
 		// Bifrost handles any additional cleanup internally on normal stream completion.
 		if shouldSendDoneMarker && config.Type != RouteConfigTypeGenAI && config.Type != RouteConfigTypeBedrock {
-			if _, err := fmt.Fprint(w, "data: [DONE]\n\n"); err != nil {
-				g.logger.Warn("Failed to write SSE done marker: %v", err)
+			if !reader.SendDone() {
+				g.logger.Warn("Failed to write SSE done marker: client disconnected")
 				cancel()
-				return // End stream on error, Bifrost handles cleanup internally
+				return
 			}
 		}
-	})
+	}()
 }
 
 // extractPassthroughModel extracts the model from the passthrough request path and/or body.
@@ -2789,19 +2766,19 @@ func (g *GenericRouter) handlePassthroughStream(
 		}
 	}
 
-	ctx.Response.SetBodyStreamWriter(func(w *bufio.Writer) {
+	// Use SSEStreamReader to bypass fasthttp's internal pipe batching
+	reader := lib.NewSSEStreamReader()
+	ctx.Response.SetBodyStream(reader, -1)
+
+	go func() {
 		defer func() {
-			w.Flush()
+			reader.Done()
 			cancel()
 		}()
 
 		// Write the first chunk's data.
 		if len(passthroughResp.Body) > 0 {
-			if _, err := w.Write(passthroughResp.Body); err != nil {
-				cancel()
-				return
-			}
-			if err := w.Flush(); err != nil {
+			if !reader.Send(passthroughResp.Body) {
 				cancel()
 				return
 			}
@@ -2815,15 +2792,11 @@ func (g *GenericRouter) handlePassthroughStream(
 				break
 			}
 			if chunk.BifrostPassthroughResponse != nil && len(chunk.BifrostPassthroughResponse.Body) > 0 {
-				if _, err := w.Write(chunk.BifrostPassthroughResponse.Body); err != nil {
-					cancel()
-					return
-				}
-				if err := w.Flush(); err != nil {
+				if !reader.Send(chunk.BifrostPassthroughResponse.Body) {
 					cancel()
 					return
 				}
 			}
 		}
-	})
+	}()
 }

--- a/transports/bifrost-http/lib/streamreader.go
+++ b/transports/bifrost-http/lib/streamreader.go
@@ -1,0 +1,114 @@
+package lib
+
+import (
+	"io"
+	"sync"
+)
+
+// SSEStreamReader is an io.ReadCloser that delivers one event per Read call,
+// bypassing fasthttp's internal pipe mechanism (fasthttputil.PipeConns) which
+// batches multiple events into single TCP segments.
+//
+// Usage:
+//  1. Create with NewSSEStreamReader()
+//  2. Pass to ctx.Response.SetBodyStream(reader, -1)
+//  3. Start a producer goroutine that calls Send()/SendEvent()/SendError() for each event
+//  4. Producer calls Done() when finished (closes the event channel)
+//  5. fasthttp calls Close() on write errors (signals producer to stop)
+type SSEStreamReader struct {
+	eventCh   chan []byte
+	closeCh   chan struct{}
+	closeOnce sync.Once
+	current   []byte // remaining bytes from a partial read
+}
+
+// NewSSEStreamReader creates a new SSEStreamReader with a buffered event channel.
+// Channel capacity of 1 allows one event of pipeline parallelism between
+// the producer goroutine and fasthttp's writeBodyChunked loop.
+func NewSSEStreamReader() *SSEStreamReader {
+	return &SSEStreamReader{
+		eventCh: make(chan []byte, 1),
+		closeCh: make(chan struct{}),
+	}
+}
+
+// Read implements io.Reader. It blocks until an event is available, then returns
+// that event's bytes. If the caller's buffer is smaller than the event, remaining
+// bytes are stored and returned on subsequent calls. Returns io.EOF when Done()
+// has been called and all events have been consumed.
+func (r *SSEStreamReader) Read(p []byte) (int, error) {
+	if len(r.current) == 0 {
+		event, ok := <-r.eventCh
+		if !ok {
+			return 0, io.EOF
+		}
+		r.current = event
+	}
+	n := copy(p, r.current)
+	r.current = r.current[n:]
+	return n, nil
+}
+
+// Close implements io.Closer. Called by fasthttp when writeBodyChunked encounters
+// a write error (client disconnect). Signals the producer goroutine to stop via closeCh.
+// Safe to call multiple times.
+func (r *SSEStreamReader) Close() error {
+	r.closeOnce.Do(func() {
+		close(r.closeCh)
+	})
+	return nil
+}
+
+// Send delivers a pre-formatted event to the reader. Returns false if the reader
+// has been closed (client disconnected), in which case the producer should stop.
+func (r *SSEStreamReader) Send(event []byte) bool {
+	// Check closeCh first (non-blocking) to avoid sending after Close
+	select {
+	case <-r.closeCh:
+		return false
+	default:
+	}
+	select {
+	case r.eventCh <- event:
+		return true
+	case <-r.closeCh:
+		return false
+	}
+}
+
+// SendEvent sends an SSE-framed event. If eventType is empty, it sends "data: <data>\n\n".
+// If eventType is non-empty, it sends "event: <eventType>\ndata: <data>\n\n".
+// Returns false if the reader has been closed (client disconnected).
+func (r *SSEStreamReader) SendEvent(eventType string, data []byte) bool {
+	var buf []byte
+	if eventType != "" {
+		buf = make([]byte, 0, 7+len(eventType)+7+len(data)+2)
+		buf = append(buf, "event: "...)
+		buf = append(buf, eventType...)
+		buf = append(buf, "\ndata: "...)
+	} else {
+		buf = make([]byte, 0, 6+len(data)+2)
+		buf = append(buf, "data: "...)
+	}
+	buf = append(buf, data...)
+	buf = append(buf, '\n', '\n')
+	return r.Send(buf)
+}
+
+// SendError sends an SSE error event: "event: error\ndata: <data>\n\n".
+// Returns false if the reader has been closed (client disconnected).
+func (r *SSEStreamReader) SendError(data []byte) bool {
+	return r.SendEvent("error", data)
+}
+
+// SendDone sends the standard SSE done marker: "data: [DONE]\n\n".
+// Returns false if the reader has been closed (client disconnected).
+func (r *SSEStreamReader) SendDone() bool {
+	return r.Send([]byte("data: [DONE]\n\n"))
+}
+
+// Done closes the event channel, signaling to Read that the stream is finished.
+// Must be called exactly once by the producer goroutine when streaming is complete.
+func (r *SSEStreamReader) Done() {
+	close(r.eventCh)
+}

--- a/transports/bifrost-http/lib/streamreader_test.go
+++ b/transports/bifrost-http/lib/streamreader_test.go
@@ -1,0 +1,714 @@
+package lib
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestSSEStreamReaderSingleEventPerRead(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	events := [][]byte{
+		[]byte("data: {\"chunk\":1}\n\n"),
+		[]byte("data: {\"chunk\":2}\n\n"),
+		[]byte("data: {\"chunk\":3}\n\n"),
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		for _, e := range events {
+			if !r.Send(e) {
+				select {
+				case errCh <- fmt.Errorf("Send returned false unexpectedly"):
+				default:
+				}
+				return
+			}
+		}
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	for i, want := range events {
+		n, err := r.Read(buf)
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+		got := string(buf[:n])
+		if got != string(want) {
+			t.Errorf("event %d: got %q, want %q", i, got, want)
+		}
+	}
+
+	// Next read should return EOF
+	n, err := r.Read(buf)
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got err=%v n=%d", err, n)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Error(err)
+	default:
+	}
+}
+
+func TestSSEStreamReaderPartialRead(t *testing.T) {
+	r := NewSSEStreamReader()
+	event := []byte("data: {\"content\":\"hello world\"}\n\n")
+
+	go func() {
+		r.Send(event)
+		r.Done()
+	}()
+
+	// Read with a small buffer (5 bytes at a time)
+	var result []byte
+	buf := make([]byte, 5)
+	for {
+		n, err := r.Read(buf)
+		result = append(result, buf[:n]...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if string(result) != string(event) {
+		t.Errorf("reassembled data: got %q, want %q", result, event)
+	}
+}
+
+func TestSSEStreamReaderEOFOnDone(t *testing.T) {
+	r := NewSSEStreamReader()
+	r.Done() // Close immediately
+
+	buf := make([]byte, 4096)
+	n, err := r.Read(buf)
+	if err != io.EOF {
+		t.Errorf("expected io.EOF, got err=%v n=%d", err, n)
+	}
+}
+
+func TestSSEStreamReaderCloseSignalsProducer(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	r.Close()
+
+	if r.Send([]byte("data: test\n\n")) {
+		t.Error("Send should return false after Close")
+	}
+}
+
+func TestSSEStreamReaderIdempotentClose(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	// Should not panic
+	r.Close()
+	r.Close()
+	r.Close()
+}
+
+func TestSSEStreamReaderConcurrent(t *testing.T) {
+	r := NewSSEStreamReader()
+	const numEvents = 100
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Producer
+	go func() {
+		for i := 0; i < numEvents; i++ {
+			if !r.Send([]byte("data: event\n\n")) {
+				break
+			}
+		}
+		r.Done()
+	}()
+
+	// Consumer
+	errCh := make(chan error, 2)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 4096)
+		count := 0
+		for {
+			_, err := r.Read(buf)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				select {
+				case errCh <- fmt.Errorf("unexpected error: %v", err):
+				default:
+				}
+				break
+			}
+			count++
+		}
+		if count != numEvents {
+			select {
+			case errCh <- fmt.Errorf("got %d events, want %d", count, numEvents):
+			default:
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Error(err)
+	}
+}
+
+func TestSSEStreamReaderSendEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      []byte
+		want      string
+	}{
+		{
+			name:      "data only",
+			eventType: "",
+			data:      []byte(`{"chunk":1}`),
+			want:      "data: {\"chunk\":1}\n\n",
+		},
+		{
+			name:      "with event type",
+			eventType: "response.delta",
+			data:      []byte(`{"delta":"hi"}`),
+			want:      "event: response.delta\ndata: {\"delta\":\"hi\"}\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSSEStreamReader()
+			go func() {
+				r.SendEvent(tt.eventType, tt.data)
+				r.Done()
+			}()
+
+			buf := make([]byte, 4096)
+			n, err := r.Read(buf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := string(buf[:n]); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSSEStreamReaderSendError(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() {
+		r.SendError([]byte(`{"error":"bad"}`))
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "event: error\ndata: {\"error\":\"bad\"}\n\n"
+	if got := string(buf[:n]); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSSEStreamReaderSendDone(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() {
+		r.SendDone()
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "data: [DONE]\n\n"
+	if got := string(buf[:n]); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSSEStreamReaderSendEventAfterClose(t *testing.T) {
+	r := NewSSEStreamReader()
+	r.Close()
+
+	if r.SendEvent("test", []byte("data")) {
+		t.Error("SendEvent should return false after Close")
+	}
+	if r.SendError([]byte("err")) {
+		t.Error("SendError should return false after Close")
+	}
+	if r.SendDone() {
+		t.Error("SendDone should return false after Close")
+	}
+}
+
+// TestSSEStreamReaderSendEventByteAccuracy verifies that SendEvent produces
+// the exact same bytes that the old manual buffer assembly in the handlers did.
+func TestSSEStreamReaderSendEventByteAccuracy(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		data      []byte
+		want      []byte
+	}{
+		{
+			name:      "standard SSE data (old inference.go pattern)",
+			eventType: "",
+			data:      []byte(`{"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}`),
+			want: func() []byte {
+				// Old code: buf = append(buf, "data: "...); buf = append(buf, chunkJSON...); buf = append(buf, '\n', '\n')
+				data := []byte(`{"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}`)
+				buf := make([]byte, 0, len(data)+8)
+				buf = append(buf, "data: "...)
+				buf = append(buf, data...)
+				buf = append(buf, '\n', '\n')
+				return buf
+			}(),
+		},
+		{
+			name:      "OpenAI responses format with event type (old inference.go pattern)",
+			eventType: "response.output_item.added",
+			data:      []byte(`{"type":"response.output_item.added","item":{"id":"item_1"}}`),
+			want: func() []byte {
+				// Old code: buf = append(buf, "event: "...); buf = append(buf, eventType...); buf = append(buf, "\ndata: "...); ...
+				eventType := "response.output_item.added"
+				data := []byte(`{"type":"response.output_item.added","item":{"id":"item_1"}}`)
+				buf := make([]byte, 0, len(eventType)+len(data)+16)
+				buf = append(buf, "event: "...)
+				buf = append(buf, eventType...)
+				buf = append(buf, "\ndata: "...)
+				buf = append(buf, data...)
+				buf = append(buf, '\n', '\n')
+				return buf
+			}(),
+		},
+		{
+			name:      "error event (old interceptor pattern)",
+			eventType: "error",
+			data:      []byte(`{"error":"stream interrupted"}`),
+			want: func() []byte {
+				data := []byte(`{"error":"stream interrupted"}`)
+				buf := make([]byte, 0, len(data)+24)
+				buf = append(buf, "event: error\ndata: "...)
+				buf = append(buf, data...)
+				buf = append(buf, '\n', '\n')
+				return buf
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSSEStreamReader()
+			go func() {
+				r.SendEvent(tt.eventType, tt.data)
+				r.Done()
+			}()
+
+			buf := make([]byte, 4096)
+			n, err := r.Read(buf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := buf[:n]
+			if string(got) != string(tt.want) {
+				t.Errorf("byte mismatch:\n  got:  %q\n  want: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSSEStreamReaderSendErrorByteAccuracy verifies SendError matches
+// the old "event: error\ndata: ..." manual assembly.
+func TestSSEStreamReaderSendErrorByteAccuracy(t *testing.T) {
+	r := NewSSEStreamReader()
+	errorJSON := []byte(`{"error":{"type":"internal_error","message":"An error occurred"}}`)
+
+	go func() {
+		r.SendError(errorJSON)
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Must match the old pattern exactly:
+	// buf = append(buf, "event: error\ndata: "...)
+	// buf = append(buf, errorJSON...)
+	// buf = append(buf, '\n', '\n')
+	want := "event: error\ndata: " + string(errorJSON) + "\n\n"
+	if got := string(buf[:n]); got != want {
+		t.Errorf("byte mismatch:\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+// TestSSEStreamReaderMixedMethodStream simulates a realistic stream
+// that uses multiple methods (like router.go does): data events,
+// typed events, error, and done marker.
+func TestSSEStreamReaderMixedMethodStream(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	expected := []string{
+		"data: {\"chunk\":1}\n\n",
+		"event: response.delta\ndata: {\"delta\":\"hi\"}\n\n",
+		"data: {\"chunk\":2}\n\n",
+		"event: error\ndata: {\"error\":\"timeout\"}\n\n",
+		"data: [DONE]\n\n",
+	}
+
+	go func() {
+		r.SendEvent("", []byte(`{"chunk":1}`))
+		r.SendEvent("response.delta", []byte(`{"delta":"hi"}`))
+		r.SendEvent("", []byte(`{"chunk":2}`))
+		r.SendError([]byte(`{"error":"timeout"}`))
+		r.SendDone()
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	for i, want := range expected {
+		n, err := r.Read(buf)
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+		if got := string(buf[:n]); got != want {
+			t.Errorf("event %d:\n  got:  %q\n  want: %q", i, got, want)
+		}
+	}
+
+	// Should be EOF after all events
+	n, err := r.Read(buf)
+	if err != io.EOF {
+		t.Errorf("expected EOF, got err=%v n=%d", err, n)
+	}
+}
+
+// TestSSEStreamReaderRawAndWrapperMixed simulates the router.go pattern
+// where raw Send (for Bedrock/passthrough) is mixed with wrapper methods.
+func TestSSEStreamReaderRawAndWrapperMixed(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	// Simulate: Bedrock binary event (raw), followed by SSE events, then done
+	bedrockBinary := []byte{0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x2A} // fake binary
+	preformattedSSE := []byte("event: content_block_delta\ndata: {\"delta\":\"test\"}\n\n")
+
+	expected := [][]byte{
+		bedrockBinary,
+		preformattedSSE,
+		[]byte("data: {\"final\":true}\n\n"),
+	}
+
+	go func() {
+		r.Send(bedrockBinary)                       // raw binary passthrough
+		r.Send(preformattedSSE)                     // pre-formatted SSE string
+		r.SendEvent("", []byte(`{"final":true}`))   // wrapper method
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	for i, want := range expected {
+		n, err := r.Read(buf)
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+		if string(buf[:n]) != string(want) {
+			t.Errorf("event %d:\n  got:  %q\n  want: %q", i, buf[:n], want)
+		}
+	}
+}
+
+// TestSSEStreamReaderSendEventEmptyData verifies behavior with empty data payload.
+func TestSSEStreamReaderSendEventEmptyData(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		want      string
+	}{
+		{
+			name:      "empty data no event type",
+			eventType: "",
+			want:      "data: \n\n",
+		},
+		{
+			name:      "empty data with event type",
+			eventType: "heartbeat",
+			want:      "event: heartbeat\ndata: \n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSSEStreamReader()
+			go func() {
+				r.SendEvent(tt.eventType, []byte{})
+				r.Done()
+			}()
+
+			buf := make([]byte, 4096)
+			n, err := r.Read(buf)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := string(buf[:n]); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSSEStreamReaderSendEventNilData verifies behavior with nil data payload.
+func TestSSEStreamReaderSendEventNilData(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() {
+		r.SendEvent("", nil)
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// nil data should produce same as empty: "data: \n\n"
+	if got := string(buf[:n]); got != "data: \n\n" {
+		t.Errorf("got %q, want %q", got, "data: \n\n")
+	}
+}
+
+// TestSSEStreamReaderSendEventLargePayload verifies no corruption with large JSON payloads.
+func TestSSEStreamReaderSendEventLargePayload(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	// Build a large JSON payload (~64KB, larger than typical ReadBufferSize)
+	largeContent := make([]byte, 65536)
+	for i := range largeContent {
+		largeContent[i] = 'A' + byte(i%26)
+	}
+	data := append([]byte(`{"content":"`), largeContent...)
+	data = append(data, '"', '}')
+
+	go func() {
+		r.SendEvent("response.delta", data)
+		r.Done()
+	}()
+
+	// Read the entire event using small buffer to exercise partial reads
+	var result []byte
+	buf := make([]byte, 1024)
+	for {
+		n, err := r.Read(buf)
+		result = append(result, buf[:n]...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	want := "event: response.delta\ndata: " + string(data) + "\n\n"
+	if string(result) != want {
+		t.Errorf("large payload mismatch: got len=%d, want len=%d", len(result), len(want))
+		// Check prefix and suffix for debugging
+		if len(result) > 40 {
+			t.Errorf("  got prefix:  %q", result[:40])
+			t.Errorf("  want prefix: %q", want[:40])
+		}
+	}
+}
+
+// TestSSEStreamReaderMidStreamDisconnect simulates a client disconnecting
+// mid-stream while the producer is using SendEvent.
+func TestSSEStreamReaderMidStreamDisconnect(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	producerDone := make(chan int) // reports how many events were sent
+	go func() {
+		sent := 0
+		for i := 0; i < 100; i++ {
+			if !r.SendEvent("", []byte(fmt.Sprintf(`{"chunk":%d}`, i))) {
+				break
+			}
+			sent++
+		}
+		close(producerDone)
+	}()
+
+	// Read a few events then simulate client disconnect
+	buf := make([]byte, 4096)
+	for i := 0; i < 3; i++ {
+		_, err := r.Read(buf)
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+	}
+
+	// Client disconnects
+	r.Close()
+
+	// Producer should stop promptly
+	<-producerDone
+}
+
+// TestSSEStreamReaderSendErrorThenDone verifies the handler pattern
+// of sending an error event and immediately closing the stream.
+func TestSSEStreamReaderSendErrorThenDone(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	go func() {
+		// Send a few normal events
+		r.SendEvent("", []byte(`{"chunk":1}`))
+		r.SendEvent("", []byte(`{"chunk":2}`))
+		// Error occurs, send error and stop
+		r.SendError([]byte(`{"error":"rate_limit"}`))
+		r.Done()
+	}()
+
+	buf := make([]byte, 4096)
+	expected := []string{
+		"data: {\"chunk\":1}\n\n",
+		"data: {\"chunk\":2}\n\n",
+		"event: error\ndata: {\"error\":\"rate_limit\"}\n\n",
+	}
+
+	for i, want := range expected {
+		n, err := r.Read(buf)
+		if err != nil {
+			t.Fatalf("event %d: unexpected error: %v", i, err)
+		}
+		if got := string(buf[:n]); got != want {
+			t.Errorf("event %d: got %q, want %q", i, got, want)
+		}
+	}
+
+	// Should be EOF (stream ended after error, no [DONE] marker)
+	n, err := r.Read(buf)
+	if err != io.EOF {
+		t.Errorf("expected EOF after error event, got err=%v n=%d data=%q", err, n, buf[:n])
+	}
+}
+
+// TestSSEStreamReaderSendDoneByteExact verifies SendDone produces
+// exactly "data: [DONE]\n\n" — the standard OpenAI SSE terminator.
+func TestSSEStreamReaderSendDoneByteExact(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() {
+		r.SendDone()
+		r.Done()
+	}()
+
+	// Use exact-size buffer to verify no extra bytes
+	want := []byte("data: [DONE]\n\n")
+	buf := make([]byte, len(want))
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != len(want) {
+		t.Errorf("expected %d bytes, got %d", len(want), n)
+	}
+	if string(buf[:n]) != string(want) {
+		t.Errorf("got %q, want %q", buf[:n], want)
+	}
+}
+
+// TestSSEStreamReaderConcurrentSendEvent verifies thread safety of SendEvent
+// with multiple concurrent producers (not a real pattern but validates safety).
+func TestSSEStreamReaderConcurrentSendEvent(t *testing.T) {
+	r := NewSSEStreamReader()
+	const numProducers = 5
+	const eventsPerProducer = 20
+
+	var wg sync.WaitGroup
+	wg.Add(numProducers)
+
+	// Launch multiple producers
+	for p := 0; p < numProducers; p++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < eventsPerProducer; i++ {
+				if !r.SendEvent("", []byte(fmt.Sprintf(`{"p":%d,"i":%d}`, id, i))) {
+					return
+				}
+			}
+		}(p)
+	}
+
+	// Close after all producers finish
+	go func() {
+		wg.Wait()
+		r.Done()
+	}()
+
+	// Consume all events
+	buf := make([]byte, 4096)
+	count := 0
+	for {
+		n, err := r.Read(buf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Every event must be a valid SSE data line
+		got := string(buf[:n])
+		if len(got) < 8 || got[:6] != "data: " || got[len(got)-2:] != "\n\n" {
+			t.Errorf("event %d: invalid SSE format: %q", count, got)
+		}
+		count++
+	}
+
+	if count != numProducers*eventsPerProducer {
+		t.Errorf("got %d events, want %d", count, numProducers*eventsPerProducer)
+	}
+}
+
+func TestSSEStreamReaderCloseUnblocksProducer(t *testing.T) {
+	r := NewSSEStreamReader()
+
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(done)
+		// Fill the channel buffer (cap=1)
+		r.Send([]byte("data: first\n\n"))
+		// This Send should block until Close is called
+		r.Send([]byte("data: second\n\n"))
+		// After Close, the next Send should return false
+		if r.Send([]byte("data: third\n\n")) {
+			select {
+			case errCh <- fmt.Errorf("Send should return false after Close"):
+			default:
+			}
+		}
+	}()
+
+	// Close unblocks the blocked Send
+	r.Close()
+	<-done
+
+	select {
+	case err := <-errCh:
+		t.Error(err)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

Replaces fasthttp's `SetBodyStreamWriter` with a custom `SSEStreamReader` to fix SSE event batching issues. The previous implementation used `fasthttputil.PipeConns` which batched multiple SSE events into single TCP segments, causing delayed delivery to clients.

## Changes

- **Introduced `SSEStreamReader`**: Custom `io.ReadCloser` that delivers one event per Read call, bypassing fasthttp's internal pipe batching mechanism
- **Replaced `SetBodyStreamWriter` with `SetBodyStream`**: All streaming handlers now use the new reader instead of `bufio.Writer`
- **Eliminated manual buffer flushing**: Events are sent individually through channels, ensuring one HTTP chunk per event
- **Improved error handling**: Client disconnects are detected via `Send()` return values rather than write errors
- **Added comprehensive tests**: Validates that SSE events are delivered individually without batching

The new approach uses a producer-consumer pattern where a goroutine formats SSE events and sends them through a buffered channel, while the reader delivers each event as a separate HTTP chunk.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the new SSE streaming tests to verify events are delivered individually:

```sh
# Test the SSE streaming fix
go test ./transports/bifrost-http/handlers -run TestSSEStreamReaderNoEventBatching -v
go test ./transports/bifrost-http/lib -run TestSSEStreamReader -v

# Run all tests to ensure no regressions
go test ./...
```

Test with a real streaming endpoint to verify events arrive immediately without batching delays.

## Screenshots/Recordings

N/A - Backend streaming behavior change

## Breaking changes

- [ ] Yes
- [x] No

This is an internal implementation change that maintains the same API and behavior from the client perspective.

## Related issues

Fixes SSE event batching issues where multiple events were combined into single TCP segments, causing delayed delivery to streaming clients.

## Security considerations

No security implications. This change only affects the internal mechanism for delivering SSE events and maintains the same authentication and authorization flows.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable