### PR TITLE
feat: add Plus icon and responsive text to pricing override create button

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -26,7 +26,7 @@ import { getProviderLabel } from "@/lib/constants/logs";
 import { PricingOverride, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { Input } from "@/components/ui/input";
-import { ChevronLeft, ChevronRight, Edit, Search, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -237,13 +237,16 @@ export default function ScopedPricingOverridesView() {
 	}
 
 	return (
-		<div className="mt-6 space-y-4">
-			<div className="flex items-start justify-between gap-4">
+		<div className="space-y-4">
+			<div className="flex items-center justify-between gap-4">
 				<div>
 					<h2 className="text-lg font-semibold tracking-tight">Pricing Overrides</h2>
 					<p className="text-muted-foreground text-sm">Set custom rates for any model across global or virtual key scopes, optionally narrowed to a specific provider or key</p>
 				</div>
-				<Button data-testid="pricing-override-create-btn" onClick={openCreateDrawer}>Create Override</Button>
+				<Button data-testid="pricing-override-create-btn" onClick={openCreateDrawer} className="gap-2">
+					<Plus className="h-4 w-4" />
+					<span className="hidden sm:inline">New Override</span>
+				</Button>
 			</div>
 
 			{/* Search */}


### PR DESCRIPTION
## Summary

Improves the visual design and mobile responsiveness of the pricing overrides section by adding a Plus icon to the create button and optimizing the button text for different screen sizes.

## Changes

- Added Plus icon import from lucide-react
- Enhanced the "Create Override" button with a Plus icon and responsive text that shows "New Override" on larger screens and hides text on mobile
- Adjusted container spacing by removing top margin and changing flex alignment from `items-start` to `items-center` for better visual balance

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the custom pricing overrides page and verify:
1. The "New Override" button displays with a Plus icon
2. On mobile screens, only the Plus icon is visible
3. On larger screens (sm and above), both icon and "New Override" text are visible
4. The button functionality remains unchanged when clicked

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots showing the button design changes and responsive behavior would be helpful.

## Breaking changes

- [x] Yes
- [ ] No

## Related issues

## Security considerations

No security implications - this is a purely visual enhancement.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable