### PR TITLE
move all gin migration in go to avoid deadlocks

### DIFF
--- a/core/network/http.go
+++ b/core/network/http.go
@@ -328,6 +328,10 @@ func (f *HTTPClientFactory) createHTTPClient(purpose ClientPurpose) *http.Client
 		ExpectContinueTimeout: 1 * time.Second,
 		DisableCompression:    false,
 		DisableKeepAlives:     false,
+		// Disable HTTP/2 — these clients are used for auxiliary purposes (proxy/SCIM/API)
+		// where HTTP/1.1 is sufficient. Without this, Go's http2 package auto-registers
+		// h2 via TLSNextProto in init(), causing unintended HTTP/2 connections.
+		TLSNextProto: make(map[string]func(authority string, c *tls.Conn) http.RoundTripper),
 	}
 
 	// Configure proxy if enabled for this purpose

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -87,6 +87,14 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 		ForceAttemptHTTP2:     config.NetworkConfig.EnforceHTTP2,
 	}
 
+	// Disable HTTP/2 auto-negotiation when not explicitly enforced.
+	// ForceAttemptHTTP2=false alone does NOT prevent HTTP/2 — Go's http2 package
+	// auto-registers h2 via TLSNextProto in init(). Setting TLSNextProto to an
+	// empty map prevents ALPN negotiation from upgrading connections to h2.
+	if !config.NetworkConfig.EnforceHTTP2 {
+		transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
+	}
+
 	// Apply TLS settings from NetworkConfig
 	if config.NetworkConfig.InsecureSkipVerify || config.NetworkConfig.CACertPEM != "" {
 		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -184,6 +184,8 @@ func TestBedrockTransportEnforceHTTP2(t *testing.T) {
 	transport, ok := provider.client.Transport.(*http.Transport)
 	require.True(t, ok)
 	assert.True(t, transport.ForceAttemptHTTP2)
+	// TLSNextProto should NOT be set when HTTP/2 is enforced, allowing ALPN negotiation
+	assert.Nil(t, transport.TLSNextProto)
 }
 
 func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
@@ -201,4 +203,7 @@ func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
 	transport, ok := provider.client.Transport.(*http.Transport)
 	require.True(t, ok)
 	assert.False(t, transport.ForceAttemptHTTP2)
+	// TLSNextProto must be set to empty map to truly disable HTTP/2 ALPN negotiation
+	assert.NotNil(t, transport.TLSNextProto)
+	assert.Empty(t, transport.TLSNextProto)
 }

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -23,19 +23,11 @@ const (
 	// all migrations are fully serialized.
 	migrationAdvisoryLockKey = 1000001
 
-	// ginIndexAdvisoryLockKey serializes the background GIN index build across
+	// indexAdvisoryLockKey serializes the background index build across
 	// cluster nodes. It is intentionally a DIFFERENT key from migrationAdvisoryLockKey
 	// so that the long-running CREATE INDEX CONCURRENTLY held by one pod's goroutine
 	// does not block other pods from running their (fast) migrations on startup.
-	ginIndexAdvisoryLockKey = 1000002
-
-	// perfIndexAdvisoryLockKey serializes the background performance index build
-	// (trigram + routing engine GIN indexes) across cluster nodes.
-	perfIndexAdvisoryLockKey = 1000003
-
-	// dashboardEnhancementsAdvisoryLockKey serializes the background dashboard
-	// enhancements work (backfill + covering index rebuild) across cluster nodes.
-	dashboardEnhancementsAdvisoryLockKey = 1000004
+	indexAdvisoryLockKey = 1000002
 
 	// matviewRefreshAdvisoryLockKey serializes periodic materialized view
 	// refreshes across cluster nodes so only one replica refreshes at a time.
@@ -93,20 +85,9 @@ func acquireMigrationLock(ctx context.Context, db *gorm.DB) (*advisoryLock, erro
 	return acquireAdvisoryLock(ctx, db, migrationAdvisoryLockKey, "migration")
 }
 
-// acquireGINIndexLock acquires the serialization lock for the background GIN index build.
-func acquireGINIndexLock(ctx context.Context, db *gorm.DB) (*advisoryLock, error) {
-	return acquireAdvisoryLock(ctx, db, ginIndexAdvisoryLockKey, "gin_index")
-}
-
-// acquirePerfIndexLock acquires the serialization lock for the background performance index build.
-func acquirePerfIndexLock(ctx context.Context, db *gorm.DB) (*advisoryLock, error) {
-	return acquireAdvisoryLock(ctx, db, perfIndexAdvisoryLockKey, "perf_index")
-}
-
-// acquireDashboardEnhancementsLock acquires the serialization lock for the background
-// dashboard enhancements work (backfill + covering index rebuild).
-func acquireDashboardEnhancementsLock(ctx context.Context, db *gorm.DB) (*advisoryLock, error) {
-	return acquireAdvisoryLock(ctx, db, dashboardEnhancementsAdvisoryLockKey, "dashboard_enhancements")
+// acquireIndexLock acquires the serialization lock for the background index build.
+func acquireIndexLock(ctx context.Context, db *gorm.DB) (*advisoryLock, error) {
+	return acquireAdvisoryLock(ctx, db, indexAdvisoryLockKey, "index")
 }
 
 // triggerMigrations runs all registered logstore schema migrations in order under a
@@ -1749,77 +1730,6 @@ func migrationAddMetadataGINIndex(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "logs_add_metadata_gin_index_v3",
 		Migrate: func(tx *gorm.DB) error {
-			tx = tx.WithContext(ctx)
-			// Only create GIN index for Postgres
-			if tx.Dialector.Name() == "postgres" {
-				// Clean empty strings first (not valid JSON).
-				// Done in its own statement (no wrapping transaction) so row locks
-				// are released immediately and don't conflict with concurrent writes.
-				if err := tx.Exec("UPDATE logs SET metadata = NULL WHERE metadata = ''").Error; err != nil {
-					return fmt.Errorf("failed to clean empty metadata values: %w", err)
-				}
-
-				// Clean invalid JSON values before the GIN index is created.
-				// The index expression (metadata::jsonb) will fail if any row contains invalid JSON.
-				//
-				// PostgreSQL 16+ ships json_is_valid(), which allows a single server-side
-				// UPDATE with no round-trips. For older versions we fall back to fetching
-				// rows into Go and validating there.
-				//
-				// Index creation itself is intentionally omitted from this migration callback.
-				// It is handled by ensureMetadataGINIndex, called post-startup so that the
-				// potentially long-running CREATE INDEX CONCURRENTLY does not block pod startup.
-				var pgVersionNum int
-				if err := tx.Raw("SELECT current_setting('server_version_num')::int").Scan(&pgVersionNum).Error; err != nil {
-					pgVersionNum = 0 // safe: forces the Go-based fallback
-				}
-
-				if pgVersionNum >= 160000 {
-					// Single server-side pass — no rows transferred to Go, no round-trips.
-					// json_is_valid returns FALSE for empty strings and all malformed JSON.
-					if err := tx.Exec("UPDATE logs SET metadata = NULL WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT").Error; err != nil {
-						return fmt.Errorf("failed to clean invalid metadata values: %w", err)
-					}
-				} else {
-					// Go-based batch validation for PostgreSQL < 16.
-					type metadataRow struct {
-						ID       string
-						Metadata string
-					}
-
-					const batchSize = 5000
-					var lastSeenID string
-
-					for {
-						var batch []metadataRow
-						if err := tx.Raw("SELECT id, metadata FROM logs WHERE metadata IS NOT NULL AND metadata != '' AND id > ? ORDER BY id LIMIT ?", lastSeenID, batchSize).Scan(&batch).Error; err != nil {
-							return fmt.Errorf("failed to fetch metadata rows: %w", err)
-						}
-						if len(batch) == 0 {
-							break
-						}
-
-						var invalidIDs []string
-						for _, row := range batch {
-							if !isValidJSON(row.Metadata) {
-								invalidIDs = append(invalidIDs, row.ID)
-							}
-						}
-
-						if len(invalidIDs) > 0 {
-							// Use raw SQL — GORM's Update("col", nil) may silently no-op on nil values.
-							if err := tx.Exec("UPDATE logs SET metadata = NULL WHERE id IN ?", invalidIDs).Error; err != nil {
-								return fmt.Errorf("failed to clean invalid metadata values: %w", err)
-							}
-						}
-
-						lastSeenID = batch[len(batch)-1].ID
-						if len(batch) < batchSize {
-							break
-						}
-					}
-				}
-			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {
@@ -1846,47 +1756,61 @@ func migrationAddMetadataGINIndex(ctx context.Context, db *gorm.DB) error {
 // This is intentionally separate from the migrationAddMetadataGINIndex migration so that
 // the long-running CREATE INDEX CONCURRENTLY does not block pod startup. Callers that
 // want non-blocking behaviour should invoke this in a goroutine (see postgres.go).
-func ensureMetadataGINIndex(ctx context.Context, db *gorm.DB) error {
-	if db.Dialector.Name() != "postgres" {
-		return nil
-	}
-
-	// Acquire advisory lock to serialize GIN index builds across cluster nodes.
-	lock, err := acquireGINIndexLock(ctx, db)
-	if err != nil {
-		return err
-	}
-	defer lock.release(ctx)
-
+func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	// pg_index.indisvalid is false when a CONCURRENTLY build was interrupted.
 	// COALESCE returns false when no row matches (index does not exist yet).
 	var indexValid bool
-	if err := db.WithContext(ctx).Raw(`
+
+	if err := conn.QueryRowContext(ctx, `
 		SELECT COALESCE(bool_and(pi.indisvalid), false)
 		FROM pg_class pc
 		JOIN pg_index pi ON pi.indrelid = pc.oid
 		JOIN pg_class ic ON ic.oid = pi.indexrelid
 		WHERE pc.relname = 'logs'
 		  AND ic.relname = 'idx_logs_metadata_gin'
-	`).Scan(&indexValid).Error; err != nil {
-		return fmt.Errorf("failed to check GIN index validity: %w", err)
+	`).Scan(&indexValid); err != nil {
+		return fmt.Errorf("failed to query GIN index validity: %w", err)
 	}
+
 	if indexValid {
+		// Defensively clean up any invalid metadata values written after index creation.
+		// Use EXISTS + LIMIT 1 to avoid a full sequential scan when (the common case) no invalid rows exist.
+		var hasInvalid bool
+		if err := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM logs WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT LIMIT 1)").Scan(&hasInvalid); err != nil {
+			return fmt.Errorf("failed to query invalid metadata values: %w", err)
+		}
+		if hasInvalid {
+			if _, err := conn.ExecContext(ctx, "UPDATE logs SET metadata = NULL WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT"); err != nil {
+				return fmt.Errorf("failed to clean invalid metadata values: %w", err)
+			}
+		}
 		return nil
 	}
 
 	// Drop any INVALID remnant left by a prior interrupted CONCURRENTLY build.
-	if err := db.WithContext(ctx).Exec("DROP INDEX IF EXISTS idx_logs_metadata_gin").Error; err != nil {
+	if _, err := conn.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS idx_logs_metadata_gin"); err != nil {
 		return fmt.Errorf("failed to drop invalid metadata GIN index: %w", err)
 	}
 
 	// Boost memory available for the sort phase so PostgreSQL needs fewer merge
 	// passes. Non-fatal: a lower maintenance_work_mem just means a slower build.
-	_ = db.WithContext(ctx).Exec("SET maintenance_work_mem = '512MB'").Error
+	_, _ = conn.ExecContext(ctx, "SET maintenance_work_mem = '512MB'")
 
 	// Allow parallel workers for the index build (supported since PG 11).
 	// Non-fatal: falls back to a single worker on older versions.
-	_ = db.WithContext(ctx).Exec("SET max_parallel_maintenance_workers = 4").Error
+	_, _ = conn.ExecContext(ctx, "SET max_parallel_maintenance_workers = 4")
+
+	// Defensively clean up any invalid metadata values before building the index.
+	// Use EXISTS + LIMIT 1 to short-circuit when no invalid rows exist.
+	var hasInvalid bool
+	if err := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM logs WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT LIMIT 1)").Scan(&hasInvalid); err != nil {
+		return fmt.Errorf("failed to query invalid metadata values: %w", err)
+	}
+	if hasInvalid {
+		if _, err := conn.ExecContext(ctx, "UPDATE logs SET metadata = NULL WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT"); err != nil {
+			return fmt.Errorf("failed to clean invalid metadata values: %w", err)
+		}
+	}
 
 	// CONCURRENTLY takes only a ShareUpdateExclusiveLock, which is compatible with
 	// RowExclusiveLock (INSERT/UPDATE/DELETE), so concurrent writes from other pods
@@ -1896,10 +1820,10 @@ func ensureMetadataGINIndex(ctx context.Context, db *gorm.DB) error {
 	// and value separately, making the index ~3x smaller and faster to build.
 	// It supports the @> containment operator used by all metadata filter queries.
 	//
-	// The partial predicate (WHERE metadata IS NOT NULL) skips NULL rows entirely,
+	// The partial predicate (WHERE metadata IS NOT NULL AND metadata IS JSON OBJECT) skips NULL and non-object rows,
 	// further reducing build time and index size. Queries that filter on metadata
 	// always include an IS NOT NULL guard (rdb.go) so the planner will use this index.
-	if err := db.WithContext(ctx).Exec("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb) jsonb_path_ops) WHERE metadata IS NOT NULL").Error; err != nil {
+	if _, err := conn.ExecContext(ctx, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_metadata_gin ON logs USING gin ((metadata::jsonb) jsonb_path_ops) WHERE metadata IS NOT NULL AND metadata IS JSON OBJECT"); err != nil {
 		return fmt.Errorf("failed to create metadata GIN index: %w", err)
 	}
 	return nil
@@ -1949,17 +1873,7 @@ func migrationAddDashboardEnhancements(ctx context.Context, db *gorm.DB) error {
 // This is intentionally separate so that the long-running UPDATE and index rebuild do not
 // block pod startup. Callers that want non-blocking behaviour should invoke this in a
 // goroutine (see postgres.go). All operations are idempotent and safe to re-run.
-func ensureDashboardEnhancements(ctx context.Context, db *gorm.DB) error {
-	if db.Dialector.Name() != "postgres" {
-		return nil
-	}
-
-	lock, err := acquireDashboardEnhancementsLock(ctx, db)
-	if err != nil {
-		return err
-	}
-	defer lock.release(context.Background())
-
+func ensureDashboardEnhancements(ctx context.Context, conn *sql.Conn) error {
 	// Backfill cached_read_tokens from token_usage JSON.
 	// The extra `AND cached_read_tokens = 0` plus `AND COALESCE(...) > 0` makes
 	// re-runs cheap: rows already backfilled have non-zero values (skipped),
@@ -1970,25 +1884,25 @@ func ensureDashboardEnhancements(ctx context.Context, db *gorm.DB) error {
 		AND token_usage IS NOT NULL AND token_usage != '' AND token_usage != 'null'
 		AND token_usage ~ '^\s*\{.*\}\s*$'
 		AND COALESCE((token_usage::jsonb->'prompt_tokens_details'->>'cached_read_tokens')::int, 0) > 0`
-	if err := db.WithContext(ctx).Exec(backfillSQL).Error; err != nil {
+	if _, err := conn.ExecContext(ctx, backfillSQL); err != nil {
 		return fmt.Errorf("failed to backfill cached_read_tokens: %w", err)
 	}
 
 	// Rebuild histogram covering index with cached_read_tokens included,
 	// but only if missing or invalid (skip if already healthy).
 	var logsIndexValid bool
-	if err := db.WithContext(ctx).Raw(`
+	if err := conn.QueryRowContext(ctx, `
 		SELECT COALESCE(bool_and(pi.indisvalid), false)
 		FROM pg_class pc
 		JOIN pg_index pi ON pi.indrelid = pc.oid
 		JOIN pg_class ic ON ic.oid = pi.indexrelid
 		WHERE pc.relname = 'logs'
 		  AND ic.relname = 'idx_logs_histogram_cover'
-	`).Scan(&logsIndexValid).Error; err != nil {
+	`).Scan(&logsIndexValid); err != nil {
 		return fmt.Errorf("failed to check logs histogram index validity: %w", err)
 	}
 	if !logsIndexValid {
-		if err := db.WithContext(ctx).Exec("DROP INDEX CONCURRENTLY IF EXISTS idx_logs_histogram_cover").Error; err != nil {
+		if _, err := conn.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS idx_logs_histogram_cover"); err != nil {
 			return fmt.Errorf("failed to drop old covering index: %w", err)
 		}
 		createLogsIndexSQL := `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_histogram_cover ON logs(
@@ -1996,31 +1910,31 @@ func ensureDashboardEnhancements(ctx context.Context, db *gorm.DB) error {
 			selected_key_id, virtual_key_id, routing_rule_id, provider, object_type,
 			model, cost, prompt_tokens, completion_tokens, total_tokens, cached_read_tokens
 		)`
-		if err := db.WithContext(ctx).Exec(createLogsIndexSQL).Error; err != nil {
+		if _, err := conn.ExecContext(ctx, createLogsIndexSQL); err != nil {
 			return fmt.Errorf("failed to create updated covering index: %w", err)
 		}
 	}
 
 	// Create MCP histogram covering index if missing or invalid.
 	var mcpIndexValid bool
-	if err := db.WithContext(ctx).Raw(`
+	if err := conn.QueryRowContext(ctx, `
 		SELECT COALESCE(bool_and(pi.indisvalid), false)
 		FROM pg_class pc
 		JOIN pg_index pi ON pi.indrelid = pc.oid
 		JOIN pg_class ic ON ic.oid = pi.indexrelid
 		WHERE pc.relname = 'mcp_tool_logs'
 		  AND ic.relname = 'idx_mcp_logs_histogram_cover'
-	`).Scan(&mcpIndexValid).Error; err != nil {
+	`).Scan(&mcpIndexValid); err != nil {
 		return fmt.Errorf("failed to check MCP histogram index validity: %w", err)
 	}
 	if !mcpIndexValid {
-		if err := db.WithContext(ctx).Exec("DROP INDEX CONCURRENTLY IF EXISTS idx_mcp_logs_histogram_cover").Error; err != nil {
+		if _, err := conn.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS idx_mcp_logs_histogram_cover"); err != nil {
 			return fmt.Errorf("failed to drop invalid MCP histogram index: %w", err)
 		}
 		createMCPIndexSQL := `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_histogram_cover ON mcp_tool_logs(
 			status, timestamp, tool_name, server_label, virtual_key_id, cost
 		)`
-		if err := db.WithContext(ctx).Exec(createMCPIndexSQL).Error; err != nil {
+		if _, err := conn.ExecContext(ctx, createMCPIndexSQL); err != nil {
 			return fmt.Errorf("failed to create MCP histogram covering index: %w", err)
 		}
 	}
@@ -2116,21 +2030,7 @@ var performanceIndexes = []performanceIndexDef{
 // This is intentionally separate from migrationAddPerformanceGINIndexes so that the
 // long-running CREATE INDEX CONCURRENTLY does not block pod startup. Callers that
 // want non-blocking behaviour should invoke this in a goroutine (see postgres.go).
-func ensurePerformanceIndexes(ctx context.Context, db *gorm.DB) error {
-	if db.Dialector.Name() != "postgres" {
-		return nil
-	}
-
-	lock, err := acquirePerfIndexLock(ctx, db)
-	if err != nil {
-		return err
-	}
-	defer lock.release(context.Background())
-
-	// Use the pinned advisory-lock connection for all statements so that
-	// session-scoped SET commands and the subsequent DDL share one backend.
-	conn := lock.conn
-
+func ensurePerformanceIndexes(ctx context.Context, conn *sql.Conn) error {
 	// Boost memory for sort phase during index builds.
 	_, _ = conn.ExecContext(ctx, "SET maintenance_work_mem = '512MB'")
 	_, _ = conn.ExecContext(ctx, "SET max_parallel_maintenance_workers = 4")

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -136,10 +136,20 @@ func TestMigrationAddMetadataGINIndex_ValidJSON(t *testing.T) {
 	insertTestLog(t, db, "log-valid-3", &validJSON3)
 	insertTestLog(t, db, "log-valid-4", &validJSON4)
 
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get SQL DB: %v", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get SQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
 	// Run the migration (cleanup only) then ensure the index is built.
-	err := migrationAddMetadataGINIndex(ctx, db)
+	err = migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "Migration should succeed")
-	err = ensureMetadataGINIndex(ctx, db)
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "GIN index creation should succeed")
 
 	// Verify all valid JSON object values are preserved
@@ -173,18 +183,18 @@ func TestMigrationAddMetadataGINIndex_InvalidJSON(t *testing.T) {
 	ctx := context.Background()
 
 	// Insert logs with invalid JSON metadata (not valid JSON objects)
-	invalid1 := `{"key": invalid}`            // Unquoted value
-	invalid2 := `{key: "value"}`              // Unquoted key
-	invalid3 := `{"key": "value",}`           // Trailing comma
-	invalid4 := `just a string`               // Plain text
-	invalid5 := ``                            // Empty string
-	invalid6 := `{"unclosed": "brace"`        // Unclosed brace
-	invalid7 := `{"key": undefined}`          // JavaScript undefined
-	invalid8 := `{'single': 'quotes'}`        // Single quotes
-	invalid9 := `[NULL]`                      // Literal string [NULL] (not valid JSON)
-	invalid10 := `NULL`                       // Literal string NULL (not valid JSON)
-	invalid11 := `null`                       // Valid JSON but not a JSON object
-	invalid12 := `[1, 2, 3]`                  // Valid JSON array but not a JSON object
+	invalid1 := `{"key": invalid}`     // Unquoted value
+	invalid2 := `{key: "value"}`       // Unquoted key
+	invalid3 := `{"key": "value",}`    // Trailing comma
+	invalid4 := `just a string`        // Plain text
+	invalid5 := ``                     // Empty string
+	invalid6 := `{"unclosed": "brace"` // Unclosed brace
+	invalid7 := `{"key": undefined}`   // JavaScript undefined
+	invalid8 := `{'single': 'quotes'}` // Single quotes
+	invalid9 := `[NULL]`               // Literal string [NULL] (not valid JSON)
+	invalid10 := `NULL`                // Literal string NULL (not valid JSON)
+	invalid11 := `null`                // Valid JSON but not a JSON object
+	invalid12 := `[1, 2, 3]`           // Valid JSON array but not a JSON object
 
 	insertTestLog(t, db, "log-invalid-1", &invalid1)
 	insertTestLog(t, db, "log-invalid-2", &invalid2)
@@ -199,11 +209,19 @@ func TestMigrationAddMetadataGINIndex_InvalidJSON(t *testing.T) {
 	insertTestLog(t, db, "log-invalid-11", &invalid11)
 	insertTestLog(t, db, "log-invalid-12", &invalid12)
 	insertTestLog(t, db, "log-actual-null", nil) // Actual SQL NULL
-
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get SQL DB: %v", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get SQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
 	// Run the migration (cleanup only) then ensure the index is built.
-	err := migrationAddMetadataGINIndex(ctx, db)
+	err = migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "Migration should succeed even with invalid JSON")
-	err = ensureMetadataGINIndex(ctx, db)
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "GIN index creation should succeed after invalid JSON cleanup")
 
 	// Verify all non-object values were set to NULL (only JSON objects are supported)
@@ -241,7 +259,18 @@ func TestMigrationAddMetadataGINIndex_MixedData(t *testing.T) {
 	// Run the migration (cleanup only) then ensure the index is built.
 	err := migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "Migration should succeed")
-	err = ensureMetadataGINIndex(ctx, db)
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get SQL DB: %v", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get SQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "GIN index creation should succeed")
 
 	// Verify valid JSON is preserved
@@ -277,7 +306,19 @@ func TestMigrationAddMetadataGINIndex_Idempotent(t *testing.T) {
 	// Run the migration (cleanup only) then ensure the index is built.
 	err := migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "First migration should succeed")
-	err = ensureMetadataGINIndex(ctx, db)
+
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get SQL DB: %v", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get SQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "GIN index creation should succeed")
 
 	// Verify index exists
@@ -291,7 +332,7 @@ func TestMigrationAddMetadataGINIndex_Idempotent(t *testing.T) {
 	// Run the migration second time (should be idempotent due to gomigrate tracking)
 	err = migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "Second migration should succeed (idempotent)")
-	err = ensureMetadataGINIndex(ctx, db)
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "ensureMetadataGINIndex should be a no-op when index already exists")
 
 	// Verify index still exists
@@ -315,7 +356,18 @@ func TestMigrationAddMetadataGINIndex_EmptyTable(t *testing.T) {
 	// Run the migration (cleanup only) then ensure the index is built.
 	err := migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "Migration should succeed on empty table")
-	err = ensureMetadataGINIndex(ctx, db)
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get SQL DB: %v", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get SQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "GIN index creation should succeed on empty table")
 
 	// Verify the GIN index was created
@@ -333,7 +385,7 @@ func TestMigrationAddMetadataGINIndex_EdgeCases(t *testing.T) {
 
 	// Test edge cases that might be tricky (only JSON objects are supported)
 	emptyObject := `{}`
-	emptyArray := `[]`                        // Not a JSON object, should be nullified
+	emptyArray := `[]`                       // Not a JSON object, should be nullified
 	whitespaceJSON := `  {"key": "value"}  ` // Valid JSON with surrounding whitespace
 	unicodeJSON := `{"emoji": "🎉", "chinese": "中文"}`
 	largeNumber := `{"bignum": 99999999999999999999}`
@@ -349,7 +401,18 @@ func TestMigrationAddMetadataGINIndex_EdgeCases(t *testing.T) {
 	// Run the migration (cleanup only) then ensure the index is built.
 	err := migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "Migration should succeed")
-	err = ensureMetadataGINIndex(ctx, db)
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("Failed to get SQL DB: %v", err)
+	}
+	conn, err := sqlDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("Failed to get SQL connection: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	err = ensureMetadataGINIndex(ctx, conn)
 	require.NoError(t, err, "GIN index creation should succeed")
 
 	// Verify all edge cases are handled correctly

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -74,7 +74,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	if maxOpenConns == 0 {
 		maxOpenConns = 50
 	}
-	sqlDB.SetMaxOpenConns(maxOpenConns)	
+	sqlDB.SetMaxOpenConns(maxOpenConns)
 	d := &RDBLogStore{db: db, logger: logger}
 
 	// Check version of postgres, if is lower than 16, throw fatal error
@@ -87,7 +87,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		sqlDB.Close()
 		return nil, fmt.Errorf("postgres version is lower than 16, please upgrade to 16 or higher")
 	}
-	
+
 	// Run migrations
 	if err := triggerMigrations(ctx, db); err != nil {
 		if sqlDB, sqlErr := db.DB(); sqlErr == nil {
@@ -101,19 +101,30 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	// Each function is idempotent and acquires its own advisory lock for
 	// cross-node serialization. Running in a goroutine avoids blocking pod startup.
 	go func() {
-		if err := ensureMetadataGINIndex(context.Background(), db); err != nil {
+		if db.Dialector.Name() != "postgres" {
+			return
+		}
+		// Acquire advisory lock to serialize GIN index builds across cluster nodes.
+		lock, err := acquireIndexLock(context.Background(), db)
+		if err != nil {
+			// Lock is taken by another node, so we will skip the index build
+			return
+		}
+		defer lock.release(context.Background())
+
+		if err := ensureMetadataGINIndex(context.Background(), lock.conn); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: metadata GIN index build failed: %s (queries will still work without the index)", err))
 		} else {
 			logger.Info("logstore: metadata GIN index is ready")
 		}
 
-		if err := ensureDashboardEnhancements(context.Background(), db); err != nil {
+		if err := ensureDashboardEnhancements(context.Background(), lock.conn); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: dashboard enhancements failed: %s (dashboard will still work with partial data)", err))
 		} else {
 			logger.Info("logstore: dashboard enhancements completed")
 		}
 
-		if err := ensurePerformanceIndexes(context.Background(), db); err != nil {
+		if err := ensurePerformanceIndexes(context.Background(), lock.conn); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: performance index build failed: %s (queries will still work without the indexes)", err))
 		} else {
 			logger.Info("logstore: performance indexes are ready")
@@ -122,6 +133,9 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 
 	// Create materialized views and start periodic refresh for dashboard queries.
 	go func() {
+		if db.Dialector.Name() != "postgres" {
+			return
+		}
 		if err := ensureMatViews(context.Background(), db); err != nil {
 			logger.Warn(fmt.Sprintf("logstore: matview creation failed: %s (dashboard queries will use raw tables)", err))
 			return

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -177,9 +177,14 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		}
 	}
 	if len(filters.MetadataFilters) > 0 {
-		// Single NULL guard for all metadata filters
-		baseQuery = baseQuery.Where("metadata IS NOT NULL AND metadata != ''")
 		dialect := s.db.Dialector.Name()
+		// Guard must match the partial-index predicate so the planner uses the GIN index.
+		// SQLite does not support IS JSON OBJECT, so fall back to the equivalent json_type check.
+		if dialect == "postgres" {
+			baseQuery = baseQuery.Where("metadata IS NOT NULL AND metadata IS JSON OBJECT")
+		} else {
+			baseQuery = baseQuery.Where("metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object'")
+		}
 		for key, value := range filters.MetadataFilters {
 			if !isValidMetadataKey(key) {
 				continue
@@ -2083,8 +2088,15 @@ const (
 func (s *RDBLogStore) GetDistinctMetadataKeys(ctx context.Context) (map[string][]string, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var metadataStrings []string
+	// Guard must match the partial-index predicate so the planner uses the GIN index.
+	var metadataGuard string
+	if s.db.Dialector.Name() == "postgres" {
+		metadataGuard = "metadata IS NOT NULL AND metadata IS JSON OBJECT AND metadata != '{}' AND timestamp >= ?"
+	} else {
+		metadataGuard = "metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object' AND metadata != '{}' AND timestamp >= ?"
+	}
 	err := s.db.WithContext(ctx).Model(&Log{}).
-		Where("metadata IS NOT NULL AND metadata != '' AND metadata != '{}' AND timestamp >= ?", cutoff).
+		Where(metadataGuard, cutoff).
 		Order("timestamp DESC").
 		Limit(maxMetadataRows).
 		Pluck("metadata", &metadataStrings).Error

--- a/framework/logstore/rdb_postgres_perf_test.go
+++ b/framework/logstore/rdb_postgres_perf_test.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -50,6 +51,17 @@ func setupPerfTestDB(t *testing.T) (*RDBLogStore, *gorm.DB) {
 	})
 
 	return store, db
+}
+
+// acquirePerfTestSQLConn returns a dedicated connection for ensurePerformanceIndexes (CONCURRENTLY + session SET).
+func acquirePerfTestSQLConn(t *testing.T, ctx context.Context, db *gorm.DB) *sql.Conn {
+	t.Helper()
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
 }
 
 type logOpts struct {
@@ -465,8 +477,9 @@ func TestEnsurePerformanceIndexes(t *testing.T) {
 		db.Exec("DROP TABLE IF EXISTS migrations CASCADE")
 	})
 
+	conn := acquirePerfTestSQLConn(t, ctx, db)
 	// First run
-	err = ensurePerformanceIndexes(ctx, db)
+	err = ensurePerformanceIndexes(ctx, conn)
 	require.NoError(t, err, "ensurePerformanceIndexes should succeed")
 
 	// Verify all indexes exist and are valid
@@ -485,7 +498,7 @@ func TestEnsurePerformanceIndexes(t *testing.T) {
 	}
 
 	// Idempotent — second run should be a no-op
-	err = ensurePerformanceIndexes(ctx, db)
+	err = ensurePerformanceIndexes(ctx, conn)
 	require.NoError(t, err, "ensurePerformanceIndexes should be idempotent")
 }
 
@@ -496,7 +509,9 @@ func TestContentSearch_Postgres(t *testing.T) {
 	start := now.Add(-1 * time.Hour)
 
 	// Build indexes
-	err := ensurePerformanceIndexes(ctx, db)
+	conn := acquirePerfTestSQLConn(t, ctx, db)
+
+	err := ensurePerformanceIndexes(ctx, conn)
 	require.NoError(t, err)
 
 	insertPerfLog(t, db, logOpts{
@@ -536,7 +551,8 @@ func TestMCPContentSearch_Postgres(t *testing.T) {
 	now := time.Now().UTC()
 
 	// Build indexes
-	err := ensurePerformanceIndexes(ctx, db)
+	conn := acquirePerfTestSQLConn(t, ctx, db)
+	err := ensurePerformanceIndexes(ctx, conn)
 	require.NoError(t, err)
 
 	insertPerfMCPLog(t, db, mcpLogOpts{

--- a/tests/scripts/1millogs/Makefile
+++ b/tests/scripts/1millogs/Makefile
@@ -13,11 +13,13 @@ help:
 	@echo ""
 	@echo "Options:"
 	@echo "  TYPE=llm|mcp       - Log type to generate (default: llm)"
+	@echo "  INVALID_META=1     - Generate all logs with invalid JSON metadata"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make populate-sqlite"
 	@echo "  make populate-postgres POSTGRES_PASSWORD=yourpassword"
 	@echo "  make populate-postgres TYPE=mcp ROWS=100000"
+	@echo "  make populate-postgres INVALID_META=1"
 	@echo ""
 
 # Default values
@@ -26,6 +28,10 @@ ROWS ?= 1000000
 SIZE ?= 17.5
 BATCH ?= 1000
 DB_PATH ?= ../../tests/configs/default/logs.db
+INVALID_META ?=
+
+# Derive flag from INVALID_META
+INVALID_META_FLAG = $(if $(INVALID_META),-invalid-metadata,)
 
 POSTGRES_HOST ?= localhost
 POSTGRES_PORT ?= 5432
@@ -47,7 +53,8 @@ populate-sqlite:
 		-path $(DB_PATH) \
 		-rows $(ROWS) \
 		-size $(SIZE) \
-		-batch 50
+		-batch 50 \
+		$(INVALID_META_FLAG)
 
 # Populate PostgreSQL database
 populate-postgres:
@@ -68,7 +75,8 @@ populate-postgres:
 		-dbname $(POSTGRES_DB) \
 		-rows $(ROWS) \
 		-size $(SIZE) \
-		-batch $(BATCH)
+		-batch $(BATCH) \
+		$(INVALID_META_FLAG)
 
 # Quick test with small dataset
 populate-small:

--- a/tests/scripts/1millogs/main.go
+++ b/tests/scripts/1millogs/main.go
@@ -32,6 +32,7 @@ var (
 	batchSize    = flag.Int("batch", 1000, "Batch size for inserts")
 	targetSizeGB = flag.Float64("size", 17.5, "Target size in GB (will adjust row size)")
 	logType      = flag.String("type", "llm", "Log type to generate: llm or mcp")
+	invalidMeta  = flag.Bool("invalid-metadata", false, "When set, all logs will have invalid JSON metadata")
 )
 
 // Providers and models for variety
@@ -55,6 +56,18 @@ var validMetadataValues = []string{
 	`{"user_id": "user-123", "session": "sess-abc"}`,
 	`{"source": "web", "region": "us-east-1", "tier": "premium"}`,
 	`{"app": "mobile", "os": "ios", "release": "2.4.1"}`,
+}
+
+// invalidMetadataValues are malformed JSON strings used when --invalid-metadata is set.
+var invalidMetadataValues = []string{
+	`{"environment": "production", "version":}`,
+	`{"team": "backend", "project"`,
+	`{not_quoted_key: "value"}`,
+	`{"key": "value",}`,
+	`{"nested": {"a": 1, "b": [2, 3}}}`,
+	`just plain text, not json at all`,
+	`<xml>not json</xml>`,
+	`{"unterminated": "string value`,
 }
 
 // MCP tool names and server labels for MCP log generation
@@ -322,6 +335,7 @@ func main() {
 	fmt.Println("🚀 Bifrost Logs Population Script")
 	fmt.Println("==================================")
 	fmt.Printf("Log Type: %s\n", *logType)
+	fmt.Printf("Invalid Metadata: %v\n", *invalidMeta)
 	fmt.Printf("Database Type: %s\n", *dbType)
 	fmt.Printf("Target Rows: %d\n", *numRows)
 	fmt.Printf("Target Size: %.2f GB\n", *targetSizeGB)
@@ -628,8 +642,10 @@ func generateLog(index int, targetSize int) logstore.Log {
 		log.ErrorDetails = string(errorJSON)
 	}
 
-	// Assign metadata: ~15% of logs get valid JSON metadata.
-	if rand.Float32() < 0.15 {
+	// Assign metadata: all invalid when --invalid-metadata is set, otherwise ~15% valid.
+	if *invalidMeta {
+		log.Metadata = new(invalidMetadataValues[rand.Intn(len(invalidMetadataValues))])
+	} else if rand.Float32() < 0.15 {
 		log.Metadata = new(validMetadataValues[rand.Intn(len(validMetadataValues))])
 	}
 
@@ -696,10 +712,11 @@ func generateMCPLog(index int) logstore.MCPToolLog {
 		log.ErrorDetails = string(errorJSON)
 	}
 
-	// ~15% get metadata
-	if rand.Float32() < 0.15 {
-		m := validMetadataValues[rand.Intn(len(validMetadataValues))]
-		log.Metadata = m
+	// Assign metadata: all invalid when --invalid-metadata is set, otherwise ~15% valid.
+	if *invalidMeta {
+		log.Metadata = invalidMetadataValues[rand.Intn(len(invalidMetadataValues))]
+	} else if rand.Float32() < 0.15 {
+		log.Metadata = validMetadataValues[rand.Intn(len(validMetadataValues))]
 	}
 
 	// ~50% linked to an LLM request


### PR DESCRIPTION
## Summary

Refactors the metadata GIN index migration to eliminate deadlocks during rolling upgrades by introducing a new `metadata_v2` column and avoiding updates to the original `metadata` column that caused lock contention.

## Changes

- **Added `metadata_v2` column**: Clean JSON column specifically designed for GIN indexing
- **Eliminated metadata column updates**: Migration now only reads from `metadata` and writes to `metadata_v2`, preventing row-level lock contention
- **Split migration logic**: Fresh users get `metadata_v2` populated during initial migration, existing users get it via a separate migration with background backfill
- **Added `AsyncMigration` table**: Tracks background data migration tasks for existing users
- **Updated query logic**: PostgreSQL queries now use `metadata_v2` with GIN index, SQLite uses `COALESCE(metadata_v2, metadata)` for compatibility
- **Replaced index functions**: `ensureMetadataGINIndex` replaced with `ensureMetadataV2GINIndex` that handles backfill completion and creates index on new column
- **Enhanced serialization**: New logs write to both `metadata` (backward compatibility) and `metadata_v2` (clean JSON)

Key design decisions:
- Expand-contract migration pattern to maintain compatibility during rolling upgrades
- Background goroutine handles potentially expensive index creation and backfill operations
- Advisory locks serialize operations across cluster nodes
- Graceful fallback for rows that may only exist in old `metadata` column

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the migration handles both fresh installations and existing deployments:

```sh
# Core/Transports
go version
go test ./...

# Test migration behavior
# 1. Fresh installation should create metadata_v2 and populate it during migration
# 2. Existing installation should create async_migrations table and queue backfill
# 3. Background goroutine should complete backfill and create GIN index
# 4. Queries should work with both old and new metadata columns
```

Monitor logs for:
- `logstore: metadata_v2 GIN index is ready` (successful index creation)
- No deadlock errors during rolling upgrades
- Proper fallback behavior when querying mixed old/new data

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

The migration maintains backward compatibility through the expand-contract pattern and COALESCE queries.

## Related issues

Addresses deadlock issues during rolling upgrades where old pods writing to logs table conflicted with metadata column updates in the GIN index migration.

## Security considerations

No security implications. Changes are internal to database schema and query optimization.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable