### PR TITLE
fix(gemini): skip OutputTextDone to prevent duplicate text in genai streaming

### DIFF
--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -630,11 +630,8 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 		}
 
 	case schemas.ResponsesStreamResponseTypeOutputTextDone:
-		if bifrostResp.Text != nil && *bifrostResp.Text != "" {
-			candidate.Content.Parts = append(candidate.Content.Parts, &Part{
-				Text: *bifrostResp.Text,
-			})
-		}
+		// Text was already streamed via OutputTextDelta chunks, skip to avoid duplication
+		return nil
 
 	case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone,
 		schemas.ResponsesStreamResponseTypeReasoningSummaryPartDone:


### PR DESCRIPTION
## Summary

- `ToGeminiResponsesStreamResponse` was emitting the full accumulated text again on `OutputTextDone`, even though the text had already been streamed incrementally via `OutputTextDelta` chunks
- This caused the genai SSE stream to contain duplicate text content (same response appearing twice)
- Fix: return `nil` for `OutputTextDone`, consistent with how `ReasoningSummaryTextDone` is handled

## Repro

```bash
curl -s '<bifrost>/genai/v1beta/models/gemini-3-flash-preview:streamGenerateContent?alt=sse' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer <key>' \
  -d '{"contents":[{"role":"user","parts":[{"text":"hello"}]}],"generationConfig":{"thinkingConfig":{"thinkingBudget":500,"includeThoughts":true}}}'
```

**Before:** same text chunk appears twice in the SSE stream  
**After:** text appears once

## Test plan

- [ ] Verify genai streaming endpoint no longer duplicates text content
- [ ] Verify reasoning/thought content still streams correctly via `OutputTextDelta`
- [ ] Verify tool calls are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)