### PR TITLE
routing: add model templating support in routing targets

### DIFF
--- a/plugins/governance/main_routing_template_test.go
+++ b/plugins/governance/main_routing_template_test.go
@@ -1,0 +1,92 @@
+package governance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyRoutingRules_TargetModelTemplate(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	engine, err := NewRoutingEngine(store, logger)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{
+		store:  store,
+		engine: engine,
+		logger: logger,
+	}
+
+	rule := &configstoreTables.TableRoutingRule{
+		ID:            "tmpl-apply-1",
+		Name:          "Template Apply Rule",
+		CelExpression: "true",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
+
+	body := map[string]any{"model": "claude-sonnet-4-5"}
+	req := &schemas.HTTPRequest{Path: "/v1/chat/completions", Headers: map[string]string{}, Query: map[string]string{}}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	updatedBody, decision, err := plugin.applyRoutingRules(ctx, req, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.Equal(t, "openrouter", decision.Provider)
+	assert.Equal(t, "anthropic/claude-sonnet-4-5", decision.Model)
+	assert.Equal(t, "openrouter/anthropic/claude-sonnet-4-5", updatedBody["model"])
+}
+
+func TestApplyRoutingRules_StaticTargetUnchanged(t *testing.T) {
+	logger := NewMockLogger()
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	engine, err := NewRoutingEngine(store, logger)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{
+		store:  store,
+		engine: engine,
+		logger: logger,
+	}
+
+	rule := &configstoreTables.TableRoutingRule{
+		ID:            "static-apply-1",
+		Name:          "Static Apply Rule",
+		CelExpression: "true",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/claude-sonnet-4-5"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
+
+	body := map[string]any{"model": "claude-sonnet-4-5"}
+	req := &schemas.HTTPRequest{Path: "/v1/chat/completions", Headers: map[string]string{}, Query: map[string]string{}}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	updatedBody, decision, err := plugin.applyRoutingRules(ctx, req, body, nil)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.Equal(t, "openrouter", decision.Provider)
+	assert.Equal(t, "anthropic/claude-sonnet-4-5", decision.Model)
+	assert.Equal(t, "openrouter/anthropic/claude-sonnet-4-5", updatedBody["model"])
+}

--- a/plugins/governance/main_routing_template_test.go
+++ b/plugins/governance/main_routing_template_test.go
@@ -27,12 +27,13 @@ func TestApplyRoutingRules_TargetModelTemplate(t *testing.T) {
 		logger: logger,
 	}
 
+	// Uses CEL string expression for model transformation
 	rule := &configstoreTables.TableRoutingRule{
-		ID:            "tmpl-apply-1",
-		Name:          "Template Apply Rule",
+		ID:            "cel-apply-1",
+		Name:          "CEL Model Transform Apply Rule",
 		CelExpression: "true",
 		Targets: []configstoreTables.TableRoutingTarget{
-			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr(`"anthropic/" + model`), Weight: 1.0},
 		},
 		Enabled:  true,
 		Scope:    "global",

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/google/cel-go/cel"
@@ -22,6 +23,9 @@ var paramKeyPattern = regexp.MustCompile(`params\[["']([^"']+)["']\]`)
 
 // paramInPattern matches "in params" membership test patterns like "Region" in params or 'Region' in params
 var paramInPattern = regexp.MustCompile(`["']([^"']+)["']\s+in\s+params`)
+
+// targetTemplatePattern matches template placeholders like {{input.model}}.
+var targetTemplatePattern = regexp.MustCompile(`\{\{\s*([^{}\s]+)\s*\}\}`)
 
 // ScopeLevel represents a level in the scope precedence hierarchy
 type ScopeLevel struct {
@@ -155,7 +159,13 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 
 				model := routingCtx.Model
 				if target.Model != nil && *target.Model != "" {
-					model = *target.Model
+					resolvedModel, resolveErr := resolveRoutingModelTemplate(*target.Model, routingCtx)
+					if resolveErr != nil {
+						re.logger.Warn("[RoutingEngine] Rule %s skipped: model template resolution failed: %v", rule.Name, resolveErr)
+						ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → skipped: model template resolution failed: %v", rule.Name, rule.CelExpression, resolveErr))
+						continue
+					}
+					model = resolvedModel
 				}
 
 				keyID := ""
@@ -186,6 +196,71 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 	// No rule matched - return nil decision (caller should use default routing)
 	re.logger.Debug("[RoutingEngine] No routing rule matched, using default routing")
 	return nil, nil
+}
+
+// NOTE:
+// CEL is used for rule matching (boolean evaluation) and does not currently
+// support string transformations. This lightweight templating is intentionally
+// scoped only for deriving the final target model string after a rule matches.
+//
+// This avoids introducing a full expression language into routing targets.
+// Future improvements may unify this under CEL or a dedicated transformation layer.
+//
+// Supported template variables (intentionally minimal):
+// - input.model
+// - model
+//
+// This is intentionally restricted to avoid turning routing into a full templating system.
+func resolveRoutingModelTemplate(templateValue string, ctx *RoutingContext) (string, error) {
+       if templateValue == "" {
+	       return "", nil
+       }
+       if ctx == nil {
+	       return "", fmt.Errorf("routing context cannot be nil")
+       }
+       if !strings.Contains(templateValue, "{{") {
+	       return templateValue, nil
+       }
+
+       matches := targetTemplatePattern.FindAllStringSubmatch(templateValue, -1)
+       if len(matches) == 0 {
+	       return "", fmt.Errorf("invalid template syntax in model target")
+       }
+
+       variables := map[string]string{
+	       "input.model": ctx.Model,
+	       "model":       ctx.Model,
+       }
+
+       unknownVars := make(map[string]struct{})
+       rendered := targetTemplatePattern.ReplaceAllStringFunc(templateValue, func(match string) string {
+	       submatches := targetTemplatePattern.FindStringSubmatch(match)
+	       if len(submatches) != 2 {
+		       return match
+	       }
+	       name := submatches[1]
+	       value, ok := variables[name]
+	       if !ok {
+		       unknownVars[name] = struct{}{}
+		       return match
+	       }
+	       return value
+       })
+
+       if len(unknownVars) > 0 {
+	       keys := make([]string, 0, len(unknownVars))
+	       for key := range unknownVars {
+		       keys = append(keys, key)
+	       }
+	       sort.Strings(keys)
+	       return "", fmt.Errorf("unknown template variable(s): %s", strings.Join(keys, ", "))
+       }
+
+       if strings.Contains(rendered, "{{") || strings.Contains(rendered, "}}") {
+	       return "", fmt.Errorf("invalid template syntax in model target")
+       }
+
+       return rendered, nil
 }
 
 // selectWeightedTarget picks one target from the slice using weighted random selection.

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/google/cel-go/cel"
@@ -23,9 +22,6 @@ var paramKeyPattern = regexp.MustCompile(`params\[["']([^"']+)["']\]`)
 
 // paramInPattern matches "in params" membership test patterns like "Region" in params or 'Region' in params
 var paramInPattern = regexp.MustCompile(`["']([^"']+)["']\s+in\s+params`)
-
-// targetTemplatePattern matches template placeholders like {{input.model}}.
-var targetTemplatePattern = regexp.MustCompile(`\{\{\s*([^{}\s]+)\s*\}\}`)
 
 // ScopeLevel represents a level in the scope precedence hierarchy
 type ScopeLevel struct {
@@ -159,13 +155,32 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 
 				model := routingCtx.Model
 				if target.Model != nil && *target.Model != "" {
-					resolvedModel, resolveErr := resolveRoutingModelTemplate(*target.Model, routingCtx)
-					if resolveErr != nil {
-						re.logger.Warn("[RoutingEngine] Rule %s skipped: model template resolution failed: %v", rule.Name, resolveErr)
-						ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → skipped: model template resolution failed: %v", rule.Name, rule.CelExpression, resolveErr))
+					targetModel := strings.TrimSpace(*target.Model)
+					// Model transform: cached sync.Map lookup (zero allocs), then either
+					// static passthrough or precompiled CEL eval. Errors are also cached
+					// so misconfigured rules cost only one map lookup per request, not
+					// repeated compilation or log-spam.
+					modelProg, modelErr := re.store.GetModelTransformProgram(targetModel)
+					if modelErr != nil {
+						// Log at Debug — the operator was already warned at rule-load time
+						// in UpdateRoutingRuleInMemory. Debug avoids per-request log spam.
+						re.logger.Debug("[RoutingEngine] Rule %s skipped: model expression error: %v", rule.Name, modelErr)
+						ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → skipped: model expression error: %v", rule.Name, rule.CelExpression, modelErr))
 						continue
 					}
-					model = resolvedModel
+					if modelProg != nil {
+						// CEL string expression — evaluate with routing variables (already extracted above)
+						resolved, evalErr := evaluateCELStringExpression(modelProg, variables)
+						if evalErr != nil {
+							re.logger.Debug("[RoutingEngine] Rule %s skipped: model CEL evaluation failed: %v", rule.Name, evalErr)
+							ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Rule '%s' [%s] → skipped: model CEL eval failed: %v", rule.Name, rule.CelExpression, evalErr))
+							continue
+						}
+						model = resolved
+					} else {
+						// Static model string — use directly (already trimmed), no computation
+						model = targetModel
+					}
 				}
 
 				keyID := ""
@@ -198,69 +213,25 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 	return nil, nil
 }
 
-// NOTE:
-// CEL is used for rule matching (boolean evaluation) and does not currently
-// support string transformations. This lightweight templating is intentionally
-// scoped only for deriving the final target model string after a rule matches.
-//
-// This avoids introducing a full expression language into routing targets.
-// Future improvements may unify this under CEL or a dedicated transformation layer.
-//
-// Supported template variables (intentionally minimal):
-// - input.model
-// - model
-//
-// This is intentionally restricted to avoid turning routing into a full templating system.
-func resolveRoutingModelTemplate(templateValue string, ctx *RoutingContext) (string, error) {
-       if templateValue == "" {
-	       return "", nil
-       }
-       if ctx == nil {
-	       return "", fmt.Errorf("routing context cannot be nil")
-       }
-       if !strings.Contains(templateValue, "{{") {
-	       return templateValue, nil
-       }
+// evaluateCELStringExpression evaluates a precompiled CEL program that produces a string result.
+// Used for model transformation expressions (e.g., "anthropic/" + model).
+// The program must have been compiled against the routing CEL environment.
+func evaluateCELStringExpression(program cel.Program, variables map[string]interface{}) (string, error) {
+	if program == nil {
+		return "", fmt.Errorf("CEL program is nil")
+	}
 
-       matches := targetTemplatePattern.FindAllStringSubmatch(templateValue, -1)
-       if len(matches) == 0 {
-	       return "", fmt.Errorf("invalid template syntax in model target")
-       }
+	out, _, err := program.Eval(variables)
+	if err != nil {
+		return "", fmt.Errorf("CEL evaluation error: %w", err)
+	}
 
-       variables := map[string]string{
-	       "input.model": ctx.Model,
-	       "model":       ctx.Model,
-       }
+	result, ok := out.Value().(string)
+	if !ok {
+		return "", fmt.Errorf("CEL expression did not return string, got: %T", out.Value())
+	}
 
-       unknownVars := make(map[string]struct{})
-       rendered := targetTemplatePattern.ReplaceAllStringFunc(templateValue, func(match string) string {
-	       submatches := targetTemplatePattern.FindStringSubmatch(match)
-	       if len(submatches) != 2 {
-		       return match
-	       }
-	       name := submatches[1]
-	       value, ok := variables[name]
-	       if !ok {
-		       unknownVars[name] = struct{}{}
-		       return match
-	       }
-	       return value
-       })
-
-       if len(unknownVars) > 0 {
-	       keys := make([]string, 0, len(unknownVars))
-	       for key := range unknownVars {
-		       keys = append(keys, key)
-	       }
-	       sort.Strings(keys)
-	       return "", fmt.Errorf("unknown template variable(s): %s", strings.Join(keys, ", "))
-       }
-
-       if strings.Contains(rendered, "{{") || strings.Contains(rendered, "}}") {
-	       return "", fmt.Errorf("invalid template syntax in model target")
-       }
-
-       return rendered, nil
+	return result, nil
 }
 
 // selectWeightedTarget picks one target from the slice using weighted random selection.
@@ -382,8 +353,13 @@ func evaluateCELExpression(program cel.Program, variables map[string]interface{}
 	return matched, nil
 }
 
-// extractRoutingVariables builds a map of CEL variables from routing context
-// This map is used to evaluate CEL expressions in routing rules
+// extractRoutingVariables builds a map of CEL variables from routing context.
+// This map is used to evaluate CEL expressions in routing rules.
+//
+// NOTE: This allocates a new map per call (one per EvaluateRoutingRules invocation).
+// The allocation is acceptable given that CEL evaluation itself dominates the cost,
+// and the map is needed for both boolean rule matching and model transformation.
+// If profiling shows this as a bottleneck, the map can be pooled via sync.Pool.
 func extractRoutingVariables(ctx *RoutingContext) (map[string]interface{}, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("routing context cannot be nil")

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -3,6 +3,7 @@ package governance
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -266,67 +267,161 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 	assert.Equal(t, "Global Rule", decision.MatchedRuleName)
 }
 
-func TestResolveRoutingModelTemplate(t *testing.T) {
+func TestGetModelTransformProgram(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
 	tests := []struct {
-		name     string
-		input    string
-		ctx      *RoutingContext
-		expected string
-		err      string
+		name          string
+		modelExpr     string
+		model         string // input model for CEL evaluation
+		expected      string // expected resolved model
+		expectStatic  bool   // true = static string (nil program)
+		expectErr     bool
+		errContains   string
 	}{
 		{
-			name:     "multiple placeholders",
-			input:    "x/{{input.model}}/y/{{model}}",
-			ctx:      &RoutingContext{Model: "claude-sonnet-4-5"},
-			expected: "x/claude-sonnet-4-5/y/claude-sonnet-4-5",
+			name:         "static model value",
+			modelExpr:    "gpt-4-turbo",
+			expected:     "gpt-4-turbo",
+			expectStatic: true,
 		},
 		{
-			name:  "partial invalid template",
-			input: "anthropic/{{input.model}}-{{bad}}",
-			ctx:   &RoutingContext{Model: "claude-sonnet-4-5"},
-			err:   "unknown template variable",
+			name:         "static model with slashes",
+			modelExpr:    "claude-sonnet-4-5",
+			expected:     "claude-sonnet-4-5",
+			expectStatic: true,
 		},
 		{
-			name:     "static value",
-			input:    "claude-sonnet-4-5",
-			ctx:      &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
-			expected: "claude-sonnet-4-5",
+			name:      "CEL string concatenation",
+			modelExpr: `"anthropic/" + model`,
+			model:     "claude-sonnet-4-5",
+			expected:  "anthropic/claude-sonnet-4-5",
 		},
 		{
-			name:     "model template",
-			input:    "anthropic/{{input.model}}",
-			ctx:      &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
-			expected: "anthropic/claude-sonnet-4-5",
+			name:      "CEL model passthrough",
+			modelExpr: `model`,
+			model:     "gpt-4o",
+			expected:  "gpt-4o",
 		},
 		{
-			name:  "unknown variable",
-			input: "anthropic/{{input.unknown}}",
-			ctx:   &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
-			err:   "unknown template variable",
+			name:      "quoted string literal is treated as CEL not static",
+			modelExpr: `"gpt-4"`,
+			model:     "",
+			expected:  "gpt-4",
 		},
 		{
-			name:  "malformed template",
-			input: "anthropic/{{input.model}",
-			ctx:   &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
-			err:   "invalid template syntax in model target",
+			name:      "CEL prefix and suffix",
+			modelExpr: `"prefix/" + model + "/suffix"`,
+			model:     "claude-sonnet-4-5",
+			expected:  "prefix/claude-sonnet-4-5/suffix",
+		},
+		{
+			name:        "deprecated template syntax rejected",
+			modelExpr:   "anthropic/{{input.model}}",
+			expectErr:   true,
+			errContains: "no longer supported",
+		},
+		{
+			name:        "deprecated template with model variable rejected",
+			modelExpr:   "x/{{model}}/y",
+			expectErr:   true,
+			errContains: "no longer supported",
+		},
+		{
+			name:        "broken CEL syntax is error not silent static",
+			modelExpr:   `"anthropic/" +`,
+			expectErr:   true,
+			errContains: "invalid model target",
+		},
+		{
+			name:        "CEL non-string output type is error",
+			modelExpr:   `1 + 2`,
+			expectErr:   true,
+			errContains: "must evaluate to string",
+		},
+		{
+			name:        "boolean CEL expression is error for model target",
+			modelExpr:   `model == "gpt-4"`,
+			expectErr:   true,
+			errContains: "must evaluate to string",
+		},
+		{
+			name:         "static model with slashes and dots",
+			modelExpr:    "meta/llama-3.1-70b",
+			expected:     "meta/llama-3.1-70b",
+			expectStatic: true,
+		},
+		{
+			name:         "whitespace is trimmed",
+			modelExpr:    "  gpt-4-turbo  ",
+			expected:     "gpt-4-turbo",
+			expectStatic: true,
+		},
+		{
+			name:         "static model with plus sign (false-positive protection)",
+			modelExpr:    "gpt-4+turbo",
+			expected:     "gpt-4+turbo",
+			expectStatic: true,
+		},
+		{
+			name:         "static model with at-sign version",
+			modelExpr:    "claude-sonnet-4-5@20250514",
+			expected:     "claude-sonnet-4-5@20250514",
+			expectStatic: true,
+		},
+		{
+			name:         "static model with colon separator",
+			modelExpr:    "anthropic:claude-3",
+			expected:     "anthropic:claude-3",
+			expectStatic: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := resolveRoutingModelTemplate(tt.input, tt.ctx)
-			if tt.err != "" {
+			prog, err := store.GetModelTransformProgram(tt.modelExpr)
+			if tt.expectErr {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.err)
+				assert.Contains(t, err.Error(), tt.errContains)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, actual)
+
+			if tt.expectStatic {
+				assert.Nil(t, prog, "expected nil program for static string")
+				// For static strings, the caller uses the expression directly
+				// (after TrimSpace normalization by GetModelTransformProgram)
+				assert.Equal(t, tt.expected, strings.TrimSpace(tt.modelExpr))
+				return
+			}
+
+			// CEL expression — evaluate with routing variables
+			require.NotNil(t, prog, "expected non-nil program for CEL expression")
+			variables := map[string]interface{}{
+				"model":            tt.model,
+				"provider":         "openai",
+				"request_type":     "chat_completion",
+				"headers":          map[string]string{},
+				"params":           map[string]string{},
+				"virtual_key_id":   "",
+				"virtual_key_name": "",
+				"team_id":          "",
+				"team_name":        "",
+				"customer_id":      "",
+				"customer_name":    "",
+				"tokens_used":      0.0,
+				"request":          0.0,
+				"budget_used":      0.0,
+			}
+			result, evalErr := evaluateCELStringExpression(prog, variables)
+			require.NoError(t, evalErr)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }
 
-func TestEvaluateRoutingRules_TargetTemplateModel(t *testing.T) {
+func TestEvaluateRoutingRules_TargetCELModelTransform(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
@@ -335,12 +430,13 @@ func TestEvaluateRoutingRules_TargetTemplateModel(t *testing.T) {
 
 	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
 
+	// Model target uses a CEL string expression instead of the old {{input.model}} template
 	rule := &configstoreTables.TableRoutingRule{
-		ID:            "tmpl-1",
-		Name:          "Template Rule",
+		ID:            "cel-1",
+		Name:          "CEL Model Transform Rule",
 		CelExpression: "true",
 		Targets: []configstoreTables.TableRoutingTarget{
-			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr(`"anthropic/" + model`), Weight: 1.0},
 		},
 		Enabled:  true,
 		Scope:    "global",
@@ -362,7 +458,7 @@ func TestEvaluateRoutingRules_TargetTemplateModel(t *testing.T) {
 	assert.Equal(t, "anthropic/claude-sonnet-4-5", decision.Model)
 }
 
-func TestEvaluateRoutingRules_InvalidTemplateSkipsRule(t *testing.T) {
+func TestEvaluateRoutingRules_InvalidModelExprSkipsRule(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
@@ -371,23 +467,25 @@ func TestEvaluateRoutingRules_InvalidTemplateSkipsRule(t *testing.T) {
 
 	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
 
+	// Bad rule: uses deprecated {{}} template syntax — should be skipped with error
 	badRule := &configstoreTables.TableRoutingRule{
-		ID:            "tmpl-bad",
-		Name:          "Bad Template Rule",
+		ID:            "cel-bad",
+		Name:          "Bad Model Expr Rule",
 		CelExpression: "true",
 		Targets: []configstoreTables.TableRoutingTarget{
-			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.unknown}}"), Weight: 1.0},
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
 		},
 		Enabled:  true,
 		Scope:    "global",
 		Priority: 0,
 	}
+	// Good rule: uses CEL expression — should be selected as fallback
 	goodRule := &configstoreTables.TableRoutingRule{
-		ID:            "tmpl-good",
-		Name:          "Fallback Rule",
+		ID:            "cel-good",
+		Name:          "Good CEL Rule",
 		CelExpression: "true",
 		Targets: []configstoreTables.TableRoutingTarget{
-			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr(`"anthropic/" + model`), Weight: 1.0},
 		},
 		Enabled:  true,
 		Scope:    "global",
@@ -406,7 +504,8 @@ func TestEvaluateRoutingRules_InvalidTemplateSkipsRule(t *testing.T) {
 	decision, err := engine.EvaluateRoutingRules(bgCtx, routingCtx)
 	require.NoError(t, err)
 	require.NotNil(t, decision)
-	assert.Equal(t, "tmpl-good", decision.MatchedRuleID)
+	// Bad rule skipped, good rule selected
+	assert.Equal(t, "cel-good", decision.MatchedRuleID)
 	assert.Equal(t, "anthropic/claude-sonnet-4-5", decision.Model)
 }
 
@@ -1727,5 +1826,122 @@ func getDefaultRouting(ctx *RoutingContext) *RoutingDecision {
 		Model:         ctx.Model,
 		Fallbacks:     ctx.Fallbacks,
 		MatchedRuleID: "0",
+	}
+}
+
+// BenchmarkModelTransform_CEL benchmarks the precompiled CEL model transformation path.
+// The program is compiled once during setup; the benchmark loop measures only the eval cost
+// (sync.Map lookup + CEL Eval), which is the per-request hot path.
+// NOTE: CEL evaluation has internal allocations (ref-counted values, activation structs).
+// The benchmark measures realistic per-request cost, not zero-allocation claims.
+func BenchmarkModelTransform_CEL(b *testing.B) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	expr := `"anthropic/" + model`
+	// Pre-compile so the benchmark measures only evaluation
+	prog, err := store.GetModelTransformProgram(expr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if prog == nil {
+		b.Fatal("expected non-nil program for CEL expression")
+	}
+
+	variables := map[string]interface{}{
+		"model":            "claude-sonnet-4-5",
+		"provider":         "openai",
+		"request_type":     "chat_completion",
+		"headers":          map[string]string{},
+		"params":           map[string]string{},
+		"virtual_key_id":   "",
+		"virtual_key_name": "",
+		"team_id":          "",
+		"team_name":        "",
+		"customer_id":      "",
+		"customer_name":    "",
+		"tokens_used":      0.0,
+		"request":          0.0,
+		"budget_used":      0.0,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		result, err := evaluateCELStringExpression(prog, variables)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if result != "anthropic/claude-sonnet-4-5" {
+			b.Fatalf("unexpected result: %s", result)
+		}
+	}
+}
+
+// TestCELEnvironmentVariables asserts that the routing CEL environment declares all
+// expected variables. This catches accidental removals or renames that would silently
+// break rule evaluation at runtime.
+func TestCELEnvironmentVariables(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	// These are the variables that routing rules and model transform expressions rely on.
+	// If any are removed from createCELEnvironment, this test must be updated in tandem.
+	requiredVars := []string{
+		"model", "provider", "request_type",
+		"headers", "params",
+		"virtual_key_id", "virtual_key_name",
+		"team_id", "team_name",
+		"customer_id", "customer_name",
+		"tokens_used", "request", "budget_used",
+	}
+
+	for _, varName := range requiredVars {
+		// Compiling a simple expression that references the variable will fail
+		// if the variable is not declared in the environment.
+		expr := varName + ` == ""` // works for string vars; numeric vars will compile as type mismatch but still prove declaration
+		if varName == "tokens_used" || varName == "request" || varName == "budget_used" {
+			expr = varName + " >= 0.0"
+		} else if varName == "headers" || varName == "params" {
+			expr = `"key" in ` + varName
+		}
+		_, issues := store.routingCELEnv.Compile(expr)
+		if issues != nil && issues.Err() != nil {
+			t.Errorf("CEL environment missing required variable %q: compile error: %v", varName, issues.Err())
+		}
+	}
+}
+
+// BenchmarkModelTransform_Static benchmarks the static model path (sync.Map lookup only).
+func BenchmarkModelTransform_Static(b *testing.B) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	expr := "gpt-4-turbo"
+	// Pre-compile (will be cached as static)
+	prog, err := store.GetModelTransformProgram(expr)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if prog != nil {
+		b.Fatal("expected nil program for static string")
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		prog, err := store.GetModelTransformProgram(expr)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if prog != nil {
+			// Static string — use expr directly
+			b.Fatal("expected nil program")
+		}
+		_ = expr // simulate using the static string
 	}
 }

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -266,6 +266,150 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 	assert.Equal(t, "Global Rule", decision.MatchedRuleName)
 }
 
+func TestResolveRoutingModelTemplate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		ctx      *RoutingContext
+		expected string
+		err      string
+	}{
+		{
+			name:     "multiple placeholders",
+			input:    "x/{{input.model}}/y/{{model}}",
+			ctx:      &RoutingContext{Model: "claude-sonnet-4-5"},
+			expected: "x/claude-sonnet-4-5/y/claude-sonnet-4-5",
+		},
+		{
+			name:  "partial invalid template",
+			input: "anthropic/{{input.model}}-{{bad}}",
+			ctx:   &RoutingContext{Model: "claude-sonnet-4-5"},
+			err:   "unknown template variable",
+		},
+		{
+			name:     "static value",
+			input:    "claude-sonnet-4-5",
+			ctx:      &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
+			expected: "claude-sonnet-4-5",
+		},
+		{
+			name:     "model template",
+			input:    "anthropic/{{input.model}}",
+			ctx:      &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
+			expected: "anthropic/claude-sonnet-4-5",
+		},
+		{
+			name:  "unknown variable",
+			input: "anthropic/{{input.unknown}}",
+			ctx:   &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
+			err:   "unknown template variable",
+		},
+		{
+			name:  "malformed template",
+			input: "anthropic/{{input.model}",
+			ctx:   &RoutingContext{Provider: schemas.OpenRouter, Model: "claude-sonnet-4-5", RequestType: "chat_completion"},
+			err:   "invalid template syntax in model target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := resolveRoutingModelTemplate(tt.input, tt.ctx)
+			if tt.err != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestEvaluateRoutingRules_TargetTemplateModel(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	engine, err := NewRoutingEngine(store, NewMockLogger())
+	require.NoError(t, err)
+
+	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	rule := &configstoreTables.TableRoutingRule{
+		ID:            "tmpl-1",
+		Name:          "Template Rule",
+		CelExpression: "true",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(rule))
+
+	routingCtx := &RoutingContext{
+		Provider:    "",
+		Model:       "claude-sonnet-4-5",
+		Headers:     map[string]string{},
+		QueryParams: map[string]string{},
+	}
+
+	decision, err := engine.EvaluateRoutingRules(bgCtx, routingCtx)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.Equal(t, "openrouter", decision.Provider)
+	assert.Equal(t, "anthropic/claude-sonnet-4-5", decision.Model)
+}
+
+func TestEvaluateRoutingRules_InvalidTemplateSkipsRule(t *testing.T) {
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{}, nil)
+	require.NoError(t, err)
+
+	engine, err := NewRoutingEngine(store, NewMockLogger())
+	require.NoError(t, err)
+
+	bgCtx := schemas.NewBifrostContext(context.Background(), time.Now())
+
+	badRule := &configstoreTables.TableRoutingRule{
+		ID:            "tmpl-bad",
+		Name:          "Bad Template Rule",
+		CelExpression: "true",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.unknown}}"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 0,
+	}
+	goodRule := &configstoreTables.TableRoutingRule{
+		ID:            "tmpl-good",
+		Name:          "Fallback Rule",
+		CelExpression: "true",
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: bifrost.Ptr("openrouter"), Model: bifrost.Ptr("anthropic/{{input.model}}"), Weight: 1.0},
+		},
+		Enabled:  true,
+		Scope:    "global",
+		Priority: 1,
+	}
+	require.NoError(t, store.UpdateRoutingRuleInMemory(badRule))
+	require.NoError(t, store.UpdateRoutingRuleInMemory(goodRule))
+
+	routingCtx := &RoutingContext{
+		Provider:    "",
+		Model:       "claude-sonnet-4-5",
+		Headers:     map[string]string{},
+		QueryParams: map[string]string{},
+	}
+
+	decision, err := engine.EvaluateRoutingRules(bgCtx, routingCtx)
+	require.NoError(t, err)
+	require.NotNil(t, decision)
+	assert.Equal(t, "tmpl-good", decision.MatchedRuleID)
+	assert.Equal(t, "anthropic/claude-sonnet-4-5", decision.Model)
+}
+
 // TestEvaluateRoutingRules_MultiTargetDeterministicWithPinnedKey tests weighted target selection
 // with a seeded/stubbed approach: one target carries all the weight (1.0) and the other carries
 // none (0.0). Because selectWeightedTarget accumulates weights and picks the first target whose

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -40,7 +40,12 @@ type LocalGovernanceStore struct {
 
 	// CEL caching layer for routing rules
 	compiledRoutingPrograms sync.Map // string -> cel.Program (key: ruleID -> compiled CEL program)
-	routingCELEnv           *cel.Env // Singleton CEL environment reused for all compilations
+	compiledModelPrograms   sync.Map // string -> *modelTransformEntry (key: model expression -> compiled CEL program or nil for static)
+	// NOTE: compiledModelPrograms is unbounded. In practice, the number of entries is
+	// limited by routing rule configuration (each target contributes at most one entry).
+	// If dynamic rule creation at high cardinality is introduced, an LRU or size-bounded
+	// cache should replace this.
+	routingCELEnv *cel.Env // Singleton CEL environment reused for all compilations
 
 	// Config store for refresh operations
 	configStore configstore.ConfigStore
@@ -145,6 +150,9 @@ type GovernanceStore interface {
 	DeleteProviderInMemory(providerName string)
 	// Routing Rules CEL caching
 	GetRoutingProgram(rule *configstoreTables.TableRoutingRule) (cel.Program, error)
+	// Model transform CEL program: returns (program, nil) for CEL expressions,
+	// (nil, nil) for static strings, or (nil, error) for invalid expressions.
+	GetModelTransformProgram(modelExpr string) (cel.Program, error)
 	// Budget and rate limit status queries for routing with baseline support
 	GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
 	// Routing Rules CRUD
@@ -3338,6 +3346,133 @@ func (gs *LocalGovernanceStore) GetRoutingProgram(rule *configstoreTables.TableR
 	return program, nil
 }
 
+// modelTransformEntry caches the result of compiling a model target as a CEL string expression.
+// All outcomes are cached (success, static, and errors) so the hot path is always a single
+// sync.Map lookup with zero compilation overhead.
+type modelTransformEntry struct {
+	program cel.Program // non-nil for valid CEL string expressions
+	err     error       // non-nil for invalid expressions (cached to avoid recompilation)
+}
+
+// GetModelTransformProgram compiles a model target string as a CEL string expression and caches the result.
+// Returns (program, nil) if the expression is valid CEL producing a string — evaluate at runtime.
+// Returns (nil, nil) if the expression is a plain static model name (e.g., "gpt-4-turbo").
+// Returns (nil, error) for any invalid expression — deprecated templates, broken CEL syntax,
+// or CEL that produces a non-string type.
+//
+// All results (including errors) are cached by normalized expression string, so identical
+// expressions across rules share one entry. This ensures the hot path is a single sync.Map
+// lookup per request with zero compilation and zero allocations beyond the lookup itself.
+//
+// Detection strategy (deterministic, no heuristic guessing):
+//  1. Attempt CEL compilation.
+//  2a. If compilation succeeds and output type is string → CEL expression.
+//  2b. If compilation fails → check isValidStaticModel (character allowlist:
+//      alphanumerics, hyphens, underscores, dots, slashes, colons, @, +).
+//      All chars match → static model name. Otherwise → error (malformed CEL).
+//
+// This ensures model names like "gpt-4+turbo" or "meta/llama-3.1-70b" are never
+// misclassified as CEL, and broken CEL like '"anthropic/" +' always errors.
+//
+// The CEL environment exposes: model, provider, request_type, headers, params,
+// virtual_key_id/name, team_id/name, customer_id/name, tokens_used, request, budget_used.
+func (gs *LocalGovernanceStore) GetModelTransformProgram(modelExpr string) (cel.Program, error) {
+	modelExpr = strings.TrimSpace(modelExpr)
+
+	// Check cache first — single atomic load covers all previously seen expressions
+	// (valid programs, static strings, and errors). No allocations on the hot path.
+	if entry, ok := gs.compiledModelPrograms.Load(modelExpr); ok {
+		e := entry.(*modelTransformEntry)
+		return e.program, e.err
+	}
+
+	// Reject deprecated template syntax with a clear migration message
+	if strings.Contains(modelExpr, "{{") {
+		err := fmt.Errorf(
+			"invalid model expression '%s': template syntax {{}} is no longer supported; "+
+				"use a CEL string expression instead (e.g., '\"anthropic/\" + model' instead of 'anthropic/{{input.model}}')",
+			modelExpr,
+		)
+		gs.compiledModelPrograms.Store(modelExpr, &modelTransformEntry{err: err})
+		return nil, err
+	}
+
+	// Try to compile as a CEL expression
+	ast, issues := gs.routingCELEnv.Compile(modelExpr)
+	if issues != nil && issues.Err() != nil {
+		// Compile failed — determine if this was intended as a static model name
+		// or a malformed CEL expression using a deterministic character allowlist.
+		if isValidStaticModel(modelExpr) {
+			// All characters are valid model-name characters → treat as static
+			gs.compiledModelPrograms.Store(modelExpr, &modelTransformEntry{})
+			return nil, nil
+		}
+		// Contains characters outside the model-name allowlist → malformed CEL
+		err := fmt.Errorf(
+			"invalid model target '%s': %w; must be either: "+
+				"(1) a valid CEL string expression (e.g., '\"anthropic/\" + model'), or "+
+				"(2) a static model name using only alphanumerics, '-', '.', '/', ':', '@', '+'",
+			modelExpr, issues.Err(),
+		)
+		gs.compiledModelPrograms.Store(modelExpr, &modelTransformEntry{err: err})
+		return nil, err
+	}
+
+	// Compiled successfully as valid CEL — treat as a dynamic expression.
+	// NOTE: This means that quoted string literals like '"gpt-4"' are treated as CEL
+	// (evaluated to "gpt-4") rather than as static model names. This is intentional:
+	// it keeps the system deterministic (compiles → CEL, doesn't compile → allowlist)
+	// and avoids a second layer of heuristic guessing about author intent.
+	//
+	// Enforce string output type — a CEL expression that produces int/bool/etc.
+	// is always an authoring mistake.
+	if ast.OutputType() != cel.StringType {
+		err := fmt.Errorf(
+			"model expression '%s' must evaluate to string, got %s",
+			modelExpr, ast.OutputType(),
+		)
+		gs.compiledModelPrograms.Store(modelExpr, &modelTransformEntry{err: err})
+		return nil, err
+	}
+
+	// Create and cache the program
+	program, err := gs.routingCELEnv.Program(ast)
+	if err != nil {
+		err = fmt.Errorf("CEL model transform program error for '%s': %w", modelExpr, err)
+		gs.compiledModelPrograms.Store(modelExpr, &modelTransformEntry{err: err})
+		return nil, err
+	}
+
+	gs.compiledModelPrograms.Store(modelExpr, &modelTransformEntry{program: program})
+	return program, nil
+}
+
+// isValidStaticModel reports whether s consists entirely of characters that are valid
+// in model names/identifiers: alphanumerics, hyphens, underscores, dots, slashes,
+// colons, at-signs, and plus signs (e.g., "gpt-4-turbo", "meta/llama-3.1-70b",
+// "gpt-4+turbo"). Empty strings return false.
+//
+// This is used as a deterministic allowlist to distinguish static model names from
+// malformed CEL expressions when CEL compilation fails. Any string that passes this
+// check is safe to use as a literal model name; anything that fails it and also fails
+// CEL compilation is treated as a syntax error.
+//
+// NOTE: The allowlist is based on observed model naming conventions across all major
+// providers (OpenAI, Anthropic, Google, Meta, Mistral, Cohere, etc.). If a new provider
+// introduces characters outside this set, the allowlist should be extended here.
+func isValidStaticModel(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			c == '-' || c == '_' || c == '.' || c == '/' || c == ':' || c == '@' || c == '+') {
+			return false
+		}
+	}
+	return true
+}
+
 // GetBudgetAndRateLimitStatus returns the current budget and rate limit status for provider and model combination
 // Accounts for baseline usage from remote nodes when calculating percentages
 func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx context.Context, model string, provider schemas.ModelProvider, vk *configstoreTables.TableVirtualKey, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
@@ -3647,6 +3782,16 @@ func (gs *LocalGovernanceStore) UpdateRoutingRuleInMemory(rule *configstoreTable
 	// Recompile the program immediately to update cache with fresh compilation
 	if _, err := gs.GetRoutingProgram(rule); err != nil {
 		gs.logger.Warn("Failed to recompile routing program for rule %s: %v", rule.ID, err)
+	}
+
+	// Pre-compile model transform programs for all targets so the first request
+	// hitting this rule pays zero compilation cost.
+	for _, target := range rule.Targets {
+		if target.Model != nil && *target.Model != "" {
+			if _, err := gs.GetModelTransformProgram(*target.Model); err != nil {
+				gs.logger.Warn("Failed to pre-compile model transform for rule %s, model=%s: %v", rule.ID, *target.Model, err)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

This PR adds support for **modifying the target model dynamically using input values in routing rules**.

While investigating issue #2128, it was confirmed that routing rules only support static model values. This creates problems when different providers expect different model formats (for example, `claude-sonnet-4-5` vs `anthropic/claude-sonnet-4-5`). As a result, requests either fail or require manual duplication of routing rules.

This change allows deriving the target model from the incoming request using a minimal templating approach, enabling consistent routing across providers.

---

## Changes

* Added support for templated model values in routing targets

  * Example:

    ```json
    "model": "anthropic/{{input.model}}"
    ```

* Introduced `resolveRoutingModelTemplate` to:

  * resolve placeholders using request context
  * validate template syntax
  * return errors for unknown variables

* Applied transformation only to `target.Model`

  * provider and key_id behavior remain unchanged

* Added fail-safe handling:

  * if template resolution fails, the rule is skipped
  * warning + routing logs are emitted

* Added tests covering:

  * valid template resolution
  * multiple placeholders
  * unknown variables
  * invalid syntax
  * fallback to next rule when template fails

### Design decisions / trade-offs

* Kept templating limited and simple instead of extending CEL

  * CEL is currently used for rule matching (boolean evaluation)
  * Adding string transformation to CEL would increase complexity
* Avoided expanding scope beyond model transformation to keep the change minimal and safe

---

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [ ] Core (Go)
* [ ] Transports (HTTP)
* [ ] Providers/Integrations
* [x] Plugins
* [ ] UI (Next.js)
* [ ] Docs

---

## How to test

### Start server

```sh
cd bifrost
go run main.go -app-dir ./tmp/test -port 18080 -host 127.0.0.1
```

---

### Create virtual key

```sh
curl --request POST \
  --url http://127.0.0.1:18080/api/governance/virtual-keys \
  --header 'Content-Type: application/json' \
  --data '{"name":"routing-model-transform-test"}'
```

---

### Baseline (no routing rule)

```sh
curl --request POST \
  --url http://127.0.0.1:18080/v1/chat/completions \
  --header 'Content-Type: application/json' \
  --header 'x-bf-vk: <VK>' \
  --data '{
    "model": "anthropic/claude-sonnet-4-5",
    "messages": [{"role": "user", "content": "Hello"}],
    "max_tokens": 10
  }'
```

Expected:

* provider: `anthropic`
* error: `failed to get config`

---

### Add routing rule

```sh
curl --request POST \
  --url http://127.0.0.1:18080/api/governance/routing-rules \
  --header 'Content-Type: application/json' \
  --data '{
    "name": "model-prefix-routing",
    "cel_expression": "true",
    "targets": [
      {
        "provider": "openrouter",
        "model": "anthropic/{{input.model}}",
        "weight": 1
      }
    ],
    "scope": "virtual_key",
    "scope_id": "<VK_ID>",
    "priority": 0,
    "enabled": true
  }'
```

---

### Validate

```sh
curl --request POST \
  --url http://127.0.0.1:18080/v1/chat/completions \
  --header 'Content-Type: application/json' \
  --header 'x-bf-vk: <VK>' \
  --data '{
    "model": "claude-sonnet-4-5",
    "messages": [{"role": "user", "content": "Hello"}],
    "max_tokens": 10
  }'
```

Expected:

* provider: `openrouter`
* model_requested: `anthropic/claude-sonnet-4-5`

---

### Run tests

```sh
go test ./plugins/governance -count=1
```

---

## Screenshots/Recordings

<img width="1130" height="414" alt="Screenshot 2026-03-23 072631" src="https://github.com/user-attachments/assets/cfa24915-8154-4caf-9841-5fb00b2c4478" />


---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #2128

---

## Security considerations

* Template variables are restricted to known values (`input.model`, `model`)
* No arbitrary code execution or external evaluation

---

## Checklist

* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified tests pass locally

