### PR TITLE
linker fix

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -913,7 +913,7 @@ jobs:
         plugins-release,
       ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && needs.test-bifrost-http.result == 'success' && needs.test-migrations.result == 'success' && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
-    runs-on: ubuntu-22.04  # Pinned: ubuntu-24.04 removed ld.gold, breaking Go's ARM64 cross-compilation
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/scripts/install-cross-compilers.sh
+++ b/.github/workflows/scripts/install-cross-compilers.sh
@@ -18,11 +18,42 @@ sudo apt-get install -y \
   xz-utils \
   curl
 
-# Create symbolic links for musl compilers
+# Create symbolic links for x86_64 musl compilers
 sudo ln -sf /usr/bin/x86_64-linux-gnu-gcc /usr/local/bin/x86_64-linux-musl-gcc
 sudo ln -sf /usr/bin/x86_64-linux-gnu-g++ /usr/local/bin/x86_64-linux-musl-g++
-sudo ln -sf /usr/bin/aarch64-linux-gnu-gcc /usr/local/bin/aarch64-linux-musl-gcc
-sudo ln -sf /usr/bin/aarch64-linux-gnu-g++ /usr/local/bin/aarch64-linux-musl-g++
+
+# Create wrapper scripts for aarch64 musl compilers
+# Go passes -fuse-ld=gold for ARM64, but ld.gold is unavailable on Ubuntu 24.04+
+# Wrapper intercepts and rewrites to -fuse-ld=lld
+sudo tee /usr/local/bin/aarch64-linux-musl-gcc > /dev/null << 'WRAPPER_EOF'
+#!/bin/bash
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    -fuse-ld=gold) args+=("-fuse-ld=lld") ;;
+    *) args+=("$arg") ;;
+  esac
+done
+exec /usr/bin/aarch64-linux-gnu-gcc "${args[@]}"
+WRAPPER_EOF
+
+sudo tee /usr/local/bin/aarch64-linux-musl-g++ > /dev/null << 'WRAPPER_EOF'
+#!/bin/bash
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    -fuse-ld=gold) args+=("-fuse-ld=lld") ;;
+    *) args+=("$arg") ;;
+  esac
+done
+exec /usr/bin/aarch64-linux-gnu-g++ "${args[@]}"
+WRAPPER_EOF
+
+sudo chmod +x /usr/local/bin/aarch64-linux-musl-gcc /usr/local/bin/aarch64-linux-musl-g++
+
+# GCC's collect2 searches for cross-prefixed linker (aarch64-linux-gnu-ld.lld)
+# but apt's lld package only provides /usr/bin/ld.lld — create the cross-prefixed symlink
+sudo ln -sf /usr/bin/ld.lld /usr/bin/aarch64-linux-gnu-ld.lld
 
 echo "🍎 Setting up Darwin cross-compilation..."
 


### PR DESCRIPTION
## Summary

Fixes ARM64 cross-compilation issues on Ubuntu 24.04+ by replacing the removed `ld.gold` linker with `lld` through wrapper scripts, allowing the release pipeline to use `ubuntu-latest` instead of being pinned to Ubuntu 22.04.

## Changes

- Updated release pipeline to use `ubuntu-latest` instead of `ubuntu-22.04`
- Created wrapper scripts for `aarch64-linux-musl-gcc` and `aarch64-linux-musl-g++` that intercept `-fuse-ld=gold` flags and rewrite them to `-fuse-ld=lld`
- Added symlink for cross-prefixed LLD linker (`aarch64-linux-gnu-ld.lld`) to satisfy GCC's collect2 requirements
- Maintained existing x86_64 musl compiler symlinks unchanged

The wrapper approach preserves Go's existing ARM64 cross-compilation behavior while adapting to Ubuntu 24.04's removal of the gold linker.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify ARM64 cross-compilation works on Ubuntu 24.04:

```sh
# Test cross-compilation setup
./github/workflows/scripts/install-cross-compilers.sh

# Verify ARM64 compilation
CGO_ENABLED=1 GOOS=linux GOARCH=arm64 CC=aarch64-linux-musl-gcc go build -o test-arm64 ./...

# Check that the binary was created and is ARM64
file test-arm64
```

Expected outcome: Binary should be created successfully and identified as ARM64 architecture.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Resolves the ARM64 cross-compilation failure caused by Ubuntu 24.04 removing `ld.gold`.

## Security considerations

None - this change only affects the build environment and linker selection during cross-compilation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable