### PR TITLE
fix(docs): keys to be added under provider configs

### DIFF
--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -70,7 +70,8 @@ curl -X POST http://localhost:8080/api/governance/virtual-keys \
       {
         "provider": "anthropic",
         "weight": 0.5,
-        "allowed_models": ["claude-3-sonnet-20240229"]
+        "allowed_models": ["claude-3-sonnet-20240229"],
+        "key_ids": ["d7a1b3c4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"]
       }
     ],
     "team_id": "team-eng-001",
@@ -84,7 +85,6 @@ curl -X POST http://localhost:8080/api/governance/virtual-keys \
       "request_max_limit": 100,
       "request_reset_duration": "1m"
     },
-    "key_ids": ["8c52039e-38c6-48b2-8016-0bd884b7befb"],
     "is_active": true
   }'
 ```
@@ -105,7 +105,8 @@ curl -X POST http://localhost:8080/api/governance/virtual-keys \
       {
         "provider": "anthropic",
         "weight": 0.5,
-        "allowed_models": ["claude-3-opus-20240229"]
+        "allowed_models": ["claude-3-opus-20240229"],
+        "key_ids": ["d7a1b3c4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"]
       }
     ],
     "customer_id": "customer-acme-corp",
@@ -173,15 +174,17 @@ curl -X DELETE http://localhost:8080/api/governance/virtual-keys/{vk_id}
           {
             "provider": "anthropic",
             "weight": 0.5,
-            "allowed_models": ["claude-3-sonnet-20240229"]
+            "allowed_models": ["claude-3-sonnet-20240229"],
+            "keys": [
+              {
+                "key_id": "d7a1b3c4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+              }
+            ]
           }
         ],
         "team_id": "team-eng-001",
         "budget_id": "budget-eng-vk",
-        "rate_limit_id": "rate-limit-eng-vk",
-        "keys": [
-          {"key_id": "8c52039e-38c6-48b2-8016-0bd884b7befb"}
-        ]
+        "rate_limit_id": "rate-limit-eng-vk"
       },
       {
         "id": "vk-002",
@@ -198,14 +201,16 @@ curl -X DELETE http://localhost:8080/api/governance/virtual-keys/{vk_id}
           {
             "provider": "anthropic",
             "weight": 0.5,
-            "allowed_models": ["claude-3-opus-20240229"]
+            "allowed_models": ["claude-3-opus-20240229"],
+            "keys": [
+              {
+                "key_id": "d7a1b3c4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+              }
+            ]
           }
         ],
         "customer_id": "customer-acme-corp",
-        "budget_id": "budget-exec-vk",
-        "keys": [
-          {"key_id": "8c52039e-38c6-48b2-8016-0bd884b7befb"}
-        ]
+        "budget_id": "budget-exec-vk"
       }
     ],
     "budgets": [


### PR DESCRIPTION
## Summary

Refactored the virtual keys API documentation to move `key_ids` from the top-level configuration into individual provider configurations, improving the logical organization of key assignments.

## Changes

- Moved `key_ids` array from virtual key root level to individual provider configurations
- Updated all API examples to reflect the new nested structure where keys are associated directly with their respective providers
- Modified response examples to show `keys` objects within provider configurations instead of at the virtual key level

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation examples are consistent and follow the new API structure:

```sh
# Review the updated virtual keys documentation
cat docs/features/governance/virtual-keys.mdx

# Ensure all curl examples use the new nested key_ids structure
grep -A 10 -B 5 "key_ids\|keys" docs/features/governance/virtual-keys.mdx
```

## Screenshots/Recordings

N/A - Documentation changes only

## Breaking changes

- [x] Yes
- [ ] No

This represents a breaking change to the virtual keys API structure. Existing integrations will need to migrate from specifying `key_ids` at the virtual key level to specifying them within individual provider configurations.

## Related issues

N/A

## Security considerations

No security implications - this is a documentation restructure that improves the logical association between API keys and their providers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable