### PR TITLE
pins snyk to our own fork

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -57,7 +57,9 @@ jobs:
           go-version: "1.26.1"
 
       - name: Install Snyk CLI
-        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        uses: maximhq/snyk-actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        with:
+          snyk-version: v1.1303.2
 
       - name: Snyk test (all projects)
         env:
@@ -113,7 +115,9 @@ jobs:
         run: make build
 
       - name: Install Snyk CLI
-        uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        uses: maximhq/snyk-actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        with:
+          snyk-version: v1.1303.2
 
       - name: Snyk Code test
         env:


### PR DESCRIPTION
## Summary

Updates the Snyk CLI action to use a forked version with pinned version control to ensure consistent security scanning behavior across CI runs.

## Changes

- Switched from `snyk/actions/setup` to `maximhq/snyk-actions/setup` action
- Pinned Snyk CLI version to `v1.1303.2` for both security scanning jobs
- Applied changes to both the general Snyk test job and the Snyk Code test job

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the CI pipeline runs successfully with the updated Snyk action:

```sh
# Trigger the workflow by pushing changes or creating a PR
# Monitor the GitHub Actions workflow to ensure:
# 1. Snyk CLI installs correctly with the specified version
# 2. Security scans complete without errors
# 3. Both "Snyk test (all projects)" and "Snyk Code test" jobs pass
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security scanning consistency by pinning the Snyk CLI version, preventing potential issues from automatic version updates during security scans.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable