### PR TITLE
feat: add URL-based log selection with keyboard navigation and cross-page browsing

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -18,6 +18,7 @@ import {
 	useLazyGetLogsQuery,
 	useLazyGetLogsStatsQuery,
 } from "@/lib/store";
+import { useLazyGetLogByIdQuery } from "@/lib/store/apis/logsApi";
 import type {
 	ChatMessage,
 	ChatMessageContent,
@@ -54,8 +55,9 @@ export default function LogsPage() {
 	const [triggerGetHistogram] = useLazyGetLogsHistogramQuery();
 	const [deleteLogs] = useDeleteLogsMutation();
 
-	const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
 	const [isChartOpen, setIsChartOpen] = useState(true);
+	const [triggerGetLogById] = useLazyGetLogByIdQuery();
+	const [fetchedLog, setFetchedLog] = useState<LogEntry | null>(null);
 
 	// Debouncing for streaming updates (client-side)
 	const streamingUpdateTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -94,12 +96,43 @@ export default function LogsPage() {
 			live_enabled: parseAsBoolean.withDefault(true),
 			missing_cost_only: parseAsBoolean.withDefault(false),
 			metadata_filters: parseAsString.withDefault(""),
+			selected_log: parseAsString.withDefault(""),
 		},
 		{
 			history: "push",
 			shallow: false,
 		},
 	);
+
+	// Derive selectedLog: find in current logs array, or fetch by ID from API
+	const selectedLogId = urlState.selected_log || null;
+	const selectedLogFromData = useMemo(
+		() => (selectedLogId ? logs.find((l) => l.id === selectedLogId) ?? null : null),
+		[selectedLogId, logs],
+	);
+
+	const activeLogFetchId = useRef<string | null>(null);
+	useEffect(() => {
+		if (!selectedLogId || selectedLogFromData) {
+			setFetchedLog(null);
+			activeLogFetchId.current = null;
+			return;
+		}
+		// Track which log ID this fetch is for to prevent stale responses
+		const fetchId = selectedLogId;
+		activeLogFetchId.current = fetchId;
+		triggerGetLogById(selectedLogId).then((result) => {
+			if (activeLogFetchId.current === fetchId) {
+				if (result.data) {
+					setFetchedLog(result.data);
+				} else if (result.error) {
+					setError(getErrorMessage(result.error));
+				}
+			}
+		});
+	}, [selectedLogId, selectedLogFromData, triggerGetLogById]);
+
+	const selectedLog = selectedLogFromData ?? fetchedLog;
 
 	// Refresh time range defaults on page focus/visibility
 	useEffect(() => {
@@ -278,11 +311,15 @@ export default function LogsPage() {
 				await deleteLogs({ ids: [log.id] }).unwrap();
 				setLogs((prevLogs) => prevLogs.filter((l) => l.id !== log.id));
 				setTotalItems((prev) => prev - 1);
+				// Clear selected log if it was the deleted one
+				if (urlState.selected_log === log.id) {
+					setUrlState({ selected_log: "" });
+				}
 			} catch (error) {
 				setError(getErrorMessage(error));
 			}
 		},
-		[deleteLogs],
+		[deleteLogs, urlState.selected_log, setUrlState],
 	);
 
 	const handleLogMessage = useCallback((log: LogEntry, operation: "create" | "update") => {
@@ -315,12 +352,12 @@ export default function LogsPage() {
 					return updatedLogs;
 				});
 
-				// Update selectedLog if it matches (for detail sheet real-time updates)
-				setSelectedLog((prevSelectedLog) => {
-					if (prevSelectedLog && prevSelectedLog.id === log.id) {
+				// Update fetchedLog if it matches (for real-time detail sheet updates when log is not on current page)
+				setFetchedLog((prev) => {
+					if (prev && prev.id === log.id) {
 						return log;
 					}
-					return prevSelectedLog;
+					return prev;
 				});
 
 				setTotalItems((prev: number) => prev + 1);
@@ -456,12 +493,12 @@ export default function LogsPage() {
 			return prevLogs.map((existingLog) => (existingLog.id === updatedLog.id ? updatedLog : existingLog));
 		});
 
-		// Update selectedLog if it matches the updated log (for real-time detail sheet updates)
-		setSelectedLog((prevSelectedLog) => {
-			if (prevSelectedLog && prevSelectedLog.id === updatedLog.id) {
+		// Update fetchedLog if it matches the updated log (for real-time detail sheet updates when log is not on current page)
+		setFetchedLog((prev) => {
+			if (prev && prev.id === updatedLog.id) {
 				return updatedLog;
 			}
-			return prevSelectedLog;
+			return prev;
 		});
 	}, []);
 
@@ -735,6 +772,64 @@ export default function LogsPage() {
 
 	const columns = useMemo(() => createColumns(handleDelete, hasDeleteAccess, metadataKeys), [handleDelete, hasDeleteAccess, metadataKeys]);
 
+	// Navigation for log detail sheet
+	const selectedLogIndex = useMemo(
+		() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1),
+		[selectedLogId, logs],
+	);
+
+	const handleLogNavigate = useCallback(
+		(direction: "prev" | "next") => {
+			const currentLogId = selectedLogId || "";
+			if (direction === "prev") {
+				if (selectedLogIndex > 0) {
+					// Navigate to previous log on current page
+					setUrlState({ selected_log: logs[selectedLogIndex - 1].id });
+				} else if (pagination.offset > 0) {
+					// Go to previous page and select the last item
+					const newOffset = Math.max(0, pagination.offset - pagination.limit);
+					setUrlState({ offset: newOffset, selected_log: "" });
+					// Fetch previous page, then select last log
+					triggerGetLogs({
+						filters,
+						pagination: { ...pagination, offset: newOffset },
+					}).then((result) => {
+						if (result.data?.logs?.length) {
+							const lastLog = result.data.logs[result.data.logs.length - 1];
+							setUrlState({ selected_log: lastLog.id });
+						} else if (result.error) {
+							setUrlState({ offset: pagination.offset, selected_log: currentLogId });
+							setError(getErrorMessage(result.error));
+						}
+					});
+				}
+			} else {
+				if (selectedLogIndex >= 0 && selectedLogIndex < logs.length - 1) {
+					// Navigate to next log on current page
+					setUrlState({ selected_log: logs[selectedLogIndex + 1].id });
+				} else if (pagination.offset + pagination.limit < totalItems) {
+					// Go to next page and select the first item
+					const newOffset = pagination.offset + pagination.limit;
+					setUrlState({ offset: newOffset, selected_log: "" });
+					// Fetch next page, then select first log
+					triggerGetLogs({
+						filters,
+						pagination: { ...pagination, offset: newOffset },
+					}).then((result) => {
+						if (result.data?.logs?.length) {
+							const firstLog = result.data.logs[0];
+							setUrlState({ selected_log: firstLog.id });
+						} else if (result.error) {
+							setUrlState({ offset: pagination.offset, selected_log: currentLogId });
+							setError(getErrorMessage(result.error));
+						}
+					});
+				}
+			}
+		},
+		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
+	);
+
 	return (
 		<div className="dark:bg-card h-[calc(100dvh-3.3rem)] max-h-[calc(100dvh-1.5rem)] bg-white">
 			{initialLoading ? (
@@ -793,7 +888,7 @@ export default function LogsPage() {
 								onPaginationChange={setPagination}
 								onRowClick={(row, columnId) => {
 									if (columnId === "actions") return;
-									setSelectedLog(row);
+									setUrlState({ selected_log: row.id }, { history: "replace" });
 								}}
 								isSocketConnected={isSocketConnected}
 								liveEnabled={liveEnabled}
@@ -809,8 +904,11 @@ export default function LogsPage() {
 					<LogDetailSheet
 						log={selectedLog}
 						open={selectedLog !== null}
-						onOpenChange={(open) => !open && setSelectedLog(null)}
+						onOpenChange={(open) => !open && setUrlState({ selected_log: "" })}
 						handleDelete={handleDelete}
+						onNavigate={handleLogNavigate}
+						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
+						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}
 					/>
 				</div>
 			)}

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useLazyGetLogByIdQuery } from "@/lib/store/apis/logsApi";
 import {
 	AlertDialog,
@@ -28,7 +29,7 @@ import {
 	StatusColors,
 } from "@/lib/constants/logs";
 import { LogEntry } from "@/lib/types/logs";
-import { Clipboard, Loader2, MoreVertical, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Clipboard, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import moment from "moment";
 import { toast } from "sonner";
 import BlockHeader from "../views/blockHeader";
@@ -55,6 +56,9 @@ interface LogDetailSheetProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	handleDelete: (log: LogEntry) => void;
+	onNavigate?: (direction: "prev" | "next") => void;
+	hasPrev?: boolean;
+	hasNext?: boolean;
 }
 
 // Helper to detect passthrough operations
@@ -77,7 +81,7 @@ const isContainerOperation = (object: string) => {
 	return containerTypes.includes(object?.toLowerCase());
 };
 
-export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDetailSheetProps) {
+export function LogDetailSheet({ log, open, onOpenChange, handleDelete, onNavigate, hasPrev = false, hasNext = false }: LogDetailSheetProps) {
 	const [fetchLog, { data: fullLog, isFetching }] = useLazyGetLogByIdQuery();
 
 	useEffect(() => {
@@ -85,6 +89,10 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 			fetchLog(log.id);
 		}
 	}, [open, log?.id, fetchLog]);
+
+	// Keyboard navigation: arrow up/down to navigate between logs
+	useHotkeys("up", () => onNavigate?.("prev"), { enabled: open && hasPrev, preventDefault: true });
+	useHotkeys("down", () => onNavigate?.("next"), { enabled: open && hasNext, preventDefault: true });
 
 	if (!log) return null;
 
@@ -126,6 +134,7 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
 				{!isFullDataReady ? (
 					<div className="flex h-full items-center justify-center">
+						<SheetTitle className="sr-only">Loading log details</SheetTitle>
 						<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
 					</div>
 				) : (
@@ -167,10 +176,18 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							)}
 						</SheetTitle>
 					</div>
+					<div className="flex items-center">
+						<Button variant="ghost" className="size-8" disabled={!hasPrev} onClick={() => onNavigate?.("prev")} aria-label="Previous log" data-testid="logdetails-prev-button">
+							<ChevronUp className="size-4" />
+						</Button>
+						<Button variant="ghost" className="size-8" disabled={!hasNext} onClick={() => onNavigate?.("next")} aria-label="Next log" data-testid="logdetails-next-button">
+							<ChevronDown className="size-4" />
+						</Button>
+					</div>
 					<AlertDialog>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
-								<Button variant="ghost" size="icon">
+								<Button variant="ghost" className="size-8">
 									<MoreVertical className="h-3 w-3" />
 								</Button>
 							</DropdownMenuTrigger>

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -26,8 +26,6 @@ export default function MCPLogsPage() {
 	const [fetchingStats, setFetchingStats] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
-	const [selectedLog, setSelectedLog] = useState<MCPToolLogEntry | null>(null);
-
 	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
 
 	const [triggerGetLogs] = useLazyGetMCPLogsQuery();
@@ -62,11 +60,19 @@ export default function MCPLogsPage() {
 			sort_by: parseAsString.withDefault("timestamp"),
 			order: parseAsString.withDefault("desc"),
 			live_enabled: parseAsBoolean.withDefault(true),
+			selected_log: parseAsString.withDefault(""),
 		},
 		{
 			history: "push",
 			shallow: false,
 		},
+	);
+
+	// Derive selectedLog from URL param
+	const selectedLogId = urlState.selected_log || null;
+	const selectedLog = useMemo(
+		() => (selectedLogId ? logs.find((l) => l.id === selectedLogId) ?? null : null),
+		[selectedLogId, logs],
 	);
 
 	// Refresh time range defaults on page focus/visibility
@@ -196,13 +202,16 @@ export default function MCPLogsPage() {
 				await deleteLogs({ ids: [log.id] }).unwrap();
 				setLogs((prevLogs) => prevLogs.filter((l) => l.id !== log.id));
 				setTotalItems((prev) => prev - 1);
+				if (urlState.selected_log === log.id) {
+					setUrlState({ selected_log: "" });
+				}
 			} catch (err) {
 				const errorMessage = getErrorMessage(err);
 				setError(errorMessage);
 				throw new Error(errorMessage);
 			}
 		},
-		[deleteLogs, hasDeleteAccess],
+		[deleteLogs, hasDeleteAccess, urlState.selected_log, setUrlState],
 	);
 
 	// Ref to track latest state for WebSocket callbacks
@@ -263,14 +272,7 @@ export default function MCPLogsPage() {
 					return updatedLogs;
 				});
 
-				// Update selected log if it matches
-				setSelectedLog((prevSelectedLog) => {
-					if (prevSelectedLog && prevSelectedLog.id === log.id) {
-						return log;
-					}
-					return prevSelectedLog;
-				});
-
+	
 				setTotalItems((prev: number) => prev + 1);
 			}
 		} else if (operation === "update") {
@@ -299,14 +301,7 @@ export default function MCPLogsPage() {
 					return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
 				});
 
-				// Update selected log if it matches
-				setSelectedLog((prevSelectedLog) => {
-					if (prevSelectedLog && prevSelectedLog.id === log.id) {
-						return log;
-					}
-					return prevSelectedLog;
-				});
-
+	
 				// Update stats for completed requests
 				if (log.status === "success" || log.status === "error") {
 					setStats((prevStats) => {
@@ -454,6 +449,59 @@ export default function MCPLogsPage() {
 
 	const columns = useMemo(() => createMCPColumns(handleDelete, hasDeleteAccess), [handleDelete, hasDeleteAccess]);
 
+	// Navigation for log detail sheet
+	const selectedLogIndex = useMemo(
+		() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1),
+		[selectedLogId, logs],
+	);
+
+	const handleLogNavigate = useCallback(
+		(direction: "prev" | "next") => {
+			const replaceHistory = { history: "replace" as const };
+			const currentLogId = selectedLogId || "";
+			if (direction === "prev") {
+				if (selectedLogIndex > 0) {
+					setUrlState({ selected_log: logs[selectedLogIndex - 1].id }, replaceHistory);
+				} else if (pagination.offset > 0) {
+					const newOffset = Math.max(0, pagination.offset - pagination.limit);
+					setUrlState({ offset: newOffset, selected_log: "" }, replaceHistory);
+					triggerGetLogs({
+						filters,
+						pagination: { ...pagination, offset: newOffset },
+					}).then((result) => {
+						const pageLogs = result.data?.logs;
+						if (pageLogs?.length) {
+							setUrlState({ selected_log: pageLogs[pageLogs.length - 1].id }, replaceHistory);
+						} else if (result.error) {
+							setUrlState({ offset: pagination.offset, selected_log: currentLogId }, replaceHistory);
+							setError(getErrorMessage(result.error));
+						}
+					});
+				}
+			} else {
+				if (selectedLogIndex >= 0 && selectedLogIndex < logs.length - 1) {
+					setUrlState({ selected_log: logs[selectedLogIndex + 1].id }, replaceHistory);
+				} else if (pagination.offset + pagination.limit < totalItems) {
+					const newOffset = pagination.offset + pagination.limit;
+					setUrlState({ offset: newOffset, selected_log: "" }, replaceHistory);
+					triggerGetLogs({
+						filters,
+						pagination: { ...pagination, offset: newOffset },
+					}).then((result) => {
+						const pageLogs = result.data?.logs;
+						if (pageLogs?.length) {
+							setUrlState({ selected_log: pageLogs[0].id }, replaceHistory);
+						} else if (result.error) {
+							setUrlState({ offset: pagination.offset, selected_log: currentLogId }, replaceHistory);
+							setError(getErrorMessage(result.error));
+						}
+					});
+				}
+			}
+		},
+		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
+	);
+
 	return (
 		<div className="dark:bg-card bg-white">
 			{initialLoading ? (
@@ -509,7 +557,7 @@ export default function MCPLogsPage() {
 							onPaginationChange={setPagination}
 							onRowClick={(row, columnId) => {
 								if (columnId === "actions") return;
-								setSelectedLog(row);
+								setUrlState({ selected_log: row.id }, { history: "replace" });
 							}}
 							isSocketConnected={isSocketConnected}
 							liveEnabled={liveEnabled}
@@ -522,9 +570,12 @@ export default function MCPLogsPage() {
 					{/* Log Detail Sheet */}
 					<MCPLogDetailSheet
 						log={selectedLog}
-						open={selectedLog !== null}
-						onOpenChange={(open) => !open && setSelectedLog(null)}
+						open={selectedLogId !== null}
+						onOpenChange={(open) => !open && setUrlState({ selected_log: "" }, { history: "replace" })}
 						handleDelete={handleDelete}
+						onNavigate={handleLogNavigate}
+						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
+						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}
 					/>
 				</div>
 			)}

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -19,9 +19,10 @@ import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
-import { MoreVertical, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, MoreVertical, Trash2 } from "lucide-react";
 import moment from "moment";
 import { useState, type ReactNode } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
 
 interface MCPLogDetailSheetProps {
@@ -29,6 +30,9 @@ interface MCPLogDetailSheetProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	handleDelete: (log: MCPToolLogEntry) => Promise<void>;
+	onNavigate?: (direction: "prev" | "next") => void;
+	hasPrev?: boolean;
+	hasNext?: boolean;
 }
 
 const LogEntryDetailsView = ({ label, value, className }: { label: string; value: React.ReactNode; className?: string }) => (
@@ -57,8 +61,12 @@ const getValidatedStatus = (status: string): Status => {
 	return "processing";
 };
 
-export function MCPLogDetailSheet({ log, open, onOpenChange, handleDelete }: MCPLogDetailSheetProps) {
+export function MCPLogDetailSheet({ log, open, onOpenChange, handleDelete, onNavigate, hasPrev = false, hasNext = false }: MCPLogDetailSheetProps) {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+
+	// Keyboard navigation: arrow up/down to navigate between logs
+	useHotkeys("up", () => onNavigate?.("prev"), { enabled: open && hasPrev, preventDefault: true });
+	useHotkeys("down", () => onNavigate?.("next"), { enabled: open && hasNext, preventDefault: true });
 
 	if (!log) return null;
 
@@ -74,10 +82,18 @@ export function MCPLogDetailSheet({ log, open, onOpenChange, handleDelete }: MCP
 							</Badge>
 						</SheetTitle>
 					</div>
+					<div className="flex items-center">
+						<Button variant="ghost" className="size-8" disabled={!hasPrev} onClick={() => onNavigate?.("prev")} aria-label="Previous log" data-testid="mcp-log-nav-prev">
+							<ChevronUp className="size-4" />
+						</Button>
+						<Button variant="ghost" className="size-8" disabled={!hasNext} onClick={() => onNavigate?.("next")} aria-label="Next log" data-testid="mcp-log-nav-next">
+							<ChevronDown className="size-4" />
+						</Button>
+					</div>
 					<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
-								<Button variant="ghost" size="icon">
+								<Button variant="ghost" className="size-8">
 									<MoreVertical className="h-3 w-3" />
 								</Button>
 							</DropdownMenuTrigger>


### PR DESCRIPTION
## Summary

Adds keyboard navigation and URL state management for log detail sheets in both regular logs and MCP logs pages. Users can now navigate between logs using arrow keys and share direct links to specific log entries.

## Changes

- Added `selected_log` URL parameter to persist selected log state across page refreshes and enable direct linking
- Implemented keyboard navigation (arrow up/down) to move between logs in the detail sheet
- Added navigation buttons (chevron up/down) in the detail sheet header for mouse-based navigation
- Enhanced log selection logic to fetch logs by ID when they're not in the current page data
- Added cross-page navigation that automatically loads previous/next pages when navigating beyond current page boundaries
- Updated delete operations to clear selected log state when the selected log is deleted
- Added proper accessibility labels for navigation buttons

## Type of change

- [x] Feature

## Affected areas

- [x] UI (Next.js)

## How to test

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

1. Navigate to the logs page and click on any log entry to open the detail sheet
2. Verify the URL updates with a `selected_log` parameter
3. Test keyboard navigation using arrow up/down keys to move between logs
4. Test the navigation buttons in the detail sheet header
5. Navigate to the edge of a page and verify it loads the next/previous page automatically
6. Copy a URL with a selected log and paste it in a new tab to verify direct linking works
7. Delete a selected log and verify the detail sheet closes and URL state is cleared

## Screenshots/Recordings

N/A - Navigation enhancement without visual UI changes beyond new navigation buttons.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - only adds client-side navigation and URL state management.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable