### PR TITLE
feat: add Bedrock invoke endpoint support for images and embeddings

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -900,7 +900,9 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx *schemas.BifrostContext, req *schem
 			},
 		}
 	}
-	if (req.Input == nil || (req.Input.Text == nil && req.Input.Texts == nil && req.Input.Embedding == nil && req.Input.Embeddings == nil)) && !isLargePayloadPassthrough(ctx) {
+	hasExtraInputs := req.Params != nil && req.Params.ExtraParams != nil &&
+		(req.Params.ExtraParams["inputs"] != nil || req.Params.ExtraParams["images"] != nil)
+	if (req.Input == nil || (req.Input.Text == nil && req.Input.Texts == nil && req.Input.Embedding == nil && req.Input.Embeddings == nil)) && !hasExtraInputs && !isLargePayloadPassthrough(ctx) {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -26,7 +26,6 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
-	"github.com/maximhq/bifrost/core/providers/cohere"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
@@ -1763,12 +1762,25 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		bifrostResponse.Model = request.Model
 
 	case "cohere":
-		var cohereResp cohere.CohereEmbeddingResponse
+		var cohereResp BedrockCohereEmbeddingResponse
 		if err := sonic.Unmarshal(rawResponse, &cohereResp); err != nil {
 			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", err, providerName), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		}
-		bifrostResponse = cohereResp.ToBifrostEmbeddingResponse()
+		converted, convErr := cohereResp.ToBifrostEmbeddingResponse()
+		if convErr != nil {
+			return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("error parsing Cohere embedding response", convErr, providerName), jsonData, rawResponse, provider.sendBackRawRequest, provider.sendBackRawResponse)
+		}
+		bifrostResponse = converted
 		bifrostResponse.Model = request.Model
+		// For embeddings_by_type responses preserve the raw Bedrock payload so the
+		// invoke-endpoint converter can return all encoding variants verbatim, since
+		// the internal BifrostEmbeddingResponse only has float32 and string fields.
+		if cohereResp.ResponseType == "embeddings_by_type" {
+			var rawResponseData interface{}
+			if err := sonic.Unmarshal(rawResponse, &rawResponseData); err == nil {
+				bifrostResponse.ExtraFields.RawResponse = rawResponseData
+			}
+		}
 	}
 
 	// Set ExtraFields

--- a/core/providers/bedrock/embedding.go
+++ b/core/providers/bedrock/embedding.go
@@ -1,10 +1,10 @@
 package bedrock
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/maximhq/bifrost/core/providers/cohere"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -19,11 +19,6 @@ func ToBedrockTitanEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest)
 		return nil, fmt.Errorf("no input text provided for embedding")
 	}
 
-	// Validate dimensions parameter - Titan models do not support it
-	if bifrostReq.Params != nil && bifrostReq.Params.Dimensions != nil {
-		return nil, fmt.Errorf("amazon Titan embedding models do not support custom dimensions parameter")
-	}
-
 	titanReq := &BedrockTitanEmbeddingRequest{}
 
 	// Set input text
@@ -36,8 +31,26 @@ func ToBedrockTitanEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest)
 		}
 		titanReq.InputText = embeddingText
 	}
+
 	if bifrostReq.Params != nil {
-		titanReq.ExtraParams = bifrostReq.Params.ExtraParams
+		titanReq.Dimensions = bifrostReq.Params.Dimensions
+		if normalize, ok := bifrostReq.Params.ExtraParams["normalize"]; ok {
+			if b, ok := normalize.(bool); ok {
+				titanReq.Normalize = &b
+			}
+		}
+		// Forward remaining extra params (excluding normalize which is now a first-class field)
+		if len(bifrostReq.Params.ExtraParams) > 0 {
+			extra := make(map[string]interface{})
+			for k, v := range bifrostReq.Params.ExtraParams {
+				if k != "normalize" {
+					extra[k] = v
+				}
+			}
+			if len(extra) > 0 {
+				titanReq.ExtraParams = extra
+			}
+		}
 	}
 
 	return titanReq, nil
@@ -69,20 +82,81 @@ func (response *BedrockTitanEmbeddingResponse) ToBifrostEmbeddingResponse() *sch
 	return bifrostResponse
 }
 
-// ToBedrockCohereEmbeddingRequest converts a Bifrost embedding request to Bedrock Cohere format
-// Reuses the Cohere converter since the format is identical
-func ToBedrockCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) (*cohere.CohereEmbeddingRequest, error) {
+// ToBedrockCohereEmbeddingRequest converts a Bifrost embedding request to Bedrock Cohere format.
+// Unlike the direct Cohere API, Bedrock does not accept a "model" field in the request body.
+func ToBedrockCohereEmbeddingRequest(bifrostReq *schemas.BifrostEmbeddingRequest) (*BedrockCohereEmbeddingRequest, error) {
 	if bifrostReq == nil {
 		return nil, fmt.Errorf("bifrost embedding request is nil")
 	}
-
-	// Reuse Cohere's converter - the format is identical for Bedrock
-	cohereReq := cohere.ToCohereEmbeddingRequest(bifrostReq)
-	if cohereReq == nil {
-		return nil, fmt.Errorf("failed to convert to Cohere embedding request")
+	if bifrostReq.Input == nil {
+		return nil, fmt.Errorf("no input provided for embedding")
 	}
 
-	return cohereReq, nil
+	req := &BedrockCohereEmbeddingRequest{}
+
+	// Map texts
+	if bifrostReq.Input.Text != nil {
+		req.Texts = []string{*bifrostReq.Input.Text}
+	} else if len(bifrostReq.Input.Texts) > 0 {
+		req.Texts = bifrostReq.Input.Texts
+	}
+
+	if bifrostReq.Params != nil {
+		extra := make(map[string]interface{}, len(bifrostReq.Params.ExtraParams))
+		for k, v := range bifrostReq.Params.ExtraParams {
+			extra[k] = v
+		}
+
+		if v, ok := extra["input_type"]; ok {
+			if s, ok := v.(string); ok {
+				req.InputType = s
+				delete(extra, "input_type")
+			}
+		}
+		if v, ok := extra["truncate"]; ok {
+			if s, ok := v.(string); ok {
+				req.Truncate = &s
+				delete(extra, "truncate")
+			}
+		}
+		if v, ok := extra["embedding_types"]; ok {
+			if ss, ok := v.([]string); ok {
+				req.EmbeddingTypes = ss
+				delete(extra, "embedding_types")
+			}
+		}
+		if v, ok := extra["images"]; ok {
+			if ss, ok := v.([]string); ok {
+				req.Images = ss
+				delete(extra, "images")
+			}
+		}
+		if v, ok := extra["inputs"]; ok {
+			if inputs, ok := v.([]BedrockCohereEmbeddingInput); ok {
+				req.Inputs = inputs
+				delete(extra, "inputs")
+			}
+		}
+		if v, ok := extra["max_tokens"]; ok {
+			switch n := v.(type) {
+			case int:
+				req.MaxTokens = &n
+				delete(extra, "max_tokens")
+			case float64:
+				i := int(n)
+				req.MaxTokens = &i
+				delete(extra, "max_tokens")
+			}
+		}
+		if bifrostReq.Params.Dimensions != nil {
+			req.OutputDimension = bifrostReq.Params.Dimensions
+		}
+		if len(extra) > 0 {
+			req.ExtraParams = extra
+		}
+	}
+
+	return req, nil
 }
 
 // DetermineEmbeddingModelType determines the embedding model type from the model name
@@ -95,4 +169,103 @@ func DetermineEmbeddingModelType(model string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported embedding model: %s", model)
 	}
+}
+
+// ToBifrostEmbeddingResponse converts a BedrockCohereEmbeddingResponse to Bifrost format.
+// Bedrock returns embeddings as a raw [][]float32 when response_type is "embeddings_floats"
+// (the default, when no embedding_types are requested), and as a typed object when
+// response_type is "embeddings_by_type".
+func (r *BedrockCohereEmbeddingResponse) ToBifrostEmbeddingResponse() (*schemas.BifrostEmbeddingResponse, error) {
+	if r == nil {
+		return nil, fmt.Errorf("nil Bedrock Cohere embedding response")
+	}
+
+	bifrostResponse := &schemas.BifrostEmbeddingResponse{Object: "list"}
+
+	switch r.ResponseType {
+	case "embeddings_by_type":
+		// Object form: {"float": [[...]], "int8": [[...]], "uint8": [[...]], "binary": [[...]], "ubinary": [[...]], "base64": [...]}
+		var typed struct {
+			Float   [][]float32 `json:"float"`
+			Base64  []string    `json:"base64"`
+			Int8    [][]int8    `json:"int8"`
+			Uint8   [][]int32   `json:"uint8"`  // int32 avoids []byte→base64 JSON issue
+			Binary  [][]int8    `json:"binary"`
+			Ubinary [][]int32   `json:"ubinary"` // int32 avoids []byte→base64 JSON issue
+		}
+		if err := json.Unmarshal(r.Embeddings, &typed); err != nil {
+			return nil, fmt.Errorf("error parsing embeddings_by_type: %w", err)
+		}
+		if typed.Float != nil {
+			for i, emb := range typed.Float {
+				float64Emb := make([]float64, len(emb))
+				for j, v := range emb {
+					float64Emb[j] = float64(v)
+				}
+				bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+					Object:    "embedding",
+					Index:     i,
+					Embedding: schemas.EmbeddingStruct{EmbeddingArray: float64Emb},
+				})
+			}
+		}
+		if typed.Base64 != nil {
+			for i, emb := range typed.Base64 {
+				e := emb
+				bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+					Object:    "embedding",
+					Index:     i,
+					Embedding: schemas.EmbeddingStruct{EmbeddingStr: &e},
+				})
+			}
+		}
+		for i, emb := range typed.Int8 {
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:    "embedding",
+				Index:     i,
+				Embedding: schemas.EmbeddingStruct{EmbeddingInt8Array: emb},
+			})
+		}
+		for i, emb := range typed.Binary {
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:    "embedding",
+				Index:     i,
+				Embedding: schemas.EmbeddingStruct{EmbeddingInt8Array: emb},
+			})
+		}
+		for i, emb := range typed.Uint8 {
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:    "embedding",
+				Index:     i,
+				Embedding: schemas.EmbeddingStruct{EmbeddingInt32Array: emb},
+			})
+		}
+		for i, emb := range typed.Ubinary {
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:    "embedding",
+				Index:     i,
+				Embedding: schemas.EmbeddingStruct{EmbeddingInt32Array: emb},
+			})
+		}
+
+	default:
+		// Default / "embeddings_floats": raw array form [[...], [...]]
+		var floats [][]float32
+		if err := json.Unmarshal(r.Embeddings, &floats); err != nil {
+			return nil, fmt.Errorf("error parsing embeddings_floats: %w", err)
+		}
+		for i, emb := range floats {
+			float64Emb := make([]float64, len(emb))
+			for j, v := range emb {
+				float64Emb[j] = float64(v)
+			}
+			bifrostResponse.Data = append(bifrostResponse.Data, schemas.EmbeddingData{
+				Object:    "embedding",
+				Index:     i,
+				Embedding: schemas.EmbeddingStruct{EmbeddingArray: float64Emb},
+			})
+		}
+	}
+
+	return bifrostResponse, nil
 }

--- a/core/providers/bedrock/images.go
+++ b/core/providers/bedrock/images.go
@@ -39,6 +39,14 @@ func isStabilityAIModel(model string) bool {
 	return strings.Contains(strings.ToLower(model), "stability.")
 }
 
+// isPromptOnlyImageGenerationModel returns true for image generation models that use a flat
+// {"prompt": "..."} payload (no taskType field). Covers Vertex Imagen and similar models.
+// Stability AI is excluded here — it's handled separately because it also supports image edit.
+func isPromptOnlyImageGenerationModel(model string) bool {
+	m := strings.ToLower(model)
+	return strings.Contains(m, "image")
+}
+
 // ToStabilityAIImageGenerationRequest converts a Bifrost image generation request to the Stability AI
 // flat request format used by Bedrock (stability.stable-image-* models).
 func ToStabilityAIImageGenerationRequest(request *schemas.BifrostImageGenerationRequest) (*StabilityAIImageGenerationRequest, error) {
@@ -146,6 +154,24 @@ func ToBedrockImageGenerationRequest(request *schemas.BifrostImageGenerationRequ
 
 	return bedrockReq, nil
 
+}
+
+// ToStabilityAIImageGenerationResponse converts a BifrostImageGenerationResponse back to
+// the native Bedrock invoke API response format used by Stability AI models.
+// Stability AI models use the same BedrockImageGenerationResponse format as Titan/Nova Canvas.
+func ToStabilityAIImageGenerationResponse(response *schemas.BifrostImageGenerationResponse) (*BedrockImageGenerationResponse, error) {
+	if response == nil {
+		return nil, fmt.Errorf("response is nil")
+	}
+	result := &BedrockImageGenerationResponse{}
+	for _, d := range response.Data {
+		result.Images = append(result.Images, d.B64JSON)
+	}
+	if response.ImageGenerationResponseParameters != nil {
+		result.FinishReasons = response.ImageGenerationResponseParameters.FinishReasons
+		result.Seeds = response.ImageGenerationResponseParameters.Seeds
+	}
+	return result, nil
 }
 
 // ToBedrockImageVariationRequest converts a Bifrost image variation request to a Bedrock image variation request
@@ -698,6 +724,13 @@ func ToBifrostImageGenerationResponse(response *BedrockImageGenerationResponse) 
 	}
 
 	bifrostResponse := &schemas.BifrostImageGenerationResponse{}
+
+	if len(response.FinishReasons) > 0 || len(response.Seeds) > 0 {
+		bifrostResponse.ImageGenerationResponseParameters = &schemas.ImageGenerationResponseParameters{
+			FinishReasons: append([]*string(nil), response.FinishReasons...),
+			Seeds:         append([]int(nil), response.Seeds...),
+		}
+	}
 
 	for index, image := range response.Images {
 		bifrostResponse.Data = append(bifrostResponse.Data, schemas.ImageData{

--- a/core/providers/bedrock/invoke.go
+++ b/core/providers/bedrock/invoke.go
@@ -2,8 +2,10 @@ package bedrock
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -44,6 +46,17 @@ var bedrockInvokeRequestKnownFields = map[string]bool{
 	"message": true, "chat_history": true,
 	// AI21
 	"n": true, "frequency_penalty": true, "presence_penalty": true,
+	// Bedrock image gen / edit / variation (Titan/Nova Canvas)
+	"taskType": true, "textToImageParams": true, "imageVariationParams": true,
+	"inPaintingParams": true, "outPaintingParams": true, "backgroundRemovalParams": true,
+	"imageGenerationConfig": true,
+	// Stability AI image
+	"image": true, "mask": true, "negative_prompt": true,
+	"aspect_ratio": true, "output_format": true, "seed": true,
+	// Embeddings
+	"inputText": true, "texts": true, "input_type": true,
+	"normalize": true, "dimensions": true,
+	"embedding_types": true, "output_dimension": true, "inputs": true,
 	// Internal
 	"stream": true, "extra_params": true,
 }
@@ -125,17 +138,74 @@ func (r *BedrockInvokeRequest) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// DetectInvokeRequestType determines the request type from raw JSON body
-// without full deserialization, keeping detection logic colocated with IsMessagesRequest.
-func DetectInvokeRequestType(body []byte) schemas.RequestType {
-	node, _ := sonic.Get(body, "messages")
-	if node.Exists() {
-		raw, err := node.Raw()
-		if err == nil && raw != "null" && raw != "[]" {
+// DetectInvokeRequestType determines the request type from raw JSON body and model ID
+// without full deserialization, keeping detection logic colocated with conversion methods.
+func DetectInvokeRequestType(body []byte, modelID string) schemas.RequestType {
+	// Messages → chat/responses path
+	if node, _ := sonic.Get(body, "messages"); node.Exists() {
+		if raw, err := node.Raw(); err == nil && raw != "null" && raw != "[]" {
 			return schemas.ResponsesRequest
+		}
+	}
+
+	// Titan uses "inputText" for both embeddings and text generation.
+	// Use the model ID to disambiguate: embedding models contain "embed".
+	if node, _ := sonic.Get(body, "inputText"); node.Exists() {
+		if strings.Contains(strings.ToLower(modelID), "embed") {
+			return schemas.EmbeddingRequest
 		}
 		return schemas.TextCompletionRequest
 	}
+
+	// Cohere embedding: text-only (texts), image-only (images), or mixed (inputs).
+	// Use model ID to identify embed models, then check for any non-empty payload field.
+	if strings.Contains(strings.ToLower(modelID), "embed") {
+		for _, field := range []string{"texts", "images", "inputs"} {
+			if node, _ := sonic.Get(body, field); node.Exists() {
+				if raw, err := node.Raw(); err == nil && raw != "null" && raw != "[]" {
+					return schemas.EmbeddingRequest
+				}
+			}
+		}
+	}
+
+	// taskType-based image routing
+	if taskNode, _ := sonic.Get(body, "taskType"); taskNode.Exists() {
+		taskType, _ := taskNode.String()
+		switch taskType {
+		case TaskTypeTextImage:
+			return schemas.ImageGenerationRequest
+		case TaskTypeImageVariation:
+			return schemas.ImageVariationRequest
+		case TaskTypeInpainting, TaskTypeOutpainting, TaskTypeBackgroundRemoval:
+			return schemas.ImageEditRequest
+		}
+	}
+
+	// URL-decode the model ID once for all model-name checks below
+	decodedModelID := modelID
+	if unescaped, err := url.PathUnescape(modelID); err == nil {
+		decodedModelID = unescaped
+	}
+
+	// Stability AI: supports both generation (prompt-only) and edit (image+prompt)
+	if isStabilityAIModel(decodedModelID) {
+		if node, _ := sonic.Get(body, "image"); node.Exists() {
+			return schemas.ImageEditRequest
+		}
+		return schemas.ImageGenerationRequest
+	}
+
+	// explicit image field -> edit request
+	if node, _ := sonic.Get(body, "image"); node.Exists() {
+		return schemas.ImageEditRequest
+	}
+
+	// Checked after all body-field and model-specific signals so it doesn't shadow known models.
+	if isPromptOnlyImageGenerationModel(decodedModelID) {
+		return schemas.ImageGenerationRequest
+	}
+
 	return schemas.TextCompletionRequest
 }
 
@@ -310,6 +380,382 @@ func (r *BedrockInvokeRequest) ToBifrostTextCompletionRequest(ctx *schemas.Bifro
 	return textReq.ToBifrostTextCompletionRequest(ctx)
 }
 
+// ToBifrostEmbeddingRequest converts the invoke request to a BifrostEmbeddingRequest.
+// Handles both Titan (inputText) and Cohere (texts) embedding formats.
+func (r *BedrockInvokeRequest) ToBifrostEmbeddingRequest(ctx *schemas.BifrostContext) *schemas.BifrostEmbeddingRequest {
+	modelID := r.ModelID
+	if unescaped, err := url.PathUnescape(r.ModelID); err == nil {
+		modelID = unescaped
+	}
+	provider, model := schemas.ParseModelString(modelID, providerUtils.CheckAndSetDefaultProvider(ctx, schemas.Bedrock))
+	req := &schemas.BifrostEmbeddingRequest{
+		Provider: provider,
+		Model:    model,
+	}
+
+	if r.InputText != "" {
+		req.Input = &schemas.EmbeddingInput{Text: &r.InputText}
+	} else if len(r.Texts) > 0 {
+		req.Input = &schemas.EmbeddingInput{Texts: r.Texts}
+	}
+	// image-only (r.Images) or mixed (r.Inputs): req.Input stays nil; data flows via ExtraParams
+
+	extraParams := make(map[string]interface{})
+	// Forward known embedding-only params into ExtraParams so the provider can pick them up
+	if r.InputType != nil {
+		extraParams["input_type"] = *r.InputType
+	}
+	if r.Normalize != nil {
+		extraParams["normalize"] = *r.Normalize
+	}
+	if len(r.EmbeddingTypes) > 0 {
+		extraParams["embedding_types"] = r.EmbeddingTypes
+	}
+	if r.Truncate != nil {
+		extraParams["truncate"] = *r.Truncate
+	}
+	if len(r.Images) > 0 {
+		extraParams["images"] = r.Images
+	}
+	if len(r.Inputs) > 0 {
+		extraParams["inputs"] = r.Inputs
+	}
+	if r.MaxTokens != nil {
+		extraParams["max_tokens"] = *r.MaxTokens
+	}
+	// Merge any remaining extra params from the request
+	for k, v := range r.ExtraParams {
+		extraParams[k] = v
+	}
+
+	// output_dimension maps to Dimensions; prefer OutputDimension over Dimensions
+	dimensions := r.Dimensions
+	if r.OutputDimension != nil {
+		dimensions = r.OutputDimension
+	}
+	params := &schemas.EmbeddingParameters{
+		Dimensions: dimensions,
+	}
+	if len(extraParams) > 0 {
+		params.ExtraParams = extraParams
+	}
+	req.Params = params
+
+	return req
+}
+
+// ToBifrostImageGenerationRequest converts the invoke request to a BifrostImageGenerationRequest.
+// Handles Titan/Nova Canvas (taskType=TEXT_IMAGE with textToImageParams) and Stability AI (flat prompt fields).
+func (r *BedrockInvokeRequest) ToBifrostImageGenerationRequest(ctx *schemas.BifrostContext) *schemas.BifrostImageGenerationRequest {
+	modelID := r.ModelID
+	if unescaped, err := url.PathUnescape(r.ModelID); err == nil {
+		modelID = unescaped
+	}
+	provider, model := schemas.ParseModelString(modelID, providerUtils.CheckAndSetDefaultProvider(ctx, schemas.Bedrock))
+	req := &schemas.BifrostImageGenerationRequest{
+		Provider: provider,
+		Model:    model,
+	}
+
+	params := &schemas.ImageGenerationParameters{
+		NegativePrompt: r.NegativePrompt,
+		AspectRatio:    r.AspectRatio,
+		N:              r.N,
+		OutputFormat:   r.OutputFormat,
+		Seed:           r.Seed,
+	}
+
+	if r.TextToImageParams != nil {
+		// Titan / Nova Canvas path
+		req.Input = &schemas.ImageGenerationInput{Prompt: r.TextToImageParams.Text}
+		if r.TextToImageParams.NegativeText != nil {
+			params.NegativePrompt = r.TextToImageParams.NegativeText
+		}
+		if r.TextToImageParams.Style != nil {
+			params.Style = r.TextToImageParams.Style
+		}
+		if cfg := r.ImageGenerationConfig; cfg != nil {
+			params.N = cfg.NumberOfImages
+			params.Seed = cfg.Seed
+			params.Quality = cfg.Quality
+			if cfg.Width != nil && cfg.Height != nil {
+				size := fmt.Sprintf("%dx%d", *cfg.Width, *cfg.Height)
+				params.Size = &size
+			}
+			if cfg.CfgScale != nil {
+				if params.ExtraParams == nil {
+					params.ExtraParams = make(map[string]interface{})
+				}
+				params.ExtraParams["cfgScale"] = *cfg.CfgScale
+			}
+		}
+	} else {
+		// Stability AI path — prompt comes from the top-level "prompt" field
+		req.Input = &schemas.ImageGenerationInput{Prompt: r.Prompt}
+	}
+
+	// Forward any remaining ExtraParams
+	if len(r.ExtraParams) > 0 {
+		if params.ExtraParams == nil {
+			params.ExtraParams = make(map[string]interface{})
+		}
+		for k, v := range r.ExtraParams {
+			params.ExtraParams[k] = v
+		}
+	}
+
+	req.Params = params
+	return req
+}
+
+// ToBifrostImageEditRequest converts the invoke request to a BifrostImageEditRequest.
+// Handles Titan/Nova Canvas (taskType in INPAINTING/OUTPAINTING/BACKGROUND_REMOVAL) and Stability AI (flat image/mask fields).
+func (r *BedrockInvokeRequest) ToBifrostImageEditRequest(ctx *schemas.BifrostContext) (*schemas.BifrostImageEditRequest, error) {
+	modelID := r.ModelID
+	if unescaped, err := url.PathUnescape(r.ModelID); err == nil {
+		modelID = unescaped
+	}
+	provider, model := schemas.ParseModelString(modelID, providerUtils.CheckAndSetDefaultProvider(ctx, schemas.Bedrock))
+	req := &schemas.BifrostImageEditRequest{
+		Provider: provider,
+		Model:    model,
+	}
+	params := &schemas.ImageEditParameters{
+		NegativePrompt: r.NegativePrompt,
+		Seed:           r.Seed,
+	}
+
+	if r.TaskType != nil {
+		// Titan / Nova Canvas path
+		switch *r.TaskType {
+		case TaskTypeInpainting:
+			if r.InPaintingParams == nil {
+				return nil, fmt.Errorf("inPaintingParams required for INPAINTING task")
+			}
+			imgBytes, err := base64.StdEncoding.DecodeString(r.InPaintingParams.Image)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode inpainting image: %w", err)
+			}
+			req.Input = &schemas.ImageEditInput{
+				Images: []schemas.ImageInput{{Image: imgBytes}},
+				Prompt: r.InPaintingParams.Text,
+			}
+			params.Type = schemas.Ptr("inpainting")
+			if r.InPaintingParams.NegativeText != nil {
+				params.NegativePrompt = r.InPaintingParams.NegativeText
+			}
+			if r.InPaintingParams.MaskImage != nil {
+				maskBytes, err := base64.StdEncoding.DecodeString(*r.InPaintingParams.MaskImage)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode inpainting mask: %w", err)
+				}
+				params.Mask = maskBytes
+			}
+			if r.InPaintingParams.MaskPrompt != nil || r.InPaintingParams.ReturnMask != nil {
+				if params.ExtraParams == nil {
+					params.ExtraParams = make(map[string]interface{})
+				}
+				if r.InPaintingParams.MaskPrompt != nil {
+					params.ExtraParams["mask_prompt"] = *r.InPaintingParams.MaskPrompt
+				}
+				if r.InPaintingParams.ReturnMask != nil {
+					params.ExtraParams["return_mask"] = *r.InPaintingParams.ReturnMask
+				}
+			}
+
+		case TaskTypeOutpainting:
+			if r.OutPaintingParams == nil {
+				return nil, fmt.Errorf("outPaintingParams required for OUTPAINTING task")
+			}
+			imgBytes, err := base64.StdEncoding.DecodeString(r.OutPaintingParams.Image)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode outpainting image: %w", err)
+			}
+			req.Input = &schemas.ImageEditInput{
+				Images: []schemas.ImageInput{{Image: imgBytes}},
+				Prompt: r.OutPaintingParams.Text,
+			}
+			params.Type = schemas.Ptr("outpainting")
+			if r.OutPaintingParams.NegativeText != nil {
+				params.NegativePrompt = r.OutPaintingParams.NegativeText
+			}
+			if r.OutPaintingParams.MaskImage != nil {
+				maskBytes, err := base64.StdEncoding.DecodeString(*r.OutPaintingParams.MaskImage)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode outpainting mask: %w", err)
+				}
+				params.Mask = maskBytes
+			}
+			if r.OutPaintingParams.MaskPrompt != nil || r.OutPaintingParams.ReturnMask != nil || r.OutPaintingParams.OutPaintingMode != nil {
+				if params.ExtraParams == nil {
+					params.ExtraParams = make(map[string]interface{})
+				}
+				if r.OutPaintingParams.MaskPrompt != nil {
+					params.ExtraParams["mask_prompt"] = *r.OutPaintingParams.MaskPrompt
+				}
+				if r.OutPaintingParams.ReturnMask != nil {
+					params.ExtraParams["return_mask"] = *r.OutPaintingParams.ReturnMask
+				}
+				if r.OutPaintingParams.OutPaintingMode != nil {
+					params.ExtraParams["outpainting_mode"] = *r.OutPaintingParams.OutPaintingMode
+				}
+			}
+
+		case TaskTypeBackgroundRemoval:
+			if r.BackgroundRemovalParams == nil {
+				return nil, fmt.Errorf("backgroundRemovalParams required for BACKGROUND_REMOVAL task")
+			}
+			imgBytes, err := base64.StdEncoding.DecodeString(r.BackgroundRemovalParams.Image)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode background removal image: %w", err)
+			}
+			req.Input = &schemas.ImageEditInput{
+				Images: []schemas.ImageInput{{Image: imgBytes}},
+			}
+			params.Type = schemas.Ptr("background_removal")
+
+		default:
+			return nil, fmt.Errorf("unsupported taskType for image edit: %s", *r.TaskType)
+		}
+
+		// Map imageGenerationConfig fields into edit params (Titan/Nova Canvas only)
+		if cfg := r.ImageGenerationConfig; cfg != nil {
+			params.N = cfg.NumberOfImages
+			params.Seed = cfg.Seed
+			params.Quality = cfg.Quality
+			if cfg.Width != nil && cfg.Height != nil {
+				size := fmt.Sprintf("%dx%d", *cfg.Width, *cfg.Height)
+				params.Size = &size
+			}
+			if cfg.CfgScale != nil {
+				if params.ExtraParams == nil {
+					params.ExtraParams = make(map[string]interface{})
+				}
+				params.ExtraParams["cfgScale"] = *cfg.CfgScale
+			}
+		}
+	} else {
+		// Stability AI path
+		if r.Image == nil {
+			return nil, fmt.Errorf("image field is required for Stability AI image edit")
+		}
+		imgBytes, err := base64.StdEncoding.DecodeString(*r.Image)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode stability AI image: %w", err)
+		}
+		req.Input = &schemas.ImageEditInput{
+			Images: []schemas.ImageInput{{Image: imgBytes}},
+			Prompt: r.Prompt,
+		}
+		// Infer task type from model name
+		taskType, err := getStabilityAIEditTaskType(r.ModelID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine Stability AI edit task: %w", err)
+		}
+		params.Type = &taskType
+		if r.Mask != nil {
+			maskBytes, err := base64.StdEncoding.DecodeString(*r.Mask)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode stability AI mask: %w", err)
+			}
+			params.Mask = maskBytes
+		}
+	}
+
+	if len(r.ExtraParams) > 0 {
+		if params.ExtraParams == nil {
+			params.ExtraParams = make(map[string]interface{}, len(r.ExtraParams))
+		}
+		for k, v := range r.ExtraParams {
+			params.ExtraParams[k] = v
+		}
+	}
+	req.Params = params
+	return req, nil
+}
+
+// ToBifrostImageVariationRequest converts the invoke request to a BifrostImageVariationRequest.
+// Reads from imageVariationParams (Titan/Nova Canvas format).
+func (r *BedrockInvokeRequest) ToBifrostImageVariationRequest(ctx *schemas.BifrostContext) (*schemas.BifrostImageVariationRequest, error) {
+	if r.ImageVariationParams == nil || len(r.ImageVariationParams.Images) == 0 {
+		return nil, fmt.Errorf("imageVariationParams.images is required for IMAGE_VARIATION")
+	}
+
+	primaryBytes, err := base64.StdEncoding.DecodeString(r.ImageVariationParams.Images[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode primary variation image: %w", err)
+	}
+
+	modelID := r.ModelID
+	if unescaped, err := url.PathUnescape(r.ModelID); err == nil {
+		modelID = unescaped
+	}
+	provider, model := schemas.ParseModelString(modelID, providerUtils.CheckAndSetDefaultProvider(ctx, schemas.Bedrock))
+	req := &schemas.BifrostImageVariationRequest{
+		Provider: provider,
+		Model:    model,
+		Input: &schemas.ImageVariationInput{
+			Image: schemas.ImageInput{Image: primaryBytes},
+		},
+	}
+
+	params := &schemas.ImageVariationParameters{}
+	extraParams := make(map[string]interface{})
+
+	// Additional images (index 1+) stored under "images" key for the provider
+	if len(r.ImageVariationParams.Images) > 1 {
+		additionalImages := make([][]byte, 0, len(r.ImageVariationParams.Images)-1)
+		for _, imgB64 := range r.ImageVariationParams.Images[1:] {
+			imgBytes, err := base64.StdEncoding.DecodeString(imgB64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode additional variation image: %w", err)
+			}
+			additionalImages = append(additionalImages, imgBytes)
+		}
+		extraParams["images"] = additionalImages
+	}
+
+	// Text / negative text / similarity strength go to ExtraParams (provider reads them from there)
+	if r.ImageVariationParams.Text != nil {
+		extraParams["prompt"] = *r.ImageVariationParams.Text
+	}
+	if r.ImageVariationParams.NegativeText != nil {
+		extraParams["negativeText"] = *r.ImageVariationParams.NegativeText
+	}
+	if r.ImageVariationParams.SimilarityStrength != nil {
+		extraParams["similarityStrength"] = *r.ImageVariationParams.SimilarityStrength
+	}
+
+	// ImageGenerationConfig → N, Size, Seed, Quality, CfgScale
+	if cfg := r.ImageGenerationConfig; cfg != nil {
+		params.N = cfg.NumberOfImages
+		if cfg.Width != nil && cfg.Height != nil {
+			size := fmt.Sprintf("%dx%d", *cfg.Width, *cfg.Height)
+			params.Size = &size
+		}
+		if cfg.Seed != nil {
+			extraParams["seed"] = *cfg.Seed
+		}
+		if cfg.Quality != nil {
+			extraParams["quality"] = *cfg.Quality
+		}
+		if cfg.CfgScale != nil {
+			extraParams["cfgScale"] = *cfg.CfgScale
+		}
+	}
+
+	// Forward any remaining ExtraParams from the request body
+	for k, v := range r.ExtraParams {
+		extraParams[k] = v
+	}
+	if len(extraParams) > 0 {
+		params.ExtraParams = extraParams
+	}
+
+	req.Params = params
+	return req, nil
+}
+
 // buildCohereCommandRPrompt converts Cohere Command R's message + chat_history into a text prompt.
 func (r *BedrockInvokeRequest) buildCohereCommandRPrompt() string {
 	var sb strings.Builder
@@ -465,6 +911,93 @@ func ToBedrockInvokeMessagesResponse(ctx *schemas.BifrostContext, resp *schemas.
 
 	// Default: Anthropic Messages API format (most common InvokeModel + messages use case)
 	return toBedrockInvokeAnthropicResponse(resp, model), nil
+}
+
+func ToBedrockInvokeImagesResponse(ctx *schemas.BifrostContext, resp *schemas.BifrostImageGenerationResponse) (interface{}, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("bifrost response is nil")
+	}
+
+	// If the provider stored the raw Bedrock response, return it verbatim (preserves seeds, finish_reasons, etc.)
+	if resp.ExtraFields.RawResponse != nil {
+		return resp.ExtraFields.RawResponse, nil
+	}
+
+	model := resp.Model
+	if resp.ExtraFields.ModelRequested != "" {
+		model = resp.ExtraFields.ModelRequested
+	}
+
+	// Stability AI models use the same BedrockImageGenerationResponse format as Titan/Nova Canvas
+	if isStabilityAIModel(model) {
+		return ToStabilityAIImageGenerationResponse(resp)
+	}
+
+	// Default: Titan Image Generator v1/v2, Nova Canvas — reconstruct from Bifrost data
+	result := &BedrockImageGenerationResponse{}
+	for _, d := range resp.Data {
+		result.Images = append(result.Images, d.B64JSON)
+	}
+	return result, nil
+}
+
+// ToBedrockEmbeddingInvokeResponse converts a BifrostEmbeddingResponse back to the native
+// Bedrock invoke API response format.
+// Single-embedding (Titan) responses use: {"embedding": [...], "inputTextTokenCount": N}
+// Multi-embedding (Cohere) responses use:  {"embeddings": [[...],[...]], "response_type": "embeddings_floats"}
+func ToBedrockEmbeddingInvokeResponse(resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("bifrost embedding response is nil")
+	}
+
+	// If the provider stored the raw Bedrock response, return it verbatim
+	if resp.ExtraFields.RawResponse != nil {
+		return resp.ExtraFields.RawResponse, nil
+	}
+
+	tokenCount := 0
+	if resp.Usage != nil {
+		tokenCount = resp.Usage.PromptTokens
+	}
+
+	if len(resp.Data) == 0 {
+		return &BedrockInvokeEmbeddingResp{InputTextTokenCount: tokenCount}, nil
+	}
+
+	// Use model name to distinguish Cohere from Titan — not batch size.
+	// A single-input Cohere request must still return the Cohere envelope format.
+	model := resp.Model
+	if resp.ExtraFields.ModelRequested != "" {
+		model = resp.ExtraFields.ModelRequested
+	}
+
+	if strings.Contains(strings.ToLower(model), "cohere") {
+		floats := make([][]float32, 0, len(resp.Data))
+		for _, d := range resp.Data {
+			float32Emb := make([]float32, len(d.Embedding.EmbeddingArray))
+			for i, v := range d.Embedding.EmbeddingArray {
+				float32Emb[i] = float32(v)
+			}
+			floats = append(floats, float32Emb)
+		}
+		return &BedrockInvokeCohereEmbeddingResp{
+			Embeddings:   floats,
+			ResponseType: "embeddings_floats",
+		}, nil
+	}
+
+	// Titan format
+	if resp.Data[0].Embedding.EmbeddingArray == nil {
+		return &BedrockInvokeEmbeddingResp{InputTextTokenCount: tokenCount}, nil
+	}
+	float32Emb := make([]float32, len(resp.Data[0].Embedding.EmbeddingArray))
+	for i, v := range resp.Data[0].Embedding.EmbeddingArray {
+		float32Emb[i] = float32(v)
+	}
+	return &BedrockInvokeEmbeddingResp{
+		Embedding:           float32Emb,
+		InputTextTokenCount: tokenCount,
+	}, nil
 }
 
 // toBedrockInvokeAnthropicResponse converts BifrostResponsesResponse to Anthropic Messages API format.
@@ -656,6 +1189,7 @@ func ToBedrockInvokeMessagesStreamResponse(ctx *schemas.BifrostContext, resp *sc
 	bedrockEvent := &BedrockStreamEvent{
 		InvokeModelRawChunk: rawBytes,
 	}
+
 	return "", bedrockEvent, nil
 }
 
@@ -777,7 +1311,7 @@ func toAnthropicInvokeStreamBytes(resp *schemas.BifrostResponsesStreamResponse) 
 				"type":  "content_block_delta",
 				"index": idx,
 				"delta": map[string]interface{}{
-					"type":          "input_json_delta",
+					"type":         "input_json_delta",
 					"partial_json": *resp.Delta,
 				},
 			}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -645,10 +645,10 @@ type BedrockMetadataEvent struct {
 
 // BedrockTitanEmbeddingRequest represents a Bedrock Titan embedding request
 type BedrockTitanEmbeddingRequest struct {
-	InputText   string                 `json:"inputText"` // Required: Text to embed
+	InputText   string                 `json:"inputText"`            // Required: Text to embed
+	Dimensions  *int                   `json:"dimensions,omitempty"` // Optional: 256, 512, or 1024 (titan-embed-text-v2 only)
+	Normalize   *bool                  `json:"normalize,omitempty"`  // Optional: normalize the embedding
 	ExtraParams map[string]interface{} `json:"-"`
-	// Note: Titan models have fixed dimensions and don't support the dimensions parameter
-	// ExtraParams can be used for any additional model-specific parameters
 }
 
 // GetExtraParams implements the RequestBodyWithExtraParams interface
@@ -660,6 +660,53 @@ func (req *BedrockTitanEmbeddingRequest) GetExtraParams() map[string]interface{}
 type BedrockTitanEmbeddingResponse struct {
 	Embedding           []float64 `json:"embedding"`           // The embedding vector
 	InputTextTokenCount int       `json:"inputTextTokenCount"` // Number of tokens in input
+}
+
+// BedrockCohereEmbeddingContentBlock represents a single content block in a mixed input
+type BedrockCohereEmbeddingContentBlock struct {
+	Type     string                          `json:"type"`                // "text" or "image_url"
+	Text     *string                         `json:"text,omitempty"`      // for type=text
+	ImageURL *BedrockCohereEmbeddingImageURL `json:"image_url,omitempty"` // for type=image_url
+}
+
+// BedrockCohereEmbeddingImageURL holds the URL for an image content block
+type BedrockCohereEmbeddingImageURL struct {
+	URL string `json:"url"`
+}
+
+// BedrockCohereEmbeddingInput represents a mixed text+image input
+type BedrockCohereEmbeddingInput struct {
+	Content []BedrockCohereEmbeddingContentBlock `json:"content"`
+}
+
+// BedrockCohereEmbeddingRequest represents a Bedrock Cohere embedding request.
+// Unlike the direct Cohere API, Bedrock does not accept a "model" field in the body.
+type BedrockCohereEmbeddingRequest struct {
+	InputType       string                        `json:"input_type"`                 // Required
+	Texts           []string                      `json:"texts,omitempty"`            // text-only inputs
+	Images          []string                      `json:"images,omitempty"`           // image-only inputs (data URIs)
+	Inputs          []BedrockCohereEmbeddingInput `json:"inputs,omitempty"`           // mixed text+image inputs
+	EmbeddingTypes  []string                      `json:"embedding_types,omitempty"`  // e.g. ["float"]
+	OutputDimension *int                          `json:"output_dimension,omitempty"` // 256, 512, 1024, or 1536
+	MaxTokens       *int                          `json:"max_tokens,omitempty"`       // max 128000
+	Truncate        *string                       `json:"truncate,omitempty"`         // NONE, LEFT, or RIGHT
+	ExtraParams     map[string]interface{}        `json:"-"`
+}
+
+// GetExtraParams implements the RequestBodyWithExtraParams interface
+func (req *BedrockCohereEmbeddingRequest) GetExtraParams() map[string]interface{} {
+	return req.ExtraParams
+}
+
+// BedrockCohereEmbeddingResponse handles both Bedrock Cohere embedding response shapes.
+// When embedding_types is not set, Bedrock returns embeddings as a raw [][]float32
+// ("embeddings_floats"). When embedding_types is set, it returns an object with typed
+// arrays ("embeddings_by_type"). Using json.RawMessage defers parsing until we know the shape.
+type BedrockCohereEmbeddingResponse struct {
+	ID           string          `json:"id"`
+	Embeddings   json.RawMessage `json:"embeddings"`
+	ResponseType string          `json:"response_type"`
+	Texts        []string        `json:"texts,omitempty"`
 }
 
 const TaskTypeTextImage = "TEXT_IMAGE"
@@ -822,11 +869,11 @@ func (req *StabilityAIImageEditRequest) GetExtraParams() map[string]interface{} 
 // BedrockImageGenerationResponse represents a Bedrock image generation response.
 // The Seeds and FinishReasons fields are populated by Stability AI edit models only.
 type BedrockImageGenerationResponse struct {
-	Images        []string  `json:"images"`         // list of Base64 encoded images
-	MaskImage     string    `json:"maskImage"`      // Base64 encoded mask image (optional)
-	Error         string    `json:"error"`          // error message (if present)
-	Seeds         []int     `json:"seeds"`          // Stability AI: seeds used per image
-	FinishReasons []*string `json:"finish_reasons"` // Stability AI: finish reason per image (may be null)
+	Images        []string  `json:"images"`                   // list of Base64 encoded images
+	MaskImage     string    `json:"maskImage,omitempty"`      // Base64 encoded mask image (optional)
+	Error         string    `json:"error,omitempty"`          // error message (if present)
+	Seeds         []int     `json:"seeds,omitempty"`          // Stability AI: seeds used per image
+	FinishReasons []*string `json:"finish_reasons,omitempty"` // Stability AI: finish reason per image (may be null)
 }
 
 // ==================== MODELS TYPES ====================
@@ -1019,6 +1066,37 @@ type BedrockInvokeRequest struct {
 	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
 	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 
+	// ==================== BEDROCK IMAGE GEN / EDIT / VARIATION (Titan/Nova Canvas) ====================
+
+	TaskType                *string                         `json:"taskType,omitempty"`
+	TextToImageParams       *BedrockTextToImageParams       `json:"textToImageParams,omitempty"`
+	ImageVariationParams    *BedrockImageVariationParams    `json:"imageVariationParams,omitempty"`
+	InPaintingParams        *BedrockInPaintingParams        `json:"inPaintingParams,omitempty"`
+	OutPaintingParams       *BedrockOutPaintingParams       `json:"outPaintingParams,omitempty"`
+	BackgroundRemovalParams *BedrockBackgroundRemovalParams `json:"backgroundRemovalParams,omitempty"`
+	ImageGenerationConfig   *ImageGenerationConfig          `json:"imageGenerationConfig,omitempty"`
+
+	// ==================== STABILITY AI IMAGE ====================
+
+	// Image is the base64-encoded input image (SA edit / variation)
+	Image          *string `json:"image,omitempty"`
+	Mask           *string `json:"mask,omitempty"`            // base64 mask for inpainting
+	NegativePrompt *string `json:"negative_prompt,omitempty"` // SA gen / edit
+	AspectRatio    *string `json:"aspect_ratio,omitempty"`    // SA gen
+	OutputFormat   *string `json:"output_format,omitempty"`   // SA gen
+	Seed           *int    `json:"seed,omitempty"`            // SA gen / edit
+
+	// ==================== EMBEDDINGS ====================
+
+	InputText       string                        `json:"inputText,omitempty"`        // Titan embed
+	Texts           []string                      `json:"texts,omitempty"`            // Cohere embed
+	InputType       *string                       `json:"input_type,omitempty"`       // Cohere embed
+	Normalize       *bool                         `json:"normalize,omitempty"`        // Titan embed v2
+	Dimensions      *int                          `json:"dimensions,omitempty"`       // Titan embed v2
+	EmbeddingTypes  []string                      `json:"embedding_types,omitempty"`  // Cohere embed: ["float","int8","uint8","binary","ubinary"]
+	OutputDimension *int                          `json:"output_dimension,omitempty"` // Cohere embed: 256, 512, 1024, 1536
+	Inputs          []BedrockCohereEmbeddingInput `json:"inputs,omitempty"`           // Cohere embed: mixed text+image inputs
+
 	// ==================== INTERNAL ====================
 	Stream      bool                   `json:"-"`
 	ExtraParams map[string]interface{} `json:"-"`
@@ -1028,4 +1106,16 @@ type BedrockInvokeRequest struct {
 type BedrockCohereRMessage struct {
 	Role    string `json:"role"`    // "USER" or "CHATBOT"
 	Message string `json:"message"` // Message content
+}
+
+// BedrockInvokeEmbeddingResp is the Titan single-embedding invoke response format.
+type BedrockInvokeEmbeddingResp struct {
+	Embedding           []float32 `json:"embedding"`
+	InputTextTokenCount int       `json:"inputTextTokenCount"`
+}
+
+// BedrockInvokeCohereEmbeddingResp is the Cohere multi-embedding invoke response format.
+type BedrockInvokeCohereEmbeddingResp struct {
+	Embeddings   [][]float32 `json:"embeddings"`
+	ResponseType string      `json:"response_type"`
 }

--- a/core/schemas/embedding.go
+++ b/core/schemas/embedding.go
@@ -116,14 +116,16 @@ type EmbeddingParameters struct {
 type EmbeddingData struct {
 	Index     int             `json:"index"`
 	Object    string          `json:"object"`    // "embedding"
-	Embedding EmbeddingStruct `json:"embedding"` // can be string, []float64 or [][]float64
+	Embedding EmbeddingStruct `json:"embedding"` // can be string, []float64, [][]float64, []int8, or []int32
 }
 
 type EmbeddingStruct struct {
 	// Embedding responses preserve provider precision in normalized API output.
-	EmbeddingStr     *string
-	EmbeddingArray   []float64
-	Embedding2DArray [][]float64
+	EmbeddingStr        *string
+	EmbeddingArray      []float64
+	Embedding2DArray    [][]float64
+	EmbeddingInt8Array  []int8  // for int8 / binary formats
+	EmbeddingInt32Array []int32 // for uint8 / ubinary formats
 }
 
 func (be EmbeddingStruct) MarshalJSON() ([]byte, error) {
@@ -135,6 +137,12 @@ func (be EmbeddingStruct) MarshalJSON() ([]byte, error) {
 	}
 	if be.Embedding2DArray != nil {
 		return MarshalSorted(be.Embedding2DArray)
+	}
+	if be.EmbeddingInt8Array != nil {
+		return Marshal(be.EmbeddingInt8Array)
+	}
+	if be.EmbeddingInt32Array != nil {
+		return Marshal(be.EmbeddingInt32Array)
 	}
 	return nil, fmt.Errorf("no embedding found")
 }
@@ -161,5 +169,19 @@ func (be *EmbeddingStruct) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return fmt.Errorf("embedding field is neither a string nor an array of float64 nor a 2D array of float64")
+	// Try to unmarshal as a direct array of int8
+	var int8Content []int8
+	if err := Unmarshal(data, &int8Content); err == nil {
+		be.EmbeddingInt8Array = int8Content
+		return nil
+	}
+
+	// Try to unmarshal as a direct array of int32
+	var int32Content []int32
+	if err := Unmarshal(data, &int32Content); err == nil {
+		be.EmbeddingInt32Array = int32Content
+		return nil
+	}
+
+	return fmt.Errorf("embedding field is neither a string, []float64, [][]float64, []int8, nor []int32")
 }

--- a/core/schemas/images.go
+++ b/core/schemas/images.go
@@ -151,10 +151,12 @@ func normalizeImageQuality(q string) string {
 }
 
 type ImageGenerationResponseParameters struct {
-	Background   string `json:"background,omitempty"`
-	OutputFormat string `json:"output_format,omitempty"`
-	Quality      string `json:"quality,omitempty"`
-	Size         string `json:"size,omitempty"`
+	Background    string    `json:"background,omitempty"`
+	OutputFormat  string    `json:"output_format,omitempty"`
+	Quality       string    `json:"quality,omitempty"`
+	Size          string    `json:"size,omitempty"`
+	FinishReasons []*string `json:"finish_reasons,omitempty"`
+	Seeds         []int     `json:"seeds,omitempty"`
 }
 
 type ImageData struct {

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -174,6 +174,8 @@ providers:
     thinking: "us.anthropic.claude-opus-4-5-20251101-v1:0"
     text_completion: "mistral.mistral-7b-instruct-v0:2"
     embeddings: "global.cohere.embed-v4:0"
+    image_generation: "amazon.titan-image-generator-v2:0"
+    image_variation: "amazon.titan-image-generator-v2:0"
     batch_inline: "anthropic.claude-3-5-sonnet-20240620-v1:0"
     image_edit: "amazon.nova-canvas-v1:0"
     batch_list: "anthropic.claude-3-5-sonnet-20240620-v1:0"
@@ -517,9 +519,11 @@ provider_scenarios:
     file_retrieve: true  # Bedrock retrieves S3 object metadata
     file_delete: true  # Bedrock deletes S3 objects
     file_content: true  # Bedrock downloads S3 object content
-    image_edit: true  # Bedrock supports image editing via Nova Canvas
+    image_generation: true  # Bedrock supports image generation via invoke (Titan, SA, cross-provider)
+    image_edit: true  # Bedrock supports image editing via invoke (Titan, SA)
+    image_variation: true  # Bedrock supports image variation via invoke (Titan IMAGE_VARIATION)
     count_tokens: true  # Bedrock supports token counting via CountTokens API
-    
+
   cohere:
     simple_chat: true
     multi_turn_conversation: true

--- a/tests/integrations/python/tests/test_bedrock.py
+++ b/tests/integrations/python/tests/test_bedrock.py
@@ -45,6 +45,29 @@ Count Tokens Tests:
 26. Count tokens with tool definitions - Cross-provider
 27. Count tokens from long text - Cross-provider
 28. Count tokens from multi-turn conversation - Cross-provider
+
+Invoke Endpoint — Image Generation Tests (TestBedrockInvokeEndpoint):
+29. Titan image generation via invoke (taskType=TEXT_IMAGE)
+30. Titan embeddings via invoke (inputText)
+31. Titan embeddings with params via invoke (inputText + params)
+32. Cohere embeddings via invoke (texts array)
+33. Titan inpainting via invoke (taskType=INPAINTING)
+34. Titan outpainting via invoke (taskType=OUTPAINTING)
+35. Titan background removal via invoke (taskType=BACKGROUND_REMOVAL)
+36. Titan image variation via invoke (taskType=IMAGE_VARIATION)
+37. Stability AI image inpaint via invoke (image+mask)
+38. Vertex Imagen image generation via invoke (cross-provider)
+39. OpenAI gpt-image-1 via invoke (cross-provider)
+40. Titan text generation via invoke (inputText+textGenerationConfig, not misrouted as embedding)
+41. Cohere embeddings via invoke with inputs payload (mixed text+image, not misrouted as text completion)
+42. Cohere embeddings via invoke with explicit embedding_types=["float"]
+43. Cohere embeddings via invoke with embedding_types=["int8"] (regression: was silently dropped)
+44. Cohere embeddings via invoke with embedding_types=["uint8"] (regression: was silently dropped)
+45. Cohere embeddings via invoke with embedding_types=["float","int8"] (multi-type, none dropped)
+46. Anthropic claude via invoke with messages array (ResponsesRequest path → Anthropic Messages format)
+47. Nova via invoke with messages array (ResponsesRequest path → Converse/Nova format)
+48. AI21 Jamba via invoke with messages array (ResponsesRequest path → AI21 Choices format)
+49. Anthropic claude via invoke-with-response-stream with messages (ResponsesRequest streaming path)
 """
 
 import base64
@@ -54,10 +77,12 @@ import urllib.request
 from typing import Any, Dict, List
 
 import boto3
+import botocore.exceptions
 import pytest
 
 from .utils.common import (
-    BASE64_IMAGE,
+    BASE64_IMAGE_LARGE,
+    BASE64_TITAN_MASK_IMAGE,
     CALCULATOR_TOOL,
     LOCATION_KEYWORDS,
     MULTI_TURN_MESSAGES,
@@ -335,9 +360,9 @@ def extract_system_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, An
 class TestBedrockIntegration:
     """Test suite for Bedrock integration covering core scenarios"""
 
+    @pytest.mark.skip(reason="Skipping text completion invoke test")
     @skip_if_no_api_key("bedrock")
     def test_01_text_completion_invoke(self, bedrock_client, test_config):
-        pytest.skip("Skipping text completion invoke test")
         model_id = get_model("bedrock", "text_completion")
 
         request_body = {
@@ -474,7 +499,7 @@ class TestBedrockIntegration:
                         },
                         {
                             "type": "image_url",
-                            "image_url": {"url": f"data:image/png;base64,{BASE64_IMAGE}"},
+                            "image_url": {"url": f"data:image/png;base64,{BASE64_IMAGE_LARGE}"},
                         },
                     ],
                 }
@@ -2038,3 +2063,833 @@ class TestBedrockCountTokens:
         ), f"Multi-turn conversation should have >15 tokens, got {response['inputTokens']}"
 
         print(f"✓ Multi-turn conversation token count: {response['inputTokens']} tokens")
+
+
+# ---------------------------------------------------------------------------
+# Invoke Endpoint — Image Generation, Image Edit, Image Variation, Embeddings
+# ---------------------------------------------------------------------------
+# These tests exercise the /bedrock/model/{modelId}/invoke route using
+# native Bedrock payload formats (taskType-based for Titan/Nova Canvas,
+# flat-field for Stability AI) as well as cross-provider model IDs
+# (vertex/..., openai/...) routed through the same invoke endpoint.
+# ---------------------------------------------------------------------------
+
+def _assert_invoke_images(response_body: dict, min_images: int = 1) -> None:
+    """Assert that an invoke response contains at least min_images base64 images."""
+    images = response_body.get("images") or []
+    assert isinstance(images, list), (
+        f"Expected 'images' to be a list, got {type(images).__name__}. "
+        f"Response keys: {list(response_body.keys())}"
+    )
+    assert len(images) >= min_images, (
+        f"Expected at least {min_images} image(s) in response, got {len(images)}. "
+        f"Response keys: {list(response_body.keys())}"
+    )
+    for i, img in enumerate(images):
+        assert isinstance(img, str) and len(img) > 0, f"Image {i} is not a non-empty string"
+    print(f"  ✓ {len(images)} image(s) returned")
+
+
+def _assert_invoke_embedding(response_body: dict) -> None:
+    """Assert that an invoke response contains a non-empty embedding vector."""
+    embedding = response_body.get("embedding") or []
+    assert len(embedding) > 0, (
+        f"Expected 'embedding' array in response, got keys: {list(response_body.keys())}"
+    )
+    assert all(isinstance(v, (int, float)) for v in embedding), "Embedding must be numeric"
+    print(f"  ✓ embedding dim={len(embedding)}")
+
+
+class TestBedrockInvokeEndpoint:
+    """
+    Tests for the Bedrock /invoke and /invoke-with-response-stream endpoints.
+
+    Covers native Bedrock payload formats for:
+      - Image generation  (Titan TEXT_IMAGE, Stability AI, Vertex Imagen, OpenAI)
+      - Image editing     (Titan INPAINTING / OUTPAINTING / BACKGROUND_REMOVAL, SA inpaint)
+      - Image variation   (Titan IMAGE_VARIATION)
+      - Embeddings        (Titan embed text v2, Cohere embed English v3)
+      - Messages path     (Anthropic, Nova, AI21 Jamba via messages array → ResponsesRequest)
+      - Messages streaming (invoke-with-response-stream with messages array)
+    """
+
+    # ------------------------------------------------------------------ #
+    # 29. Titan image generation                                           #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_29_invoke_titan_image_generation(self, bedrock_client):
+        """Test Case 29: Titan Image Generator v2 via invoke — taskType=TEXT_IMAGE"""
+        print("\n=== Test 29: Titan image generation via invoke ===")
+
+        body = {
+            "taskType": "TEXT_IMAGE",
+            "textToImageParams": {
+                "text": "a serene mountain lake at sunset",
+                "negativeText": "blurry, low quality",
+            },
+            "imageGenerationConfig": {
+                "numberOfImages": 1,
+                "width": 512,
+                "height": 512,
+            },
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-image-generator-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 30. Titan embed text v2                                              #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_30_invoke_titan_embeddings(self, bedrock_client):
+        """Test Case 30: Titan Embed Text v2 via invoke — inputText"""
+        print("\n=== Test 30: Titan embeddings via invoke ===")
+
+        body = {"inputText": "the quick brown fox jumps over the lazy dog"}
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_embedding(out)
+        # inputTextTokenCount is returned by the Bedrock-format response
+        assert "inputTextTokenCount" in out, (
+            f"Expected 'inputTextTokenCount' in Titan embed response, got: {list(out.keys())}"
+        )
+        print(f"  ✓ inputTextTokenCount={out['inputTextTokenCount']}")
+
+    # ------------------------------------------------------------------ #
+    # 31. Titan embed with dimensions + normalize                          #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_31_invoke_titan_embeddings_with_params(self, bedrock_client):
+        """Test Case 31: Titan Embed Text v2 via invoke — dimensions + normalize"""
+        print("\n=== Test 31: Titan embeddings with params via invoke ===")
+
+        body = {
+            "inputText": "machine learning and artificial intelligence",
+            "dimensions": 256,
+            "normalize": True,
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-embed-text-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_embedding(out)
+        assert len(out["embedding"]) == 256, (
+            f"Expected 256-dim embedding, got {len(out['embedding'])}"
+        )
+
+    # ------------------------------------------------------------------ #
+    # 32. Cohere embed English v3                                          #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_32_invoke_cohere_embeddings(self, bedrock_client):
+        """Test Case 32: Cohere Embed English v3 via invoke — texts array"""
+        print("\n=== Test 32: Cohere embeddings via invoke ===")
+
+        body = {
+            "texts": ["hello world", "goodbye world"],
+            "input_type": "search_document",
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="cohere.embed-english-v3",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        # Cohere native response uses "embeddings" (plural list-of-lists)
+        # Bifrost may return Titan-compat single "embedding" for invoke
+        if "embedding" in out:
+            _assert_invoke_embedding(out)
+        else:
+            embeddings = out.get("embeddings")
+            assert isinstance(embeddings, list) and len(embeddings) == len(body["texts"]), (
+                f"Expected {len(body['texts'])} embeddings, got: {out}"
+            )
+            for i, vector in enumerate(embeddings):
+                assert isinstance(vector, list) and len(vector) > 0, f"Embedding {i} is empty"
+                assert all(isinstance(v, (int, float)) for v in vector), (
+                    f"Embedding {i} must be numeric"
+                )
+        print(f"  ✓ Cohere embedding response keys: {list(out.keys())}")
+
+    # ------------------------------------------------------------------ #
+    # 33. Titan INPAINTING                                                 #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_33_invoke_titan_inpainting(self, bedrock_client):
+        """Test Case 33: Titan Image Generator v2 via invoke — INPAINTING"""
+        print("\n=== Test 33: Titan INPAINTING via invoke ===")
+
+        body = {
+            "taskType": "INPAINTING",
+            "inPaintingParams": {
+                "image": BASE64_IMAGE_LARGE,
+                "maskImage": BASE64_TITAN_MASK_IMAGE,
+                "text": "a beautiful garden with flowers",
+                "negativeText": "blurry",
+            },
+            "imageGenerationConfig": {"numberOfImages": 1},
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-image-generator-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 34. Titan OUTPAINTING                                                #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_34_invoke_titan_outpainting(self, bedrock_client):
+        """Test Case 34: Titan Image Generator v2 via invoke — OUTPAINTING"""
+        print("\n=== Test 34: Titan OUTPAINTING via invoke ===")
+
+        body = {
+            "taskType": "OUTPAINTING",
+            "outPaintingParams": {
+                "image": BASE64_IMAGE_LARGE,
+                "maskImage": BASE64_TITAN_MASK_IMAGE,
+                "text": "extend the scene with a meadow",
+                "outPaintingMode": "DEFAULT",
+            },
+            "imageGenerationConfig": {"numberOfImages": 1},
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-image-generator-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 35. Titan BACKGROUND_REMOVAL                                         #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_35_invoke_titan_background_removal(self, bedrock_client):
+        """Test Case 35: Titan Image Generator v2 via invoke — BACKGROUND_REMOVAL"""
+        print("\n=== Test 35: Titan BACKGROUND_REMOVAL via invoke ===")
+
+        body = {
+            "taskType": "BACKGROUND_REMOVAL",
+            "backgroundRemovalParams": {"image": BASE64_IMAGE_LARGE},
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-image-generator-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 36. Titan IMAGE_VARIATION                                            #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_36_invoke_titan_image_variation(self, bedrock_client):
+        """Test Case 36: Titan Image Generator v2 via invoke — IMAGE_VARIATION"""
+        print("\n=== Test 36: Titan IMAGE_VARIATION via invoke ===")
+
+        body = {
+            "taskType": "IMAGE_VARIATION",
+            "imageVariationParams": {
+                "images": [BASE64_IMAGE_LARGE],
+                "text": "same style with a different color palette",
+                "similarityStrength": 0.7,
+            },
+            "imageGenerationConfig": {"numberOfImages": 1},
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="amazon.titan-image-generator-v2:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 37. Stability AI — image inpaint                                     #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_37_invoke_stability_ai_inpaint(self, bedrock_client):
+        """Test Case 37: Stability AI stable-image-inpaint via invoke — image+mask+prompt"""
+        print("\n=== Test 37: Stability AI inpaint via invoke ===")
+
+        body = {
+            "image": BASE64_IMAGE_LARGE,
+            "mask": BASE64_IMAGE_LARGE,
+            "prompt": "replace masked area with flowers",
+            "output_format": "png",
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="us.stability.stable-image-inpaint-v1:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 38. Vertex Imagen — cross-provider via invoke                        #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("vertex")
+    def test_38_invoke_vertex_imagen(self, bedrock_client):
+        """Test Case 38: Vertex Imagen 4 via Bedrock invoke endpoint (cross-provider)"""
+        print("\n=== Test 38: Vertex Imagen via invoke ===")
+
+        body = {"prompt": "a gecko resting on a tropical leaf"}
+
+        response = bedrock_client.invoke_model(
+            modelId="vertex/imagen-4.0-generate-001",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 39. OpenAI gpt-image-1 — cross-provider via invoke                  #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("openai")
+    def test_39_invoke_openai_image_generation(self, bedrock_client):
+        """Test Case 39: OpenAI gpt-image-1 via Bedrock invoke endpoint (cross-provider)"""
+        print("\n=== Test 39: OpenAI gpt-image-1 via invoke ===")
+
+        body = {
+            "prompt": "a gecko resting on a tropical leaf",
+            "n": 1,
+            "quality": "low",
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="openai/gpt-image-1",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+        _assert_invoke_images(out)
+
+    # ------------------------------------------------------------------ #
+    # 40. Titan text generation — inputText must NOT route as embedding    #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_40_invoke_titan_text_generation(self, bedrock_client):
+        """Test Case 40: Titan Text via invoke — inputText must not be misrouted as embedding.
+
+        Regression test for the bug where DetectInvokeRequestType returned EmbeddingRequest for any
+        body with 'inputText', regardless of model. Detection is now model-ID-based: only models
+        whose ID contains 'embed' are routed as embeddings. The response must contain 'results'.
+        """
+        print("\n=== Test 40: Titan text generation via invoke (not embedding) ===")
+
+        # Intentionally omit textGenerationConfig to cover the bare-inputText case —
+        # the fix must use model ID (not body shape) to distinguish text-gen from embedding.
+        body = {
+            "inputText": "What is the capital of France? Answer in one word.",
+        }
+
+        try:
+            response = bedrock_client.invoke_model(
+                modelId="amazon.titan-text-express-v1",
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(body),
+            )
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("ResourceNotFoundException", "ValidationException"):
+                pytest.skip(f"Titan text model no longer available: {e}")
+            raise
+        out = json.loads(response["body"].read())
+
+        assert "embedding" not in out, (
+            f"Request was misrouted to the embedding path — response contains 'embedding' key. "
+            f"Response keys: {list(out.keys())}"
+        )
+        assert "results" in out, (
+            f"Expected 'results' in Titan text generation response, got: {list(out.keys())}"
+        )
+        results = out["results"]
+        assert len(results) > 0 and results[0].get("outputText"), (
+            f"Expected non-empty outputText in results, got: {results}"
+        )
+        print(f"  ✓ outputText={results[0]['outputText'][:60]!r}")
+
+    # ------------------------------------------------------------------ #
+    # 41. Cohere embed — inputs payload must NOT route as text completion  #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_41_invoke_cohere_embeddings_inputs(self, bedrock_client):
+        """Test Case 41: Cohere Embed via invoke — inputs payload must not be misrouted as text completion.
+
+        Regression test for the bug where DetectInvokeRequestType only checked for the 'texts' field
+        when detecting Cohere embeddings. Requests using the 'inputs' field (mixed text+image payloads)
+        fell through to TextCompletionRequest. Detection must be model-ID-based (contains 'embed')
+        and cover all Cohere embedding payload shapes: 'texts', 'inputs', and 'images'.
+        """
+        print("\n=== Test 41: Cohere embeddings via invoke (inputs payload, not text completion) ===")
+
+        # Use 'inputs' field instead of 'texts' — this is the payload shape that was misrouted
+        body = {
+            "inputs": [{"text": "hello world"}, {"text": "goodbye world"}],
+            "input_type": "search_document",
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="cohere.embed-english-v3",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+
+        has_embedding = "embedding" in out or "embeddings" in out
+        assert has_embedding, (
+            f"Request was misrouted — expected 'embedding' or 'embeddings' key but got: {list(out.keys())}. "
+            f"If 'results' is present, the request was routed to text completion instead of embeddings."
+        )
+        print(f"  ✓ Cohere inputs embedding response keys: {list(out.keys())}")
+
+    # ------------------------------------------------------------------ #
+    # 42. Cohere embed — embedding_types float (explicit)                  #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_42_invoke_cohere_embedding_type_float(self, bedrock_client):
+        """Test Case 42: Cohere Embed via invoke — explicit embedding_types=["float"].
+
+        Verifies that requesting a single float encoding returns the expected
+        embeddings_by_type response structure with float vectors.
+        """
+        print("\n=== Test 42: Cohere embedding_types float ===")
+
+        body = {
+            "texts": ["the quick brown fox"],
+            "input_type": "search_document",
+            "embedding_types": ["float"],
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="cohere.embed-english-v3",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+
+        assert out.get("response_type") == "embeddings_by_type", (
+            f"Expected response_type='embeddings_by_type', got: {out.get('response_type')}"
+        )
+        embeddings = out.get("embeddings", {})
+        assert "float" in embeddings, f"Expected 'float' key in embeddings, got: {list(embeddings.keys())}"
+        float_vecs = embeddings["float"]
+        assert isinstance(float_vecs, list) and len(float_vecs) == 1, (
+            f"Expected 1 float vector, got: {float_vecs}"
+        )
+        assert isinstance(float_vecs[0], list) and len(float_vecs[0]) > 0, "Float vector is empty"
+        assert all(isinstance(v, float) for v in float_vecs[0]), "Float vector must contain floats"
+        print(f"  ✓ float embedding dim={len(float_vecs[0])}")
+
+    # ------------------------------------------------------------------ #
+    # 43. Cohere embed — embedding_types int8                              #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_43_invoke_cohere_embedding_type_int8(self, bedrock_client):
+        """Test Case 43: Cohere Embed via invoke — embedding_types=["int8"].
+
+        Regression test for the bug where int8 (and other non-float encoding types)
+        were silently dropped because the embeddings_by_type parser only declared
+        'float' and 'base64' fields in its anonymous struct.
+        """
+        print("\n=== Test 43: Cohere embedding_types int8 ===")
+
+        body = {
+            "texts": ["the quick brown fox"],
+            "input_type": "search_document",
+            "embedding_types": ["int8"],
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="cohere.embed-english-v3",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+
+        assert out.get("response_type") == "embeddings_by_type", (
+            f"Expected response_type='embeddings_by_type', got: {out.get('response_type')}"
+        )
+        embeddings = out.get("embeddings", {})
+        assert "int8" in embeddings, (
+            f"Expected 'int8' key in embeddings — was it silently dropped? Got: {list(embeddings.keys())}"
+        )
+        int8_vecs = embeddings["int8"]
+        assert isinstance(int8_vecs, list) and len(int8_vecs) == 1, (
+            f"Expected 1 int8 vector, got: {int8_vecs}"
+        )
+        assert isinstance(int8_vecs[0], list) and len(int8_vecs[0]) > 0, "int8 vector is empty"
+        assert all(isinstance(v, int) and -128 <= v <= 127 for v in int8_vecs[0]), (
+            "int8 vector values must be integers in [-128, 127]"
+        )
+        print(f"  ✓ int8 embedding dim={len(int8_vecs[0])}")
+
+    # ------------------------------------------------------------------ #
+    # 44. Cohere embed — embedding_types uint8                             #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_44_invoke_cohere_embedding_type_uint8(self, bedrock_client):
+        """Test Case 44: Cohere Embed via invoke — embedding_types=["uint8"].
+
+        Verifies that uint8 encoding is not dropped (previously silently lost
+        because the parser mapped []uint8 as base64 via json.Marshal).
+        """
+        print("\n=== Test 44: Cohere embedding_types uint8 ===")
+
+        body = {
+            "texts": ["the quick brown fox"],
+            "input_type": "search_document",
+            "embedding_types": ["uint8"],
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="cohere.embed-english-v3",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+
+        assert out.get("response_type") == "embeddings_by_type", (
+            f"Expected response_type='embeddings_by_type', got: {out.get('response_type')}"
+        )
+        embeddings = out.get("embeddings", {})
+        assert "uint8" in embeddings, (
+            f"Expected 'uint8' key in embeddings — was it silently dropped? Got: {list(embeddings.keys())}"
+        )
+        uint8_vecs = embeddings["uint8"]
+        assert isinstance(uint8_vecs, list) and len(uint8_vecs) == 1, (
+            f"Expected 1 uint8 vector, got: {uint8_vecs}"
+        )
+        assert isinstance(uint8_vecs[0], list) and len(uint8_vecs[0]) > 0, "uint8 vector is empty"
+        assert all(isinstance(v, int) and 0 <= v <= 255 for v in uint8_vecs[0]), (
+            "uint8 vector values must be integers in [0, 255]"
+        )
+        print(f"  ✓ uint8 embedding dim={len(uint8_vecs[0])}")
+
+    # ------------------------------------------------------------------ #
+    # 45. Cohere embed — multiple embedding_types (float + int8)           #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_45_invoke_cohere_embedding_types_multi(self, bedrock_client):
+        """Test Case 45: Cohere Embed via invoke — embedding_types=["float", "int8"].
+
+        Verifies that multiple encoding types are all returned without any being
+        dropped, and that each type contains the correct number of vectors.
+        """
+        print("\n=== Test 45: Cohere embedding_types multi (float + int8) ===")
+
+        texts = ["the quick brown fox", "machine learning"]
+        body = {
+            "texts": texts,
+            "input_type": "search_document",
+            "embedding_types": ["float", "int8"],
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="cohere.embed-english-v3",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+
+        assert out.get("response_type") == "embeddings_by_type", (
+            f"Expected response_type='embeddings_by_type', got: {out.get('response_type')}"
+        )
+        embeddings = out.get("embeddings", {})
+        for enc_type in ("float", "int8"):
+            assert enc_type in embeddings, (
+                f"Expected '{enc_type}' key in embeddings — was it dropped? Got: {list(embeddings.keys())}"
+            )
+            vecs = embeddings[enc_type]
+            assert isinstance(vecs, list) and len(vecs) == len(texts), (
+                f"Expected {len(texts)} {enc_type} vectors, got {len(vecs)}"
+            )
+            for i, vec in enumerate(vecs):
+                assert isinstance(vec, list) and len(vec) > 0, f"{enc_type} vector {i} is empty"
+        print(f"  ✓ float dim={len(embeddings['float'][0])}, int8 dim={len(embeddings['int8'][0])}")
+
+    # ------------------------------------------------------------------ #
+    # 46. Anthropic claude — messages path via invoke                      #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_46_invoke_anthropic_messages(self, bedrock_client):
+        """Test Case 46: Anthropic Claude via invoke with messages array → ResponsesRequest path.
+
+        Verifies that a payload containing a 'messages' array is detected as ResponsesRequest
+        (not TextCompletionRequest) and returns the Anthropic Messages API format:
+        {"type": "message", "role": "assistant", "content": [...], "stop_reason": "end_turn"}.
+        """
+        print("\n=== Test 46: Anthropic claude via invoke (messages path) ===")
+
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Say hello in one word."}],
+                }
+            ],
+            "max_tokens": 50,
+        }
+
+        response = bedrock_client.invoke_model(
+            modelId="anthropic.claude-3-haiku-20240307-v1:0",
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps(body),
+        )
+        out = json.loads(response["body"].read())
+
+        # Must NOT be text-completion format
+        assert "results" not in out and "outputs" not in out, (
+            f"Request was misrouted to text-completion path — got keys: {list(out.keys())}"
+        )
+        # Must be Anthropic Messages API format
+        assert out.get("type") == "message", (
+            f"Expected type='message', got: {out.get('type')}. Keys: {list(out.keys())}"
+        )
+        assert out.get("role") == "assistant", (
+            f"Expected role='assistant', got: {out.get('role')}"
+        )
+        content = out.get("content", [])
+        assert isinstance(content, list) and len(content) > 0, (
+            f"Expected non-empty content list, got: {content}"
+        )
+        text_block = next((b for b in content if b.get("type") == "text"), None)
+        assert text_block is not None and text_block.get("text"), (
+            f"Expected a text content block, got: {content}"
+        )
+        assert out.get("stop_reason") in ("end_turn", "max_tokens"), (
+            f"Unexpected stop_reason: {out.get('stop_reason')}"
+        )
+        print(f"  ✓ stop_reason={out['stop_reason']!r}, text={text_block['text'][:60]!r}")
+
+    # ------------------------------------------------------------------ #
+    # 47. Nova — messages path via invoke                                  #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_47_invoke_nova_messages(self, bedrock_client):
+        """Test Case 47: Amazon Nova via invoke with messages array → ResponsesRequest path.
+
+        Nova invoke with a messages array routes through ResponsesRequest and returns
+        the Converse-compatible format: {"output": {"message": {"role": ..., "content": [...]}},
+        "stopReason": "end_turn"}.
+        """
+        print("\n=== Test 47: Nova via invoke (messages path) ===")
+
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"text": "Say hello in one word."}],
+                }
+            ],
+            "inferenceConfig": {"maxTokens": 50},
+        }
+
+        try:
+            response = bedrock_client.invoke_model(
+                modelId="us.amazon.nova-lite-v1:0",
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(body),
+            )
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("ValidationException", "ResourceNotFoundException"):
+                pytest.skip(f"Nova model not available with this configuration: {e}")
+            raise
+        out = json.loads(response["body"].read())
+
+        # Must NOT be text-completion format
+        assert "results" not in out and "outputs" not in out, (
+            f"Request was misrouted to text-completion path — got keys: {list(out.keys())}"
+        )
+        # Must be Converse-compatible format
+        assert "output" in out, f"Expected 'output' in response, got: {list(out.keys())}"
+        msg = out["output"].get("message", {})
+        assert msg.get("role") == "assistant", (
+            f"Expected role='assistant', got: {msg.get('role')}"
+        )
+        content_blocks = msg.get("content", [])
+        assert isinstance(content_blocks, list) and len(content_blocks) > 0, (
+            f"Expected non-empty content blocks, got: {content_blocks}"
+        )
+        text_block = next((b for b in content_blocks if "text" in b), None)
+        assert text_block is not None and text_block["text"], (
+            f"Expected a text content block, got: {content_blocks}"
+        )
+        assert out.get("stopReason") in ("end_turn", "max_tokens"), (
+            f"Unexpected stopReason: {out.get('stopReason')}"
+        )
+        print(f"  ✓ stopReason={out['stopReason']!r}, text={text_block['text'][:60]!r}")
+
+    # ------------------------------------------------------------------ #
+    # 48. AI21 Jamba — messages path via invoke                           #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_48_invoke_ai21_messages(self, bedrock_client):
+        """Test Case 48: AI21 Jamba via invoke with messages array → ResponsesRequest path.
+
+        AI21 Jamba invoke with a messages array routes through ResponsesRequest and returns
+        the AI21 Chat Completions format: {"id": ..., "choices": [{"message": {"role": "assistant",
+        "content": "..."}, "finish_reason": "stop"}]}.
+        """
+        print("\n=== Test 48: AI21 Jamba via invoke (messages path) ===")
+
+        body = {
+            "messages": [{"role": "user", "content": "Say hello in one word."}],
+            "max_tokens": 50,
+        }
+
+        try:
+            response = bedrock_client.invoke_model(
+                modelId="ai21.j2-mid-v1",
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(body),
+            )
+        except botocore.exceptions.ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("ResourceNotFoundException", "ValidationException"):
+                pytest.skip(f"Titan text model no longer available: {e}")
+            raise
+        out = json.loads(response["body"].read())
+
+        # Must NOT be text-completion format
+        assert "results" not in out and "outputs" not in out, (
+            f"Request was misrouted to text-completion path — got keys: {list(out.keys())}"
+        )
+        # Must be AI21 Chat Completions format
+        choices = out.get("choices", [])
+        assert isinstance(choices, list) and len(choices) > 0, (
+            f"Expected non-empty 'choices', got: {out}"
+        )
+        msg = choices[0].get("message", {})
+        assert msg.get("role") == "assistant", (
+            f"Expected role='assistant', got: {msg.get('role')}"
+        )
+        assert msg.get("content"), f"Expected non-empty content, got: {msg}"
+        assert choices[0].get("finish_reason") in ("stop", "length"), (
+            f"Unexpected finish_reason: {choices[0].get('finish_reason')}"
+        )
+        print(f"  ✓ finish_reason={choices[0]['finish_reason']!r}, content={msg['content'][:60]!r}")
+
+    # ------------------------------------------------------------------ #
+    # 49. Anthropic claude — messages streaming via invoke-stream          #
+    # ------------------------------------------------------------------ #
+    @skip_if_no_api_key("bedrock")
+    def test_49_invoke_stream_anthropic_messages(self, bedrock_client):
+        """Test Case 49: Anthropic Claude via invoke-with-response-stream with messages array.
+
+        Verifies the ResponsesRequest streaming path: a 'messages' payload sent to
+        invoke-with-response-stream returns Anthropic SSE events (message_start,
+        content_block_delta, message_delta, message_stop) wrapped in InvokeModelRawChunk bytes.
+        """
+        print("\n=== Test 49: Anthropic claude via invoke-with-response-stream (messages path) ===")
+
+        body = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Say hello in one word."}],
+                }
+            ],
+            "max_tokens": 50,
+        }
+
+        try:
+            response = bedrock_client.invoke_model_with_response_stream(
+                modelId="anthropic.claude-3-haiku-20240307-v1:0",
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(body),
+            )
+        except AttributeError:
+            pytest.skip("invoke_model_with_response_stream not available in this boto3 version")
+        except Exception as e:
+            pytest.fail(f"invoke_model_with_response_stream failed: {e}")
+
+        stream = response.get("body")
+        if stream is None:
+            pytest.fail("Response missing 'body' stream")
+
+        event_types = []
+        text_parts = []
+        start_time = time.time()
+        timeout = 30
+
+        for event in stream:
+            if time.time() - start_time > timeout:
+                pytest.fail(f"Streaming took longer than {timeout} seconds")
+
+            if "chunk" not in event:
+                continue
+            raw_bytes = event["chunk"].get("bytes", b"")
+            if not raw_bytes:
+                continue
+            try:
+                chunk_json = json.loads(raw_bytes.decode("utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue
+
+            event_type = chunk_json.get("type", "")
+            event_types.append(event_type)
+
+            # Collect text deltas
+            if event_type == "content_block_delta":
+                delta = chunk_json.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    text_parts.append(delta.get("text", ""))
+
+        # Must have seen at least message_start and message_stop
+        assert "message_start" in event_types, (
+            f"Expected 'message_start' event in stream, got event types: {event_types}"
+        )
+        assert "message_stop" in event_types, (
+            f"Expected 'message_stop' event in stream, got event types: {event_types}"
+        )
+        full_text = "".join(text_parts)
+        assert full_text, f"Expected non-empty streamed text, got: {full_text!r}"
+        print(f"  ✓ event_types={event_types}, text={full_text[:60]!r}")

--- a/tests/integrations/python/tests/utils/common.py
+++ b/tests/integrations/python/tests/utils/common.py
@@ -59,6 +59,31 @@ def _create_base64_image(width: int = 64, height: int = 64) -> str:
     return base64.b64encode(img_bytes).decode('utf-8')
 
 BASE64_IMAGE = _create_base64_image(64, 64)
+BASE64_IMAGE_LARGE = _create_base64_image(512, 512)
+
+
+def _create_titan_mask_image(width: int = 512, height: int = 512) -> str:
+    """Create a base64-encoded grayscale PNG mask for Titan inpainting/outpainting.
+    Titan requires mask pixel values to be exactly 0 (preserve) or 255 (edit area)."""
+    from PIL import Image, ImageDraw
+    import io
+    import base64
+
+    # Grayscale image, all black (preserve) by default
+    mask = Image.new('L', (width, height), 0)
+
+    # White rectangle in center marks the area to edit
+    draw = ImageDraw.Draw(mask)
+    cx, cy = width // 2, height // 2
+    w, h = width // 3, height // 3
+    draw.rectangle([cx - w // 2, cy - h // 2, cx + w // 2, cy + h // 2], fill=255)
+
+    buffer = io.BytesIO()
+    mask.save(buffer, format='PNG')
+    return base64.b64encode(buffer.getvalue()).decode('utf-8')
+
+
+BASE64_TITAN_MASK_IMAGE = _create_titan_mask_image(512, 512)
 
 # Common Test Data
 SIMPLE_CHAT_MESSAGES = [{"role": "user", "content": "Hello! How are you today?"}]

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -121,15 +121,21 @@ func createBedrockInvokeWithResponseStreamRouteConfig(pathPrefix string, handler
 		Path:   pathPrefix + "/model/{modelId}/invoke-with-response-stream",
 		Method: "POST",
 		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
-			return bedrock.DetectInvokeRequestType(ctx.Request.Body())
+			modelID, _ := ctx.UserValue("modelId").(string)
+			return bedrock.DetectInvokeRequestType(ctx.Request.Body(), modelID)
 		},
 		GetRequestTypeInstance: func(ctx context.Context) interface{} {
 			return &bedrock.BedrockInvokeRequest{}
 		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
 			if invokeReq, ok := req.(*bedrock.BedrockInvokeRequest); ok {
+				requestType, _ := ctx.Value(schemas.BifrostContextKeyHTTPRequestType).(schemas.RequestType)
+				switch requestType {
+				case schemas.EmbeddingRequest, schemas.ImageGenerationRequest, schemas.ImageEditRequest, schemas.ImageVariationRequest:
+					return nil, fmt.Errorf("request type %v is not supported on invoke-with-response-stream", requestType)
+				}
 				invokeReq.Stream = true
-				if invokeReq.IsMessagesRequest() {
+				if requestType == schemas.ResponsesRequest {
 					// Messages-based → Responses path (streaming)
 					converseReq := invokeReq.ToBedrockConverseRequest()
 					responsesReq, err := converseReq.ToBifrostResponsesRequest(ctx)
@@ -176,43 +182,84 @@ func createBedrockInvokeWithResponseStreamRouteConfig(pathPrefix string, handler
 // createBedrockInvokeRouteConfig creates a route configuration for the Bedrock Invoke API endpoint
 // Handles POST /bedrock/model/{modelId}/invoke
 // Uses BedrockInvokeRequest as a union type that supports all model families.
-// Messages-based requests (Anthropic Messages, Nova, AI21) are routed through the Responses path,
-// while prompt-based requests (Anthropic legacy, Mistral, Llama, Cohere) go through Text Completion.
+// Request type is detected from the body + model ID and dispatched accordingly:
+//   - Embedding (Titan inputText, Cohere texts)
+//   - ImageGeneration (taskType=TEXT_IMAGE, Stability AI and other providers prompt-only)
+//   - ImageEdit (taskType=INPAINTING/OUTPAINTING/BACKGROUND_REMOVAL, Stability AI image+prompt)
+//   - ImageVariation (taskType=IMAGE_VARIATION)
+//   - ResponsesRequest (messages array — Anthropic Messages, Nova, AI21)
+//   - TextCompletionRequest (prompt — Anthropic legacy, Mistral, Llama, Cohere)
 func createBedrockInvokeRouteConfig(pathPrefix string, handlerStore lib.HandlerStore) RouteConfig {
 	return RouteConfig{
 		Type:   RouteConfigTypeBedrock,
 		Path:   pathPrefix + "/model/{modelId}/invoke",
 		Method: "POST",
 		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
-			return bedrock.DetectInvokeRequestType(ctx.Request.Body())
+			modelID, _ := ctx.UserValue("modelId").(string)
+			return bedrock.DetectInvokeRequestType(ctx.Request.Body(), modelID)
 		},
 		GetRequestTypeInstance: func(ctx context.Context) interface{} {
 			return &bedrock.BedrockInvokeRequest{}
 		},
 		RequestConverter: func(ctx *schemas.BifrostContext, req interface{}) (*schemas.BifrostRequest, error) {
-			if invokeReq, ok := req.(*bedrock.BedrockInvokeRequest); ok {
-				if invokeReq.IsMessagesRequest() {
-					// Messages-based (Anthropic Messages, Nova, AI21) → Responses path
-					converseReq := invokeReq.ToBedrockConverseRequest()
-					responsesReq, err := converseReq.ToBifrostResponsesRequest(ctx)
-					if err != nil {
-						return nil, fmt.Errorf("failed to convert invoke messages request: %w", err)
-					}
-					return &schemas.BifrostRequest{ResponsesRequest: responsesReq}, nil
+			invokeReq, ok := req.(*bedrock.BedrockInvokeRequest)
+			if !ok {
+				return nil, errors.New("invalid request type")
+			}
+
+			requestType, _ := ctx.Value(schemas.BifrostContextKeyHTTPRequestType).(schemas.RequestType)
+			switch requestType {
+			case schemas.EmbeddingRequest:
+				return &schemas.BifrostRequest{
+					EmbeddingRequest: invokeReq.ToBifrostEmbeddingRequest(ctx),
+				}, nil
+
+			case schemas.ImageGenerationRequest:
+				return &schemas.BifrostRequest{
+					ImageGenerationRequest: invokeReq.ToBifrostImageGenerationRequest(ctx),
+				}, nil
+
+			case schemas.ImageEditRequest:
+				editReq, err := invokeReq.ToBifrostImageEditRequest(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert invoke image edit request: %w", err)
 				}
-				// Prompt-based (Anthropic legacy, Mistral, Llama, Cohere) → Text Completion path
-				// Also handles Cohere Command R (message → prompt conversion)
+				return &schemas.BifrostRequest{ImageEditRequest: editReq}, nil
+
+			case schemas.ImageVariationRequest:
+				varReq, err := invokeReq.ToBifrostImageVariationRequest(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert invoke image variation request: %w", err)
+				}
+				return &schemas.BifrostRequest{ImageVariationRequest: varReq}, nil
+
+			case schemas.ResponsesRequest:
+				// Messages-based (Anthropic Messages, Nova, AI21) -> Responses path
+				converseReq := invokeReq.ToBedrockConverseRequest()
+				responsesReq, err := converseReq.ToBifrostResponsesRequest(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to convert invoke messages request: %w", err)
+				}
+				return &schemas.BifrostRequest{ResponsesRequest: responsesReq}, nil
+
+			default:
+				// TextCompletionRequest and any unrecognised type forwarded to text completion path
 				return &schemas.BifrostRequest{
 					TextCompletionRequest: invokeReq.ToBifrostTextCompletionRequest(ctx),
 				}, nil
 			}
-			return nil, errors.New("invalid request type")
 		},
 		TextResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTextCompletionResponse) (interface{}, error) {
 			return bedrock.ToBedrockTextCompletionResponse(resp), nil
 		},
 		ResponsesResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesResponse) (interface{}, error) {
 			return bedrock.ToBedrockInvokeMessagesResponse(ctx, resp)
+		},
+		EmbeddingResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostEmbeddingResponse) (interface{}, error) {
+			return bedrock.ToBedrockEmbeddingInvokeResponse(resp)
+		},
+		ImageGenerationResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostImageGenerationResponse) (interface{}, error) {
+			return bedrock.ToBedrockInvokeImagesResponse(ctx, resp)
 		},
 		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 			return bedrock.ToBedrockError(err)


### PR DESCRIPTION
## Summary

Adds comprehensive support for Bedrock's native invoke API endpoint, enabling image generation, image editing, image variation, and embedding operations through the `/bedrock/model/{modelId}/invoke` route. This enhancement allows users to interact with Bedrock models using their native payload formats while maintaining cross-provider compatibility.

## Changes

- **Enhanced request type detection**: Modified `DetectInvokeRequestType` to analyze both request body and model ID to properly route embedding, image generation, image editing, and image variation requests
- **Bedrock-specific embedding support**: Added native Bedrock embedding request/response handling for both Titan (`inputText`) and Cohere (`texts`) formats, removing dependency on generic Cohere provider
- **Image operation support**: Implemented comprehensive image generation, editing, and variation support for Titan/Nova Canvas (taskType-based) and Stability AI (flat field) formats
- **Cross-provider routing**: Added support for routing non-Bedrock models (Vertex Imagen, OpenAI) through the Bedrock invoke endpoint
- **Request conversion**: Enhanced `BedrockInvokeRequest` with conversion methods for all supported operation types
- **Response handling**: Added proper response conversion back to native Bedrock formats while preserving metadata like seeds and finish reasons
- **Test coverage**: Added 12 new integration tests covering all invoke endpoint scenarios

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Run the new Bedrock invoke endpoint integration tests:

```sh
# Run Bedrock-specific invoke tests
cd tests/integrations/python
python -m pytest tests/test_bedrock.py::TestBedrockInvokeEndpoint -v

# Run all Bedrock integration tests
python -m pytest tests/test_bedrock.py -v

# Core provider tests
cd ../../../
go test ./core/providers/bedrock/... -v
```

The tests cover:

- Titan image generation via taskType=TEXT_IMAGE
- Titan and Cohere embeddings via native formats
- Titan image editing (inpainting, outpainting, background removal)
- Titan image variation via taskType=IMAGE_VARIATION
- Stability AI image operations
- Cross-provider routing (Vertex Imagen, OpenAI via Bedrock endpoint)

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Enhances Bedrock provider capabilities by supporting the full range of operations available through the native invoke API.

## Security considerations

No new security implications. Uses existing authentication and authorization mechanisms for Bedrock access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable