### PR TITLE
add ctx.Log for plugin logging

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -152,6 +152,9 @@ type PluginPipeline struct {
 	postHookTimings     map[string]*pluginTimingAccumulator // keyed by plugin name
 	postHookPluginOrder []string                            // order in which post-hooks ran (for nested span creation)
 	chunkCount          int
+
+	// Cached scoped contexts for streaming post-hooks (reused across chunks, released on reset)
+	streamScopedCtxs map[string]*schemas.BifrostContext
 }
 
 // pluginTimingAccumulator accumulates timing information for a plugin across streaming chunks
@@ -5556,6 +5559,7 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 	defer ctx.UnblockRestrictedWrites()
 	for i, plugin := range p.llmPlugins {
 		pluginName := plugin.GetName()
+		pluginCtx := ctx.WithPluginScope(pluginName)
 		p.logger.Debug("running pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreLLMHook
 		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
@@ -5566,7 +5570,8 @@ func (p *PluginPipeline) RunLLMPreHooks(ctx *schemas.BifrostContext, req *schema
 			}
 		}
 
-		req, shortCircuit, err = plugin.PreLLMHook(ctx, req)
+		req, shortCircuit, err = plugin.PreLLMHook(pluginCtx, req)
+		pluginCtx.ReleasePluginScope()
 
 		// End span with appropriate status
 		if err != nil {
@@ -5610,15 +5615,24 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 	isStreaming := ctx.Value(schemas.BifrostContextKeyStreamStartTime) != nil
 	ctx.BlockRestrictedWrites()
 	defer ctx.UnblockRestrictedWrites()
+	// For streaming: lazily create scoped contexts once, reuse across all chunks
+	if isStreaming && p.streamScopedCtxs == nil {
+		p.streamScopedCtxs = make(map[string]*schemas.BifrostContext, len(p.llmPlugins))
+		for _, plugin := range p.llmPlugins {
+			name := plugin.GetName()
+			p.streamScopedCtxs[name] = ctx.WithPluginScope(name)
+		}
+	}
 	var err error
 	for i := runFrom - 1; i >= 0; i-- {
 		plugin := p.llmPlugins[i]
 		pluginName := plugin.GetName()
 		p.logger.Debug("running post-hook for plugin %s", pluginName)
 		if isStreaming {
-			// For streaming: accumulate timing, don't create individual spans per chunk
+			// For streaming: reuse cached scoped context, accumulate timing
+			pluginCtx := p.streamScopedCtxs[pluginName]
 			start := time.Now()
-			resp, bifrostErr, err = plugin.PostLLMHook(ctx, resp, bifrostErr)
+			resp, bifrostErr, err = plugin.PostLLMHook(pluginCtx, resp, bifrostErr)
 			duration := time.Since(start)
 
 			p.accumulatePluginTiming(pluginName, duration, err != nil)
@@ -5627,7 +5641,8 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 				p.logger.Warn("error in PostLLMHook for plugin %s: %v", pluginName, err)
 			}
 		} else {
-			// For non-streaming: create span per plugin (existing behavior)
+			// For non-streaming: create scoped context per plugin, create span per plugin
+			pluginCtx := ctx.WithPluginScope(pluginName)
 			spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
 			// Update pluginCtx with span context for nested operations
 			if spanCtx != nil {
@@ -5635,7 +5650,8 @@ func (p *PluginPipeline) RunPostLLMHooks(ctx *schemas.BifrostContext, resp *sche
 					ctx.SetValue(schemas.BifrostContextKeySpanID, spanID)
 				}
 			}
-			resp, bifrostErr, err = plugin.PostLLMHook(ctx, resp, bifrostErr)
+			resp, bifrostErr, err = plugin.PostLLMHook(pluginCtx, resp, bifrostErr)
+			pluginCtx.ReleasePluginScope()
 			// End span with appropriate status
 			if err != nil {
 				p.tracer.SetAttribute(handle, "error", err.Error())
@@ -5679,6 +5695,7 @@ func (p *PluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schema
 	defer ctx.UnblockRestrictedWrites()
 	for i, plugin := range p.mcpPlugins {
 		pluginName := plugin.GetName()
+		pluginCtx := ctx.WithPluginScope(pluginName)
 		p.logger.Debug("running MCP pre-hook for plugin %s", pluginName)
 		// Start span for this plugin's PreMCPHook
 		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_prehook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
@@ -5689,7 +5706,8 @@ func (p *PluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schema
 			}
 		}
 
-		req, shortCircuit, err = plugin.PreMCPHook(ctx, req)
+		req, shortCircuit, err = plugin.PreMCPHook(pluginCtx, req)
+		pluginCtx.ReleasePluginScope()
 
 		// End span with appropriate status
 		if err != nil {
@@ -5734,6 +5752,7 @@ func (p *PluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *s
 	for i := runFrom - 1; i >= 0; i-- {
 		plugin := p.mcpPlugins[i]
 		pluginName := plugin.GetName()
+		pluginCtx := ctx.WithPluginScope(pluginName)
 		p.logger.Debug("running MCP post-hook for plugin %s", pluginName)
 		// Create span per plugin
 		spanCtx, handle := p.tracer.StartSpan(ctx, fmt.Sprintf("plugin.%s.mcp_posthook", sanitizeSpanName(pluginName)), schemas.SpanKindPlugin)
@@ -5744,7 +5763,8 @@ func (p *PluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *s
 			}
 		}
 
-		mcpResp, bifrostErr, err = plugin.PostMCPHook(ctx, mcpResp, bifrostErr)
+		mcpResp, bifrostErr, err = plugin.PostMCPHook(pluginCtx, mcpResp, bifrostErr)
+		pluginCtx.ReleasePluginScope()
 
 		// End span with appropriate status
 		if err != nil {
@@ -5781,6 +5801,14 @@ func (p *PluginPipeline) resetPluginPipeline() {
 		clear(p.postHookTimings)
 	}
 	p.postHookPluginOrder = p.postHookPluginOrder[:0]
+	// Release cached streaming scoped contexts back to the pool
+	for name, scoped := range p.streamScopedCtxs {
+		if scoped != nil {
+			scoped.ReleasePluginScope()
+		}
+		delete(p.streamScopedCtxs, name)
+	}
+	p.streamScopedCtxs = nil
 }
 
 // accumulatePluginTiming accumulates timing for a plugin during streaming

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -199,7 +199,8 @@ const (
 	BifrostContextKeyStreamStartTime                     BifrostContextKey = "bifrost-stream-start-time"                        // time.Time (start time for streaming TTFT calculation - set by bifrost)
 	BifrostContextKeyTracer                              BifrostContextKey = "bifrost-tracer"                                   // Tracer (tracer instance for completing deferred spans - set by bifrost)
 	BifrostContextKeyDeferTraceCompletion                BifrostContextKey = "bifrost-defer-trace-completion"                   // bool (signals trace completion should be deferred for streaming - set by streaming handlers)
-	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func() (callback to complete trace after streaming - set by tracing middleware)
+	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func(string, []PluginLogEntry) (callback to complete trace with requestID and plugin logs after streaming - set by tracing middleware)
+	BifrostContextKeyTransportPluginLogs                 BifrostContextKey = "bifrost-transport-plugin-logs"                    // []PluginLogEntry (transport hook plugin logs - set by transport interceptor middleware)
 	BifrostContextKeyPostHookSpanFinalizer               BifrostContextKey = "bifrost-posthook-span-finalizer"                  // func(context.Context) (callback to finalize post-hook spans after streaming - set by bifrost)
 	BifrostContextKeyAccumulatorID                       BifrostContextKey = "bifrost-accumulator-id"                           // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)
 	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
@@ -265,6 +266,27 @@ type RoutingEngineLogEntry struct {
 	Engine    string // e.g., "governance", "routing-rule", "openrouter"
 	Message   string // Human-readable decision/action message
 	Timestamp int64  // Unix milliseconds
+}
+
+// PluginLogEntry represents a single log entry emitted by a plugin via ctx.Log()
+type PluginLogEntry struct {
+	PluginName string   `json:"plugin_name"`
+	Level      LogLevel `json:"level"`
+	Message    string   `json:"message"`
+	Timestamp  int64    `json:"timestamp"` // Unix milliseconds
+}
+
+// GroupPluginLogsByName groups a flat slice of plugin log entries by plugin name.
+// Returns nil if the input is empty.
+func GroupPluginLogsByName(logs []PluginLogEntry) map[string][]PluginLogEntry {
+	if len(logs) == 0 {
+		return nil
+	}
+	grouped := make(map[string][]PluginLogEntry, 4)
+	for _, entry := range logs {
+		grouped[entry.PluginName] = append(grouped[entry.PluginName], entry)
+	}
+	return grouped
 }
 
 // NOTE: for custom plugin implementation dealing with streaming short circuit,

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -40,6 +40,22 @@ type BifrostContext struct {
 	userValues            map[any]any
 	valuesMu              sync.RWMutex
 	blockRestrictedWrites atomic.Bool
+	pluginScope           *string          // non-nil when this is a plugin-scoped context (pointer avoids string comparison)
+	valueDelegate         *BifrostContext  // non-nil for scoped contexts; write operations delegate here
+	pluginLogs            *pluginLogStore  // shared log store (pointer, shared across scoped contexts)
+}
+
+// pluginLogStore is a thread-safe store for plugin log entries.
+// It is shared between a root BifrostContext and its plugin-scoped derivatives.
+// Uses a flat slice instead of map to avoid heap map allocations on every Log() call.
+type pluginLogStore struct {
+	mu   sync.Mutex
+	logs []PluginLogEntry
+}
+
+// pluginScopePool pools scoped BifrostContext objects to avoid per-hook heap allocations.
+var pluginScopePool = sync.Pool{
+	New: func() any { return &BifrostContext{} },
 }
 
 // NewBifrostContext creates a new BifrostContext with the given parent context and deadline.
@@ -111,6 +127,10 @@ func (bc *BifrostContext) UnblockRestrictedWrites() {
 
 // Cancel cancels the context, closing the Done channel and setting the error to context.Canceled.
 func (bc *BifrostContext) Cancel() {
+	if bc.valueDelegate != nil {
+		bc.valueDelegate.Cancel()
+		return
+	}
 	bc.cancel(context.Canceled)
 }
 
@@ -197,6 +217,9 @@ func (bc *BifrostContext) Done() <-chan struct{} {
 // Err returns the error explaining why the context was cancelled.
 // Returns nil if the context has not been cancelled.
 func (bc *BifrostContext) Err() error {
+	if bc.valueDelegate != nil {
+		return bc.valueDelegate.Err()
+	}
 	bc.errMu.RLock()
 	defer bc.errMu.RUnlock()
 	return bc.err
@@ -212,12 +235,19 @@ func (bc *BifrostContext) Value(key any) any {
 	}
 	bc.valuesMu.RUnlock()
 
+	if bc.parent == nil {
+		return nil
+	}
 	return bc.parent.Value(key)
 }
 
 // SetValue sets a value in the internal userValues map.
 // This is thread-safe and can be called concurrently.
 func (bc *BifrostContext) SetValue(key, value any) {
+	if bc.valueDelegate != nil {
+		bc.valueDelegate.SetValue(key, value)
+		return
+	}
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
 		// we silently drop writes for these reserved keys
@@ -233,6 +263,10 @@ func (bc *BifrostContext) SetValue(key, value any) {
 
 // ClearValue clears a value from the internal userValues map.
 func (bc *BifrostContext) ClearValue(key any) {
+	if bc.valueDelegate != nil {
+		bc.valueDelegate.ClearValue(key)
+		return
+	}
 	// Check if the key is a reserved key
 	if bc.blockRestrictedWrites.Load() && slices.Contains(reservedKeys, key) {
 		// we silently drop writes for these reserved keys
@@ -247,6 +281,9 @@ func (bc *BifrostContext) ClearValue(key any) {
 
 // GetAndSetValue gets a value from the internal userValues map and sets it
 func (bc *BifrostContext) GetAndSetValue(key any, value any) any {
+	if bc.valueDelegate != nil {
+		return bc.valueDelegate.GetAndSetValue(key, value)
+	}
 	bc.valuesMu.Lock()
 	defer bc.valuesMu.Unlock()
 	// Check if the key is a reserved key
@@ -266,6 +303,9 @@ func (bc *BifrostContext) GetAndSetValue(key any, value any) any {
 // If the parent is also a PluginContext, the values are merged with parent values
 // (this context's values take precedence over parent values).
 func (bc *BifrostContext) GetUserValues() map[any]any {
+	if bc.valueDelegate != nil {
+		return bc.valueDelegate.GetUserValues()
+	}
 	result := make(map[any]any)
 
 	// First, get parent's user values if parent is a PluginContext
@@ -287,6 +327,9 @@ func (bc *BifrostContext) GetUserValues() map[any]any {
 
 // GetParentCtxWithUserValues returns a copy of the parent context with all user-set values merged in.
 func (bc *BifrostContext) GetParentCtxWithUserValues() context.Context {
+	if bc.valueDelegate != nil {
+		return bc.valueDelegate.GetParentCtxWithUserValues()
+	}
 	parentCtx := bc.parent
 	bc.valuesMu.RLock()
 	for k, v := range bc.userValues {
@@ -323,6 +366,107 @@ func (bc *BifrostContext) GetRoutingEngineLogs() []RoutingEngineLogEntry {
 		}
 	}
 	return nil
+}
+
+// WithPluginScope returns a lightweight derived context where Log() always attributes
+// entries to the given plugin name. The scoped context shares the root context's
+// user values, cancellation, and plugin log store. It is safe to pass to goroutines.
+// Scoped contexts are obtained from a pool. Call ReleasePluginScope when done to return
+// the context to the pool. If not released, the GC will collect it normally.
+// The reason we have chosen this flow is - pluginName matters when we are collecting logs
+// because we want to be able to filter logs by plugin name in the UI.
+// And plugins can call Log() methods in async manner till the context is alive
+// This method is thread-safe - and would allow plugins to log till context is alive
+func (bc *BifrostContext) WithPluginScope(pluginName string) *BifrostContext {
+	root := bc
+	if bc.valueDelegate != nil {
+		root = bc.valueDelegate
+	}
+	// Lazily initialize the log store on the root context
+	if root.pluginLogs == nil {
+		root.pluginLogs = &pluginLogStore{}
+	}
+	scoped := pluginScopePool.Get().(*BifrostContext)
+	scoped.parent = root
+	scoped.done = root.done
+	scoped.pluginScope = &pluginName
+	scoped.valueDelegate = root
+	scoped.pluginLogs = root.pluginLogs
+	return scoped
+}
+
+// ReleasePluginScope returns a scoped context to the pool.
+// After release, any calls to Log() on this context are safe no-ops.
+// Must only be called on contexts created via WithPluginScope.
+func (bc *BifrostContext) ReleasePluginScope() {
+	if bc.valueDelegate == nil {
+		return // not a scoped context
+	}
+	bc.parent = nil
+	bc.done = nil
+	bc.pluginScope = nil
+	bc.valueDelegate = nil
+	bc.pluginLogs = nil
+	pluginScopePool.Put(bc)
+}
+
+// Log appends a plugin log entry to the shared log store.
+// If this context was not created via WithPluginScope, the log is silently dropped.
+// This method is safe for concurrent use.
+func (bc *BifrostContext) Log(level LogLevel, msg string) {
+	if bc.pluginScope == nil || bc.pluginLogs == nil {
+		return
+	}
+	bc.pluginLogs.mu.Lock()
+	bc.pluginLogs.logs = append(bc.pluginLogs.logs, PluginLogEntry{
+		PluginName: *bc.pluginScope,
+		Level:      level,
+		Message:    msg,
+		Timestamp:  time.Now().UnixMilli(),
+	})
+	bc.pluginLogs.mu.Unlock()
+}
+
+// GetPluginLogs retrieves all plugin logs from the context.
+// Returns a deep copy of the plugin logs as a flat slice. Returns nil if no plugin has logged anything.
+// This method is safe for concurrent use.
+func (bc *BifrostContext) GetPluginLogs() []PluginLogEntry {
+	if bc.valueDelegate != nil {
+		return bc.valueDelegate.GetPluginLogs()
+	}
+	store := bc.pluginLogs
+	if store == nil {
+		return nil
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.logs) == 0 {
+		return nil
+	}
+	result := make([]PluginLogEntry, len(store.logs))
+	copy(result, store.logs)
+	return result
+}
+
+// DrainPluginLogs retrieves all plugin logs and transfers ownership to the caller.
+// Unlike GetPluginLogs which returns a deep copy, this method returns the internal slice
+// directly and nils out the store — zero allocation. Entries are already in chronological
+// order from sequential appends. Safe to call when all hooks are done and no more Log()
+// calls will be made (e.g., at trace completion time).
+// Returns nil if no plugin has logged anything.
+func (bc *BifrostContext) DrainPluginLogs() []PluginLogEntry {
+	if bc.valueDelegate != nil {
+		return bc.valueDelegate.DrainPluginLogs()
+	}
+	store := bc.pluginLogs
+	if store == nil {
+		return nil
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	logs := store.logs
+	store.logs = nil
+	return logs
 }
 
 // AppendToContextList appends a value to the context list value.

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -207,3 +207,119 @@ func TestNewBifrostContext_NilParent(t *testing.T) {
 		t.Errorf("Cancelled context should have Canceled error, got %v", ctx.Err())
 	}
 }
+
+func TestBifrostContext_LogWithNoPluginName(t *testing.T) {
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	ctx.Log(LogLevelInfo, "should be dropped")
+
+	if logs := ctx.GetPluginLogs(); logs != nil {
+		t.Errorf("Expected nil plugin logs when no plugin name set, got %v", logs)
+	}
+}
+
+func TestBifrostContext_LogSinglePlugin(t *testing.T) {
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	pluginCtx := ctx.WithPluginScope("my-plugin")
+	pluginCtx.Log(LogLevelInfo, "msg1")
+	pluginCtx.Log(LogLevelWarn, "msg2")
+
+	logs := ctx.GetPluginLogs()
+	if logs == nil {
+		t.Fatal("Expected non-nil plugin logs")
+	}
+	if len(logs) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(logs))
+	}
+	if logs[0].PluginName != "my-plugin" || logs[0].Level != LogLevelInfo || logs[0].Message != "msg1" {
+		t.Errorf("Entry 0: expected my-plugin/info/msg1, got %s/%s/%s", logs[0].PluginName, logs[0].Level, logs[0].Message)
+	}
+	if logs[1].PluginName != "my-plugin" || logs[1].Level != LogLevelWarn || logs[1].Message != "msg2" {
+		t.Errorf("Entry 1: expected my-plugin/warn/msg2, got %s/%s/%s", logs[1].PluginName, logs[1].Level, logs[1].Message)
+	}
+	if logs[0].Timestamp == 0 || logs[1].Timestamp == 0 {
+		t.Error("Expected non-zero timestamps")
+	}
+}
+
+func TestBifrostContext_LogMultiplePlugins(t *testing.T) {
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	pluginA := ctx.WithPluginScope("plugin-a")
+	pluginA.Log(LogLevelInfo, "from a")
+
+	pluginB := ctx.WithPluginScope("plugin-b")
+	pluginB.Log(LogLevelError, "from b")
+
+	logs := ctx.GetPluginLogs()
+	if len(logs) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(logs))
+	}
+	if logs[0].PluginName != "plugin-a" || logs[0].Message != "from a" {
+		t.Error("Expected entry for plugin-a with message 'from a'")
+	}
+	if logs[1].PluginName != "plugin-b" || logs[1].Message != "from b" {
+		t.Error("Expected entry for plugin-b with message 'from b'")
+	}
+}
+
+func TestBifrostContext_LogLazyAllocation(t *testing.T) {
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	// No allocation until first log
+	if logs := ctx.GetPluginLogs(); logs != nil {
+		t.Errorf("Expected nil plugin logs before any Log() call, got %v", logs)
+	}
+
+	pluginCtx := ctx.WithPluginScope("test")
+	pluginCtx.Log(LogLevelDebug, "first log")
+
+	if logs := ctx.GetPluginLogs(); logs == nil {
+		t.Error("Expected non-nil plugin logs after Log() call")
+	}
+}
+
+func TestBifrostContext_ScopedContextIsolation(t *testing.T) {
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	// Scoped context logs under its plugin name
+	pluginCtx := ctx.WithPluginScope("my-plugin")
+	pluginCtx.Log(LogLevelInfo, "scoped log")
+
+	// Logging directly on root context (no scope) is dropped
+	ctx.Log(LogLevelInfo, "root log should be dropped")
+
+	logs := ctx.GetPluginLogs()
+	if len(logs) != 1 {
+		t.Fatalf("Expected 1 entry, got %d", len(logs))
+	}
+	if logs[0].PluginName != "my-plugin" || logs[0].Message != "scoped log" {
+		t.Errorf("Expected my-plugin/'scoped log', got %s/%s", logs[0].PluginName, logs[0].Message)
+	}
+}
+
+func TestBifrostContext_ScopedContextValueDelegation(t *testing.T) {
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	defer ctx.Cancel()
+
+	ctx.SetValue("root-key", "root-value")
+
+	pluginCtx := ctx.WithPluginScope("test-plugin")
+
+	// Scoped context can read root values
+	if val := pluginCtx.Value("root-key"); val != "root-value" {
+		t.Errorf("Expected scoped context to read root value, got %v", val)
+	}
+
+	// Scoped context writes delegate to root
+	pluginCtx.SetValue("plugin-key", "plugin-value")
+	if val := ctx.Value("plugin-key"); val != "plugin-value" {
+		t.Errorf("Expected root to see value written by scoped context, got %v", val)
+	}
+}

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -14,8 +14,10 @@ type Trace struct {
 	Spans      []*Span        // All spans in this trace
 	StartTime  time.Time      // When the trace started
 	EndTime    time.Time      // When the trace completed
-	Attributes map[string]any // Additional attributes for the trace
-	mu         sync.Mutex     // Mutex for thread-safe span operations
+	Attributes map[string]any    // Additional attributes for the trace
+	RequestID  string            // Bifrost request ID for correlating with log entries
+	PluginLogs []PluginLogEntry  // Plugin logs from all hook types (HTTP, LLM, MCP), sorted by timestamp
+	mu         sync.Mutex        // Mutex for thread-safe span operations
 }
 
 // AddSpan adds a span to the trace in a thread-safe manner
@@ -46,6 +48,8 @@ func (t *Trace) Reset() {
 	t.StartTime = time.Time{}
 	t.EndTime = time.Time{}
 	t.Attributes = nil
+	t.RequestID = ""
+	t.PluginLogs = nil
 }
 
 // Span represents a single operation within a trace

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -154,7 +154,7 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 // PreLLMHook is called before the request is sent to the provider
 // This is where you can modify requests or short-circuit the flow
 func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
-	fmt.Println("PreLLMHook called")
+	ctx.Log(schemas.LogLevelInfo, "pre-hook: processing request")
 	// Modify the request or return a short-circuit to skip provider call
 	return req, nil, nil
 }
@@ -162,7 +162,11 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 // PostLLMHook is called after receiving a response from the provider
 // This is where you can modify responses or handle errors
 func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
-	fmt.Println("PostLLMHook called")
+	if bifrostErr != nil {
+		ctx.Log(schemas.LogLevelError, fmt.Sprintf("post-hook: request failed: %s", bifrostErr.Error.Message))
+	} else {
+		ctx.Log(schemas.LogLevelInfo, "post-hook: request completed successfully")
+	}
 	// Modify the response or error before returning to caller
 	return resp, bifrostErr, nil
 }
@@ -396,6 +400,38 @@ func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bif
 }
 ```
 
+#### `ctx.Log(level, msg)` — Plugin Logging
+
+All hooks receive a `*schemas.BifrostContext` that exposes a `Log` method. Use it to emit structured logs that are stored with the request and visible in the Bifrost dashboard under **Plugin Logs**.
+
+```go
+func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	ctx.Log(schemas.LogLevelInfo, fmt.Sprintf("processing request for model %s", req.Model))
+
+	if shouldBlock(req) {
+		ctx.Log(schemas.LogLevelWarn, "request blocked by policy")
+		return req, &schemas.LLMPluginShortCircuit{...}, nil
+	}
+
+	return req, nil, nil
+}
+```
+
+Available log levels:
+
+| Level | Constant | Use for |
+|-------|----------|---------|
+| `debug` | `schemas.LogLevelDebug` | Verbose diagnostic info |
+| `info` | `schemas.LogLevelInfo` | Normal operations |
+| `warn` | `schemas.LogLevelWarn` | Unexpected but recoverable situations |
+| `error` | `schemas.LogLevelError` | Failures and errors |
+
+Logs are automatically keyed by plugin name — you don't need to identify your plugin. They appear in the dashboard log details sheet grouped by plugin, with timestamps and level indicators.
+
+<Note>
+Plugin logs are only captured during hook execution. Calls to `ctx.Log()` outside of a hook (e.g., in a background goroutine) will be silently dropped.
+</Note>
+
 #### `Cleanup() error`
 
 Called on Bifrost shutdown. Use this to:
@@ -562,6 +598,54 @@ PostHook called
 </Tabs>
 
 ## Advanced Plugin Patterns
+
+### Plugin Logging
+
+Use `ctx.Log()` to emit structured logs from any hook. Logs are stored as JSON alongside the request and rendered in the Bifrost dashboard's **Plugin Logs** section.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func GetName() string {
+	return "my-auditing-plugin"
+}
+
+func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	ctx.Log(schemas.LogLevelInfo, fmt.Sprintf("incoming request: model=%s", req.Model))
+
+	// Log decisions your plugin makes
+	if req.ChatRequest != nil && len(req.ChatRequest.Messages) > 100 {
+		ctx.Log(schemas.LogLevelWarn, "large conversation detected, truncating to last 100 messages")
+		req.ChatRequest.Messages = req.ChatRequest.Messages[len(req.ChatRequest.Messages)-100:]
+	}
+
+	return req, nil, nil
+}
+
+func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	if bifrostErr != nil {
+		ctx.Log(schemas.LogLevelError, fmt.Sprintf("provider error: %s", bifrostErr.Error.Message))
+	} else {
+		ctx.Log(schemas.LogLevelInfo, "request completed successfully")
+	}
+	return resp, bifrostErr, nil
+}
+```
+
+In the dashboard, these logs appear grouped under your plugin name with timestamps and color-coded log levels:
+
+```
+my-auditing-plugin
+  2024-03-22 14:30:01 PM  INFO   incoming request: model=gpt-4o
+  2024-03-22 14:30:01 PM  WARN   large conversation detected, truncating to last 100 messages
+  2024-03-22 14:30:02 PM  INFO   request completed successfully
+```
 
 ### Stateful Plugins
 

--- a/examples/plugins/hello-world/main.go
+++ b/examples/plugins/hello-world/main.go
@@ -20,6 +20,7 @@ func GetName() string {
 
 func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	fmt.Println("HTTPTransportPreHook called")
+	ctx.Log(schemas.LogLevelDebug, "transport pre-hook fired")
 	// Modify request in-place
 	req.Headers["x-hello-world-plugin"] = "transport-pre-hook-value"
 	// Store value in context for PreLLMHook/PostLLMHook
@@ -44,11 +45,13 @@ func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTP
 	if chunk.BifrostChatResponse != nil && chunk.BifrostChatResponse.Choices != nil && len(chunk.BifrostChatResponse.Choices) > 0 && chunk.BifrostChatResponse.Choices[0].ChatStreamResponseChoice != nil && chunk.BifrostChatResponse.Choices[0].ChatStreamResponseChoice.Delta != nil && chunk.BifrostChatResponse.Choices[0].ChatStreamResponseChoice.Delta.Content != nil {
 		*chunk.BifrostChatResponse.Choices[0].ChatStreamResponseChoice.Delta.Content += " - modified by hello-world-plugin"
 	}
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportStreamChunkHook called")
 	// Return the modified chunk
 	return chunk, nil
 }
 
 func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	ctx.Log(schemas.LogLevelInfo, fmt.Sprintf("pre-hook: processing request"))
 	value1 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-transport-pre-hook"))
 	fmt.Println("value1:", value1)
 	ctx.SetValue(schemas.BifrostContextKey("hello-world-plugin-pre-hook"), "pre-hook-value")
@@ -58,6 +61,15 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 
 func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	fmt.Println("PostLLMHook called")
+	if bifrostErr != nil {
+		message := "post-hook: request failed"
+		if bifrostErr.Error != nil && bifrostErr.Error.Message != "" {
+			message = fmt.Sprintf("%s: %s", message, bifrostErr.Error.Message)
+		}
+		ctx.Log(schemas.LogLevelError, message)
+	} else {
+		ctx.Log(schemas.LogLevelInfo, "post-hook: request completed successfully")
+	}
 	value1 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-transport-pre-hook"))
 	fmt.Println("value1:", value1)
 	value2 := ctx.Value(schemas.BifrostContextKey("hello-world-plugin-pre-hook"))

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -222,6 +222,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPerformanceGINIndexes(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddPluginLogsColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2180,5 +2183,39 @@ func ensurePerformanceIndexes(ctx context.Context, db *gorm.DB) error {
 		}
 	}
 
+	return nil
+}
+
+// migrationAddPluginLogsColumn adds the plugin_logs column to the logs table.
+func migrationAddPluginLogsColumn(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_plugin_logs_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "plugin_logs") {
+				if err := migrator.AddColumn(&Log{}, "plugin_logs"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&Log{}, "plugin_logs") {
+				if err := migrator.DropColumn(&Log{}, "plugin_logs"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding plugin logs column: %s", err.Error())
+	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -128,6 +128,7 @@ type Log struct {
 	PassthroughRequestBody  string    `gorm:"type:text" json:"passthrough_request_body,omitempty"`  // Raw body for passthrough requests (UTF-8)
 	PassthroughResponseBody string    `gorm:"type:text" json:"passthrough_response_body,omitempty"` // Raw body for passthrough responses (UTF-8)
 	RoutingEngineLogs      string    `gorm:"type:text" json:"routing_engine_logs,omitempty"`       // Formatted routing engine decision logs
+	PluginLogs             string    `gorm:"type:text" json:"plugin_logs,omitempty"`              // JSON serialized map[string][]PluginLogEntry
 	Metadata               *string    `gorm:"type:text" json:"-"`                                  // JSON serialized map[string]interface{}
 	IsLargePayloadRequest  bool      `gorm:"default:false" json:"is_large_payload_request"`
 	IsLargePayloadResponse bool      `gorm:"default:false" json:"is_large_payload_response"`

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -172,6 +172,7 @@ type LogMessage struct {
 	UpdateData         *UpdateLogData                     // For update operations
 	StreamResponse     *streaming.ProcessedStreamResponse // For streaming delta updates
 	RoutingEngineLogs  string                             // Formatted routing engine decision logs
+	PluginLogs         string                             // JSON serialized plugin logs
 }
 
 // InitialLogData contains data for initial log entry creation
@@ -204,7 +205,7 @@ type Config struct {
 	LoggingHeaders        *[]string `json:"logging_headers"` // Pointer to live config slice; changes are reflected immediately without restart
 }
 
-// LoggerPlugin implements the schemas.LLMPlugin and schemas.MCPPlugin interfaces
+// LoggerPlugin implements the schemas.LLMPlugin, schemas.MCPPlugin, and schemas.ObservabilityPlugin interfaces
 type LoggerPlugin struct {
 	ctx                   context.Context
 	store                 logstore.LogStore
@@ -226,7 +227,7 @@ type LoggerPlugin struct {
 	pendingLogs           sync.Map              // Maps requestID -> *PendingLogData (PreLLMHook input data awaiting PostLLMHook)
 	writeQueue            chan *writeQueueEntry // Buffered channel for batch write queue
 	closed                atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
-	deferredUsageSem      chan struct{}          // Limits concurrent deferred usage DB updates
+	deferredUsageSem      chan struct{}         // Limits concurrent deferred usage DB updates
 }
 
 // Init creates new logger plugin with given log store
@@ -623,7 +624,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 		return result, bifrostErr, nil
 	}
-	// Extract routing engine logs from context before entering goroutine
+	// Extract routing engine logs from context before entering goroutine.
+	// Plugin logs are NOT captured here — they are deferred to Inject where
+	// complete logs from all hook types (HTTP, LLM, MCP) are available on the Trace.
 	routingEngineLogs := formatRoutingEngineLogs(ctx.GetRoutingEngineLogs())
 
 	// Retrieve pending input data from PreLLMHook
@@ -824,6 +827,21 @@ func (p *LoggerPlugin) Cleanup() error {
 		// Note: Accumulator cleanup is handled by the tracer, not the logging plugin
 		// GORM handles connection cleanup automatically
 	})
+	return nil
+}
+
+// Inject receives a completed trace and updates the log entry with plugin logs from all hook types.
+// Implements schemas.ObservabilityPlugin interface.
+func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
+	if trace == nil || len(trace.PluginLogs) == 0 || trace.RequestID == "" {
+		return nil
+	}
+	pluginLogsStr := formatPluginLogs(trace.PluginLogs)
+	if pluginLogsStr != "" {
+		if err := p.store.Update(p.ctx, trace.RequestID, map[string]interface{}{"plugin_logs": pluginLogsStr}); err != nil {
+			p.logger.Warn("failed to update plugin logs for request %s: %v", trace.RequestID, err)
+		}
+	}
 	return nil
 }
 

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -178,6 +178,7 @@ func (p *LoggerPlugin) updateLogEntry(
 	numberOfRetries int,
 	cacheDebug *schemas.BifrostCacheDebug,
 	routingEngineLogs string,
+	pluginLogs string,
 	data *UpdateLogData,
 ) error {
 	updates := make(map[string]interface{})
@@ -204,6 +205,9 @@ func (p *LoggerPlugin) updateLogEntry(
 	}
 	if routingEngineLogs != "" {
 		updates["routing_engine_logs"] = routingEngineLogs
+	}
+	if pluginLogs != "" {
+		updates["plugin_logs"] = pluginLogs
 	}
 	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
 	tempEntry := &logstore.Log{}
@@ -347,6 +351,7 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	numberOfRetries int,
 	cacheDebug *schemas.BifrostCacheDebug,
 	routingEngineLogs string,
+	pluginLogs string,
 	streamResponse *streaming.ProcessedStreamResponse,
 	isFinalChunk bool,
 	isLargePayloadRequest bool,
@@ -373,6 +378,9 @@ func (p *LoggerPlugin) updateStreamingLogEntry(
 	}
 	if routingEngineLogs != "" {
 		updates["routing_engine_logs"] = routingEngineLogs
+	}
+	if pluginLogs != "" {
+		updates["plugin_logs"] = pluginLogs
 	}
 	// Handle error case first
 	if streamResponse.Data.ErrorDetails != nil {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -76,7 +76,7 @@ func TestUpdateLogEntryPreservesResponsesInputContentSummary(t *testing.T) {
 		}},
 	}
 
-	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update); err != nil {
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", "", update); err != nil {
 		t.Fatalf("updateLogEntry() error = %v", err)
 	}
 
@@ -122,7 +122,7 @@ func TestUpdateLogEntryUpdatesContentSummaryForChatOutput(t *testing.T) {
 		},
 	}
 
-	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update); err != nil {
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", "", update); err != nil {
 		t.Fatalf("updateLogEntry() error = %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestUpdateLogEntrySuppressesChatOutputWhenContentLoggingDisabled(t *testing
 		},
 	}
 
-	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update); err != nil {
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", "", update); err != nil {
 		t.Fatalf("updateLogEntry() error = %v", err)
 	}
 
@@ -225,7 +225,7 @@ func TestUpdateStreamingLogEntryPreservesResponsesInputContentSummary(t *testing
 		},
 	}
 
-	if err := plugin.updateStreamingLogEntry(context.Background(), requestID, "", "", "", "", "", "", 0, nil, "", streamResponse, true, false, false); err != nil {
+	if err := plugin.updateStreamingLogEntry(context.Background(), requestID, "", "", "", "", "", "", 0, nil, "", "", streamResponse, true, false, false); err != nil {
 		t.Fatalf("updateStreamingLogEntry() error = %v", err)
 	}
 
@@ -241,5 +241,35 @@ func TestUpdateStreamingLogEntryPreservesResponsesInputContentSummary(t *testing
 	}
 	if strings.Contains(logEntry.ContentSummary, responsesText) {
 		t.Fatalf("expected content summary to avoid overwriting with streamed responses output-only data, got %q", logEntry.ContentSummary)
+	}
+}
+
+func TestFormatPluginLogs_Empty(t *testing.T) {
+	if result := formatPluginLogs(nil); result != "" {
+		t.Errorf("Expected empty string for nil logs, got %q", result)
+	}
+	if result := formatPluginLogs([]schemas.PluginLogEntry{}); result != "" {
+		t.Errorf("Expected empty string for empty slice, got %q", result)
+	}
+}
+
+func TestFormatPluginLogs_WithEntries(t *testing.T) {
+	logs := []schemas.PluginLogEntry{
+		{PluginName: "my-plugin", Level: schemas.LogLevelInfo, Message: "hello", Timestamp: 1000},
+		{PluginName: "my-plugin", Level: schemas.LogLevelError, Message: "oops", Timestamp: 2000},
+	}
+	result := formatPluginLogs(logs)
+	if result == "" {
+		t.Fatal("Expected non-empty result")
+	}
+	// Verify it's valid JSON by round-tripping
+	if !strings.Contains(result, "my-plugin") {
+		t.Errorf("Expected result to contain plugin name, got %q", result)
+	}
+	if !strings.Contains(result, "hello") {
+		t.Errorf("Expected result to contain message, got %q", result)
+	}
+	if !strings.Contains(result, "error") {
+		t.Errorf("Expected result to contain level, got %q", result)
 	}
 }

--- a/plugins/logging/pool.go
+++ b/plugins/logging/pool.go
@@ -16,7 +16,8 @@ func (p *LoggerPlugin) putLogMessage(msg *LogMessage) {
 	msg.RequestID = ""
 	msg.Timestamp = time.Time{}
 	msg.InitialData = nil
-
+	msg.PluginLogs =""
+	msg.RoutingEngineLogs =""
 	// Don't reset UpdateData and StreamResponse here since they're returned
 	// to their own pools in the defer function - just clear the pointers
 	msg.UpdateData = nil

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/streaming"
@@ -534,4 +535,19 @@ func formatRoutingEngineLogs(logs []schemas.RoutingEngineLogEntry) string {
 		sb.WriteString(fmt.Sprintf("[%d] [%s] - %s\n", log.Timestamp, log.Engine, log.Message))
 	}
 	return sb.String()
+}
+
+// formatPluginLogs groups a flat slice of plugin log entries by plugin name
+// and serializes to JSON for DB storage. The JSON format is {"plugin_name": [{...}]}
+// which is what the API and UI expect.
+func formatPluginLogs(logs []schemas.PluginLogEntry) string {
+	grouped := schemas.GroupPluginLogsByName(logs)
+	if grouped == nil {
+		return ""
+	}
+	data, err := sonic.Marshal(grouped)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -245,7 +245,8 @@ func estimateLogEntrySize(log *logstore.Log) int {
 		len(log.PassthroughResponseBody) +
 		len(log.ContentSummary) +
 		len(log.CacheDebug) +		
-		len(log.RoutingEngineLogs)
+		len(log.RoutingEngineLogs) +
+		len(log.PluginLogs)
 	// Baseline for fixed-width columns and struct overhead
 	return n + 512
 }

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
@@ -71,9 +72,15 @@ func hexToBytes(hexStr string, length int) []byte {
 
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan
 func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
+	// Build plugin log index once (group by plugin name) for O(1) lookup per span
+	var pluginLogIndex map[string][]schemas.PluginLogEntry
+	if p.forwardPluginLogs {
+		pluginLogIndex = schemas.GroupPluginLogsByName(trace.PluginLogs)
+	}
+
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
-		otelSpans = append(otelSpans, p.convertSpanToOTELSpan(trace.TraceID, span))
+		otelSpans = append(otelSpans, p.convertSpanToOTELSpan(trace.TraceID, span, pluginLogIndex))
 	}
 
 	return &ResourceSpan{
@@ -88,7 +95,7 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 }
 
 // convertSpanToOTELSpan converts a single Bifrost span to OTEL format
-func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
+func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span, pluginLogIndex map[string][]schemas.PluginLogEntry) *Span {
 	otelSpan := &Span{
 		TraceId:           hexToBytes(traceID, 16),
 		SpanId:            hexToBytes(span.SpanID, 8),
@@ -101,12 +108,50 @@ func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *
 		Events:            convertSpanEvents(span.Events),
 	}
 
+	// Attach plugin logs as span events only to posthook spans to avoid duplication
+	if len(pluginLogIndex) > 0 && span.Kind == schemas.SpanKindPlugin {
+		if pluginName, hookType := extractPluginNameAndHookFromSpan(span.Name); pluginName != "" && hookType == "posthook" {
+			if logs, ok := pluginLogIndex[pluginName]; ok && len(logs) > 0 {
+				otelSpan.Events = append(otelSpan.Events, convertPluginLogsToEvents(logs)...)
+			}
+		}
+	}
+
 	// Set parent span ID if present
 	if span.ParentID != "" {
 		otelSpan.ParentSpanId = hexToBytes(span.ParentID, 8)
 	}
 
 	return otelSpan
+}
+
+// convertPluginLogsToEvents converts plugin log entries to OTEL span events
+func convertPluginLogsToEvents(logs []schemas.PluginLogEntry) []*Event {
+	events := make([]*Event, len(logs))
+	for i, entry := range logs {
+		events[i] = &Event{
+			TimeUnixNano: uint64(time.UnixMilli(entry.Timestamp).UnixNano()),
+			Name:         "plugin.log",
+			Attributes: []*KeyValue{
+				kvStr("level", string(entry.Level)),
+				kvStr("message", entry.Message),
+			},
+		}
+	}
+	return events
+}
+
+// extractPluginNameAndHookFromSpan extracts the plugin name and hook type from a span name like "plugin.{name}.prehook"
+func extractPluginNameAndHookFromSpan(spanName string) (string, string) {
+	// Span names follow the pattern: plugin.{name}.{hook_type}
+	parts := strings.SplitN(spanName, ".", 3)
+	if len(parts) >= 3 && parts[0] == "plugin" {
+		return parts[1], parts[2]
+	}
+	if len(parts) >= 2 && parts[0] == "plugin" {
+		return parts[1], ""
+	}
+	return "", ""
 }
 
 // getResourceAttributes returns the resource attributes for the OTEL span

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -56,6 +56,9 @@ type Config struct {
 	MetricsEnabled      bool   `json:"metrics_enabled"`
 	MetricsEndpoint     string `json:"metrics_endpoint"`
 	MetricsPushInterval int    `json:"metrics_push_interval"` // in seconds, default 15
+
+	// Forward plugin logs as span events on plugin spans
+	ForwardPluginLogs bool `json:"forward_plugin_logs"`
 }
 
 // OtelPlugin is the plugin for OpenTelemetry.
@@ -81,6 +84,8 @@ type OtelPlugin struct {
 
 	// Metrics push support
 	metricsExporter *MetricsExporter
+
+	forwardPluginLogs bool
 }
 
 // Init function for the OTEL plugin
@@ -129,6 +134,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
+		forwardPluginLogs:         config.ForwardPluginLogs,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
@@ -243,8 +249,8 @@ func (p *OtelPlugin) PreLLMHook(_ *schemas.BifrostContext, req *schemas.BifrostR
 	return req, nil, nil
 }
 
-// PostLLMHook is a no-op - tracing is handled via the Inject method.
-// The OTEL plugin receives completed traces from TracingMiddleware.
+// PostLLMHook is a no-op — plugin logs are now attached to the Trace by the middleware
+// and read directly in Inject. No need to capture them here.
 func (p *OtelPlugin) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	return resp, bifrostErr, nil
 }
@@ -261,6 +267,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	// Emit trace to collector if client is initialized
 	if p.client != nil {
 		// Convert schemas.Trace to OTEL ResourceSpan
+		// Plugin logs are now on the trace itself (set by middleware)
 		resourceSpan := p.convertTraceToResourceSpan(trace)
 
 		// Emit to collector

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1531,7 +1531,7 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 	ctx.SetUserValue(schemas.BifrostContextKeyDeferTraceCompletion, true)
 
 	// Get the trace completer function for use in the streaming callback
-	traceCompleter, _ := ctx.UserValue(schemas.BifrostContextKeyTraceCompleter).(func())
+	traceCompleter, _ := ctx.UserValue(schemas.BifrostContextKeyTraceCompleter).(func(string, []schemas.PluginLogEntry))
 
 	// Get stream chunk interceptor for plugin hooks
 	interceptor := h.config.GetStreamChunkInterceptor()
@@ -1549,11 +1549,16 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 	go func() {
 		defer func() {
 			schemas.ReleaseHTTPRequest(httpReq)
+			if interceptor != nil {
+				interceptor.Release()
+			}
 			reader.Done()
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL
+			// Pass LLM plugin logs so they can be merged with transport logs in the completer
 			if traceCompleter != nil {
-				traceCompleter()
+				requestID, _ := bifrostCtx.Value(schemas.BifrostContextKeyRequestID).(string)
+				traceCompleter(requestID, bifrostCtx.DrainPluginLogs())
 			}
 		}()
 

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -283,6 +283,32 @@ func newDecompressReader(r io.Reader, encoding string) (io.Reader, func(), error
 	}
 }
 
+// mergePluginLogs merges two chronologically-ordered plugin log slices into a single
+// sorted slice using O(n) merge. Both inputs must already be in timestamp order
+// (as guaranteed by DrainPluginLogs which appends sequentially).
+func mergePluginLogs(a, b []schemas.PluginLogEntry) []schemas.PluginLogEntry {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	merged := make([]schemas.PluginLogEntry, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i].Timestamp <= b[j].Timestamp {
+			merged = append(merged, a[i])
+			i++
+		} else {
+			merged = append(merged, b[j])
+			j++
+		}
+	}
+	merged = append(merged, a[i:]...)
+	merged = append(merged, b[j:]...)
+	return merged
+}
+
 // TransportInterceptorMiddleware runs all plugin HTTP transport interceptors.
 // It converts the fasthttp request to a serializable HTTPRequest, runs all plugin interceptors,
 // and applies any modifications back to the fasthttp context.
@@ -296,13 +322,22 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 			}
 			// Get or create BifrostContext from fasthttp context
 			bifrostCtx := getBifrostContextFromFastHTTP(ctx)
+			// Store transport plugin logs on fasthttp context at function exit.
+			// Covers both pre-hook and post-hook logs in a single drain call.
+			defer func() {
+				if logs := bifrostCtx.DrainPluginLogs(); len(logs) > 0 {
+					ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, logs)
+				}
+			}()
 			// Acquire pooled request
 			req := schemas.AcquireHTTPRequest()
 			defer schemas.ReleaseHTTPRequest(req)
 			fasthttpToHTTPRequest(ctx, req)
 			// Run plugin interceptors
 			for _, plugin := range plugins {
-				resp, err := plugin.HTTPTransportPreHook(bifrostCtx, req)
+				pluginCtx := bifrostCtx.WithPluginScope(plugin.GetName())
+				resp, err := plugin.HTTPTransportPreHook(pluginCtx, req)
+				pluginCtx.ReleasePluginScope()
 				if err != nil {
 					// Short-circuit with error
 					ctx.SetStatusCode(fasthttp.StatusInternalServerError)
@@ -337,7 +372,9 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 			// Run http post-hooks in reverse order
 			for i := len(plugins) - 1; i >= 0; i-- {
 				plugin := plugins[i]
-				err := plugin.HTTPTransportPostHook(bifrostCtx, req, httpResp)
+				pluginCtx := bifrostCtx.WithPluginScope(plugin.GetName())
+				err := plugin.HTTPTransportPostHook(pluginCtx, req, httpResp)
+				pluginCtx.ReleasePluginScope()
 				if err != nil {
 					logger.Warn("error in HTTPTransportPostHook for plugin %s: %s", plugin.GetName(), err.Error())
 					// Short-circuit with response
@@ -781,10 +818,12 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 			if parentSpanID != "" {
 				ctx.SetUserValue(schemas.BifrostContextKeyParentSpanID, parentSpanID)
 			}
-
-			// Store a trace completion callback for streaming handlers to use
-			ctx.SetUserValue(schemas.BifrostContextKeyTraceCompleter, func() {
-				m.completeAndFlushTrace(traceID)
+			// Store a trace completion callback for streaming handlers to use.
+			// Capture transport pre-hook logs in the closure since the fasthttp ctx
+			// will be recycled before streaming completes.
+			transportLogs, _ := ctx.UserValue(schemas.BifrostContextKeyTransportPluginLogs).([]schemas.PluginLogEntry)
+			ctx.SetUserValue(schemas.BifrostContextKeyTraceCompleter, func(requestID string, llmLogs []schemas.PluginLogEntry) {
+				m.completeAndFlushTrace(traceID, requestID, llmLogs, transportLogs)
 			})
 			// Create root span for the HTTP request
 			spanCtx, rootSpan := m.tracer.Load().StartSpan(ctx, string(ctx.RequestURI()), schemas.SpanKindHTTPRequest)
@@ -812,8 +851,16 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 				if deferred, ok := ctx.UserValue(schemas.BifrostContextKeyDeferTraceCompletion).(bool); ok && deferred {
 					return
 				}
-				// After response written - async flush
-				m.completeAndFlushTrace(traceID)
+				// After response written - collect plugin logs (cheap: just pointer/nil reads) and async flush
+				// The expensive merge happens inside the goroutine, off the request hot path.
+				var llmLogs []schemas.PluginLogEntry
+				var requestID string
+				if bifrostCtx, ok := ctx.UserValue(lib.FastHTTPUserValueBifrostContext).(*schemas.BifrostContext); ok && bifrostCtx != nil {
+					llmLogs = bifrostCtx.DrainPluginLogs()
+					requestID, _ = bifrostCtx.Value(schemas.BifrostContextKeyRequestID).(string)
+				}
+				transportLogs, _ := ctx.UserValue(schemas.BifrostContextKeyTransportPluginLogs).([]schemas.PluginLogEntry)
+				m.completeAndFlushTrace(traceID, requestID, llmLogs, transportLogs)
 			}()
 
 			next(ctx)
@@ -823,7 +870,10 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 
 // completeAndFlushTrace completes the trace and forwards it to observability plugins.
 // This is called either by the middleware defer (for non-streaming) or by streaming handlers.
-func (m *TracingMiddleware) completeAndFlushTrace(traceID string) {
+// requestID is the Bifrost request ID for correlating with log entries.
+// llmLogs and transportLogs are plugin logs from LLM/MCP hooks and HTTP transport hooks respectively.
+// The merge happens inside the goroutine to keep it off the request hot path.
+func (m *TracingMiddleware) completeAndFlushTrace(traceID string, requestID string, llmLogs, transportLogs []schemas.PluginLogEntry) {
 	go func() {
 		// Clean up the stream accumulator for this trace
 
@@ -831,6 +881,11 @@ func (m *TracingMiddleware) completeAndFlushTrace(traceID string) {
 		completedTrace := m.tracer.Load().EndTrace(traceID)
 		if completedTrace == nil {
 			return
+		}
+		// Set request ID and merge plugin logs on the trace for observability plugins (off the hot path)
+		completedTrace.RequestID = requestID
+		if len(llmLogs) > 0 || len(transportLogs) > 0 {
+			completedTrace.PluginLogs = mergePluginLogs(llmLogs, transportLogs)
 		}
 		// Forward to all observability plugins
 		for _, plugin := range *m.obsPlugins.Load() {

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2270,7 +2270,7 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 	ctx.SetUserValue(schemas.BifrostContextKeyDeferTraceCompletion, true)
 
 	// Get the trace completer function for use in the streaming callback
-	traceCompleter, _ := ctx.UserValue(schemas.BifrostContextKeyTraceCompleter).(func())
+	traceCompleter, _ := ctx.UserValue(schemas.BifrostContextKeyTraceCompleter).(func(string, []schemas.PluginLogEntry))
 
 	// Get stream chunk interceptor for plugin hooks
 	interceptor := g.handlerStore.GetStreamChunkInterceptor()
@@ -2288,11 +2288,16 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 	go func() {
 		defer func() {
 			schemas.ReleaseHTTPRequest(httpReq)
+			if interceptor != nil {
+				interceptor.Release()
+			}
 			reader.Done()
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL
+			// Pass LLM plugin logs so they can be merged with transport logs in the completer
 			if traceCompleter != nil {
-				traceCompleter()
+				requestID, _ := bifrostCtx.Value(schemas.BifrostContextKeyRequestID).(string)
+				traceCompleter(requestID, bifrostCtx.DrainPluginLogs())
 			}
 		}()
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -52,6 +52,9 @@ type StreamChunkInterceptor interface {
 	// InterceptChunk processes a chunk before it's written to the client.
 	// Returns the (potentially modified) chunk, or nil to skip the chunk entirely.
 	InterceptChunk(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, chunk *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error)
+	// Release returns cached plugin-scoped contexts to the pool.
+	// Must be called when streaming is complete.
+	Release()
 }
 
 // HandlerStore provides access to runtime configuration values for handlers.
@@ -2324,16 +2327,26 @@ func (c *Config) GetLoadedLLMPlugins() []schemas.LLMPlugin {
 	return nil
 }
 
-// pluginChunkInterceptor implements StreamChunkInterceptor by calling plugin hooks
+// pluginChunkInterceptor implements StreamChunkInterceptor by calling plugin hooks.
+// It caches scoped contexts across chunks and releases them on Release().
 type pluginChunkInterceptor struct {
-	plugins []schemas.HTTPTransportPlugin
+	plugins    []schemas.HTTPTransportPlugin
+	scopedCtxs []*schemas.BifrostContext // lazily created, reused across chunks
 }
 
 // InterceptChunk processes a chunk through all plugin HTTPTransportStreamChunkHook methods.
 // Plugins are called in reverse order (same as PostHook) so modifications chain correctly.
+// Scoped contexts are created once on the first call and reused for subsequent chunks.
 func (i *pluginChunkInterceptor) InterceptChunk(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, stream *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error) {
+	// Lazily create scoped contexts on first chunk
+	if i.scopedCtxs == nil {
+		i.scopedCtxs = make([]*schemas.BifrostContext, len(i.plugins))
+		for j, plugin := range i.plugins {
+			i.scopedCtxs[j] = ctx.WithPluginScope(plugin.GetName())
+		}
+	}
 	for j := len(i.plugins) - 1; j >= 0; j-- {
-		modified, err := i.plugins[j].HTTPTransportStreamChunkHook(ctx, req, stream)
+		modified, err := i.plugins[j].HTTPTransportStreamChunkHook(i.scopedCtxs[j], req, stream)
 		if err != nil {
 			return modified, fmt.Errorf("failed to intercept chunk with plugin %s: %w", i.plugins[j].GetName(), err)
 		}
@@ -2343,6 +2356,17 @@ func (i *pluginChunkInterceptor) InterceptChunk(ctx *schemas.BifrostContext, req
 		stream = modified
 	}
 	return stream, nil
+}
+
+// Release returns all cached scoped contexts to the pool.
+func (i *pluginChunkInterceptor) Release() {
+	for j, scoped := range i.scopedCtxs {
+		if scoped != nil {
+			scoped.ReleasePluginScope()
+			i.scopedCtxs[j] = nil
+		}
+	}
+	i.scopedCtxs = nil
 }
 
 // GetStreamChunkInterceptor returns the chunk interceptor for streaming responses.

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -40,6 +40,7 @@ import LogResponsesMessageView from "../views/logResponsesMessageView";
 import SpeechView from "../views/speechView";
 import TranscriptionView from "../views/transcriptionView";
 import VideoView from "../views/videoView";
+import { PluginLogsView } from "../views/pluginLogsView";
 import { CodeEditor } from "@/components/ui/codeEditor";
 
 const formatJsonSafe = (str: string | undefined): string => {
@@ -563,6 +564,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 						</div>
 					</CollapsibleBox>
 				)}
+				{displayLog.plugin_logs && <PluginLogsView pluginLogs={displayLog.plugin_logs} />}
 				{toolsParameter && (
 					<CollapsibleBox title={`Tools (${displayLog.params?.tools?.length || 0})`} onCopy={() => toolsParameter}>
 						<CodeEditor

--- a/ui/app/workspace/logs/views/pluginLogsView.tsx
+++ b/ui/app/workspace/logs/views/pluginLogsView.tsx
@@ -1,0 +1,72 @@
+import { Puzzle } from "lucide-react";
+import moment from "moment";
+import CollapsibleBox from "./collapsibleBox";
+
+interface PluginLogEntry {
+	level: string;
+	message: string;
+	timestamp: number;
+}
+
+const levelStyles: Record<string, string> = {
+	error: "border-red-300 text-red-700 dark:border-red-700 dark:text-red-400",
+	warn: "border-yellow-300 text-yellow-700 dark:border-yellow-700 dark:text-yellow-400",
+	debug: "border-gray-300 text-gray-500 dark:border-gray-600 dark:text-gray-400",
+	info: "border-blue-300 text-blue-700 dark:border-blue-700 dark:text-blue-400",
+};
+
+interface PluginLogEntriesViewProps {
+	pluginName: string;
+	logs: PluginLogEntry[];
+}
+
+export function PluginLogEntriesView({ pluginName, logs }: PluginLogEntriesViewProps) {
+	return (
+		<div data-testid={`plugin-log-entry-${pluginName}`} className="flex flex-col gap-1">
+			<div className="mb-1 flex items-center gap-2 text-sm font-semibold">
+				<Puzzle className="h-4 w-4" />
+				{pluginName}
+			</div>
+			<div className="space-y-0.5 font-mono text-xs">
+				{logs.map((log, i) => (
+					<div key={i} className="flex items-center justify-start gap-2">
+						<div className="text-muted-foreground shrink-0 pt-0.5 text-[10px]">{moment(log.timestamp).format("YYYY-MM-DD HH:mm:ss")}</div>
+						<div className={`shrink-0 pt-0.5 text-[10px] uppercase ${levelStyles[log.level] || levelStyles.info}`}>{log.level}</div>
+						<div className="text-sm break-words whitespace-pre-wrap">{log.message}</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+interface PluginLogsViewProps {
+	pluginLogs: string;
+}
+
+export function PluginLogsView({ pluginLogs }: PluginLogsViewProps) {
+	let parsed: Record<string, PluginLogEntry[]>;
+	try {
+		const raw = JSON.parse(pluginLogs);
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+		parsed = Object.fromEntries(
+			Object.entries(raw).filter(([, value]) => Array.isArray(value))
+		) as Record<string, PluginLogEntry[]>;
+	} catch {
+		return null;
+	}
+
+	if (Object.keys(parsed).length === 0) return null;
+
+	return (
+		<div data-testid="plugin-logs-container">
+			<CollapsibleBox title="Plugin Logs" onCopy={() => pluginLogs}>
+				<div data-testid="plugin-logs-content" className="custom-scrollbar max-h-[400px] space-y-3 overflow-y-auto px-6 py-3">
+					{Object.entries(parsed).map(([pluginName, logs]) => (
+						<PluginLogEntriesView key={pluginName} pluginName={pluginName} logs={logs} />
+					))}
+				</div>
+			</CollapsibleBox>
+		</div>
+	);
+}

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -30,6 +30,8 @@ interface OtelFormFragmentProps {
 		metrics_enabled?: boolean;
 		metrics_endpoint?: string;
 		metrics_push_interval?: number;
+		// Plugin log forwarding
+		forward_plugin_logs?: boolean;
 	};
 	onSave: (config: OtelFormSchema) => Promise<void>;
 	onDelete?: () => void;
@@ -57,6 +59,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 				metrics_enabled: initialConfig?.metrics_enabled ?? false,
 				metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
 				metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
+				forward_plugin_logs: initialConfig?.forward_plugin_logs ?? false,
 			},
 		},
 	});
@@ -101,6 +104,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 				metrics_enabled: initialConfig?.metrics_enabled ?? false,
 				metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
 				metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
+				forward_plugin_logs: initialConfig?.forward_plugin_logs ?? false,
 			},
 		});
 	}, [form, initialConfig]);
@@ -363,6 +367,34 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 					)}
 				</div>
 
+				{/* Plugin Log Forwarding */}
+				<div className="space-y-4 border-t pt-4">
+					<FormField
+						control={form.control}
+						name="otel_config.forward_plugin_logs"
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center gap-2">
+								<div className="flex w-full flex-row items-center gap-2">
+									<div className="flex flex-col gap-1">
+										<h3 className="text-sm font-medium">Forward Plugin Logs</h3>
+										<p className="text-muted-foreground text-xs">
+											Include plugin log entries as span events on plugin spans in exported traces
+										</p>
+									</div>
+									<div className="ml-auto">
+										<Switch
+											data-testid="otel-plugin-logs-toggle"
+											checked={field.value}
+											onCheckedChange={field.onChange}
+											disabled={!hasOtelAccess}
+										/>
+									</div>
+								</div>
+							</FormItem>
+						)}
+					/>
+				</div>
+
 				{/* Form Actions */}
 				<div className="flex w-full flex-row items-center">
 					<FormField
@@ -413,6 +445,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 										metrics_enabled: initialConfig?.metrics_enabled ?? false,
 										metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
 										metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
+										forward_plugin_logs: initialConfig?.forward_plugin_logs ?? false,
 									},
 								});
 							}}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -436,6 +436,7 @@ export interface LogEntry {
 	routing_engines_used?: string[];
 	routing_rule_id?: string;
 	routing_engine_logs?: string; // Human-readable routing decision logs
+	plugin_logs?: string; // JSON serialized map of plugin name -> log entries
 	selected_key?: DBKey;
 	virtual_key?: VirtualKey;
 	routing_rule?: RoutingRule;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -702,6 +702,8 @@ export const otelConfigSchema = z
 		metrics_enabled: z.boolean().default(false),
 		metrics_endpoint: z.string().optional(),
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
+		// Plugin log forwarding
+		forward_plugin_logs: z.boolean().default(false),
 	})
 	.superRefine((data, ctx) => {
 		const protocol = data.protocol;


### PR DESCRIPTION
## Summary

Adds plugin logging functionality to Bifrost, allowing plugins to emit structured logs that are captured, stored, and displayed in the UI. This enables better debugging and monitoring of plugin behavior during request processing.

## Changes

- Added `PluginLogEntry` struct to capture plugin log entries with level, message, and timestamp
- Extended `BifrostContext` with plugin logging methods (`Log`, `SetCurrentPluginName`, `GetPluginLogs`)
- Modified plugin pipeline execution to set current plugin name before each hook execution
- Added `plugin_logs` column to the logs database table with migration
- Updated logging plugin to capture and serialize plugin logs to the database
- Enhanced UI to display plugin logs in the log details sheet with color-coded log levels
- Added comprehensive tests for plugin logging functionality
- Updated hello-world example plugin to demonstrate logging usage

The implementation uses lazy allocation for plugin logs and automatically associates logs with the currently executing plugin. Plugin names are cleared after hook execution to prevent logs from being attributed to the wrong plugin.

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Plugins
- [x] UI (Next.js)

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test plugin logging by:
1. Running the hello-world example plugin
2. Making requests through Bifrost
3. Checking the logs UI to see plugin log entries with different levels
4. Verifying logs are properly attributed to the correct plugins

## Screenshots/Recordings

Plugin logs are displayed in the log details sheet with color-coded badges for different log levels (error=red, warn=yellow, debug=gray, info=blue).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Plugin logs are stored in the same database as other log data and follow the same access controls. No additional security implications as plugins already have access to request/response data.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable