### PR TITLE
fixes enforce http2 toggle for  bedrock

### DIFF
--- a/core/network/http.go
+++ b/core/network/http.go
@@ -328,6 +328,10 @@ func (f *HTTPClientFactory) createHTTPClient(purpose ClientPurpose) *http.Client
 		ExpectContinueTimeout: 1 * time.Second,
 		DisableCompression:    false,
 		DisableKeepAlives:     false,
+		// Disable HTTP/2 — these clients are used for auxiliary purposes (proxy/SCIM/API)
+		// where HTTP/1.1 is sufficient. Without this, Go's http2 package auto-registers
+		// h2 via TLSNextProto in init(), causing unintended HTTP/2 connections.
+		TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 
 	// Configure proxy if enabled for this purpose

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -87,6 +87,14 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		ForceAttemptHTTP2:     config.NetworkConfig.EnforceHTTP2,
 	}
 
+	// Disable HTTP/2 auto-negotiation when not explicitly enforced.
+	// ForceAttemptHTTP2=false alone does NOT prevent HTTP/2 — Go's http2 package
+	// auto-registers h2 via TLSNextProto in init(). Setting TLSNextProto to an
+	// empty map prevents ALPN negotiation from upgrading connections to h2.
+	if !config.NetworkConfig.EnforceHTTP2 {
+		transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+	}
+
 	// Apply TLS settings from NetworkConfig
 	if config.NetworkConfig.InsecureSkipVerify || config.NetworkConfig.CACertPEM != "" {
 		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -184,6 +184,8 @@ func TestBedrockTransportEnforceHTTP2(t *testing.T) {
 	transport, ok := provider.client.Transport.(*http.Transport)
 	require.True(t, ok)
 	assert.True(t, transport.ForceAttemptHTTP2)
+	// TLSNextProto should NOT be set when HTTP/2 is enforced, allowing ALPN negotiation
+	assert.Nil(t, transport.TLSNextProto)
 }
 
 func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
@@ -201,4 +203,7 @@ func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
 	transport, ok := provider.client.Transport.(*http.Transport)
 	require.True(t, ok)
 	assert.False(t, transport.ForceAttemptHTTP2)
+	// TLSNextProto must be set to empty map to truly disable HTTP/2 ALPN negotiation
+	assert.NotNil(t, transport.TLSNextProto)
+	assert.Empty(t, transport.TLSNextProto)
 }


### PR DESCRIPTION
## Summary

Disables HTTP/2 auto-negotiation for HTTP clients to ensure HTTP/1.1 connections are used when HTTP/2 is not explicitly enforced. This addresses an issue where Go's http2 package automatically registers HTTP/2 support via TLSNextProto, causing unintended protocol upgrades even when `ForceAttemptHTTP2` is set to false.

## Changes

- Added `TLSNextProto` configuration to HTTP client factory to disable HTTP/2 for auxiliary clients (proxy/SCIM/API)
- Modified Bedrock provider to conditionally disable HTTP/2 auto-negotiation when `EnforceHTTP2` is false
- Added test coverage to verify HTTP/2 behavior is correctly controlled in both enabled and disabled states
- Set `TLSNextProto` to an empty map to prevent ALPN negotiation from upgrading connections to HTTP/2

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that HTTP protocol version is correctly controlled based on configuration:

```sh
# Run transport tests to verify HTTP/2 behavior
go test ./core/providers/bedrock -v -run TestBedrockTransportEnforceHTTP2

# Run all tests to ensure no regressions
go test ./...

# Test with network monitoring to verify actual protocol usage
# when EnforceHTTP2 is true vs false in provider configuration
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves network behavior predictability by ensuring the intended HTTP protocol version is used, which may have implications for connection security and performance characteristics.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable