### PR TITLE
feat: add image edit input view on logs

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -203,6 +203,12 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddLogsAndDashboardPerformanceIndexes(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddImageEditInputColumn(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddImageVariationInputColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddPluginLogsColumn(ctx, db); err != nil {
 		return err
 	}
@@ -2066,6 +2072,74 @@ func ensurePerformanceIndexes(ctx context.Context, conn *sql.Conn) error {
 		}
 	}
 
+	return nil
+}
+
+// migrationAddImageEditInputColumn adds the image_edit_input column to the logs table.
+func migrationAddImageEditInputColumn(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_image_edit_input_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "image_edit_input") {
+				if err := migrator.AddColumn(&Log{}, "image_edit_input"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&Log{}, "image_edit_input") {
+				if err := migrator.DropColumn(&Log{}, "image_edit_input"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding image edit input column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddImageVariationInputColumn adds the image_variation_input column to the logs table.
+func migrationAddImageVariationInputColumn(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_image_variation_input_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&Log{}, "image_variation_input") {
+				if err := migrator.AddColumn(&Log{}, "image_variation_input"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&Log{}, "image_variation_input") {
+				if err := migrator.DropColumn(&Log{}, "image_variation_input"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding image variation input column: %s", err.Error())
+	}
 	return nil
 }
 

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -105,6 +105,8 @@ type Log struct {
 	SpeechInput             string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.SpeechInput
 	TranscriptionInput      string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.TranscriptionInput
 	ImageGenerationInput    string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ImageGenerationInput
+	ImageEditInput          string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ImageEditInput
+	ImageVariationInput     string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ImageVariationInput
 	VideoGenerationInput    string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.VideoGenerationInput
 	SpeechOutput            string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostSpeech
 	TranscriptionOutput     string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostTranscribe
@@ -157,6 +159,8 @@ type Log struct {
 	SpeechInputParsed           *schemas.SpeechInput                    `gorm:"-" json:"speech_input,omitempty"`
 	TranscriptionInputParsed    *schemas.TranscriptionInput             `gorm:"-" json:"transcription_input,omitempty"`
 	ImageGenerationInputParsed  *schemas.ImageGenerationInput           `gorm:"-" json:"image_generation_input,omitempty"`
+	ImageEditInputParsed        *schemas.ImageEditInput                 `gorm:"-" json:"image_edit_input,omitempty"`
+	ImageVariationInputParsed   *schemas.ImageVariationInput            `gorm:"-" json:"image_variation_input,omitempty"`
 	SpeechOutputParsed          *schemas.BifrostSpeechResponse          `gorm:"-" json:"speech_output,omitempty"`
 	TranscriptionOutputParsed   *schemas.BifrostTranscriptionResponse   `gorm:"-" json:"transcription_output,omitempty"`
 	ImageGenerationOutputParsed *schemas.BifrostImageGenerationResponse `gorm:"-" json:"image_generation_output,omitempty"`
@@ -286,6 +290,22 @@ func (l *Log) SerializeFields() error {
 			return err
 		} else {
 			l.ImageGenerationInput = string(data)
+		}
+	}
+
+	if l.ImageEditInputParsed != nil {
+		if data, err := sonic.Marshal(l.ImageEditInputParsed); err != nil {
+			return err
+		} else {
+			l.ImageEditInput = string(data)
+		}
+	}
+
+	if l.ImageVariationInputParsed != nil {
+		if data, err := sonic.Marshal(l.ImageVariationInputParsed); err != nil {
+			return err
+		} else {
+			l.ImageVariationInput = string(data)
 		}
 	}
 
@@ -588,6 +608,18 @@ func (l *Log) DeserializeFields() error {
 		if err := sonic.Unmarshal([]byte(l.ImageGenerationInput), &l.ImageGenerationInputParsed); err != nil {
 			// Log error but don't fail the operation - initialize as nil
 			l.ImageGenerationInputParsed = nil
+		}
+	}
+
+	if l.ImageEditInput != "" {
+		if err := sonic.Unmarshal([]byte(l.ImageEditInput), &l.ImageEditInputParsed); err != nil {
+			l.ImageEditInputParsed = nil
+		}
+	}
+
+	if l.ImageVariationInput != "" {
+		if err := sonic.Unmarshal([]byte(l.ImageVariationInput), &l.ImageVariationInputParsed); err != nil {
+			l.ImageVariationInputParsed = nil
 		}
 	}
 
@@ -1001,6 +1033,11 @@ func (l *Log) BuildContentSummary() string {
 	// Add image generation input prompt
 	if l.ImageGenerationInputParsed != nil && l.ImageGenerationInputParsed.Prompt != "" {
 		parts = append(parts, l.ImageGenerationInputParsed.Prompt)
+	}
+
+	// Add image edit input prompt
+	if l.ImageEditInputParsed != nil && l.ImageEditInputParsed.Prompt != "" {
+		parts = append(parts, l.ImageEditInputParsed.Prompt)
 	}
 
 	// Add video generation input prompt

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -208,6 +208,8 @@ type InitialLogData struct {
 	SpeechInput            *schemas.SpeechInput
 	TranscriptionInput     *schemas.TranscriptionInput
 	ImageGenerationInput   *schemas.ImageGenerationInput
+	ImageEditInput         *schemas.ImageEditInput
+	ImageVariationInput    *schemas.ImageVariationInput
 	VideoGenerationInput   *schemas.VideoGenerationInput
 	Tools                  []schemas.ChatTool
 	RoutingEngineUsed      []string
@@ -492,6 +494,50 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
 			initialData.Params = req.ImageGenerationRequest.Params
 			initialData.ImageGenerationInput = req.ImageGenerationRequest.Input
+		case schemas.ImageEditRequest, schemas.ImageEditStreamRequest:
+			params := req.ImageEditRequest.Params
+			input := req.ImageEditRequest.Input
+			if input != nil {
+				reqThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadRequestThreshold).(int64)
+				if reqThreshold > 0 {
+					var totalSize int64
+					for _, img := range input.Images {
+						totalSize += int64(len(img.Image))
+					}
+					if totalSize > reqThreshold {
+						logInput := *input
+						logInput.Images = nil
+						initialData.ImageEditInput = &logInput
+					} else {
+						initialData.ImageEditInput = input
+					}
+					if params != nil && int64(len(params.Mask)) > reqThreshold {
+						logParams := *params
+						logParams.Mask = nil
+						initialData.Params = &logParams
+					} else {
+						initialData.Params = params
+					}
+				} else {
+					initialData.ImageEditInput = input
+					initialData.Params = params
+				}
+			} else {
+				initialData.Params = params
+			}
+		case schemas.ImageVariationRequest:
+			initialData.Params = req.ImageVariationRequest.Params
+			input := req.ImageVariationRequest.Input
+			if input != nil {
+				reqThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadRequestThreshold).(int64)
+				if reqThreshold > 0 && int64(len(input.Image.Image)) > reqThreshold {
+					logInput := *input
+					logInput.Image = schemas.ImageInput{}
+					initialData.ImageVariationInput = &logInput
+				} else {
+					initialData.ImageVariationInput = input
+				}
+			}
 		case schemas.VideoGenerationRequest:
 			initialData.Params = req.VideoGenerationRequest.Params
 			initialData.VideoGenerationInput = req.VideoGenerationRequest.Input

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -41,6 +41,8 @@ func (p *LoggerPlugin) insertInitialLogEntry(
 		SpeechInputParsed:           data.SpeechInput,
 		TranscriptionInputParsed:    data.TranscriptionInput,
 		ImageGenerationInputParsed:  data.ImageGenerationInput,
+		ImageEditInputParsed:        data.ImageEditInput,
+		ImageVariationInputParsed:   data.ImageVariationInput,
 		RoutingEnginesUsed:          routingEnginesUsed,
 		MetadataParsed:              data.Metadata,
 		VideoGenerationInputParsed:  data.VideoGenerationInput,

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -315,6 +315,8 @@ func buildCompleteLogEntryFromPending(pending *PendingLogData) *logstore.Log {
 		SpeechInputParsed:           pending.InitialData.SpeechInput,
 		TranscriptionInputParsed:    pending.InitialData.TranscriptionInput,
 		ImageGenerationInputParsed:  pending.InitialData.ImageGenerationInput,
+		ImageEditInputParsed:        pending.InitialData.ImageEditInput,
+		ImageVariationInputParsed:   pending.InitialData.ImageVariationInput,
 		PassthroughRequestBody:      pending.InitialData.PassthroughRequestBody,
 	}
 	if pending.ParentRequestID != "" {

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -628,9 +628,11 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete }: LogDet
 							/>
 						)}
 
-						{(displayLog.image_generation_input || displayLog.image_generation_output) && (
+						{(displayLog.image_generation_input || displayLog.image_edit_input || displayLog.image_variation_input || displayLog.image_generation_output) && (
 							<ImageView
 								imageInput={displayLog.image_generation_input}
+								imageEditInput={displayLog.image_edit_input}
+								imageVariationInput={displayLog.image_variation_input}
 								imageOutput={displayLog.image_generation_output}
 								requestType={displayLog.object}
 							/>

--- a/ui/app/workspace/logs/views/imageView.tsx
+++ b/ui/app/workspace/logs/views/imageView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { BifrostImageGenerationOutput } from "@/lib/types/logs";
+import { BifrostImageGenerationOutput, ImageEditInput, ImageVariationInput } from "@/lib/types/logs";
 import { Image, ChevronLeft, ChevronRight } from "lucide-react";
 import { ImageMessage } from "@/components/chat/ImageMessage";
 import { Button } from "@/components/ui/button";
@@ -13,8 +13,19 @@ interface ImageGenerationInput {
 
 interface ImageViewProps {
 	imageInput?: ImageGenerationInput;
+	imageEditInput?: ImageEditInput;
+	imageVariationInput?: ImageVariationInput;
 	imageOutput?: BifrostImageGenerationOutput;
 	requestType?: string;
+}
+
+// Detect MIME type from base64 magic bytes and return a data URL
+function getImageSrc(b64: string): string {
+	if (b64.startsWith("/9j/")) return `data:image/jpeg;base64,${b64}`;
+	if (b64.startsWith("iVBOR")) return `data:image/png;base64,${b64}`;
+	if (b64.startsWith("UklGR")) return `data:image/webp;base64,${b64}`;
+	if (b64.startsWith("R0lGO")) return `data:image/gif;base64,${b64}`;
+	return `data:image/png;base64,${b64}`;
 }
 
 // Helper function to get method type label from request type
@@ -31,7 +42,7 @@ function getMethodTypeLabel(requestType?: string): string {
 	return RequestTypeLabels[normalizedType as keyof typeof RequestTypeLabels] || "Image Generation";
 }
 
-export default function ImageView({ imageInput, imageOutput, requestType }: ImageViewProps) {
+export default function ImageView({ imageInput, imageEditInput, imageVariationInput, imageOutput, requestType }: ImageViewProps) {
 	const [currentIndex, setCurrentIndex] = useState(0);
 
 	// Get all valid images
@@ -67,6 +78,57 @@ export default function ImageView({ imageInput, imageOutput, requestType }: Imag
 					<div className="space-y-4 p-6">
 						<div className="text-muted-foreground mb-2 text-xs font-medium">PROMPT</div>
 						<div className="font-mono text-xs">{imageInput.prompt}</div>
+					</div>
+				</div>
+			)}
+
+			{/* Image Edit Input */}
+			{imageEditInput && (
+				<div className="w-full rounded-sm border">
+					<div className="flex items-center gap-2 border-b px-6 py-2 text-sm font-medium">
+						<Image className="h-4 w-4" />
+						{methodTypeLabel} Input
+					</div>
+					<div className="space-y-4 p-6">
+						{imageEditInput.images && imageEditInput.images.length > 0 && (
+							<div>
+								<div className="text-muted-foreground mb-2 text-xs font-medium">INPUT IMAGES</div>
+								<div className="flex flex-wrap gap-2">
+									{imageEditInput.images.map((img, i) =>
+										img.image ? (
+											<img
+												key={i}
+												src={getImageSrc(img.image)}
+												alt={`Input image ${i + 1}`}
+												className="max-h-48 max-w-48 rounded border object-contain"
+											/>
+										) : null
+									)}
+								</div>
+							</div>
+						)}
+						<div>
+							<div className="text-muted-foreground mb-2 text-xs font-medium">PROMPT</div>
+							<div className="font-mono text-xs">{imageEditInput.prompt}</div>
+						</div>
+					</div>
+				</div>
+			)}
+
+			{/* Image Variation Input */}
+			{imageVariationInput && imageVariationInput.image?.image && (
+				<div className="w-full rounded-sm border">
+					<div className="flex items-center gap-2 border-b px-6 py-2 text-sm font-medium">
+						<Image className="h-4 w-4" />
+						{methodTypeLabel} Input
+					</div>
+					<div className="space-y-4 p-6">
+						<div className="text-muted-foreground mb-2 text-xs font-medium">INPUT IMAGE</div>
+						<img
+							src={getImageSrc(imageVariationInput.image.image)}
+							alt="Input image"
+							className="max-h-48 max-w-48 rounded border object-contain"
+						/>
 					</div>
 				</div>
 			)}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -429,6 +429,16 @@ export interface PluginLogEntry {
 	timestamp: number;
 }
 
+export interface ImageEditInput {
+	images?: Array<{ image: string | null }> | null; // null when stripped by large-payload threshold
+	prompt: string;
+}
+
+export interface ImageVariationInput {
+	image: { image: string | null }; // image bytes null when stripped by large-payload threshold
+}
+
+
 // Main LogEntry interface matching backend
 export interface LogEntry {
 	id: string;
@@ -463,6 +473,8 @@ export interface LogEntry {
 	speech_input?: SpeechInput;
 	transcription_input?: TranscriptionInput;
 	image_generation_input?: { prompt: string };
+	image_edit_input?: ImageEditInput;
+	image_variation_input?: ImageVariationInput;
 	video_generation_input?: { prompt: string };
 	speech_output?: BifrostSpeech;
 	transcription_output?: BifrostTranscribe;


### PR DESCRIPTION
## Summary

Adds support for logging image edit and image variation requests by introducing new database columns and UI components to track and display these image manipulation operations alongside existing image generation functionality.

## Changes

- Added `image_edit_input` and `image_variation_input` columns to the logs table with corresponding database migrations
- Extended the Log struct with new fields for storing and parsing image edit/variation input data
- Updated logging plugin to capture image edit and variation request data with large payload threshold handling
- Enhanced UI to display input images and prompts for image edit operations and input images for variation operations
- Added image MIME type detection for proper display of base64-encoded images in the UI

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test by making image edit and image variation API requests and verifying that the input data is properly logged and displayed in the UI logs section.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

The implementation includes large payload threshold handling to prevent logging oversized image data, which helps manage storage and potential memory issues when processing large images.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable