### PR TITLE
enable all tests again

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -24,8 +24,6 @@ set -euo pipefail
 #   BIFROST_PORT      - Port for bifrost server (default: 8089)
 #   VERSIONS_TO_TEST  - Number of previous versions to test (default: 3)
 
-exit 0
-
 # Pull all the tags available
 git fetch --tags
 

--- a/.github/workflows/scripts/test-bifrost-http.sh
+++ b/.github/workflows/scripts/test-bifrost-http.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 # Test bifrost-http component
 # Usage: ./test-bifrost-http.sh
 
-exit 0
-
 # Get the absolute path of the script directory
 if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
   SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"

--- a/.github/workflows/scripts/test-docker-image.sh
+++ b/.github/workflows/scripts/test-docker-image.sh
@@ -5,8 +5,6 @@ set -e
 # Usage: ./test-docker-image.sh <platform>
 # Example: ./test-docker-image.sh linux/amd64
 
-exit 0
-
 # Get the absolute path of the script directory
 if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
   SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"

--- a/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
@@ -28,7 +28,12 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyIndex, pro
 				if (!open) onCancel();
 			}}
 		>
-			<SheetContent className="custom-scrollbar p-8" data-testid="key-form">
+			<SheetContent
+				className="custom-scrollbar p-8"
+				data-testid="key-form"
+				onInteractOutside={(e) => e.preventDefault()}
+				onEscapeKeyDown={(e) => e.preventDefault()}
+			>
 				<SheetHeader className="flex flex-col items-start">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">


### PR DESCRIPTION
## Summary

Re-enables previously disabled test scripts and prevents accidental closure of the add new key dialog in the UI.

## Changes

- Removed `exit 0` statements from three GitHub workflow test scripts that were preventing them from executing:
  - `run-migration-tests.sh` - migration testing script
  - `test-bifrost-http.sh` - bifrost HTTP component testing script  
  - `test-docker-image.sh` - Docker image testing script
- Added event handlers to the add new key sheet dialog to prevent closing when clicking outside or pressing escape key

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

For the test scripts:
```sh
# Verify the scripts can now execute properly
./.github/workflows/scripts/run-migration-tests.sh
./.github/workflows/scripts/test-bifrost-http.sh
./.github/workflows/scripts/test-docker-image.sh
```

For the UI changes:
```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test the dialog behavior by opening the add new key dialog and verifying it doesn't close when clicking outside or pressing escape.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - these changes restore test functionality and improve UI user experience without affecting security.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable