### PR TITLE
chore: adds migration guide for 1.5 and test fixes

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -453,10 +453,10 @@ VALUES (1, 'migration-test-hash-abc123def456', $now, $now)
 ON CONFLICT DO NOTHING;
 
 -- governance_budgets (reset_duration is a string like "1d", "1h", etc.)
-INSERT INTO governance_budgets (id, max_limit, current_usage, reset_duration, last_reset, config_hash, created_at, updated_at, calendar_aligned)
+INSERT INTO governance_budgets (id, max_limit, current_usage, reset_duration, last_reset, config_hash, calendar_aligned, created_at, updated_at)
 VALUES
-  ('budget-migration-test-1', 1000.00, 100.00, '1d', $now, 'budget-hash-001', $now, $now, 0),
-  ('budget-migration-test-2', 5000.00, 250.00, '7d', $now, 'budget-hash-002', $now, $now, 1)
+  ('budget-migration-test-1', 1000.00, 100.00, '1d', $now, 'budget-hash-001', false, $now, $now),
+  ('budget-migration-test-2', 5000.00, 250.00, '7d', $now, 'budget-hash-002', false, $now, $now)
 ON CONFLICT DO NOTHING;
 
 -- governance_rate_limits (flexible duration format with token_* and request_* columns)
@@ -623,12 +623,9 @@ CROSS JOIN config_keys ck
 WHERE vpc.virtual_key_id = 'vk-migration-test-1' AND ck.name = 'migration-test-key-openai'
 ON CONFLICT DO NOTHING;
 
--- governance_virtual_key_mcp_configs (references virtual_keys and mcp_clients)
--- We need to reference the mcp_client by its internal ID, so use a subquery
-INSERT INTO governance_virtual_key_mcp_configs (virtual_key_id, mcp_client_id, tools_to_execute)
-SELECT 'vk-migration-test-1', id, '["tool1"]'
-FROM config_mcp_clients WHERE client_id = 'mcp-migration-test-001'
-ON CONFLICT DO NOTHING;
+-- governance_virtual_key_mcp_configs: handled dynamically after config_mcp_clients is inserted
+-- (see generate_mcp_clients_insert_postgres/sqlite) so the subquery finds the MCP client row.
+-- Both test VKs are covered to prevent migrationBackfillEmptyVirtualKeyConfigs from adding rows.
 
 -- sessions (id is auto-increment integer, not a string)
 INSERT INTO sessions (token, expires_at, created_at, updated_at)
@@ -707,6 +704,7 @@ append_dynamic_mcp_clients_insert() {
     generate_prompt_repo_tables_insert_postgres "$now" "$faker_sql"
     generate_model_parameters_insert_postgres "$now" "$faker_sql"
     generate_routing_targets_insert_postgres "$now" "$faker_sql"
+    generate_pricing_overrides_insert_postgres "$now" "$faker_sql"
     append_dynamic_columns_postgres "$now" "$past" "$faker_sql"
   else
     now="datetime('now')"
@@ -717,6 +715,7 @@ append_dynamic_mcp_clients_insert() {
     generate_prompt_repo_tables_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_model_parameters_insert_sqlite "$now" "$faker_sql" "$config_db"
     generate_routing_targets_insert_sqlite "$now" "$faker_sql" "$config_db"
+    generate_pricing_overrides_insert_sqlite "$now" "$faker_sql" "$config_db"
     append_dynamic_columns_sqlite "$now" "$past" "$faker_sql" "$config_db"
   fi
 }
@@ -1191,6 +1190,56 @@ append_dynamic_columns_postgres() {
   fi
 
   # -------------------------------------------------------------------------
+  # v1.5.0 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  # config_client.mcp_disable_auto_tool_inject (added in v1.5.0)
+  if column_exists_postgres "config_client" "mcp_disable_auto_tool_inject"; then
+    echo "UPDATE config_client SET mcp_disable_auto_tool_inject = false WHERE id = 1;" >> "$output_file"
+  fi
+
+  # governance_virtual_key_provider_configs.allow_all_keys (added in v1.5.0)
+  # vk-migration-test-1 has a key in the join table, so old behavior was restricted to that key -> allow_all_keys=false
+  # vk-migration-test-2 has no key rows, so old "empty=allow-all" semantics -> allow_all_keys=true
+  if column_exists_postgres "governance_virtual_key_provider_configs" "allow_all_keys"; then
+    echo "UPDATE governance_virtual_key_provider_configs SET allow_all_keys = false WHERE virtual_key_id = 'vk-migration-test-1';" >> "$output_file"
+    echo "UPDATE governance_virtual_key_provider_configs SET allow_all_keys = true WHERE virtual_key_id = 'vk-migration-test-2';" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
+  # v1.5.0 columns - log store tables
+  # -------------------------------------------------------------------------
+
+  # logs.plugin_logs (added in v1.5.0)
+  if column_exists_postgres "logs" "plugin_logs"; then
+    echo "UPDATE logs SET plugin_logs = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET plugin_logs = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET plugin_logs = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
+  # v1.4.19 columns
+  # -------------------------------------------------------------------------
+
+  # governance_model_pricing: context_length, max_input_tokens, max_output_tokens, architecture (added in v1.4.19, removed later)
+  if column_exists_postgres "governance_model_pricing" "context_length"; then
+    echo "UPDATE governance_model_pricing SET context_length = NULL WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET context_length = NULL WHERE id = 2;" >> "$output_file"
+  fi
+  if column_exists_postgres "governance_model_pricing" "max_input_tokens"; then
+    echo "UPDATE governance_model_pricing SET max_input_tokens = NULL WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET max_input_tokens = NULL WHERE id = 2;" >> "$output_file"
+  fi
+  if column_exists_postgres "governance_model_pricing" "max_output_tokens"; then
+    echo "UPDATE governance_model_pricing SET max_output_tokens = NULL WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET max_output_tokens = NULL WHERE id = 2;" >> "$output_file"
+  fi
+  if column_exists_postgres "governance_model_pricing" "architecture"; then
+    echo "UPDATE governance_model_pricing SET architecture = NULL WHERE id = 1;" >> "$output_file"
+    echo "UPDATE governance_model_pricing SET architecture = NULL WHERE id = 2;" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
   # v1.4.17 columns
   # -------------------------------------------------------------------------
 
@@ -1656,6 +1705,58 @@ append_dynamic_columns_sqlite() {
   echo "UPDATE logs SET cached_read_tokens = 0 WHERE id = 'log-migration-test-003';" >> "$output_file"
 
   # -------------------------------------------------------------------------
+  # v1.5.0 columns - config store tables
+  # -------------------------------------------------------------------------
+
+  if [ -f "$config_db" ]; then
+    # config_client.mcp_disable_auto_tool_inject (added in v1.5.0)
+    if column_exists_sqlite "$config_db" "config_client" "mcp_disable_auto_tool_inject"; then
+      echo "UPDATE config_client SET mcp_disable_auto_tool_inject = 0 WHERE id = 1;" >> "$output_file"
+    fi
+
+    # governance_virtual_key_provider_configs.allow_all_keys (added in v1.5.0)
+    # vk-migration-test-1 has a key in the join table, so old behavior was restricted to that key -> allow_all_keys=false
+    # vk-migration-test-2 has no key rows, so old "empty=allow-all" semantics -> allow_all_keys=true
+    if column_exists_sqlite "$config_db" "governance_virtual_key_provider_configs" "allow_all_keys"; then
+      echo "UPDATE governance_virtual_key_provider_configs SET allow_all_keys = 0 WHERE virtual_key_id = 'vk-migration-test-1';" >> "$output_file"
+      echo "UPDATE governance_virtual_key_provider_configs SET allow_all_keys = 1 WHERE virtual_key_id = 'vk-migration-test-2';" >> "$output_file"
+    fi
+  fi
+
+  # -------------------------------------------------------------------------
+  # v1.5.0 columns - log store tables (emitted unconditionally; fail silently on config_db)
+  # -------------------------------------------------------------------------
+
+  # logs.plugin_logs (added in v1.5.0)
+  echo "UPDATE logs SET plugin_logs = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
+  echo "UPDATE logs SET plugin_logs = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
+  echo "UPDATE logs SET plugin_logs = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+
+  # -------------------------------------------------------------------------
+  # v1.4.19 columns
+  # -------------------------------------------------------------------------
+
+  if [ -f "$config_db" ]; then
+    # governance_model_pricing: context_length, max_input_tokens, max_output_tokens, architecture (added in v1.4.19, removed later)
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "context_length"; then
+      echo "UPDATE governance_model_pricing SET context_length = NULL WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET context_length = NULL WHERE id = 2;" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "max_input_tokens"; then
+      echo "UPDATE governance_model_pricing SET max_input_tokens = NULL WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET max_input_tokens = NULL WHERE id = 2;" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "max_output_tokens"; then
+      echo "UPDATE governance_model_pricing SET max_output_tokens = NULL WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET max_output_tokens = NULL WHERE id = 2;" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "governance_model_pricing" "architecture"; then
+      echo "UPDATE governance_model_pricing SET architecture = NULL WHERE id = 1;" >> "$output_file"
+      echo "UPDATE governance_model_pricing SET architecture = NULL WHERE id = 2;" >> "$output_file"
+    fi
+  fi
+
+  # -------------------------------------------------------------------------
   # v1.4.17 columns
   # -------------------------------------------------------------------------
 
@@ -1758,11 +1859,30 @@ generate_mcp_clients_insert_postgres() {
     cols="$cols, encryption_status"
     vals="$vals, 'plain_text'"
   fi
+
+  # config_mcp_clients.allowed_extra_headers_json (added in v1.5.0)
+  if column_exists_postgres "config_mcp_clients" "allowed_extra_headers_json"; then
+    cols="$cols, allowed_extra_headers_json"
+    vals="$vals, '[]'"
+  fi
+
+  # config_mcp_clients.allow_on_all_virtual_keys (added in v1.5.0)
+  if column_exists_postgres "config_mcp_clients" "allow_on_all_virtual_keys"; then
+    cols="$cols, allow_on_all_virtual_keys"
+    vals="$vals, false"
+  fi
   
   # Append the dynamic INSERT to the output file
   echo "" >> "$output_file"
   echo "-- config_mcp_clients (MCP server configurations - dynamically generated based on schema)" >> "$output_file"
   echo "INSERT INTO config_mcp_clients ($cols) VALUES ($vals) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+  # governance_virtual_key_mcp_configs: link both test VKs to the test MCP client.
+  # Must run AFTER config_mcp_clients INSERT so the subquery finds the row.
+  # Both VKs covered to prevent migrationBackfillEmptyVirtualKeyConfigs from adding rows.
+  echo "" >> "$output_file"
+  echo "-- governance_virtual_key_mcp_configs (dynamically generated after config_mcp_clients)" >> "$output_file"
+  echo "INSERT INTO governance_virtual_key_mcp_configs (virtual_key_id, mcp_client_id, tools_to_execute) SELECT vk.id, mc.id, '[\"tool1\"]' FROM governance_virtual_keys vk CROSS JOIN config_mcp_clients mc WHERE mc.client_id = 'mcp-migration-test-001' AND vk.id IN ('vk-migration-test-1', 'vk-migration-test-2') ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Get columns that are auto-increment primary keys (don't need faker coverage)
@@ -1972,11 +2092,30 @@ generate_mcp_clients_insert_sqlite() {
     cols="$cols, encryption_status"
     vals="$vals, 'plain_text'"
   fi
+
+  # config_mcp_clients.allowed_extra_headers_json (added in v1.5.0)
+  if column_exists_sqlite "$config_db" "config_mcp_clients" "allowed_extra_headers_json"; then
+    cols="$cols, allowed_extra_headers_json"
+    vals="$vals, '[]'"
+  fi
+
+  # config_mcp_clients.allow_on_all_virtual_keys (added in v1.5.0)
+  if column_exists_sqlite "$config_db" "config_mcp_clients" "allow_on_all_virtual_keys"; then
+    cols="$cols, allow_on_all_virtual_keys"
+    vals="$vals, 0"
+  fi
   
   # Append the dynamic INSERT to the output file
   echo "" >> "$output_file"
   echo "-- config_mcp_clients (MCP server configurations - dynamically generated based on schema)" >> "$output_file"
   echo "INSERT INTO config_mcp_clients ($cols) VALUES ($vals) ON CONFLICT DO NOTHING;" >> "$output_file"
+
+  # governance_virtual_key_mcp_configs: link both test VKs to the test MCP client.
+  # Must run AFTER config_mcp_clients INSERT so the subquery finds the row.
+  # Both VKs covered to prevent migrationBackfillEmptyVirtualKeyConfigs from adding rows.
+  echo "" >> "$output_file"
+  echo "-- governance_virtual_key_mcp_configs (dynamically generated after config_mcp_clients)" >> "$output_file"
+  echo "INSERT INTO governance_virtual_key_mcp_configs (virtual_key_id, mcp_client_id, tools_to_execute) SELECT vk.id, mc.id, '[\"tool1\"]' FROM governance_virtual_keys vk CROSS JOIN config_mcp_clients mc WHERE mc.client_id = 'mcp-migration-test-001' AND vk.id IN ('vk-migration-test-1', 'vk-migration-test-2') ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Generate async_jobs INSERT based on schema existence for PostgreSQL
@@ -2203,6 +2342,49 @@ generate_routing_targets_insert_sqlite() {
   echo "INSERT INTO routing_targets (rule_id, provider, model, key_id, weight) VALUES ('rule-migration-test-1', 'openai', 'gpt-4', NULL, 1.0) ON CONFLICT DO NOTHING;" >> "$output_file"
   echo "INSERT INTO routing_targets (rule_id, provider, model, key_id, weight) VALUES ('rule-migration-test-2', 'anthropic', 'claude-3-opus', NULL, 0.7) ON CONFLICT DO NOTHING;" >> "$output_file"
   echo "INSERT INTO routing_targets (rule_id, provider, model, key_id, weight) VALUES ('rule-migration-test-2', NULL, NULL, NULL, 0.3) ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate governance_pricing_overrides INSERT for PostgreSQL
+# This table was added in v1.5.0 as part of the custom pricing refactor.
+# Two rows: one global (no FK deps) and one virtual_key-scoped (references vk-migration-test-1).
+generate_pricing_overrides_insert_postgres() {
+  local now="$1"
+  local output_file="$2"
+
+  # Check if the table exists
+  if ! column_exists_postgres "governance_pricing_overrides" "id"; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- governance_pricing_overrides (scoped pricing overrides - added in v1.5.0, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO governance_pricing_overrides (id, name, scope_kind, virtual_key_id, provider_id, provider_key_id, match_type, pattern, request_types_json, pricing_patch_json, config_hash, created_at, updated_at) VALUES ('pricing-override-migration-001', 'Migration Test Override Global', 'global', NULL, NULL, NULL, 'exact', 'gpt-4', '[]', '{\"input_cost_per_token\": 0.00001}', 'po-hash-001', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO governance_pricing_overrides (id, name, scope_kind, virtual_key_id, provider_id, provider_key_id, match_type, pattern, request_types_json, pricing_patch_json, config_hash, created_at, updated_at) VALUES ('pricing-override-migration-002', 'Migration Test Override VK', 'virtual_key', 'vk-migration-test-1', NULL, NULL, 'prefix', 'claude', '[]', '{\"output_cost_per_token\": 0.00002}', 'po-hash-002', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+}
+
+# Generate governance_pricing_overrides INSERT for SQLite
+# This table was added in v1.5.0 as part of the custom pricing refactor.
+generate_pricing_overrides_insert_sqlite() {
+  local now="$1"
+  local output_file="$2"
+  local config_db="$3"
+
+  # Check if the table exists in the database
+  if [ ! -f "$config_db" ]; then
+    return
+  fi
+
+  local table_exists
+  table_exists=$(sqlite3 "$config_db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='governance_pricing_overrides';" 2>/dev/null || echo "0")
+
+  if [ "$table_exists" != "1" ]; then
+    return
+  fi
+
+  echo "" >> "$output_file"
+  echo "-- governance_pricing_overrides (scoped pricing overrides - added in v1.5.0, dynamically generated)" >> "$output_file"
+  echo "INSERT INTO governance_pricing_overrides (id, name, scope_kind, virtual_key_id, provider_id, provider_key_id, match_type, pattern, request_types_json, pricing_patch_json, config_hash, created_at, updated_at) VALUES ('pricing-override-migration-001', 'Migration Test Override Global', 'global', NULL, NULL, NULL, 'exact', 'gpt-4', '[]', '{\"input_cost_per_token\": 0.00001}', 'po-hash-001', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
+  echo "INSERT INTO governance_pricing_overrides (id, name, scope_kind, virtual_key_id, provider_id, provider_key_id, match_type, pattern, request_types_json, pricing_patch_json, config_hash, created_at, updated_at) VALUES ('pricing-override-migration-002', 'Migration Test Override VK', 'virtual_key', 'vk-migration-test-1', NULL, NULL, 'prefix', 'claude', '[]', '{\"output_cost_per_token\": 0.00002}', 'po-hash-002', $now, $now) ON CONFLICT DO NOTHING;" >> "$output_file"
 }
 
 # Validate faker column coverage for SQLite

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3495,11 +3495,31 @@ func (bifrost *Bifrost) RemoveMCPClient(id string) error {
 
 // SetMCPManager sets the MCP manager for this Bifrost instance.
 // This allows injecting a custom MCP manager implementation (e.g., for enterprise features).
+// If the provided manager is a concrete *mcp.MCPManager, Bifrost's plugin pipeline is injected
+// into the manager's CodeMode so that nested tool calls run through the plugin hooks.
 //
 // Parameters:
 //   - manager: The MCP manager to set (must implement MCPManagerInterface)
 func (bifrost *Bifrost) SetMCPManager(manager mcp.MCPManagerInterface) {
 	bifrost.MCPManager = manager
+	// Inject Bifrost's plugin pipeline into the manager's CodeMode so that
+	// nested tool calls (e.g. via Starlark executeCode) run through plugin hooks.
+	if m, ok := manager.(*mcp.MCPManager); ok {
+		m.SetPluginPipeline(
+			func() mcp.PluginPipeline {
+				pipeline := bifrost.getPluginPipeline()
+				if pp, ok := any(pipeline).(mcp.PluginPipeline); ok {
+					return pp
+				}
+				return nil
+			},
+			func(pipeline mcp.PluginPipeline) {
+				if pp, ok := pipeline.(*PluginPipeline); ok {
+					bifrost.releasePluginPipeline(pp)
+				}
+			},
+		)
+	}
 }
 
 // UpdateMCPClient updates the MCP client.

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -760,8 +760,8 @@ func TestSelectKeyFromProviderForModel_SessionStickiness(t *testing.T) {
 	account.AddProvider(schemas.OpenAI, 5, 1000)
 	// Use 2 keys so we hit the keySelector path (single key returns early)
 	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{
-		{ID: "key-a", Name: "Key A", Value: *schemas.NewEnvVar("sk-a"), Weight: 1},
-		{ID: "key-b", Name: "Key B", Value: *schemas.NewEnvVar("sk-b"), Weight: 1},
+		{ID: "key-a", Name: "Key A", Value: *schemas.NewEnvVar("sk-a"), Models: schemas.WhiteList{"*"}, Weight: 1},
+		{ID: "key-b", Name: "Key B", Value: *schemas.NewEnvVar("sk-b"), Models: schemas.WhiteList{"*"}, Weight: 1},
 	})
 
 	var keySelectorCalls int
@@ -821,8 +821,8 @@ func TestSelectKeyFromProviderForModel_NoStickinessWithoutSessionID(t *testing.T
 	account := NewMockAccount()
 	account.AddProvider(schemas.OpenAI, 5, 1000)
 	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{
-		{ID: "key-a", Name: "Key A", Value: *schemas.NewEnvVar("sk-a"), Weight: 1},
-		{ID: "key-b", Name: "Key B", Value: *schemas.NewEnvVar("sk-b"), Weight: 1},
+		{ID: "key-a", Name: "Key A", Value: *schemas.NewEnvVar("sk-a"), Models: schemas.WhiteList{"*"}, Weight: 1},
+		{ID: "key-b", Name: "Key B", Value: *schemas.NewEnvVar("sk-b"), Models: schemas.WhiteList{"*"}, Weight: 1},
 	})
 
 	var keySelectorCalls int

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -179,7 +179,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.OPENAI_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -188,7 +188,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.OPENAI_API_KEY"), // Use GROQ API key for OpenAI-compatible endpoint
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -197,7 +197,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.ANTHROPIC_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -205,7 +205,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 	case schemas.Bedrock:
 		return []schemas.Key{
 			{
-				Models: []string{},
+				Models: []string{"*"},
 				Weight: 1.0,
 				BedrockKeyConfig: &schemas.BedrockKeyConfig{
 					AccessKey:    *schemas.NewEnvVar("env.AWS_ACCESS_KEY_ID"),
@@ -222,7 +222,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 				},
 			},
 			{
-				Models: []string{},
+				Models: []string{"*"},
 				Weight: 1.0,
 				BedrockKeyConfig: &schemas.BedrockKeyConfig{
 					AccessKey:    *schemas.NewEnvVar("env.AWS_ACCESS_KEY_ID"),
@@ -255,7 +255,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.COHERE_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -264,7 +264,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:  *schemas.NewEnvVar("env.AZURE_API_KEY"),
-				Models: []string{},
+				Models: []string{"*"},
 				Weight: 1.0,
 				AzureKeyConfig: &schemas.AzureKeyConfig{
 					Endpoint:   *schemas.NewEnvVar("env.AZURE_ENDPOINT"),
@@ -286,7 +286,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 			},
 			{
 				Value:  *schemas.NewEnvVar("env.AZURE_API_KEY"),
-				Models: []string{},
+				Models: []string{"*"},
 				Weight: 1.0,
 				AzureKeyConfig: &schemas.AzureKeyConfig{
 					Endpoint:   *schemas.NewEnvVar("env.AZURE_ENDPOINT"),
@@ -346,7 +346,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.MISTRAL_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -355,7 +355,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.GROQ_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -364,7 +364,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.PARASAIL_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -373,7 +373,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.ELEVENLABS_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -382,7 +382,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.PERPLEXITY_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -391,7 +391,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.CEREBRAS_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -400,7 +400,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.GEMINI_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -409,7 +409,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.OPENROUTER_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -418,7 +418,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.HUGGING_FACE_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -427,7 +427,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.NEBIUS_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -436,7 +436,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.XAI_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -445,7 +445,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.REPLICATE_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},
@@ -454,7 +454,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.RUNWAY_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},

--- a/core/internal/mcptests/fixtures.go
+++ b/core/internal/mcptests/fixtures.go
@@ -1422,7 +1422,7 @@ func (a *testAccount) GetKeysForProvider(ctx context.Context, providerKey schema
 	return []schemas.Key{
 		{
 			Value:  *schemas.NewEnvVar(apiKey),
-			Models: []string{}, // Empty means all models
+			Models: schemas.WhiteList{"*"},
 			Weight: 1.0,
 		},
 	}, nil
@@ -1460,6 +1460,17 @@ func setupBifrost(t *testing.T) *bifrost.Bifrost {
 	return bifrostInstance
 }
 
+// noopPluginPipeline is a passthrough pipeline used in tests that don't need plugin hooks.
+type noopPluginPipeline struct{}
+
+func (n *noopPluginPipeline) RunMCPPreHooks(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest) (*schemas.BifrostMCPRequest, *schemas.MCPPluginShortCircuit, int) {
+	return req, nil, 0
+}
+
+func (n *noopPluginPipeline) RunMCPPostHooks(ctx *schemas.BifrostContext, mcpResp *schemas.BifrostMCPResponse, bifrostErr *schemas.BifrostError, runFrom int) (*schemas.BifrostMCPResponse, *schemas.BifrostError) {
+	return mcpResp, bifrostErr
+}
+
 // setupMCPManager creates an MCP manager for testing
 func setupMCPManager(t *testing.T, clientConfigs ...schemas.MCPClientConfig) *mcp.MCPManager {
 	t.Helper()
@@ -1472,9 +1483,14 @@ func setupMCPManager(t *testing.T, clientConfigs ...schemas.MCPClientConfig) *mc
 		clientConfigPtrs[i] = &clientConfigs[i]
 	}
 
-	// Create MCP config
+	// Create MCP config with a no-op plugin pipeline so that codemode tool calls
+	// work correctly even when no Bifrost instance is attached.
 	mcpConfig := &schemas.MCPConfig{
 		ClientConfigs: clientConfigPtrs,
+		PluginPipelineProvider: func() interface{} {
+			return &noopPluginPipeline{}
+		},
+		ReleasePluginPipeline: func(pipeline interface{}) {},
 	}
 
 	// Create Starlark CodeMode

--- a/core/internal/mcptests/tool_filtering_test.go
+++ b/core/internal/mcptests/tool_filtering_test.go
@@ -160,7 +160,7 @@ func TestToolsToExecute_ExplicitList(t *testing.T) {
 	// Verify configuration was set correctly
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
 }
 
 func TestToolsToExecute_SingleTool(t *testing.T) {
@@ -178,10 +178,10 @@ func TestToolsToExecute_SingleTool(t *testing.T) {
 	// Verify configuration
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
 
 	// Verify it's not allow-all
-	assert.NotEqual(t, []string{"*"}, clients[0].ExecutionConfig.ToolsToExecute, "should not be wildcard")
+	assert.NotEqual(t, schemas.WhiteList{"*"}, clients[0].ExecutionConfig.ToolsToExecute, "should not be wildcard")
 }
 
 // =============================================================================
@@ -204,8 +204,8 @@ func TestToolsToAutoExecute_Basic(t *testing.T) {
 	// Verify the client was created with correct configuration
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"*"}, clients[0].ExecutionConfig.ToolsToExecute)
-	assert.Equal(t, []string{"encode"}, clients[0].ExecutionConfig.ToolsToAutoExecute)
+	assert.Equal(t, schemas.WhiteList{"*"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"encode"}, clients[0].ExecutionConfig.ToolsToAutoExecute)
 }
 
 func TestToolsToAutoExecute_NotInExecuteList(t *testing.T) {
@@ -224,8 +224,8 @@ func TestToolsToAutoExecute_NotInExecuteList(t *testing.T) {
 	// Verify configuration
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
-	assert.Equal(t, []string{"hash"}, clients[0].ExecutionConfig.ToolsToAutoExecute)
+	assert.Equal(t, schemas.WhiteList{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"hash"}, clients[0].ExecutionConfig.ToolsToAutoExecute)
 	assert.NotEqual(t, clients[0].ExecutionConfig.ToolsToExecute, clients[0].ExecutionConfig.ToolsToAutoExecute)
 }
 
@@ -245,7 +245,7 @@ func TestToolsToAutoExecute_Wildcard(t *testing.T) {
 	// Verify configuration
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"*"}, clients[0].ExecutionConfig.ToolsToAutoExecute)
+	assert.Equal(t, schemas.WhiteList{"*"}, clients[0].ExecutionConfig.ToolsToAutoExecute)
 }
 
 // =============================================================================
@@ -267,7 +267,7 @@ func TestContextFilteringRestrictsWildcard(t *testing.T) {
 	// Verify client configuration allows all
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"*"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"*"}, clients[0].ExecutionConfig.ToolsToExecute)
 
 	// Context restricts to only specific tools (verify context works separately)
 	ctx := CreateTestContextWithMCPFilter(nil, []string{"encode"})
@@ -305,9 +305,9 @@ func TestFilteringMultipleClients_DifferentRules(t *testing.T) {
 	// Find and verify each client
 	for _, client := range clients {
 		if client.ExecutionConfig.ID == "stdio-client-1" {
-			assert.Equal(t, []string{"encode"}, client.ExecutionConfig.ToolsToExecute)
+			assert.Equal(t, schemas.WhiteList{"encode"}, client.ExecutionConfig.ToolsToExecute)
 		} else if client.ExecutionConfig.ID == "stdio-client-2" {
-			assert.Equal(t, []string{"*"}, client.ExecutionConfig.ToolsToExecute)
+			assert.Equal(t, schemas.WhiteList{"*"}, client.ExecutionConfig.ToolsToExecute)
 		}
 	}
 }
@@ -331,7 +331,7 @@ func TestFilteringChangesAfterClientEdit(t *testing.T) {
 	// Verify initial configuration
 	clients := manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
 
 	// Edit client to only allow second tool
 	clientConfig.ToolsToExecute = []string{"hash"}
@@ -341,6 +341,6 @@ func TestFilteringChangesAfterClientEdit(t *testing.T) {
 	// Verify configuration changed
 	clients = manager.GetClients()
 	require.Len(t, clients, 1)
-	assert.Equal(t, []string{"hash"}, clients[0].ExecutionConfig.ToolsToExecute)
-	assert.NotEqual(t, []string{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.Equal(t, schemas.WhiteList{"hash"}, clients[0].ExecutionConfig.ToolsToExecute)
+	assert.NotEqual(t, schemas.WhiteList{"encode"}, clients[0].ExecutionConfig.ToolsToExecute)
 }

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -331,8 +331,14 @@ func (s *StarlarkCodeMode) executeCode(ctx *schemas.BifrostContext, code string)
 		},
 	}
 
-	// Set up cancellation check
+	// Set up cancellation check — watch the context and cancel the Starlark
+	// thread so that infinite loops and other long-running scripts are interrupted
+	// when the execution timeout fires.
 	thread.SetLocal("context", timeoutCtx)
+	go func() {
+		<-timeoutCtx.Done()
+		thread.Cancel(timeoutCtx.Err().Error())
+	}()
 
 	// Step 4: Configure Starlark dialect options for a Python-like experience
 	starlarkOpts := &syntax.FileOptions{

--- a/core/mcp/healthmonitor.go
+++ b/core/mcp/healthmonitor.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -140,9 +141,14 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 	}
 	chm.mu.Unlock()
 
-	// Get the client connection
+	// Get the client connection — capture Conn while holding the lock so we
+	// don't race with removeClientUnsafe zeroing it under the write lock.
 	chm.manager.mu.RLock()
 	clientState, exists := chm.manager.clientMap[chm.clientID]
+	var conn *client.Client
+	if exists && clientState != nil {
+		conn = clientState.Conn
+	}
 	chm.manager.mu.RUnlock()
 
 	if !exists {
@@ -151,7 +157,7 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 	}
 
 	var err error
-	if clientState.Conn == nil {
+	if conn == nil {
 		// No active connection — treat as a health check failure
 		err = fmt.Errorf("no active connection")
 	} else {
@@ -160,7 +166,7 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 		defer cancel()
 
 		if chm.isPingAvailable {
-			err = clientState.Conn.Ping(ctx)
+			err = conn.Ping(ctx)
 		} else {
 			listRequest := mcp.ListToolsRequest{
 				PaginatedRequest: mcp.PaginatedRequest{
@@ -169,7 +175,7 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 					},
 				},
 			}
-			_, err = clientState.Conn.ListTools(ctx, listRequest)
+			_, err = conn.ListTools(ctx, listRequest)
 		}
 	}
 

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -143,10 +143,10 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 					}
 					manager.mu.Unlock()
 					isPingAvailable := true
-				if clientConfig.IsPingAvailable != nil {
-					isPingAvailable = *clientConfig.IsPingAvailable
-				}
-				monitor := NewClientHealthMonitor(manager, clientConfig.ID, DefaultHealthCheckInterval, isPingAvailable, manager.logger)
+					if clientConfig.IsPingAvailable != nil {
+						isPingAvailable = *clientConfig.IsPingAvailable
+					}
+					monitor := NewClientHealthMonitor(manager, clientConfig.ID, DefaultHealthCheckInterval, isPingAvailable, manager.logger)
 					manager.healthMonitorManager.StartMonitoring(monitor)
 				}
 			}(clientConfig)
@@ -155,6 +155,13 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 	}
 	manager.logger.Info(MCPLogPrefix + " MCP Manager initialized")
 	return manager
+}
+
+// SetPluginPipeline updates the plugin pipeline provider and release function on the manager's
+// ToolsManager and CodeMode. Call this after attaching an externally-created MCPManager to a Bifrost
+// instance so that nested tool calls in code mode can run through Bifrost's plugin hooks.
+func (manager *MCPManager) SetPluginPipeline(provider func() PluginPipeline, release func(PluginPipeline)) {
+	manager.toolsManager.SetPluginPipeline(provider, release)
 }
 
 // AddToolsToRequest parses available MCP tools from the context and adds them to the request.

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -176,6 +176,18 @@ func (m *ToolsManager) GetCodeModeDependencies() *CodeModeDependencies {
 	}
 }
 
+// SetPluginPipeline updates the plugin pipeline provider and release function
+// on both the ToolsManager and its CodeMode implementation.
+// This is used when an externally-created MCPManager is attached to a Bifrost instance
+// via SetMCPManager, so the CodeMode can route nested tool calls through Bifrost's plugin hooks.
+func (m *ToolsManager) SetPluginPipeline(provider func() PluginPipeline, release func(PluginPipeline)) {
+	m.pluginPipelineProvider = provider
+	m.releasePluginPipeline = release
+	if m.codeMode != nil {
+		m.codeMode.SetDependencies(m.GetCodeModeDependencies())
+	}
+}
+
 // GetAvailableTools returns the available tools for the given context.
 func (m *ToolsManager) GetAvailableTools(ctx *schemas.BifrostContext) []schemas.ChatTool {
 	availableToolsPerClient := m.clientManager.GetToolPerClient(ctx)
@@ -665,8 +677,8 @@ func (m *ToolsManager) UpdateConfig(config *schemas.MCPToolManagerConfig) {
 		m.maxAgentDepth.Store(int32(config.MaxAgentDepth))
 	}
 
-	// Update CodeMode configuration if present
-	if m.codeMode != nil && config.CodeModeBindingLevel != "" {
+	// Update CodeMode configuration — propagate whenever either field is set
+	if m.codeMode != nil && (config.CodeModeBindingLevel != "" || config.ToolExecutionTimeout > 0) {
 		m.codeMode.UpdateConfig(&CodeModeConfig{
 			BindingLevel:         config.CodeModeBindingLevel,
 			ToolExecutionTimeout: config.ToolExecutionTimeout,

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -910,7 +910,7 @@ func HandleAnthropicChatCompletionStreaming(
 			usage.PromptTokens = usage.PromptTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
 			usage.TotalTokens = usage.TotalTokens + usage.PromptTokensDetails.CachedReadTokens + usage.PromptTokensDetails.CachedWriteTokens
 		}
-		response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.ChatCompletionStreamRequest, providerName, modelName)
+		response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finishReason, chunkIndex, schemas.ChatCompletionStreamRequest, providerName, modelName, 0)
 		if postResponseConverter != nil {
 			response = postResponseConverter(response)
 			if response == nil {

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1341,7 +1341,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		}
 
 		// Send final response
-		response := providerUtils.CreateBifrostChatCompletionChunkResponse(id, usage, finishReason, chunkIndex, schemas.ChatCompletionStreamRequest, providerName, request.Model)
+		response := providerUtils.CreateBifrostChatCompletionChunkResponse(id, usage, finishReason, chunkIndex, schemas.ChatCompletionStreamRequest, providerName, request.Model, 0)
 		response.ExtraFields.ModelDeployment = deployment
 		// Set raw request if enabled
 		if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1132,6 +1132,7 @@ func HandleOpenAIChatCompletionStreaming(
 
 		var finishReason *string
 		var messageID string
+		var created int
 		forwardedTerminalFinishReason := false
 
 		for {
@@ -1315,6 +1316,9 @@ func HandleOpenAIChatCompletionStreaming(
 				if response.ID != "" && messageID == "" {
 					messageID = response.ID
 				}
+				if response.Created != 0 && created == 0 {
+					created = response.Created
+				}
 
 				// Handle regular content chunks, including reasoning
 				if choice.ChatStreamResponseChoice != nil &&
@@ -1355,7 +1359,7 @@ func HandleOpenAIChatCompletionStreaming(
 			if forwardedTerminalFinishReason {
 				finalFinishReason = nil
 			}
-			response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finalFinishReason, chunkIndex, streamRequestType, providerName, request.Model)
+			response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finalFinishReason, chunkIndex, streamRequestType, providerName, request.Model, created)
 			if postResponseConverter != nil {
 				response = postResponseConverter(response)
 			}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2176,10 +2176,13 @@ func CreateBifrostChatCompletionChunkResponse(
 	requestType schemas.RequestType,
 	providerName schemas.ModelProvider,
 	model string,
+	created int,
 ) *schemas.BifrostChatResponse {
 	response := &schemas.BifrostChatResponse{
-		ID:     id,
-		Object: "chat.completion.chunk",
+		ID:      id,
+		Model:   model,
+		Created: created,
+		Object:  "chat.completion.chunk",
 		Usage:  usage,
 		Choices: []schemas.BifrostResponseChoice{
 			{

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -64,9 +64,9 @@ type BifrostContext struct {
 	blockRestrictedWrites atomic.Bool
 
 	// Plugin scoping fields
-	pluginScope   *string         // Non-nil when this is a scoped plugin context
+	pluginScope   *string                        // Non-nil when this is a scoped plugin context
 	pluginLogs    atomic.Pointer[pluginLogStore] // Shared log store; lazily initialized on root, shared by scoped contexts
-	valueDelegate *BifrostContext // For scoped contexts: delegate Value/SetValue to this root context
+	valueDelegate *BifrostContext                // For scoped contexts: delegate Value/SetValue to this root context
 }
 
 // NewBifrostContext creates a new BifrostContext with the given parent context and deadline.
@@ -250,6 +250,10 @@ func (bc *BifrostContext) Value(key any) any {
 		return val
 	}
 	bc.valuesMu.RUnlock()
+
+	if bc.parent == nil {
+		return nil
+	}
 
 	return bc.parent.Value(key)
 }

--- a/docs/architecture/framework/model-catalog.mdx
+++ b/docs/architecture/framework/model-catalog.mdx
@@ -258,11 +258,11 @@ This cross-provider logic powers Bifrost's intelligent routing capabilities. See
 Validate if a model is allowed for a specific provider based on an allowed models list. This method is used internally by governance and load balancing plugins.
 
 ```go
-// Empty allowedModels - uses catalog to determine support
+// ["*"] wildcard - uses catalog to determine support
 isAllowed := modelCatalog.IsModelAllowedForProvider(
     schemas.OpenRouter,
     "gpt-4o",
-    []string{}, // empty = check catalog
+    schemas.WhiteList{"*"}, // wildcard = check catalog
 )
 // Returns: true (catalog knows OpenRouter supports openai/gpt-4o)
 
@@ -270,7 +270,7 @@ isAllowed := modelCatalog.IsModelAllowedForProvider(
 isAllowed := modelCatalog.IsModelAllowedForProvider(
     schemas.OpenRouter,
     "gpt-4o",
-    []string{"openai/gpt-4o", "anthropic/claude-3-5-sonnet"},
+    schemas.WhiteList{"openai/gpt-4o", "anthropic/claude-3-5-sonnet"},
 )
 // Returns: true (strips "openai/" prefix and matches "gpt-4o")
 
@@ -278,14 +278,19 @@ isAllowed := modelCatalog.IsModelAllowedForProvider(
 isAllowed := modelCatalog.IsModelAllowedForProvider(
     schemas.OpenAI,
     "gpt-4o",
-    []string{"gpt-4o", "gpt-4o-mini"},
+    schemas.WhiteList{"gpt-4o", "gpt-4o-mini"},
 )
 // Returns: true (direct match)
 ```
 
 **Behavior**:
-- **Empty `allowedModels`**: Delegates to `GetProvidersForModel` (includes cross-provider logic)
-- **Non-empty `allowedModels`**: Checks for both direct matches and provider-prefixed entries
+- **`["*"]` wildcard**: Delegates to `GetProvidersForModel` (includes cross-provider logic) — this is the "allow all via catalog" mode
+- **Non-empty explicit list**: Checks for both direct matches and provider-prefixed entries
+- **Empty slice (`[]string{}` / empty `schemas.WhiteList`)**: Returns `false` (deny-all) — mirrors the config deny-by-default semantics
+
+<Note>
+In `config.json` and the governance API, `allowed_models: []` (empty array) means **deny all models** (deny-by-default, v1.5.0+). The Go helper `IsModelAllowedForProvider` behaves the same way: an empty `allowedModels` slice also returns `false`. Use `["*"]` to allow all models validated through the catalog.
+</Note>
   - Direct: `"gpt-4o"` matches `"gpt-4o"`
   - Prefixed: `"openai/gpt-4o"` matches request for `"gpt-4o"` (prefix stripped)
 

--- a/docs/features/governance/routing.mdx
+++ b/docs/features/governance/routing.mdx
@@ -44,7 +44,7 @@ When you configure provider restrictions on a Virtual Key, Bifrost validates tha
 
 ## Weighted Load Balancing
 
-When you configure multiple providers on a Virtual Key, Bifrost automatically implements weighted load balancing. Each provider is assigned a weight, and requests are distributed proportionally.
+When you configure multiple providers on a Virtual Key, Bifrost automatically implements weighted load balancing. Each provider can be assigned a weight, and requests are distributed proportionally. The `weight` field is optional — omitting it (or setting it to `null`) excludes the provider from weighted selection while still allowing it to be used for direct `provider/model` requests or as a fallback.
 
 **Example Configuration:**
 ```
@@ -152,7 +152,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
    - **Specify models**: Enter specific models (e.g., `["gpt-4o", "gpt-4o-mini"]`) to explicitly whitelist only those models
    - **`["*"]`**: Allow all models (uses the Model Catalog for validation).
    - **Leave blank**: Deny all models (deny-by-default).
-5. Add the weight you want to give to this provider
+5. Optionally add a weight for this provider (numeric value for weighted load balancing, or leave blank to exclude from weighted routing while keeping the provider available for direct requests and fallbacks)
 6. Click on the **Save** button
 </Tab>
 
@@ -214,8 +214,9 @@ curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id} \
 Virtual Keys can be restricted to use only specific provider API keys. When key restrictions are configured, the VK can only access those designated keys, providing fine-grained control over which API keys different users or applications can utilize.
 
 **How It Works:**
-- **No Restrictions** (default): VK can use any available provider keys based on load balancing
+- **No Restrictions** (`key_ids: ["*"]`): VK can use any available provider keys based on load balancing
 - **With Restrictions**: VK limited to only the specified key IDs, regardless of other available keys
+- **All Blocked** (`key_ids: []` or field omitted): VK cannot use any provider keys (deny-by-default)
 
 **Example Scenario:**
 ```
@@ -232,7 +233,7 @@ Virtual Key Restrictions:
 │   ├── Allowed Models: [gpt-4o-mini]
 │   └── Restricted Keys: [key-dev-002, key-test-003] ← Dev + test keys
 └── vk-unrestricted
-    ├── Allowed Models: [all models]
+    ├── Allowed Models: ["*"]  ← All models via catalog
     └── Restricted Keys: ["*"] ← Can use ANY available key
 ```
 
@@ -248,7 +249,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   -H "x-bf-vk: vk-dev-main" \
   -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello!"}]}'
 
-# VK with no key restrictions - can use any available OpenAI key
+# VK with key_ids: ["*"] - can use any available OpenAI key
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "x-bf-vk: vk-unrestricted" \
   -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello!"}]}'

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -120,7 +120,7 @@ curl -X POST http://localhost:8080/api/governance/virtual-keys \
 
 > **Note**: 
 > - `team_id` and `customer_id` are mutually exclusive - a VK can only belong to one team OR one customer, not both.
-> - `key_ids` restricts the VK to only use those specific provider API keys. Omit this field to allow access to all available keys.
+> - `key_ids` restricts the VK to only use those specific provider API keys. Use `["*"]` to allow access to all available keys. An empty array `[]` or omitting the field entirely denies all keys.
 
 **Update Virtual Key:**
 ```bash

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -44,7 +44,7 @@ curl -X POST http://localhost:8080/api/providers \
       {
         "name": "openai-key-2",
         "value": "env.OPENAI_API_KEY_2", 
-        "models": [],
+        "models": ["*"],
         "weight": 0.3
       }
     ]
@@ -93,7 +93,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
             {
                 ID:     "secondary-key", 
                 Value:  "env.OPENAI_API_KEY_2",
-                Models: [], // Empty = supports all models
+                Models: []string{"*"}, // ["*"] = supports all models (empty slice denies all in v1.5.0+)
                 Weight: 0.3, // 30% of traffic
             },
         }, nil
@@ -161,7 +161,7 @@ Random selection ensures statistical distribution over time
 Keys can be restricted to specific models for access control and cost management:
 
 **Model Filtering Logic:**
-- **Empty `models` array**: Key supports ALL models for that provider (except any listed under `blacklisted_models`)
+- **Empty `models` array (`[]`)**: Denies ALL models (deny-by-default, v1.5.0+) — use `["*"]` to allow all
 - **Populated `models` array**: Key only supports listed models
 - **`blacklisted_models`**: Optional per-key denylist. If non-empty and the requested model appears in it, the key is excluded—even if that model is also in `models` (denylist wins over the allowlist)
 - **Model mismatch**: Key is excluded from selection for that request

--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -55,7 +55,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-custom-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -94,7 +94,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-custom-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -301,7 +301,7 @@ When a full URL (with scheme and host) is provided in `request_path_overrides`, 
 ```json
 {
     "custom-llm": {
-        "keys": [{ "name": "custom-llm-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "custom-llm-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "network_config": {
             "base_url": "https://your-openai-compatible-endpoint.com"
         },
@@ -338,7 +338,7 @@ These options are mutually exclusive. Do not set `insecure_skip_verify: true` to
 ```json
 {
     "my-air-gapped-provider": {
-        "keys": [{ "name": "key-1", "value": "env.API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "key-1", "value": "env.API_KEY", "models": ["*"], "weight": 1.0 }],
         "network_config": {
             "base_url": "https://internal-llm.example.com",
             "insecure_skip_verify": true
@@ -359,7 +359,7 @@ These options are mutually exclusive. Do not set `insecure_skip_verify: true` to
 ```json
 {
     "my-internal-provider": {
-        "keys": [{ "name": "key-1", "value": "env.API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "key-1", "value": "env.API_KEY", "models": ["*"], "weight": 1.0 }],
         "network_config": {
             "base_url": "https://internal-llm.example.com",
             "ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----"
@@ -388,7 +388,7 @@ Create different configurations for production, staging, and development environ
 ```json
 {
     "openai-production": {
-        "keys": [{ "name": "openai-prod-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-prod-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -401,7 +401,7 @@ Create different configurations for production, staging, and development environ
         }
     },
     "openai-staging": {
-        "keys": [{ "name": "openai-stage-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-stage-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -414,7 +414,7 @@ Create different configurations for production, staging, and development environ
         }
     },
     "openai-dev": {
-        "keys": [{ "name": "openai-dev-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-dev-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -436,7 +436,7 @@ Restrict capabilities based on user roles or team permissions. You can then crea
 ```json
 {
     "openai-developers": {
-        "keys": [{ "name": "openai-developers-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-developers-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -448,7 +448,7 @@ Restrict capabilities based on user roles or team permissions. You can then crea
         }
     },
     "openai-analysts": {
-        "keys": [{ "name": "openai-analysts-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-analysts-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -458,7 +458,7 @@ Restrict capabilities based on user roles or team permissions. You can then crea
         }
     },
     "openai-support": {
-        "keys": [{ "name": "openai-support-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-support-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -477,7 +477,7 @@ Test new features with limited user groups:
 ```json
 {
     "openai-beta-streaming": {
-        "keys": [{ "name": "openai-streaming-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-streaming-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {
@@ -488,7 +488,7 @@ Test new features with limited user groups:
         }
     },
     "openai-stable": {
-        "keys": [{ "name": "openai-stable-key-1", "value": "env.PROVIDER_API_KEY", "models": [], "weight": 1.0 }],
+        "keys": [{ "name": "openai-stable-key-1", "value": "env.PROVIDER_API_KEY", "models": ["*"], "weight": 1.0 }],
         "custom_provider_config": {
             "base_provider_type": "openai",
             "allowed_requests": {

--- a/docs/providers/provider-routing.mdx
+++ b/docs/providers/provider-routing.mdx
@@ -304,7 +304,7 @@ Bifrost uses a sophisticated multi-step process to determine if a model is avail
 The `allowed_models` field in provider configs controls which models can be used with that provider. Understanding its behavior is crucial for governance routing.
 
 <Tabs>
-<Tab title="Empty allowed_models (Use Catalog)">
+<Tab title="Wildcard allowed_models (Use Catalog)">
 
 **Configuration**:
 ```json
@@ -312,7 +312,7 @@ The `allowed_models` field in provider configs controls which models can be used
   "provider_configs": [
     {
       "provider": "openai",
-      "allowed_models": [],  // Empty = defer to catalog
+      "allowed_models": ["*"],
       "weight": 1.0
     }
   ]
@@ -340,6 +340,10 @@ curl -H "x-bf-vk: vk-123" -d '{"model": "claude-3-5-sonnet"}'
 - Default behavior for most deployments
 - Automatically stays up-to-date with provider's model offerings
 - No manual model list maintenance required
+
+<Warning>
+Using `"allowed_models": []` (empty array) means **deny all models** — no requests will be served. Use `["*"]` to allow all models via the catalog.
+</Warning>
 
 </Tab>
 
@@ -610,7 +614,7 @@ curl -H "x-bf-vk: vk-123" \
       "provider_configs": [
         {
           "provider": "openrouter",
-          "allowed_models": []  // Use catalog
+          "allowed_models": ["*"]
         }
       ]
     }
@@ -700,13 +704,13 @@ curl -H "x-bf-vk: vk-123" \
 
 When a Virtual Key has `provider_configs`, governance uses the model catalog for validation:
 
-**Empty allowed_models Example**:
+**Wildcard allowed_models Example**:
 ```json
 {
   "provider_configs": [
     {
       "provider": "openai",
-      "allowed_models": [],  // Use catalog
+      "allowed_models": ["*"],
       "weight": 0.5
     }
   ]
@@ -871,8 +875,8 @@ When a Virtual Key has `provider_configs` defined:
     ```json
     {
       "provider_configs": [
-        {"provider": "groq", "weight": 0.7},
-        {"provider": "openai", "weight": 0.3}
+        {"provider": "groq", "allowed_models": ["*"], "key_ids": ["*"], "weight": 0.7},
+        {"provider": "openai", "allowed_models": ["*"], "key_ids": ["*"], "weight": 0.3}
       ]
     }
     ```
@@ -885,11 +889,14 @@ When a Virtual Key has `provider_configs` defined:
       "virtual_keys": [
         {
           "id": "vk-dev",
-          "provider_configs": [{"provider": "ollama"}]
+          "provider_configs": [{"provider": "ollama", "allowed_models": ["*"], "key_ids": ["*"]}]
         },
         {
           "id": "vk-prod",
-          "provider_configs": [{"provider": "openai"}, {"provider": "azure"}]
+          "provider_configs": [
+            {"provider": "openai", "allowed_models": ["*"], "key_ids": ["*"]},
+            {"provider": "azure", "allowed_models": ["*"], "key_ids": ["*"]}
+          ]
         }
       ]
     }
@@ -910,7 +917,9 @@ When a Virtual Key has `provider_configs` defined:
 </AccordionGroup>
 
 <Note>
-**Empty `allowed_models`**: When left empty, Bifrost uses the Model Catalog (populated from pricing data and the provider's list models API) to determine which models are supported. See the [Model Catalog section](#the-model-catalog) above for how syncing works. For configuration instructions, see [Governance Routing](/features/governance/routing).
+**`allowed_models: ["*"]`**: Allows all models supported by the provider, validated via the Model Catalog (populated from pricing data and the provider's list models API). See the [Model Catalog section](#the-model-catalog) above for how syncing works. For configuration instructions, see [Governance Routing](/features/governance/routing).
+
+**`allowed_models: []` (empty array)**: Denies **all** models — no requests will be served for this provider config. This is deny-by-default behavior introduced in v1.5.0.
 
 **Empty `provider_configs`**: When `provider_configs` is empty (no providers configured), **all providers are blocked** (deny-by-default). You must explicitly add provider configurations to allow traffic through a Virtual Key.
 </Note>

--- a/docs/providers/supported-providers/runway.mdx
+++ b/docs/providers/supported-providers/runway.mdx
@@ -82,7 +82,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "runway-key-1",
             "value": "env.RUNWAY_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ]
@@ -98,7 +98,7 @@ See **[Provider Configuration](../../quickstart/gateway/provider-configuration)*
 case schemas.Runway:
     return []schemas.Key{{
         Value:  os.Getenv("RUNWAY_API_KEY"),
-        Models: []string{},
+        Models: []string{"*"},
         Weight: 1.0,
     }}, nil
 ```

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -32,7 +32,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ]
@@ -47,7 +47,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "anthropic-key-1",
             "value": "env.ANTHROPIC_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ]
@@ -62,7 +62,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "vllm-key-1",
             "value": "dummy",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -97,7 +97,7 @@ Each key in a provider needs to have a unique name.
                 {
                     "name": "openai-key",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ]
@@ -107,7 +107,7 @@ Each key in a provider needs to have a unique name.
                 {
                     "name": "anthropic-key",
                     "value": "env.ANTHROPIC_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ]
@@ -117,7 +117,7 @@ Each key in a provider needs to have a unique name.
                 {
                     "name": "vllm-key",
                     "value": "dummy",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -213,13 +213,13 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY_1",
-            "models": [],
+            "models": ["*"],
             "weight": 0.7
         },
         {
             "name": "openai-key-2",
             "value": "env.OPENAI_API_KEY_2", 
-            "models": [],
+            "models": ["*"],
             "weight": 0.3
         }
     ]
@@ -238,13 +238,13 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY_1",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 0.7
                 },
                 {
                     "name": "openai-key-2",
                     "value": "env.OPENAI_API_KEY_2",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 0.3
                 }
             ]
@@ -356,7 +356,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -378,7 +378,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -427,7 +427,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -451,7 +451,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -498,7 +498,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -517,7 +517,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.ANTHROPIC_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -540,7 +540,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -554,7 +554,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "anthropic-key-1",
                     "value": "env.ANTHROPIC_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -602,7 +602,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -627,7 +627,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -779,7 +779,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -798,7 +798,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "anthropic-key-1",
             "value": "env.ANTHROPIC_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -823,7 +823,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -837,7 +837,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "anthropic-key-1",
                     "value": "env.ANTHROPIC_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -883,7 +883,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -903,7 +903,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],
@@ -959,7 +959,7 @@ curl --location 'http://localhost:8080/api/providers' \
         {
             "name": "openai-key-1",
             "value": "env.OPENAI_API_KEY",
-            "models": [],
+            "models": ["*"],
             "weight": 1.0
         }
     ],
@@ -979,7 +979,7 @@ curl --location 'http://localhost:8080/api/providers' \
                 {
                     "name": "openai-key-1",
                     "value": "env.OPENAI_API_KEY",
-                    "models": [],
+                    "models": ["*"],
                     "weight": 1.0
                 }
             ],

--- a/framework/modelcatalog/capabilities_test.go
+++ b/framework/modelcatalog/capabilities_test.go
@@ -185,13 +185,17 @@ func TestGetModelCapabilityEntryForModel_PrefersLiteralMatchOverAliasFamily(t *t
 
 func TestCapabilityFieldsRoundTripThroughPricingConversions(t *testing.T) {
 	modality := "text"
+	inputCost := float64(1)
+	outputCost := float64(2)
 	entry := PricingEntry{
-		BaseModel:          "gpt-4o",
-		Provider:           "openai",
-		Mode:               "chat",
-		InputCostPerToken:  1,
-		OutputCostPerToken: 2,
-		ContextLength:      capabilityIntPtr(128000),
+		BaseModel: "gpt-4o",
+		Provider:  "openai",
+		Mode:      "chat",
+		PricingOptions: PricingOptions{
+			InputCostPerToken:  &inputCost,
+			OutputCostPerToken: &outputCost,
+		},
+		ContextLength:  capabilityIntPtr(128000),
 		MaxInputTokens:     capabilityIntPtr(64000),
 		MaxOutputTokens:    capabilityIntPtr(16000),
 		Architecture: &schemas.Architecture{

--- a/framework/modelcatalog/overrides_test.go
+++ b/framework/modelcatalog/overrides_test.go
@@ -498,7 +498,8 @@ func TestApplyScopedPricingOverrides_ScopePrecedence(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			patched, applied := mc.applyPricingOverrides("gpt-5-nano", schemas.ChatCompletionRequest, base, tc.scopes)
 			require.True(t, applied)
-			assert.Equal(t, tc.expected, patched.InputCostPerToken)
+			require.NotNil(t, patched.InputCostPerToken)
+			assert.Equal(t, tc.expected, *patched.InputCostPerToken)
 		})
 	}
 }

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -15556,8 +15556,10 @@ var excludedGoFields = map[string]map[string]bool{
 		"customer":    true, // GORM relation
 	},
 	"tables.TableVirtualKeyProviderConfig": {
-		"budget":     true, // GORM relation
-		"rate_limit": true, // GORM relation
+		"budget":       true, // GORM relation
+		"rate_limit":   true, // GORM relation
+		"allow_all_keys": true, // Internal DB field; users configure via key_ids
+		"keys":          true, // GORM many2many relation; users configure via key_ids
 	},
 	"tables.TableVirtualKeyMCPConfig": {
 		"mcp_client": true, // GORM relation
@@ -15601,7 +15603,8 @@ var excludedSchemaFields = map[string]map[string]bool{
 		"allowed_headers": true, // Not in ClientConfig
 	},
 	"governance.virtual_keys.provider_configs": {
-		"keys": true, // Complex nested type, validated separately
+		"keys":    true, // Complex nested type, validated separately
+		"key_ids": true, // Config-file format; handled via custom UnmarshalJSON into allow_all_keys/keys
 	},
 	"mcp.client_configs": {
 		"websocket_config": true, // Schema documents all connection types

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -7,4 +7,788 @@
 - refactor: parallelize model listing for providers to speed up startup time.
 - fix: send back accumulated usage in MCP agent mode.
 - feat: MCP edit UI now supports assigning virtual keys with per-tool access control directly from the MCP server edit sheet.
-- feat: adds option to allow MCP clients to run on all virtual keys without explicit assignments.
+- feat: adds option to allow MCP clients to run on all virtual keys without explicit assignment.
+- feat: add support for pricing overrides.
+
+<Warning>
+**v1.5.0 contains multiple breaking changes** to how Bifrost interprets empty arrays and wildcard values across Virtual Keys, provider keys, and MCP configurations. Existing deployments are protected by automatic database migrations — but any **new** configuration created after upgrading must follow the new semantics described below.
+</Warning>
+
+## What Changed (The Short Version)
+
+v1.5.0 flips the meaning of empty arrays across all allow-list fields:
+
+| What you write | v1.4.x meaning | v1.5.0 meaning |
+|---|---|---|
+| `[]` (empty array) | ✅ Allow **all** | ❌ Allow **none** (deny by default) |
+| `["*"]` (wildcard) | Not applicable | ✅ Allow **all** |
+| `["a", "b"]` | Only `a` and `b` | Only `a` and `b` (unchanged) |
+
+**The old behavior was "allow all unless restricted." The new behavior is "deny all unless explicitly permitted."**
+
+This affects:
+1. Provider key `models` field — which models a key can serve
+2. Virtual Key `provider_configs[].allowed_models` — which models a VK can use per provider
+3. Virtual Key `provider_configs[].key_ids` — which API keys a VK can use (also renamed from `allowed_keys`)
+4. Virtual Key `mcp_configs[].tools_to_execute` — which MCP tools a VK can execute
+5. Virtual Key `provider_configs` itself — which providers a VK can access
+
+There are also two additional structural changes:
+- `allowed_keys` field renamed to `key_ids` in VK provider configs
+- `weight` field is now optional (nullable) on VK provider configs
+
+---
+
+## Automatic Migration for Existing Data
+
+<Note>
+**If you are running Bifrost with a database** (SQLite or Postgres), all existing data is automatically migrated on startup. You do not need to manually update your database records.
+
+The following automatic migrations run on upgrade:
+- All provider keys with `models: []` are converted to `models: ["*"]`
+- All virtual key provider configs with `allowed_models: []` are converted to `allowed_models: ["*"]`
+- All virtual keys with no `provider_configs` get backfilled with all currently configured providers (with `allowed_models: ["*"]` and `key_ids: ["*"]`)
+- All virtual keys with no `mcp_configs` get backfilled with all currently connected MCP clients (with `tools_to_execute: ["*"]`)
+</Note>
+
+<Warning>
+**This migration is not revertible.** Although all migrations are correctly handled automatically, it is recommended to **make a backup copy of your config store database** before upgrading to v1.5.0-prerelease1. If anything goes wrong, a backup is the only way to restore your previous state.
+</Warning>
+
+**The automatic migration only protects your existing data.** If you also define your configuration through `config.json` or manage virtual keys via the API, you must update those manually using this guide.
+
+---
+
+## Breaking Change 1: Provider Key `models` Field
+
+**Who is affected:** Anyone who configures provider keys in `config.json` or programmatically with the field `models` absent or set to `[]`.
+
+### What changed
+
+The `models` field on a provider key previously defaulted to "allow all" when empty. It now means "allow none." You must explicitly use `["*"]` to allow a key to serve all models.
+
+<Tabs>
+<Tab title="config.json">
+
+**Before (v1.4.x):**
+```json
+{
+  "providers": {
+    "openai": {
+      "keys": [
+        {
+          "id": "key-openai-1",
+          "value": "env.OPENAI_API_KEY",
+          "models": []
+        }
+      ]
+    }
+  }
+}
+```
+`models: []` → key served all models
+
+**After (v1.5.0):**
+```json
+{
+  "providers": {
+    "openai": {
+      "keys": [
+        {
+          "id": "key-openai-1",
+          "value": "env.OPENAI_API_KEY",
+          "models": ["*"]
+        }
+      ]
+    }
+  }
+}
+```
+`models: ["*"]` → key serves all models
+
+</Tab>
+<Tab title="Specific Model List (unchanged)">
+
+If you already specify explicit models, no change is needed:
+
+```json
+{
+  "id": "key-openai-gpt4-only",
+  "value": "env.OPENAI_API_KEY",
+  "models": ["gpt-4o", "gpt-4o-mini"]
+}
+```
+
+This behaves the same in both versions — only the listed models are served.
+
+</Tab>
+</Tabs>
+
+### How to update
+
+Search your `config.json` for any provider key that has `"models": []` or no `models` field at all, and add `"models": ["*"]` to restore the "allow all" behavior.
+
+<Tip>
+The `models` field on provider keys acts as a hard floor: even if a Virtual Key's `allowed_models` permits a model, the provider key must also have that model in its `models` list. If `models` is empty, the key will never serve any requests, regardless of Virtual Key settings.
+</Tip>
+
+---
+
+## Breaking Change 2: Virtual Key `allowed_models` Field
+
+**Who is affected:** Anyone who creates or updates Virtual Keys via `config.json`, the REST API, or the SDK with `allowed_models` absent or set to `[]`.
+
+### What changed
+
+The `allowed_models` field on a Virtual Key provider config previously defaulted to "allow all models for this provider" when empty. It now means "block all models from this provider." You must use `["*"]` to allow all models.
+
+<Tabs>
+<Tab title="config.json">
+
+**Before (v1.4.x):**
+```json
+{
+  "governance": {
+    "virtual_keys": [
+      {
+        "id": "vk-my-app",
+        "provider_configs": [
+          {
+            "provider": "openai",
+            "weight": 1.0
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+Missing `allowed_models` → all OpenAI models allowed
+
+**After (v1.5.0):**
+```json
+{
+  "governance": {
+    "virtual_keys": [
+      {
+        "id": "vk-my-app",
+        "provider_configs": [
+          {
+            "provider": "openai",
+            "allowed_models": ["*"],
+            "key_ids": ["*"],
+            "weight": 1.0
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+`allowed_models: ["*"]` → all OpenAI models allowed
+
+</Tab>
+<Tab title="REST API">
+
+**Before (v1.4.x):**
+```bash
+curl -X POST http://localhost:8080/api/governance/virtual-keys \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-app-key",
+    "provider_configs": [
+      {
+        "provider": "openai",
+        "weight": 1.0
+      }
+    ]
+  }'
+```
+Missing `allowed_models` → all OpenAI models allowed
+
+**After (v1.5.0):**
+```bash
+curl -X POST http://localhost:8080/api/governance/virtual-keys \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-app-key",
+    "provider_configs": [
+      {
+        "provider": "openai",
+        "allowed_models": ["*"],
+        "key_ids": ["*"],
+        "weight": 1.0
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Breaking Change 3: Virtual Key Provider Configs — Deny-by-Default
+
+**Who is affected:** Anyone creating Virtual Keys with no `provider_configs` array (or an empty one), expecting those keys to have unrestricted provider access.
+
+### What changed
+
+In v1.4.x, a Virtual Key with no `provider_configs` had access to all configured providers. In v1.5.0, a Virtual Key with no `provider_configs` blocks all providers by default.
+
+**Before (v1.4.x):** Virtual Key with `provider_configs: []` → access to all providers
+
+**After (v1.5.0):** Virtual Key with `provider_configs: []` → no provider access (all blocked)
+
+### How to update
+
+Every Virtual Key must now explicitly list the providers it is permitted to use. To allow access to all providers, add a config entry per provider with `"allowed_models": ["*"]`.
+
+```json
+{
+  "governance": {
+    "virtual_keys": [
+      {
+        "id": "vk-unrestricted",
+        "provider_configs": [
+          { "provider": "openai",    "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 },
+          { "provider": "anthropic", "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 },
+          { "provider": "azure",     "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+<Tip>
+The automatic database migration handles this for you on existing virtual keys — it backfills all currently configured providers into any VK that has an empty `provider_configs`. However, any VK you create after upgrading (via API or config.json) must include explicit provider configs.
+</Tip>
+
+---
+
+## Breaking Change 4: `allowed_keys` Renamed to `key_ids`
+
+**Who is affected:** Anyone using the `allowed_keys` field in Virtual Key provider configs in `config.json` or the REST API.
+
+### What changed
+
+The field used to restrict which provider API keys a Virtual Key can use has been renamed from `allowed_keys` to `key_ids`. The semantics follow the same deny-by-default model as all other v1.5.0 whitelist fields:
+
+| Value | v1.4.x behavior | v1.5.0 behavior |
+|---|---|---|
+| Field absent / `[]` | Allow all keys | **Deny all keys** |
+| `["*"]` | Not applicable | Allow all keys (explicit wildcard) |
+| `["key-1"]` | Only key-1 | Only key-1 (unchanged) |
+
+<Note>
+Unlike `allowed_models`, there is no automatic database migration for `key_ids`. The "allow all when empty" behavior is **not preserved** — an empty or omitted `key_ids` sets `allow_all_keys: false` internally, which blocks all key selection. You must explicitly use `["*"]` to restore allow-all behavior.
+</Note>
+
+<Tabs>
+<Tab title="Allow all keys (most common)">
+
+**Before (v1.4.x):** `allowed_keys` omitted or `[]` → all keys allowed
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "weight": 1.0
+    }
+  ]
+}
+```
+
+**After (v1.5.0):** must use `["*"]` explicitly — omitting `key_ids` or leaving it `[]` now blocks all keys
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "key_ids": ["*"],
+      "allowed_models": ["*"],
+      "weight": 1.0
+    }
+  ]
+}
+```
+
+</Tab>
+<Tab title="Specific keys">
+
+**Before (v1.4.x):**
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "allowed_keys": ["key-prod-001"],
+      "weight": 1.0
+    }
+  ]
+}
+```
+
+**After (v1.5.0):** rename the field, no value change needed
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "key_ids": ["key-prod-001"],
+      "allowed_models": ["*"],
+      "weight": 1.0
+    }
+  ]
+}
+```
+
+</Tab>
+<Tab title="REST API">
+
+**Before (v1.4.x):**
+```bash
+curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id} \
+  -d '{
+    "provider_configs": [
+      {
+        "provider": "openai",
+        "allowed_keys": ["key-prod-001"],
+        "weight": 1.0
+      }
+    ]
+  }'
+```
+
+**After (v1.5.0):**
+```bash
+curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id} \
+  -d '{
+    "provider_configs": [
+      {
+        "provider": "openai",
+        "key_ids": ["key-prod-001"],
+        "allowed_models": ["*"],
+        "weight": 1.0
+      }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Breaking Change 5: Virtual Key MCP `tools_to_execute` Field
+
+**Who is affected:** Anyone configuring MCP tool filtering on Virtual Keys in `config.json` or the REST API.
+
+### What changed
+
+The `tools_to_execute` field on a Virtual Key MCP config previously defaulted to "allow all tools" when empty. It now means "block all tools from this client." You must use `["*"]` to allow all tools.
+
+Additionally, the Virtual Key `mcp_configs` list itself now acts as a strict allow-list:
+- **No `mcp_configs`** → all MCP tools blocked for this VK
+- **`mcp_configs` with entries** → only the listed clients and tools are accessible
+
+<Tabs>
+<Tab title="config.json">
+
+**Before (v1.4.x):**
+```json
+{
+  "mcp_configs": [
+    {
+      "mcp_client_name": "my-tools-server",
+      "tools_to_execute": []
+    }
+  ]
+}
+```
+Empty `tools_to_execute` → all tools from `my-tools-server` allowed
+
+**After (v1.5.0):**
+```json
+{
+  "mcp_configs": [
+    {
+      "mcp_client_name": "my-tools-server",
+      "tools_to_execute": ["*"]
+    }
+  ]
+}
+```
+`["*"]` → all tools from `my-tools-server` allowed
+
+</Tab>
+<Tab title="REST API">
+
+**Before (v1.4.x):**
+```bash
+curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id} \
+  -d '{
+    "mcp_configs": [
+      { "mcp_client_name": "billing-client", "tools_to_execute": [] }
+    ]
+  }'
+```
+
+**After (v1.5.0):**
+```bash
+curl -X PUT http://localhost:8080/api/governance/virtual-keys/{vk_id} \
+  -d '{
+    "mcp_configs": [
+      { "mcp_client_name": "billing-client", "tools_to_execute": ["*"] }
+    ]
+  }'
+```
+
+</Tab>
+</Tabs>
+
+**MCP tool filtering semantics at a glance:**
+
+| `mcp_configs` | `tools_to_execute` | Result |
+|---|---|---|
+| Not configured | N/A | All MCP tools blocked |
+| `[{ client: "X" }]` | `[]` | All tools from X blocked |
+| `[{ client: "X" }]` | `["*"]` | All tools from X allowed |
+| `[{ client: "X" }]` | `["tool-a"]` | Only `tool-a` from X allowed |
+| `[{ client: "X" }, { client: "Y" }]` | `["*"]` / `["*"]` | All tools from X and Y allowed; all other clients blocked |
+
+---
+
+## Breaking Change 6: `weight` Field is Now Optional
+
+**Who is affected:** Anyone programmatically processing or constructing Virtual Key provider config objects via the API.
+
+### What changed
+
+The `weight` field on a Virtual Key provider config was previously a required `float64`. It is now an optional nullable value (`*float64`). The new semantics:
+
+- **`weight: 0.5`** — provider participates in weighted load balancing
+- **`weight: null` or omitted** — provider is configured and accessible but is **excluded from weighted routing** (it can still be used for direct `provider/model` requests or fallbacks)
+
+This allows you to configure a provider on a VK for fallback purposes without including it in the normal weighted selection pool.
+
+**API response change:** The `weight` field may now be `null` in API responses. Update any client code that assumes `weight` is always a number.
+
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "allowed_models": ["*"],
+      "weight": 0.8
+    },
+    {
+      "provider": "anthropic",
+      "allowed_models": ["*"],
+      "weight": null
+    }
+  ]
+}
+```
+In this example: 100% of weighted traffic goes to OpenAI. Anthropic is still reachable via `anthropic/claude-3-5-sonnet-20241022` direct routing or as a manual fallback, but won't receive any traffic from weighted load balancing.
+
+---
+
+## New Validation: WhiteList Rules
+
+v1.5.0 introduces the `WhiteList` type, which enforces two new validation rules on all allow-list fields. The API now returns **HTTP 400** if either rule is violated.
+
+### Rule 1: Wildcard cannot be mixed with other values
+
+`["*"]` is only valid when it is the sole element. Using it alongside specific values is a validation error.
+
+```json
+// ❌ Invalid — rejected with 400
+{ "allowed_models": ["*", "gpt-4o"] }
+
+// ✅ Valid
+{ "allowed_models": ["*"] }
+
+// ✅ Valid
+{ "allowed_models": ["gpt-4o", "gpt-4o-mini"] }
+```
+
+### Rule 2: No duplicate values
+
+```json
+// ❌ Invalid — rejected with 400
+{ "allowed_models": ["gpt-4o", "gpt-4o"] }
+
+// ✅ Valid
+{ "allowed_models": ["gpt-4o", "gpt-4o-mini"] }
+```
+
+These rules apply to: `allowed_models`, `key_ids`, `models` (on provider keys), `tools_to_execute`, `tools_to_auto_execute`, and `allowed_extra_headers`.
+
+---
+
+## Complete Before/After Reference
+
+### Provider Key (config.json)
+
+**Before:**
+```json
+{
+  "providers": {
+    "openai": {
+      "keys": [
+        { "id": "key-1", "value": "env.OPENAI_API_KEY", "weight": 1 }
+      ]
+    }
+  }
+}
+```
+
+**After:**
+```json
+{
+  "providers": {
+    "openai": {
+      "keys": [
+        { "id": "key-1", "value": "env.OPENAI_API_KEY", "weight": 1, "models": ["*"] }
+      ]
+    }
+  }
+}
+```
+
+---
+
+### Simple Virtual Key (config.json)
+
+**Before:**
+```json
+{
+  "governance": {
+    "virtual_keys": [
+      {
+        "id": "vk-simple",
+        "provider_configs": [
+          { "provider": "openai", "weight": 1.0 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**After:**
+```json
+{
+  "governance": {
+    "virtual_keys": [
+      {
+        "id": "vk-simple",
+        "provider_configs": [
+          { "provider": "openai", "allowed_models": ["*"], "key_ids": ["*"], "weight": 1.0 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+### Virtual Key with Key Restrictions (config.json)
+
+**Before:**
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "allowed_keys": ["key-prod-001"],
+      "weight": 0.5
+    }
+  ]
+}
+```
+
+**After:**
+```json
+{
+  "provider_configs": [
+    {
+      "provider": "openai",
+      "key_ids": ["key-prod-001"],
+      "allowed_models": ["*"],
+      "weight": 0.5
+    }
+  ]
+}
+```
+
+---
+
+### Virtual Key with MCP Tools (config.json)
+
+**Before:**
+```json
+{
+  "mcp_configs": [
+    { "mcp_client_name": "tools-server", "tools_to_execute": [] }
+  ]
+}
+```
+
+**After:**
+```json
+{
+  "mcp_configs": [
+    { "mcp_client_name": "tools-server", "tools_to_execute": ["*"] }
+  ]
+}
+```
+
+---
+
+### Full Virtual Key (REST API)
+
+**Before:**
+```bash
+curl -X POST http://localhost:8080/api/governance/virtual-keys \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "prod-key",
+    "provider_configs": [
+      {
+        "provider": "openai",
+        "allowed_keys": ["key-prod-001"],
+        "weight": 0.7
+      },
+      {
+        "provider": "anthropic",
+        "weight": 0.3
+      }
+    ],
+    "mcp_configs": [
+      { "mcp_client_name": "my-mcp", "tools_to_execute": [] }
+    ]
+  }'
+```
+
+**After:**
+```bash
+curl -X POST http://localhost:8080/api/governance/virtual-keys \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "prod-key",
+    "provider_configs": [
+      {
+        "provider": "openai",
+        "key_ids": ["key-prod-001"],
+        "allowed_models": ["*"],
+        "weight": 0.7
+      },
+      {
+        "provider": "anthropic",
+        "key_ids": ["*"],
+        "allowed_models": ["*"],
+        "weight": 0.3
+      }
+    ],
+    "mcp_configs": [
+      { "mcp_client_name": "my-mcp", "tools_to_execute": ["*"] }
+    ]
+  }'
+```
+
+---
+
+## Breaking Change 7: Compact plugin supports two new modes
+
+**Who is affected:** Anyone using the `compact` plugin.
+
+### What changed
+
+The `compact` plugin now supports two new modes:
+
+- Chat to responses fallback: If Chat completion API is hit for models that only support Responses API, the chat completion is routed via the responses API.
+- OpenAI Compatible parameters dropping: If a model does not support any standard OpenAI compatible model parameter, it is dropped.
+
+The option `enable_litellm_fallbacks` is removed and replaced with:
+- `compat.convert_text_to_chat`: Enable text completion to chat completion fallback (original behavior)
+- `compat.convert_chat_to_responses`: Enable chat completion to responses fallback
+- `compat.should_drop_params`: Enable OpenAI Compatible parameters dropping
+
+The following fields are removed or added to the response:
+- `extra_fields.litellm_compat` is removed
+- `extra_fields.dropped_compat_plugin_params` returns which parameters were dropped by this plugin
+- `extra_fields.converted_request_type` returns the type of convert to (NOTE: If the request is a streaming request, this will still be base request type. For streaming chat completions, converted_request_type will be "chat_completions" and not "chat_completion_stream")
+
+---
+
+## Quick Migration Checklist
+
+Use this checklist when upgrading to v1.5.0:
+
+<Steps>
+<Step title="Update provider key models in config.json">
+Find every provider key in your `config.json` that has `"models": []` or no `models` field. Add `"models": ["*"]` to each.
+</Step>
+
+<Step title="Add allowed_models to every VK provider config">
+Find every `provider_configs` entry in your Virtual Keys (in `config.json` and any automation that calls the API). Add `"allowed_models": ["*"]` if you want all models, or list specific models you want to allow.
+</Step>
+
+<Step title="Ensure every VK has at least one provider config">
+Any Virtual Key with `"provider_configs": []` or no `provider_configs` will block all traffic. Add the providers you want to allow.
+</Step>
+
+<Step title="Rename allowed_keys to key_ids and set explicit values">
+Search your `config.json` and API calls for `"allowed_keys"` and rename it to `"key_ids"`. Then:
+- If `allowed_keys` was omitted or `[]` (previously meaning "allow all"), change to `"key_ids": ["*"]` — an empty or omitted `key_ids` now **blocks all keys**.
+- If `allowed_keys` listed specific key IDs, keep the same values — only the field name changes.
+</Step>
+
+<Step title="Update tools_to_execute for MCP configs">
+Change any `"tools_to_execute": []` to `"tools_to_execute": ["*"]` if you want to allow all tools. Ensure every VK that needs MCP access has at least one `mcp_configs` entry.
+</Step>
+
+<Step title="Handle nullable weight in API consumers">
+If you parse the Virtual Key API response in your code, update the `weight` field handler to accept `null` values in addition to numbers.
+</Step>
+
+<Step title="Fix any invalid WhiteList values">
+Check that none of your lists mix `"*"` with other values (e.g., `["*", "gpt-4o"]`), and that none have duplicate entries. These will now be rejected with HTTP 400.
+</Step>
+</Steps>
+
+---
+
+## Troubleshooting
+
+### All requests are returning 403/blocked after upgrade
+
+This usually means a provider key has `models: []` or a Virtual Key has no `provider_configs`, or a provider config has `allowed_models: []`. Check the Bifrost logs — a blocked request will log which rule denied it.
+
+**Fix:** Follow the checklist above. Ensure `models: ["*"]` on provider keys and `allowed_models: ["*"]` on VK provider configs.
+
+### MCP tools are not being injected / tool calls are blocked
+
+The VK needs an `mcp_configs` entry for the MCP client, and that entry needs `"tools_to_execute": ["*"]` (or a specific tool list).
+
+**Fix:** Add or update the `mcp_configs` on the Virtual Key.
+
+### API returning 400 on virtual key create/update
+
+The most common cause is a whitelist validation failure — either `["*", "gpt-4o"]` mixing a wildcard with a specific value, or a duplicate value in a list.
+
+**Fix:** Use only `["*"]` alone or a list of specific values without duplicates.
+
+### Requests fail with "no keys available" or key selection errors after upgrade
+
+A provider config with `key_ids` omitted or set to `[]` now **blocks all keys** (`allow_all_keys: false`, no specific keys configured). This is different from `allowed_models` — there is no automatic migration for `key_ids`.
+
+**Fix:** Add `"key_ids": ["*"]` to any provider config that previously had `allowed_keys: []` or no `allowed_keys` field.
+
+### Existing keys work fine but newly created keys are blocked
+
+The automatic migration only updates existing data. New keys created after upgrade must follow the new semantics. Use `["*"]` for all allow-list fields where you want unrestricted access.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1610,7 +1610,7 @@
         },
         "tools_to_execute": {
           "type": "array",
-          "description": "Tools to execute for this MCP config",
+          "description": "Include-only list of tools this Virtual Key is permitted to execute from this MCP client. ['*'] means all tools allowed, [] means no tools allowed (deny-by-default).",
           "items": {
             "type": "string"
           }
@@ -2278,6 +2278,13 @@
         "tool_sync_interval": {
           "type": "string",
           "description": "Per-client override for tool sync interval (Go duration, e.g. '10m', '1h', 0 = use global, negative = disabled)"
+        },
+        "allowed_extra_headers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowlist of request-level headers that callers may forward to this MCP server at execution time. Use ['*'] to allow all headers."
         },
         "is_ping_available": {
           "type": "boolean",


### PR DESCRIPTION
## Summary

This PR introduces breaking changes for v1.5.0 that flip the semantics of empty arrays across all allow-list fields from "allow all" to "deny all" by default. The changes implement a more secure deny-by-default approach where explicit wildcards (`["*"]`) must be used to allow unrestricted access.

## Changes

- Updated test account configuration to use explicit wildcard `["*"]` instead of empty arrays for all provider key `models` fields across OpenAI, Anthropic, Bedrock, Azure, Cohere, Mistral, Groq, and other providers
- Added comprehensive migration guide documentation explaining the breaking changes and how to update existing configurations
- Changed semantics for provider key `models`, Virtual Key `allowed_models`, `key_ids` (renamed from `allowed_keys`), `tools_to_execute`, and `provider_configs` fields
- Introduced automatic database migrations to protect existing deployments while requiring manual updates for new configurations

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Docs

## How to test

```sh
# Verify test account configurations work with new semantics
go test ./core/internal/llmtests/...

# Test provider key model restrictions
go test ./...

# Verify migration guide examples
# Check that wildcard configurations allow all models as expected
# Verify empty arrays now block access appropriately
```

## Breaking changes

- [x] Yes

**Major breaking changes:**
- Empty arrays (`[]`) now mean "allow none" instead of "allow all"
- Must use `["*"]` wildcard to explicitly allow all items
- `allowed_keys` field renamed to `key_ids` in Virtual Key provider configs
- `weight` field is now optional/nullable on VK provider configs
- New validation rules prevent mixing wildcards with specific values and duplicate entries

**Migration:** Existing database records are automatically migrated on startup. New configurations must follow the new semantics - see the comprehensive migration guide for detailed instructions.

## Related issues

Implements v1.5.0 breaking changes for improved security posture with deny-by-default semantics.

## Security considerations

This change significantly improves security by implementing deny-by-default semantics. Previously, misconfigured or incomplete configurations could inadvertently grant broader access than intended. The new approach requires explicit permission grants, reducing the risk of accidental over-permissioning.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable