### PR TITLE
merged indexing go rotines for postgres to avoid any kind of deadlocks

### DIFF
--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -96,22 +96,17 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		return nil, err
 	}
 
-	// Ensure the metadata GIN index exists and is valid. This is done in a
-	// goroutine so that CREATE INDEX CONCURRENTLY (which can take minutes on
-	// large tables) does not block pod startup. The function is idempotent —
-	// it is a no-op when the index is already healthy.
+	// Run all index builds sequentially in a single goroutine to prevent
+	// deadlocks from concurrent CREATE INDEX CONCURRENTLY on the same table.
+	// Each function is idempotent and acquires its own advisory lock for
+	// cross-node serialization. Running in a goroutine avoids blocking pod startup.
 	go func() {
 		if err := ensureMetadataGINIndex(context.Background(), db); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: metadata GIN index build failed: %s (queries will still work without the index)", err))
-			return
+		} else {
+			logger.Info("logstore: metadata GIN index is ready")
 		}
-		logger.Info("logstore: metadata GIN index is ready")
-	}()
 
-	// Run dashboard enhancements first (backfill + covering index rebuild),
-	// then performance indexes second, in a single goroutine to avoid
-	// deadlocks from concurrent DDL on the same table.
-	go func() {
 		if err := ensureDashboardEnhancements(context.Background(), db); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: dashboard enhancements failed: %s (dashboard will still work with partial data)", err))
 		} else {


### PR DESCRIPTION
## Summary

Consolidates PostgreSQL index creation operations into a single goroutine to prevent deadlocks from concurrent `CREATE INDEX CONCURRENTLY` operations on the same table.

## Changes

- Merged two separate goroutines for index creation into one sequential execution flow
- Moved dashboard enhancements execution into the same goroutine as metadata GIN index creation
- Updated comments to clarify that sequential execution prevents deadlocks while advisory locks handle cross-node serialization
- Maintained idempotent behavior and non-blocking pod startup by keeping operations in a background goroutine

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that PostgreSQL logstore initialization completes without deadlocks during index creation:

```sh
# Test the logstore initialization
go test ./framework/logstore/...

# Run full test suite to ensure no regressions
go test ./...
```

Monitor logs during pod startup to confirm both metadata GIN index and dashboard enhancements complete successfully without blocking.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects the timing and sequencing of database index operations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable