### PR TITLE
feat(otel): propagate raw request/response to OTEL span attributes

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -203,6 +203,10 @@ const (
 	AttrTimeToFirstToken = "gen_ai.response.time_to_first_token"
 	AttrTotalChunks      = "gen_ai.response.total_chunks"
 
+	// Raw Payload Attributes
+	AttrRawRequest  = "gen_ai.raw_request"
+	AttrRawResponse = "gen_ai.raw_response"
+
 	// Plugin Attributes (for aggregated streaming post-hook spans)
 	AttrPluginInvocations     = "plugin.invocation_count"
 	AttrPluginAvgDurationMs   = "plugin.avg_duration_ms"

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -85,6 +85,30 @@ This is useful for:
 
 ---
 
+## Raw Request/Response in Traces
+
+When raw request/response capture is enabled on a provider (via `send_back_raw_request` or `send_back_raw_response`), the raw payloads are automatically included as OTEL span attributes. This lets you see exactly what was sent to and received from the provider in your OTEL backend (Langfuse, Datadog, Grafana, etc.) without cross-referencing HTTP logs.
+
+### Span Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `gen_ai.raw_request` | `string` | JSON-serialized raw request body sent to the provider |
+| `gen_ai.raw_response` | `string` | JSON-serialized raw response body received from the provider |
+
+### Interaction with Capture Flags
+
+| Flag | Client Response | Logging Plugin | OTEL Spans |
+|------|----------------|----------------|------------|
+| `send_back_raw_request` / `send_back_raw_response` | Yes | Yes | Yes |
+| `store_raw_request_response` | No | Yes | No |
+
+<Note>
+Raw payloads can be large (avg ~95KB per request). Enable capture selectively for debugging or when your observability pipeline can handle the additional data volume.
+</Note>
+
+---
+
 ## Setup
 
 <Tabs group="setup-method">

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -40,6 +40,7 @@ The plugin supports multiple trace formats to match your observability platform:
 | `protocol` | `string` | ✅ Yes | Transport protocol: `http` or `grpc` |
 | `headers` | `object` | ❌ No | Custom headers for authentication (supports `env.VAR_NAME`) |
 | `tls_ca_cert` | `string` | ❌ No | File path to client CA certificate for TLS. Optional. Works with both gRPC and HTTP protocol |
+| `forward_raw_request_response` | `boolean` | ❌ No | Forward raw request/response payloads to OTEL span attributes. Defaults to `false` |
 
 ### Environment Variable Substitution
 
@@ -87,7 +88,7 @@ This is useful for:
 
 ## Raw Request/Response in Traces
 
-When raw request/response capture is enabled on a provider (via `send_back_raw_request` or `send_back_raw_response`), the raw payloads are automatically included as OTEL span attributes. This lets you see exactly what was sent to and received from the provider in your OTEL backend (Langfuse, Datadog, Grafana, etc.) without cross-referencing HTTP logs.
+When raw request/response capture is enabled on a provider (via `send_back_raw_request` or `send_back_raw_response`) **and** `forward_raw_request_response` is set to `true` in the OTEL plugin config, the raw payloads are included as OTEL span attributes. This lets you see exactly what was sent to and received from the provider in your OTEL backend (Langfuse, Datadog, Grafana, etc.) without cross-referencing HTTP logs.
 
 ### Span Attributes
 
@@ -98,7 +99,7 @@ When raw request/response capture is enabled on a provider (via `send_back_raw_r
 
 ### Interaction with Capture Flags
 
-| Flag | Client Response | Logging Plugin | OTEL Spans |
+| Flag | Client Response | Logging Plugin | OTEL Spans (when `forward_raw_request_response: true`) |
 |------|----------------|----------------|------------|
 | `send_back_raw_request` / `send_back_raw_response` | Yes | Yes | Yes |
 | `store_raw_request_response` | No | Yes | No |
@@ -181,12 +182,15 @@ For Gateway mode, configure via `config.json`:
         "protocol": "http",
         "headers": {
           "Authorization": "env.OTEL_API_KEY"
-        }
+        },
+        "forward_raw_request_response": false
       }
     }
   ]
 }
 ```
+
+Set `forward_raw_request_response` to `true` to include raw provider payloads in span attributes (requires provider-level `send_back_raw_request` / `send_back_raw_response` to be enabled).
 
 If you need to connect to an OTEL collector that requires TLS, configure `tls_ca_cert`:
 

--- a/docs/providers/supported-providers/overview.mdx
+++ b/docs/providers/supported-providers/overview.mdx
@@ -195,6 +195,7 @@ Bifrost can optionally return the raw request that was sent to the provider and 
 **Configuration options:**
 - **[Go SDK Provider Configuration](../../quickstart/go-sdk/provider-configuration)** - Configure `SendBackRawResponse` and other provider settings
 - **[Gateway Provider Configuration](../../quickstart/gateway/provider-configuration)** - Configure `send_back_raw_response` via API, UI, or config file
+- **[OTEL Observability](../../features/observability/otel)** - Raw payloads are automatically included as OTEL span attributes when capture is enabled
 
 <Note>
 Enabling raw request/response may increase response payload size and has minimal performance impact. Use it selectively in debugging/testing environments or when you need audit trails.

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -99,6 +100,22 @@ func PopulateResponseAttributes(resp *schemas.BifrostResponse) map[string]any {
 		PopulateFileDeleteResponseAttributes(resp.FileDeleteResponse, attrs)
 	case resp.FileContentResponse != nil:
 		PopulateFileContentResponseAttributes(resp.FileContentResponse, attrs)
+	}
+
+	// Propagate raw request/response to span attributes when present.
+	// These fields are populated when send_back_raw_request or send_back_raw_response
+	// is enabled on the provider. Marshal errors are intentionally suppressed:
+	// a serialisation failure must not degrade the span.
+	extraFields := resp.GetExtraFields()
+	if extraFields.RawRequest != nil {
+		if rawBytes, err := sonic.Marshal(extraFields.RawRequest); err == nil {
+			attrs[schemas.AttrRawRequest] = string(rawBytes)
+		}
+	}
+	if extraFields.RawResponse != nil {
+		if rawBytes, err := sonic.Marshal(extraFields.RawResponse); err == nil {
+			attrs[schemas.AttrRawResponse] = string(rawBytes)
+		}
 	}
 
 	return attrs

--- a/framework/tracing/llmspan_test.go
+++ b/framework/tracing/llmspan_test.go
@@ -1,0 +1,185 @@
+package tracing
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestPopulateResponseAttributes_RawRequestResponse(t *testing.T) {
+	rawReq := map[string]any{
+		"model":    "gpt-4",
+		"messages": []any{map[string]any{"role": "user", "content": "hello"}},
+	}
+	rawResp := map[string]any{
+		"id":      "chatcmpl-abc123",
+		"object":  "chat.completion",
+		"choices": []any{map[string]any{"index": 0, "message": map[string]any{"role": "assistant", "content": "hi"}}},
+	}
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RawRequest:  rawReq,
+				RawResponse: rawResp,
+			},
+		},
+	}
+
+	attrs := PopulateResponseAttributes(resp)
+
+	rawReqAttr, ok := attrs[schemas.AttrRawRequest]
+	if !ok {
+		t.Fatal("expected gen_ai.raw_request attribute to be present")
+	}
+	rawRespAttr, ok := attrs[schemas.AttrRawResponse]
+	if !ok {
+		t.Fatal("expected gen_ai.raw_response attribute to be present")
+	}
+
+	// Verify they are valid JSON strings
+	reqStr, ok := rawReqAttr.(string)
+	if !ok {
+		t.Fatalf("expected gen_ai.raw_request to be a string, got %T", rawReqAttr)
+	}
+	respStr, ok := rawRespAttr.(string)
+	if !ok {
+		t.Fatalf("expected gen_ai.raw_response to be a string, got %T", rawRespAttr)
+	}
+
+	var parsedReq map[string]any
+	if err := json.Unmarshal([]byte(reqStr), &parsedReq); err != nil {
+		t.Fatalf("gen_ai.raw_request is not valid JSON: %v", err)
+	}
+	if parsedReq["model"] != "gpt-4" {
+		t.Errorf("expected model=gpt-4, got %v", parsedReq["model"])
+	}
+
+	var parsedResp map[string]any
+	if err := json.Unmarshal([]byte(respStr), &parsedResp); err != nil {
+		t.Fatalf("gen_ai.raw_response is not valid JSON: %v", err)
+	}
+	if parsedResp["id"] != "chatcmpl-abc123" {
+		t.Errorf("expected id=chatcmpl-abc123, got %v", parsedResp["id"])
+	}
+}
+
+func TestPopulateResponseAttributes_NilRawFields(t *testing.T) {
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RawRequest:  nil,
+				RawResponse: nil,
+			},
+		},
+	}
+
+	attrs := PopulateResponseAttributes(resp)
+
+	if _, ok := attrs[schemas.AttrRawRequest]; ok {
+		t.Error("expected gen_ai.raw_request to be absent when RawRequest is nil")
+	}
+	if _, ok := attrs[schemas.AttrRawResponse]; ok {
+		t.Error("expected gen_ai.raw_response to be absent when RawResponse is nil")
+	}
+}
+
+func TestPopulateResponseAttributes_NilResponse(t *testing.T) {
+	attrs := PopulateResponseAttributes(nil)
+
+	if len(attrs) != 0 {
+		t.Errorf("expected empty attributes for nil response, got %d attributes", len(attrs))
+	}
+}
+
+func TestPopulateResponseAttributes_OnlyRawRequestSet(t *testing.T) {
+	rawReq := map[string]any{"model": "claude-3"}
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RawRequest:  rawReq,
+				RawResponse: nil,
+			},
+		},
+	}
+
+	attrs := PopulateResponseAttributes(resp)
+
+	if _, ok := attrs[schemas.AttrRawRequest]; !ok {
+		t.Error("expected gen_ai.raw_request to be present")
+	}
+	if _, ok := attrs[schemas.AttrRawResponse]; ok {
+		t.Error("expected gen_ai.raw_response to be absent when RawResponse is nil")
+	}
+}
+
+func TestPopulateResponseAttributes_OnlyRawResponseSet(t *testing.T) {
+	rawResp := map[string]any{"id": "msg_123"}
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RawRequest:  nil,
+				RawResponse: rawResp,
+			},
+		},
+	}
+
+	attrs := PopulateResponseAttributes(resp)
+
+	if _, ok := attrs[schemas.AttrRawRequest]; ok {
+		t.Error("expected gen_ai.raw_request to be absent when RawRequest is nil")
+	}
+	if _, ok := attrs[schemas.AttrRawResponse]; !ok {
+		t.Error("expected gen_ai.raw_response to be present")
+	}
+}
+
+func TestPopulateResponseAttributes_JsonRawMessageType(t *testing.T) {
+	raw := json.RawMessage(`{"model":"gpt-4","messages":[]}`)
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RawRequest: raw,
+			},
+		},
+	}
+
+	attrs := PopulateResponseAttributes(resp)
+
+	got, ok := attrs[schemas.AttrRawRequest].(string)
+	if !ok {
+		t.Fatal("expected gen_ai.raw_request to be a string")
+	}
+	if got != string(raw) {
+		t.Errorf("expected %q, got %q", string(raw), got)
+	}
+}
+
+func TestPopulateResponseAttributes_UnmarshalableRawRequest(t *testing.T) {
+	// channels cannot be marshaled to JSON
+	unmarshalable := make(chan int)
+
+	resp := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RawRequest:  unmarshalable,
+				RawResponse: map[string]any{"id": "msg_123"},
+			},
+		},
+	}
+
+	attrs := PopulateResponseAttributes(resp)
+
+	// RawRequest should be absent due to marshal error
+	if _, ok := attrs[schemas.AttrRawRequest]; ok {
+		t.Error("expected gen_ai.raw_request to be absent when marshal fails")
+	}
+	// RawResponse should still be present
+	if _, ok := attrs[schemas.AttrRawResponse]; !ok {
+		t.Error("expected gen_ai.raw_response to be present")
+	}
+}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -783,6 +783,11 @@
                     "insecure": {
                       "type": "boolean",
                       "description": "Skip TLS verification (ignored if tls_ca_cert is set)"
+                    },
+                    "forward_raw_request_response": {
+                      "type": "boolean",
+                      "description": "Forward raw request/response payloads to OTEL span attributes (gen_ai.raw_request, gen_ai.raw_response). Requires provider-level raw capture to be enabled.",
+                      "default": false
                     }
                   },
                   "if": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -395,6 +395,7 @@ bifrost:
         # TLS configuration
         tls_ca_cert: ""               # Path to TLS CA certificate file
         insecure: false               # Skip TLS verification (ignored if tls_ca_cert is set)
+        forward_raw_request_response: false  # Forward raw request/response payloads to OTEL span attributes
 
     datadog:
       enabled: false

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -89,6 +89,20 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 
 // convertSpanToOTELSpan converts a single Bifrost span to OTEL format
 func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *Span {
+	attrs := convertAttributesToKeyValues(span.Attributes)
+
+	// Strip raw request/response attributes when forwarding is disabled
+	if !p.forwardRawRequestResponse {
+		filtered := attrs[:0]
+		for _, kv := range attrs {
+			if kv.Key == schemas.AttrRawRequest || kv.Key == schemas.AttrRawResponse {
+				continue
+			}
+			filtered = append(filtered, kv)
+		}
+		attrs = filtered
+	}
+
 	otelSpan := &Span{
 		TraceId:           hexToBytes(traceID, 16),
 		SpanId:            hexToBytes(span.SpanID, 8),
@@ -96,7 +110,7 @@ func (p *OtelPlugin) convertSpanToOTELSpan(traceID string, span *schemas.Span) *
 		Kind:              convertSpanKind(span.Kind),
 		StartTimeUnixNano: uint64(span.StartTime.UnixNano()),
 		EndTimeUnixNano:   uint64(span.EndTime.UnixNano()),
-		Attributes:        convertAttributesToKeyValues(span.Attributes),
+		Attributes:        attrs,
 		Status:            convertSpanStatus(span.Status, span.StatusMsg),
 		Events:            convertSpanEvents(span.Events),
 	}

--- a/plugins/otel/converter_test.go
+++ b/plugins/otel/converter_test.go
@@ -1,0 +1,106 @@
+package otel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestConvertSpanToOTELSpan_ForwardRawEnabled(t *testing.T) {
+	p := &OtelPlugin{forwardRawRequestResponse: true}
+	span := &schemas.Span{
+		SpanID:    "abc123",
+		Name:      "llm.call",
+		Kind:      schemas.SpanKindLLMCall,
+		Status:    schemas.SpanStatusOk,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+		Attributes: map[string]any{
+			schemas.AttrRawRequest:  `{"model":"gpt-4"}`,
+			schemas.AttrRawResponse: `{"choices":[]}`,
+			schemas.AttrRequestModel: "gpt-4",
+		},
+	}
+
+	otelSpan := p.convertSpanToOTELSpan("aabbccdd", span)
+
+	found := map[string]bool{
+		schemas.AttrRawRequest:   false,
+		schemas.AttrRawResponse:  false,
+		schemas.AttrRequestModel: false,
+	}
+	for _, kv := range otelSpan.Attributes {
+		if _, ok := found[kv.Key]; ok {
+			found[kv.Key] = true
+		}
+	}
+	for key, present := range found {
+		if !present {
+			t.Errorf("expected attribute %q to be present when forwarding is enabled", key)
+		}
+	}
+}
+
+func TestConvertSpanToOTELSpan_ForwardRawDisabled(t *testing.T) {
+	p := &OtelPlugin{forwardRawRequestResponse: false}
+	span := &schemas.Span{
+		SpanID:    "abc123",
+		Name:      "llm.call",
+		Kind:      schemas.SpanKindLLMCall,
+		Status:    schemas.SpanStatusOk,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+		Attributes: map[string]any{
+			schemas.AttrRawRequest:   `{"model":"gpt-4"}`,
+			schemas.AttrRawResponse:  `{"choices":[]}`,
+			schemas.AttrRequestModel: "gpt-4",
+		},
+	}
+
+	otelSpan := p.convertSpanToOTELSpan("aabbccdd", span)
+
+	for _, kv := range otelSpan.Attributes {
+		if kv.Key == schemas.AttrRawRequest || kv.Key == schemas.AttrRawResponse {
+			t.Errorf("attribute %q should be stripped when forwarding is disabled", kv.Key)
+		}
+	}
+
+	// Other attributes should still be present
+	foundModel := false
+	for _, kv := range otelSpan.Attributes {
+		if kv.Key == schemas.AttrRequestModel {
+			foundModel = true
+		}
+	}
+	if !foundModel {
+		t.Error("non-raw attributes should be preserved when forwarding is disabled")
+	}
+}
+
+func TestConvertSpanToOTELSpan_NoRawAttrs(t *testing.T) {
+	p := &OtelPlugin{forwardRawRequestResponse: false}
+	span := &schemas.Span{
+		SpanID:    "abc123",
+		Name:      "llm.call",
+		Kind:      schemas.SpanKindLLMCall,
+		Status:    schemas.SpanStatusOk,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+		Attributes: map[string]any{
+			schemas.AttrRequestModel: "gpt-4",
+		},
+	}
+
+	otelSpan := p.convertSpanToOTELSpan("aabbccdd", span)
+
+	foundModel := false
+	for _, kv := range otelSpan.Attributes {
+		if kv.Key == schemas.AttrRequestModel {
+			foundModel = true
+		}
+	}
+	if !foundModel {
+		t.Error("attributes should be unaffected when no raw attrs are present")
+	}
+}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -52,6 +52,9 @@ type Config struct {
 	TLSCACert    string            `json:"tls_ca_cert"`
 	Insecure     bool              `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set
 
+	// Forward raw request/response payloads to OTEL span attributes (default: false)
+	ForwardRawRequestResponse *bool `json:"forward_raw_request_response"`
+
 	// Metrics push configuration
 	MetricsEnabled      bool   `json:"metrics_enabled"`
 	MetricsEndpoint     string `json:"metrics_endpoint"`
@@ -78,6 +81,9 @@ type OtelPlugin struct {
 	client OtelClient
 
 	pricingManager *modelcatalog.ModelCatalog
+
+	// Forward raw request/response to OTEL spans
+	forwardRawRequestResponse bool
 
 	// Metrics push support
 	metricsExporter *MetricsExporter
@@ -119,6 +125,12 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			}
 		}
 	}
+	// Resolve forward_raw_request_response (default false)
+	forwardRaw := false
+	if config.ForwardRawRequestResponse != nil {
+		forwardRaw = *config.ForwardRawRequestResponse
+	}
+
 	// Preparing the plugin
 	p := &OtelPlugin{
 		serviceName:               config.ServiceName,
@@ -129,6 +141,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
+		forwardRawRequestResponse: forwardRaw,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1315,6 +1315,11 @@
                     "insecure": {
                       "type": "boolean",
                       "description": "Skip TLS verification (ignored if tls_ca_cert is set)"
+                    },
+                    "forward_raw_request_response": {
+                      "type": "boolean",
+                      "description": "Forward raw request/response payloads to OTEL span attributes (gen_ai.raw_request, gen_ai.raw_response). Requires provider-level raw capture to be enabled.",
+                      "default": false
                     }
                   },
                   "required": [

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -26,6 +26,8 @@ interface OtelFormFragmentProps {
 		// TLS configuration
 		tls_ca_cert?: string;
 		insecure?: boolean;
+		// Raw request/response forwarding
+		forward_raw_request_response?: boolean;
 		// Metrics push configuration
 		metrics_enabled?: boolean;
 		metrics_endpoint?: string;
@@ -54,6 +56,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 				protocol: initialConfig?.protocol ?? "http",
 				tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
 				insecure: initialConfig?.insecure ?? true,
+				forward_raw_request_response: initialConfig?.forward_raw_request_response ?? false,
 				metrics_enabled: initialConfig?.metrics_enabled ?? false,
 				metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
 				metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
@@ -98,6 +101,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 				protocol: initialConfig?.protocol || "http",
 				tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
 				insecure: initialConfig?.insecure ?? true,
+				forward_raw_request_response: initialConfig?.forward_raw_request_response ?? false,
 				metrics_enabled: initialConfig?.metrics_enabled ?? false,
 				metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
 				metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
@@ -283,6 +287,34 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 					</div>
 				</div>
 
+				{/* Raw Request/Response Forwarding */}
+				<div className="space-y-4 border-t pt-4">
+					<FormField
+						control={form.control}
+						name="otel_config.forward_raw_request_response"
+						render={({ field }) => (
+							<FormItem className="flex flex-row items-center gap-2">
+								<div className="flex w-full flex-row items-center gap-2">
+									<div className="flex flex-col gap-1">
+										<h3 className="text-sm font-medium">Forward Raw Request/Response</h3>
+										<p className="text-muted-foreground text-xs">
+											Include raw provider request/response payloads in OTEL span attributes. Requires provider-level raw capture to be enabled.
+										</p>
+									</div>
+									<div className="ml-auto">
+										<Switch
+											data-testid="otel-forward-raw-toggle"
+											checked={field.value}
+											onCheckedChange={field.onChange}
+											disabled={!hasOtelAccess}
+										/>
+									</div>
+								</div>
+							</FormItem>
+						)}
+					/>
+				</div>
+
 				{/* Metrics Push Configuration */}
 				<div className="space-y-4 border-t pt-4">
 					<FormField
@@ -410,6 +442,7 @@ export function OtelFormFragment({ currentConfig: initialConfig, onSave, onDelet
 										protocol: initialConfig?.protocol ?? "http",
 										tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
 										insecure: initialConfig?.insecure ?? true,
+										forward_raw_request_response: initialConfig?.forward_raw_request_response ?? false,
 										metrics_enabled: initialConfig?.metrics_enabled ?? false,
 										metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
 										metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -698,6 +698,8 @@ export const otelConfigSchema = z
 		// TLS configuration
 		tls_ca_cert: z.string().optional(),
 		insecure: z.boolean().default(true),
+		// Raw request/response forwarding
+		forward_raw_request_response: z.boolean().default(false),
 		// Metrics push configuration
 		metrics_enabled: z.boolean().default(false),
 		metrics_endpoint: z.string().optional(),


### PR DESCRIPTION
> **Disclaimer:** I am not a Go developer — the code was written by AI but I did my best to review all its decisions.

## Summary
- Add `gen_ai.raw_request` / `gen_ai.raw_response` as OTEL span attributes in `PopulateResponseAttributes`
- Add attribute constants to `core/schemas/trace.go`
- Gate emission behind `forward_raw_request_response` OTEL plugin config (default `false`)
- Document the new attributes and their interaction with capture flags in `otel.mdx`

## Design decisions

**Attribute naming**: Uses `gen_ai.raw_request` / `gen_ai.raw_response` under the existing `gen_ai.*` namespace, consistent with other span attributes in the codebase.

**`sonic` for serialisation**: Uses `sonic.Marshal` following the logging plugin's established pattern for raw payload serialisation (`plugins/logging/main.go`, `plugins/logging/operations.go`). The `framework/tracing` package previously had no `sonic` dependency; this PR introduces it for consistency with the rest of the framework module.

**`forward_raw_request_response` config flag**: Raw attributes are always populated in the internal tracing layer, but the OTEL plugin strips them at emission time unless `forward_raw_request_response: true` is set. This keeps the default safe (no large payloads in spans) while letting operators opt-in. Addresses feedback from @akshaydeo.

**`store_raw_request_response` does NOT propagate to OTEL**: When only `store_raw_request_response` is enabled (with both `send_back_raw_*` off), `core/bifrost.go` temporarily populates the raw fields for PostLLMHooks but strips them before `PopulateResponseAttributes` runs. The docs table reflects this accurately. A follow-up could add a dedicated flag or move span population earlier if this behavior is desired.

**Release order**: The new constants live in `core/schemas/trace.go`. Since `framework/go.mod` pins `core` to a published version, the `core` module must be tagged first before the `framework` change passes CI (`GOWORK=off`).

## Test plan
- [x] Unit tests for all cases: both fields set, both nil, only request, only response, nil response, json.RawMessage production type, unmarshalable value
- [x] Converter tests: forward enabled, forward disabled, no raw attrs present
- [ ] Verify tests pass in CI after `core` is tagged
- [ ] Manual verification: enable `send_back_raw_request` on a provider, set `forward_raw_request_response: true`, make an LLM call, confirm `gen_ai.raw_request` appears in the OTEL span

Closes #2104