### PR TITLE
fixes reasoning merge for bedrock provider

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -590,7 +590,7 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 		}
 	}
 
-	if len(contentBlocks) > 0 {
+	if len(contentBlocks) > 0 && ctx.Value(schemas.BifrostContextKeyIntegrationType) == "openai" {
 		allText := true
 		for _, block := range contentBlocks {
 			if block.Type != schemas.ChatContentBlockTypeText {

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1030,7 +1030,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	// Convert using the new response converter
+	// Convert using the new response converter	
 	bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -179,7 +179,8 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(ctx context.Conte
 		}
 	}
 
-	if len(contentBlocks) > 0 {
+	// We do merging of text blocks for Anthropic models while using /openai integration
+	if len(contentBlocks) > 0 && schemas.IsAnthropicModel(model) && ctx.Value(schemas.BifrostContextKeyIntegrationType) == "openai" {
 		allText := true
 		for _, block := range contentBlocks {
 			if block.Type != schemas.ChatContentBlockTypeText {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -30,6 +30,7 @@ type OpenAIProvider struct {
 	sendBackRawRequest   bool                          // Whether to include raw request in BifrostResponse
 	sendBackRawResponse  bool                          // Whether to include raw response in BifrostResponse
 	customProviderConfig *schemas.CustomProviderConfig // Custom provider config
+	disableStore         bool                          // Whether to force store=false on outgoing requests
 }
 
 // NewOpenAIProvider creates a new OpenAI provider instance.
@@ -71,6 +72,7 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 		sendBackRawRequest:   config.SendBackRawRequest,
 		sendBackRawResponse:  config.SendBackRawResponse,
 		customProviderConfig: config.CustomProviderConfig,
+		disableStore:         config.OpenAIConfig != nil && config.OpenAIConfig.DisableStore,
 	}
 }
 
@@ -746,6 +748,13 @@ func (provider *OpenAIProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		return nil, err
 	}
 
+	if provider.disableStore {
+		if request.Params == nil {
+			request.Params = &schemas.ChatParameters{}
+		}
+		request.Params.Store = schemas.Ptr(false)
+	}
+
 	return HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
@@ -911,6 +920,13 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
 	}
+	if provider.disableStore {
+		if request.Params == nil {
+			request.Params = &schemas.ChatParameters{}
+		}
+		request.Params.Store = schemas.Ptr(false)
+	}
+
 	// Use shared streaming logic
 	return HandleOpenAIChatCompletionStreaming(
 		ctx,
@@ -1363,6 +1379,13 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
+	if provider.disableStore {
+		if request.Params == nil {
+			request.Params = &schemas.ResponsesParameters{}
+		}
+		request.Params.Store = schemas.Ptr(false)
+	}
+
 	return HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
@@ -1526,6 +1549,13 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
 	}
+	if provider.disableStore {
+		if request.Params == nil {
+			request.Params = &schemas.ResponsesParameters{}
+		}
+		request.Params.Store = schemas.Ptr(false)
+	}
+
 	// Use shared streaming logic
 	return HandleOpenAIResponsesStreaming(
 		ctx,

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -96,7 +96,7 @@ func isOpenAIReasoningModel(model string) bool {
 	return false
 }
 
-// OpenAI enforces a 64 character maximum on the user field
+// MaxUserFieldLength for OpenAI enforces a 64 character maximum on the user field
 const MaxUserFieldLength = 64
 
 // SanitizeUserField returns nil if user exceeds MaxUserFieldLength, otherwise returns the original value

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -483,7 +483,13 @@ type ProviderConfig struct {
 	SendBackRawResponse       bool                      `json:"send_back_raw_response"`        // Send raw response back in the bifrost response (default: false)
 	StoreRawRequestResponse   bool                      `json:"store_raw_request_response"`    // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
 	CustomProviderConfig *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
+	OpenAIConfig         *OpenAIConfig             `json:"openai_config,omitempty"`
 	PricingOverrides     []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
+}
+
+// OpenAIConfig holds OpenAI-specific provider configuration.
+type OpenAIConfig struct {
+	DisableStore bool `json:"disable_store"` // When true, forces store=false on all outgoing OpenAI requests (default: false)
 }
 
 func (config *ProviderConfig) CheckAndSetDefaults() {

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -39,7 +39,7 @@ type ClientConfig struct {
 	DropExcessRequests              bool                             `json:"drop_excess_requests"`    // Drop excess requests if the provider queue is full
 	InitialPoolSize                 int                              `json:"initial_pool_size"`       // The initial pool size for the bifrost client
 	PrometheusLabels                []string                         `json:"prometheus_labels"`       // The labels to be used for prometheus metrics
-	EnableLogging                   bool                             `json:"enable_logging"`          // Enable logging of requests and responses
+	EnableLogging                   *bool                            `json:"enable_logging"`          // Enable logging of requests and responses
 	DisableContentLogging           bool                             `json:"disable_content_logging"` // Disable logging of content
 	DisableDBPingsInHealth          bool                             `json:"disable_db_pings_in_health"`
 	LogRetentionDays                int                              `json:"log_retention_days" validate:"min=1"`  // Number of days to retain logs (minimum 1 day)
@@ -75,7 +75,8 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 		hash.Write([]byte("dropExcessRequests:false"))
 	}
 
-	if c.EnableLogging {
+	enableLogging := c.EnableLogging == nil || *c.EnableLogging
+	if enableLogging {
 		hash.Write([]byte("enableLogging:true"))
 	} else {
 		hash.Write([]byte("enableLogging:false"))

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -256,6 +256,7 @@ type ProviderConfig struct {
 	SendBackRawResponse      bool                              `json:"send_back_raw_response"`                // Include raw response in BifrostResponse
 	StoreRawRequestResponse  bool                              `json:"store_raw_request_response"`            // Capture raw request/response for internal logging only; strip from API responses returned to clients
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
+	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"`               // OpenAI-specific configuration
 	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`           // Provider-level pricing overrides
 	ConfigHash               string                            `json:"config_hash,omitempty"`                 // Hash of config.json version, used for change detection
 	Status                   string                            `json:"status,omitempty"`                      // Model discovery status for keyless providers
@@ -276,6 +277,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		SendBackRawResponse:      p.SendBackRawResponse,
 		StoreRawRequestResponse:  p.StoreRawRequestResponse,
 		CustomProviderConfig:     p.CustomProviderConfig,
+		OpenAIConfig:             p.OpenAIConfig,
 		PricingOverrides:         p.PricingOverrides,
 		ConfigHash:               p.ConfigHash,
 		Status:                   p.Status,
@@ -439,6 +441,15 @@ func (p *ProviderConfig) GenerateConfigHash(providerName string) (string, error)
 	// Hash CustomProviderConfig
 	if p.CustomProviderConfig != nil {
 		data, err := sonic.Marshal(p.CustomProviderConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+
+	// Hash OpenAIConfig
+	if p.OpenAIConfig != nil {
+		data, err := sonic.Marshal(p.OpenAIConfig)
 		if err != nil {
 			return "", err
 		}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -317,6 +317,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddPluginOrderColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddOpenAIConfigJSONColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4764,6 +4767,37 @@ func migrationAddPluginOrderColumns(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while running add_plugin_order_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddOpenAIConfigJSONColumn adds the open_ai_config_json column to the provider table
+func migrationAddOpenAIConfigJSONColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_open_ai_config_json_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableProvider{}, "open_ai_config_json") {
+				if err := migrator.AddColumn(&tables.TableProvider{}, "OpenAIConfigJSON"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&tables.TableProvider{}, "open_ai_config_json") {
+				if err := migrator.DropColumn(&tables.TableProvider{}, "open_ai_config_json"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running add_open_ai_config_json_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -250,6 +250,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			SendBackRawResponse:      providerConfig.SendBackRawResponse,
 			StoreRawRequestResponse:  providerConfig.StoreRawRequestResponse,
 			CustomProviderConfig:     providerConfig.CustomProviderConfig,
+			OpenAIConfig:             providerConfig.OpenAIConfig,
 			PricingOverrides:         providerConfig.PricingOverrides,
 			ConfigHash:               providerConfig.ConfigHash,
 			Status:                   providerConfig.Status,
@@ -421,6 +422,7 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 	dbProvider.SendBackRawResponse = configCopy.SendBackRawResponse
 	dbProvider.StoreRawRequestResponse = configCopy.StoreRawRequestResponse
 	dbProvider.CustomProviderConfig = configCopy.CustomProviderConfig
+	dbProvider.OpenAIConfig = configCopy.OpenAIConfig
 	dbProvider.PricingOverrides = configCopy.PricingOverrides
 	dbProvider.ConfigHash = configCopy.ConfigHash
 
@@ -560,6 +562,7 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		SendBackRawResponse:      configCopy.SendBackRawResponse,
 		StoreRawRequestResponse:  configCopy.StoreRawRequestResponse,
 		CustomProviderConfig:     configCopy.CustomProviderConfig,
+		OpenAIConfig:             configCopy.OpenAIConfig,
 		PricingOverrides:         configCopy.PricingOverrides,
 		ConfigHash:               configCopy.ConfigHash,
 	}
@@ -719,6 +722,7 @@ func (s *RDBConfigStore) GetProvidersConfig(ctx context.Context) (map[schemas.Mo
 			SendBackRawResponse:      dbProvider.SendBackRawResponse,
 			StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
 			CustomProviderConfig:     dbProvider.CustomProviderConfig,
+			OpenAIConfig:             dbProvider.OpenAIConfig,
 			PricingOverrides:         dbProvider.PricingOverrides,
 			ConfigHash:               dbProvider.ConfigHash,
 			Status:                   dbProvider.Status,
@@ -768,6 +772,7 @@ func (s *RDBConfigStore) GetProviderConfig(ctx context.Context, provider schemas
 		SendBackRawResponse:      dbProvider.SendBackRawResponse,
 		StoreRawRequestResponse:  dbProvider.StoreRawRequestResponse,
 		CustomProviderConfig:     dbProvider.CustomProviderConfig,
+		OpenAIConfig:             dbProvider.OpenAIConfig,
 		PricingOverrides:         dbProvider.PricingOverrides,
 		ConfigHash:               dbProvider.ConfigHash,
 		Status:                   dbProvider.Status,

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -676,7 +676,7 @@ func TestUpdateClientConfig(t *testing.T) {
 	ctx := context.Background()
 
 	config := &ClientConfig{
-		EnableLogging:        true,
+		EnableLogging:        new(true),
 		AllowDirectKeys:      true,
 		InitialPoolSize:      100,
 		LogRetentionDays:     30,
@@ -688,7 +688,7 @@ func TestUpdateClientConfig(t *testing.T) {
 
 	result, err := store.GetClientConfig(ctx)
 	require.NoError(t, err)
-	assert.True(t, result.EnableLogging)
+	assert.True(t, result.EnableLogging != nil && *result.EnableLogging)
 	assert.Equal(t, 100, result.InitialPoolSize)
 }
 

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -16,7 +16,7 @@ type TableClientConfig struct {
 	AllowedHeadersJSON              string `gorm:"type:text" json:"-"` // JSON serialized []string
 	HeaderFilterConfigJSON          string `gorm:"type:text" json:"-"` // JSON serialized GlobalHeaderFilterConfig
 	InitialPoolSize                 int    `gorm:"default:300" json:"initial_pool_size"`
-	EnableLogging                   bool   `gorm:"" json:"enable_logging"`
+	EnableLogging                   *bool  `gorm:"default:true" json:"enable_logging"`
 	DisableContentLogging           bool   `gorm:"default:false" json:"disable_content_logging"` // DisableContentLogging controls whether sensitive content (inputs, outputs, embeddings, etc.) is logged
 	DisableDBPingsInHealth          bool   `gorm:"default:false" json:"disable_db_pings_in_health"`
 	LogRetentionDays                int    `gorm:"default:365" json:"log_retention_days" validate:"min=1"` // Number of days to retain logs (minimum 1 day)

--- a/framework/configstore/tables/provider.go
+++ b/framework/configstore/tables/provider.go
@@ -21,6 +21,7 @@ type TableProvider struct {
 	ConcurrencyBufferJSON    string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ConcurrencyAndBufferSize
 	ProxyConfigJSON          string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.ProxyConfig
 	CustomProviderConfigJSON string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.CustomProviderConfig
+	OpenAIConfigJSON         string    `gorm:"type:text" json:"-"`                                // JSON serialized schemas.OpenAIConfig
 	PricingOverridesJSON     string    `gorm:"type:text" json:"-"`                                // JSON serialized []schemas.ProviderPricingOverride
 	SendBackRawRequest       bool      `json:"send_back_raw_request"`
 	SendBackRawResponse      bool      `json:"send_back_raw_response"`
@@ -38,6 +39,7 @@ type TableProvider struct {
 
 	// Custom provider fields
 	CustomProviderConfig *schemas.CustomProviderConfig     `gorm:"-" json:"custom_provider_config,omitempty"`
+	OpenAIConfig         *schemas.OpenAIConfig             `gorm:"-" json:"openai_config,omitempty"`
 	PricingOverrides     []schemas.ProviderPricingOverride `gorm:"-" json:"pricing_overrides,omitempty"`
 
 	// Foreign keys
@@ -99,6 +101,15 @@ func (p *TableProvider) BeforeSave(tx *gorm.DB) error {
 			return err
 		}
 		p.CustomProviderConfigJSON = string(data)
+	}
+	if p.OpenAIConfig != nil {
+		data, err := json.Marshal(p.OpenAIConfig)
+		if err != nil {
+			return err
+		}
+		p.OpenAIConfigJSON = string(data)
+	} else {
+		p.OpenAIConfigJSON = ""
 	}
 	if p.PricingOverrides != nil {
 		data, err := json.Marshal(p.PricingOverrides)
@@ -171,6 +182,14 @@ func (p *TableProvider) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 		p.CustomProviderConfig = &customConfig
+	}
+
+	if p.OpenAIConfigJSON != "" {
+		var openaiConfig schemas.OpenAIConfig
+		if err := json.Unmarshal([]byte(p.OpenAIConfigJSON), &openaiConfig); err != nil {
+			return err
+		}
+		p.OpenAIConfig = &openaiConfig
 	}
 
 	if p.PricingOverridesJSON != "" {

--- a/tests/integrations/python/uv.lock
+++ b/tests/integrations/python/uv.lock
@@ -312,7 +312,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.1.0" },
     { name = "langchain-tests", specifier = ">=1.0.2" },
     { name = "langgraph", specifier = ">=0.1.0" },
-    { name = "litellm", specifier = ">=1.80.5" },
+    { name = "litellm", specifier = "==1.80.5" },
     { name = "mistralai", specifier = ">=0.4.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "openai", specifier = ">=1.30.0" },

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -308,10 +308,14 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		updatedConfig.InitialPoolSize = payload.ClientConfig.InitialPoolSize
 	}
 
-	if payload.ClientConfig.EnableLogging != currentConfig.EnableLogging {
-		restartReasons = append(restartReasons, "Logging enabled")
+	if payload.ClientConfig.EnableLogging != nil {
+		payloadLogging := *payload.ClientConfig.EnableLogging
+		currentLogging := currentConfig.EnableLogging == nil || *currentConfig.EnableLogging
+		if payloadLogging != currentLogging {
+			restartReasons = append(restartReasons, "Logging enabled")
+		}
+		updatedConfig.EnableLogging = payload.ClientConfig.EnableLogging
 	}
-	updatedConfig.EnableLogging = payload.ClientConfig.EnableLogging
 
 	if payload.ClientConfig.DisableContentLogging != currentConfig.DisableContentLogging {
 		restartReasons = append(restartReasons, "Content logging")

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -312,7 +312,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		payloadLogging := *payload.ClientConfig.EnableLogging
 		currentLogging := currentConfig.EnableLogging == nil || *currentConfig.EnableLogging
 		if payloadLogging != currentLogging {
-			restartReasons = append(restartReasons, "Logging enabled")
+			restartReasons = append(restartReasons, "Logging changed")
 		}
 		updatedConfig.EnableLogging = payload.ClientConfig.EnableLogging
 	}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -69,6 +69,7 @@ type ProviderResponse struct {
 	SendBackRawResponse      bool                              `json:"send_back_raw_response"`           // Include raw response in BifrostResponse
 	StoreRawRequestResponse  bool                              `json:"store_raw_request_response"`       // Capture raw request/response for internal logging only
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"` // Custom provider configuration
+	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"`          // OpenAI-specific configuration
 	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`      // Provider-level pricing overrides
 	ProviderStatus           ProviderStatus                    `json:"provider_status"`                  // Health/initialization status of the provider
 	Status                   string                            `json:"status,omitempty"`                 // Operational status (e.g., list_models_failed)
@@ -208,6 +209,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"`      // Include raw response in BifrostResponse
 		StoreRawRequestResponse  *bool                             `json:"store_raw_request_response,omitempty"`  // Capture raw request/response for internal logging only
 		CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`      // Custom provider configuration
+		OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"`               // OpenAI-specific configuration
 		PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`           // Provider-level pricing overrides
 	}{}
 	if err := json.Unmarshal(ctx.PostBody(), &payload); err != nil {
@@ -281,6 +283,7 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 		SendBackRawResponse:      payload.SendBackRawResponse != nil && *payload.SendBackRawResponse,
 		StoreRawRequestResponse:  payload.StoreRawRequestResponse != nil && *payload.StoreRawRequestResponse,
 		CustomProviderConfig:     payload.CustomProviderConfig,
+		OpenAIConfig:             payload.OpenAIConfig,
 		PricingOverrides:         payload.PricingOverrides,
 	}
 	// Validate custom provider configuration before persisting
@@ -360,6 +363,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		SendBackRawResponse      *bool                             `json:"send_back_raw_response,omitempty"` // Include raw response in BifrostResponse
 		StoreRawRequestResponse  *bool                             `json:"store_raw_request_response,omitempty"` // Capture raw request/response for internal logging only
 		CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"` // Custom provider configuration
+		OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"`          // OpenAI-specific configuration
 		PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`      // Provider-level pricing overrides
 	}{}
 
@@ -406,6 +410,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		ConcurrencyAndBufferSize: oldConfigRaw.ConcurrencyAndBufferSize,
 		ProxyConfig:              oldConfigRaw.ProxyConfig,
 		CustomProviderConfig:     oldConfigRaw.CustomProviderConfig,
+		OpenAIConfig:             oldConfigRaw.OpenAIConfig,
 		PricingOverrides:         oldConfigRaw.PricingOverrides,
 		StoreRawRequestResponse:  oldConfigRaw.StoreRawRequestResponse,
 		Status:                   oldConfigRaw.Status,
@@ -493,6 +498,7 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 
 	config.ProxyConfig = payload.ProxyConfig
 	config.CustomProviderConfig = payload.CustomProviderConfig
+	config.OpenAIConfig = payload.OpenAIConfig
 	config.PricingOverrides = payload.PricingOverrides
 	if payload.SendBackRawRequest != nil {
 		config.SendBackRawRequest = *payload.SendBackRawRequest
@@ -1106,6 +1112,7 @@ func (h *ProviderHandler) getProviderResponseFromConfig(provider schemas.ModelPr
 		SendBackRawResponse:      config.SendBackRawResponse,
 		StoreRawRequestResponse:  config.StoreRawRequestResponse,
 		CustomProviderConfig:     config.CustomProviderConfig,
+		OpenAIConfig:             config.OpenAIConfig,
 		PricingOverrides:         config.PricingOverrides,
 		ProviderStatus:           status,
 		Status:                   config.Status,

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -155,9 +155,26 @@ func (h *WSResponsesHandler) eventLoop(conn *ws.Conn, session *bfws.Session, aut
 // If native WS upstream fails mid-stream, falls back to HTTP bridge.
 func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *authHeaders, message []byte) {
 	var event schemas.WebSocketResponsesEvent
+
 	if err := sonic.Unmarshal(message, &event); err != nil {
 		writeWSError(session, 400, "invalid_request_error", "failed to parse response.create event")
 		return
+	}
+
+	// Store override: default to store=true (Codex sends false by default but expects true).
+	// If DisableStore is set in provider config, force store=false.
+	// If client explicitly sets store, respect that value unless DisableStore overrides it.
+	provider, modelName := schemas.ParseModelString(event.Model, "")
+	if provider == "" || modelName == "" {
+		writeWSError(session, 400, "invalid_request_error", "failed to parse model string")
+		return
+	}
+
+	if providerCfg, cfgErr := h.config.GetProviderConfigRaw(provider); cfgErr == nil &&
+		providerCfg.OpenAIConfig != nil && providerCfg.OpenAIConfig.DisableStore {
+		event.Store = schemas.Ptr(false)
+	} else if event.Store == nil {
+		event.Store = schemas.Ptr(true)
 	}
 
 	bifrostReq, err := h.convertEventToRequest(&event)
@@ -166,6 +183,7 @@ func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *a
 		return
 	}
 
+	
 	// Extract extra params (unknown fields) and forward them, matching the HTTP path behavior
 	extraParams, extractErr := extractExtraParams(message, wsResponsesKnownFields)
 	if extractErr == nil && len(extraParams) > 0 {
@@ -416,6 +434,7 @@ func (h *WSResponsesHandler) convertEventToRequest(event *schemas.WebSocketRespo
 	if len(input) == 0 {
 		return nil, errInputRequired
 	}
+	
 
 	params := &schemas.ResponsesParameters{}
 	if event.Temperature != nil {

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"strings"
-	"sync"
 
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
@@ -15,6 +14,12 @@ import (
 	bfws "github.com/maximhq/bifrost/transports/bifrost-http/websocket"
 	"github.com/valyala/fasthttp"
 )
+
+// wsWriter abstracts a WebSocket write target. Both *ws.Conn (pre-session)
+// and *bfws.Session (post-session, mutex-protected) satisfy this interface.
+type wsWriter interface {
+	WriteMessage(messageType int, data []byte) error
+}
 
 // WSResponsesHandler handles WebSocket connections for the Responses API WebSocket Mode.
 // Clients connect via `GET /v1/responses` with a WS upgrade and send `response.create` events.
@@ -132,15 +137,15 @@ func (h *WSResponsesHandler) eventLoop(conn *ws.Conn, session *bfws.Session, aut
 			Type string `json:"type"`
 		}
 		if err := sonic.Unmarshal(message, &envelope); err != nil {
-			writeWSError(conn, 400, "invalid_request_error", "failed to parse event JSON")
+			writeWSError(session, 400, "invalid_request_error", "failed to parse event JSON")
 			continue
 		}
 
 		switch schemas.WebSocketEventType(envelope.Type) {
 		case schemas.WSEventResponseCreate:
-			h.handleResponseCreate(conn, session, auth, message)
+			h.handleResponseCreate(session, auth, message)
 		default:
-			writeWSError(conn, 400, "invalid_request_error", "unsupported event type: "+envelope.Type)
+			writeWSError(session, 400, "invalid_request_error", "unsupported event type: "+envelope.Type)
 		}
 	}
 }
@@ -148,16 +153,16 @@ func (h *WSResponsesHandler) eventLoop(conn *ws.Conn, session *bfws.Session, aut
 // handleResponseCreate processes a response.create event.
 // Strategy: try native WS upstream for providers that support it, otherwise use HTTP bridge.
 // If native WS upstream fails mid-stream, falls back to HTTP bridge.
-func (h *WSResponsesHandler) handleResponseCreate(conn *ws.Conn, session *bfws.Session, auth *authHeaders, message []byte) {
+func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *authHeaders, message []byte) {
 	var event schemas.WebSocketResponsesEvent
 	if err := sonic.Unmarshal(message, &event); err != nil {
-		writeWSError(conn, 400, "invalid_request_error", "failed to parse response.create event")
+		writeWSError(session, 400, "invalid_request_error", "failed to parse response.create event")
 		return
 	}
 
 	bifrostReq, err := h.convertEventToRequest(&event)
 	if err != nil {
-		writeWSError(conn, 400, "invalid_request_error", err.Error())
+		writeWSError(session, 400, "invalid_request_error", err.Error())
 		return
 	}
 
@@ -172,25 +177,24 @@ func (h *WSResponsesHandler) handleResponseCreate(conn *ws.Conn, session *bfws.S
 
 	bifrostCtx, cancel := h.createBifrostContext(auth)
 	if bifrostCtx == nil {
-		writeWSError(conn, 500, "server_error", "failed to create request context")
+		writeWSError(session, 500, "server_error", "failed to create request context")
 		return
 	}
 
 	// Try native WS upstream first
-	if h.tryNativeWSUpstream(conn, session, bifrostCtx, bifrostReq, message) {
+	if h.tryNativeWSUpstream(session, bifrostCtx, bifrostReq, message) {
 		cancel()
 		return
 	}
 
 	// Fall back to HTTP bridge
-	h.executeHTTPBridge(conn, session, bifrostCtx, cancel, bifrostReq)
+	h.executeHTTPBridge(session, bifrostCtx, cancel, bifrostReq)
 }
 
 // tryNativeWSUpstream attempts to forward the event to a native WS upstream connection.
 // Returns true if the event was handled (successfully or with error sent to client).
 // Returns false if the provider doesn't support WS and we should fall back to HTTP bridge.
 func (h *WSResponsesHandler) tryNativeWSUpstream(
-	conn *ws.Conn,
 	session *bfws.Session,
 	ctx *schemas.BifrostContext,
 	req *schemas.BifrostResponsesRequest,
@@ -247,14 +251,14 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 
 	hooks, preErr := h.client.RunStreamPreHooks(ctx, bifrostReq)
 	if preErr != nil {
-		writeWSBifrostError(conn, preErr)
+		writeWSBifrostError(session, preErr)
 		return true
 	}
 	defer hooks.Cleanup()
 
 	// If a plugin short-circuited with a cached response, write it and skip upstream
 	if hooks.ShortCircuitResponse != nil {
-		writeWSShortCircuitResponse(conn, session, hooks.ShortCircuitResponse)
+		writeWSShortCircuitResponse(session, hooks.ShortCircuitResponse)
 		return true
 	}
 
@@ -281,7 +285,7 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 			if !forwardedAny {
 				return false
 			}
-			writeWSError(conn, 502, "upstream_connection_error", "upstream websocket stream interrupted")
+			writeWSError(session, 502, "upstream_connection_error", "upstream websocket stream interrupted")
 			return true
 		}
 
@@ -303,12 +307,12 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 			if postErr != nil {
 				h.pool.Discard(upstream)
 				session.SetUpstream(nil)
-				writeWSBifrostError(conn, postErr)
+				writeWSBifrostError(session, postErr)
 				return true
 			}
 		}
 
-		if writeErr := conn.WriteMessage(msgType, data); writeErr != nil {
+		if writeErr := session.WriteMessage(msgType, data); writeErr != nil {
 			h.pool.Discard(upstream)
 			session.SetUpstream(nil)
 			return true
@@ -323,13 +327,15 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 }
 
 // writeWSShortCircuitResponse writes a short-circuited plugin response as WS events.
-func writeWSShortCircuitResponse(conn *ws.Conn, session *bfws.Session, resp *schemas.BifrostResponse) {
+func writeWSShortCircuitResponse(session *bfws.Session, resp *schemas.BifrostResponse) {
 	if resp.ResponsesResponse != nil {
 		data, err := sonic.Marshal(resp.ResponsesResponse)
 		if err != nil {
 			return
 		}
-		conn.WriteMessage(ws.TextMessage, data)
+		if err := session.WriteMessage(ws.TextMessage, data); err != nil {
+			return
+		}
 		if resp.ResponsesResponse.ID != nil && *resp.ResponsesResponse.ID != "" {
 			session.SetLastResponseID(*resp.ResponsesResponse.ID)
 		}
@@ -338,7 +344,7 @@ func writeWSShortCircuitResponse(conn *ws.Conn, session *bfws.Session, resp *sch
 		if err != nil {
 			return
 		}
-		conn.WriteMessage(ws.TextMessage, data)
+		session.WriteMessage(ws.TextMessage, data)
 	}
 }
 
@@ -548,7 +554,6 @@ func (h *WSResponsesHandler) createBifrostContext(auth *authHeaders) (*schemas.B
 
 // executeHTTPBridge runs the response through the existing streaming inference pipeline.
 func (h *WSResponsesHandler) executeHTTPBridge(
-	conn *ws.Conn,
 	session *bfws.Session,
 	ctx *schemas.BifrostContext,
 	cancel context.CancelFunc,
@@ -558,12 +563,11 @@ func (h *WSResponsesHandler) executeHTTPBridge(
 
 	stream, bifrostErr := h.client.ResponsesStreamRequest(ctx, req)
 	if bifrostErr != nil {
-		writeWSBifrostError(conn, bifrostErr)
+		writeWSBifrostError(session, bifrostErr)
 		return
 	}
 
 	// Relay streaming chunks as WS messages
-	var writeMu sync.Mutex
 	for chunk := range stream {
 		if chunk == nil {
 			continue
@@ -575,12 +579,7 @@ func (h *WSResponsesHandler) executeHTTPBridge(
 			continue
 		}
 
-		writeMu.Lock()
-		writeErr := conn.WriteMessage(ws.TextMessage, chunkJSON)
-		writeMu.Unlock()
-
-		if writeErr != nil {
-			cancel()
+		if writeErr := session.WriteMessage(ws.TextMessage, chunkJSON); writeErr != nil {
 			return
 		}
 
@@ -594,8 +593,9 @@ func (h *WSResponsesHandler) executeHTTPBridge(
 	}
 }
 
-// writeWSError sends a JSON error event to the client WebSocket.
-func writeWSError(conn *ws.Conn, status int, code, message string) {
+// writeWSError sends a JSON error event to a WebSocket write target.
+// Accepts either a raw *ws.Conn (pre-session) or a *bfws.Session (mutex-protected).
+func writeWSError(w wsWriter, status int, code, message string) {
 	event := schemas.WebSocketErrorEvent{
 		Type:   schemas.WSEventError,
 		Status: status,
@@ -608,11 +608,11 @@ func writeWSError(conn *ws.Conn, status int, code, message string) {
 	if err != nil {
 		return
 	}
-	conn.WriteMessage(ws.TextMessage, data)
+	w.WriteMessage(ws.TextMessage, data)
 }
 
 // writeWSBifrostError converts a BifrostError to a WS error event.
-func writeWSBifrostError(conn *ws.Conn, bifrostErr *schemas.BifrostError) {
+func writeWSBifrostError(w wsWriter, bifrostErr *schemas.BifrostError) {
 	status := 500
 	if bifrostErr.StatusCode != nil && *bifrostErr.StatusCode > 0 {
 		status = *bifrostErr.StatusCode
@@ -629,7 +629,7 @@ func writeWSBifrostError(conn *ws.Conn, bifrostErr *schemas.BifrostError) {
 			msg = bifrostErr.Error.Message
 		}
 	}
-	writeWSError(conn, status, code, msg)
+	writeWSError(w, status, code, msg)
 }
 
 // wsResponsesKnownFields lists the fields explicitly handled by WebSocketResponsesEvent.

--- a/transports/bifrost-http/lib/account.go
+++ b/transports/bifrost-http/lib/account.go
@@ -98,5 +98,8 @@ func (baseAccount *BaseAccount) GetConfigForProvider(providerKey schemas.ModelPr
 	if config.CustomProviderConfig != nil {
 		providerConfig.CustomProviderConfig = config.CustomProviderConfig
 	}
+	if config.OpenAIConfig != nil {
+		providerConfig.OpenAIConfig = config.OpenAIConfig
+	}
 	return providerConfig, nil
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -338,7 +338,7 @@ var DefaultClientConfig = configstore.ClientConfig{
 	DropExcessRequests:              false,
 	PrometheusLabels:                []string{},
 	InitialPoolSize:                 schemas.DefaultInitialPoolSize,
-	EnableLogging:                   true,
+	EnableLogging:                   new(true),
 	DisableContentLogging:           false,
 	EnforceAuthOnInference:          false,
 	AllowDirectKeys:                 false,
@@ -617,6 +617,9 @@ func applyClientConfigDefaults(cc *configstore.ClientConfig) {
 	}
 	if cc.AllowedOrigins == nil {
 		cc.AllowedOrigins = DefaultClientConfig.AllowedOrigins
+	}
+	if cc.EnableLogging == nil {
+		cc.EnableLogging = new(true)
 	}
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1151,7 +1151,7 @@ func createConfigFile(t *testing.T, dir string, data *ConfigData) {
 func makeClientConfig(initialPoolSize int, enableLogging bool) *configstore.ClientConfig {
 	return &configstore.ClientConfig{
 		InitialPoolSize:      initialPoolSize,
-		EnableLogging:        enableLogging,
+		EnableLogging:        schemas.Ptr(enableLogging),
 		MaxRequestBodySizeMB: 10,
 		PrometheusLabels:     []string{"label1"},
 		AllowedOrigins:       []string{"http://localhost:3000"},
@@ -1236,7 +1236,7 @@ func makeConfigDataWithProvidersAndDir(providers map[string]configstore.Provider
 	return &ConfigData{
 		Client: &configstore.ClientConfig{
 			InitialPoolSize:      10,
-			EnableLogging:        true,
+			EnableLogging:        new(true),
 			MaxRequestBodySizeMB: 100,
 			AllowedOrigins:       []string{"*"},
 		},
@@ -1262,7 +1262,7 @@ func makeConfigDataWithVirtualKeysAndDir(providers map[string]configstore.Provid
 	return &ConfigData{
 		Client: &configstore.ClientConfig{
 			InitialPoolSize:      10,
-			EnableLogging:        true,
+			EnableLogging:        new(true),
 			MaxRequestBodySizeMB: 100,
 			AllowedOrigins:       []string{"*"},
 		},
@@ -1290,7 +1290,7 @@ func makeConfigDataFullWithDir(client *configstore.ClientConfig, providers map[s
 	if client == nil {
 		client = &configstore.ClientConfig{
 			InitialPoolSize:      10,
-			EnableLogging:        true,
+			EnableLogging:        new(true),
 			MaxRequestBodySizeMB: 100,
 			AllowedOrigins:       []string{"*"},
 		}
@@ -1456,7 +1456,7 @@ func TestLoadConfig_ClientConfig_Merge(t *testing.T) {
 	// Create config file with client config
 	fileClientConfig := &configstore.ClientConfig{
 		InitialPoolSize:       20,
-		EnableLogging:         true,
+		EnableLogging:         new(true),
 		PrometheusLabels:      []string{"file-label"},
 		AllowedOrigins:        []string{"http://file-origin.com"},
 		MaxRequestBodySizeMB:  15,
@@ -1472,7 +1472,7 @@ func TestLoadConfig_ClientConfig_Merge(t *testing.T) {
 	mockStore := NewMockConfigStore()
 	mockStore.clientConfig = &configstore.ClientConfig{
 		InitialPoolSize:      10,
-		EnableLogging:        false,
+		EnableLogging:        new(false),
 		PrometheusLabels:     []string{"db-label"},
 		MaxRequestBodySizeMB: 5,
 		// AllowedOrigins is empty in DB
@@ -1508,7 +1508,9 @@ func TestLoadConfig_ClientConfig_Merge(t *testing.T) {
 	}
 
 	// Boolean fields: file true overrides DB false
-	if !mergedConfig.EnableLogging && fileClientConfig.EnableLogging {
+	mergedLogging := mergedConfig.EnableLogging == nil || *mergedConfig.EnableLogging
+	fileLogging := fileClientConfig.EnableLogging != nil && *fileClientConfig.EnableLogging
+	if !mergedLogging && fileLogging {
 		mergedConfig.EnableLogging = fileClientConfig.EnableLogging
 	}
 	if !mergedConfig.DisableContentLogging && fileClientConfig.DisableContentLogging {
@@ -1532,7 +1534,7 @@ func TestLoadConfig_ClientConfig_Merge(t *testing.T) {
 		t.Errorf("Expected MaxRequestBodySizeMB to be 5 (from DB), got %d", mergedConfig.MaxRequestBodySizeMB)
 	}
 
-	if !mergedConfig.EnableLogging {
+	if mergedConfig.EnableLogging == nil || !*mergedConfig.EnableLogging {
 		t.Error("Expected EnableLogging to be true (file true overrides DB false)")
 	}
 
@@ -12293,7 +12295,7 @@ func TestGenerateClientConfigHash(t *testing.T) {
 		DropExcessRequests:      true,
 		InitialPoolSize:         300,
 		PrometheusLabels:        []string{"label1", "label2"},
-		EnableLogging:           true,
+		EnableLogging:           new(true),
 		DisableContentLogging:   false,
 		LogRetentionDays:        30,
 		EnforceAuthOnInference: false,
@@ -12343,7 +12345,7 @@ func TestGenerateClientConfigHash(t *testing.T) {
 
 	// Different EnableLogging should produce different hash
 	cc5 := cc1
-	cc5.EnableLogging = false
+	cc5.EnableLogging = new(false)
 	hash5, _ := cc5.GenerateClientConfigHash()
 	if hash1 == hash5 {
 		t.Error("Different EnableLogging should produce different hash")
@@ -13342,7 +13344,7 @@ func TestGenerateClientConfigHash_RuntimeVsMigrationParity(t *testing.T) {
 			DropExcessRequests:      true,
 			InitialPoolSize:         300,
 			PrometheusLabels:        labels,
-			EnableLogging:           true,
+			EnableLogging:           new(true),
 			DisableContentLogging:   false,
 			LogRetentionDays:        30,
 			EnforceAuthOnInference: false,
@@ -13403,7 +13405,7 @@ func TestGenerateClientConfigHash_RuntimeVsMigrationParity(t *testing.T) {
 			DropExcessRequests:   true,
 			InitialPoolSize:      300,
 			AllowedOrigins:       origins,
-			EnableLogging:        true,
+			EnableLogging:        new(true),
 			LogRetentionDays:     30,
 			MaxRequestBodySizeMB: 100,
 		}
@@ -16692,7 +16694,8 @@ func assertDefaultClientConfigValues(t *testing.T, cc configstore.ClientConfig) 
 	t.Helper()
 	require.Equal(t, false, cc.DropExcessRequests, "DropExcessRequests should default to false")
 	require.Equal(t, schemas.DefaultInitialPoolSize, cc.InitialPoolSize, "InitialPoolSize should match default")
-	require.Equal(t, true, cc.EnableLogging, "EnableLogging should default to true")
+	require.NotNil(t, cc.EnableLogging, "EnableLogging should not be nil")
+	require.Equal(t, true, *cc.EnableLogging, "EnableLogging should default to true")
 	require.Equal(t, false, cc.DisableContentLogging, "DisableContentLogging should default to false")
 	require.Equal(t, false, cc.EnforceAuthOnInference, "EnforceAuthOnInference should default to false")
 	require.Equal(t, false, cc.AllowDirectKeys, "AllowDirectKeys should default to false")
@@ -16897,7 +16900,7 @@ func TestLoadConfig_PartialConfigFile_OnlyClient(t *testing.T) {
 	configData := makeMinimalConfigData(tempDir)
 	configData.Client = &configstore.ClientConfig{
 		InitialPoolSize:      50,
-		EnableLogging:        false,
+		EnableLogging:        new(false),
 		MaxRequestBodySizeMB: 200,
 		AllowedOrigins:       []string{"http://example.com"},
 	}
@@ -16911,7 +16914,8 @@ func TestLoadConfig_PartialConfigFile_OnlyClient(t *testing.T) {
 
 	// Verify client config from file
 	require.Equal(t, 50, config.ClientConfig.InitialPoolSize, "InitialPoolSize from file")
-	require.Equal(t, false, config.ClientConfig.EnableLogging, "EnableLogging from file")
+	require.NotNil(t, config.ClientConfig.EnableLogging, "EnableLogging should not be nil")
+	require.Equal(t, false, *config.ClientConfig.EnableLogging, "EnableLogging from file")
 	require.Equal(t, 200, config.ClientConfig.MaxRequestBodySizeMB, "MaxRequestBodySizeMB from file")
 
 	// Verify providers auto-detected (no providers in file)
@@ -17013,7 +17017,7 @@ func TestLoadConfig_PartialConfigFile_ClientAndProviders(t *testing.T) {
 	configData := makeMinimalConfigData(tempDir)
 	configData.Client = &configstore.ClientConfig{
 		InitialPoolSize:      100,
-		EnableLogging:        true,
+		EnableLogging:        new(true),
 		MaxRequestBodySizeMB: 50,
 		AllowedOrigins:       []string{"*"},
 	}
@@ -17240,7 +17244,7 @@ func TestLoadConfig_PartialClientConfig_DefaultsFillGaps(t *testing.T) {
 	// Only set InitialPoolSize, leave MaxRequestBodySizeMB as 0 (should get default)
 	configData.Client = &configstore.ClientConfig{
 		InitialPoolSize: 50,
-		EnableLogging:   true,
+		EnableLogging:   new(true),
 		AllowedOrigins:  []string{"http://myapp.com"},
 		// MaxRequestBodySizeMB is 0 -> should get default 100
 	}
@@ -17254,7 +17258,8 @@ func TestLoadConfig_PartialClientConfig_DefaultsFillGaps(t *testing.T) {
 
 	// Verify explicit values from file
 	require.Equal(t, 50, config.ClientConfig.InitialPoolSize, "InitialPoolSize from file")
-	require.Equal(t, true, config.ClientConfig.EnableLogging, "EnableLogging from file")
+	require.NotNil(t, config.ClientConfig.EnableLogging, "EnableLogging should not be nil")
+	require.Equal(t, true, *config.ClientConfig.EnableLogging, "EnableLogging from file")
 
 	// Verify zero-value fields get defaults
 	require.Equal(t, DefaultClientConfig.MaxRequestBodySizeMB, config.ClientConfig.MaxRequestBodySizeMB,

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -160,7 +160,7 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	s.Config.SetPluginOrderInfo(telemetry.PluginName, builtinPlacement, schemas.Ptr(1))
 
 	// 2. Logging (if enabled)
-	if s.Config.ClientConfig.EnableLogging && s.Config.LogsStore != nil {
+	if (s.Config.ClientConfig.EnableLogging == nil || *s.Config.ClientConfig.EnableLogging) && s.Config.LogsStore != nil {
 		config := &logging.Config{
 			DisableContentLogging: &s.Config.ClientConfig.DisableContentLogging,
 			LoggingHeaders:        &s.Config.ClientConfig.LoggingHeaders,

--- a/transports/bifrost-http/websocket/session.go
+++ b/transports/bifrost-http/websocket/session.go
@@ -9,7 +9,8 @@ import (
 // Session tracks the binding between a client WebSocket connection and its upstream state.
 // For Responses WS mode, it tracks previous_response_id → upstream connection pinning.
 type Session struct {
-	mu sync.RWMutex
+	mu      sync.RWMutex
+	writeMu sync.Mutex // serializes all WriteMessage calls to clientConn
 
 	// Client connection
 	clientConn *ws.Conn
@@ -34,6 +35,15 @@ func NewSession(clientConn *ws.Conn) *Session {
 // ClientConn returns the client's WebSocket connection.
 func (s *Session) ClientConn() *ws.Conn {
 	return s.clientConn
+}
+
+// WriteMessage sends a message to the client WebSocket connection.
+// It serializes concurrent writes via writeMu to prevent panics from
+// simultaneous goroutine writes (e.g., heartbeat vs streaming relay).
+func (s *Session) WriteMessage(messageType int, data []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	return s.clientConn.WriteMessage(messageType, data)
 }
 
 // SetUpstream pins an upstream connection to this session.

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ModelProvider } from "@/lib/types/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useMemo, useState } from "react";
-import { ApiStructureFormFragment, GovernanceFormFragment, ProxyFormFragment } from "../fragments";
+import { ApiStructureFormFragment, GovernanceFormFragment, OpenAIConfigFormFragment, ProxyFormFragment } from "../fragments";
 import { DebuggingFormFragment } from "../fragments/debuggingFormFragment";
 import { NetworkFormFragment } from "../fragments/networkFormFragment";
 import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
@@ -15,7 +15,7 @@ interface Props {
 	provider: ModelProvider;
 }
 
-const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: boolean) => {
+const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: boolean, isOpenAI: boolean) => {
 	const tabs = [];
 	if (hasCustomProviderConfig) {
 		tabs.push({
@@ -45,6 +45,12 @@ const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: bo
 		id: "debugging",
 		label: "Debugging",
 	});
+	if (isOpenAI) {
+		tabs.push({
+			id: "openai-config",
+			label: "OpenAI Config",
+		});
+	}
 	return tabs;
 };
 
@@ -52,10 +58,11 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 	const [selectedTab, setSelectedTab] = useState<string | undefined>(undefined);
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 	const hasCustomProviderConfig = !!provider.custom_provider_config;
+	const isOpenAI = provider.name === "openai";
 
 	const tabs = useMemo(() => {
-		return availableTabs(hasCustomProviderConfig, hasGovernanceAccess);
-	}, [hasCustomProviderConfig, hasGovernanceAccess]);
+		return availableTabs(hasCustomProviderConfig, hasGovernanceAccess, isOpenAI);
+	}, [hasCustomProviderConfig, hasGovernanceAccess, isOpenAI]);
 
 	useEffect(() => {
 		setSelectedTab((previousTab) => {
@@ -90,7 +97,12 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 						<div className="custom-scrollbar mb-4 w-full overflow-x-auto">
 							<TabsList className="h-10 w-max min-w-full justify-start rounded-tl-sm rounded-tr-sm rounded-br-none rounded-bl-none">
 								{tabs.map((tab) => (
-									<TabsTrigger key={tab.id} value={tab.id} data-testid={`provider-tab-${tab.id}`} className="flex-none px-3 whitespace-nowrap">
+									<TabsTrigger
+										key={tab.id}
+										value={tab.id}
+										data-testid={`provider-tab-${tab.id}`}
+										className="flex-none px-3 whitespace-nowrap"
+									>
 										{tab.label}
 									</TabsTrigger>
 								))}
@@ -98,6 +110,9 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 						</div>
 						<TabsContent value="api-structure">
 							<ApiStructureFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="openai-config">
+							<OpenAIConfigFormFragment provider={provider} />
 						</TabsContent>
 						<TabsContent value="network">
 							<NetworkFormFragment provider={provider} />

--- a/ui/app/workspace/providers/fragments/index.ts
+++ b/ui/app/workspace/providers/fragments/index.ts
@@ -3,6 +3,7 @@ export { ApiKeyFormFragment } from "./apiKeysFormFragment";
 export { ApiStructureFormFragment } from "./apiStructureFormFragment";
 export { DebuggingFormFragment } from "./debuggingFormFragment";
 export { GovernanceFormFragment } from "./governanceFormFragment";
+export { OpenAIConfigFormFragment } from "./openaiConfigFormFragment";
 export { NetworkFormFragment } from "./networkFormFragment";
 export { PerformanceFormFragment } from "./performanceFormFragment";
 export { PerformanceFormFragment as PerformanceTab } from "./performanceFormFragment";

--- a/ui/app/workspace/providers/fragments/openaiConfigFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/openaiConfigFormFragment.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Switch } from "@/components/ui/switch";
+import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
+import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
+import { ModelProvider } from "@/lib/types/config";
+import { openaiConfigFormSchema, type OpenAIConfigFormSchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { toast } from "sonner";
+
+interface OpenAIConfigFormFragmentProps {
+	provider: ModelProvider;
+}
+
+export function OpenAIConfigFormFragment({ provider }: OpenAIConfigFormFragmentProps) {
+	const dispatch = useAppDispatch();
+	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
+	const form = useForm<OpenAIConfigFormSchema, any, OpenAIConfigFormSchema>({
+		resolver: zodResolver(openaiConfigFormSchema) as Resolver<OpenAIConfigFormSchema, any, OpenAIConfigFormSchema>,
+		mode: "onChange",
+		reValidateMode: "onChange",
+		defaultValues: {
+			disable_store: provider.openai_config?.disable_store ?? false,
+		},
+	});
+
+	useEffect(() => {
+		dispatch(setProviderFormDirtyState(form.formState.isDirty));
+	}, [form.formState.isDirty, dispatch]);
+
+	useEffect(() => {
+		form.reset({
+			disable_store: provider.openai_config?.disable_store ?? false,
+		});
+	}, [form, provider.name, provider.openai_config?.disable_store]);
+
+	const onSubmit = (data: OpenAIConfigFormSchema) => {
+		const updatedProvider: ModelProvider = {
+			...provider,
+			openai_config: {
+				disable_store: data.disable_store,
+			},
+		};
+		updateProvider(updatedProvider)
+			.unwrap()
+			.then(() => {
+				toast.success("OpenAI configuration updated successfully");
+				form.reset(data);
+			})
+			.catch((err) => {
+				toast.error("Failed to update OpenAI configuration", {
+					description: getErrorMessage(err),
+				});
+			});
+	};
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6" data-testid="provider-config-openai-content">
+				<div className="space-y-4">
+					<FormField
+						control={form.control}
+						name="disable_store"
+						render={({ field }) => (
+							<FormItem>
+								<div className="flex items-center justify-between space-x-2">
+									<div className="space-y-0.5">
+										<FormLabel>Disable Store</FormLabel>
+										<p className="text-muted-foreground text-xs">
+											With the Responses API, store defaults to true, and when it is on, the generated response is stored for later retrieval via API. OpenAI
+											exposes endpoints to retrieve and delete stored responses, so your response IDs become durable server-side objects instead of one-shot
+											IDs.
+										</p>
+									</div>
+									<FormControl>
+										<Switch
+											data-testid="provider-openai-disable-store-switch"
+											size="md"
+											checked={field.value}
+											disabled={!hasUpdateProviderAccess}
+											onCheckedChange={(checked) => {
+												field.onChange(checked);
+												form.trigger("disable_store");
+											}}
+										/>
+									</FormControl>
+								</div>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</div>
+
+				<div className="flex justify-end space-x-2 pb-6">
+					<Button
+						type="submit"
+						disabled={!form.formState.isDirty || !form.formState.isValid || !hasUpdateProviderAccess || isUpdatingProvider}
+						isLoading={isUpdatingProvider}
+					>
+						Save OpenAI Configuration
+					</Button>
+				</div>
+			</form>
+		</Form>
+	);
+}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -302,6 +302,11 @@ export interface ProviderPricingOverride {
 	cache_read_input_image_token_cost?: number;
 }
 
+// OpenAIConfig holds OpenAI-specific provider configuration.
+export interface OpenAIConfig {
+	disable_store?: boolean;
+}
+
 // ProviderConfig matching Go's lib.ProviderConfig
 export interface ModelProviderConfig {
 	keys: ModelProviderKey[];
@@ -312,6 +317,7 @@ export interface ModelProviderConfig {
 	send_back_raw_response?: boolean;
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+	openai_config?: OpenAIConfig;
 	pricing_overrides?: ProviderPricingOverride[];
 	status?: "unknown" | "success" | "list_models_failed";
 	description?: string;
@@ -341,6 +347,7 @@ export interface AddProviderRequest {
 	send_back_raw_response?: boolean;
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+	openai_config?: OpenAIConfig;
 	pricing_overrides?: ProviderPricingOverride[];
 }
 
@@ -354,6 +361,7 @@ export interface UpdateProviderRequest {
 	send_back_raw_response?: boolean;
 	store_raw_request_response?: boolean;
 	custom_provider_config?: CustomProviderConfig;
+	openai_config?: OpenAIConfig;
 	pricing_overrides?: ProviderPricingOverride[];
 }
 

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -679,6 +679,13 @@ export const debuggingFormSchema = z.object({
 
 export type DebuggingFormSchema = z.infer<typeof debuggingFormSchema>;
 
+// OpenAI Config tab
+export const openaiConfigFormSchema = z.object({
+	disable_store: z.boolean(),
+});
+
+export type OpenAIConfigFormSchema = z.infer<typeof openaiConfigFormSchema>;
+
 // OTEL Configuration Schema
 export const otelConfigSchema = z
 	.object({


### PR DESCRIPTION
## Summary

Adds model-specific filtering to only apply content block processing for Anthropic models in the Bedrock provider's chat response conversion.

## Changes

- Modified the content block processing condition in `ToBifrostChatResponse` to only execute when the model contains "anthropic"
- This prevents unnecessary processing for non-Anthropic models that may not require the same content block handling logic

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test chat completions with both Anthropic and non-Anthropic models through the Bedrock provider to ensure proper response handling.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a model-specific processing change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable