### PR TITLE
fix: add support for x-bf-mcp-include-clients and x-bf-mcp-include-tools headers in MCP gateway

### DIFF
--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -29,7 +29,7 @@ Bifrost provides request options that control behavior, enable features, and pas
 | `semanticcache.CacheTypeKey` | `x-bf-cache-type` | `string` | Cache type |
 | `semanticcache.CacheNoStoreKey` | `x-bf-cache-no-store` | `bool` | Prevent caching |
 | `mcp-include-clients` | `x-bf-mcp-include-clients` | `[]string` | Filter MCP clients (comma-separated). |
-| `mcp-include-tools` | `x-bf-mcp-include-tools` | `[]string` | Filter MCP tools (comma-separated) |
+| `mcp-include-tools` | `x-bf-mcp-include-tools` | `[]string` | Filter MCP tools (`clientName-toolName` format, comma-separated) |
 | `maxim.TraceIDKey` | `x-bf-maxim-trace-id` | `string` | Maxim trace ID |
 | `maxim.GenerationIDKey` | `x-bf-maxim-generation-id` | `string` | Maxim generation ID |
 | `maxim.TagsKey` | `x-bf-maxim-*` | `map[string]string` | Maxim tags (custom tag names) |
@@ -742,18 +742,18 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 
 ### Include Tools
 
-**Context Key:** `mcp-include-tools`  
-**Header:** `x-bf-mcp-include-tools`  
-**Type:** `[]string` (comma-separated values)  
+**Context Key:** `mcp-include-tools`
+**Header:** `x-bf-mcp-include-tools`
+**Type:** `[]string` (comma-separated values)
 **Required:** No
 
-Filter MCP tools to include only the specified ones.
+Filter MCP tools to include only the specified ones. Values must use the `clientName-toolName` format (e.g. `gmail-send_email`). Use `clientName-*` to include all tools from a client.
 
 <Tabs>
 <Tab title="Gateway (cURL)">
 ```bash
 curl --location 'http://localhost:8080/v1/chat/completions' \
---header 'x-bf-mcp-include-tools: tool1,tool2' \
+--header 'x-bf-mcp-include-tools: gmail-send_email,filesystem-read_file' \
 --header 'Content-Type: application/json' \
 --data '{
     "model": "openai/gpt-4o-mini",
@@ -764,7 +764,7 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
 <Tab title="Go SDK">
 ```go
 ctx := context.Background()
-ctx = context.WithValue(ctx, schemas.BifrostContextKey("mcp-include-tools"), []string{"tool1", "tool2"})
+ctx = context.WithValue(ctx, schemas.BifrostContextKey("mcp-include-tools"), []string{"gmail-send_email", "filesystem-read_file"})
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
     Provider: schemas.OpenAI,

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -61,6 +61,9 @@ func NewMCPServerHandler(ctx context.Context, config *lib.Config, toolManager MC
 		vkMCPServers:    make(map[string]*server.MCPServer),
 	}
 
+	// Register per-request tool filter so x-bf-mcp-include-clients and x-bf-mcp-include-tools are respected on tools/list
+	server.WithToolFilter(handler.makeIncludeClientsFilter())(handler.globalMCPServer)
+
 	if err := handler.SyncAllMCPServers(ctx); err != nil {
 		return nil, fmt.Errorf("failed to sync all MCP servers: %w", err)
 	}
@@ -171,11 +174,13 @@ func (h *MCPServerHandler) SyncAllMCPServers(ctx context.Context) error {
 		h.vkMCPServers = make(map[string]*server.MCPServer)
 		for i := range virtualKeys {
 			vk := &virtualKeys[i]
-			h.vkMCPServers[vk.Value] = server.NewMCPServer(
+			vkServer := server.NewMCPServer(
 				vk.Name,
 				version,
 				server.WithToolCapabilities(true),
 			)
+			server.WithToolFilter(h.makeIncludeClientsFilter())(vkServer)
+			h.vkMCPServers[vk.Value] = vkServer
 			availableTools, toolFilter := h.fetchToolsForVK(vk)
 			h.syncServer(h.vkMCPServers[vk.Value], availableTools, toolFilter)
 			logger.Debug("Synced MCP server for virtual key '%s' with %d tools", vk.Name, len(availableTools))
@@ -195,6 +200,7 @@ func (h *MCPServerHandler) SyncVKMCPServer(vk *tables.TableVirtualKey) {
 			version,
 			server.WithToolCapabilities(true),
 		)
+		server.WithToolFilter(h.makeIncludeClientsFilter())(vkServer)
 		h.vkMCPServers[vk.Value] = vkServer
 	}
 	availableTools, toolFilter := h.fetchToolsForVK(vk)
@@ -347,6 +353,31 @@ func (h *MCPServerHandler) fetchToolsForVK(vk *tables.TableVirtualKey) ([]schema
 	}
 
 	return h.toolManager.GetAvailableMCPTools(ctx), toolFilter
+}
+
+// makeIncludeClientsFilter returns a ToolFilterFunc that dynamically filters the tools/list
+// response based on the x-bf-mcp-include-clients and x-bf-mcp-include-tools request headers.
+// When neither header is present the filter is a no-op, preserving existing behaviour.
+func (h *MCPServerHandler) makeIncludeClientsFilter() server.ToolFilterFunc {
+	return func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		if ctx.Value(schemas.BifrostContextKey("mcp-include-clients")) == nil && ctx.Value(schemas.BifrostContextKey("mcp-include-tools")) == nil {
+			return tools
+		}
+		allowed := h.toolManager.GetAvailableMCPTools(ctx)
+		allowedNames := make(map[string]bool, len(allowed))
+		for _, t := range allowed {
+			if t.Function != nil {
+				allowedNames[t.Function.Name] = true
+			}
+		}
+		result := make([]mcp.Tool, 0, len(tools))
+		for _, tool := range tools {
+			if allowedNames[tool.Name] {
+				result = append(result, tool)
+			}
+		}
+		return result
+	}
 }
 
 // Utility methods

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: add support for `x-bf-mcp-include-clients` and `x-bf-mcp-include-tools` request headers to filter MCP tools/list response when using bifrost as an MCP gateway.


### PR DESCRIPTION
## Summary

Adds support for `x-bf-mcp-include-clients` and `x-bf-mcp-include-tools` request headers to filter MCP tools/list responses when using bifrost as an MCP gateway.

## Changes

- Implemented a dynamic tool filter function that respects the `x-bf-mcp-include-clients` and `x-bf-mcp-include-tools` headers
- Registered the tool filter on all MCP servers (global and virtual key servers) to ensure consistent filtering behavior
- Changed HTTP status code from 202 (Accepted) to 200 (OK) for MCP notification responses
- The filter preserves existing behavior when neither header is present, only filtering when headers are explicitly set

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

Test the MCP gateway functionality with the new headers:

```sh
# Test without headers (should return all tools)
curl -X POST http://localhost:8080/mcp \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'

# Test with include headers (should filter tools)
curl -X POST http://localhost:8080/mcp \
  -H "Content-Type: application/json" \
  -H "x-bf-mcp-include-clients: client1,client2" \
  -d '{"jsonrpc": "2.0", "id": 1, "method": "tools/list"}'

# Verify core functionality
go test ./transports/bifrost-http/handlers/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] No

The change is backward compatible - existing behavior is preserved when headers are not present.

## Related issues

N/A

## Security considerations

The filtering mechanism only restricts the tools returned in the response based on available tools from the tool manager, maintaining existing access control patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable