### PR TITLE
nil pointer fix

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -103,11 +103,19 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 
 // listProviders handles GET /api/providers - List all providers
 func (h *ProviderHandler) listProviders(ctx *fasthttp.RequestCtx) {
-	// Fetching providers from database
-	providers, err := h.dbStore.GetProvidersConfig(ctx)
-	if err != nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get providers: %v", err))
-		return
+	// Fetching providers from database or in-memory store
+	var providers map[schemas.ModelProvider]configstore.ProviderConfig
+	if h.dbStore != nil {
+		var err error
+		providers, err = h.dbStore.GetProvidersConfig(ctx)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get providers: %v", err))
+			return
+		}
+	} else {
+		h.inMemoryStore.Mu.RLock()
+		providers = h.inMemoryStore.Providers
+		h.inMemoryStore.Mu.RUnlock()
 	}
 	providersInClient, err := h.client.GetConfiguredProviders()
 	if err != nil {
@@ -151,14 +159,27 @@ func (h *ProviderHandler) getProvider(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	config, err := h.dbStore.GetProviderConfig(ctx, provider)
-	if err != nil {
-		if errors.Is(err, configstore.ErrNotFound) {
-			SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider not found: %v", err))
+	var config *configstore.ProviderConfig
+	if h.dbStore != nil {
+		config, err = h.dbStore.GetProviderConfig(ctx, provider)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider not found: %v", err))
+				return
+			}
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider config: %v", err))
 			return
 		}
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider config: %v", err))
-		return
+	} else {
+		config, err = h.inMemoryStore.GetProviderConfigRaw(provider)
+		if err != nil {
+			if errors.Is(err, lib.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusNotFound, fmt.Sprintf("Provider not found: %v", err))
+				return
+			}
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get provider config: %v", err))
+			return
+		}
 	}
 	redactedConfig := config.Redacted()
 


### PR DESCRIPTION
## Summary

Added support for in-memory storage as a fallback option for provider configuration retrieval in the HTTP transport layer. This enables the system to function when a database store is not available.

## Changes

- Modified `listProviders` to check if `dbStore` is available, otherwise fall back to reading from `inMemoryStore` with proper mutex locking
- Updated `getProvider` to follow the same pattern, using `GetProviderConfigRaw` method for in-memory retrieval
- Added appropriate error handling for both storage types, mapping `lib.ErrNotFound` for in-memory store to the same HTTP 404 response as `configstore.ErrNotFound` for database store

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test both storage scenarios to ensure provider endpoints work correctly:

```sh
# Test with database store
go test ./transports/bifrost-http/handlers/...

# Test with in-memory store only
# Configure system without database and verify:
# GET /api/providers returns provider list
# GET /api/providers/{provider} returns individual provider config

go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The change maintains the same security posture by preserving the redacted configuration response pattern for both storage types.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable