### PR TITLE
add loader for logDetailsSheet till details are laoded

### DIFF
--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -207,7 +207,7 @@ func main() {
 
 Retrieve and analyze logs with powerful filtering capabilities via the UI, API, and WebSockets.
 
-![Advanced Log Filtering Interface](../../media/ui-log-filtering.gif)
+![Advanced Log Filtering Interface](/media/ui-log-filtering.gif)
 
 ### Web UI
 

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -28,7 +28,7 @@ import {
 	StatusColors,
 } from "@/lib/constants/logs";
 import { LogEntry } from "@/lib/types/logs";
-import { Clipboard, MoreVertical, Trash2 } from "lucide-react";
+import { Clipboard, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import moment from "moment";
 import { toast } from "sonner";
 import BlockHeader from "../views/blockHeader";
@@ -78,7 +78,7 @@ const isContainerOperation = (object: string) => {
 };
 
 export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDetailSheetProps) {
-	const [fetchLog, { data: fullLog }] = useLazyGetLogByIdQuery();
+	const [fetchLog, { data: fullLog, isFetching }] = useLazyGetLogByIdQuery();
 
 	useEffect(() => {
 		if (open && log?.id) {
@@ -88,10 +88,9 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 
 	if (!log) return null;
 
-	// The list query omits large fields for performance (output_message, tools, params, etc.).
-	// Use the full log from the dedicated single-log fetch as the primary data source for the
-	// detail sheet, falling back to the list entry while the fetch is in flight.
-	const displayLog = fullLog?.id === log.id ? fullLog : log;
+	// Show a loader until the full log data is fetched from the dedicated single-log endpoint.
+	const isFullDataReady = fullLog?.id === log.id && !isFetching;
+	const displayLog = isFullDataReady ? fullLog : log;
 
 	const isContainer = isContainerOperation(displayLog.object);
 	const isPassthrough = isPassthroughOperation(displayLog.object);
@@ -125,6 +124,12 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
+				{!isFullDataReady ? (
+					<div className="flex h-full items-center justify-center">
+						<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+					</div>
+				) : (
+				<>
 				<SheetHeader className="flex flex-row items-center px-0">
 					<div className="flex w-full items-center justify-between">
 						<SheetTitle className="flex w-fit items-center gap-2 font-medium">
@@ -854,6 +859,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							</>
 						)}
 					</>
+				)}
+				</>
 				)}
 			</SheetContent>
 		</Sheet>


### PR DESCRIPTION
## Summary

Added a loading spinner to the log details sheet to improve user experience while fetching complete log data from the server.

## Changes

- Added `isFetching` state tracking to the lazy query hook for log details
- Imported `Loader2` icon component for the loading indicator
- Implemented conditional rendering to show a centered loading spinner until full log data is available
- Updated the logic to determine when full data is ready by checking both data presence and fetch status

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the logs section in the workspace
2. Click on any log entry to open the details sheet
3. Verify that a loading spinner appears while the full log data is being fetched
4. Confirm that the spinner disappears and log details are displayed once data loading completes

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Log details sheet would show partial data immediately
After: Loading spinner displays until complete log data is fetched

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications - this is a UI enhancement for loading states.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable