### PR TITLE
anthropic streaming usage fixes

### DIFF
--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -427,23 +427,6 @@ func TestToBifrostChatResponse_MultipleTextBlocksWithThinking(t *testing.T) {
 	if lastRD.Text == nil {
 		t.Fatal("expected content blocks metadata to be non-nil")
 	}
-
-	var meta []contentBlockMeta
-	if err := json.Unmarshal([]byte(*lastRD.Text), &meta); err != nil {
-		t.Fatalf("failed to unmarshal block metadata: %v", err)
-	}
-	if len(meta) != 3 {
-		t.Fatalf("expected 3 block metadata entries, got %d", len(meta))
-	}
-	if meta[0].T != "thinking" || meta[0].L != len(thinkingText) {
-		t.Errorf("block 0: expected thinking/%d, got %s/%d", len(thinkingText), meta[0].T, meta[0].L)
-	}
-	if meta[1].T != "text" || meta[1].L != len(textBlock1) {
-		t.Errorf("block 1: expected text/%d, got %s/%d", len(textBlock1), meta[1].T, meta[1].L)
-	}
-	if meta[2].T != "text" || meta[2].L != len(textBlock2) {
-		t.Errorf("block 2: expected text/%d, got %s/%d", len(textBlock2), meta[2].T, meta[2].L)
-	}
 }
 
 func TestToBifrostChatResponse_SingleTextBlockNoThinking(t *testing.T) {
@@ -488,13 +471,6 @@ func TestToAnthropicChatRequest_ReconstructsFromBoundaries(t *testing.T) {
 	combined := thinkingText + "\n\n" + textBlock1 + "\n\n" + textBlock2
 
 	// Build block metadata
-	meta := []contentBlockMeta{
-		{T: "thinking", L: len(thinkingText)},
-		{T: "text", L: len(textBlock1)},
-		{T: "text", L: len(textBlock2)},
-	}
-	metaJSON, _ := json.Marshal(meta)
-	metaStr := string(metaJSON)
 
 	bifrostReq := &schemas.BifrostChatRequest{
 		Provider: schemas.Anthropic,
@@ -514,11 +490,6 @@ func TestToAnthropicChatRequest_ReconstructsFromBoundaries(t *testing.T) {
 							Type:      schemas.BifrostReasoningDetailsTypeText,
 							Signature: &signature,
 							// Text is nil — was cleared during response conversion
-						},
-						{
-							Index: 1,
-							Type:  schemas.BifrostReasoningDetailsTypeContentBlocks,
-							Text:  &metaStr,
 						},
 					},
 				},
@@ -588,13 +559,6 @@ func TestToAnthropicChatRequest_BoundaryMismatchFallback(t *testing.T) {
 	signature := "sig_fallback"
 	modifiedContent := "The user edited this content"
 
-	meta := []contentBlockMeta{
-		{T: "thinking", L: 100}, // Original was 100 chars, but content is now different
-		{T: "text", L: 50},
-	}
-	metaJSON, _ := json.Marshal(meta)
-	metaStr := string(metaJSON)
-
 	bifrostReq := &schemas.BifrostChatRequest{
 		Provider: schemas.Anthropic,
 		Model:    "claude-opus-4-6-20250514",
@@ -608,8 +572,7 @@ func TestToAnthropicChatRequest_BoundaryMismatchFallback(t *testing.T) {
 				Content: &schemas.ChatMessageContent{ContentStr: &modifiedContent},
 				ChatAssistantMessage: &schemas.ChatAssistantMessage{
 					ReasoningDetails: []schemas.ChatReasoningDetails{
-						{Index: 0, Type: schemas.BifrostReasoningDetailsTypeText, Signature: &signature},
-						{Index: 1, Type: schemas.BifrostReasoningDetailsTypeContentBlocks, Text: &metaStr},
+						{Index: 0, Type: schemas.BifrostReasoningDetailsTypeText, Text: &modifiedContent, Signature: &signature},
 					},
 				},
 			},

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -253,6 +253,23 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 				if state.Model != nil {
 					response.Model = *state.Model
 				}
+				// Forward input usage from message_start so clients see cache metrics early
+				if chunk.Message.Usage != nil {
+					response.Usage = &schemas.ResponsesResponseUsage{
+						InputTokens:  chunk.Message.Usage.InputTokens,
+						OutputTokens: chunk.Message.Usage.OutputTokens,
+						TotalTokens:  chunk.Message.Usage.InputTokens + chunk.Message.Usage.OutputTokens,
+					}
+					if chunk.Message.Usage.CacheReadInputTokens > 0 || chunk.Message.Usage.CacheCreationInputTokens > 0 {
+						response.Usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
+							CachedReadTokens:  chunk.Message.Usage.CacheReadInputTokens,
+							CachedWriteTokens: chunk.Message.Usage.CacheCreationInputTokens,
+						}
+						// Bifrost convention: InputTokens includes cached tokens
+						response.Usage.InputTokens += chunk.Message.Usage.CacheReadInputTokens + chunk.Message.Usage.CacheCreationInputTokens
+						response.Usage.TotalTokens += chunk.Message.Usage.CacheReadInputTokens + chunk.Message.Usage.CacheCreationInputTokens
+					}
+				}
 				responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeCreated,
 					SequenceNumber: sequenceNumber,
@@ -1379,11 +1396,13 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		// Only convert response.created back to message_start (not response.in_progress to avoid duplicates)
 		streamResp.Type = AnthropicStreamEventTypeMessageStart
 		if bifrostResp.Response != nil {
-			streamMessage := &AnthropicMessageResponse{
-				Type:    "message",
-				Role:    "assistant",
-				Content: []AnthropicContentBlock{}, // Always empty array in message_start
-				Usage: &AnthropicUsage{
+			// Use actual usage if available (forwarded from upstream message_start),
+			// otherwise fall back to zeros for non-Anthropic providers
+			var messageUsage *AnthropicUsage
+			if bifrostResp.Response.Usage != nil {
+				messageUsage = ConvertBifrostUsageToAnthropicUsage(bifrostResp.Response.Usage)
+			} else {
+				messageUsage = &AnthropicUsage{
 					InputTokens:              0,
 					OutputTokens:             0,
 					CacheReadInputTokens:     0,
@@ -1392,7 +1411,13 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 						Ephemeral5mInputTokens: 0,
 						Ephemeral1hInputTokens: 0,
 					},
-				},
+				}
+			}
+			streamMessage := &AnthropicMessageResponse{
+				Type:    "message",
+				Role:    "assistant",
+				Content: []AnthropicContentBlock{}, // Always empty array in message_start
+				Usage:   messageUsage,
 			}
 			if bifrostResp.Response.ID != nil {
 				streamMessage.ID = *bifrostResp.Response.ID


### PR DESCRIPTION
## Summary

Removes content block metadata tracking from Anthropic provider and forwards input usage from message_start events to provide early cache metrics visibility to clients.

## Changes

- Removed content block metadata generation and validation logic from chat response conversion
- Eliminated contentBlockMeta struct usage in tests and request reconstruction
- Added early forwarding of input usage (including cache metrics) from message_start events in streaming responses
- Updated ToAnthropicResponsesStreamResponse to use actual usage data when available instead of always defaulting to zeros
- Simplified test cases by removing metadata-related assertions and setup

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Verify that Anthropic provider streaming responses now include early cache metrics and that content block handling still works without metadata tracking:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

Test streaming chat requests with cache-enabled models to confirm usage metrics appear in message_start events.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects internal metadata handling and usage reporting timing.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable