### PR TITLE
added lock split for model parameter sync

### DIFF
--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -219,6 +219,11 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 				}
 			}()
 		} else {
+			// Load initial pricing data
+			if err := mc.loadPricingFromDatabase(ctx); err != nil {
+				return nil, fmt.Errorf("failed to load initial pricing data: %w", err)
+			}
+			// lock for model_catalog_pricing_sync
 			lock, err := mc.distributedLockManager.NewLock("model_catalog_pricing_sync")
 			if err != nil {
 				return nil, fmt.Errorf("failed to create model catalog pricing sync lock: %w", err)
@@ -227,15 +232,22 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 				return nil, fmt.Errorf("failed to acquire model catalog pricing sync lock: %w", err)
 			}
 			defer lock.Unlock(ctx)
-			// Load initial pricing data
-			if err := mc.loadPricingFromDatabase(ctx); err != nil {
-				return nil, fmt.Errorf("failed to load initial pricing data: %w", err)
-			}
 			if err := mc.syncPricing(ctx); err != nil {
 				return nil, fmt.Errorf("failed to sync pricing data: %w", err)
 			}
 			// Sync model parameters asynchronously - not needed for startup
 			go func() {
+				// We created separate lock as here pods can keep on waiting on this lock
+				parameterSyncLock, err := mc.distributedLockManager.NewLockWithTTL("model_catalog_parameter_sync", 1*time.Minute)
+				if err != nil {
+					mc.logger.Warn("failed to create model catalog parameter sync lock: %v", err)
+					return
+				}
+				if err := parameterSyncLock.LockWithRetry(ctx, 10); err != nil {
+					mc.logger.Warn("failed to acquire model catalog parameter sync lock: %v", err)
+					return
+				}
+				defer parameterSyncLock.Unlock(ctx)
 				if err := mc.syncModelParameters(ctx); err != nil {
 					mc.logger.Warn("failed to sync model parameters data: %v", err)
 				}


### PR DESCRIPTION
## Summary

Improves model catalog initialization by loading pricing data before acquiring distributed locks and adds separate locking mechanism for parameter synchronization to prevent blocking during startup.

## Changes

- Moved initial pricing data loading to occur before acquiring the pricing sync lock to ensure data is available earlier in the initialization process
- Added a separate distributed lock with TTL for model parameter synchronization to prevent pods from waiting indefinitely on this lock
- Implemented retry mechanism for parameter sync lock acquisition with a 1-minute TTL and 10 retry attempts
- Made parameter synchronization more resilient by using warn-level logging instead of failing the entire initialization

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that model catalog initialization works correctly with multiple pods and that pricing data is loaded properly:

```sh
# Core/Transports
go version
go test ./...

# Test model catalog initialization with concurrent instances
# Verify pricing data loads before lock acquisition
# Verify parameter sync doesn't block startup process
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The changes introduce distributed locking mechanisms which should be reviewed to ensure proper lock cleanup and prevent potential deadlocks.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable