### PR TITLE
feat(otel): add llm_spans_only config to filter infrastructure spans

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -40,6 +40,7 @@ The plugin supports multiple trace formats to match your observability platform:
 | `protocol` | `string` | ✅ Yes | Transport protocol: `http` or `grpc` |
 | `headers` | `object` | ❌ No | Custom headers for authentication (supports `env.VAR_NAME`) |
 | `tls_ca_cert` | `string` | ❌ No | File path to client CA certificate for TLS. Optional. Works with both gRPC and HTTP protocol |
+| `llm_spans_only` | `boolean` | ❌ No | When `true`, only export LLM operation spans and filter out infrastructure spans. Defaults to `false` |
 
 ### Environment Variable Substitution
 
@@ -577,6 +578,7 @@ Configure the OTel plugin with the following settings:
         "collector_url": "https://cloud.langfuse.com/api/public/otel",
         "trace_type": "genai_extension",
         "protocol": "http",
+        "llm_spans_only": true,
         "headers": {
           "Authorization": "env.LANGFUSE_AUTH"
         }
@@ -587,6 +589,10 @@ Configure the OTel plugin with the following settings:
 ```
 
 For US region, use `https://us.cloud.langfuse.com/api/public/otel` instead.
+
+<Tip>
+Set `llm_spans_only` to `true` to only export LLM operation span kinds: `llm.call`, `retry`, `fallback`, `embedding`, `speech`, and `transcription`. Infrastructure spans (HTTP requests, plugin hooks, key selection, MCP tool calls) are filtered out before export. This can significantly reduce telemetry volume and billing on collectors like Langfuse. Note that filtered parent spans may leave child spans with dangling parent references — most collectors handle this gracefully by promoting them to root level.
+</Tip>
 
 </Tab>
 </Tabs>

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -73,7 +73,18 @@ func hexToBytes(hexStr string, length int) []byte {
 func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
+		// When llmSpansOnly is enabled, skip non-LLM spans. Note: filtered spans
+		// may leave child spans with dangling ParentSpanId references. Most
+		// collectors (including Langfuse and Jaeger) handle this gracefully by
+		// promoting orphan spans to root level.
+		if p.llmSpansOnly && !isLLMOperationSpan(span.Kind) {
+			continue
+		}
 		otelSpans = append(otelSpans, p.convertSpanToOTELSpan(trace.TraceID, span))
+	}
+
+	if len(otelSpans) == 0 {
+		return nil
 	}
 
 	return &ResourceSpan{
@@ -84,6 +95,24 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 			Scope:  p.getInstrumentationScope(),
 			Spans:  otelSpans,
 		}},
+	}
+}
+
+// isLLMOperationSpan returns true for span kinds that represent LLM operations.
+// Infrastructure spans (HTTP requests, plugin hooks, key selection) and MCP tool
+// spans are intentionally excluded — MCP tool invocations are infrastructure-level
+// calls not directly related to LLM cost and latency analysis.
+func isLLMOperationSpan(kind schemas.SpanKind) bool {
+	switch kind {
+	case schemas.SpanKindLLMCall,
+		schemas.SpanKindRetry,
+		schemas.SpanKindFallback,
+		schemas.SpanKindEmbedding,
+		schemas.SpanKindSpeech,
+		schemas.SpanKindTranscription:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/plugins/otel/converter_test.go
+++ b/plugins/otel/converter_test.go
@@ -1,0 +1,152 @@
+package otel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// makeSpan creates a test span with the given name and kind.
+func makeSpan(name string, kind schemas.SpanKind) *schemas.Span {
+	now := time.Now()
+	return &schemas.Span{
+		SpanID:    "abcdef1234567890",
+		Name:      name,
+		Kind:      kind,
+		StartTime: now,
+		EndTime:   now.Add(10 * time.Millisecond),
+		Status:    schemas.SpanStatusOk,
+	}
+}
+
+// TestConvertTraceToResourceSpan_LLMSpansOnlyFalse verifies all spans are exported when llmSpansOnly is disabled.
+func TestConvertTraceToResourceSpan_LLMSpansOnlyFalse(t *testing.T) {
+	p := &OtelPlugin{
+		serviceName:  "test",
+		llmSpansOnly: false,
+	}
+	trace := &schemas.Trace{
+		TraceID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Spans: []*schemas.Span{
+			makeSpan("http.request", schemas.SpanKindHTTPRequest),
+			makeSpan("llm.call", schemas.SpanKindLLMCall),
+			makeSpan("plugin.otel.prehook", schemas.SpanKindPlugin),
+			makeSpan("plugin.telemetry.posthook", schemas.SpanKindPlugin),
+			makeSpan("key.selection", schemas.SpanKindInternal),
+		},
+	}
+
+	result := p.convertTraceToResourceSpan(trace)
+	if result == nil {
+		t.Fatal("expected non-nil ResourceSpan, got nil")
+	}
+	spans := result.ScopeSpans[0].Spans
+	if len(spans) != 5 {
+		t.Errorf("expected 5 spans (all exported), got %d", len(spans))
+	}
+}
+
+// TestConvertTraceToResourceSpan_LLMSpansOnlyTrue verifies only LLM operation spans are exported when llmSpansOnly is enabled.
+func TestConvertTraceToResourceSpan_LLMSpansOnlyTrue(t *testing.T) {
+	p := &OtelPlugin{
+		serviceName:  "test",
+		llmSpansOnly: true,
+	}
+	trace := &schemas.Trace{
+		TraceID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Spans: []*schemas.Span{
+			makeSpan("/v1/chat/completions", schemas.SpanKindHTTPRequest),
+			makeSpan("llm.call", schemas.SpanKindLLMCall),
+			makeSpan("plugin.otel.prehook", schemas.SpanKindPlugin),
+			makeSpan("plugin.telemetry.posthook", schemas.SpanKindPlugin),
+			makeSpan("key.selection", schemas.SpanKindInternal),
+			makeSpan("retry.attempt.1", schemas.SpanKindRetry),
+			makeSpan("fallback.openai.gpt-4", schemas.SpanKindFallback),
+			makeSpan("embedding.ada-002", schemas.SpanKindEmbedding),
+			makeSpan("speech.tts-1", schemas.SpanKindSpeech),
+			makeSpan("transcription.whisper-1", schemas.SpanKindTranscription),
+			makeSpan("mcp.tool.search", schemas.SpanKindMCPTool),
+		},
+	}
+
+	result := p.convertTraceToResourceSpan(trace)
+	if result == nil {
+		t.Fatal("expected non-nil ResourceSpan, got nil")
+	}
+	spans := result.ScopeSpans[0].Spans
+
+	// Only LLM operation spans should be kept (all 6 kinds)
+	if len(spans) != 6 {
+		t.Errorf("expected 6 spans (LLM operations only), got %d", len(spans))
+		for _, s := range spans {
+			t.Logf("  span: %s", s.Name)
+		}
+	}
+
+	expectedNames := map[string]bool{
+		"llm.call":               true,
+		"retry.attempt.1":        true,
+		"fallback.openai.gpt-4": true,
+		"embedding.ada-002":      true,
+		"speech.tts-1":           true,
+		"transcription.whisper-1": true,
+	}
+	for _, s := range spans {
+		if !expectedNames[s.Name] {
+			t.Errorf("unexpected span exported: %s", s.Name)
+		}
+	}
+}
+
+// TestConvertTraceToResourceSpan_LLMSpansOnlyNoLLMSpans verifies nil is returned when no LLM spans exist after filtering.
+func TestConvertTraceToResourceSpan_LLMSpansOnlyNoLLMSpans(t *testing.T) {
+	p := &OtelPlugin{
+		serviceName:  "test",
+		llmSpansOnly: true,
+	}
+	trace := &schemas.Trace{
+		TraceID: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1",
+		Spans: []*schemas.Span{
+			makeSpan("/v1/chat/completions", schemas.SpanKindHTTPRequest),
+			makeSpan("plugin.otel.prehook", schemas.SpanKindPlugin),
+			makeSpan("plugin.telemetry.posthook", schemas.SpanKindPlugin),
+			makeSpan("key.selection", schemas.SpanKindInternal),
+		},
+	}
+
+	result := p.convertTraceToResourceSpan(trace)
+	if result != nil {
+		t.Errorf("expected nil ResourceSpan when no LLM spans exist, got non-nil with %d scope spans", len(result.ScopeSpans))
+	}
+}
+
+// TestIsLLMOperationSpan validates classification of all span kinds as LLM or infrastructure.
+func TestIsLLMOperationSpan(t *testing.T) {
+	llmKinds := []schemas.SpanKind{
+		schemas.SpanKindLLMCall,
+		schemas.SpanKindRetry,
+		schemas.SpanKindFallback,
+		schemas.SpanKindEmbedding,
+		schemas.SpanKindSpeech,
+		schemas.SpanKindTranscription,
+	}
+	for _, kind := range llmKinds {
+		if !isLLMOperationSpan(kind) {
+			t.Errorf("expected %s to be an LLM operation span", kind)
+		}
+	}
+
+	infraKinds := []schemas.SpanKind{
+		schemas.SpanKindHTTPRequest,
+		schemas.SpanKindPlugin,
+		schemas.SpanKindInternal,
+		schemas.SpanKindMCPTool,
+		schemas.SpanKindUnspecified,
+	}
+	for _, kind := range infraKinds {
+		if isLLMOperationSpan(kind) {
+			t.Errorf("expected %s to NOT be an LLM operation span", kind)
+		}
+	}
+}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -52,6 +52,9 @@ type Config struct {
 	TLSCACert    string            `json:"tls_ca_cert"`
 	Insecure     bool              `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set
 
+	// Span export configuration
+	LLMSpansOnly *bool `json:"llm_spans_only,omitempty"` // When true, only export LLM operation spans and filter out infrastructure spans (default: false).
+
 	// Metrics push configuration
 	MetricsEnabled      bool   `json:"metrics_enabled"`
 	MetricsEndpoint     string `json:"metrics_endpoint"`
@@ -78,6 +81,8 @@ type OtelPlugin struct {
 	client OtelClient
 
 	pricingManager *modelcatalog.ModelCatalog
+
+	llmSpansOnly bool
 
 	// Metrics push support
 	metricsExporter *MetricsExporter
@@ -119,6 +124,11 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			}
 		}
 	}
+	// Resolve llm_spans_only (default false)
+	llmSpansOnly := false
+	if config.LLMSpansOnly != nil {
+		llmSpansOnly = *config.LLMSpansOnly
+	}
 	// Preparing the plugin
 	p := &OtelPlugin{
 		serviceName:               config.ServiceName,
@@ -129,6 +139,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
+		llmSpansOnly:              llmSpansOnly,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
@@ -263,9 +274,12 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 		// Convert schemas.Trace to OTEL ResourceSpan
 		resourceSpan := p.convertTraceToResourceSpan(trace)
 
-		// Emit to collector
-		if err := p.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
-			logger.Error("failed to emit trace %s: %v", trace.TraceID, err)
+		// Emit to collector. Skip if nil: either all spans were filtered out by
+		// llmSpansOnly, or the trace had no spans to begin with.
+		if resourceSpan != nil {
+			if err := p.client.Emit(ctx, []*ResourceSpan{resourceSpan}); err != nil {
+				logger.Error("failed to emit trace %s: %v", trace.TraceID, err)
+			}
 		}
 	}
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1315,6 +1315,11 @@
                     "insecure": {
                       "type": "boolean",
                       "description": "Skip TLS verification (ignored if tls_ca_cert is set)"
+                    },
+                    "llm_spans_only": {
+                      "type": "boolean",
+                      "description": "When true, only export LLM operation spans (llm.call, retry, fallback, embedding, speech, transcription) and filter out infrastructure spans.",
+                      "default": false
                     }
                   },
                   "required": [


### PR DESCRIPTION
_Disclaimer: I am not a Go developer — the code was written by AI but I did my best to review all its decisions._

## Summary

Adds a new `llm_spans_only` boolean config option (default: `false`) to the OTel plugin that filters out infrastructure spans and only exports LLM operation spans.

- When enabled, only `llm.call`, `retry`, `fallback`, `embedding`, `speech`, and `transcription` spans are exported
- Infrastructure spans (HTTP requests, plugin hooks, key selection) are filtered out
- Traces with zero spans after filtering are skipped entirely to avoid sending empty traces to collectors
- Reduces span count and billing on collectors like Langfuse (see issue for context on 5-10x billing impact)

**Note:** The issue proposed `export_plugin_spans` (default `true`), but I went with `llm_spans_only` (default `false`) since it describes what *is* exported rather than what's excluded. Happy to rename if preferred.

Closes #1561

## Test plan

- [x] Added unit tests for `isLLMOperationSpan` covering all span kinds
- [x] Added test for `llm_spans_only=false` (all spans exported)
- [x] Added test for `llm_spans_only=true` (only LLM spans exported)
- [x] Added test for `llm_spans_only=true` with no LLM spans (returns nil, no empty trace sent)
- [x] `go vet` passes
- [ ] Manual test with Langfuse collector