### PR TITLE
[codemode]: fixing string escape corruption, enable top-level control flow in starlark, refining the prompt of executecode tool

### DIFF
--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -208,14 +208,8 @@ func (a *AgentModeExecutor) executeAgent(
 						continue
 					}
 
-					// Step 1: Convert literal \n escape sequences to actual newlines for parsing
-					codeWithNewlines := strings.ReplaceAll(code, "\\n", "\n")
-					if len(codeWithNewlines) != len(code) {
-						a.logger.Debug("%s Converted literal \\n escape sequences to actual newlines", CodeModeLogPrefix)
-					}
-
-					// Step 2: Extract tool calls from code during AST formation
-					extractedToolCalls, err := extractToolCallsFromCode(codeWithNewlines)
+					// Step 1: Extract tool calls from the original source code during validation
+					extractedToolCalls, err := extractToolCallsFromCode(code)
 					if err != nil {
 						a.logger.Debug("%s Failed to parse code for tool calls: %v", CodeModeLogPrefix, err)
 						nonAutoExecutableTools = append(nonAutoExecutableTools, toolCall)

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -16,6 +16,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
+	"go.starlark.net/syntax"
 )
 
 // ExecutionResult represents the result of code execution
@@ -52,8 +53,11 @@ type ExecutionEnvironment struct {
 func (s *StarlarkCodeMode) createExecuteToolCodeTool() schemas.ChatTool {
 	executeToolCodeProps := schemas.NewOrderedMapFromPairs(
 		schemas.KV("code", map[string]interface{}{
-			"type":        "string",
-			"description": "Python code to execute. The code runs in a Starlark interpreter (Python subset). Tool calls are synchronous - no async/await needed. For loops/conditionals, wrap in a function. Use print() for logging. ALWAYS retry if code fails. Example: def main():\n  items = server.list_items()\n  for item in items:\n    print(item)\nresult = main()",
+			"type": "string",
+			"description": "Python (Starlark) code to execute. Tool calls are synchronous: result = server.tool(param=\"value\"). " +
+				"Use print() for logging. Assign to 'result' variable to return a value. " +
+				"Retry after fixing syntax or logic errors, especially for read-only flows. Before rerunning code that already made tool calls, inspect prior outputs and avoid replaying stateful operations. " +
+				"Example: items = server.list_items()\nfor item in items:\n    print(item[\"name\"])\nresult = items",
 		}),
 	)
 	return schemas.ChatTool{
@@ -61,36 +65,36 @@ func (s *StarlarkCodeMode) createExecuteToolCodeTool() schemas.ChatTool {
 		Function: &schemas.ChatToolFunction{
 			Name: codemcp.ToolTypeExecuteToolCode,
 			Description: schemas.Ptr(
-				"Executes Python code inside a sandboxed Starlark interpreter with access to all connected MCP servers' tools. " +
-					"All connected servers are exposed as global objects named after their configuration keys, and each server " +
-					"provides functions for every tool available on that server. The canonical usage pattern is: " +
-					"result = <serverName>.<toolName>(param=\"value\"). Both <serverName> and <toolName> should be discovered " +
-					"using listToolFiles and readToolFile. " +
+				"Executes Python code in a sandboxed Starlark interpreter with MCP server tool access. " +
+					"Servers are exposed as global objects: result = serverName.toolName(param=\"value\"). " +
+					"This is the final step of the four-tool code mode workflow: listToolFiles -> readToolFile -> (optional) getToolDocs -> executeToolCode. " +
+					"If you have not already read a tool's .pyi stub in this conversation, do that before writing code. " +
+					"Do NOT guess callable tool names from natural language or stale assumptions; use the exact identifier returned by listToolFiles/readToolFile. " +
 
-					"IMPORTANT WORKFLOW: Always follow this order — first use listToolFiles to see available servers and tools, " +
-					"then use readToolFile to understand the tool definitions and their parameters, and finally use executeToolCode " +
-					"to execute your code. " +
+					"STARLARK DIFFERENCES FROM PYTHON — READ BEFORE WRITING CODE: " +
+					"1. NO try/except/finally/raise — error handling is not supported, and tool failures cannot be caught inside Starlark. " +
+					"2. NO classes — use dicts and functions. " +
+					"3. NO imports, direct network access, or direct filesystem access — use MCP tools instead. " +
+					"4. NO is operator — use == for comparison. " +
+					"5. NO f-strings — use % formatting: \"Hello %s, count=%d\" % (name, n). " +
+					"6. Each executeToolCode call runs in a FRESH ISOLATED SCOPE — no variables, functions, or state persist between calls. Re-fetch data or store it via MCP tools (e.g., SQLite, FileSystem) if needed across calls. " +
 
 					"SYNTAX NOTES: " +
-					"• Tool calls are synchronous - NO async/await needed, just call directly: result = server.tool(arg=\"value\") " +
+					"• Synchronous calls — NO async/await: result = server.tool(arg=\"value\") " +
 					"• Use keyword arguments: server.tool(param=\"value\") NOT server.tool({\"param\": \"value\"}) " +
 					"• Access dict values with brackets: result[\"key\"] NOT result.key " +
-					"• Use print() for logging (not console.log) " +
-					"• List comprehensions work: [x for x in items if x[\"active\"]] " +
-					"• To return a value, assign to 'result' variable: result = computed_value " +
-					"• CRITICAL: for/if/while at top level MUST be inside a function - def main(): ... then result = main() " +
+					"• Use print() for logging/debugging " +
+					"• List comprehensions: [x for x in items if x[\"active\"]] " +
+					"• String escapes work normally: \"line1\\nline2\" produces a newline " +
+					"• Triple-quoted strings for multiline: \"\"\"multi\\nline\"\"\" " +
+					"• chr(10) for newline character, chr(9) for tab " +
+					"• To return a value, assign to 'result': result = computed_value " +
+					"• MCP tool calls are timeout-limited; avoid long or infinite loops " +
 
-					"RETRY POLICY: ALWAYS retry if a code block fails. Analyze the error, adjust your code, and retry. " +
+					"AVAILABLE BUILTINS: print, len, range, enumerate, zip, sorted, reversed, min, max, " +
+					"int, float, str, bool, list, dict, tuple, set, hasattr, getattr, type, chr, ord, any, all, hash, repr. " +
 
-					"The environment is intentionally minimal: " +
-					"• No imports needed or supported " +
-					"• No network APIs (use MCP tools for external interactions) " +
-					"• No file system access (use MCP tools) " +
-					"• No classes (use dicts and functions) " +
-					"• Deterministic execution (no random, no time) " +
-
-					"Long-running operations are interrupted via execution timeout. " +
-					"This tool is designed specifically for orchestrating MCP tool calls and lightweight computation.",
+					"RETRY POLICY: Retry after fixing syntax or logic errors, especially for read-only flows. Before rerunning code that already made tool calls, inspect prior outputs and avoid replaying stateful operations.",
 			),
 
 			Parameters: &schemas.ToolFunctionParameters{
@@ -202,11 +206,8 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 
 	s.logger.Debug("%s Starting Starlark code execution", codemcp.CodeModeLogPrefix)
 
-	// Step 1: Convert literal \n escape sequences to actual newlines
-	codeWithNewlines := strings.ReplaceAll(code, "\\n", "\n")
-
-	// Step 2: Handle empty code
-	trimmedCode := strings.TrimSpace(codeWithNewlines)
+	// Step 1: Handle empty code
+	trimmedCode := strings.TrimSpace(code)
 	if trimmedCode == "" {
 		return ExecutionResult{
 			Result: nil,
@@ -218,7 +219,7 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 		}
 	}
 
-	// Step 3: Build tool bindings for all connected servers
+	// Step 2: Build tool bindings for all connected servers
 	availableToolsPerClient := s.clientManager.GetToolPerClient(ctx)
 	serverKeys := make([]string, 0, len(availableToolsPerClient))
 	predeclared := starlark.StringDict{}
@@ -254,9 +255,8 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 			}
 
 			originalToolName := tool.Function.Name
-			unprefixedToolName := stripClientPrefix(originalToolName, clientName)
-			unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-			parsedToolName := parseToolName(unprefixedToolName)
+			parsedToolName := getCanonicalToolName(clientName, originalToolName)
+			compatibilityAlias := getCompatibilityToolAlias(clientName, originalToolName)
 
 			s.logger.Debug("%s [%s] Binding tool: %s -> %s", codemcp.CodeModeLogPrefix, clientName, originalToolName, parsedToolName)
 
@@ -298,6 +298,13 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 			})
 
 			structMembers[parsedToolName] = toolFunc
+
+			if compatibilityAlias != parsedToolName && isValidStarlarkIdentifier(compatibilityAlias) {
+				if _, exists := structMembers[compatibilityAlias]; !exists {
+					structMembers[compatibilityAlias] = toolFunc
+					s.logger.Debug("%s [%s] Added compatibility alias: %s -> %s", codemcp.CodeModeLogPrefix, clientName, compatibilityAlias, parsedToolName)
+				}
+			}
 		}
 
 		// Create a struct for this server
@@ -312,7 +319,7 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 		s.logger.Debug("%s No servers available for code mode execution", codemcp.CodeModeLogPrefix)
 	}
 
-	// Step 4: Create Starlark thread with print function and timeout
+	// Step 3: Create Starlark thread with print function and timeout
 	toolExecutionTimeout := s.getToolExecutionTimeout()
 	timeoutCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
 	defer cancel()
@@ -327,8 +334,17 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 	// Set up cancellation check
 	thread.SetLocal("context", timeoutCtx)
 
+	// Step 4: Configure Starlark dialect options for a Python-like experience
+	starlarkOpts := &syntax.FileOptions{
+		TopLevelControl: true, // allow if/for/while at top level (not just inside functions)
+		While:           true, // enable while loops
+		Set:             true, // enable set() builtin
+		GlobalReassign:  true, // allow reassignment to top-level names
+		Recursion:       true, // allow recursive functions
+	}
+
 	// Step 5: Execute the code
-	globals, err := starlark.ExecFile(thread, "code.star", trimmedCode, predeclared)
+	globals, err := starlark.ExecFileOptions(starlarkOpts, thread, "code.star", trimmedCode, predeclared)
 
 	if err != nil {
 		errorMessage := err.Error()

--- a/core/mcp/codemode/starlark/getdocs.go
+++ b/core/mcp/codemode/starlark/getdocs.go
@@ -71,8 +71,6 @@ func (s *StarlarkCodeMode) handleGetToolDocs(ctx context.Context, toolCall schem
 	var matchedTool *schemas.ChatTool
 
 	serverNameLower := strings.ToLower(serverName)
-	toolNameLower := strings.ToLower(toolName)
-
 	for clientName, tools := range availableToolsPerClient {
 		client := s.clientManager.GetClientByName(clientName)
 		if client == nil {
@@ -90,10 +88,7 @@ func (s *StarlarkCodeMode) handleGetToolDocs(ctx context.Context, toolCall schem
 			// Find the specific tool
 			for i, tool := range tools {
 				if tool.Function != nil {
-					// Strip client prefix and replace - with _ for comparison
-					unprefixedToolName := stripClientPrefix(tool.Function.Name, clientName)
-					unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-					if strings.ToLower(unprefixedToolName) == toolNameLower {
+					if matchesToolReference(toolName, clientName, tool.Function.Name) {
 						matchedTool = &tools[i]
 						break
 					}
@@ -125,9 +120,7 @@ func (s *StarlarkCodeMode) handleGetToolDocs(ctx context.Context, toolCall schem
 		var availableTools []string
 		for _, tool := range tools {
 			if tool.Function != nil {
-				unprefixedToolName := stripClientPrefix(tool.Function.Name, matchedClientName)
-				unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-				availableTools = append(availableTools, unprefixedToolName)
+				availableTools = append(availableTools, getCanonicalToolName(matchedClientName, tool.Function.Name))
 			}
 		}
 		errorMsg := fmt.Sprintf("Tool '%s' not found in server '%s'. Available tools are:\n", toolName, matchedClientName)
@@ -150,7 +143,7 @@ func generateTypeDefinitions(clientName string, tools []schemas.ChatTool, isTool
 	// Write comprehensive header
 	sb.WriteString("# ============================================================================\n")
 	if isToolLevel && len(tools) == 1 && tools[0].Function != nil {
-		sb.WriteString(fmt.Sprintf("# Documentation for %s.%s tool\n", clientName, tools[0].Function.Name))
+		sb.WriteString(fmt.Sprintf("# Documentation for %s.%s tool\n", clientName, getCanonicalToolName(clientName, tools[0].Function.Name)))
 	} else {
 		sb.WriteString(fmt.Sprintf("# Documentation for %s MCP server\n", clientName))
 	}
@@ -187,9 +180,7 @@ func generateTypeDefinitions(clientName string, tools []schemas.ChatTool, isTool
 		}
 
 		originalToolName := tool.Function.Name
-		unprefixedToolName := stripClientPrefix(originalToolName, clientName)
-		unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-		toolName := parseToolName(unprefixedToolName)
+		toolName := getCanonicalToolName(clientName, originalToolName)
 		description := ""
 		if tool.Function.Description != nil {
 			description = *tool.Function.Description

--- a/core/mcp/codemode/starlark/listfiles.go
+++ b/core/mcp/codemode/starlark/listfiles.go
@@ -21,7 +21,8 @@ func (s *StarlarkCodeMode) createListToolFilesTool() schemas.ChatTool {
 	if bindingLevel == schemas.CodeModeBindingLevelServer {
 		description = "Returns a tree structure listing all virtual .pyi stub files available for connected MCP servers. " +
 			"Each server has a corresponding file (e.g., servers/<serverName>.pyi) that contains compact Python signatures for all tools in that server. " +
-			"Use readToolFile to read a specific server file and see all available tools with their signatures. " +
+			"Safe workflow: listToolFiles -> readToolFile -> (optional) getToolDocs -> executeToolCode. " +
+			"Use readToolFile before executeToolCode to read a specific server file and confirm exact callable tool names and parameters. " +
 			"Use getToolDocs if you need detailed documentation for a specific tool. " +
 			"In code, access tools via: server_name.tool_name(param=value). " +
 			"The server names used in code correspond to the human-readable names shown in this listing. " +
@@ -30,7 +31,9 @@ func (s *StarlarkCodeMode) createListToolFilesTool() schemas.ChatTool {
 	} else {
 		description = "Returns a tree structure listing all virtual .pyi stub files available for connected MCP servers, organized by individual tool. " +
 			"Each tool has a corresponding file (e.g., servers/<serverName>/<toolName>.pyi) that contains compact Python signatures for that specific tool. " +
-			"Use readToolFile to read a specific tool file and see its signature. " +
+			"The <toolName> shown in each filename is the exact canonical identifier exposed in executeToolCode. " +
+			"Safe workflow: listToolFiles -> readToolFile -> (optional) getToolDocs -> executeToolCode. " +
+			"Use readToolFile before executeToolCode to confirm the exact signature and parameters for the tool you want to call. " +
 			"Use getToolDocs if you need detailed documentation for a specific tool. " +
 			"In code, access tools via: server_name.tool_name(param=value). " +
 			"The server names used in code correspond to the human-readable names shown in this listing. " +
@@ -88,12 +91,7 @@ func (s *StarlarkCodeMode) handleListToolFiles(ctx context.Context, toolCall sch
 			// Tool-level: one file per tool
 			for _, tool := range tools {
 				if tool.Function != nil && tool.Function.Name != "" {
-					// Strip the client prefix from tool name (format: "client-toolname" -> "toolname")
-					// But replace - with _ for valid Python identifiers
-					toolName := stripClientPrefix(tool.Function.Name, clientName)
-					// Replace any remaining hyphens with underscores for Python compatibility
-					toolName = strings.ReplaceAll(toolName, "-", "_")
-					// Validate normalized tool name to prevent path traversal
+					toolName := getCanonicalToolName(clientName, tool.Function.Name)
 					if err := validateNormalizedToolName(toolName); err != nil {
 						s.logger.Warn("%s Skipping tool '%s' from client '%s': %v", codemcp.CodeModeLogPrefix, tool.Function.Name, clientName, err)
 						continue
@@ -112,8 +110,30 @@ func (s *StarlarkCodeMode) handleListToolFiles(ctx context.Context, toolCall sch
 	}
 
 	// Build tree structure from file list
-	responseText := buildVFSTree(files)
+	responseText := buildListToolFilesResponse(files, bindingLevel)
 	return createToolResponseMessage(toolCall, responseText), nil
+}
+
+func buildListToolFilesResponse(files []string, bindingLevel schemas.CodeModeBindingLevel) string {
+	tree := buildVFSTree(files)
+	if tree == "" {
+		return ""
+	}
+
+	header := []string{
+		"# Workflow: listToolFiles -> readToolFile -> (optional) getToolDocs -> executeToolCode",
+	}
+
+	if bindingLevel == schemas.CodeModeBindingLevelServer {
+		header = append(header, "# Read the server .pyi file before executeToolCode to confirm exact tool names and parameters.")
+	} else {
+		header = append(header,
+			"# Filenames below use the exact canonical tool identifiers available in executeToolCode.",
+			"# Still call readToolFile before executeToolCode to confirm parameters and return shape.",
+		)
+	}
+
+	return strings.Join(append(header, "", tree), "\n")
 }
 
 // VFS tree node structure for building hierarchical file structure

--- a/core/mcp/codemode/starlark/readfile.go
+++ b/core/mcp/codemode/starlark/readfile.go
@@ -21,21 +21,23 @@ func (s *StarlarkCodeMode) createReadToolFileTool() schemas.ChatTool {
 	var fileNameDescription, toolDescription string
 
 	if bindingLevel == schemas.CodeModeBindingLevelServer {
-		fileNameDescription = "The virtual filename from listToolFiles in format: servers/<serverName>.pyi (e.g., 'calculator.pyi')"
+		fileNameDescription = "The virtual filename from listToolFiles in format: servers/<serverName>.pyi (e.g., 'servers/calculator.pyi')"
 		toolDescription = "Reads a virtual .pyi stub file for a specific MCP server, returning compact Python function signatures " +
 			"for all tools available on that server. The fileName should be in format servers/<serverName>.pyi as listed by listToolFiles. " +
 			"The function performs case-insensitive matching and removes the .pyi extension. " +
+			"This is the authoritative source for the exact callable tool names and parameters to use in executeToolCode. " +
 			"Each tool can be accessed in code via: serverName.tool_name(param=value). " +
 			"If the compact signature is not enough to understand a tool, use getToolDocs for detailed documentation. " +
 			"Workflow: listToolFiles -> readToolFile -> (optional) getToolDocs -> executeToolCode. " +
 			"IMPORTANT: If the response header shows 'Total lines: X (this is the complete file)', " +
 			"do NOT call this tool again with startLine/endLine - you already have the complete file."
 	} else {
-		fileNameDescription = "The virtual filename from listToolFiles in format: servers/<serverName>/<toolName>.pyi (e.g., 'calculator/add.pyi')"
+		fileNameDescription = "The virtual filename from listToolFiles in format: servers/<serverName>/<toolName>.pyi (e.g., 'servers/calculator/add.pyi')"
 		toolDescription = "Reads a virtual .pyi stub file for a specific tool, returning its compact Python function signature. " +
 			"The fileName should be in format servers/<serverName>/<toolName>.pyi as listed by listToolFiles. " +
 			"The function performs case-insensitive matching and removes the .pyi extension. " +
-			"The tool can be accessed in code via: serverName.tool_name(param=value). " +
+			"This is the authoritative source for the exact callable tool name and arguments to use in executeToolCode. " +
+			"The tool can be accessed in code via: serverName.tool_name(param=value) using the def name shown in the file. " +
 			"If the compact signature is not enough to understand the tool, use getToolDocs for detailed documentation. " +
 			"Workflow: listToolFiles -> readToolFile -> (optional) getToolDocs -> executeToolCode. " +
 			"IMPORTANT: If the response header shows 'Total lines: X (this is the complete file)', " +
@@ -126,13 +128,9 @@ func (s *StarlarkCodeMode) handleReadToolFile(ctx context.Context, toolCall sche
 			if isToolLevel {
 				// Tool-level: filter to specific tool
 				var foundTool *schemas.ChatTool
-				toolNameLower := strings.ToLower(toolName)
 				for i, tool := range tools {
 					if tool.Function != nil {
-						// Strip client prefix and replace - with _ for comparison
-						unprefixedToolName := stripClientPrefix(tool.Function.Name, clientName)
-						unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-						if strings.ToLower(unprefixedToolName) == toolNameLower {
+						if matchesToolReference(toolName, clientName, tool.Function.Name) {
 							foundTool = &tools[i]
 							break
 						}
@@ -143,15 +141,12 @@ func (s *StarlarkCodeMode) handleReadToolFile(ctx context.Context, toolCall sche
 					availableTools := make([]string, 0)
 					for _, tool := range tools {
 						if tool.Function != nil {
-							// Strip client prefix and replace - with _ for display
-							unprefixedToolName := stripClientPrefix(tool.Function.Name, clientName)
-							unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-							availableTools = append(availableTools, unprefixedToolName)
+							availableTools = append(availableTools, getCanonicalToolName(clientName, tool.Function.Name))
 						}
 					}
 					errorMsg := fmt.Sprintf("Tool '%s' not found in server '%s'. Available tools in this server are:\n", toolName, clientName)
 					for _, t := range availableTools {
-						errorMsg += fmt.Sprintf("  - %s/%s.pyi\n", clientName, t)
+						errorMsg += fmt.Sprintf("  - servers/%s/%s.pyi\n", clientName, t)
 					}
 					return createToolResponseMessage(toolCall, errorMsg), nil
 				}
@@ -171,17 +166,14 @@ func (s *StarlarkCodeMode) handleReadToolFile(ctx context.Context, toolCall sche
 
 		for name := range availableToolsPerClient {
 			if bindingLevel == schemas.CodeModeBindingLevelServer {
-				availableFiles = append(availableFiles, fmt.Sprintf("%s.pyi", name))
+				availableFiles = append(availableFiles, fmt.Sprintf("servers/%s.pyi", name))
 			} else {
 				client := s.clientManager.GetClientByName(name)
 				if client != nil && client.ExecutionConfig.IsCodeModeClient {
 					if tools, ok := availableToolsPerClient[name]; ok {
 						for _, tool := range tools {
 							if tool.Function != nil {
-								// Strip client prefix and replace - with _ for display
-								unprefixedToolName := stripClientPrefix(tool.Function.Name, name)
-								unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-								availableFiles = append(availableFiles, fmt.Sprintf("%s/%s.pyi", name, unprefixedToolName))
+								availableFiles = append(availableFiles, fmt.Sprintf("servers/%s/%s.pyi", name, getCanonicalToolName(name, tool.Function.Name)))
 							}
 						}
 					}
@@ -295,12 +287,14 @@ func generateCompactSignatures(clientName string, tools []schemas.ChatTool, isTo
 
 	// Minimal header
 	if isToolLevel && len(tools) == 1 && tools[0].Function != nil {
-		toolName := parseToolName(stripClientPrefix(tools[0].Function.Name, clientName))
+		toolName := getCanonicalToolName(clientName, tools[0].Function.Name)
 		sb.WriteString(fmt.Sprintf("# %s.%s tool\n", clientName, toolName))
 	} else {
 		sb.WriteString(fmt.Sprintf("# %s server tools\n", clientName))
 	}
 	sb.WriteString(fmt.Sprintf("# Usage: %s.tool_name(param=value)\n", clientName))
+	sb.WriteString("# The def names below are the exact callable names to use in executeToolCode.\n")
+	sb.WriteString("# Read this file before executeToolCode to confirm parameters and return shape.\n")
 	sb.WriteString(fmt.Sprintf("# For detailed docs: use getToolDocs(server=\"%s\", tool=\"tool_name\")\n", clientName))
 	sb.WriteString("# Note: Descriptions may be truncated. Use getToolDocs for full details.\n\n")
 
@@ -309,10 +303,7 @@ func generateCompactSignatures(clientName string, tools []schemas.ChatTool, isTo
 			continue
 		}
 
-		// Strip client prefix and replace - with _ for code mode compatibility
-		unprefixedToolName := stripClientPrefix(tool.Function.Name, clientName)
-		unprefixedToolName = strings.ReplaceAll(unprefixedToolName, "-", "_")
-		toolName := parseToolName(unprefixedToolName)
+		toolName := getCanonicalToolName(clientName, tool.Function.Name)
 
 		// Format inline parameters in Python style
 		params := formatPythonParams(tool.Function.Parameters)

--- a/core/mcp/codemode/starlark/starlark_test.go
+++ b/core/mcp/codemode/starlark/starlark_test.go
@@ -3,12 +3,41 @@
 package starlark
 
 import (
+	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/bytedance/sonic"
+	codemcp "github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
+
+type testClientManager struct {
+	clients map[string]*schemas.MCPClientState
+	tools   map[string][]schemas.ChatTool
+}
+
+func (m *testClientManager) GetClientForTool(toolName string) *schemas.MCPClientState {
+	for clientName, tools := range m.tools {
+		for _, tool := range tools {
+			if tool.Function != nil && tool.Function.Name == toolName {
+				return m.clients[clientName]
+			}
+		}
+	}
+	return nil
+}
+
+func (m *testClientManager) GetClientByName(clientName string) *schemas.MCPClientState {
+	return m.clients[clientName]
+}
+
+func (m *testClientManager) GetToolPerClient(ctx context.Context) map[string][]schemas.ChatTool {
+	return m.tools
+}
 
 func TestStarlarkToGo(t *testing.T) {
 	t.Run("Convert None", func(t *testing.T) {
@@ -151,6 +180,83 @@ func TestGoToStarlark(t *testing.T) {
 	})
 }
 
+func TestGetCanonicalToolName(t *testing.T) {
+	if got := getCanonicalToolName("github", "github-SEARCH_REPOS"); got != "search_repos" {
+		t.Fatalf("expected canonical tool name search_repos, got %q", got)
+	}
+
+	if got := getCanonicalToolName("math", "math-123Add!"); got != "_123add" {
+		t.Fatalf("expected canonical tool name _123add, got %q", got)
+	}
+}
+
+func TestMatchesToolReferenceSupportsCanonicalAndLegacyNames(t *testing.T) {
+	clientName := "github"
+	originalToolName := "github-SEARCH_REPOS"
+
+	testCases := []string{
+		"search_repos",
+		"SEARCH_REPOS",
+	}
+
+	for _, toolRef := range testCases {
+		if !matchesToolReference(toolRef, clientName, originalToolName) {
+			t.Fatalf("expected %q to match %q", toolRef, originalToolName)
+		}
+	}
+}
+
+func TestHandleListToolFilesUsesCanonicalToolIdentifiers(t *testing.T) {
+	mode := NewStarlarkCodeMode(&codemcp.CodeModeConfig{
+		BindingLevel:         schemas.CodeModeBindingLevelTool,
+		ToolExecutionTimeout: time.Second,
+	}, nil)
+
+	clientName := "github"
+	mode.clientManager = &testClientManager{
+		clients: map[string]*schemas.MCPClientState{
+			clientName: {
+				Name: clientName,
+				ExecutionConfig: &schemas.MCPClientConfig{
+					Name:             clientName,
+					IsCodeModeClient: true,
+				},
+			},
+		},
+		tools: map[string][]schemas.ChatTool{
+			clientName: {
+				{
+					Function: &schemas.ChatToolFunction{
+						Name: "github-SEARCH_REPOS",
+					},
+				},
+			},
+		},
+	}
+
+	msg, err := mode.handleListToolFiles(context.Background(), schemas.ChatAssistantMessageToolCall{
+		ID: schemas.Ptr("tool-call-1"),
+	})
+	if err != nil {
+		t.Fatalf("handleListToolFiles returned error: %v", err)
+	}
+
+	if msg == nil || msg.Content == nil || msg.Content.ContentStr == nil {
+		t.Fatal("expected tool response content")
+	}
+
+	content := *msg.Content.ContentStr
+	if !strings.Contains(content, "search_repos.pyi") {
+		t.Fatalf("expected canonical tool file path in response, got:\n%s", content)
+	}
+	if strings.Contains(content, "SEARCH_REPOS.pyi") {
+		t.Fatalf("did not expect raw uppercase tool file path in response, got:\n%s", content)
+	}
+	if !strings.Contains(content, "readToolFile before executeToolCode") {
+		t.Fatalf("expected workflow guidance in response, got:\n%s", content)
+	}
+}
+
 func TestGeneratePythonErrorHints(t *testing.T) {
 	serverKeys := []string{"calculator", "weather"}
 
@@ -161,13 +267,13 @@ func TestGeneratePythonErrorHints(t *testing.T) {
 		}
 		found := false
 		for _, hint := range hints {
-			if containsAny(hint, "not defined", "undefined") {
+			if strings.Contains(hint, "Variable 'foo' is not defined.") {
 				found = true
 				break
 			}
 		}
 		if !found {
-			t.Error("Expected hint about undefined variable")
+			t.Errorf("Expected exact undefined variable hint for foo, got: %v", hints)
 		}
 	})
 
@@ -486,6 +592,408 @@ func TestFormatResultForLog(t *testing.T) {
 		if len(result) > 200 {
 			// Should be truncated to around 200 chars (plus quotes and ellipsis)
 			t.Logf("Result length: %d (truncated as expected)", len(result))
+		}
+	})
+}
+
+// starlarkOpts returns the FileOptions used by the code mode executor.
+// Kept in sync with executecode.go to test the same dialect configuration.
+func starlarkOpts() *syntax.FileOptions {
+	return &syntax.FileOptions{
+		TopLevelControl: true,
+		While:           true,
+		Set:             true,
+		GlobalReassign:  true,
+		Recursion:       true,
+	}
+}
+
+// execStarlark is a test helper that executes Starlark code with our dialect options
+// and returns the globals and any error.
+func execStarlark(code string) (starlark.StringDict, error) {
+	thread := &starlark.Thread{Name: "test"}
+	return starlark.ExecFileOptions(starlarkOpts(), thread, "test.star", code, nil)
+}
+
+func TestStarlarkDialectOptions(t *testing.T) {
+	t.Run("Top-level for loop", func(t *testing.T) {
+		code := `
+items = []
+for i in range(3):
+    items.append(i)
+result = items
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Top-level for loop should work, got error: %v", err)
+		}
+		resultVal := globals["result"]
+		list, ok := resultVal.(*starlark.List)
+		if !ok {
+			t.Fatalf("Expected list, got %T", resultVal)
+		}
+		if list.Len() != 3 {
+			t.Errorf("Expected 3 items, got %d", list.Len())
+		}
+	})
+
+	t.Run("Top-level if statement", func(t *testing.T) {
+		code := `
+x = 10
+if x > 5:
+    result = "big"
+else:
+    result = "small"
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Top-level if should work, got error: %v", err)
+		}
+		if globals["result"] != starlark.String("big") {
+			t.Errorf("Expected 'big', got %v", globals["result"])
+		}
+	})
+
+	t.Run("Top-level while loop", func(t *testing.T) {
+		code := `
+count = 0
+while count < 5:
+    count += 1
+result = count
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Top-level while loop should work, got error: %v", err)
+		}
+		resultVal := globals["result"]
+		if resultVal.String() != "5" {
+			t.Errorf("Expected 5, got %v", resultVal)
+		}
+	})
+
+	t.Run("While loop inside function", func(t *testing.T) {
+		code := `
+def countdown(n):
+    items = []
+    while n > 0:
+        items.append(n)
+        n -= 1
+    return items
+result = countdown(3)
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("While in function should work, got error: %v", err)
+		}
+		list := globals["result"].(*starlark.List)
+		if list.Len() != 3 {
+			t.Errorf("Expected 3 items, got %d", list.Len())
+		}
+	})
+
+	t.Run("set() builtin", func(t *testing.T) {
+		code := `
+s = set([1, 2, 3, 2, 1])
+result = len(s)
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("set() should work, got error: %v", err)
+		}
+		if globals["result"].String() != "3" {
+			t.Errorf("Expected 3 unique items, got %v", globals["result"])
+		}
+	})
+
+	t.Run("Global variable reassignment", func(t *testing.T) {
+		code := `
+x = 1
+x = x + 1
+x = x * 3
+result = x
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Global reassignment should work, got error: %v", err)
+		}
+		if globals["result"].String() != "6" {
+			t.Errorf("Expected 6, got %v", globals["result"])
+		}
+	})
+
+	t.Run("Recursive function", func(t *testing.T) {
+		code := `
+def factorial(n):
+    if n <= 1:
+        return 1
+    return n * factorial(n - 1)
+result = factorial(5)
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Recursion should work, got error: %v", err)
+		}
+		if globals["result"].String() != "120" {
+			t.Errorf("Expected 120, got %v", globals["result"])
+		}
+	})
+}
+
+func TestStarlarkStringEscapePreservation(t *testing.T) {
+	t.Run("Backslash-n in string literal preserved", func(t *testing.T) {
+		// Simulate what happens after JSON deserialization:
+		// Model writes: {"code": "msg = \"hello\\nworld\""}
+		// sonic.Unmarshal produces: msg = "hello\nworld" (where \n is two chars: \ + n)
+		// Starlark should interpret \n as newline escape inside the string
+		code := "msg = \"hello\\nworld\"\nresult = msg"
+
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("String with \\n escape should work, got error: %v", err)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		if resultStr != "hello\nworld" {
+			t.Errorf("Expected 'hello<newline>world', got %q", resultStr)
+		}
+	})
+
+	t.Run("Multiple escape sequences in strings", func(t *testing.T) {
+		code := "msg = \"col1\\tcol2\\nrow1\\trow2\"\nresult = msg"
+
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("String with multiple escapes should work, got error: %v", err)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		if resultStr != "col1\tcol2\nrow1\trow2" {
+			t.Errorf("Expected tab/newline escapes, got %q", resultStr)
+		}
+	})
+
+	t.Run("Newline join pattern", func(t *testing.T) {
+		// This is the exact pattern that failed 7 times in benchmarks
+		code := `
+def main():
+    lines = ["line1", "line2", "line3"]
+    content = "\n".join(lines)
+    return content
+result = main()
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Newline join pattern should work, got error: %v", err)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		if resultStr != "line1\nline2\nline3" {
+			t.Errorf("Expected joined lines, got %q", resultStr)
+		}
+	})
+
+	t.Run("chr() for newline", func(t *testing.T) {
+		code := `
+nl = chr(10)
+result = "hello" + nl + "world"
+`
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("chr(10) should work, got error: %v", err)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		if resultStr != "hello\nworld" {
+			t.Errorf("Expected 'hello<newline>world', got %q", resultStr)
+		}
+	})
+
+	t.Run("Triple-quoted strings", func(t *testing.T) {
+		code := "result = \"\"\"line1\nline2\nline3\"\"\""
+
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Triple-quoted string should work, got error: %v", err)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		if resultStr != "line1\nline2\nline3" {
+			t.Errorf("Expected multiline string, got %q", resultStr)
+		}
+	})
+
+	t.Run("Raw string preserves backslash", func(t *testing.T) {
+		code := "result = r\"hello\\nworld\""
+
+		globals, err := execStarlark(code)
+		if err != nil {
+			t.Fatalf("Raw string should work, got error: %v", err)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		// Raw string: \n stays as two characters \ and n
+		if resultStr != "hello\\nworld" {
+			t.Errorf("Expected literal backslash-n, got %q", resultStr)
+		}
+	})
+
+	t.Run("JSON deserialization then Starlark execution", func(t *testing.T) {
+		// End-to-end: simulate the exact flow from model JSON → sonic.Unmarshal → Starlark
+		jsonArgs := `{"code": "lines = [\"a\", \"b\", \"c\"]\nresult = \"\\n\".join(lines)"}`
+
+		var arguments map[string]interface{}
+		err := sonic.Unmarshal([]byte(jsonArgs), &arguments)
+		if err != nil {
+			t.Fatalf("JSON unmarshal failed: %v", err)
+		}
+
+		code := arguments["code"].(string)
+
+		globals, starlarkErr := execStarlark(code)
+		if starlarkErr != nil {
+			t.Fatalf("Starlark execution failed: %v", starlarkErr)
+		}
+		resultStr := string(globals["result"].(starlark.String))
+		if resultStr != "a\nb\nc" {
+			t.Errorf("Expected 'a<newline>b<newline>c', got %q", resultStr)
+		}
+	})
+}
+
+func TestStarlarkUnsupportedFeatures(t *testing.T) {
+	t.Run("try/except rejected", func(t *testing.T) {
+		code := `
+def main():
+    try:
+        x = 1
+    except:
+        x = 0
+result = main()
+`
+		_, err := execStarlark(code)
+		if err == nil {
+			t.Fatal("try/except should be rejected by Starlark")
+		}
+		if !strings.Contains(err.Error(), "got try") {
+			t.Errorf("Expected 'got try' in error, got: %v", err)
+		}
+	})
+
+	t.Run("raise rejected", func(t *testing.T) {
+		code := `raise ValueError("test")`
+
+		_, err := execStarlark(code)
+		if err == nil {
+			t.Fatal("raise should be rejected by Starlark")
+		}
+	})
+
+	t.Run("class rejected", func(t *testing.T) {
+		code := `
+class Foo:
+    pass
+`
+		_, err := execStarlark(code)
+		if err == nil {
+			t.Fatal("class should be rejected by Starlark")
+		}
+	})
+
+	t.Run("import rejected", func(t *testing.T) {
+		code := `import json`
+
+		_, err := execStarlark(code)
+		if err == nil {
+			t.Fatal("import should be rejected by Starlark")
+		}
+	})
+}
+
+func TestGeneratePythonErrorHintsNewCases(t *testing.T) {
+	serverKeys := []string{"Github", "SqLite"}
+
+	t.Run("try/except hint", func(t *testing.T) {
+		hints := generatePythonErrorHints("code.star:3:9: got try, want primary expression", serverKeys)
+		if len(hints) == 0 {
+			t.Fatal("Expected hints for try/except error")
+		}
+		found := false
+		for _, hint := range hints {
+			if containsAny(hint, "try/except", "exception handling") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected hint about try/except not being supported, got: %v", hints)
+		}
+	})
+
+	t.Run("except hint", func(t *testing.T) {
+		hints := generatePythonErrorHints("code.star:5:9: got except, want primary expression", serverKeys)
+		if len(hints) == 0 {
+			t.Fatal("Expected hints for except error")
+		}
+		found := false
+		for _, hint := range hints {
+			if containsAny(hint, "try/except", "exception handling") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected hint about exception handling, got: %v", hints)
+		}
+	})
+
+	t.Run("finally hint", func(t *testing.T) {
+		hints := generatePythonErrorHints("code.star:7:9: got finally, want primary expression", serverKeys)
+		if len(hints) == 0 {
+			t.Fatal("Expected hints for finally error")
+		}
+		found := false
+		for _, hint := range hints {
+			if containsAny(hint, "try/except", "exception handling") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected hint about exception handling, got: %v", hints)
+		}
+	})
+
+	t.Run("raise hint", func(t *testing.T) {
+		hints := generatePythonErrorHints("code.star:2:1: got raise, want primary expression", serverKeys)
+		if len(hints) == 0 {
+			t.Fatal("Expected hints for raise error")
+		}
+		found := false
+		for _, hint := range hints {
+			if containsAny(hint, "try/except", "exception handling") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected hint about exception handling, got: %v", hints)
+		}
+	})
+
+	t.Run("Undefined variable includes scope hint", func(t *testing.T) {
+		hints := generatePythonErrorHints("code.star:3:17: undefined: commits_n8n", serverKeys)
+		if len(hints) == 0 {
+			t.Fatal("Expected hints for undefined variable")
+		}
+		foundVar := false
+		foundScope := false
+		for _, hint := range hints {
+			if strings.Contains(hint, "Variable 'commits_n8n' is not defined.") {
+				foundVar = true
+			}
+			if containsAny(hint, "fresh scope", "persist") {
+				foundScope = true
+			}
+		}
+		if !foundVar {
+			t.Errorf("Expected exact undefined variable hint for commits_n8n, got: %v", hints)
+		}
+		if !foundScope {
+			t.Errorf("Expected scope persistence hint, got: %v", hints)
 		}
 	})
 }

--- a/core/mcp/codemode/starlark/utils.go
+++ b/core/mcp/codemode/starlark/utils.go
@@ -191,11 +191,25 @@ func formatResultForLog(result interface{}) string {
 func generatePythonErrorHints(errorMessage string, serverKeys []string) []string {
 	hints := []string{}
 
-	if strings.Contains(errorMessage, "undefined") || strings.Contains(errorMessage, "not defined") {
-		re := regexp.MustCompile(`(\w+).*(?:undefined|not defined)`)
-		if match := re.FindStringSubmatch(errorMessage); len(match) > 1 {
-			undefinedVar := match[1]
+	if strings.Contains(errorMessage, "got try") || strings.Contains(errorMessage, "got except") ||
+		strings.Contains(errorMessage, "got finally") || strings.Contains(errorMessage, "got raise") {
+		hints = append(hints, "Starlark does NOT support try/except/finally/raise — there is no exception handling.")
+		hints = append(hints, "Instead, check return values for errors:")
+		hints = append(hints, "  result = server.tool(param=\"value\")")
+		hints = append(hints, "  if result == None or (type(result) == \"dict\" and \"error\" in result):")
+		hints = append(hints, "    print(\"Error:\", result)")
+	} else if strings.Contains(errorMessage, "undefined") || strings.Contains(errorMessage, "not defined") {
+		var undefinedVar string
+		if match := regexp.MustCompile(`name ['"]([^'"]+)['"] is not defined`).FindStringSubmatch(errorMessage); len(match) > 1 {
+			undefinedVar = match[1]
+		} else if match := regexp.MustCompile(`undefined:\s*([A-Za-z_][A-Za-z0-9_]*)`).FindStringSubmatch(errorMessage); len(match) > 1 {
+			undefinedVar = match[1]
+		} else if match := regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)[^A-Za-z0-9_]+(?:undefined|not defined)`).FindStringSubmatch(errorMessage); len(match) > 1 {
+			undefinedVar = match[1]
+		}
+		if undefinedVar != "" {
 			hints = append(hints, fmt.Sprintf("Variable '%s' is not defined.", undefinedVar))
+			hints = append(hints, "Note: Each executeToolCode call runs in a fresh scope — no variables persist between calls.")
 			if len(serverKeys) > 0 {
 				hints = append(hints, fmt.Sprintf("Available server keys: %s", strings.Join(serverKeys, ", ")))
 				hints = append(hints, "Access tools using: server_name.tool_name(param=\"value\")")
@@ -298,7 +312,7 @@ func createToolResponseMessage(toolCall schemas.ChatAssistantMessageToolCall, re
 	}
 }
 
-// parseToolName parses the tool name to be JavaScript-compatible.
+// parseToolName normalizes a raw tool name into a Starlark-compatible identifier.
 func parseToolName(toolName string) string {
 	if toolName == "" {
 		return ""
@@ -347,6 +361,61 @@ func parseToolName(toolName string) string {
 	}
 
 	return parsed
+}
+
+// getCanonicalToolName returns the exact callable tool identifier exposed in Starlark.
+func getCanonicalToolName(clientName, originalToolName string) string {
+	return parseToolName(stripClientPrefix(originalToolName, clientName))
+}
+
+// getCompatibilityToolAlias returns the case-preserving alias derived from the raw tool name.
+// This is used as a compatibility alias when the raw name is still a valid Starlark identifier.
+func getCompatibilityToolAlias(clientName, originalToolName string) string {
+	return strings.ReplaceAll(stripClientPrefix(originalToolName, clientName), "-", "_")
+}
+
+// matchesToolReference reports whether the requested tool name matches any supported identifier form.
+// We accept the canonical callable name plus legacy display forms for backward compatibility.
+func matchesToolReference(requestedToolName, clientName, originalToolName string) bool {
+	requested := strings.ToLower(requestedToolName)
+	if requested == "" {
+		return false
+	}
+
+	candidates := []string{
+		getCanonicalToolName(clientName, originalToolName),
+		getCompatibilityToolAlias(clientName, originalToolName),
+		stripClientPrefix(originalToolName, clientName),
+	}
+
+	for _, candidate := range candidates {
+		if candidate != "" && requested == strings.ToLower(candidate) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isValidStarlarkIdentifier reports whether name can be used directly in Starlark code.
+func isValidStarlarkIdentifier(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	runes := []rune(name)
+	first := runes[0]
+	if !unicode.IsLetter(first) && first != '_' && first != '$' {
+		return false
+	}
+
+	for _, r := range runes[1:] {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // validateNormalizedToolName validates a normalized tool name to prevent path traversal.


### PR DESCRIPTION
## Changes

- **Enhanced Starlark dialect configuration**: Enabled top-level control flow statements (if/for/while), while loops, set() builtin, global variable reassignment, and recursive functions for a more Python-like experience
- **Improved string escape handling**: Removed automatic `\n` to newline conversion, allowing Starlark's native string escape processing to handle `\n`, `\t`, and other escape sequences correctly
- **Updated tool description**: Streamlined the executeToolCode tool description with clearer syntax notes, explicit documentation of Starlark differences from Python (no try/except, no classes, no imports, no f-strings), and emphasis on fresh isolated scope per execution
- **Enhanced error hints**: Added specific error messages for unsupported Python features like try/except/finally/raise, with guidance on alternative approaches and scope persistence warnings
- **Comprehensive test coverage**: Added tests for dialect options, string escape preservation, unsupported feature detection, and end-to-end JSON deserialization scenarios

## Type of change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go) - Starlark CodeMode improvements
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the enhanced Starlark features with MCP CodeMode:

```sh
# Test dialect options (top-level control flow, while loops, etc.)
make test-mcp TESTCASE=TestStarlarkDialectOptions

# Test string escape handling
make test-mcp PATTERN=TestStarlarkStringEscape

# Test unsupported feature detection
make test-mcp PATTERN=TestStarlarkUnsupportedFeatures
```

## Breaking changes

- [ ] Yes
- [x] No

The Starlark changes are additive and maintain backward compatibility while enabling more Python-like syntax.

## Security considerations

Starlark CodeMode maintains its existing sandboxing with no additional network or filesystem access. The dialect enhancements only affect language features within the existing security boundary.