### PR TITLE
fixed bifrost builds

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -951,7 +951,7 @@ jobs:
   # Build darwin, windows, linux/amd64 binaries and upload to R2
   build-binaries-x86:
     needs: [bifrost-http-prep, detect-changes]
-    if: needs.bifrost-http-prep.outputs.success == 'true'
+    if: "always() && needs.bifrost-http-prep.result == 'success' && needs.bifrost-http-prep.outputs.success == 'true'"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1002,7 +1002,7 @@ jobs:
   # Build linux/arm64 natively on ARM runner and upload to R2
   build-binaries-arm64:
     needs: [bifrost-http-prep, detect-changes]
-    if: needs.bifrost-http-prep.outputs.success == 'true'
+    if: "always() && needs.bifrost-http-prep.result == 'success' && needs.bifrost-http-prep.outputs.success == 'true'"
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fixes GitHub Actions workflow condition to ensure binary build jobs run even when dependency jobs are skipped, preventing build failures in the release pipeline.

## Changes

- Modified conditional logic for `build-binaries-x86` and `build-binaries-arm64` jobs to use `always()` function
- Added explicit check for `needs.bifrost-http-prep.result == 'success'` alongside existing output condition
- Ensures binary builds execute when the prep job succeeds, regardless of whether other dependency jobs were skipped

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Trigger the release pipeline workflow and verify that binary build jobs execute properly when `bifrost-http-prep` succeeds but other dependency jobs are skipped.

```sh
# Monitor the GitHub Actions workflow execution
# Verify build-binaries-x86 and build-binaries-arm64 jobs run when expected
# Check that binaries are successfully built and uploaded to R2
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a workflow condition fix that doesn't affect runtime behavior or expose any sensitive data.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable