### PR TITLE
docs: update request options example to show nested parameters

### DIFF
--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -341,9 +341,10 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
 --data '{
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}],
-    "extra_params": {
-        "custom_param": "value",
-        "another_param": 123
+    "custom_param": "value",
+    "nested_param": {
+        "a": "value",
+        "b": 123
     }
 }'
 ```
@@ -360,7 +361,10 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
     Params: &schemas.ChatParameters{
         ExtraParams: map[string]interface{}{
             "custom_param":  "value",
-            "another_param": 123,
+            "nested_param": map[string]interface{}{
+                "a": "value",
+                "b": 123,
+            },
         },
     },
 })


### PR DESCRIPTION
## Summary

Updated the request options documentation to demonstrate passing custom parameters directly in the request body instead of nesting them under an `extra_params` object.

## Changes

- Removed the `extra_params` wrapper object from the curl example
- Updated parameter names to `custom_param` and `nested_param` for better clarity
- Demonstrated that nested objects can be passed directly as custom parameters

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation renders correctly and the curl example is valid:

```sh
# Test the curl command from the documentation
curl --location 'http://localhost:8080/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "model": "openai/gpt-4o-mini",
    "messages": [{"role": "user", "content": "Hello!"}],
    "custom_param": "value",
    "nested_param": {
        "a": "value",
        "b": 123
    }
}'
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a documentation-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable