### PR TITLE
fix: pass correct model in passthrough test anthropic

### DIFF
--- a/tests/integrations/python/tests/test_anthropic.py
+++ b/tests/integrations/python/tests/test_anthropic.py
@@ -2857,7 +2857,7 @@ This document is used to verify that the AI can read and understand text documen
         messages = convert_to_anthropic_messages(SIMPLE_CHAT_MESSAGES)
 
         response = client.messages.create(
-            model=format_provider_model(provider, model),
+            model=model,
             messages=messages,
             max_tokens=100,
         )
@@ -2885,7 +2885,7 @@ This document is used to verify that the AI can read and understand text documen
         messages = convert_to_anthropic_messages(STREAMING_CHAT_MESSAGES)
 
         stream = client.messages.create(
-            model=format_provider_model(provider, model),
+            model=model,
             messages=messages,
             max_tokens=200,
             stream=True,


### PR DESCRIPTION
## Summary

Simplified model parameter usage in Anthropic integration tests by removing unnecessary provider formatting.

## Changes

- Removed `format_provider_model(provider, model)` calls in favor of using the `model` parameter directly in both regular and streaming message creation tests
- This change affects `test_51_passthrough_messages` and `test_52_passthrough_messages_streaming` test methods

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Anthropic integration tests to ensure the model parameter is correctly passed without formatting:

```sh
# Run specific Anthropic tests
python -m pytest tests/integrations/python/tests/test_anthropic.py::test_51_passthrough_messages -v
python -m pytest tests/integrations/python/tests/test_anthropic.py::test_52_passthrough_messages_streaming -v

# Run all Anthropic tests
python -m pytest tests/integrations/python/tests/test_anthropic.py -v
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a test-only change that simplifies parameter handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable