### PR TITLE
feat: allow passthrough extra_body params for OpenAI-compatible providers

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3921,74 +3921,151 @@ func (bifrost *Bifrost) prepareFallbackRequest(req *schemas.BifrostRequest, fall
 
 	// Create a new request with the fallback provider and model
 	fallbackReq := *req
+	sourceProvider, _, _ := req.GetRequestFields()
+	preserveExtraParams := bifrost.shouldPreserveExtraParamsForFallback(sourceProvider, fallback.Provider)
+	setFallbackTarget := func(provider *schemas.ModelProvider, model *string) {
+		*provider = fallback.Provider
+		*model = fallback.Model
+	}
 
 	if req.TextCompletionRequest != nil {
 		tmp := *req.TextCompletionRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.TextCompletionRequest = &tmp
 	}
 
 	if req.ChatRequest != nil {
 		tmp := *req.ChatRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.ChatRequest = &tmp
 	}
 
 	if req.ResponsesRequest != nil {
 		tmp := *req.ResponsesRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.ResponsesRequest = &tmp
 	}
 
 	if req.CountTokensRequest != nil {
 		tmp := *req.CountTokensRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.CountTokensRequest = &tmp
 	}
 
 	if req.EmbeddingRequest != nil {
 		tmp := *req.EmbeddingRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.EmbeddingRequest = &tmp
 	}
 	if req.RerankRequest != nil {
 		tmp := *req.RerankRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.RerankRequest = &tmp
 	}
 
 	if req.SpeechRequest != nil {
 		tmp := *req.SpeechRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.SpeechRequest = &tmp
 	}
 
 	if req.TranscriptionRequest != nil {
 		tmp := *req.TranscriptionRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.TranscriptionRequest = &tmp
 	}
 	if req.ImageGenerationRequest != nil {
 		tmp := *req.ImageGenerationRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.ImageGenerationRequest = &tmp
+	}
+	if req.ImageEditRequest != nil {
+		tmp := *req.ImageEditRequest
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
+		fallbackReq.ImageEditRequest = &tmp
+	}
+	if req.ImageVariationRequest != nil {
+		tmp := *req.ImageVariationRequest
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
+		fallbackReq.ImageVariationRequest = &tmp
 	}
 	if req.VideoGenerationRequest != nil {
 		tmp := *req.VideoGenerationRequest
-		tmp.Provider = fallback.Provider
-		tmp.Model = fallback.Model
+		setFallbackTarget(&tmp.Provider, &tmp.Model)
+		if tmp.Params != nil {
+			paramsCopy := *tmp.Params
+			paramsCopy.ExtraParams = cloneExtraParamsIfPreserved(paramsCopy.ExtraParams, preserveExtraParams)
+			tmp.Params = &paramsCopy
+		}
 		fallbackReq.VideoGenerationRequest = &tmp
 	}
 	return &fallbackReq
+}
+
+func (bifrost *Bifrost) shouldPreserveExtraParamsForFallback(sourceProvider, fallbackProvider schemas.ModelProvider) bool {
+	sourceBase := resolveProviderBaseType(bifrost.account, sourceProvider)
+	fallbackBase := resolveProviderBaseType(bifrost.account, fallbackProvider)
+
+	if sourceBase == fallbackBase {
+		return true
+	}
+
+	return isOpenAICompatiblePassthroughProvider(sourceBase) && isOpenAICompatiblePassthroughProvider(fallbackBase)
 }
 
 // shouldContinueWithFallbacks processes errors from fallback attempts

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -1171,3 +1171,150 @@ func TestUpdateProvider_ProviderSliceIntegrity(t *testing.T) {
 	})
 }
 
+func TestPrepareFallbackRequest_ExtraParamsCompatibility(t *testing.T) {
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 5, 1000)
+	account.AddProvider(schemas.Anthropic, 3, 500)
+	account.AddProvider(schemas.VLLM, 5, 1000)
+	customOpenAIProvider := schemas.ModelProvider("openai-custom")
+	account.AddProvider(customOpenAIProvider, 5, 1000)
+	account.configs[customOpenAIProvider].CustomProviderConfig = &schemas.CustomProviderConfig{
+		BaseProviderType: schemas.OpenAI,
+	}
+
+	ctx := context.Background()
+	b, err := Init(ctx, schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	extraParams := map[string]interface{}{
+		"guided_json": map[string]interface{}{"type": "object"},
+		"min_tokens":  10,
+	}
+
+	t.Run("preserves extra params for openai-compatible fallback", func(t *testing.T) {
+		req := &schemas.BifrostRequest{
+			ChatRequest: &schemas.BifrostChatRequest{
+				Provider: schemas.OpenAI,
+				Model:    "gpt-4",
+				Params: &schemas.ChatParameters{
+					ExtraParams: extraParams,
+				},
+			},
+		}
+
+		fallbackReq := b.prepareFallbackRequest(req, schemas.Fallback{
+			Provider: schemas.VLLM,
+			Model:    "meta-llama/Llama-3-8b",
+		})
+		if fallbackReq == nil {
+			t.Fatal("prepareFallbackRequest returned nil")
+		}
+		if fallbackReq.ChatRequest.Params == nil {
+			t.Fatal("fallback chat params should not be nil")
+		}
+		if fallbackReq.ChatRequest.Params.ExtraParams == nil {
+			t.Fatal("fallback chat extra params should be preserved")
+		}
+		if fallbackReq.ChatRequest.Params.ExtraParams["min_tokens"] != 10 {
+			t.Fatalf("expected preserved extra params, got %v", fallbackReq.ChatRequest.Params.ExtraParams)
+		}
+
+		fallbackGuidedJSON, ok := fallbackReq.ChatRequest.Params.ExtraParams["guided_json"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected guided_json map, got %T", fallbackReq.ChatRequest.Params.ExtraParams["guided_json"])
+		}
+		fallbackGuidedJSON["type"] = "array"
+		if originalGuidedJSON, ok := req.ChatRequest.Params.ExtraParams["guided_json"].(map[string]interface{}); !ok || originalGuidedJSON["type"] != "object" {
+			t.Fatalf("original extra params should remain isolated, got %v", req.ChatRequest.Params.ExtraParams["guided_json"])
+		}
+	})
+
+	t.Run("preserves extra params for custom providers with openai base", func(t *testing.T) {
+		req := &schemas.BifrostRequest{
+			ResponsesRequest: &schemas.BifrostResponsesRequest{
+				Provider: customOpenAIProvider,
+				Model:    "gpt-4o-mini",
+				Params: &schemas.ResponsesParameters{
+					ExtraParams: extraParams,
+				},
+			},
+		}
+
+		fallbackReq := b.prepareFallbackRequest(req, schemas.Fallback{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4.1-mini",
+		})
+		if fallbackReq == nil {
+			t.Fatal("prepareFallbackRequest returned nil")
+		}
+		if fallbackReq.ResponsesRequest.Params == nil || fallbackReq.ResponsesRequest.Params.ExtraParams == nil {
+			t.Fatal("fallback responses extra params should be preserved")
+		}
+		if fallbackReq.ResponsesRequest.Params.ExtraParams["min_tokens"] != 10 {
+			t.Fatalf("expected preserved extra params, got %v", fallbackReq.ResponsesRequest.Params.ExtraParams)
+		}
+	})
+
+	t.Run("strips extra params for incompatible fallback", func(t *testing.T) {
+		req := &schemas.BifrostRequest{
+			EmbeddingRequest: &schemas.BifrostEmbeddingRequest{
+				Provider: schemas.OpenAI,
+				Model:    "text-embedding-3-small",
+				Params: &schemas.EmbeddingParameters{
+					ExtraParams: extraParams,
+				},
+			},
+		}
+
+		fallbackReq := b.prepareFallbackRequest(req, schemas.Fallback{
+			Provider: schemas.Anthropic,
+			Model:    "claude-3-haiku",
+		})
+		if fallbackReq == nil {
+			t.Fatal("prepareFallbackRequest returned nil")
+		}
+		if fallbackReq.EmbeddingRequest.Params == nil {
+			t.Fatal("fallback embedding params should not be nil")
+		}
+		if fallbackReq.EmbeddingRequest.Params.ExtraParams != nil {
+			t.Fatalf("expected incompatible fallback to strip extra params, got %v", fallbackReq.EmbeddingRequest.Params.ExtraParams)
+		}
+		if req.EmbeddingRequest.Params.ExtraParams == nil {
+			t.Fatal("original embedding request should not be mutated")
+		}
+	})
+
+	t.Run("preserves video generation extra params for openai-compatible fallback", func(t *testing.T) {
+		req := &schemas.BifrostRequest{
+			VideoGenerationRequest: &schemas.BifrostVideoGenerationRequest{
+				Provider: schemas.OpenAI,
+				Model:    "sora-2",
+				Input: &schemas.VideoGenerationInput{
+					Prompt: "generate a city flythrough",
+				},
+				Params: &schemas.VideoGenerationParameters{
+					ExtraParams: extraParams,
+				},
+			},
+		}
+
+		fallbackReq := b.prepareFallbackRequest(req, schemas.Fallback{
+			Provider: schemas.VLLM,
+			Model:    "sora-compatible",
+		})
+		if fallbackReq == nil {
+			t.Fatal("prepareFallbackRequest returned nil")
+		}
+		if fallbackReq.VideoGenerationRequest.Params == nil || fallbackReq.VideoGenerationRequest.Params.ExtraParams == nil {
+			t.Fatal("video generation extra params should be preserved for compatible fallback")
+		}
+		if fallbackReq.VideoGenerationRequest.Params.ExtraParams["min_tokens"] != 10 {
+			t.Fatalf("expected preserved video extra params, got %v", fallbackReq.VideoGenerationRequest.Params.ExtraParams)
+		}
+	})
+}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -860,6 +860,12 @@ func (req *OpenAIVideoGenerationRequest) GetExtraParams() map[string]interface{}
 	return req.ExtraParams
 }
 
+// SetExtraParams implements RequestWithSettableExtraParams.
+func (req *OpenAIVideoGenerationRequest) SetExtraParams(params map[string]interface{}) {
+	req.ExtraParams = params
+	req.VideoGenerationParameters.ExtraParams = params
+}
+
 // OpenAIVideoRemixRequest represents an OpenAI video remix request
 type OpenAIVideoRemixRequest struct {
 	Prompt string `json:"prompt"`
@@ -874,6 +880,11 @@ type OpenAIVideoRemixRequest struct {
 // GetExtraParams implements the ExtraParamsGetter interface
 func (r *OpenAIVideoRemixRequest) GetExtraParams() map[string]interface{} {
 	return r.ExtraParams
+}
+
+// SetExtraParams implements RequestWithSettableExtraParams.
+func (r *OpenAIVideoRemixRequest) SetExtraParams(params map[string]interface{}) {
+	r.ExtraParams = params
 }
 
 // ErrVideoNotReady is an error that is returned when a video is not ready yet

--- a/core/providers/openai/types_test.go
+++ b/core/providers/openai/types_test.go
@@ -1,9 +1,11 @@
 package openai
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -330,6 +332,78 @@ func TestOpenAIChatRequest_UnmarshalJSON_ChatParametersCustomLogic(t *testing.T)
 	}
 }
 
+func TestOpenAIVideoRemixRequest_PreservesExtraParams(t *testing.T) {
+	extraParams := map[string]interface{}{
+		"guided_json": map[string]interface{}{"type": "object"},
+		"min_tokens":  10,
+	}
+
+	req, err := ToOpenAIVideoRemixRequest(&schemas.BifrostVideoRemixRequest{
+		ID:          "video_123",
+		Provider:    schemas.OpenAI,
+		ExtraParams: extraParams,
+		Input: &schemas.VideoGenerationInput{
+			Prompt: "add dramatic lighting",
+		},
+	})
+	if err != nil {
+		t.Fatalf("ToOpenAIVideoRemixRequest returned error: %v", err)
+	}
+
+	if req.ExtraParams == nil {
+		t.Fatal("expected extra params to be preserved on the OpenAI remix request")
+	}
+	if req.ExtraParams["min_tokens"] != 10 {
+		t.Fatalf("expected min_tokens to be preserved, got %v", req.ExtraParams["min_tokens"])
+	}
+}
+
+func TestOpenAIVideoRemixRequestBodyIncludesPassthroughExtraParams(t *testing.T) {
+	extraParams := map[string]interface{}{
+		"guided_json": map[string]interface{}{"type": "object"},
+		"min_tokens":  10,
+	}
+	request := &schemas.BifrostVideoRemixRequest{
+		ID:          "video_123",
+		Provider:    schemas.OpenAI,
+		ExtraParams: extraParams,
+		Input: &schemas.VideoGenerationInput{
+			Prompt: "add dramatic lighting",
+		},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+
+	jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		request,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIVideoRemixRequest(request)
+		},
+		schemas.OpenAI,
+	)
+	if bifrostErr != nil {
+		t.Fatalf("CheckContextAndGetRequestBody returned error: %v", bifrostErr)
+	}
+
+	var body map[string]interface{}
+	if err := sonic.Unmarshal(jsonBody, &body); err != nil {
+		t.Fatalf("failed to parse generated request body: %v", err)
+	}
+
+	guidedJSON, ok := body["guided_json"].(map[string]interface{})
+	if !ok || guidedJSON["type"] != "object" {
+		t.Fatalf("expected guided_json passthrough field in request body, got %#v", body["guided_json"])
+	}
+	if body["min_tokens"] != float64(10) {
+		t.Fatalf("expected min_tokens passthrough field in request body, got %#v", body["min_tokens"])
+	}
+	if body["prompt"] != "add dramatic lighting" {
+		t.Fatalf("expected prompt in request body, got %#v", body["prompt"])
+	}
+}
+
 func TestOpenAIChatRequest_UnmarshalJSON_PresenceAssertions(t *testing.T) {
 	// Test that verifies presence of fields (not just values)
 	jsonPayload := `{
@@ -460,4 +534,3 @@ func TestOpenAIChatRequest_UnmarshalJSON_ValueAssertions(t *testing.T) {
 		t.Errorf("Expected Stop value ['END', 'STOP'], got %v", req.Stop)
 	}
 }
-

--- a/core/providers/openai/videos.go
+++ b/core/providers/openai/videos.go
@@ -71,7 +71,8 @@ func ToOpenAIVideoRemixRequest(bifrostReq *schemas.BifrostVideoRemixRequest) (*O
 	}
 
 	req := &OpenAIVideoRemixRequest{
-		Prompt: bifrostReq.Input.Prompt,
+		Prompt:      bifrostReq.Input.Prompt,
+		ExtraParams: bifrostReq.ExtraParams,
 	}
 
 	return req, nil
@@ -88,8 +89,9 @@ func ToBifrostVideoRemixRequest(openaiReq *OpenAIVideoRemixRequest) *schemas.Bif
 	}
 
 	return &schemas.BifrostVideoRemixRequest{
-		ID:       openaiReq.ID,
-		Provider: provider,
+		ID:          openaiReq.ID,
+		Provider:    provider,
+		ExtraParams: openaiReq.ExtraParams,
 		Input: &schemas.VideoGenerationInput{
 			Prompt: openaiReq.Prompt,
 		},

--- a/core/utils.go
+++ b/core/utils.go
@@ -229,6 +229,66 @@ func IsKeylessProvider(providerKey schemas.ModelProvider) bool {
 	return providerKey == schemas.Ollama || providerKey == schemas.SGL
 }
 
+// isOpenAICompatiblePassthroughProvider reports whether a provider uses the
+// OpenAI-compatible request/body family for passthrough fallback purposes.
+func isOpenAICompatiblePassthroughProvider(providerKey schemas.ModelProvider) bool {
+	switch providerKey {
+	case schemas.OpenAI,
+		schemas.Azure,
+		schemas.Cerebras,
+		schemas.Groq,
+		schemas.Nebius,
+		schemas.Ollama,
+		schemas.OpenRouter,
+		schemas.Parasail,
+		schemas.Perplexity,
+		schemas.SGL,
+		schemas.VLLM,
+		schemas.XAI:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveProviderBaseType(account schemas.Account, provider schemas.ModelProvider) schemas.ModelProvider {
+	config, err := account.GetConfigForProvider(provider)
+	if err != nil || config == nil || config.CustomProviderConfig == nil || config.CustomProviderConfig.BaseProviderType == "" {
+		return provider
+	}
+	return config.CustomProviderConfig.BaseProviderType
+}
+
+func cloneExtraParamsIfPreserved(params map[string]interface{}, preserve bool) map[string]interface{} {
+	if !preserve || len(params) == 0 {
+		return nil
+	}
+	return cloneExtraParamsMap(params)
+}
+
+func cloneExtraParamsMap(params map[string]interface{}) map[string]interface{} {
+	cloned := make(map[string]interface{}, len(params))
+	for key, value := range params {
+		cloned[key] = cloneExtraParamsAny(value)
+	}
+	return cloned
+}
+
+func cloneExtraParamsAny(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		return cloneExtraParamsMap(typed)
+	case []interface{}:
+		cloned := make([]interface{}, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneExtraParamsAny(item)
+		}
+		return cloned
+	default:
+		return typed
+	}
+}
+
 // IsStreamRequestType returns true if the given request type is a stream request.
 func IsStreamRequestType(reqType schemas.RequestType) bool {
 	return reqType == schemas.TextCompletionStreamRequest || reqType == schemas.ChatCompletionStreamRequest || reqType == schemas.ResponsesStreamRequest || reqType == schemas.SpeechStreamRequest || reqType == schemas.TranscriptionStreamRequest || reqType == schemas.ImageGenerationStreamRequest || reqType == schemas.ImageEditStreamRequest || reqType == schemas.PassthroughStreamRequest || reqType == schemas.WebSocketResponsesRequest || reqType == schemas.RealtimeRequest

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -50,12 +50,15 @@ package integrations
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
+	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
 	"github.com/bytedance/sonic"
@@ -592,6 +595,142 @@ func (g *GenericRouter) RegisterRoutes(r *router.Router, middlewares ...schemas.
 	}
 }
 
+// extraBodyBlocklist contains Bifrost control fields that must be filtered out
+// when extracting extra_body parameters. These fields are used for routing and
+// fallback configuration and should not be forwarded to downstream providers.
+// If a new Bifrost control field is added to the SDK compat request types,
+// it must also be added here.
+var extraBodyBlocklist = map[string]struct{}{
+	"provider":     {},
+	"fallbacks":    {},
+	"extra_params": {},
+	"extra_body":   {},
+}
+
+var sdkCompatCanonicalFieldCache sync.Map
+
+func extractSDKPassthroughParams(rawBody []byte, req interface{}) (map[string]interface{}, error, error) {
+	if len(rawBody) == 0 {
+		return nil, nil, nil
+	}
+
+	var root map[string]json.RawMessage
+	if err := sonic.Unmarshal(rawBody, &root); err != nil {
+		return nil, err, err
+	}
+
+	merged := make(map[string]interface{})
+	canonicalFields := sdkCompatCanonicalJSONFields(req)
+
+	extraBody, extraBodyErr := extractJSONObjectField(root, "extra_body")
+	for key, value := range extraBody {
+		if _, blocked := extraBodyBlocklist[key]; blocked {
+			continue
+		}
+		if _, canonical := canonicalFields[key]; canonical {
+			continue
+		}
+		merged[key] = value
+	}
+
+	extraParams, extraParamsErr := extractJSONObjectField(root, "extra_params")
+	for key, value := range extraParams {
+		if _, blocked := extraBodyBlocklist[key]; blocked {
+			continue
+		}
+		if _, canonical := canonicalFields[key]; canonical {
+			continue
+		}
+		merged[key] = value
+	}
+
+	if len(merged) == 0 {
+		return nil, extraBodyErr, extraParamsErr
+	}
+	return merged, extraBodyErr, extraParamsErr
+}
+
+func extractJSONObjectField(root map[string]json.RawMessage, field string) (map[string]interface{}, error) {
+	raw, ok := root[field]
+	if !ok || len(bytes.TrimSpace(raw)) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, nil
+	}
+
+	var value map[string]interface{}
+	if err := sonic.Unmarshal(raw, &value); err != nil {
+		return nil, err
+	}
+	if len(value) == 0 {
+		return nil, nil
+	}
+	return value, nil
+}
+
+func sdkCompatCanonicalJSONFields(req interface{}) map[string]struct{} {
+	reqType := reflect.TypeOf(req)
+	if reqType == nil {
+		return extraBodyBlocklist
+	}
+	if cached, ok := sdkCompatCanonicalFieldCache.Load(reqType); ok {
+		return cached.(map[string]struct{})
+	}
+
+	fields := make(map[string]struct{}, len(extraBodyBlocklist)+8)
+	for key := range extraBodyBlocklist {
+		fields[key] = struct{}{}
+	}
+	collectSDKCompatJSONFields(reqType, fields, make(map[reflect.Type]struct{}))
+	sdkCompatCanonicalFieldCache.Store(reqType, fields)
+	return fields
+}
+
+func collectSDKCompatJSONFields(reqType reflect.Type, fields map[string]struct{}, visited map[reflect.Type]struct{}) {
+	for reqType != nil && reqType.Kind() == reflect.Pointer {
+		reqType = reqType.Elem()
+	}
+	if reqType == nil || reqType.Kind() != reflect.Struct {
+		return
+	}
+	if _, ok := visited[reqType]; ok {
+		return
+	}
+	visited[reqType] = struct{}{}
+
+	for i := 0; i < reqType.NumField(); i++ {
+		field := reqType.Field(i)
+		if field.Anonymous {
+			collectSDKCompatJSONFields(field.Type, fields, visited)
+			continue
+		}
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonName := jsonFieldName(field)
+		if jsonName == "" {
+			continue
+		}
+		fields[jsonName] = struct{}{}
+	}
+}
+
+func jsonFieldName(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "-" {
+		return ""
+	}
+	if tag == "" {
+		return field.Name
+	}
+	if commaIdx := strings.Index(tag, ","); commaIdx >= 0 {
+		tag = tag[:commaIdx]
+	}
+	if tag == "" {
+		return field.Name
+	}
+	return tag
+}
+
 // createHandler creates a fasthttp handler for the given route configuration.
 // The handler follows this flow:
 // 1. Parse JSON request body into the configured request type (for methods that expect bodies)
@@ -663,10 +802,13 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 				}
 			}
 
-			// Extract the "extra_params" JSON key when passthrough is
+			// Extract "extra_params" and "extra_body" JSON keys when passthrough is
 			// explicitly enabled via x-bf-passthrough-extra-params: true.
-			// Provider-specific fields (e.g. Bedrock guardrailConfig)
-			// must be nested under "extra_params" in the request body.
+			// Provider-specific fields can be nested under "extra_params" or passed
+			// via "extra_body" (SDK compat). Both are filtered against the route's
+			// canonical request fields so they cannot override parsed inputs.
+			// extra_body fields are merged first, then extra_params overwrites on
+			// conflict for the remaining passthrough keys.
 			// Runs after both RequestParser and default JSON paths.
 			if !isLargePayload && bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
 				if rws, ok := req.(RequestWithSettableExtraParams); ok {
@@ -674,11 +816,15 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 						rawBody = ctx.Request.Body()
 					}
 					if len(rawBody) > 0 {
-						var wrapper struct {
-							ExtraParams map[string]interface{} `json:"extra_params"`
+						merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+						if extraBodyErr != nil {
+							g.logger.Warn("failed to parse extra_body passthrough params for route %s: %v", config.Path, extraBodyErr)
 						}
-						if err := sonic.Unmarshal(rawBody, &wrapper); err == nil && len(wrapper.ExtraParams) > 0 {
-							rws.SetExtraParams(wrapper.ExtraParams)
+						if extraParamsErr != nil {
+							g.logger.Warn("failed to parse extra_params passthrough params for route %s: %v", config.Path, extraParamsErr)
+						}
+						if len(merged) > 0 {
+							rws.SetExtraParams(merged)
 						}
 					}
 				}

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
 )
 
 func TestRequestWithSettableExtraParams_OpenAIChatRequest(t *testing.T) {
@@ -67,6 +68,8 @@ func TestRequestWithSettableExtraParams_AllOpenAIRequestTypes(t *testing.T) {
 		{"OpenAIImageGenerationRequest", &openai.OpenAIImageGenerationRequest{}},
 		{"OpenAIImageEditRequest", &openai.OpenAIImageEditRequest{}},
 		{"OpenAIImageVariationRequest", &openai.OpenAIImageVariationRequest{}},
+		{"OpenAIVideoGenerationRequest", &openai.OpenAIVideoGenerationRequest{}},
+		{"OpenAIVideoRemixRequest", &openai.OpenAIVideoRemixRequest{}},
 	}
 
 	for _, tt := range tests {
@@ -82,6 +85,18 @@ func TestRequestWithSettableExtraParams_AllOpenAIRequestTypes(t *testing.T) {
 			assert.Equal(t, extra, getter.GetExtraParams())
 		})
 	}
+}
+
+func TestRequestWithSettableExtraParams_OpenAIVideoGenerationRequest(t *testing.T) {
+	req := &openai.OpenAIVideoGenerationRequest{}
+	extra := map[string]interface{}{"guided_json": map[string]interface{}{"type": "object"}}
+
+	rws, ok := interface{}(req).(RequestWithSettableExtraParams)
+	require.True(t, ok, "OpenAIVideoGenerationRequest should implement RequestWithSettableExtraParams")
+	rws.SetExtraParams(extra)
+
+	assert.Equal(t, extra, req.GetExtraParams())
+	assert.Equal(t, extra, req.VideoGenerationParameters.ExtraParams)
 }
 
 func TestExtraParamsRequiresPassthroughHeader(t *testing.T) {
@@ -286,6 +301,280 @@ func TestExtraParamsPassthrough_NoExtraParamsKey(t *testing.T) {
 
 	assert.Empty(t, req.ChatParameters.ExtraParams,
 		"ExtraParams should be empty when extra_params key is absent from JSON")
+}
+
+func TestExtraBodyPassthrough(t *testing.T) {
+	t.Run("extra_body fields propagate to ExtraParams with passthrough enabled", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"extra_body": {
+				"guided_json": {"type": "object"},
+				"min_tokens": 10
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+		require.NoError(t, extraBodyErr)
+		require.NoError(t, extraParamsErr)
+		interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+		require.Contains(t, req.ChatParameters.ExtraParams, "guided_json")
+		require.Contains(t, req.ChatParameters.ExtraParams, "min_tokens")
+		assert.Equal(t, float64(10), req.ChatParameters.ExtraParams["min_tokens"])
+	})
+
+	t.Run("extra_body control fields are filtered out", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"extra_body": {
+				"provider": "should-be-filtered",
+				"fallbacks": ["also-filtered"],
+				"extra_params": {"nested": true},
+				"guided_json": {"type": "object"}
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+		require.NoError(t, extraBodyErr)
+		require.NoError(t, extraParamsErr)
+		interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "provider")
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "fallbacks")
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "extra_params")
+		assert.Contains(t, req.ChatParameters.ExtraParams, "guided_json")
+	})
+
+	t.Run("extra_body cannot override canonical request fields", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"extra_body": {
+				"model": "should-not-pass-through",
+				"messages": [{"role": "system", "content": [{"type": "text", "text": "override"}]}],
+				"stream": true,
+				"guided_json": {"type": "object"}
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+		require.NoError(t, extraBodyErr)
+		require.NoError(t, extraParamsErr)
+		interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "model")
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "messages")
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "stream")
+		assert.Contains(t, req.ChatParameters.ExtraParams, "guided_json")
+	})
+
+	t.Run("extra_params cannot override canonical request fields", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"stream": false,
+			"extra_params": {
+				"model": "should-not-pass-through",
+				"messages": [{"role": "system", "content": [{"type": "text", "text": "override"}]}],
+				"stream": true,
+				"guided_json": {"type": "object"}
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+		require.NoError(t, extraBodyErr)
+		require.NoError(t, extraParamsErr)
+		interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "model")
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "messages")
+		assert.NotContains(t, req.ChatParameters.ExtraParams, "stream")
+		assert.Contains(t, req.ChatParameters.ExtraParams, "guided_json")
+	})
+
+	t.Run("extra_params takes precedence over extra_body for non-canonical keys", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"extra_body": {
+				"guided_json": {"from": "extra_body"},
+				"min_tokens": 5
+			},
+			"extra_params": {
+				"guided_json": {"from": "extra_params"}
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+		require.NoError(t, extraBodyErr)
+		require.NoError(t, extraParamsErr)
+		interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+		// extra_params should win
+		gj, ok := req.ChatParameters.ExtraParams["guided_json"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "extra_params", gj["from"])
+		// extra_body-only field should still be present
+		assert.Equal(t, float64(5), req.ChatParameters.ExtraParams["min_tokens"])
+	})
+
+	t.Run("extra_body without passthrough header does nothing", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"extra_body": {
+				"guided_json": {"type": "object"}
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		// Header not set -- simulate router logic
+		if bifrostCtx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+			merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+			require.NoError(t, extraBodyErr)
+			require.NoError(t, extraParamsErr)
+			interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+		}
+
+		assert.Empty(t, req.ChatParameters.ExtraParams,
+			"ExtraParams should be empty when passthrough header is not set")
+	})
+
+	t.Run("malformed extra_body does not block valid extra_params", func(t *testing.T) {
+		rawBody := []byte(`{
+			"model": "vllm/meta-llama/Llama-3-8b",
+			"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+			"extra_body": "not-an-object",
+			"extra_params": {
+				"guided_json": {"type": "object"}
+			}
+		}`)
+
+		req := &openai.OpenAIChatRequest{}
+		err := sonic.Unmarshal(rawBody, req)
+		require.NoError(t, err)
+
+		merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+		require.Error(t, extraBodyErr)
+		require.NoError(t, extraParamsErr)
+		interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+		assert.Contains(t, req.ChatParameters.ExtraParams, "guided_json")
+	})
+}
+
+func TestExtraBodyPropagatesThroughChatRouteRequestConverter(t *testing.T) {
+	handlerStore := &mockHandlerStore{allowDirectKeys: true}
+	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
+
+	var chatRoute *RouteConfig
+	for i := range routes {
+		if routes[i].Path == "/openai/v1/chat/completions" {
+			chatRoute = &routes[i]
+			break
+		}
+	}
+	require.NotNil(t, chatRoute, "should find /openai/v1/chat/completions route")
+
+	rawBody := []byte(`{
+		"model": "openai/gpt-4o-mini",
+		"messages": [{"role": "user", "content": [{"type": "text", "text": "hello"}]}],
+		"extra_body": {
+			"guided_json": {"type": "object"},
+			"model": "should-not-pass-through"
+		}
+	}`)
+
+	req := chatRoute.GetRequestTypeInstance(context.Background())
+	err := sonic.Unmarshal(rawBody, req)
+	require.NoError(t, err)
+
+	merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+	require.NoError(t, extraBodyErr)
+	require.NoError(t, extraParamsErr)
+	interface{}(req).(RequestWithSettableExtraParams).SetExtraParams(merged)
+
+	bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	bifrostReq, err := chatRoute.RequestConverter(bifrostCtx, req)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq)
+	require.NotNil(t, bifrostReq.ChatRequest)
+	require.NotNil(t, bifrostReq.ChatRequest.Params)
+	assert.Contains(t, bifrostReq.ChatRequest.Params.ExtraParams, "guided_json")
+	assert.NotContains(t, bifrostReq.ChatRequest.Params.ExtraParams, "model")
+}
+
+func TestExtraBodyPropagatesThroughVideoRemixRouteRequestConverter(t *testing.T) {
+	handlerStore := &mockHandlerStore{allowDirectKeys: true}
+	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
+
+	var remixRoute *RouteConfig
+	for i := range routes {
+		if routes[i].Path == "/openai/v1/videos/{video_id}/remix" {
+			remixRoute = &routes[i]
+			break
+		}
+	}
+	require.NotNil(t, remixRoute, "should find /openai/v1/videos/{video_id}/remix route")
+
+	rawBody := []byte(`{
+		"prompt": "add dramatic lighting",
+		"extra_body": {
+			"guided_json": {"type": "object"}
+		}
+	}`)
+
+	req := remixRoute.GetRequestTypeInstance(context.Background())
+	err := sonic.Unmarshal(rawBody, req)
+	require.NoError(t, err)
+
+	merged, extraBodyErr, extraParamsErr := extractSDKPassthroughParams(rawBody, req)
+	require.NoError(t, extraBodyErr)
+	require.NoError(t, extraParamsErr)
+
+	rws, ok := req.(RequestWithSettableExtraParams)
+	require.True(t, ok, "video remix request should implement RequestWithSettableExtraParams")
+	rws.SetExtraParams(merged)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("video_id", "video_123:openai")
+	bifrostCtx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+	err = remixRoute.PreCallback(ctx, bifrostCtx, req)
+	require.NoError(t, err)
+
+	bifrostReq, err := remixRoute.RequestConverter(bifrostCtx, req)
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq)
+	require.NotNil(t, bifrostReq.VideoRemixRequest)
+	assert.Equal(t, schemas.OpenAI, bifrostReq.VideoRemixRequest.Provider)
+	assert.Equal(t, "video_123", bifrostReq.VideoRemixRequest.ID)
+	assert.Contains(t, bifrostReq.VideoRemixRequest.ExtraParams, "guided_json")
 }
 
 // TestExtraParamsSetViaInterfaceMutatesOriginalReq verifies that setting extra


### PR DESCRIPTION
### Summary

Adds `extra_body` / `extra_params` passthrough support for OpenAI-compatible requests, preserves passthrough params across compatible fallbacks, and fixes video remix passthrough propagation.

### Changes

- Preserve `ExtraParams` on fallback when the source and fallback providers are compatible
- Deep-clone preserved `ExtraParams` so fallback requests cannot mutate the original request
- Add SDK-compatible `extra_body` passthrough alongside `extra_params`
- Filter control fields and canonical request fields so passthrough data cannot override parsed request fields
- Add `SetExtraParams` support for video generation and video remix requests
- Fix OpenAI video remix request conversion so passthrough params survive provider serialization

### Type of Change

- [x] Feature
- [x] Bug fix

### Affected Areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

### How to Test
```sh
cd core && go test
cd core && go test ./providers/openai ./providers/utils
cd transports && go test ./...
```

**Key coverage:**
- Fallback preservation for compatible providers
- Stripping on incompatible fallbacks
- `extra_body` / `extra_params` passthrough extraction and filtering
- Video remix passthrough propagation

### Breaking Changes

- [x] No

### Security Considerations

Passthrough filtering blocks control fields and canonical request fields from being overridden through `extra_body` or `extra_params`.

### Related Issues

Closes #2092

### Checklist

- [x] Read `docs/contributing/README.md` and followed the guidelines
- [x] Added/updated tests where appropriate
- [ ] Updated documentation where needed
- [x] Verified builds succeed (Go and UI)
- [x] Verified the CI pipeline passes locally if applicable