### PR TITLE
add support for ANTHROPIC_AUTH_TOKEN

### DIFF
--- a/cli/internal/harness/harness.go
+++ b/cli/internal/harness/harness.go
@@ -25,6 +25,7 @@ type Harness struct {
 	BasePath         string
 	BaseURLEnv       string
 	APIKeyEnv        string
+	AuthTokenEnv     string
 	ModelEnv         string
 	SupportsMCP      bool
 	SupportsWorktree bool
@@ -54,6 +55,7 @@ var all = map[string]Harness{
 		BasePath:         "/anthropic",
 		BaseURLEnv:       "ANTHROPIC_BASE_URL",
 		APIKeyEnv:        "ANTHROPIC_API_KEY",
+		AuthTokenEnv:     "ANTHROPIC_AUTH_TOKEN",
 		SupportsMCP:      true,
 		SupportsWorktree: true,
 		RunArgsForMod: func(model string) []string {

--- a/cli/internal/runtime/runtime.go
+++ b/cli/internal/runtime/runtime.go
@@ -34,7 +34,10 @@ func BuildEnv(spec LaunchSpec) ([]string, error) {
 	vk := strings.TrimSpace(spec.VirtualKey)
 	if vk != "" {
 		env = append(env, spec.Harness.APIKeyEnv+"="+vk)
-	} 	
+		if spec.Harness.AuthTokenEnv != "" {
+			env = append(env, spec.Harness.AuthTokenEnv+"="+vk)
+		}
+	}
 	model := strings.TrimSpace(spec.Model)
 	if model != "" {
 		env = append(env, "BIFROST_MODEL="+model)

--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -61,6 +61,7 @@ For users with Anthropic Console API keys or Bifrost virtual keys:
 1. **Configure environment variables**
    ```bash
    export ANTHROPIC_API_KEY=your-api-key  # Anthropic Console key or Bifrost virtual key
+   export ANTHROPIC_AUTH_TOKEN=your-api-key  # Same value — ensures bearer token auth works too
    export ANTHROPIC_BASE_URL=http://localhost:8080/anthropic
    ```
 
@@ -68,6 +69,10 @@ For users with Anthropic Console API keys or Bifrost virtual keys:
    ```bash
    claude
    ```
+
+<Tip>
+When launching Claude Code through the [Bifrost CLI](/quickstart/cli/getting-started), both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` are set automatically from your virtual key — no manual export needed.
+</Tip>
 
 ### Custom authentication
 


### PR DESCRIPTION
## Summary

Adds automatic setting of `ANTHROPIC_AUTH_TOKEN` environment variable to support bearer token authentication for Claude Code when using Bifrost virtual keys.

## Changes

- Modified `BuildEnv` function to set both `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` when a virtual key is provided
- Updated Claude Code documentation to show both environment variables are needed for manual setup
- Added tip explaining that Bifrost CLI sets both variables automatically

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Docs

## How to test

Test with Bifrost CLI to verify both environment variables are set:

```sh
# Launch Claude Code through Bifrost CLI
bifrost claude

# Verify both environment variables are available in the Claude Code environment
# Both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN should contain the virtual key value
```

For manual testing, set both environment variables:

```sh
export ANTHROPIC_API_KEY=your-api-key
export ANTHROPIC_AUTH_TOKEN=your-api-key
export ANTHROPIC_BASE_URL=http://localhost:8080/anthropic
claude
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The change duplicates the virtual key value into an additional environment variable (`ANTHROPIC_AUTH_TOKEN`) to support different authentication methods, but does not change the security model or expose additional secrets.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable