### PR TITLE
fixes migration test

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -1039,6 +1039,17 @@ append_dynamic_columns_postgres() {
   fi
 
   # -------------------------------------------------------------------------
+  # v1.4.15 columns - log store tables
+  # -------------------------------------------------------------------------
+
+  # logs.cached_read_tokens (added in migrationAddDashboardEnhancements)
+  if column_exists_postgres "logs" "cached_read_tokens"; then
+    echo "UPDATE logs SET cached_read_tokens = 128 WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET cached_read_tokens = 0 WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET cached_read_tokens = 0 WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+
+  # -------------------------------------------------------------------------
   # v1.4.12 columns - governance_model_pricing new pricing columns
   # -------------------------------------------------------------------------
 
@@ -1618,6 +1629,15 @@ append_dynamic_columns_sqlite() {
   echo "UPDATE logs SET is_large_payload_response = 0 WHERE id = 'log-migration-test-001';" >> "$output_file"
   echo "UPDATE logs SET is_large_payload_response = 0 WHERE id = 'log-migration-test-002';" >> "$output_file"
   echo "UPDATE logs SET is_large_payload_response = 0 WHERE id = 'log-migration-test-003';" >> "$output_file"
+
+  # -------------------------------------------------------------------------
+  # v1.4.15 columns - log store tables (emitted unconditionally; fail silently on config_db)
+  # -------------------------------------------------------------------------
+
+  # logs.cached_read_tokens (added in migrationAddDashboardEnhancements)
+  echo "UPDATE logs SET cached_read_tokens = 128 WHERE id = 'log-migration-test-001';" >> "$output_file"
+  echo "UPDATE logs SET cached_read_tokens = 0 WHERE id = 'log-migration-test-002';" >> "$output_file"
+  echo "UPDATE logs SET cached_read_tokens = 0 WHERE id = 'log-migration-test-003';" >> "$output_file"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Adds migration test data for the new `cached_read_tokens` column in the logs table, which was introduced in v1.4.15 as part of the dashboard enhancements migration.

## Changes

- Added test data updates for the `cached_read_tokens` column in both PostgreSQL and SQLite migration test functions
- PostgreSQL implementation includes conditional column existence check before updating
- SQLite implementation updates the column unconditionally with silent failure handling for config_db
- Test data sets `cached_read_tokens` to 128 for the first test log entry and 0 for the remaining two entries

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the migration tests to ensure the new column data is properly populated:

```sh
# Run migration tests
./.github/workflows/scripts/run-migration-tests.sh
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to the migrationAddDashboardEnhancements migration that added the `cached_read_tokens` column.

## Security considerations

None - this only affects test data generation for migration testing.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable