### PR TITLE
fix(semanticcache): skip unsupported count_tokens requests

### DIFF
--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -385,6 +385,8 @@ func (plugin *Plugin) clearRequestScopedContext(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(requestProviderKey)
 	ctx.ClearValue(requestEmbeddingKey)
 	ctx.ClearValue(requestEmbeddingTokensKey)
+	ctx.ClearValue(isCacheHitKey)
+	ctx.ClearValue(cacheHitTypeKey)
 }
 
 // PreLLMHook is called before a request is processed by Bifrost.

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -405,6 +405,11 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 		}
 	}
 
+	if !isSemanticCacheSupportedRequestType(req.RequestType) {
+		plugin.logger.Debug(PluginLoggerPrefix + " Skipping caching for unsupported request type: " + string(req.RequestType))
+		return req, nil, nil
+	}
+
 	// Clear any stale storage ID from a previously reused context.
 	ctx.ClearValue(requestStorageIDKey)
 

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -376,6 +376,17 @@ func (plugin *Plugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, 
 	return chunk, nil
 }
 
+func (plugin *Plugin) clearRequestScopedContext(ctx *schemas.BifrostContext) {
+	ctx.ClearValue(requestIDKey)
+	ctx.ClearValue(requestStorageIDKey)
+	ctx.ClearValue(requestHashKey)
+	ctx.ClearValue(requestParamsHashKey)
+	ctx.ClearValue(requestModelKey)
+	ctx.ClearValue(requestProviderKey)
+	ctx.ClearValue(requestEmbeddingKey)
+	ctx.ClearValue(requestEmbeddingTokensKey)
+}
+
 // PreLLMHook is called before a request is processed by Bifrost.
 // It performs a two-stage cache lookup: first direct hash matching, then semantic similarity search.
 // Uses UUID-based keys for entries stored in the VectorStore.
@@ -405,13 +416,13 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 		}
 	}
 
+	// Clear request-scoped semantic cache state up front in case the context is reused.
+	plugin.clearRequestScopedContext(ctx)
+
 	if !isSemanticCacheSupportedRequestType(req.RequestType) {
 		plugin.logger.Debug(PluginLoggerPrefix + " Skipping caching for unsupported request type: " + string(req.RequestType))
 		return req, nil, nil
 	}
-
-	// Clear any stale storage ID from a previously reused context.
-	ctx.ClearValue(requestStorageIDKey)
 
 	if plugin.isConversationHistoryThresholdExceeded(req) {
 		plugin.logger.Debug(PluginLoggerPrefix + " Skipping caching for request with conversation history threshold exceeded")

--- a/plugins/semanticcache/plugin_nil_content_test.go
+++ b/plugins/semanticcache/plugin_nil_content_test.go
@@ -180,6 +180,14 @@ func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 	}
 
 	ctx := CreateContextWithCacheKey("count-tokens-test")
+	ctx.SetValue(requestIDKey, "stale-request-id")
+	ctx.SetValue(requestStorageIDKey, "stale-storage-id")
+	ctx.SetValue(requestHashKey, "stale-request-hash")
+	ctx.SetValue(requestParamsHashKey, "stale-params-hash")
+	ctx.SetValue(requestModelKey, "stale-model")
+	ctx.SetValue(requestProviderKey, schemas.OpenAI)
+	ctx.SetValue(requestEmbeddingKey, []float32{1, 2, 3})
+	ctx.SetValue(requestEmbeddingTokensKey, 99)
 
 	modifiedReq, shortCircuit, err := plugin.PreLLMHook(ctx, req)
 	if err != nil {
@@ -202,6 +210,18 @@ func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 	}
 	if got, _ := ctx.Value(requestStorageIDKey).(string); got != "" {
 		t.Fatalf("expected requestStorageIDKey to remain unset, got %q", got)
+	}
+	if got, _ := ctx.Value(requestModelKey).(string); got != "" {
+		t.Fatalf("expected requestModelKey to remain unset, got %q", got)
+	}
+	if got, ok := ctx.Value(requestProviderKey).(schemas.ModelProvider); ok && got != "" {
+		t.Fatalf("expected requestProviderKey to remain unset, got %q", got)
+	}
+	if got := ctx.Value(requestEmbeddingKey); got != nil {
+		t.Fatalf("expected requestEmbeddingKey to remain unset, got %#v", got)
+	}
+	if got, ok := ctx.Value(requestEmbeddingTokensKey).(int); ok && got != 0 {
+		t.Fatalf("expected requestEmbeddingTokensKey to remain unset, got %d", got)
 	}
 }
 

--- a/plugins/semanticcache/plugin_nil_content_test.go
+++ b/plugins/semanticcache/plugin_nil_content_test.go
@@ -157,6 +157,54 @@ func TestPrepareDirectCacheLookup_UnsupportedRequestTypeFailsClosed(t *testing.T
 	}
 }
 
+func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
+	plugin := &Plugin{
+		config: getDefaultTestConfig(),
+		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.CountTokensRequest,
+		CountTokensRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-sonnet-4-5",
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: bifrost.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentStr: bifrost.Ptr("How many tokens is this message?"),
+					},
+				},
+			},
+		},
+	}
+
+	ctx := CreateContextWithCacheKey("count-tokens-test")
+
+	modifiedReq, shortCircuit, err := plugin.PreLLMHook(ctx, req)
+	if err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+	if modifiedReq != req {
+		t.Fatal("expected original request to be returned unchanged")
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected no short-circuit for unsupported count tokens request")
+	}
+	if got, _ := ctx.Value(requestIDKey).(string); got != "" {
+		t.Fatalf("expected requestIDKey to remain unset, got %q", got)
+	}
+	if got, _ := ctx.Value(requestHashKey).(string); got != "" {
+		t.Fatalf("expected requestHashKey to remain unset, got %q", got)
+	}
+	if got, _ := ctx.Value(requestParamsHashKey).(string); got != "" {
+		t.Fatalf("expected requestParamsHashKey to remain unset, got %q", got)
+	}
+	if got, _ := ctx.Value(requestStorageIDKey).(string); got != "" {
+		t.Fatalf("expected requestStorageIDKey to remain unset, got %q", got)
+	}
+}
+
 // TestGetNormalizedInputForCaching_NilContent verifies that getNormalizedInputForCaching
 // does not panic when chat messages have nil Content.
 func TestGetNormalizedInputForCaching_NilContent(t *testing.T) {

--- a/plugins/semanticcache/plugin_nil_content_test.go
+++ b/plugins/semanticcache/plugin_nil_content_test.go
@@ -188,6 +188,8 @@ func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 	ctx.SetValue(requestProviderKey, schemas.OpenAI)
 	ctx.SetValue(requestEmbeddingKey, []float32{1, 2, 3})
 	ctx.SetValue(requestEmbeddingTokensKey, 99)
+	ctx.SetValue(isCacheHitKey, true)
+	ctx.SetValue(cacheHitTypeKey, CacheTypeDirect)
 
 	modifiedReq, shortCircuit, err := plugin.PreLLMHook(ctx, req)
 	if err != nil {
@@ -222,6 +224,12 @@ func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 	}
 	if got, ok := ctx.Value(requestEmbeddingTokensKey).(int); ok && got != 0 {
 		t.Fatalf("expected requestEmbeddingTokensKey to remain unset, got %d", got)
+	}
+	if got, ok := ctx.Value(isCacheHitKey).(bool); ok && got {
+		t.Fatal("expected isCacheHitKey to remain unset")
+	}
+	if got, ok := ctx.Value(cacheHitTypeKey).(CacheType); ok && got != "" {
+		t.Fatalf("expected cacheHitTypeKey to remain unset, got %q", got)
 	}
 }
 

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -193,6 +193,30 @@ func (plugin *Plugin) buildRequestMetadataForCaching(req *schemas.BifrostRequest
 	return metadata, nil
 }
 
+// isSemanticCacheSupportedRequestType reports whether semantic cache supports
+// this request type for cache lookup and storage. Unsupported types are skipped.
+func isSemanticCacheSupportedRequestType(requestType schemas.RequestType) bool {
+	switch requestType {
+	case schemas.TextCompletionRequest,
+		schemas.TextCompletionStreamRequest,
+		schemas.ChatCompletionRequest,
+		schemas.ChatCompletionStreamRequest,
+		schemas.ResponsesRequest,
+		schemas.ResponsesStreamRequest,
+		schemas.WebSocketResponsesRequest,
+		schemas.SpeechRequest,
+		schemas.SpeechStreamRequest,
+		schemas.EmbeddingRequest,
+		schemas.TranscriptionRequest,
+		schemas.TranscriptionStreamRequest,
+		schemas.ImageGenerationRequest,
+		schemas.ImageGenerationStreamRequest:
+		return true
+	default:
+		return false
+	}
+}
+
 func (plugin *Plugin) computeRequestParamsHash(req *schemas.BifrostRequest) (string, error) {
 	metadata, err := plugin.buildRequestMetadataForCaching(req)
 	if err != nil {

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -195,6 +195,9 @@ func (plugin *Plugin) buildRequestMetadataForCaching(req *schemas.BifrostRequest
 
 // isSemanticCacheSupportedRequestType reports whether semantic cache supports
 // this request type for cache lookup and storage. Unsupported types are skipped.
+//
+// IMPORTANT: this list must stay in sync with the switch in buildRequestMetadataForCaching.
+// When adding a new case there, add it here too.
 func isSemanticCacheSupportedRequestType(requestType schemas.RequestType) bool {
 	switch requestType {
 	case schemas.TextCompletionRequest,


### PR DESCRIPTION
## Summary

Fixes a semantic cache bug where unsupported `CountTokensRequest` traffic was entering the semantic cache pipeline.

For `POST /anthropic/v1/messages/count_tokens?beta=true`, the request succeeded, but semantic cache attempted direct lookup preparation, failed because the request type is unsupported, and logged misleading warnings:

- `unsupported request type for semantic caching`
- `Hash is not a string. Continuing without caching`

The fix gates unsupported request types early so `count_tokens` behavior is unchanged and warning noise is eliminated.

---

## Changes

### What changed and why

- Added an early request-type gate in `semantic cache PreLLMHook` so unsupported request types are skipped before cache setup begins.
- Added a semantic-cache-specific helper to define which request types are supported for cache lookup/storage.
- Added a regression test for `CountTokensRequest` in the existing semantic cache test file to verify:
    - the request is returned unchanged
    - no short-circuit occurs
    - no cache context state is initialized

---

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

---

## Affected Areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers / Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

---

## Testing

### Targeted plugin test

```bash
cd plugins/semanticcache
GOWORK=off go test -run 'TestPreLLMHookSkipsUnsupportedCountTokensRequest|TestPerformDirectSearchDisablesScanFallbackForLegacyLookup'
```

**Expected:** test passes; `CountTokensRequest` is skipped without initializing cache state.

---

### Manual repro

```bash
curl -sS -X POST 'http://localhost:8080/anthropic/v1/messages/count_tokens?beta=true' \
  -H 'Content-Type: application/json' \
  --data-raw '{
    "model": "anthropic/claude-sonnet-4-5",
    "messages": [{ "role": "user", "content": "How many tokens is this message?" }]
  }'
```

**Expected:**

- Returns `200` with a valid body e.g. `{"input_tokens":14}`
- No `unsupported request type for semantic caching` warning
- No `Hash is not a string` warning

---

## Breaking Changes

- [x] No

---

## Related Issues

Related to semantic cache warnings observed for Anthropic `count_tokens` requests in the FPL Innovation Team investigation.

---

## Security Considerations

No auth, secret, PII, or sandboxing changes. This change only narrows plugin execution for unsupported request types and reduces misleading server-side warnings.

---

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable