### PR TITLE
fix: global region url in vertex embedding

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 - feat: added `blacklisted_models` on provider keys to exclude models from routing and filtered list-models
+- fix: handle global region url in vertex embedding method

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1552,9 +1552,14 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	// Remove google/ prefix from deployment
 	deployment = strings.TrimPrefix(deployment, "google/")
 
+	// For custom/fine-tuned models, validate projectNumber is set
+	projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+	if schemas.IsAllDigitsASCII(deployment) && projectNumber == "" {
+		return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models", providerName)
+	}
+
 	// Build the native Vertex embedding API endpoint
-	url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
-		region, projectID, region, deployment)
+	url := getCompleteURLForGeminiEndpoint(deployment, region, projectID, projectNumber, ":predict")
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,2 +1,3 @@
 - fix: add support for `x-bf-mcp-include-clients` and `x-bf-mcp-include-tools` request headers to filter MCP tools/list response when using bifrost as an 
 - feat: Provider keys support `blacklisted_models` in config and HTTP provider APIs; excluded models are omitted from filtered list-models and are not eligible for key selection (denylist wins over the `models` allow list).
+- fix: handle global region url in vertex embedding method


### PR DESCRIPTION
## Summary

Fixed handling of global region URLs in the Vertex AI embedding method to properly support custom and fine-tuned models.

fixes #2288

## Changes

- Added validation to ensure `projectNumber` is set when using fine-tuned models (identified by all-digit deployment names)
- Updated the embedding method to use `getCompleteURLForGeminiEndpoint` instead of manually constructing URLs, ensuring proper handling of global regions and custom models
- Added configuration error handling for missing project numbers on fine-tuned models

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with Vertex AI embedding requests using both standard and fine-tuned models:

```sh
# Core/Transports
go version
go test ./...

# Test with fine-tuned model (should require project number)
curl -X POST /v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "model": "1234567890",
    "input": "test text"
  }'

# Test with standard model
curl -X POST /v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{
    "model": "textembedding-gecko",
    "input": "test text"
  }'
```

Ensure `projectNumber` is configured in Vertex provider settings when using fine-tuned models.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this fix improves configuration validation for Vertex AI credentials.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable