### PR TITLE
refactor: Optimize useMemo dependencies in log pages to prevent unnecessary data re-fetching

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -173,7 +173,14 @@ export default function LogsPage() {
 				}
 			})() : undefined,
 		}),
-		[urlState],
+		// Only re-derive filters when filter-related URL params change (not pagination)
+		[
+			urlState.providers, urlState.models, urlState.status, urlState.objects,
+			urlState.selected_key_ids, urlState.virtual_key_ids, urlState.routing_rule_ids,
+			urlState.routing_engine_used, urlState.content_search,
+			urlState.start_time, urlState.end_time,
+			urlState.missing_cost_only, urlState.metadata_filters,
+		],
 	);
 
 	const pagination: Pagination = useMemo(
@@ -183,7 +190,7 @@ export default function LogsPage() {
 			sort_by: urlState.sort_by as "timestamp" | "latency" | "tokens" | "cost",
 			order: urlState.order as "asc" | "desc",
 		}),
-		[urlState],
+		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
 	);
 
 	const liveEnabled = urlState.live_enabled;

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -129,7 +129,13 @@ export default function MCPLogsPage() {
 			start_time: dateUtils.toISOString(urlState.start_time),
 			end_time: dateUtils.toISOString(urlState.end_time),
 		}),
-		[urlState],
+		// Only re-derive filters when filter-related URL params change (not pagination)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[
+			urlState.tool_names, urlState.server_labels, urlState.status,
+			urlState.virtual_key_ids, urlState.content_search,
+			urlState.start_time, urlState.end_time,
+		],
 	);
 
 	const pagination: Pagination = useMemo(
@@ -139,7 +145,7 @@ export default function MCPLogsPage() {
 			sort_by: urlState.sort_by as "timestamp" | "latency",
 			order: urlState.order as "asc" | "desc",
 		}),
-		[urlState],
+		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
 	);
 
 	const liveEnabled = urlState.live_enabled;


### PR DESCRIPTION
## Summary

Optimizes React hook dependencies in logs and MCP logs pages to prevent unnecessary re-renders and data refecthing by separating filter-related parameters from pagination parameters in `useMemo` dependency arrays.

## Changes

- Split `useMemo` dependencies for filters and pagination objects in both logs pages
- Filter objects now only re-derive when filter-related URL parameters change (providers, models, status, search terms, time ranges, etc.)
- Pagination objects now only re-derive when pagination-related parameters change (limit, offset, sort_by, order)
- Added ESLint disable comments for exhaustive-deps rule where specific dependency arrays are intentionally used

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the logs and MCP logs pages and verify that filtering and pagination work correctly without performance issues.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test by changing filter parameters and pagination separately to ensure components only re-render when necessary.

### Problem

https://github.com/user-attachments/assets/e7d94ed1-1518-4d0c-a94f-e893c8f045f1

### Solution

https://github.com/user-attachments/assets/e562a3d4-0f76-4db9-8af3-54fb17d96c53

## Breaking changes

- [] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - This is a performance optimization that doesn't affect security.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable