### PR TITLE
feat: add Pulse hot reloading support as alternative to Air

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ USE_NODE = NVM_SH="$${NVM_DIR:-$$HOME/.nvm}/nvm.sh"; \
 	[ -s "$$NVM_SH" ] || NVM_SH="$$(brew --prefix nvm 2>/dev/null)/nvm.sh"; \
 	if [ -s "$$NVM_SH" ]; then . "$$NVM_SH" >/dev/null && nvm install >/dev/null 2>&1 && nvm use >/dev/null 2>&1; fi
 
-.PHONY: all help dev build-ui build build-cli run run-cli install-air clean test test-cli install-ui setup-workspace work-init work-clean docs docker-image docker-run cleanup-enterprise mod-tidy test-integrations-py test-integrations-ts install-playwright run-e2e run-e2e-ui run-e2e-headed
+.PHONY: all help dev dev-pulse build-ui build build-cli run run-cli install-air install-pulse clean test test-cli install-ui setup-workspace work-init work-clean docs docker-image docker-run cleanup-enterprise mod-tidy test-integrations-py test-integrations-ts install-playwright run-e2e run-e2e-ui run-e2e-headed
 
 all: help
 
@@ -86,6 +86,10 @@ install-ui: cleanup-enterprise
 install-air: ## Install air for hot reloading (if not already installed)
 	@which air > /dev/null || ($(ECHO) "$(YELLOW)Installing air for hot reloading...$(NC)" && go install github.com/air-verse/air@latest)
 	@$(ECHO) "$(GREEN)Air is ready$(NC)"
+
+install-pulse: ## Install pulse for hot reloading (if not already installed)
+	@which pulse > /dev/null || ($(ECHO) "$(YELLOW)Installing pulse for hot reloading...$(NC)" && go install github.com/Pratham-Mishra04/pulse@latest)
+	@$(ECHO) "$(GREEN)Pulse is ready$(NC)"
 
 install-delve: ## Install delve for debugging (if not already installed)
 	@which dlv > /dev/null || ($(ECHO) "$(YELLOW)Installing delve for debugging...$(NC)" && go install github.com/go-delve/delve/cmd/dlv@latest)
@@ -155,6 +159,55 @@ dev: install-ui install-air setup-workspace $(if $(DEBUG),install-delve) ## Star
 			$(if $(APP_DIR),-app-dir "$(APP_DIR)"); \
 	else \
 		cd transports/bifrost-http && BIFROST_UI_DEV=true air -c .air.toml -- \
+			-host "$(HOST)" \
+			-port "$(PORT)" \
+			-log-style "$(LOG_STYLE)" \
+			-log-level "$(LOG_LEVEL)" \
+			$(if $(PROMETHEUS_LABELS),-prometheus-labels "$(PROMETHEUS_LABELS)") \
+			$(if $(APP_DIR),-app-dir "$(APP_DIR)"); \
+	fi
+
+dev-pulse: install-ui install-pulse setup-workspace $(if $(DEBUG),install-delve) ## Start complete development environment using pulse for hot reloading
+	@$(ECHO) "$(GREEN)Starting Bifrost complete development environment (pulse)...$(NC)"
+	@$(ECHO) "$(YELLOW)This will start:$(NC)"
+	@$(ECHO) "  1. UI development server (localhost:3000)"
+	@$(ECHO) "  2. API server with UI proxy (localhost:$(PORT))"
+	@$(ECHO) "$(CYAN)Access everything at: http://localhost:$(PORT)$(NC)"
+	@if [ -n "$(DEBUG)" ]; then \
+		$(ECHO) "$(CYAN)  3. Debugger (delve) listening on port 2345$(NC)"; \
+	fi
+	@if [ ! -d "transports/bifrost-http/ui" ]; then \
+		$(ECHO) "$(YELLOW)Creating transports/bifrost-http/ui directory...$(NC)"; \
+		mkdir -p transports/bifrost-http/ui; \
+		touch transports/bifrost-http/ui/.tmp; \
+	fi
+	@$(ECHO) ""
+	@$(ECHO) "$(YELLOW)Starting UI development server...$(NC)"
+	@$(USE_NODE); if [ -n "$(DISABLE_PROFILER)" ]; then \
+		$(ECHO) "$(CYAN)DevProfiler disabled for testing$(NC)"; \
+		cd ui && BIFROST_DISABLE_PROFILER=1 npm run dev & \
+	else \
+		cd ui && npm run dev & \
+	fi
+	@sleep 3
+	@$(ECHO) "$(YELLOW)Starting API server with UI proxy...$(NC)"
+	@$(MAKE) setup-workspace >/dev/null
+	@if [ -f .env ]; then \
+		$(ECHO) "$(YELLOW)Loading environment variables from .env...$(NC)"; \
+		set -a; . ./.env; set +a; \
+	fi; \
+	if [ -n "$(DEBUG)" ]; then \
+		$(ECHO) "$(CYAN)Starting with pulse + delve debugger on port 2345...$(NC)"; \
+		$(ECHO) "$(YELLOW)Attach your debugger to localhost:2345$(NC)"; \
+		BIFROST_UI_DEV=true pulse -- \
+			-host "$(HOST)" \
+			-port "$(PORT)" \
+			-log-style "$(LOG_STYLE)" \
+			-log-level "$(LOG_LEVEL)" \
+			$(if $(PROMETHEUS_LABELS),-prometheus-labels "$(PROMETHEUS_LABELS)") \
+			$(if $(APP_DIR),-app-dir "$(APP_DIR)"); \
+	else \
+		BIFROST_UI_DEV=true pulse -- \
 			-host "$(HOST)" \
 			-port "$(PORT)" \
 			-log-style "$(LOG_STYLE)" \

--- a/docs/contributing/setting-up-repo.mdx
+++ b/docs/contributing/setting-up-repo.mdx
@@ -91,6 +91,16 @@ This command will:
 
 <Note>The `make dev` command handles all setup automatically. You can skip the manual setup steps below if this works for you.</Note>
 
+#### Alternative: Using Pulse
+
+If you prefer [Pulse](https://github.com/Pratham-Mishra04/pulse) over Air for hot reloading, use:
+
+```bash
+make dev-pulse
+```
+
+This runs the same development environment but uses `pulse.yaml` for hot reloading instead of `.air.toml`.
+
 ### Manual Setup (Alternative)
 
 If you prefer to set up components manually:
@@ -154,7 +164,8 @@ The Makefile provides numerous commands for development:
 ### Development Commands
 
 ```bash
-make dev          # Start complete development environment (recommended)
+make dev          # Start complete development environment using Air for hot reloading
+make dev-pulse    # Start complete development environment using Pulse for hot reloading
 make build        # Build UI and bifrost-http binary
 make run          # Build and run (no hot reload)
 make clean        # Clean build artifacts
@@ -373,6 +384,9 @@ which air || go install github.com/air-verse/air@latest
 
 # Check if .air.toml exists in transports/bifrost-http/
 ls transports/bifrost-http/.air.toml
+
+# Alternatively, use Pulse instead of Air
+make dev-pulse
 ```
 
 ### Getting Help

--- a/pulse.yaml
+++ b/pulse.yaml
@@ -1,0 +1,16 @@
+services:
+  bifrost:
+    path: transports/bifrost-http
+    build: sh -c 'if [ -n "$DEBUG" ]; then go build -tags dev -gcflags="all=-N -l" -o tmp/main .; else go build -tags dev -o tmp/main .; fi'
+    run: sh -c 'if [ -n "$DEBUG" ]; then dlv exec ./tmp/main --listen=127.0.0.1:2345 --headless=true --api-version=2 --accept-multiclient --log -- -host "${HOST:-localhost}" -port "${PORT:-8080}" -log-style "${LOG_STYLE:-json}" -log-level "${LOG_LEVEL:-info}" ${APP_DIR:+-app-dir "$APP_DIR"}; else ./tmp/main -host "${HOST:-localhost}" -port "${PORT:-8080}" -log-style "${LOG_STYLE:-json}" -log-level "${LOG_LEVEL:-info}" ${APP_DIR:+-app-dir "$APP_DIR"}; fi'
+    env:
+      BIFROST_UI_DEV: "true"
+    watch: [".go", "go.mod", "go.sum"]
+    ignore: ["*_test.go"]
+    kill_timeout: 10s
+    proxy:
+      addr: ":${PORT}"
+    healthcheck:
+      path: /health
+      interval: 2s
+      timeout: 120s

--- a/transports/bifrost-http/.air.debug.toml
+++ b/transports/bifrost-http/.air.debug.toml
@@ -64,4 +64,3 @@ app_port = 8080
 [screen]
 clear_on_rebuild = false
 keep_scroll = true
-


### PR DESCRIPTION
## Summary

Add Pulse as an alternative hot reloading tool for development alongside the existing Air setup. This provides developers with another option for hot reloading during development.

## Changes

- Added `install-pulse` target to install the Pulse hot reloading tool
- Added `dev-pulse` target that mirrors the existing `dev` command but uses Pulse instead of Air
- Created `pulse.yaml` configuration file with service definition for the bifrost-http transport
- Updated documentation to explain the new Pulse option as an alternative to Air
- Added Pulse-related targets to the `.PHONY` declaration
- Removed trailing whitespace from `.air.debug.toml`

The Pulse configuration includes the same debug support, environment variables, and proxy setup as the Air configuration, maintaining feature parity between the two hot reloading options.

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Docs

## How to test

Test the new Pulse development environment:

```sh
# Install and run with Pulse
make dev-pulse

# Verify both hot reloading tools work
make dev          # Uses Air
make dev-pulse    # Uses Pulse

# Test with debug mode
DEBUG=1 make dev-pulse

# Verify installation targets
make install-pulse
make install-air
```

Both commands should start the complete development environment with UI server on localhost:3000 and API server with proxy on the configured port.

## Screenshots/Recordings

N/A - No UI changes, only development tooling additions.

## Breaking changes

- [ ] Yes
- [x] No

This is purely additive - existing `make dev` command continues to work unchanged.

## Related issues

N/A

## Security considerations

No security implications - this only adds an alternative development tool with the same configuration and permissions as the existing Air setup.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable