### PR TITLE
adds darwin linker

### DIFF
--- a/.github/workflows/scripts/install-cross-compilers.sh
+++ b/.github/workflows/scripts/install-cross-compilers.sh
@@ -76,24 +76,26 @@ if [ ! -d "$SDK_DIR" ]; then
 fi
 
 # Create wrapper scripts with proper shebang and linker configuration
+# -nostartfiles: Go has its own entry point, skip C startup files (crt1.o)
+#   which newer lld versions may fail to locate via syslibroot
 sudo tee /usr/local/bin/o64-clang > /dev/null << 'WRAPPER_EOF'
 #!/bin/bash
-exec clang -target x86_64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -Wno-unused-command-line-argument "$@"
+exec clang -target x86_64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -nostartfiles -Wno-unused-command-line-argument "$@"
 WRAPPER_EOF
 
 sudo tee /usr/local/bin/o64-clang++ > /dev/null << 'WRAPPER_EOF'
 #!/bin/bash
-exec clang++ -target x86_64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -Wno-unused-command-line-argument "$@"
+exec clang++ -target x86_64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -nostartfiles -Wno-unused-command-line-argument "$@"
 WRAPPER_EOF
 
 sudo tee /usr/local/bin/oa64-clang > /dev/null << 'WRAPPER_EOF'
 #!/bin/bash
-exec clang -target arm64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -Wno-unused-command-line-argument "$@"
+exec clang -target arm64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -nostartfiles -Wno-unused-command-line-argument "$@"
 WRAPPER_EOF
 
 sudo tee /usr/local/bin/oa64-clang++ > /dev/null << 'WRAPPER_EOF'
 #!/bin/bash
-exec clang++ -target arm64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -Wno-unused-command-line-argument "$@"
+exec clang++ -target arm64-apple-darwin --sysroot=/opt/MacOSX12.3.sdk -fuse-ld=lld -nostartfiles -Wno-unused-command-line-argument "$@"
 WRAPPER_EOF
 
 sudo chmod +x /usr/local/bin/o64-clang /usr/local/bin/o64-clang++ \


### PR DESCRIPTION
## Summary

Fixes cross-compilation issues for macOS targets by adding the `-nostartfiles` flag to clang wrapper scripts. This prevents newer lld versions from failing to locate C startup files when Go provides its own entry point.

## Changes

- Added `-nostartfiles` flag to all four clang wrapper scripts (o64-clang, o64-clang++, oa64-clang, oa64-clang++)
- Added explanatory comments documenting why `-nostartfiles` is needed for Go cross-compilation
- Prevents lld linker failures when attempting to locate crt1.o via syslibroot

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs
- [x] Build/CI

## How to test

Test cross-compilation to macOS targets using the updated wrapper scripts:

```sh
# Test x86_64 macOS compilation
CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC=o64-clang go build

# Test arm64 macOS compilation  
CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC=oa64-clang go build

# Verify no linker errors related to missing startup files
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects build-time linker configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable