### PR TITLE
adds back api key support for bedrock

### DIFF
--- a/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
@@ -58,7 +58,7 @@ export default function ModelCatalogTable({
 			{/* Summary Cards */}
 			<div className="grid grid-cols-4 gap-4">
 				{summaryCards.map((card) => (
-					<Card key={card.label} className="py-4">
+					<Card key={card.label} className="py-4 shadow-none">
 						<CardContent className="px-4">
 							<p className="text-muted-foreground text-xs">{card.label}</p>
 							<p className="mt-1 text-xl font-semibold">{card.value}</p>
@@ -73,7 +73,11 @@ export default function ModelCatalogTable({
 					<h2 className="text-lg font-semibold">Model Catalog</h2>
 					<p className="text-muted-foreground text-sm">Overview of all configured providers, models, and usage.</p>
 				</div>
-				<Select value={providerFilter || "all"} onValueChange={(val) => onProviderFilterChange(val === "all" ? "" : val)} data-testid="model-catalog-provider-filter">
+				<Select
+					value={providerFilter || "all"}
+					onValueChange={(val) => onProviderFilterChange(val === "all" ? "" : val)}
+					data-testid="model-catalog-provider-filter"
+				>
 					<SelectTrigger className="w-[200px]" data-testid="model-catalog-provider-trigger">
 						<SelectValue placeholder="All Providers" />
 					</SelectTrigger>

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -60,8 +60,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 	// Auth type state for Azure: 'api_key', 'entra_id', or 'default_credential'
 	const [azureAuthType, setAzureAuthType] = useState<'api_key' | 'entra_id' | 'default_credential'>('api_key')
 
-	// Auth type state for Bedrock: 'iam_role' or 'explicit'
-	const [bedrockAuthType, setBedrockAuthType] = useState<'iam_role' | 'explicit'>('iam_role')
+	// Auth type state for Bedrock: 'iam_role', 'explicit', or 'api_key'
+	const [bedrockAuthType, setBedrockAuthType] = useState<'iam_role' | 'explicit' | 'api_key'>('iam_role')
 
 	// Detect auth type from existing form values when editing
 	useEffect(() => {
@@ -84,8 +84,11 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 		if (isBedrock) {
 			const accessKey = form.getValues('key.bedrock_key_config.access_key')?.value
 			const secretKey = form.getValues('key.bedrock_key_config.secret_key')?.value
+			const apiKey = form.getValues('key.value')?.value
 			if (accessKey || secretKey) {
 				setBedrockAuthType('explicit')
+			} else if (apiKey) {
+				setBedrockAuthType('api_key')
 			}
 		}
 	}, [isBedrock, form])
@@ -167,8 +170,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 					)}
 				/>
 			</div>
-			{/* Hide API Key field for Azure when using Entra ID/Default Credential */}
-			{!(isAzure && (azureAuthType === "entra_id" || azureAuthType === "default_credential")) && (
+			{/* Hide API Key field for Azure when using Entra ID/Default Credential, and for Bedrock when not using API Key auth */}
+			{!(isAzure && (azureAuthType === "entra_id" || azureAuthType === "default_credential")) && !(isBedrock) && (
 					<FormField
 						control={control}
 						name={`key.value`}
@@ -596,22 +599,38 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 						<Tabs
 							value={bedrockAuthType}
 							onValueChange={(v) => {
-								setBedrockAuthType(v as "iam_role" | "explicit");
+								setBedrockAuthType(v as "iam_role" | "explicit" | "api_key");
 								if (v === "iam_role") {
-									// Clear explicit credentials when switching to IAM Role
+									// Clear explicit credentials and API key when switching to IAM Role
 									form.setValue("key.bedrock_key_config.access_key", undefined, { shouldDirty: true });
 									form.setValue("key.bedrock_key_config.secret_key", undefined, { shouldDirty: true });
 									form.setValue("key.bedrock_key_config.session_token", undefined, { shouldDirty: true });
+									form.setValue("key.value", undefined, { shouldDirty: true });
+								} else if (v === "explicit") {
+									// Clear API key when switching to Explicit Credentials
+									form.setValue("key.value", undefined, { shouldDirty: true });
+								} else if (v === "api_key") {
+									// Clear AWS credentials and assume-role fields when switching to API Key
+									form.setValue("key.bedrock_key_config.access_key", undefined, { shouldDirty: true });
+									form.setValue("key.bedrock_key_config.secret_key", undefined, { shouldDirty: true });
+									form.setValue("key.bedrock_key_config.session_token", undefined, { shouldDirty: true });
+									form.setValue("key.bedrock_key_config.role_arn", undefined, { shouldDirty: true });
+									form.setValue("key.bedrock_key_config.external_id", undefined, { shouldDirty: true });
+									form.setValue("key.bedrock_key_config.session_name", undefined, { shouldDirty: true });
 								}
 							}}
 						>
-							<TabsList className="grid w-full grid-cols-2">
+							<TabsList className="grid w-full grid-cols-3">
 								<TabsTrigger data-testid="apikey-bedrock-iam-role-tab" value="iam_role">IAM Role (Inherited)</TabsTrigger>
 								<TabsTrigger data-testid="apikey-bedrock-explicit-credentials-tab" value="explicit">Explicit Credentials</TabsTrigger>
+								<TabsTrigger data-testid="apikey-bedrock-api-key-tab" value="api_key">API Key</TabsTrigger>
 							</TabsList>
 						</Tabs>
 						{bedrockAuthType === "iam_role" && (
 							<p className="text-muted-foreground text-sm">Uses IAM roles attached to your environment (EC2, Lambda, ECS, EKS).</p>
+						)}
+						{bedrockAuthType === "api_key" && (
+							<p className="text-muted-foreground text-sm">Uses a Bearer token for API key authentication.</p>
 						)}
 					</div>
 
@@ -659,6 +678,22 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 						</>
 					)}
 
+					{bedrockAuthType === "api_key" && (
+						<FormField
+							control={control}
+							name={`key.value`}
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>API Key</FormLabel>
+									<FormControl>
+										<EnvVarInput data-testid="apikey-bedrock-api-key-input" placeholder="API Key or env.BEDROCK_API_KEY" type="text" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+					)}
+
 					<FormField
 						control={control}
 						name={`key.bedrock_key_config.region`}
@@ -672,58 +707,62 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							</FormItem>
 						)}
 					/>
-					<FormField
-						control={control}
-						name={`key.bedrock_key_config.role_arn`}
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>Assume Role ARN (Optional)</FormLabel>
-								<FormDescription>
-									Assume an IAM role before requests. Works with both explicit credentials and inherited IAM (EC2, ECS, EKS).
-								</FormDescription>
-								<FormControl>
-									<EnvVarInput
-										data-testid="apikey-bedrock-role-arn-input"
-										placeholder="arn:aws:iam::123456789:role/MyRole or env.AWS_ROLE_ARN"
-										{...field}
-									/>
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-					<FormField
-						control={control}
-						name={`key.bedrock_key_config.external_id`}
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>External ID (Optional)</FormLabel>
-								<FormDescription>Required by the role's trust policy when using cross-account access</FormDescription>
-								<FormControl>
-									<EnvVarInput data-testid="apikey-bedrock-external-id-input" placeholder="external-id or env.AWS_EXTERNAL_ID" {...field} />
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-					<FormField
-						control={control}
-						name={`key.bedrock_key_config.session_name`}
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>Session Name (Optional)</FormLabel>
-								<FormDescription>AssumeRole session name (defaults to bifrost-session)</FormDescription>
-								<FormControl>
-									<EnvVarInput
-										data-testid="apikey-bedrock-session-name-input"
-										placeholder="bifrost-session or env.AWS_SESSION_NAME"
-										{...field}
-									/>
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
+					{bedrockAuthType !== "api_key" && (
+						<>
+							<FormField
+								control={control}
+								name={`key.bedrock_key_config.role_arn`}
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Assume Role ARN (Optional)</FormLabel>
+										<FormDescription>
+											Assume an IAM role before requests. Works with both explicit credentials and inherited IAM (EC2, ECS, EKS).
+										</FormDescription>
+										<FormControl>
+											<EnvVarInput
+												data-testid="apikey-bedrock-role-arn-input"
+												placeholder="arn:aws:iam::123456789:role/MyRole or env.AWS_ROLE_ARN"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={control}
+								name={`key.bedrock_key_config.external_id`}
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>External ID (Optional)</FormLabel>
+										<FormDescription>Required by the role's trust policy when using cross-account access</FormDescription>
+										<FormControl>
+											<EnvVarInput data-testid="apikey-bedrock-external-id-input" placeholder="external-id or env.AWS_EXTERNAL_ID" {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+							<FormField
+								control={control}
+								name={`key.bedrock_key_config.session_name`}
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Session Name (Optional)</FormLabel>
+										<FormDescription>AssumeRole session name (defaults to bifrost-session)</FormDescription>
+										<FormControl>
+											<EnvVarInput
+												data-testid="apikey-bedrock-session-name-input"
+												placeholder="bifrost-session or env.AWS_SESSION_NAME"
+												{...field}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</>
+					)}
 					<FormField
 						control={control}
 						name={`key.bedrock_key_config.arn`}


### PR DESCRIPTION
## Summary

Adds API key authentication support for AWS Bedrock provider and removes shadows from model catalog summary cards for improved visual consistency.

## Changes

- Added third authentication option "API Key" for Bedrock provider alongside existing IAM Role and Explicit Credentials options
- Updated Bedrock authentication state management to handle three auth types instead of two
- Added form field clearing logic when switching between different Bedrock auth types
- Conditionally hide AWS-specific fields (role ARN, external ID, session name) when using API key authentication
- Added `shadow-none` class to model catalog summary cards
- Reformatted Select component in model catalog table for better code readability

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the workspace providers section
2. Configure a new Bedrock provider or edit an existing one
3. Verify three authentication tabs are available: "IAM Role (Inherited)", "Explicit Credentials", and "API Key"
4. Test switching between auth types and verify form fields clear appropriately
5. Confirm API key tab shows only API Key and Region fields (no AWS role/session fields)
6. Check model catalog page to verify summary cards display without shadows

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The API key authentication method handles sensitive credentials through the existing EnvVarInput component which supports environment variable references for secure credential management.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable