### PR TITLE
fixes duplicate content_block_stop in bedrock

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -3598,3 +3598,57 @@ func TestBedrockToolInputKeyOrderPreservation(t *testing.T) {
 	assert.True(t, cmdIdx2 < descIdx2,
 		"block 2: key order not preserved, expected command < description in: %s", s2)
 }
+
+// TestToBedrockInvokeMessagesStreamResponse_NoDuplicateContentBlockStop verifies that
+// ContentPartDone does not emit a content_block_stop event (only OutputItemDone does),
+// preventing duplicate content_block_stop events in the stream. (Issue #2293)
+func TestToBedrockInvokeMessagesStreamResponse_NoDuplicateContentBlockStop(t *testing.T) {
+	ctx := &schemas.BifrostContext{}
+	contentIdx := 0
+	model := "anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+	// Simulate the sequence FinalizeBedrockStream emits for a text block:
+	// 1. OutputTextDone  — should be skipped
+	// 2. ContentPartDone — should be skipped (was previously emitting content_block_stop)
+	// 3. OutputItemDone  — should emit content_block_stop
+	events := []*schemas.BifrostResponsesStreamResponse{
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputTextDone,
+			ContentIndex: &contentIdx,
+			ExtraFields:  schemas.BifrostResponseExtraFields{ModelRequested: model},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeContentPartDone,
+			ContentIndex: &contentIdx,
+			ExtraFields:  schemas.BifrostResponseExtraFields{ModelRequested: model},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemDone,
+			ContentIndex: &contentIdx,
+			ExtraFields:  schemas.BifrostResponseExtraFields{ModelRequested: model},
+		},
+	}
+
+	type bedrockChunk struct {
+		InvokeModelRawChunk []byte `json:"invokeModelRawChunk"`
+	}
+
+	var stopCount int
+	for _, ev := range events {
+		_, result, err := bedrock.ToBedrockInvokeMessagesStreamResponse(ctx, ev)
+		require.NoError(t, err)
+		if result == nil {
+			continue
+		}
+		raw, err := json.Marshal(result)
+		require.NoError(t, err)
+		var chunk bedrockChunk
+		require.NoError(t, json.Unmarshal(raw, &chunk))
+		if len(chunk.InvokeModelRawChunk) > 0 &&
+			strings.Contains(string(chunk.InvokeModelRawChunk), "content_block_stop") {
+			stopCount++
+		}
+	}
+
+	assert.Equal(t, 1, stopCount, "expected exactly one content_block_stop event, got %d", stopCount)
+}

--- a/core/providers/bedrock/invoke.go
+++ b/core/providers/bedrock/invoke.go
@@ -813,8 +813,7 @@ func toAnthropicInvokeStreamBytes(resp *schemas.BifrostResponsesStreamResponse) 
 			return nil, nil
 		}
 
-	case schemas.ResponsesStreamResponseTypeOutputItemDone,
-		schemas.ResponsesStreamResponseTypeContentPartDone:
+	case schemas.ResponsesStreamResponseTypeOutputItemDone:
 		idx := 0
 		if resp.ContentIndex != nil {
 			idx = *resp.ContentIndex
@@ -824,7 +823,8 @@ func toAnthropicInvokeStreamBytes(resp *schemas.BifrostResponsesStreamResponse) 
 			"index": idx,
 		}
 
-	case schemas.ResponsesStreamResponseTypeOutputTextDone,
+	case schemas.ResponsesStreamResponseTypeContentPartDone,
+		schemas.ResponsesStreamResponseTypeOutputTextDone,
 		schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone:
 		// Skip — the content_block_stop is emitted on OutputItemDone
 		return nil, nil


### PR DESCRIPTION
## Summary

Fixes duplicate `content_block_stop` events in Bedrock streaming responses by ensuring only `OutputItemDone` events emit the stop event, while `ContentPartDone` events are now skipped.

## Issues

Closes #2293

## Changes

- Modified `toAnthropicInvokeStreamBytes` to skip `ContentPartDone` events instead of emitting `content_block_stop`
- Only `OutputItemDone` events now trigger `content_block_stop` emission
- Added comprehensive test to verify exactly one `content_block_stop` event is emitted per content block
- Test simulates the complete event sequence: `OutputTextDone` → `ContentPartDone` → `OutputItemDone`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the new test to verify the fix:

```sh
go test ./core/providers/bedrock -run TestToBedrockInvokeMessagesStreamResponse_NoDuplicateContentBlockStop -v
```

Run all Bedrock provider tests to ensure no regressions:

```sh
go test ./core/providers/bedrock -v
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2293

## Security considerations

None - this is an internal streaming event handling fix.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable